### PR TITLE
Mailpoet 5796 inline notices

### DIFF
--- a/mailpoet/assets/css/src/components-automation-integrations/mailpoet/steps/send-email/index.scss
+++ b/mailpoet/assets/css/src/components-automation-integrations/mailpoet/steps/send-email/index.scss
@@ -13,3 +13,8 @@
 .mailpoet-sendmail-description-type {
   color: #787c82;
 }
+
+.components-panel__body.is-opened .mailpoet-inline-notice {
+  margin-top: -16px;
+  padding-bottom: 24px;
+}

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -271,3 +271,12 @@ export function removeStepErrors(stepId) {
     stepId,
   };
 }
+
+export function alterContext(context: string, key: string, value: unknown) {
+  return {
+    type: 'UPDATE_CONTEXT',
+    context,
+    key,
+    value,
+  };
+}

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -143,6 +143,17 @@ export function reducer(state: State, action): State {
             : undefined,
       };
     }
+    case 'UPDATE_CONTEXT':
+      return {
+        ...state,
+        context: {
+          ...state.context,
+          [action.context as string]: {
+            ...(state.context[action.context as string] as object),
+            [action.key as string]: action.value as string,
+          },
+        },
+      };
     default:
       return state;
   }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
@@ -1,4 +1,4 @@
-import { select } from '@wordpress/data';
+import { select, dispatch, useSelect } from '@wordpress/data';
 import { FormTokenItem } from '../../editor/components';
 import { storeName } from '../../editor/store';
 import { SenderRestrictionsType } from '../../../common';
@@ -23,3 +23,14 @@ export type Context = {
 
 export const getContext = (): Context =>
   select(storeName).getContext('mailpoet') as Context;
+
+export const useSelectContext = (): Context =>
+  useSelect((s) => s(storeName).getContext('mailpoet'), []);
+
+export const updateSenderDomainsConfig = (
+  senderDomainsConfig: SenderDomainsConfig,
+) => {
+  dispatch(storeName).alterContext('mailpoet', 'senderDomainsConfig', {
+    ...senderDomainsConfig,
+  });
+};

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
@@ -6,9 +6,23 @@ type Segment = FormTokenItem & {
   type: string;
 };
 
+type SenderRestrictions = {
+  lowerLimit: number;
+  upperLimit: number;
+};
+
+type SenderDomainsConfig = {
+  authorizedEmails: string[];
+  verifiedSenderDomains: string[];
+  partiallyVerifiedSenderDomains: string[];
+  allSenderDomains: string[];
+  senderRestrictions: SenderRestrictions;
+};
+
 export type Context = {
   segments?: Segment[];
   userRoles?: FormTokenItem[];
+  senderDomainsConfig?: SenderDomainsConfig;
 };
 
 export const getContext = (): Context =>

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
@@ -1,14 +1,10 @@
 import { select } from '@wordpress/data';
 import { FormTokenItem } from '../../editor/components';
 import { storeName } from '../../editor/store';
+import { SenderRestrictionsType } from '../../../common';
 
 type Segment = FormTokenItem & {
   type: string;
-};
-
-type SenderRestrictions = {
-  lowerLimit: number;
-  upperLimit: number;
 };
 
 type SenderDomainsConfig = {
@@ -16,7 +12,7 @@ type SenderDomainsConfig = {
   verifiedSenderDomains: string[];
   partiallyVerifiedSenderDomains: string[];
   allSenderDomains: string[];
-  senderRestrictions: SenderRestrictions;
+  senderRestrictions: SenderRestrictionsType;
 };
 
 export type Context = {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
@@ -2,7 +2,9 @@ import { ComponentProps } from 'react';
 import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { isEmail } from 'common/functions';
 import { ShortcodeHelpText } from './shortcode-help-text';
+import { SenderDomainNotice } from './sender-domain-notice';
 import { PlainBodyTitle } from '../../../../../editor/components';
 import { storeName } from '../../../../../editor/store';
 import { StepName } from '../../../../../editor/components/panel/step-name';
@@ -95,6 +97,12 @@ export function EmailPanel(): JSX.Element {
           )
         }
       />
+      {window.mailpoet_mss_active &&
+        isEmail((selectedStep.args.sender_address as string) ?? '') && (
+          <SenderDomainNotice
+            email={(selectedStep.args.sender_address as string) ?? ''}
+          />
+        )}
       <SingleLineTextareaControl
         className={
           subjectErrorMessage ? 'mailpoet-automation-field__error' : ''

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
@@ -1,0 +1,87 @@
+import { useState, useMemo, useEffect } from 'react';
+import { dispatch } from '@wordpress/data';
+import { extractEmailDomain } from 'common/functions';
+import { SenderEmailAddressWarning } from '../../../../../../common/sender-email-address-warning';
+import { MailPoet } from '../../../../../../mailpoet';
+import { getContext } from '../../../context';
+import { storeName } from '../../../../../editor/store';
+
+type SenderDomainInlineNoticeProps = {
+  email: string;
+};
+
+/**
+ * SenderDomainStatusNotice is a wrapper for SenderEmailAddressWarning to use with Automations.
+ * It populates the props (mostly) with data from the context, instead of the Window object.
+ * It still uses the window object for values that are present in all MailPoet pages
+ * like mailpoet_mss_active or subscribers_count further down the tree.
+ *
+ * It updates the context when the user authorizes the email or domain
+ * so that other email steps in the automation have an updated configuration.
+ *
+ * @param email - FROM address email
+ * @returns JSX.Element
+ */
+function SenderDomainStatusNotice({
+  email,
+}: SenderDomainInlineNoticeProps): JSX.Element {
+  const [senderDomainsConfig, setSendersDomainConfig] = useState(
+    getContext().senderDomainsConfig,
+  );
+
+  const domain = extractEmailDomain(email);
+  const isPartiallyVerifiedDomain =
+    senderDomainsConfig.partiallyVerifiedSenderDomains.includes(domain);
+  const isAuthorized =
+    senderDomainsConfig.authorizedEmails.includes(email) ||
+    senderDomainsConfig.verifiedSenderDomains.includes(domain);
+  const showSenderDomainWarning =
+    !senderDomainsConfig.verifiedSenderDomains.includes(domain);
+
+  useEffect(() => {
+    dispatch(storeName).alterContext('mailpoet', 'senderDomainsConfig', {
+      ...senderDomainsConfig,
+    });
+  }, [senderDomainsConfig]);
+
+  return (
+    <SenderEmailAddressWarning
+      emailAddress={email}
+      mssActive={window.mailpoet_mss_active}
+      isEmailAuthorized={isAuthorized}
+      showSenderDomainWarning={showSenderDomainWarning && isAuthorized}
+      isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
+      onSuccessfulEmailOrDomainAuthorization={(data) => {
+        if (data.type === 'email') {
+          senderDomainsConfig.authorizedEmails.push(email);
+          setSendersDomainConfig({ ...senderDomainsConfig });
+          MailPoet.trackEvent('MSS in plugin authorize email', {
+            'authorized email source': 'Automations',
+            wasSuccessful: 'yes',
+          });
+        }
+        if (data.type === 'domain') {
+          senderDomainsConfig.verifiedSenderDomains.push(domain);
+          senderDomainsConfig.partiallyVerifiedSenderDomains =
+            senderDomainsConfig.partiallyVerifiedSenderDomains.filter(
+              (item) => item !== domain,
+            );
+          if (!senderDomainsConfig.allSenderDomains.includes(domain)) {
+            senderDomainsConfig.allSenderDomains.push(domain);
+          }
+          setSendersDomainConfig({ ...senderDomainsConfig });
+          MailPoet.trackEvent('MSS in plugin verify sender domain', {
+            'verify sender domain source': 'Automations',
+            wasSuccessful: 'yes',
+          });
+        }
+      }}
+    />
+  );
+}
+
+export function SenderDomainNotice({
+  email,
+}: SenderDomainInlineNoticeProps): JSX.Element {
+  return useMemo(() => <SenderDomainStatusNotice email={email} />, [email]);
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
@@ -1,10 +1,8 @@
-import { useState, useMemo, useEffect } from 'react';
-import { dispatch } from '@wordpress/data';
+import { useMemo } from 'react';
 import { extractEmailDomain } from 'common/functions';
 import { SenderEmailAddressWarning } from '../../../../../../common/sender-email-address-warning';
 import { MailPoet } from '../../../../../../mailpoet';
-import { getContext } from '../../../context';
-import { storeName } from '../../../../../editor/store';
+import { useSelectContext, updateSenderDomainsConfig } from '../../../context';
 
 type SenderDomainInlineNoticeProps = {
   email: string;
@@ -25,9 +23,7 @@ type SenderDomainInlineNoticeProps = {
 function SenderDomainStatusNotice({
   email,
 }: SenderDomainInlineNoticeProps): JSX.Element {
-  const [senderDomainsConfig, setSendersDomainConfig] = useState(
-    getContext().senderDomainsConfig,
-  );
+  const { senderDomainsConfig } = useSelectContext();
 
   const domain = extractEmailDomain(email);
   const isPartiallyVerifiedDomain =
@@ -37,12 +33,6 @@ function SenderDomainStatusNotice({
     senderDomainsConfig.verifiedSenderDomains.includes(domain);
   const showSenderDomainWarning =
     !senderDomainsConfig.verifiedSenderDomains.includes(domain);
-
-  useEffect(() => {
-    dispatch(storeName).alterContext('mailpoet', 'senderDomainsConfig', {
-      ...senderDomainsConfig,
-    });
-  }, [senderDomainsConfig]);
 
   return (
     <SenderEmailAddressWarning
@@ -55,7 +45,7 @@ function SenderDomainStatusNotice({
       onSuccessfulEmailOrDomainAuthorization={(data) => {
         if (data.type === 'email') {
           senderDomainsConfig.authorizedEmails.push(email);
-          setSendersDomainConfig({ ...senderDomainsConfig });
+          updateSenderDomainsConfig({ ...senderDomainsConfig });
           MailPoet.trackEvent('MSS in plugin authorize email', {
             'authorized email source': 'Automations',
             wasSuccessful: 'yes',
@@ -70,7 +60,7 @@ function SenderDomainStatusNotice({
           if (!senderDomainsConfig.allSenderDomains.includes(domain)) {
             senderDomainsConfig.allSenderDomains.push(domain);
           }
-          setSendersDomainConfig({ ...senderDomainsConfig });
+          updateSenderDomainsConfig({ ...senderDomainsConfig });
           MailPoet.trackEvent('MSS in plugin verify sender domain', {
             'verify sender domain source': 'Automations',
             wasSuccessful: 'yes',

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
@@ -22,8 +22,12 @@ type SenderDomainInlineNoticeProps = {
  */
 function SenderDomainStatusNotice({
   email,
-}: SenderDomainInlineNoticeProps): JSX.Element {
+}: SenderDomainInlineNoticeProps): JSX.Element | null {
   const { senderDomainsConfig } = useSelectContext();
+
+  if (!senderDomainsConfig) {
+    return null;
+  }
 
   const domain = extractEmailDomain(email);
   const isPartiallyVerifiedDomain =

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/sender-domain-notice.tsx
@@ -51,6 +51,7 @@ function SenderDomainStatusNotice({
       isEmailAuthorized={isAuthorized}
       showSenderDomainWarning={showSenderDomainWarning && isAuthorized}
       isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
+      senderRestrictions={senderDomainsConfig.senderRestrictions}
       onSuccessfulEmailOrDomainAuthorization={(data) => {
         if (data.type === 'email') {
           senderDomainsConfig.authorizedEmails.push(email);

--- a/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
@@ -6,12 +6,19 @@ import { InlineNotice } from 'common/notices/inline-notice';
 import { SenderDomainNoticeBody } from './sender-domain-notice-body';
 import { SenderActions } from './sender-domain-notice-actions';
 
+export type SenderRestrictionsType = {
+  lowerLimit: number;
+  isNewUser: boolean;
+  isEnforcementOfNewRestrictionsInEffect: boolean;
+};
+
 type SenderDomainInlineNoticeProps = {
   authorizeAction: (e) => void;
   emailAddress: string;
   subscribersCount: number;
   isFreeDomain: boolean;
   isPartiallyVerifiedDomain: boolean;
+  senderRestrictions: SenderRestrictionsType;
 };
 
 function SenderEmailRewriteInfo({ emailAddress = '' }): JSX.Element {
@@ -38,6 +45,7 @@ function SenderDomainInlineNotice({
   subscribersCount,
   isFreeDomain,
   isPartiallyVerifiedDomain,
+  senderRestrictions,
 }: SenderDomainInlineNoticeProps) {
   let showRewrittenEmail = false;
   const showAuthorizeButton = !isFreeDomain;
@@ -45,12 +53,11 @@ function SenderDomainInlineNotice({
 
   const emailAddressDomain = extractEmailDomain(emailAddress);
 
-  const LOWER_LIMIT = window.mailpoet_sender_restrictions?.lowerLimit || 500;
+  const LOWER_LIMIT = senderRestrictions?.lowerLimit || 500;
 
-  const isNewUser = window.mailpoet_sender_restrictions?.isNewUser ?? true;
+  const isNewUser = senderRestrictions?.isNewUser ?? true;
   const isEnforcementOfNewRestrictionsInEffect =
-    window.mailpoet_sender_restrictions
-      ?.isEnforcementOfNewRestrictionsInEffect ?? true;
+    senderRestrictions?.isEnforcementOfNewRestrictionsInEffect ?? true;
   // TODO: Remove after the enforcement date has passed
   const onlyShowWarnings =
     !isNewUser && !isEnforcementOfNewRestrictionsInEffect;

--- a/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
@@ -10,6 +10,7 @@ export type SenderRestrictionsType = {
   lowerLimit: number;
   isNewUser: boolean;
   isEnforcementOfNewRestrictionsInEffect: boolean;
+  alwaysRewrite?: boolean;
 };
 
 type SenderDomainInlineNoticeProps = {
@@ -64,11 +65,19 @@ function SenderDomainInlineNotice({
 
   const isSmallSender = subscribersCount <= LOWER_LIMIT;
 
-  if (isSmallSender || isPartiallyVerifiedDomain || onlyShowWarnings) {
+  if (
+    isSmallSender ||
+    isPartiallyVerifiedDomain ||
+    senderRestrictions.alwaysRewrite ||
+    onlyShowWarnings
+  ) {
     isAlert = false;
   }
 
-  if (isSmallSender && !isPartiallyVerifiedDomain) {
+  if (
+    (isSmallSender || senderRestrictions.alwaysRewrite) &&
+    !isPartiallyVerifiedDomain
+  ) {
     showRewrittenEmail = true;
   }
 

--- a/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
@@ -66,32 +66,30 @@ function SenderDomainInlineNotice({
   }
 
   return (
-    <div key="authorizeSenderDomain">
-      <InlineNotice
-        status={isAlert ? 'alert' : 'info'}
-        topMessage={
-          showRewrittenEmail ? (
-            <SenderEmailRewriteInfo emailAddress={emailAddress} />
-          ) : undefined
-        }
-        actions={
-          <SenderActions
-            showAuthorizeButton={showAuthorizeButton}
-            authorizeAction={authorizeAction}
-            isFreeDomain={isFreeDomain}
-            isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
-          />
-        }
-      >
-        <SenderDomainNoticeBody
-          emailAddressDomain={emailAddressDomain}
+    <InlineNotice
+      status={isAlert ? 'alert' : 'info'}
+      topMessage={
+        showRewrittenEmail ? (
+          <SenderEmailRewriteInfo emailAddress={emailAddress} />
+        ) : undefined
+      }
+      actions={
+        <SenderActions
+          showAuthorizeButton={showAuthorizeButton}
+          authorizeAction={authorizeAction}
           isFreeDomain={isFreeDomain}
           isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
-          isSmallSender={isSmallSender}
-          onlyShowWarnings={onlyShowWarnings}
         />
-      </InlineNotice>
-    </div>
+      }
+    >
+      <SenderDomainNoticeBody
+        emailAddressDomain={emailAddressDomain}
+        isFreeDomain={isFreeDomain}
+        isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
+        isSmallSender={isSmallSender}
+        onlyShowWarnings={onlyShowWarnings}
+      />
+    </InlineNotice>
   );
 }
 

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
@@ -8,12 +8,14 @@ function SenderDomainNoticeBody({
   isPartiallyVerifiedDomain,
   isSmallSender,
   onlyShowWarnings = false,
+  alwaysRewrite = false,
 }: {
   emailAddressDomain: string;
   isFreeDomain: boolean;
   isPartiallyVerifiedDomain: boolean;
   isSmallSender: boolean;
   onlyShowWarnings?: boolean;
+  alwaysRewrite?: boolean;
 }) {
   const renderMessage = (messageKey: string) => {
     const messages: { [key: string]: string } = {
@@ -49,14 +51,16 @@ function SenderDomainNoticeBody({
   }
 
   if (isFreeDomain) {
-    return renderMessage(isSmallSender ? 'freeSmall' : 'free');
+    return renderMessage(isSmallSender || alwaysRewrite ? 'freeSmall' : 'free');
   }
 
   if (isPartiallyVerifiedDomain) {
     return renderMessage('partiallyVerified');
   }
 
-  return renderMessage(isSmallSender ? 'smallSender' : 'default');
+  return renderMessage(
+    isSmallSender || alwaysRewrite ? 'smallSender' : 'default',
+  );
 }
 
 export { SenderDomainNoticeBody };

--- a/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
+++ b/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
@@ -4,7 +4,10 @@ import { extractEmailDomain } from 'common/functions';
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
 import { AuthorizeSenderEmailAndDomainModal } from 'common/authorize-sender-email-and-domain-modal';
-import { SenderDomainInlineNotice } from 'common/sender-domain-notice';
+import {
+  SenderDomainInlineNotice,
+  SenderRestrictionsType,
+} from 'common/sender-domain-notice';
 
 const userHostDomain = window.location.hostname.replace('www.', '');
 const suggestedEmailAddress = `contact@${userHostDomain}`;
@@ -15,6 +18,7 @@ type Props = {
   isEmailAuthorized?: boolean;
   showSenderDomainWarning?: boolean;
   isPartiallyVerifiedDomain?: boolean;
+  senderRestrictions?: SenderRestrictionsType;
   onSuccessfulEmailOrDomainAuthorization?: (data) => void;
 };
 
@@ -24,6 +28,7 @@ function SenderEmailAddressWarning({
   isEmailAuthorized = true,
   showSenderDomainWarning = false,
   isPartiallyVerifiedDomain = false,
+  senderRestrictions,
   onSuccessfulEmailOrDomainAuthorization = () => {},
 }: Props) {
   const [showAuthorizedEmailModal, setShowAuthorizedEmailModal] =
@@ -82,6 +87,7 @@ function SenderEmailAddressWarning({
             isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
             authorizeAction={(e) => loadModal(e, 'sender_domain')}
             subscribersCount={window.mailpoet_subscribers_count}
+            senderRestrictions={senderRestrictions}
           />
         </div>,
       );

--- a/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
+++ b/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
@@ -75,13 +75,15 @@ function SenderEmailAddressWarning({
     }
     if (showSenderDomainWarning && isEmailAuthorized) {
       displayElements.push(
-        <SenderDomainInlineNotice
-          emailAddress={emailAddress}
-          isFreeDomain={isFreeDomain}
-          isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
-          authorizeAction={(e) => loadModal(e, 'sender_domain')}
-          subscribersCount={window.mailpoet_subscribers_count}
-        />,
+        <div key="authorizeSenderDomain">
+          <SenderDomainInlineNotice
+            emailAddress={emailAddress}
+            isFreeDomain={isFreeDomain}
+            isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
+            authorizeAction={(e) => loadModal(e, 'sender_domain')}
+            subscribersCount={window.mailpoet_subscribers_count}
+          />
+        </div>,
       );
     }
 

--- a/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
@@ -142,6 +142,7 @@ class SenderField extends Component {
               !this.state.showAuthEmailsError
             }
             isPartiallyVerifiedDomain={this.state.isPartiallyVerifiedDomain}
+            senderRestrictions={window.mailpoet_sender_restrictions}
             onSuccessfulEmailOrDomainAuthorization={(data) => {
               if (data.type === 'email') {
                 this.setState({ showAuthEmailsError: false });

--- a/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
@@ -117,6 +117,7 @@ export function DefaultSender() {
             isEmailAuthorized={isAuthorized}
             showSenderDomainWarning={showSenderDomainWarning}
             isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
+            senderRestrictions={window.mailpoet_sender_restrictions}
             onSuccessfulEmailOrDomainAuthorization={(data) => {
               if (data.type === 'email') {
                 setIsAuthorized(true);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/ContextFactory.php
@@ -47,7 +47,7 @@ class ContextFactory {
   }
 
   private function getSenderDomainsConfig(): array {
-    $senderDomainsConfig = $this->authorizedSenderDomainController->getContextData();
+    $senderDomainsConfig = $this->authorizedSenderDomainController->getContextDataForAutomations();
     $senderDomainsConfig['authorizedEmails'] = $this->bridge->getAuthorizedEmailAddresses();
     return $senderDomainsConfig;
   }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -322,7 +322,14 @@ class AuthorizedSenderDomainController {
         'upperLimit' => self::UPPER_LIMIT,
         'isNewUser' => $this->isNewUser(),
         'isEnforcementOfNewRestrictionsInEffect' => $this->isEnforcementOfNewRestrictionsInEffect(),
+        'alwaysRewrite' => false,
       ],
     ];
+  }
+
+  public function getContextDataForAutomations(): array {
+    $data = $this->getContextData();
+    $data['senderRestrictions']['alwaysRewrite'] = true;
+    return $data;
   }
 }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -116,12 +116,12 @@ class AuthorizedSenderDomainController {
 
     $response = $this->bridge->createAuthorizedSenderDomain($domain);
 
-    if ($response['status'] === API::RESPONSE_STATUS_ERROR) {
+    if (isset($response['status']) && $response['status'] === API::RESPONSE_STATUS_ERROR) {
       throw new \InvalidArgumentException($response['message']);
     }
 
     // Reset cached value since a new domain was added
-    $this->currentRecords = null;
+    $this->reloadCache();
 
     return $response;
   }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -311,4 +311,18 @@ class AuthorizedSenderDomainController {
   public function isAuthorizedDomainRequiredForExistingCampaigns(): bool {
     return $this->restrictionsApply() && $this->isBigSender();
   }
+
+  public function getContextData(): array {
+    return [
+      'verifiedSenderDomains' => $this->getFullyVerifiedSenderDomains(true),
+      'partiallyVerifiedSenderDomains' => $this->getPartiallyVerifiedSenderDomains(true),
+      'allSenderDomains' => $this->getAllSenderDomains(),
+      'senderRestrictions' => [
+        'lowerLimit' => self::LOWER_LIMIT,
+        'upperLimit' => self::UPPER_LIMIT,
+        'isNewUser' => $this->isNewUser(),
+        'isEnforcementOfNewRestrictionsInEffect' => $this->isEnforcementOfNewRestrictionsInEffect(),
+      ],
+    ];
+  }
 }


### PR DESCRIPTION
## Description

This PR adds the sender domain notices to Automations.
These notices are only warnings as we don't block sending for Automations.

## Code review notes

_N/A_

## QA notes

To test:

Site needs to be connected to the shop with a valid key
Edit an automation that has a couple of email steps
Click on the email step
Check that you see the notices under the from email as the screenshot in the ticket
Authenticate a domain, check the notice disappears
Click on another email step
Check that if you add the same domain that you authenticated in the other step, you don't see the notice.

You can also check that the sender notices in Settings or inside of a newsletter/post notification have not changed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5843]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5843]: https://mailpoet.atlassian.net/browse/MAILPOET-5843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ