### PR TITLE
Add a warning for opening a sent email [MAILPOET-5851]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -32,7 +32,7 @@ import { Sidebar } from '../sidebar/sidebar';
 import { Header } from '../header';
 import { ListviewSidebar } from '../listview-sidebar/listview-sidebar';
 import { InserterSidebar } from '../inserter-sidebar/inserter-sidebar';
-import { EditorNotices, EditorSnackbars } from '../notices';
+import { EditorNotices, EditorSnackbars, SentEmailNotice } from '../notices';
 
 export function BlockEditor() {
   const {
@@ -128,6 +128,7 @@ export function BlockEditor() {
       <FullscreenMode isActive={isFullscreenActive} />
       <UnsavedChangesWarning />
       <AutosaveMonitor />
+      <SentEmailNotice />
       <Sidebar />
       <InterfaceSkeleton
         className={className}

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
@@ -16,6 +16,12 @@ export function SendButton() {
     }),
     [],
   );
+  const { isEmailSent } = useSelect(
+    (select) => ({
+      isEmailSent: select(storeName).isEmailSent(),
+    }),
+    [],
+  );
 
   const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
   return (
@@ -24,7 +30,7 @@ export function SendButton() {
       onClick={() => {
         window.location.href = `admin.php?page=mailpoet-newsletters#/send/${mailpoetEmailData.id}`;
       }}
-      disabled={hasEmptyContent}
+      disabled={hasEmptyContent || isEmailSent}
     >
       {__('Send', 'mailpoet')}
     </Button>

--- a/mailpoet/assets/js/src/email-editor/engine/components/notices/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/notices/index.ts
@@ -1,2 +1,3 @@
 export { EditorNotices } from './notices';
 export { EditorSnackbars } from './snackbars';
+export { SentEmailNotice } from './sent-email-notice';

--- a/mailpoet/assets/js/src/email-editor/engine/components/notices/sent-email-notice.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/notices/sent-email-notice.tsx
@@ -1,0 +1,31 @@
+import { dispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { __ } from '@wordpress/i18n';
+
+import { storeName } from '../../store';
+
+export function SentEmailNotice() {
+  const { isEmailSent } = useSelect(
+    (select) => ({
+      isEmailSent: select(storeName).isEmailSent(),
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    if (isEmailSent) {
+      dispatch(noticesStore).createErrorNotice(
+        __(
+          'This email has already been sent. It can be edited, but not sent again. Duplicate this email if you want to send it again.',
+          'mailpoet',
+        ),
+        {
+          isDismissible: false,
+        },
+      );
+    }
+  }, [isEmailSent]);
+
+  return null;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/notices/sent-email-notice.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/notices/sent-email-notice.tsx
@@ -15,7 +15,8 @@ export function SentEmailNotice() {
 
   useEffect(() => {
     if (isEmailSent) {
-      dispatch(noticesStore).createErrorNotice(
+      dispatch(noticesStore).createNotice(
+        'warning',
         __(
           'This email has already been sent. It can be edited, but not sent again. Duplicate this email if you want to send it again.',
           'mailpoet',

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -82,6 +82,23 @@ export const hasEmptyContent = createRegistrySelector(
   },
 );
 
+export const isEmailSent = createRegistrySelector((select) => (): boolean => {
+  const postId = select(storeName).getEmailPostId();
+
+  const post = select(coreDataStore).getEntityRecord(
+    'postType',
+    'mailpoet_email',
+    postId,
+  );
+  if (!post) return false;
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const status = post.status;
+
+  return status === 'sent';
+});
+
 export function getEmailPostId(state: State): number {
   return state.postId;
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -267,6 +267,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\EmojiEncodingListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\LastSubscribedAtListener::class)->setPublic(true);
+    $container->autowire(\MailPoet\Doctrine\EventListeners\NewsletterListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\TimestampListener::class)->setPublic(true);
     $container->autowire(\MailPoet\Doctrine\EventListeners\ValidationListener::class);
     $container->autowire(\MailPoet\Doctrine\EventListeners\SubscriberListener::class);

--- a/mailpoet/lib/Doctrine/EntityManagerFactory.php
+++ b/mailpoet/lib/Doctrine/EntityManagerFactory.php
@@ -4,6 +4,7 @@ namespace MailPoet\Doctrine;
 
 use MailPoet\Doctrine\EventListeners\EmojiEncodingListener;
 use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
+use MailPoet\Doctrine\EventListeners\NewsletterListener;
 use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
 use MailPoet\Doctrine\EventListeners\ValidationListener;
@@ -37,6 +38,8 @@ class EntityManagerFactory {
   /** @var SubscriberListener */
   private $subscriberListener;
 
+  private NewsletterListener $newsletterListener;
+
   public function __construct(
     Connection $connection,
     Configuration $configuration,
@@ -44,6 +47,7 @@ class EntityManagerFactory {
     ValidationListener $validationListener,
     EmojiEncodingListener $emojiEncodingListener,
     LastSubscribedAtListener $lastSubscribedAtListener,
+    NewsletterListener $newsletterListener,
     SubscriberListener $subscriberListener
   ) {
     $this->connection = $connection;
@@ -53,6 +57,7 @@ class EntityManagerFactory {
     $this->emojiEncodingListener = $emojiEncodingListener;
     $this->lastSubscribedAtListener = $lastSubscribedAtListener;
     $this->subscriberListener = $subscriberListener;
+    $this->newsletterListener = $newsletterListener;
   }
 
   public function createEntityManager(): EntityManager {
@@ -105,6 +110,11 @@ class EntityManagerFactory {
     $entityManager->getEventManager()->addEventListener(
       [Events::prePersist, Events::preUpdate],
       $this->lastSubscribedAtListener
+    );
+
+    $entityManager->getEventManager()->addEventListener(
+      [Events::preUpdate],
+      $this->newsletterListener
     );
 
     $entityManager->getConfiguration()->getEntityListenerResolver()->register($this->subscriberListener);

--- a/mailpoet/lib/Doctrine/EventListeners/NewsletterListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/NewsletterListener.php
@@ -16,10 +16,6 @@ class NewsletterListener {
     $this->wp = $wp;
   }
 
-  public function prePersist(): void {
-    // the tests fail without this method
-  }
-
   public function preUpdate(LifecycleEventArgs $eventArgs): void {
     $entity = $eventArgs->getEntity();
     if (!$entity instanceof NewsletterEntity) {

--- a/mailpoet/lib/Doctrine/EventListeners/NewsletterListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/NewsletterListener.php
@@ -8,8 +8,7 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\ORM\Event\LifecycleEventArgs;
 
 class NewsletterListener {
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
 
   public function __construct(
     WPFunctions $wp

--- a/mailpoet/lib/Doctrine/EventListeners/NewsletterListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/NewsletterListener.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Doctrine\EventListeners;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\WpPostEntity;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\Event\LifecycleEventArgs;
+
+class NewsletterListener {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function prePersist(): void {
+    // the tests fail without this method
+  }
+
+  public function preUpdate(LifecycleEventArgs $eventArgs): void {
+    $entity = $eventArgs->getEntity();
+    if (!$entity instanceof NewsletterEntity) {
+      return;
+    }
+
+    $unitOfWork = $eventArgs->getEntityManager()->getUnitOfWork();
+
+    /** @var array{status: array{0: string, 1: string}} $changeSet */
+    $changeSet = $unitOfWork->getEntityChangeSet($entity);
+    if (!isset($changeSet['status'])) {
+      return;
+    }
+
+    [$oldStatus, $newStatus] = $changeSet['status'];
+
+    if ($oldStatus !== NewsletterEntity::STATUS_SENT && $newStatus === NewsletterEntity::STATUS_SENT) {
+      $post = $entity->getWpPost();
+      if ($post instanceof WpPostEntity) {
+        $this->wp->wpUpdatePost([
+          'ID' => $post->getId(),
+          'post_status' => NewsletterEntity::STATUS_SENT,
+        ]);
+      }
+    }
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\EmailEditor\Engine;
 
+use MailPoet\Entities\NewsletterEntity;
+
 /**
  * @phpstan-type EmailPostType array{name: string, args: array}
  * See register_post_type for details about EmailPostType args.
@@ -19,6 +21,7 @@ class EmailEditor {
   public function initialize(): void {
     do_action('mailpoet_email_editor_initialized');
     $this->registerEmailPostTypes();
+    $this->registerEmailPostSendStatus();
     $this->extendEmailPostApi();
   }
 
@@ -54,6 +57,17 @@ class EmailEditor {
       'has_archive' => true,
       'show_in_rest' => true, // Important to enable Gutenberg editor
     ];
+  }
+
+  private function registerEmailPostSendStatus(): void {
+    register_post_status( NewsletterEntity::STATUS_SENT, [
+        'public' => false,
+        'exclude_from_search' => true,
+        'internal' => true, // for now, we hide it, if we use the status in the listings we may flip this and following values
+        'show_in_admin_all_list' => false,
+        'show_in_admin_status_list' => false,
+      ]
+    );
   }
 
   public function extendEmailPostApi() {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -252,6 +252,10 @@ class Functions {
     return get_post($post, $output, $filter);
   }
 
+  public function wpUpdatePost($postarr = [], bool $wp_error = false, bool $fire_after_hooks = true) {
+    return wp_update_post($postarr, $wp_error, $fire_after_hooks);
+  }
+
   public function hasCategory($category = '', $post = null): bool {
     return has_category($category, $post);
   }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/EventListenersBaseTest.php
@@ -9,14 +9,14 @@ class EventListenersBaseTest extends \MailPoetTest {
    * Replaces event listeners. Needed to test them since EventManager
    * is shared for all entity managers using same DB connection.
    */
-  protected function replaceListeners($original, $replacement) {
+  protected function replaceListeners($original, $replacement, $listeners = [Events::prePersist, Events::preUpdate]) {
     $this->entityManager->getEventManager()->removeEventListener(
-      [Events::prePersist, Events::preUpdate],
+      $listeners,
       $original
     );
 
     $this->entityManager->getEventManager()->addEventListener(
-      [Events::prePersist, Events::preUpdate],
+      $listeners,
       $replacement
     );
   }

--- a/mailpoet/tests/integration/Doctrine/EventListeners/NewsletterListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/NewsletterListenerTest.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\WpPostEntity;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
+use MailPoetVendor\Doctrine\ORM\Events;
 
 require_once __DIR__ . '/EventListenersBaseTest.php';
 
@@ -20,7 +21,7 @@ class NewsletterListenerTest extends EventListenersBaseTest {
     $this->wp = $this->diContainer->get(WPFunctions::class);
     $newsletterListener = new NewsletterListener($this->wp);
     $originalListener = $this->diContainer->get(NewsletterListener::class);
-    $this->replaceListeners($originalListener, $newsletterListener);
+    $this->replaceListeners($originalListener, $newsletterListener, [Events::preUpdate]);
   }
 
   public function testItUpdatesPost() {

--- a/mailpoet/tests/integration/Doctrine/EventListeners/NewsletterListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/NewsletterListenerTest.php
@@ -12,8 +12,7 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
 require_once __DIR__ . '/EventListenersBaseTest.php';
 
 class NewsletterListenerTest extends EventListenersBaseTest {
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
 
   public function _before() {
     parent::_before();

--- a/mailpoet/tests/integration/Doctrine/EventListeners/NewsletterListenerTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/NewsletterListenerTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Doctrine\EventListeners;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Doctrine\EventListeners\NewsletterListener;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\WpPostEntity;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+require_once __DIR__ . '/EventListenersBaseTest.php';
+
+class NewsletterListenerTest extends EventListenersBaseTest {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function _before() {
+    parent::_before();
+
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+    $newsletterListener = new NewsletterListener($this->wp);
+    $originalListener = $this->diContainer->get(NewsletterListener::class);
+    $this->replaceListeners($originalListener, $newsletterListener);
+  }
+
+  public function testItUpdatesPost() {
+    $postId = $this->wp->wpInsertPost(['post_title' => 'Post 1', 'post_status' => 'draft']);
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+
+    $newsletter = new NewsletterEntity();
+    $this->entityManager->persist($newsletter);
+    $newsletter->setId(2);
+    $newsletter->setWpPost($entityManager->getReference(WpPostEntity::class, $postId));
+    $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setSubject('Test');
+    $this->entityManager->flush();
+
+    $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+    $this->entityManager->flush();
+
+    $post = $this->wp->getPost($postId);
+    verify($post)->instanceOf(\WP_Post::class);
+    verify($post->post_status)->equals(NewsletterEntity::STATUS_SENT);// @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+}

--- a/mailpoet/tests/integration/Doctrine/EventListeners/ValidationTest.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/ValidationTest.php
@@ -9,6 +9,7 @@ use MailPoet\Doctrine\ConfigurationFactory;
 use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Doctrine\EventListeners\EmojiEncodingListener;
 use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
+use MailPoet\Doctrine\EventListeners\NewsletterListener;
 use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
 use MailPoet\Doctrine\EventListeners\ValidationListener;
@@ -82,6 +83,7 @@ class ValidationTest extends \MailPoetTest {
     $validationListener = new ValidationListener($validatorFactory->createValidator());
     $emojiEncodingListener = new EmojiEncodingListener(new Emoji($this->wp));
     $lastSubscribedAtListener = new LastSubscribedAtListener($this->wp);
+    $newsletterListener = new NewsletterListener($this->wp);
     $subscriberListener = new SubscriberListener(new SubscriberChangesNotifier($this->wp));
     $entityManagerFactory = new EntityManagerFactory(
       $this->connection,
@@ -90,6 +92,7 @@ class ValidationTest extends \MailPoetTest {
       $validationListener,
       $emojiEncodingListener,
       $lastSubscribedAtListener,
+      $newsletterListener,
       $subscriberListener
     );
     return $entityManagerFactory->createEntityManager();

--- a/mailpoet/tests/integration/Doctrine/Types/JsonTypesTest.php
+++ b/mailpoet/tests/integration/Doctrine/Types/JsonTypesTest.php
@@ -10,6 +10,7 @@ use MailPoet\Doctrine\ConfigurationFactory;
 use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Doctrine\EventListeners\EmojiEncodingListener;
 use MailPoet\Doctrine\EventListeners\LastSubscribedAtListener;
+use MailPoet\Doctrine\EventListeners\NewsletterListener;
 use MailPoet\Doctrine\EventListeners\SubscriberListener;
 use MailPoet\Doctrine\EventListeners\TimestampListener;
 use MailPoet\Doctrine\EventListeners\ValidationListener;
@@ -192,6 +193,7 @@ class JsonTypesTest extends \MailPoetTest {
     $emojiEncodingListener = new EmojiEncodingListener(new Emoji($this->wp));
     $lastSubscribedAtListener = new LastSubscribedAtListener($this->wp);
     $subscriberListener = new SubscriberListener(new SubscriberChangesNotifier($this->wp));
+    $newsletterListener = new NewsletterListener($this->wp);
     $entityManagerFactory = new EntityManagerFactory(
       $this->connection,
       $configuration,
@@ -199,6 +201,7 @@ class JsonTypesTest extends \MailPoetTest {
       $validationListener,
       $emojiEncodingListener,
       $lastSubscribedAtListener,
+      $newsletterListener,
       $subscriberListener
     );
     return $entityManagerFactory->createEntityManager();


### PR DESCRIPTION
## Description

We have the same warning in the old email editor. If a user opens a previously sent email, we add a warning and prevent moving forward by disabling the “Send” button.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

[MAILPOET-5851]

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5851]: https://mailpoet.atlassian.net/browse/MAILPOET-5851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ