### PR TITLE
Make showModal optional

### DIFF
--- a/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
+++ b/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
@@ -15,7 +15,7 @@ const suggestedEmailAddress = `contact@${userHostDomain}`;
 type Props = {
   emailAddress: string;
   mssActive: boolean;
-  showModal: string;
+  showModal?: string;
   isEmailAuthorized?: boolean;
   showSenderDomainWarning?: boolean;
   isPartiallyVerifiedDomain?: boolean;


### PR DESCRIPTION
## Description

Fix type error by making showModal optional (which it is)

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5857]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5857]: https://mailpoet.atlassian.net/browse/MAILPOET-5857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ