### PR TITLE
Fix ampersand character rendered by [newsletter:post_title] shortcode [MAILPOET-5724]

### DIFF
--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -937,4 +937,12 @@ class Functions {
   public function getQueriedObjectId() {
     return get_queried_object_id();
   }
+
+  /**
+   * @param string $string
+   * @param bool $removeBreaks
+   */
+  public function wpStripAllTags($string, $removeBreaks = false): string {
+    return wp_strip_all_tags($string, $removeBreaks);
+  }
 }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -160,7 +160,7 @@ class ShortcodesTest extends \MailPoetTest {
       $shortcodesObject->process(['[newsletter:post_title]'], $content);
     $wpPost = get_post($this->wPPost);
     $this->assertInstanceOf(WP_Post::class, $wpPost);
-    verify($result['0'])->equals($wpPost->post_title); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify($result['0'])->equals('Sample Post &, <, >, strong');
   }
 
   public function itCanProcessPostNotificationNewsletterNumberShortcode() {
@@ -446,8 +446,9 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function _createWPPost() {
+    // Because when a user with role author publish a post containing in the title the character "&", the title is saved as "&amp;"
     $data = [
-      'post_title' => 'Sample Post',
+      'post_title' => 'Sample Post &amp;, &lt;, &gt;, <strong>strong</strong>',
       'post_content' => 'contents',
       'post_status' => 'publish',
     ];


### PR DESCRIPTION
## Description

This PR fixes rendering ampersand in post notifications when the post is published by a user with a role author.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5724]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5724]: https://mailpoet.atlassian.net/browse/MAILPOET-5724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ