### PR TITLE
Render forms on empty product pages [MAILPOET-5859]

### DIFF
--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -130,7 +130,7 @@ class DisplayFormInWPContent {
    * @return void
    */
   public function maybeRenderFormsInFooter(): void {
-    if ($this->wp->isArchive() || $this->wp->isFrontPage() || $this->wp->isHome()) {
+    if ($this->wp->isArchive() || $this->wp->isFrontPage() || $this->wp->isHome() || $this->isWooProductPageWithoutContent()) {
       $formMarkup = $this->getFormMarkup();
       if (!empty($formMarkup)) {
         $this->assetsController->setupFrontEndDependencies();
@@ -139,6 +139,20 @@ class DisplayFormInWPContent {
         echo $formMarkup;
       }
     }
+  }
+
+  /**
+   * @return bool
+   */
+  public function isWooProductPageWithoutContent(): bool {
+    if (
+      !$this->wp->isSingular('product')
+      || !$this->wp->didAction('wp_footer')
+    ) {
+      return false;
+    }
+
+    return !$this->wp->didFilter('the_content');
   }
 
   private function shouldDisplay(): bool {

--- a/mailpoet/lib/Form/DisplayFormInWPContent.php
+++ b/mailpoet/lib/Form/DisplayFormInWPContent.php
@@ -152,7 +152,7 @@ class DisplayFormInWPContent {
       return false;
     }
 
-    return !$this->wp->didFilter('the_content');
+    return $this->wp->getTheContent() === '';
   }
 
   private function shouldDisplay(): bool {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -957,4 +957,8 @@ class Functions {
   public function wpStripAllTags($string, $removeBreaks = false): string {
     return wp_strip_all_tags($string, $removeBreaks);
   }
+
+  public function getTheContent($more_link_text = null, $strip_teaser = false, $post = null) {
+    return get_the_content($more_link_text, $strip_teaser, $post);
+  }
 }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -41,6 +41,14 @@ class Functions {
     return did_action($hookName);
   }
 
+  /**
+   * @param string $hookName
+   * @return int
+   */
+  public function didFilter($hookName) {
+    return did_filter($hookName);
+  }
+
   public function trailingslashit(string $url) {
     return trailingslashit($url);
   }

--- a/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
+++ b/mailpoet/tests/unit/Form/DisplayFormInWPContentTest.php
@@ -898,7 +898,7 @@ class DisplayFormInWPContentTest extends \MailPoetUnitTest {
     $formHtml = '<form id="test-form"></form>';
     $this->wp->expects($this->any())->method('isSingular')->willReturn(true);
     $this->wp->expects($this->once())->method('didAction')->with($this->equalTo('wp_footer'))->willReturn(true);
-    $this->wp->expects($this->once())->method('didFilter')->with($this->equalTo('the_content'))->willReturn(false);
+    $this->wp->expects($this->once())->method('getTheContent')->willReturn('');
     $this->assetsController->expects($this->once())->method('setupFrontEndDependencies');
     $this->templateRenderer->expects($this->once())->method('render')->willReturn($formHtml);
     $this->wp


### PR DESCRIPTION
## Description

The current logic for form rendering assumes that a single product page will trigger the filter `the_content`. This is not always true. In cases where the product has no description, WooCommerce does not render the description tab at all, which is where that filter usually fires (in my testing).

This change ensures that we still give these forms a chance to render on such pages.

## Code review notes

_N/A_

## QA notes

This does not make the "Below pages" placement option work for product pages without content because they don't render any content. This seems reasonable to me.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5859](https://mailpoet.atlassian.net/browse/MAILPOET-5859)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5859]: https://mailpoet.atlassian.net/browse/MAILPOET-5859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ