### PR TITLE
Email editor - add block-editor-page body class [MAILPOET-5854]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -136,7 +136,3 @@
 .block-editor-block-inspector__advanced {
   display: none;
 }
-// Hide the footer that can overlay the part of the sidebar
-body.js.admin_page_mailpoet-email-editor #wpfooter {
-  display: none;
-}

--- a/mailpoet/lib/AdminPages/Pages/EmailEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/EmailEditor.php
@@ -69,6 +69,6 @@ class EmailEditor {
     // Enqueue media library scripts
     $this->wp->wpEnqueueMedia();
 
-    echo '<div id="mailpoet-email-editor"></div>';
+    echo '<div id="mailpoet-email-editor" class="block-editor"></div>';
   }
 }

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -282,7 +282,8 @@ class Menu {
       ]
     );
 
-    // add body class for form editor page
+    // Add body class for email editor page
+    // We need to mark the page as a block editor page so that some of the block editor styles are applied properly
     $this->wp->addAction('load-' . $emailEditorPage, function() {
       $this->wp->addFilter('admin_body_class', function ($classes) {
         return ltrim($classes . ' block-editor-page');

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -26,7 +26,6 @@ use MailPoet\AdminPages\Pages\Upgrade;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceSetup;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
@@ -692,12 +691,6 @@ class Menu {
       return $parentFile;
     }
 
-    if ($this->checkIsGutenbergEmailEditorPage()) {
-      $plugin_page = self::EMAILS_PAGE_SLUG;
-      $submenu_file = self::EMAILS_PAGE_SLUG;
-      return self::EMAILS_PAGE_SLUG;
-    }
-
     if ($parentFile === self::MAIN_PAGE_SLUG || !self::isOnMailPoetAdminPage()) {
       return $parentFile;
     }
@@ -802,9 +795,5 @@ class Menu {
       return self::AUTOMATIONS_PAGE_SLUG;
     }
     return null;
-  }
-
-  private function checkIsGutenbergEmailEditorPage(): bool {
-    return $this->wp->getPostType() === EmailEditor::MAILPOET_EMAIL_POST_TYPE;
   }
 }

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -270,7 +270,7 @@ class Menu {
     );
 
     // newsletter editor
-    $this->wp->addSubmenuPage(
+    $emailEditorPage = $this->wp->addSubmenuPage(
       self::EMAILS_PAGE_SLUG,
       $this->setPageTitle(__('Email', 'mailpoet')),
       esc_html__('Email Editor', 'mailpoet'),
@@ -281,6 +281,13 @@ class Menu {
         'emailEditor',
       ]
     );
+
+    // add body class for form editor page
+    $this->wp->addAction('load-' . $emailEditorPage, function() {
+      $this->wp->addFilter('admin_body_class', function ($classes) {
+        return ltrim($classes . ' block-editor-page');
+      });
+    });
 
     $this->registerAutomationMenu();
 


### PR DESCRIPTION
## Description

This PR adds `block-editor-page` to the WP admin page's body tag. The class is also applied in the post editor, and a couple of CSS rules are applied based on the class (e.g., white background, hidden wpfooter).

## Code review notes

When adding the class I noticed some leftovers after we used the built-in post editor. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5854]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5854]: https://mailpoet.atlassian.net/browse/MAILPOET-5854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ