### PR TITLE
Add migration to fix sending tasks stuck in "invalid" state [MAILPOET-5887]

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
@@ -18,7 +18,11 @@ use MailPoet\Migrator\AppMigration;
  */
 class Migration_20240207_105912_App extends AppMigration {
   public function run(): void {
-    // pause invalid tasks with unprocessed subscribers
+    $this->pauseInvalidTasksWithUnprocessedSubscribers();
+    $this->completeInvalidTasksWithAllSubscribersProcessed();
+  }
+
+  private function pauseInvalidTasksWithUnprocessedSubscribers(): void {
     $ids = $this->entityManager->createQueryBuilder()
       ->select('DISTINCT t.id')
       ->from(ScheduledTaskEntity::class, 't')
@@ -45,8 +49,9 @@ class Migration_20240207_105912_App extends AppMigration {
       ->setParameter('ids', $ids)
       ->getQuery()
       ->execute();
+  }
 
-    // complete invalid tasks with all subscribers processed, mark newsletters as sent
+  private function completeInvalidTasksWithAllSubscribersProcessed(): void {
     $result = $this->entityManager->createQueryBuilder()
       ->select('DISTINCT t.id, n.id AS nid')
       ->from(ScheduledTaskEntity::class, 't')

--- a/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
@@ -73,6 +73,16 @@ class Migration_20240207_105912_App extends AppMigration {
       ->getQuery()
       ->getSingleColumnResult();
 
+    // update sending queue counts
+    $this->entityManager->createQueryBuilder()
+      ->update(SendingQueueEntity::class, 'q')
+      ->set('q.countProcessed', 'q.countTotal')
+      ->set('q.countToProcess', 0)
+      ->where('q.task IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
     // complete the invalid tasks
     $this->entityManager->createQueryBuilder()
       ->update(ScheduledTaskEntity::class, 't')

--- a/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
@@ -138,10 +138,8 @@ class Migration_20240207_105912_App extends AppMigration {
       ->where('q.newsletter IN (:ids)')
       ->andWhere('ns.id IS NULL')
       ->andWhere('s.processed = :processed')
-      ->andWhere('s.failed = :ok')
       ->setParameter('ids', $ids)
       ->setParameter('processed', ScheduledTaskSubscriberEntity::STATUS_PROCESSED)
-      ->setParameter('ok', ScheduledTaskSubscriberEntity::FAIL_STATUS_OK)
       ->getQuery()
       ->getResult();
 

--- a/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20240207_105912_App.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Migrator\AppMigration;
+
+/**
+ * We've had a set of bugs where campaign type newsletters (see NewsletterEntity::CAMPAIGN_TYPES),
+ * such as post notifications, were getting stuck in the following state:
+ * - The newsletter was in the "sending" state.
+ * - The task failed to complete and ended up in the "invalid" state.
+ *
+ * This migration completes tasks that sent out all emails
+ * and pauses those that have unprocessed subscribers.
+ */
+class Migration_20240207_105912_App extends AppMigration {
+  public function run(): void {
+    // pause invalid tasks with unprocessed subscribers
+    $ids = $this->entityManager->createQueryBuilder()
+      ->select('DISTINCT t.id')
+      ->from(ScheduledTaskEntity::class, 't')
+      ->join('t.subscribers', 's', 'WITH', 's.processed = :unprocessed')
+      ->join('t.sendingQueue', 'q')
+      ->join('q.newsletter', 'n')
+      ->where('t.deletedAt IS NULL')
+      ->andWhere('t.status = :invalid')
+      ->andWhere('n.deletedAt IS NULL')
+      ->andWhere('n.status = :sending')
+      ->andWhere('n.type IN (:campaignTypes)')
+      ->setParameter('unprocessed', ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED)
+      ->setParameter('invalid', ScheduledTaskEntity::STATUS_INVALID)
+      ->setParameter('sending', NewsletterEntity::STATUS_SENDING)
+      ->setParameter('campaignTypes', NewsletterEntity::CAMPAIGN_TYPES)
+      ->getQuery()
+      ->getSingleColumnResult();
+
+    $this->entityManager->createQueryBuilder()
+      ->update(ScheduledTaskEntity::class, 't')
+      ->set('t.status', ':paused')
+      ->where('t.id IN (:ids)')
+      ->setParameter('paused', ScheduledTaskEntity::STATUS_PAUSED)
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    // complete invalid tasks with all subscribers processed, mark newsletters as sent
+    $result = $this->entityManager->createQueryBuilder()
+      ->select('DISTINCT t.id, n.id AS nid')
+      ->from(ScheduledTaskEntity::class, 't')
+      ->leftJoin('t.subscribers', 's', 'WITH', 's.processed = :unprocessed')
+      ->join('t.sendingQueue', 'q')
+      ->join('q.newsletter', 'n')
+      ->where('t.deletedAt IS NULL')
+      ->andWhere('t.status = :invalid')
+      ->andWhere('s.task IS NULL')
+      ->andWhere('n.deletedAt IS NULL')
+      ->andWhere('n.status = :sending')
+      ->andWhere('n.type IN (:campaignTypes)')
+      ->setParameter('unprocessed', ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED)
+      ->setParameter('invalid', ScheduledTaskEntity::STATUS_INVALID)
+      ->setParameter('sending', NewsletterEntity::STATUS_SENDING)
+      ->setParameter('campaignTypes', NewsletterEntity::CAMPAIGN_TYPES)
+      ->getQuery()
+      ->getResult();
+
+    $ids = array_column($result, 'id');
+    $newsletterIds = array_column($result, 'nid');
+
+    $this->entityManager->createQueryBuilder()
+      ->update(ScheduledTaskEntity::class, 't')
+      ->set('t.status', ':completed')
+      ->where('t.id IN (:ids)')
+      ->setParameter('completed', ScheduledTaskEntity::STATUS_COMPLETED)
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->execute();
+
+    $this->entityManager->createQueryBuilder()
+      ->update(NewsletterEntity::class, 'n')
+      ->set('n.status', ':sent')
+      ->where('n.deletedAt IS NULL')
+      ->andWhere('n.id IN (:newsletterIds)')
+      ->setParameter('sent', NewsletterEntity::STATUS_SENT)
+      ->setParameter('newsletterIds', $newsletterIds)
+      ->getQuery()
+      ->execute();
+  }
+}

--- a/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
@@ -249,11 +249,16 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
     $processedSubscribers = $task->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
     $this->assertCount(4, $stats); // 3 ok + 1 failed
     $this->assertCount(4, $processedSubscribers); // 3 ok + 1 failed
+
     for ($i = 0; $i < 4; $i++) {
       $this->assertSame($newsletter, $stats[$i]->getNewsletter());
       $this->assertSame($task->getSendingQueue(), $stats[$i]->getQueue());
-      $this->assertEquals($task->getUpdatedAt(), $stats[$i]->getSentAt());
-      $this->assertContains($stats[$i]->getSubscriber(), $processedSubscribers);
+
+      $subscriberIndex = array_search($stats[$i]->getSubscriber(), $processedSubscribers, true);
+      $subscriber = $processedSubscribers[$subscriberIndex] ?? null;
+      $this->assertNotNull($subscriber);
+      $this->assertSame($subscriber, $stats[$i]->getSubscriber());
+      $this->assertEquals($subscriber->getUpdatedAt(), $stats[$i]->getSentAt());
     }
   }
 

--- a/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
@@ -246,9 +246,9 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $stats = $repository->findAll();
     $processedSubscribers = $task->getSubscribersByProcessed(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
-    $this->assertCount(3, $stats);
+    $this->assertCount(4, $stats); // 3 ok + 1 failed
     $this->assertCount(4, $processedSubscribers); // 3 ok + 1 failed
-    for ($i = 0; $i < 3; $i++) {
+    for ($i = 0; $i < 4; $i++) {
       $this->assertSame($newsletter, $stats[$i]->getNewsletter());
       $this->assertSame($task->getSendingQueue(), $stats[$i]->getQueue());
       $this->assertEquals($task->getUpdatedAt(), $stats[$i]->getSentAt());

--- a/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
@@ -1,0 +1,239 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Migrations\App;
+
+use DateTimeImmutable;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Migrations\App\Migration_20240207_105912_App;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\ScheduledTask;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber;
+use MailPoet\Test\DataFactories\SendingQueue;
+use MailPoet\Test\DataFactories\Subscriber;
+
+// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20240207_105912_App_Test extends \MailPoetTest {
+  /** @var Migration_20240207_105912_App */
+  private $migration;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20240207_105912_App($this->diContainer);
+  }
+
+  public function testItPausesInvalidTasksWithUnprocessedSubscribers(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING);
+    $task = $this->createTask($newsletter, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter, $task]);
+    $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $task->getStatus());
+  }
+
+  public function testItCompletesInvalidTasksWithAllProcessedSubscribers(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING);
+    $task = $this->createTask($newsletter, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 0,
+      'failedSubscribers' => 1,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter, $task]);
+    $this->assertSame(NewsletterEntity::STATUS_SENT, $newsletter->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_COMPLETED, $task->getStatus());
+  }
+
+  public function testItIgnoresNonSendingNewsletters(): void {
+    $newsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SCHEDULED);
+    $task1 = $this->createTask($newsletter1, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    $newsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_ACTIVE);
+    $task2 = $this->createTask($newsletter1, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter1, $task1, $newsletter2, $task2]);
+    $this->assertSame(NewsletterEntity::STATUS_SCHEDULED, $newsletter1->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task1->getStatus());
+    $this->assertSame(NewsletterEntity::STATUS_ACTIVE, $newsletter2->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task2->getStatus());
+  }
+
+  public function testItIgnoresNonCampaignNewsletters(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_WELCOME, NewsletterEntity::STATUS_SENDING);
+    $task = $this->createTask($newsletter, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter, $task]);
+    $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task->getStatus());
+  }
+
+  public function testItIgnoresDeletedTasks(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING);
+    $task = $this->createTask($newsletter, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+      'isDeleted' => true,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter, $task]);
+    $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task->getStatus());
+    $this->assertNotNull($task->getDeletedAt());
+  }
+
+  public function testItIgnoresDeletedNewsletters(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING, true);
+    $task = $this->createTask($newsletter, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter, $task]);
+    $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task->getStatus());
+    $this->assertNotNull($newsletter->getDeletedAt());
+  }
+
+  public function testMultipleNewslettersAtOnce(): void {
+    // invalid task with unprocessed subscribers
+    $newsletter1 = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING);
+    $task1 = $this->createTask($newsletter1, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    // invalid task with all subscribers processed
+    $newsletter2 = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING);
+    $task2 = $this->createTask($newsletter2, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 0,
+      'failedSubscribers' => 1,
+    ]);
+
+    // invalid task with non-sending newsletter
+    $newsletter3 = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SCHEDULED);
+    $task3 = $this->createTask($newsletter3, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    // invalid task with non-campaign newsletter
+    $newsletter4 = $this->createNewsletter(NewsletterEntity::TYPE_WELCOME, NewsletterEntity::STATUS_SENDING);
+    $task4 = $this->createTask($newsletter4, [
+      'status' => ScheduledTaskEntity::STATUS_INVALID,
+      'processedSubscribers' => 3,
+      'unprocessedSubscribers' => 1,
+      'failedSubscribers' => 1,
+    ]);
+
+    $this->migration->run();
+
+    $this->refreshAll([$newsletter1, $task1, $newsletter2, $task2, $newsletter3, $task3, $newsletter4, $task4]);
+    $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter1->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $task1->getStatus());
+    $this->assertSame(NewsletterEntity::STATUS_SENT, $newsletter2->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_COMPLETED, $task2->getStatus());
+    $this->assertSame(NewsletterEntity::STATUS_SCHEDULED, $newsletter3->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task3->getStatus());
+    $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter4->getStatus());
+    $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task4->getStatus());
+  }
+
+  private function createNewsletter(string $newsletterType, string $newsletterStatus, bool $isDeleted = false): NewsletterEntity {
+    $newsletterFactory = (new NewsletterFactory())
+      ->withType($newsletterType)
+      ->withStatus($newsletterStatus);
+
+    if ($isDeleted) {
+      $newsletterFactory->withDeleted();
+    }
+    return $newsletterFactory->create();
+  }
+
+  /**
+   * @param NewsletterEntity $newsletter
+   * @param array{
+   *   status?: string,
+   *   processedSubscribers?: int,
+   *   unprocessedSubscribers?: int,
+   *   failedSubscribers?: int,
+   * } $params
+   */
+  private function createTask(NewsletterEntity $newsletter, array $params = []): ScheduledTaskEntity {
+    $taskStatus = $params['status'] ?? ScheduledTaskEntity::STATUS_INVALID;
+    $processedSubscribers = $params['processedSubscribers'] ?? 0;
+    $unprocessedSubscribers = $params['unprocessedSubscribers'] ?? 0;
+    $failedSubscribers = $params['failedSubscribers'] ?? 0;
+    $isDeleted = $params['isDeleted'] ?? false;
+
+    $task = (new ScheduledTask())->create(SendingQueueWorker::TASK_TYPE, $taskStatus);
+    if ($isDeleted) {
+      $task->setDeletedAt(new DateTimeImmutable());
+      $this->entityManager->flush();
+    }
+
+    for ($i = 0; $i < $processedSubscribers; $i++) {
+      (new ScheduledTaskSubscriber())->createProcessed($task, (new Subscriber())->create());
+    }
+
+    for ($i = 0; $i < $unprocessedSubscribers; $i++) {
+      (new ScheduledTaskSubscriber())->createUnprocessed($task, (new Subscriber())->create());
+    }
+
+    for ($i = 0; $i < $failedSubscribers; $i++) {
+      (new ScheduledTaskSubscriber())->createFailed($task, (new Subscriber())->create());
+    }
+
+    (new SendingQueue())->create($task, $newsletter);
+    return $task;
+  }
+
+  private function refreshAll(array $entities) {
+    foreach ($entities as $entity) {
+      $this->entityManager->refresh($entity);
+    }
+  }
+}

--- a/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
@@ -235,11 +235,13 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $repository = $this->diContainer->get(StatisticsNewslettersRepository::class);
     $this->assertCount(0, $repository->findAll());
+    $this->assertNull($newsletter->getSentAt());
 
     $this->migration->run();
 
     $this->refreshAll([$newsletter, $task]);
     $this->assertSame(NewsletterEntity::STATUS_SENT, $newsletter->getStatus());
+    $this->assertEquals($task->getUpdatedAt(), $newsletter->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_COMPLETED, $task->getStatus());
 
     $stats = $repository->findAll();

--- a/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20240207_105912_App_Test.php
@@ -52,6 +52,7 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $this->refreshAll([$newsletter, $task]);
     $this->assertSame(NewsletterEntity::STATUS_SENT, $newsletter->getStatus());
+    $this->assertEquals($task->getUpdatedAt(), $newsletter->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_COMPLETED, $task->getStatus());
   }
 
@@ -76,8 +77,10 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $this->refreshAll([$newsletter1, $task1, $newsletter2, $task2]);
     $this->assertSame(NewsletterEntity::STATUS_SCHEDULED, $newsletter1->getStatus());
+    $this->assertNull($newsletter1->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task1->getStatus());
     $this->assertSame(NewsletterEntity::STATUS_ACTIVE, $newsletter2->getStatus());
+    $this->assertNull($newsletter2->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task2->getStatus());
   }
 
@@ -94,6 +97,7 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $this->refreshAll([$newsletter, $task]);
     $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertNull($newsletter->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task->getStatus());
   }
 
@@ -111,6 +115,7 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $this->refreshAll([$newsletter, $task]);
     $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertNull($newsletter->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task->getStatus());
     $this->assertNotNull($task->getDeletedAt());
   }
@@ -128,8 +133,8 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
 
     $this->refreshAll([$newsletter, $task]);
     $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter->getStatus());
+    $this->assertNull($newsletter->getSentAt());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task->getStatus());
-    $this->assertNotNull($newsletter->getDeletedAt());
   }
 
   public function testMultipleNewslettersAtOnce(): void {
@@ -174,12 +179,16 @@ class Migration_20240207_105912_App_Test extends \MailPoetTest {
     $this->refreshAll([$newsletter1, $task1, $newsletter2, $task2, $newsletter3, $task3, $newsletter4, $task4]);
     $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter1->getStatus());
     $this->assertSame(ScheduledTaskEntity::STATUS_PAUSED, $task1->getStatus());
+    $this->assertNull($newsletter1->getSentAt());
     $this->assertSame(NewsletterEntity::STATUS_SENT, $newsletter2->getStatus());
     $this->assertSame(ScheduledTaskEntity::STATUS_COMPLETED, $task2->getStatus());
+    $this->assertEquals($task2->getUpdatedAt(), $newsletter2->getSentAt());
     $this->assertSame(NewsletterEntity::STATUS_SCHEDULED, $newsletter3->getStatus());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task3->getStatus());
+    $this->assertNull($newsletter3->getSentAt());
     $this->assertSame(NewsletterEntity::STATUS_SENDING, $newsletter4->getStatus());
     $this->assertSame(ScheduledTaskEntity::STATUS_INVALID, $task4->getStatus());
+    $this->assertNull($newsletter4->getSentAt());
   }
 
   private function createNewsletter(string $newsletterType, string $newsletterStatus, bool $isDeleted = false): NewsletterEntity {


### PR DESCRIPTION
## Description

Due to the recent issues with refactoring sending code to Doctrine in combination with https://github.com/mailpoet/mailpoet/pull/4797, there might be some sending tasks and newsletter entities incorrectly marked as invalid respectively sending. This PR adds a migration to fix those.

## Code review notes

It's hard to test the invalid tasks, and I wrote tests for them.
That said, if you have a site with some scheduled emails, notifications, and historical data, you can try to update to this branch, deactivate & activate the plugin to ensure migrations run, and then make sure all sending data still looks fine.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5887]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5887]: https://mailpoet.atlassian.net/browse/MAILPOET-5887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ