### PR TITLE
Add utm parameters by default [MAILPOET-5882]

### DIFF
--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -56,6 +56,7 @@ class GATracking {
     $params = [
       'utm_source' => 'mailpoet',
       'utm_medium' => 'email',
+      'utm_source_platform' => 'mailpoet',
     ];
     if ($gaCampaign) {
       $params['utm_campaign'] = $gaCampaign;

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -78,7 +78,7 @@ class GATracking {
       $linkParams = $params;
       if (isset($parsedUrl['query'])) {
         foreach (array_keys($params) as $param) {
-          if (strpos($parsedUrl['query'], $param) !== false) {
+          if (strpos($parsedUrl['query'], $param . '=') !== false) {
             unset($linkParams[$param]);
           }
         }

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -70,11 +70,18 @@ class GATracking {
         continue;
       }
 
+      $processedLink = $this->wp->applyFilters(
+        'mailpoet_ga_tracking_link',
+        $this->wp->addQueryArg($params, $extractedLink['link']),
+        $extractedLink['link'],
+        $params,
+        $extractedLink['type']
+      );
       $link = $extractedLink['link'];
       $processedLinks[$link] = [
         'type' => $extractedLink['type'],
         'link' => $link,
-        'processed_link' => $this->wp->addQueryArg($params, $extractedLink['link']),
+        'processed_link' => $processedLink,
       ];
     }
     return $processedLinks;

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -70,14 +70,26 @@ class GATracking {
         continue;
       }
 
+      $link = $extractedLink['link'];
+
+      // Do not overwrite existing query parameters
+      $parsedUrl = parse_url($link);
+      $linkParams = $params;
+      if (isset($parsedUrl['query'])) {
+        foreach (array_keys($params) as $param) {
+          if (strpos($parsedUrl['query'], $param) !== false) {
+            unset($linkParams[$param]);
+          }
+        }
+      }
+
       $processedLink = $this->wp->applyFilters(
         'mailpoet_ga_tracking_link',
-        $this->wp->addQueryArg($params, $extractedLink['link']),
+        $this->wp->addQueryArg($linkParams, $link),
         $extractedLink['link'],
-        $params,
+        $linkParams,
         $extractedLink['type']
       );
-      $link = $extractedLink['link'];
       $processedLinks[$link] = [
         'type' => $extractedLink['type'],
         'link' => $link,

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -58,4 +58,23 @@ class GATrackingTest extends \MailPoetTest {
     verify($result['text'])->stringContainsString('email=[subscriber:email]');
     verify($result['html'])->stringContainsString('email=[subscriber:email]');
   }
+
+  public function testItDoesNotOverwriteExistingParameters() {
+    $link = add_query_arg(
+      [
+        'utm_source' => 'another_source',
+        'utm_medium' => 'another_medium',
+      ],
+      $this->link
+    );
+    $renderedNewsletter = [
+      'html' => '<p><a href="' . $link . '">Click here</a></p>',
+      'text' => '[Click here](' . $link . ')',
+    ];
+    $result = $this->tracking->applyGATracking($renderedNewsletter, $this->newsletter, $this->internalHost);
+    verify($result['text'])->stringNotContainsString('utm_source=mailpoet');
+    verify($result['html'])->stringContainsString('utm_source=another_source');
+    verify($result['text'])->stringNotContainsString('utm_medium=email');
+    verify($result['html'])->stringContainsString('utm_medium=another_medium');
+  }
 }

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -28,24 +28,13 @@ class GATrackingTest extends \MailPoetTest {
   public function _before() {
     $this->tracking = $this->diContainer->get(GATracking::class);
     $this->internalHost = 'newsletters.mailpoet.com';
-    $this->gaCampaign = 'Spring email';
+    $this->gaCampaign = 'SpringEmail';
     $this->link = add_query_arg(['foo' => 'bar', 'baz' => 'xyz'], 'https://www.mailpoet.com/');
     $this->renderedNewsletter = [
       'html' => '<p><a href="' . $this->link . '">Click here</a>. <a href="http://somehost.com/fff/?abc=123&email=[subscriber:email]">Do not process this</a> [link:some_link_shortcode]</p>',
       'text' => '[Click here](' . $this->link . '). [Do not process this](http://somehost.com/fff/?abc=123&email=[subscriber:email]) [link:some_link_shortcode]',
     ];
     $this->newsletter = (new NewsletterFactory())->withGaCampaign($this->gaCampaign)->create();
-  }
-
-  public function testItConditionallyAppliesGATracking() {
-    // No process (empty GA campaign)
-    $newsletter = (new NewsletterFactory())->create();
-    $result = $this->tracking->applyGATracking($this->renderedNewsletter, $newsletter, $this->internalHost);
-    verify($result)->equals($this->renderedNewsletter);
-
-    // Process (filled GA campaign)
-    $result = $this->tracking->applyGATracking($this->renderedNewsletter, $this->newsletter, $this->internalHost);
-    verify($result)->notEquals($this->renderedNewsletter);
   }
 
   public function testItGetsGACampaignFromParentNewsletterForPostNotifications() {


### PR DESCRIPTION
## Description
Fixes [MAILPOET-5882]

All links in newsletters will now have the utm_source `mailpoet` and utm_medium `email` parameter added. If they exist already, they will not be overwritten.

## Code review notes

I simplified the logic a bit. We used our own `splitLink` method to separate path, parameters and hashes. WordPress provides `add_query_arg()` to do that.

I decided to apply a filter, so that the result could be customized. E.g. if someone wants to use their

## QA notes
Check if links in the newsletter get the parameters attached, even when no GA campaign has been added to the newsletter. Check that hashes and other parameters are still there.

Check also that urls which have the `url_source` etc. parameter already keep these parameters instead of the new ones.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5882]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5882]: https://mailpoet.atlassian.net/browse/MAILPOET-5882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5882]: https://mailpoet.atlassian.net/browse/MAILPOET-5882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ