### PR TITLE
Mailpoet 5844 remove uneeded code

### DIFF
--- a/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
@@ -8,8 +8,8 @@ import { SenderActions } from './sender-domain-notice-actions';
 
 export type SenderRestrictionsType = {
   lowerLimit: number;
-  isNewUser: boolean;
-  isEnforcementOfNewRestrictionsInEffect: boolean;
+  isAuthorizedDomainRequiredForNewCampaigns?: boolean;
+  campaignTypes?: string[];
   alwaysRewrite?: boolean;
 };
 
@@ -56,20 +56,12 @@ function SenderDomainInlineNotice({
 
   const LOWER_LIMIT = senderRestrictions?.lowerLimit || 500;
 
-  const isNewUser = senderRestrictions?.isNewUser ?? true;
-  const isEnforcementOfNewRestrictionsInEffect =
-    senderRestrictions?.isEnforcementOfNewRestrictionsInEffect ?? true;
-  // TODO: Remove after the enforcement date has passed
-  const onlyShowWarnings =
-    !isNewUser && !isEnforcementOfNewRestrictionsInEffect;
-
   const isSmallSender = subscribersCount <= LOWER_LIMIT;
 
   if (
     isSmallSender ||
     isPartiallyVerifiedDomain ||
-    senderRestrictions.alwaysRewrite ||
-    onlyShowWarnings
+    senderRestrictions.alwaysRewrite
   ) {
     isAlert = false;
   }
@@ -103,7 +95,6 @@ function SenderDomainInlineNotice({
         isFreeDomain={isFreeDomain}
         isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
         isSmallSender={isSmallSender}
-        onlyShowWarnings={onlyShowWarnings}
       />
     </InlineNotice>
   );

--- a/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
@@ -94,7 +94,7 @@ function SenderDomainInlineNotice({
         emailAddressDomain={emailAddressDomain}
         isFreeDomain={isFreeDomain}
         isPartiallyVerifiedDomain={isPartiallyVerifiedDomain}
-        isSmallSender={isSmallSender}
+        isSmallSender={isSmallSender || senderRestrictions.alwaysRewrite}
       />
     </InlineNotice>
   );

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
@@ -7,14 +7,12 @@ function SenderDomainNoticeBody({
   isFreeDomain,
   isPartiallyVerifiedDomain,
   isSmallSender,
-  onlyShowWarnings = false,
   alwaysRewrite = false,
 }: {
   emailAddressDomain: string;
   isFreeDomain: boolean;
   isPartiallyVerifiedDomain: boolean;
   isSmallSender: boolean;
-  onlyShowWarnings?: boolean;
   alwaysRewrite?: boolean;
 }) {
   const renderMessage = (messageKey: string) => {
@@ -25,11 +23,6 @@ function SenderDomainNoticeBody({
       ),
       free: __(
         "MailPoet cannot send email campaigns from shared 3rd-party domains like <emailDomain/>. Please send from your site's branded domain instead.",
-        'mailpoet',
-      ),
-      // TODO: Remove freeWarning after the enforcement date has passed
-      freeWarning: __(
-        "Starting on February 1st, 2024, MailPoet will no longer be able to send from email addresses on shared 3rd party domains like <emailDomain/>. Please send from your site's branded domain instead.",
         'mailpoet',
       ),
       partiallyVerified: __(
@@ -48,21 +41,10 @@ function SenderDomainNoticeBody({
 
     const defaultMessage = messages[messageKey] || messages.default;
 
-    return createInterpolateElement(__(defaultMessage, 'mailpoet'), {
+    return createInterpolateElement(defaultMessage, {
       emailDomain: <strong>{escapeHTML(emailAddressDomain)}</strong>,
     });
   };
-
-  // TODO: Remove after the enforcement date has passed
-  if (onlyShowWarnings) {
-    if (isFreeDomain) {
-      return renderMessage(isSmallSender ? 'freeSmall' : 'freeWarning');
-    }
-    if (isPartiallyVerifiedDomain) {
-      return renderMessage('partiallyVerified');
-    }
-    return renderMessage('smallSender');
-  }
 
   if (isFreeDomain) {
     return renderMessage(isSmallSender || alwaysRewrite ? 'freeSmall' : 'free');

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -155,9 +155,6 @@ interface Window {
   mailpoet_partially_verified_sender_domains?: string[];
   mailpoet_sender_restrictions?: {
     lowerLimit: number;
-    upperLimit: number;
-    isNewUser: boolean;
-    isEnforcementOfNewRestrictionsInEffect: boolean;
     isAuthorizedDomainRequiredForNewCampaigns?: boolean;
     campaignTypes?: string[];
   };

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -152,9 +152,6 @@ class Newsletters {
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();
       $data['sender_restrictions'] = [
         'lowerLimit' => AuthorizedSenderDomainController::LOWER_LIMIT,
-        'upperLimit' => AuthorizedSenderDomainController::UPPER_LIMIT,
-        'isNewUser' => $this->senderDomainController->isNewUser(),
-        'isEnforcementOfNewRestrictionsInEffect' => $this->senderDomainController->isEnforcementOfNewRestrictionsInEffect(),
         'isAuthorizedDomainRequiredForNewCampaigns' => $this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns(),
         'campaignTypes' => NewsletterEntity::CAMPAIGN_TYPES,
       ];

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -106,9 +106,6 @@ class Settings {
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();
       $data['sender_restrictions'] = [
         'lowerLimit' => AuthorizedSenderDomainController::LOWER_LIMIT,
-        'upperLimit' => AuthorizedSenderDomainController::UPPER_LIMIT,
-        'isNewUser' => $this->senderDomainController->isNewUser(),
-        'isEnforcementOfNewRestrictionsInEffect' => $this->senderDomainController->isEnforcementOfNewRestrictionsInEffect(),
       ];
     }
 

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -10,9 +10,9 @@ use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
 
 class AuthorizedSenderDomainController {
-  const OVERALL_STATUS_VERIFIED = 'verified';
-  const OVERALL_STATUS_PARTIALLY_VERIFIED = 'partially-verified';
-  const OVERALL_STATUS_UNVERIFIED = 'unverified';
+  const DOMAIN_STATUS_VERIFIED = 'verified';
+  const DOMAIN_STATUS_PARTIALLY_VERIFIED = 'partially-verified';
+  const DOMAIN_STATUS_UNVERIFIED = 'unverified';
 
   const AUTHORIZED_SENDER_DOMAIN_ERROR_ALREADY_CREATED = 'Sender domain exist';
   const AUTHORIZED_SENDER_DOMAIN_ERROR_NOT_CREATED = 'Sender domain does not exist';
@@ -176,7 +176,7 @@ class AuthorizedSenderDomainController {
    * Returns sender domains that have all required records, including DMARC.
    */
   public function getFullyVerifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_VERIFIED]);
+    $domainData = $this->getSenderDomainsByStatus([self::DOMAIN_STATUS_VERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
@@ -184,17 +184,17 @@ class AuthorizedSenderDomainController {
    * Returns sender domains that were verified before DMARC record was required.
    */
   public function getPartiallyVerifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_PARTIALLY_VERIFIED]);
+    $domainData = $this->getSenderDomainsByStatus([self::DOMAIN_STATUS_PARTIALLY_VERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
   public function getUnverifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_UNVERIFIED]);
+    $domainData = $this->getSenderDomainsByStatus([self::DOMAIN_STATUS_UNVERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 
   public function getFullyOrPartiallyVerifiedSenderDomains($domainsOnly = false): array {
-    $domainData = $this->getSenderDomainsByStatus([self::OVERALL_STATUS_PARTIALLY_VERIFIED,self::OVERALL_STATUS_VERIFIED]);
+    $domainData = $this->getSenderDomainsByStatus([self::DOMAIN_STATUS_PARTIALLY_VERIFIED,self::DOMAIN_STATUS_VERIFIED]);
     return $domainsOnly ? $this->extractDomains($domainData) : $domainData;
   }
 

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -118,6 +118,7 @@ class AuthorizedSenderDomainController {
     }
 
     // Reset cached value since a new domain was added
+    $this->currentRecords = null;
     $this->reloadCache();
 
     return $response;
@@ -147,7 +148,6 @@ class AuthorizedSenderDomainController {
       throw new \InvalidArgumentException(self::AUTHORIZED_SENDER_DOMAIN_ERROR_NOT_CREATED);
     }
 
-    $this->reloadCache();
     $verifiedDomains = $this->getFullyVerifiedSenderDomains(true);
     $alreadyVerified = in_array($domain, $verifiedDomains);
 
@@ -162,6 +162,9 @@ class AuthorizedSenderDomainController {
     if ($response['status'] === API::RESPONSE_STATUS_ERROR && !isset($response['dns'])) {
       throw new \InvalidArgumentException($response['message']);
     }
+
+    $this->currentRecords = null;
+    $this->reloadCache();
 
     return $response;
   }
@@ -233,7 +236,6 @@ class AuthorizedSenderDomainController {
   }
 
   private function reloadCache() {
-    $this->currentRecords = null;
     $this->currentRawData = $this->bridge->getRawSenderDomainData();
     $this->wp->setTransient(self::SENDER_DOMAINS_KEY, $this->currentRawData, 60 * 60 * 24);
   }

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -8,7 +8,6 @@ use MailPoet\Services\Bridge\API;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
-use MailPoetVendor\Carbon\Carbon;
 
 class AuthorizedSenderDomainController {
   const OVERALL_STATUS_VERIFIED = 'verified';
@@ -21,8 +20,6 @@ class AuthorizedSenderDomainController {
 
   const LOWER_LIMIT = 100;
   const UPPER_LIMIT = 200;
-
-  const ENFORCEMENT_START_TIME = '2024-02-01 00:00:00 UTC';
 
   const INSTALLED_AFTER_NEW_RESTRICTIONS_OPTION = 'installed_after_new_domain_restrictions';
 
@@ -261,11 +258,6 @@ class AuthorizedSenderDomainController {
     return $this->currentRecords;
   }
 
-  // TODO: Remove after the enforcement date has passed
-  public function isEnforcementOfNewRestrictionsInEffect(): bool {
-    return Carbon::now() >= Carbon::parse(self::ENFORCEMENT_START_TIME);
-  }
-
   public function isNewUser(): bool {
     $installedVersion = $this->settingsController->get('version');
 
@@ -306,9 +298,6 @@ class AuthorizedSenderDomainController {
       'allSenderDomains' => $this->getAllSenderDomains(),
       'senderRestrictions' => [
         'lowerLimit' => self::LOWER_LIMIT,
-        'upperLimit' => self::UPPER_LIMIT,
-        'isNewUser' => $this->isNewUser(),
-        'isEnforcementOfNewRestrictionsInEffect' => $this->isEnforcementOfNewRestrictionsInEffect(),
         'alwaysRewrite' => false,
       ],
     ];

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -291,25 +291,12 @@ class AuthorizedSenderDomainController {
     return $this->subscribers->getSubscribersCount() > self::UPPER_LIMIT;
   }
 
-  private function restrictionsApply(): bool {
-    if ($this->settingsController->get('mta.method') !== Mailer::METHOD_MAILPOET) {
-      return false;
-    }
-
-    // TODO: Remove after the enforcement date has passed
-    if (!$this->isNewUser() && !$this->isEnforcementOfNewRestrictionsInEffect()) {
-      return false;
-    }
-
-    return true;
-  }
-
   public function isAuthorizedDomainRequiredForNewCampaigns(): bool {
-    return $this->restrictionsApply() && !$this->isSmallSender();
+    return $this->settingsController->get('mta.method') === Mailer::METHOD_MAILPOET && !$this->isSmallSender();
   }
 
   public function isAuthorizedDomainRequiredForExistingCampaigns(): bool {
-    return $this->restrictionsApply() && $this->isBigSender();
+    return $this->settingsController->get('mta.method') === Mailer::METHOD_MAILPOET && $this->isBigSender();
   }
 
   public function getContextData(): array {

--- a/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
+++ b/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
@@ -82,9 +82,6 @@ class SenderDomainAuthenticationNotices {
   }
 
   public function isErrorStyle(): bool {
-    if (!$this->authorizedSenderDomainController->isEnforcementOfNewRestrictionsInEffect()) {
-      return false;
-    }
     if (
       $this->subscribersFeatures->getSubscribersCount() < AuthorizedSenderDomainController::UPPER_LIMIT
       || $this->isPartiallyVerified()
@@ -100,17 +97,6 @@ class SenderDomainAuthenticationNotices {
   }
 
   public function getNoticeContentForFreeMailUsers(int $contactCount): string {
-    if (!$this->authorizedSenderDomainController->isEnforcementOfNewRestrictionsInEffect()) {
-      // translators: %1$s is the domain of the user's default from address, %2$s is a rewritten version of their default from address, %3$s is HTML for an 'update sender' button, and %4$s is HTML for a Learn More button
-      return sprintf(__("<strong>Update your sender email address to a branded domain by February 1st, 2024 to continue sending your campaigns.</strong>
-<span>Starting on February 1st, 2024, MailPoet will no longer be able to send from email addresses on shared 3rd party domains like <strong>%1\$s</strong>. Please change your campaigns to send from an email address on your site's branded domain. Your emails will temporarily be sent from <strong>%2\$s</strong>.</span> <p>%3\$s &nbsp; %4\$s</p>", 'mailpoet'),
-        "@" . $this->getDefaultFromDomain(),
-        $this->authorizedSenderDomainController->getRewrittenEmailAddress($this->getDefaultFromAddress()),
-        $this->getUpdateSenderButton(),
-        $this->getLearnMoreAboutFreeMailButton()
-      );
-    }
-
     if ($contactCount <= AuthorizedSenderDomainController::UPPER_LIMIT) {
       // translators: %1$s is the domain of the user's default from address, %2$s is a rewritten version of their default from address, %3$s is HTML for an 'update sender' button, and %4$s is HTML for a Learn More button
       return sprintf(__("<strong>Update your sender email address to a branded domain to continue sending your campaigns.</strong>
@@ -133,7 +119,7 @@ class SenderDomainAuthenticationNotices {
   }
 
   public function getNoticeContentForBrandedDomainUsers(bool $isPartiallyVerified, int $contactCount): string {
-    if (!$this->authorizedSenderDomainController->isEnforcementOfNewRestrictionsInEffect() || $isPartiallyVerified || $contactCount <= AuthorizedSenderDomainController::LOWER_LIMIT) {
+    if ($isPartiallyVerified || $contactCount <= AuthorizedSenderDomainController::LOWER_LIMIT) {
       // translators: %1$s is HTML for an 'authenticate domain' button, %2$s is HTML for a Learn More button
       return sprintf(__("<strong>Authenticate your sender domain to improve email delivery rates.</strong>
 <span>Major mailbox providers require you to authenticate your sender domain to confirm you sent the emails, and may place unauthenticated emails in the “Spam” folder. Please authenticate your sender domain to ensure your marketing campaigns are compliant and will reach your contacts.</span><p>%1\$s &nbsp; %2\$s</p>", 'mailpoet'),

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -426,13 +426,6 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
     $this->assertFalse($this->getController()->isNewUser());
   }
 
-  public function testItKnowsWhenNewRestrictionsStartGettingEnforced(): void {
-    Carbon::setTestNow(Carbon::parse('2024-01-31 00:00:00 UTC'));
-    $this->assertFalse($this->getController()->isEnforcementOfNewRestrictionsInEffect());
-    Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:01 UTC'));
-    $this->assertTrue($this->getController()->isEnforcementOfNewRestrictionsInEffect());
-  }
-
   public function testIsSmallSenderIfSubscribersUnderLowerLimit(): void {
     $subscribersMock = $this->make(Subscribers::class, [
       'getSubscribersCount' => Expected::once($this->lowerLimit),

--- a/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedSenderDomainControllerTest.php
@@ -284,7 +284,7 @@ class AuthorizedSenderDomainControllerTest extends \MailPoetTest {
     ];
 
     $getSenderDomainsExpectation = Expected::once($domains);
-    $getSenderDomainsRawDataExpectation = Expected::once($domainsRawData);
+    $getSenderDomainsRawDataExpectation = Expected::exactly(2, $domainsRawData);
     $verifySenderDomainsExpectation = Expected::once($response);
 
     $bridgeMock = $this->make(Bridge::class, [

--- a/mailpoet/tests/integration/Util/Notices/SenderDomainAuthenticationNoticesTest.php
+++ b/mailpoet/tests/integration/Util/Notices/SenderDomainAuthenticationNoticesTest.php
@@ -5,7 +5,6 @@ namespace integration\Util\Notices;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Notices\SenderDomainAuthenticationNotices;
-use MailPoetVendor\Carbon\Carbon;
 
 class SenderDomainAuthenticationNoticesTest extends \MailPoetTest {
   /** @var SenderDomainAuthenticationNotices */
@@ -68,17 +67,10 @@ class SenderDomainAuthenticationNoticesTest extends \MailPoetTest {
     ]);
     $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
 
-    Carbon::setTestNow(Carbon::parse('2024-01-31 00:00:00 UTC'));
-    $beforeRestrictionsInEffectMessage = $this->notice->getNoticeContentForFreeMailUsers($this->upperLimit + 1);
-    $this->assertStringContainsString('Update your sender email address to a branded domain by February 1st, 2024 to continue sending your campaigns.', $beforeRestrictionsInEffectMessage);
-    $this->assertStringContainsString(sprintf('Your emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $beforeRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Update sender email', $beforeRestrictionsInEffectMessage);
-
-    Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:00 UTC'));
-    $afterRestrictionsInEffectMessage = $this->notice->getNoticeContentForFreeMailUsers($this->upperLimit + 1);
-    $this->assertStringContainsString('Your newsletters and post notifications have been paused. Update your sender email address to a branded domain to continue sending your campaigns', $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString(sprintf('Your marketing automations and transactional emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Update sender email', $afterRestrictionsInEffectMessage);
+    $noticeMessage = $this->notice->getNoticeContentForFreeMailUsers($this->upperLimit + 1);
+    $this->assertStringContainsString('Your newsletters and post notifications have been paused. Update your sender email address to a branded domain to continue sending your campaigns', $noticeMessage);
+    $this->assertStringContainsString(sprintf('Your marketing automations and transactional emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $noticeMessage);
+    $this->assertStringContainsString('Update sender email', $noticeMessage);
   }
 
   public function testItRetrievesAppropriateMessageForFreeMailUsersThatAreNotBigSenders(): void {
@@ -89,17 +81,10 @@ class SenderDomainAuthenticationNoticesTest extends \MailPoetTest {
     ]);
     $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
 
-    Carbon::setTestNow(Carbon::parse('2024-01-31 00:00:00 UTC'));
-    $beforeRestrictionsInEffectMessage = $this->notice->getNoticeContentForFreeMailUsers($this->upperLimit);
-    $this->assertStringContainsString('Update your sender email address to a branded domain by February 1st, 2024 to continue sending your campaigns.', $beforeRestrictionsInEffectMessage);
-    $this->assertStringContainsString(sprintf('Your emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $beforeRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Update sender email', $beforeRestrictionsInEffectMessage);
-
-    Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:00 UTC'));
-    $afterRestrictionsInEffectMessage = $this->notice->getNoticeContentForFreeMailUsers($this->upperLimit);
-    $this->assertStringContainsString('Update your sender email address to a branded domain to continue sending your campaigns', $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString(sprintf('Your existing scheduled and active emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Update sender email', $afterRestrictionsInEffectMessage);
+    $noticeMessage = $this->notice->getNoticeContentForFreeMailUsers($this->upperLimit);
+    $this->assertStringContainsString('Update your sender email address to a branded domain to continue sending your campaigns', $noticeMessage);
+    $this->assertStringContainsString(sprintf('Your existing scheduled and active emails will temporarily be sent from <strong>%s</strong>', $rewrittenEmail), $noticeMessage);
+    $this->assertStringContainsString('Update sender email', $noticeMessage);
   }
 
   public function testItRetrievesAppropriateMessageForBrandedDomainsForBigSenders(): void {
@@ -110,17 +95,11 @@ class SenderDomainAuthenticationNoticesTest extends \MailPoetTest {
     ]);
     $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
 
-    Carbon::setTestNow(Carbon::parse('2024-01-31 00:00:00 UTC'));
-    $beforeRestrictionsInEffectMessage = $this->notice->getNoticeContentForBrandedDomainUsers(false, $this->upperLimit + 1);
-    $this->assertStringContainsString('Authenticate your sender domain to improve email delivery rates.', $beforeRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Please authenticate your sender domain to ensure your marketing campaigns are compliant and will reach your contacts', $beforeRestrictionsInEffectMessage);
-
-    Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:00 UTC'));
-    $afterRestrictionsInEffectMessage = $this->notice->getNoticeContentForBrandedDomainUsers(false, $this->upperLimit + 1);
-    $this->assertStringContainsString('Your newsletters and post notifications have been paused. Authenticate your sender domain to continue sending.', $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Your marketing automations and transactional emails will temporarily be sent from', $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString($rewrittenEmail, $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Authenticate domain', $afterRestrictionsInEffectMessage);
+    $noticeMessage = $this->notice->getNoticeContentForBrandedDomainUsers(false, $this->upperLimit + 1);
+    $this->assertStringContainsString('Your newsletters and post notifications have been paused. Authenticate your sender domain to continue sending.', $noticeMessage);
+    $this->assertStringContainsString('Your marketing automations and transactional emails will temporarily be sent from', $noticeMessage);
+    $this->assertStringContainsString($rewrittenEmail, $noticeMessage);
+    $this->assertStringContainsString('Authenticate domain', $noticeMessage);
   }
 
   public function testItRetrievesAppropriateMessageForBrandedDomainsThatAreNotBigSenders(): void {
@@ -131,17 +110,11 @@ class SenderDomainAuthenticationNoticesTest extends \MailPoetTest {
     ]);
     $rewrittenEmail = $this->authorizedSenderDomainController->getRewrittenEmailAddress($email);
 
-    Carbon::setTestNow(Carbon::parse('2024-01-31 00:00:00 UTC'));
-    $beforeRestrictionsInEffectMessage = $this->notice->getNoticeContentForBrandedDomainUsers(false, $this->upperLimit);
-    $this->assertStringContainsString('Authenticate your sender domain to improve email delivery rates.', $beforeRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Please authenticate your sender domain to ensure your marketing campaigns are compliant and will reach your contacts', $beforeRestrictionsInEffectMessage);
-
-    Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:00 UTC'));
-    $afterRestrictionsInEffectMessage = $this->notice->getNoticeContentForBrandedDomainUsers(false, $this->upperLimit);
-    $this->assertStringContainsString('Authenticate your sender domain to send new emails.', $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Your existing scheduled and active emails will temporarily be sent from', $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString($rewrittenEmail, $afterRestrictionsInEffectMessage);
-    $this->assertStringContainsString('Authenticate domain', $afterRestrictionsInEffectMessage);
+    $noticeMessage = $this->notice->getNoticeContentForBrandedDomainUsers(false, $this->upperLimit);
+    $this->assertStringContainsString('Authenticate your sender domain to send new emails.', $noticeMessage);
+    $this->assertStringContainsString('Your existing scheduled and active emails will temporarily be sent from', $noticeMessage);
+    $this->assertStringContainsString($rewrittenEmail, $noticeMessage);
+    $this->assertStringContainsString('Authenticate domain', $noticeMessage);
   }
 
   public function testItRetrievesAppropriateMessageForBrandedDomainsForSmallSenders(): void {


### PR DESCRIPTION
## Description

- Removes all check for enforcement date
- Removes the notices that were displayed before the enforcement date
- Cleans up some leftover code from previous iterations
- Improves the cache loading for sender domains
- Fixes a bug in Automations notices and displays the correct body

## Code review notes

_N/A_

## QA notes

Only merge after February 1st, 2024

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
