### PR TITLE
Fix errors related to deleted task in sending queue worker [MAILPOET-5880]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -20,6 +20,7 @@ use MailPoet\Newsletter\Renderer\PostProcess\OpenTracking;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\RuntimeException;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\GATracking;
@@ -139,11 +140,22 @@ class Newsletter {
     return $newsletter;
   }
 
+  /**
+   * Pre-processes the newsletter before sending.
+   * - Renders the newsletter
+   * - Adds tracking
+   * - Extracts links
+   * - Checks if the newsletter is a post notification and if it contains at least 1 ALC post.
+   *   If not it deletes the notification history record and all associate entities.
+   *
+   * @return NewsletterEntity|false - Returns false only if the newsletter is a post notification history and was deleted.
+   *
+   */
   public function preProcessNewsletter(NewsletterEntity $newsletter, ScheduledTaskEntity $task) {
     // return the newsletter if it was previously rendered
     $queue = $task->getSendingQueue();
     if (!$queue) {
-      return false;
+      throw new RuntimeException('Can‘t pre-process newsletter without queue.');
     }
     if ($queue->getNewsletterRenderedBody() !== null) {
       return $newsletter;


### PR DESCRIPTION
## Description

This PR fixes errors logged during sending when Post Notification History newsletters contain no posts.

## Code review notes

Basically, the issue was that we can't call $entityManager->remove o other entity manager actions on a detached entity.
Please see only the two last commits. 

## QA notes

Please see the ticket description for replication instructions.
**This can be merged only after https://github.com/mailpoet/mailpoet/pull/5393 is merged!**

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5393 

## Linked tickets

[MAILPOET-5880]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5880]: https://mailpoet.atlassian.net/browse/MAILPOET-5880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ