### PR TITLE
Reduce sender domain authentication limits [MAILPOET-5856]

### DIFF
--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -19,8 +19,8 @@ class AuthorizedSenderDomainController {
   const AUTHORIZED_SENDER_DOMAIN_ERROR_NOT_CREATED = 'Sender domain does not exist';
   const AUTHORIZED_SENDER_DOMAIN_ERROR_ALREADY_VERIFIED = 'Sender domain already verified';
 
-  const LOWER_LIMIT = 500;
-  const UPPER_LIMIT = 1000;
+  const LOWER_LIMIT = 100;
+  const UPPER_LIMIT = 200;
 
   const ENFORCEMENT_START_TIME = '2024-02-01 00:00:00 UTC';
 

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -32,6 +32,10 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
   /**@var WPFunctions */
   private $wp;
 
+  private int $lowerLimit;
+
+  private int $upperLimit;
+
   public function _before() {
     parent::_before();
 
@@ -52,6 +56,9 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
       'getTransient' => false,
       'setTransient' => true,
     ]);
+
+    $this->lowerLimit = AuthorizedSenderDomainController::LOWER_LIMIT;
+    $this->upperLimit = AuthorizedSenderDomainController::UPPER_LIMIT;
   }
 
   public function testItFetchSenderDomains() {
@@ -428,7 +435,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
   public function testIsSmallSenderIfSubscribersUnderLowerLimit(): void {
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(500),
+      'getSubscribersCount' => Expected::once($this->lowerLimit),
     ]);
 
     $this->assertTrue($this->getController(null, $subscribersMock)->isSmallSender());
@@ -436,7 +443,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
   public function testIsNotSmallSenderIfSubscribersOverLowerLimit(): void {
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(501),
+      'getSubscribersCount' => Expected::once($this->lowerLimit + 1),
     ]);
 
     $this->assertFalse($this->getController(null, $subscribersMock)->isSmallSender());
@@ -449,7 +456,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     // Is not small sender
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(501),
+      'getSubscribersCount' => Expected::once($this->lowerLimit + 1),
     ]);
 
     $this->assertTrue($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForNewCampaigns());
@@ -462,7 +469,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     // Is Big Sender
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(1001),
+      'getSubscribersCount' => Expected::once($this->upperLimit + 1),
     ]);
 
     $this->assertTrue($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForExistingCampaigns());
@@ -491,7 +498,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     // Is not small sender
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(501),
+      'getSubscribersCount' => Expected::once($this->lowerLimit + 1),
     ]);
 
     $this->assertTrue($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForNewCampaigns());
@@ -508,7 +515,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     // Is small sender
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(500),
+      'getSubscribersCount' => Expected::once($this->lowerLimit),
     ]);
 
     $this->assertFalse($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForNewCampaigns());
@@ -521,7 +528,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
 
     // Is small sender
     $subscribersMock = $this->make(Subscribers::class, [
-      'getSubscribersCount' => Expected::once(500),
+      'getSubscribersCount' => Expected::once($this->lowerLimit),
     ]);
 
     $this->assertFalse($this->getController(null, $subscribersMock)->isAuthorizedDomainRequiredForNewCampaigns());


### PR DESCRIPTION
## Description

Reduce sender domain authentication limits: Small senders to 100 subscribers and big senders to 200 subscribers

Please ~do not~ merge.

## Code review notes

_N/A_

## QA notes

Please ~do not~ merge.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5856]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5856]: https://mailpoet.atlassian.net/browse/MAILPOET-5856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ