### PR TITLE
Automation transascional fixes [MAILPOET-5720] [MAILPOET-5725]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/helper/is-transactional.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/helper/is-transactional.ts
@@ -2,7 +2,12 @@ import { select } from '@wordpress/data';
 import { Step } from '../../../../../editor/components/automation/types';
 import { storeName } from '../../../../../editor/store';
 
-const transactionalTriggers = ['woocommerce:order-status-changed'];
+const transactionalTriggers = [
+  'woocommerce:order-status-changed',
+  'woocommerce:order-created',
+  'woocommerce:order-completed',
+  'woocommerce:order-cancelled',
+];
 
 export function isTransactional(step: Step): boolean {
   const automation = select(storeName).getAutomationData();

--- a/mailpoet/lib/Automation/Engine/Data/StepRunArgs.php
+++ b/mailpoet/lib/Automation/Engine/Data/StepRunArgs.php
@@ -113,14 +113,11 @@ class StepRunArgs {
   public function getSinglePayloadByClass(string $class): Payload {
     $payloads = [];
     foreach ($this->subjectEntries as $entries) {
-      if (count($entries) > 1) {
-        throw Exceptions::multiplePayloadsFound($class, $this->automationRun->getId());
-      }
-
-      $entry = $entries[0];
-      $payload = $entry->getPayload();
-      if (get_class($payload) === $class) {
-        $payloads[] = $payload;
+      foreach ($entries as $entry) {
+        $payload = $entry->getPayload();
+        if (get_class($payload) === $class) {
+          $payloads[] = $payload;
+        }
       }
     }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -33,6 +33,13 @@ use Throwable;
 class SendEmailAction implements Action {
   const KEY = 'mailpoet:send-email';
 
+  private const TRANSACTIONAL_TRIGGERS = [
+    'woocommerce:order-status-changed',
+    'woocommerce:order-created',
+    'woocommerce:order-completed',
+    'woocommerce:order-cancelled',
+  ];
+
   /** @var SettingsController */
   private $settings;
 
@@ -266,7 +273,7 @@ class SendEmailAction implements Action {
     $transactionalTriggers = array_filter(
       $triggers,
       function(Step $step): bool {
-        return in_array($step->getKey(), ['woocommerce:order-status-changed'], true);
+        return in_array($step->getKey(), self::TRANSACTIONAL_TRIGGERS, true);
       }
     );
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -293,7 +293,7 @@ class SendEmailAction implements Action {
     return (bool)array_filter(
       $automation->getTriggers(),
       function(Step $step): bool {
-        return in_array($step->getKey(), ['woocommerce:order-status-changed', 'woocommerce:abandoned-cart'], true);
+        return strpos($step->getKey(), 'woocommerce:') === 0;
       }
     );
   }

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -184,6 +184,11 @@ class Newsletter {
     return $this;
   }
 
+  public function withAutomationTransactionalType() {
+    $this->data['type'] = NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL;
+    return $this;
+  }
+
   public function withReengagementType() {
     $this->data['type'] = NewsletterEntity::TYPE_RE_ENGAGEMENT;
     return $this;


### PR DESCRIPTION
## Description

This fixes sending transactional emails from automations even to subscribers that unsubscribe after checkout, and marks order created/completed/cancelled as transactional triggers.

## Code review notes

_N/A_

## QA notes

See the tickets for more info.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5720]
[MAILPOET-5725]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5720]: https://mailpoet.atlassian.net/browse/MAILPOET-5720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5725]: https://mailpoet.atlassian.net/browse/MAILPOET-5725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ