### PR TITLE
Fix some translations [MAILPOET-5852]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/form-token-field/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/form-token-field/index.tsx
@@ -31,6 +31,7 @@ export function FormTokenField({
       suggestions={suggestions.map((item) => item.name)}
       __experimentalExpandOnFocus
       __experimentalAutoSelectFirstMatch
+      __experimentalShowHowTo={false}
       placeholder={placeholder}
       onChange={(raw: string[]) => {
         const allSelected: FormTokenItem[] = raw

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/shortcode-help-text.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/shortcode-help-text.tsx
@@ -3,13 +3,12 @@ import { __ } from '@wordpress/i18n';
 export function ShortcodeHelpText(): JSX.Element {
   return (
     <span className="mailpoet-shortcode-selector">
-      You can use{' '}
       <a
         href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes"
         target="_blank"
         rel="noopener noreferrer"
       >
-        {__('MailPoet shortcodes', 'mailpoet')}
+        {__('You can use MailPoet shortcodes.', 'mailpoet')}
       </a>
     </span>
   );

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/edit/list-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/edit/list-panel.tsx
@@ -45,6 +45,7 @@ export function ListPanel(): JSX.Element {
             values.map((item) => item.id),
           );
         }}
+        __experimentalShowHowTo={false}
       />
     </PanelBody>
   );

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/edit/role-panel.tsx
@@ -63,6 +63,7 @@ export function RolePanel(): JSX.Element {
             items.map((item) => item.id),
           );
         }}
+        __experimentalShowHowTo={false}
       />
     </PanelBody>
   );

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -17,29 +17,6 @@ import { Automation, AutomationStatus } from './automation';
 import { MailPoet } from '../../mailpoet';
 import { PageHeader } from '../../common/page-header';
 
-const tabConfig = [
-  {
-    name: 'all',
-    title: __('All', 'mailpoet'),
-    className: 'mailpoet-tab-all',
-  },
-  {
-    name: AutomationStatus.ACTIVE,
-    title: __('Active', 'mailpoet'),
-    className: 'mailpoet-tab-active',
-  },
-  {
-    name: AutomationStatus.DRAFT,
-    title: _x('Draft', 'noun', 'mailpoet'),
-    className: 'mailpoet-tab-draft',
-  },
-  {
-    name: AutomationStatus.TRASH,
-    title: _x('Trash', 'noun', 'mailpoet'),
-    className: 'mailpoet-tab-trash',
-  },
-] as const;
-
 const tableHeaders = [
   {
     key: 'name',
@@ -126,23 +103,44 @@ export function AutomationListing(): JSX.Element {
     return grouped;
   }, [automations]);
 
-  const tabs = useMemo(
-    () =>
-      tabConfig.map((tab) => {
-        const count = (groupedAutomations[tab.name] ?? []).length;
-        return {
-          name: tab.name,
-          title: (
-            <>
-              <span>{tab.title}</span>
-              {count > 0 && <span className="count">{count}</span>}
-            </>
-          ) as any, // eslint-disable-line @typescript-eslint/no-explicit-any -- typed as string but supports JSX
-          className: tab.className,
-        };
-      }),
-    [groupedAutomations],
-  );
+  const tabs = useMemo(() => {
+    const tabConfig = [
+      {
+        name: 'all',
+        title: __('All', 'mailpoet'),
+        className: 'mailpoet-tab-all',
+      },
+      {
+        name: AutomationStatus.ACTIVE,
+        title: __('Active', 'mailpoet'),
+        className: 'mailpoet-tab-active',
+      },
+      {
+        name: AutomationStatus.DRAFT,
+        title: _x('Draft', 'noun', 'mailpoet'),
+        className: 'mailpoet-tab-draft',
+      },
+      {
+        name: AutomationStatus.TRASH,
+        title: _x('Trash', 'noun', 'mailpoet'),
+        className: 'mailpoet-tab-trash',
+      },
+    ] as const;
+
+    return tabConfig.map((tab) => {
+      const count = (groupedAutomations[tab.name] ?? []).length;
+      return {
+        name: tab.name,
+        title: (
+          <>
+            <span>{tab.title}</span>
+            {count > 0 && <span className="count">{count}</span>}
+          </>
+        ) as any, // eslint-disable-line @typescript-eslint/no-explicit-any -- typed as string but supports JSX
+        className: tab.className,
+      };
+    });
+  }, [groupedAutomations]);
 
   const renderTabs = useCallback(
     (tab) => {

--- a/mailpoet/assets/js/src/common/form/token-field/token-field.tsx
+++ b/mailpoet/assets/js/src/common/form/token-field/token-field.tsx
@@ -57,6 +57,7 @@ export function TokenField({
       value={selectedValues}
       suggestions={suggestedValues}
       onChange={(tokens) => handleSave(tokens, onChange)}
+      __experimentalShowHowTo={false}
     />
   );
 }

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
@@ -17,17 +17,31 @@ function SenderDomainNoticeBody({
 }) {
   const renderMessage = (messageKey: string) => {
     const messages: { [key: string]: string } = {
-      freeSmall:
+      freeSmall: __(
         "Shared 3rd-party domains like <emailDomain/> will send from MailPoet's shared domain. We recommend that you use your site's branded domain instead.",
-      free: "MailPoet cannot send email campaigns from shared 3rd-party domains like <emailDomain/>. Please send from your site's branded domain instead.",
+        'mailpoet',
+      ),
+      free: __(
+        "MailPoet cannot send email campaigns from shared 3rd-party domains like <emailDomain/>. Please send from your site's branded domain instead.",
+        'mailpoet',
+      ),
       // TODO: Remove freeWarning after the enforcement date has passed
-      freeWarning:
+      freeWarning: __(
         "Starting on February 1st, 2024, MailPoet will no longer be able to send from email addresses on shared 3rd party domains like <emailDomain/>. Please send from your site's branded domain instead.",
-      partiallyVerified:
+        'mailpoet',
+      ),
+      partiallyVerified: __(
         'Update your domain settings to improve email deliverability and meet new sending requirements.',
-      smallSender:
+        'mailpoet',
+      ),
+      smallSender: __(
         'Authenticate to send as <emailDomain/> and improve email deliverability.',
-      default: 'Authenticate domain to send new emails as <emailDomain/>.',
+        'mailpoet',
+      ),
+      default: __(
+        'Authenticate domain to send new emails as <emailDomain/>.',
+        'mailpoet',
+      ),
     };
 
     const defaultMessage = messages[messageKey] || messages.default;


### PR DESCRIPTION
## Description
This PR fixes some translations.

## Code review notes

In https://github.com/mailpoet/mailpoet/pull/5402/commits/e43bcd4a73e821e37dc3d4c7be4c1e344f8303f5 the former setup where tabConfig was outside all methods somehow `_x()` would not translate while `__()` would. I moved the constant in the method and `_x()` got translated as well. Not sure why.

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/839

## Linked tickets
[MAILPOET-5852]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5852]: https://mailpoet.atlassian.net/browse/MAILPOET-5852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ