### PR TITLE
Fix "The EntityManager is closed" in sending [MAILPOET-5886]

### DIFF
--- a/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
+++ b/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
@@ -36,19 +36,21 @@ class StatisticsNewsletterEntity {
   private $subscriber;
 
   /**
-   * @ORM\Column(type="datetimetz", nullable=true)
-   * @var \DateTimeInterface|null
+   * @ORM\Column(type="datetimetz", nullable=false)
+   * @var \DateTimeInterface
    */
   private $sentAt;
 
   public function __construct(
     NewsletterEntity $newsletter,
     SendingQueueEntity $queue,
-    SubscriberEntity $subscriber
+    SubscriberEntity $subscriber,
+    \DateTimeInterface $sentAt = null
   ) {
     $this->newsletter = $newsletter;
     $this->queue = $queue;
     $this->subscriber = $subscriber;
+    $this->sentAt = $sentAt ?: new \DateTimeImmutable();
   }
 
   /**

--- a/mailpoet/lib/Migrations/App/Migration_20240202_130053_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20240202_130053_App.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Migrator\AppMigration;
+
+/**
+ * Due to a bug https://mailpoet.atlassian.net/browse/MAILPOET-5886
+ * The status of newsletters was not updated to sent when the task was completed
+ * In this migration we find newsletters with status sending and their tasks are completed and update their status to sent
+ */
+class Migration_20240202_130053_App extends AppMigration {
+  public function run(): void {
+    $affectedNewsletterIds = $this->entityManager->createQueryBuilder()
+      ->select('n.id')
+      ->from(NewsletterEntity::class, 'n')
+      ->join('n.queues', 'q')
+      ->join('q.task', 't')
+      ->where('n.status = :status_sending')
+      ->andWhere('t.status = :status_completed')
+      ->setParameter('status_sending', NewsletterEntity::STATUS_SENDING)
+      ->setParameter('status_completed', ScheduledTaskEntity::STATUS_COMPLETED)
+      ->getQuery()
+      ->getArrayResult();
+
+    $affectedNewsletterIds = array_column($affectedNewsletterIds, 'id');
+
+    $this->entityManager->createQueryBuilder()
+      ->update(NewsletterEntity::class, 'n')
+      ->set('n.status', ':status_sent')
+      ->where('n.id IN (:ids)')
+      ->setParameter('status_sent', NewsletterEntity::STATUS_SENT)
+      ->setParameter('ids', $affectedNewsletterIds)
+      ->getQuery()
+      ->execute();
+  }
+}

--- a/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Carbon\Carbon;
 
 /**
  * @extends Repository<StatisticsNewsletterEntity>
@@ -29,7 +30,8 @@ class StatisticsNewslettersRepository extends Repository {
           continue;
         }
 
-        $entity = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
+        $sentAt = Carbon::createFromTimestamp((int)current_time('timestamp'));
+        $entity = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber, $sentAt);
 
         $this->entityManager->persist($entity);
         $entities[] = $entity;

--- a/mailpoet/tests/integration/Migrations/App/Migration_20240202_130053_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20240202_130053_App_Test.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20240202_130053_App_Test extends \MailPoetTest {
+  /** @var Migration_20240202_130053_App */
+  private $migration;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20240202_130053_App($this->diContainer);
+  }
+
+  public function testItMigratesIncorrectlyMarkedSentNewslettersAsSent() {
+    $incorrectStandardNewsletter = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED])
+      ->create();
+    $incorrectPostNotification = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED])
+      ->create();
+    $correctlySendingNewsletter = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue(['status' => null]) // Running task
+      ->create();
+    $correctlySentNewsletter = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_SENT)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED])
+      ->create();
+    $draftNewsletter = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_DRAFT)
+      ->create();
+    $welcomeEmailNewsletter = (new NewsletterFactory())
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED])
+      ->create();
+
+    $this->migration->run();
+
+    $this->entityManager->refresh($incorrectStandardNewsletter);
+    $this->entityManager->refresh($incorrectPostNotification);
+    $this->entityManager->refresh($correctlySendingNewsletter);
+    $this->entityManager->refresh($correctlySentNewsletter);
+    $this->entityManager->refresh($draftNewsletter);
+    $this->entityManager->refresh($welcomeEmailNewsletter);
+
+    verify($incorrectStandardNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
+    verify($incorrectPostNotification->getStatus())->equals(NewsletterEntity::STATUS_SENT);
+    verify($correctlySendingNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
+    verify($correctlySentNewsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
+    verify($draftNewsletter->getStatus())->equals(NewsletterEntity::STATUS_DRAFT);
+    verify($welcomeEmailNewsletter->getStatus())->equals(NewsletterEntity::STATUS_ACTIVE);
+  }
+}

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmailHooksTest.php
@@ -154,6 +154,7 @@ class TransactionalEmailHooksTest extends \MailPoetTest {
         L::row([L::col([['type' => 'text', 'text' => 'Some text after content']])]),
       ]),
     ]);
+    $newsletter->setUpdatedAt(new \DateTimeImmutable());
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
     $this->settings->set(TransactionalEmails::SETTING_EMAIL_ID, $newsletter->getId());


### PR DESCRIPTION
## Description

This PR fixes an error happening when sending all types of emails on a site with MySQL 8. It causes that sending is very slow and you can see The EntityManager is closed errors in logs.

## Code review notes
I considered configuring the sentAt columns `insertable: false`, but using a default value seemed more common in Doctrine.
I also ran all integration tests with MySQL8 and fixed one failing test I found.

## QA notes

Please see the replication instructions in the Jira ticket.

To test the migration, please generate a reasonable number of emails sent in an invalid state (Not sent yet). This can be done by following the instructions and sending a couple of emails. After you run the migration the emails should display correct status.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5886]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5886]: https://mailpoet.atlassian.net/browse/MAILPOET-5886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ