### PR TITLE
Keep track of onboarding progress [MAILPOET-5216]

### DIFF
--- a/mailpoet/assets/css/src/components/_steps.scss
+++ b/mailpoet/assets/css/src/components/_steps.scss
@@ -72,6 +72,10 @@
   .mailpoet-step-done & {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='6' viewBox='0 0 6 6'%3E%3Cpath fill='%237ED321' fill-rule='nonzero' d='M4.647.319c.246-.35.715-.423 1.048-.165.334.257.404.75.158 1.098L3.084 5.181c-.28.397-.835.429-1.154.066L.199 3.283c-.281-.319-.262-.816.042-1.11.305-.295.78-.275 1.06.044l1.115 1.266L4.646.319z' /%3E%3C/svg%3E%0A");
   }
+
+  &.mailpoet-step-badge-has-callback {
+    cursor: pointer;
+  }
 }
 
 .mailpoet-step-title {

--- a/mailpoet/assets/js/src/common/steps/steps.tsx
+++ b/mailpoet/assets/js/src/common/steps/steps.tsx
@@ -7,31 +7,49 @@ type Props = {
   count: number;
   current: number;
   titles?: string[];
+  doneCallback?: (step: string) => void;
 };
 
-function StepsComponent({ count, current, titles }: Props) {
+function StepsComponent({ count, current, titles, doneCallback }: Props) {
   return (
     <div className="mailpoet-steps">
       <ContentWrapperFix />
-      {range(1, count + 1).map((i) => (
-        <div
-          key={i}
-          className={classnames('mailpoet-step', {
-            'mailpoet-step-done': i < current,
-            'mailpoet-step-active': i === current,
-          })}
-        >
-          <div className="mailpoet-step-badge">{i >= current ? i : ''}</div>
-          {titles[i - 1] && (
-            <div
-              className="mailpoet-step-title"
-              data-title={titles[i - 1] || ''}
+      {range(1, count + 1).map((i) => {
+        const isDone = i < current;
+        const BadgeComponent = isDone && doneCallback ? 'button' : 'div';
+
+        return (
+          <div
+            key={i}
+            className={classnames('mailpoet-step', {
+              'mailpoet-step-done': isDone,
+              'mailpoet-step-active': i === current,
+            })}
+          >
+            <BadgeComponent
+              className={classnames('mailpoet-step-badge', {
+                'mailpoet-step-badge-has-callback': isDone && doneCallback,
+              })}
+              onClick={() => {
+                if (isDone && doneCallback) {
+                  doneCallback(i.toString());
+                }
+              }}
+              {...(isDone && doneCallback ? { type: 'button' } : {})}
             >
-              {titles[i - 1] || ''}
-            </div>
-          )}
-        </div>
-      ))}
+              {i >= current ? i : ''}
+            </BadgeComponent>
+            {titles[i - 1] && (
+              <div
+                className="mailpoet-step-title"
+                data-title={titles[i - 1] || ''}
+              >
+                {titles[i - 1] || ''}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -190,6 +190,7 @@ interface Window {
     forceUpdate: () => void;
   };
   mailpoet_welcome_wizard_url: string;
+  mailpoet_welcome_wizard_current_step: string;
   mailpoet_homepage_data: {
     taskListDismissed: boolean;
     productDiscoveryDismissed: boolean;

--- a/mailpoet/assets/js/src/landingpage/footer.tsx
+++ b/mailpoet/assets/js/src/landingpage/footer.tsx
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from 'common';
 import { Heading } from 'common/typography/heading/heading';
-import { redirectToWelcomeWizard } from './util';
+import { WelcomeWizardButton } from './welcome-wizard-button';
 
 function Footer() {
   return (
@@ -11,9 +10,7 @@ function Footer() {
           {' '}
           {__('Ready to start using MailPoet?', 'mailpoet')}{' '}
         </Heading>
-        <Button onClick={redirectToWelcomeWizard} dimension="hero">
-          {__('Begin setup', 'mailpoet')}
-        </Button>
+        <WelcomeWizardButton />
       </div>
     </section>
   );

--- a/mailpoet/assets/js/src/landingpage/header.tsx
+++ b/mailpoet/assets/js/src/landingpage/header.tsx
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from 'common';
 import { Heading } from 'common/typography/heading/heading';
-import { redirectToWelcomeWizard } from './util';
+import { WelcomeWizardButton } from './welcome-wizard-button';
 
 function Header() {
   return (
@@ -16,9 +15,7 @@ function Header() {
             'mailpoet',
           )}
         </p>
-        <Button onClick={redirectToWelcomeWizard} dimension="hero">
-          {__('Begin setup', 'mailpoet')}
-        </Button>
+        <WelcomeWizardButton />
       </div>
     </section>
   );

--- a/mailpoet/assets/js/src/landingpage/welcome-wizard-button.tsx
+++ b/mailpoet/assets/js/src/landingpage/welcome-wizard-button.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { Button } from '../common';
+import { redirectToWelcomeWizard } from './util';
+
+export function WelcomeWizardButton() {
+  const savedStep = window.mailpoet_welcome_wizard_current_step;
+  const userHasStarted =
+    typeof savedStep === 'string' && savedStep.startsWith('/steps');
+
+  return (
+    <Button onClick={redirectToWelcomeWizard} dimension="hero">
+      {userHasStarted
+        ? __('Continue setup', 'mailpoet')
+        : __('Begin setup', 'mailpoet')}
+    </Button>
+  );
+}

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -219,6 +219,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
       }),
     }),
     authorized_emails_addresses_check: asIs,
+    welcome_wizard_current_step: asString(''),
   });
   return settingsSchema(data) as Settings;
 }

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -148,6 +148,7 @@ export type Settings = {
     }>;
   };
   woocommerce_import_screen_displayed: '1' | '';
+  welcome_wizard_current_step?: string;
 };
 type Segment = {
   id: string;

--- a/mailpoet/assets/js/src/wizard/finish-wizard.ts
+++ b/mailpoet/assets/js/src/wizard/finish-wizard.ts
@@ -4,6 +4,7 @@ export async function finishWizard(redirect_url = null) {
   await updateSettings({
     version: window.mailpoet_version,
     installed_after_new_domain_restrictions: 1,
+    welcome_wizard_current_step: '',
   });
   if (redirect_url) {
     window.location.href = redirect_url;

--- a/mailpoet/assets/js/src/wizard/navigate-to-path.tsx
+++ b/mailpoet/assets/js/src/wizard/navigate-to-path.tsx
@@ -1,0 +1,15 @@
+import { History } from 'history';
+import { updateSettings } from './update-settings';
+
+export const navigateToPath = (
+  history: History,
+  path: string,
+  replaceCurrent = false,
+) => {
+  void updateSettings({ welcome_wizard_current_step: path });
+  if (replaceCurrent) {
+    history.replace(path);
+  } else {
+    history.push(path);
+  }
+};

--- a/mailpoet/assets/js/src/wizard/steps-numbers.ts
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.ts
@@ -1,3 +1,5 @@
+import { updateSettings } from './update-settings';
+
 const getSteps = (): string[] => {
   const steps = ['WelcomeWizardSenderStep'];
   if (!window.mailpoet_is_dotcom) {
@@ -17,15 +19,29 @@ export const getStepsCount = (): number => getSteps().length;
 export const mapStepNumberToStepName = (stepNumber: number): string | null =>
   getSteps()[stepNumber - 1] || null;
 
-export const redirectToNextStep = (
-  history: { push: (string) => void },
+export const navigateToPath = async (history: {
+  push: (string) => void,
+  replace: (string) => void
+}, path: string, replaceCurrent = false) => {
+  await updateSettings({ welcome_wizard_current_step: path });
+  if (replaceCurrent) {
+    history.replace(path);
+  } else {
+    history.push(path);
+  }
+}
+
+export const redirectToNextStep = async (
+  history: { push: (string) => void, replace: (string) => void },
   finishWizard: () => void,
   currentStep: number,
-): void => {
+) => {
   const stepsCount = getStepsCount();
   if (currentStep < stepsCount) {
-    history.push(`/steps/${currentStep + 1}`);
+    const nextPath = `/steps/${currentStep + 1}`;
+    await navigateToPath(history, nextPath);
   } else {
     finishWizard();
   }
 };
+

--- a/mailpoet/assets/js/src/wizard/steps-numbers.ts
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.ts
@@ -1,3 +1,4 @@
+import { History } from 'history';
 import { updateSettings } from './update-settings';
 
 const getSteps = (): string[] => {
@@ -19,10 +20,7 @@ export const getStepsCount = (): number => getSteps().length;
 export const mapStepNumberToStepName = (stepNumber: number): string | null =>
   getSteps()[stepNumber - 1] || null;
 
-export const navigateToPath = async (history: {
-  push: (string) => void,
-  replace: (string) => void
-}, path: string, replaceCurrent = false) => {
+export const navigateToPath = async (history: History, path: string, replaceCurrent = false) => {
   await updateSettings({ welcome_wizard_current_step: path });
   if (replaceCurrent) {
     history.replace(path);
@@ -32,7 +30,7 @@ export const navigateToPath = async (history: {
 }
 
 export const redirectToNextStep = async (
-  history: { push: (string) => void, replace: (string) => void },
+  history: History,
   finishWizard: () => void,
   currentStep: number,
 ) => {

--- a/mailpoet/assets/js/src/wizard/steps-numbers.ts
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.ts
@@ -1,5 +1,5 @@
 import { History } from 'history';
-import { updateSettings } from './update-settings';
+import { navigateToPath } from './navigate-to-path';
 
 const getSteps = (): string[] => {
   const steps = ['WelcomeWizardSenderStep'];
@@ -19,19 +19,6 @@ export const getStepsCount = (): number => getSteps().length;
 
 export const mapStepNumberToStepName = (stepNumber: number): string | null =>
   getSteps()[stepNumber - 1] || null;
-
-export const navigateToPath = (
-  history: History,
-  path: string,
-  replaceCurrent = false,
-) => {
-  void updateSettings({ welcome_wizard_current_step: path });
-  if (replaceCurrent) {
-    history.replace(path);
-  } else {
-    history.push(path);
-  }
-};
 
 export const redirectToNextStep = async (
   history: History,

--- a/mailpoet/assets/js/src/wizard/steps-numbers.ts
+++ b/mailpoet/assets/js/src/wizard/steps-numbers.ts
@@ -20,14 +20,18 @@ export const getStepsCount = (): number => getSteps().length;
 export const mapStepNumberToStepName = (stepNumber: number): string | null =>
   getSteps()[stepNumber - 1] || null;
 
-export const navigateToPath = async (history: History, path: string, replaceCurrent = false) => {
-  await updateSettings({ welcome_wizard_current_step: path });
+export const navigateToPath = (
+  history: History,
+  path: string,
+  replaceCurrent = false,
+) => {
+  void updateSettings({ welcome_wizard_current_step: path });
   if (replaceCurrent) {
     history.replace(path);
   } else {
     history.push(path);
   }
-}
+};
 
 export const redirectToNextStep = async (
   history: History,
@@ -37,9 +41,8 @@ export const redirectToNextStep = async (
   const stepsCount = getStepsCount();
   if (currentStep < stepsCount) {
     const nextPath = `/steps/${currentStep + 1}`;
-    await navigateToPath(history, nextPath);
+    navigateToPath(history, nextPath);
   } else {
     finishWizard();
   }
 };
-

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
@@ -10,7 +10,7 @@ import { useEffect } from 'react';
 import { MSSStepFirstPart } from './pitch-mss-step/first-part';
 import { MSSStepSecondPart } from './pitch-mss-step/second-part';
 import { MSSStepThirdPart } from './pitch-mss-step/third-part';
-import { navigateToPath } from '../steps-numbers';
+import { navigateToPath } from '../navigate-to-path';
 
 function WelcomeWizardPitchMSSStep(): JSX.Element {
   const { path } = useRouteMatch();

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
@@ -20,7 +20,7 @@ function WelcomeWizardPitchMSSStep(): JSX.Element {
 
   useEffect(() => {
     if (!location.pathname.includes('part')) {
-      navigateToPath(history, `/steps/${step}/part/1`);
+      navigateToPath(history, `/steps/${step}/part/1`, true);
     }
   }, [step, path, history, location]);
 

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
@@ -2,22 +2,30 @@ import {
   useRouteMatch,
   Switch,
   Route,
-  Redirect,
   useParams,
+  useHistory,
+  useLocation,
 } from 'react-router-dom';
+import { useEffect } from 'react';
 import { MSSStepFirstPart } from './pitch-mss-step/first-part';
 import { MSSStepSecondPart } from './pitch-mss-step/second-part';
 import { MSSStepThirdPart } from './pitch-mss-step/third-part';
+import { navigateToPath } from '../steps-numbers';
 
 function WelcomeWizardPitchMSSStep(): JSX.Element {
   const { path } = useRouteMatch();
   const { step } = useParams<{ step: string }>();
+  const history = useHistory();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!location.pathname.includes('part')) {
+      void navigateToPath(history, `/steps/${step}/part/1`);
+    }
+  }, [step, path, history, location]);
 
   return (
     <Switch>
-      <Route exact path={`${path}`}>
-        <Redirect to={`/steps/${step}/part/1`} />
-      </Route>
       <Route path={`${path}/part/1`}>
         <MSSStepFirstPart />
       </Route>

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step.tsx
@@ -20,7 +20,7 @@ function WelcomeWizardPitchMSSStep(): JSX.Element {
 
   useEffect(() => {
     if (!location.pathname.includes('part')) {
-      void navigateToPath(history, `/steps/${step}/part/1`);
+      navigateToPath(history, `/steps/${step}/part/1`);
     }
   }, [step, path, history, location]);
 

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
@@ -4,16 +4,18 @@ import { external, Icon } from '@wordpress/icons';
 import { Heading } from 'common/typography/heading/heading';
 import { MailPoet } from 'mailpoet';
 import { Button, List } from 'common';
+import { History } from 'history';
 import { OwnEmailServiceNote } from './own-email-service-note';
 import { useSelector } from '../../../settings/store/hooks';
+import { navigateToPath } from '../../steps-numbers';
 
 const mailpoetAccountUrl =
   'https://account.mailpoet.com/?ref=plugin-wizard&utm_source=plugin&utm_medium=onboarding&utm_campaign=purchase';
 
-function openMailPoetShopAndGoToTheNextPart(event, history, step: string) {
+function openMailPoetShopAndGoToTheNextPart(event, history: History, step: string) {
   event.preventDefault();
   window.open(mailpoetAccountUrl);
-  history.push(`/steps/${step}/part/2`);
+  void navigateToPath(history, `/steps/${step}/part/2`);
 }
 
 function MSSStepFirstPart(): JSX.Element {
@@ -23,7 +25,7 @@ function MSSStepFirstPart(): JSX.Element {
 
   useEffect(() => {
     if (state.isKeyValid === true) {
-      history.replace(`/steps/${step}/part/3`);
+      void navigateToPath(history, `/steps/${step}/part/3`, true);
     }
   }, [state.isKeyValid, history, step]);
 

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
@@ -7,7 +7,7 @@ import { Button, List } from 'common';
 import { History } from 'history';
 import { OwnEmailServiceNote } from './own-email-service-note';
 import { useSelector } from '../../../settings/store/hooks';
-import { navigateToPath } from '../../steps-numbers';
+import { navigateToPath } from '../../navigate-to-path';
 
 const mailpoetAccountUrl =
   'https://account.mailpoet.com/?ref=plugin-wizard&utm_source=plugin&utm_medium=onboarding&utm_campaign=purchase';

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
@@ -12,10 +12,14 @@ import { navigateToPath } from '../../steps-numbers';
 const mailpoetAccountUrl =
   'https://account.mailpoet.com/?ref=plugin-wizard&utm_source=plugin&utm_medium=onboarding&utm_campaign=purchase';
 
-function openMailPoetShopAndGoToTheNextPart(event, history: History, step: string) {
+function openMailPoetShopAndGoToTheNextPart(
+  event,
+  history: History,
+  step: string,
+) {
   event.preventDefault();
   window.open(mailpoetAccountUrl);
-  void navigateToPath(history, `/steps/${step}/part/2`);
+  navigateToPath(history, `/steps/${step}/part/2`);
 }
 
 function MSSStepFirstPart(): JSX.Element {
@@ -25,7 +29,7 @@ function MSSStepFirstPart(): JSX.Element {
 
   useEffect(() => {
     if (state.isKeyValid === true) {
-      void navigateToPath(history, `/steps/${step}/part/3`, true);
+      navigateToPath(history, `/steps/${step}/part/3`, true);
     }
   }, [state.isKeyValid, history, step]);
 

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
@@ -7,6 +7,7 @@ import { KeyInput } from 'common/premium-key/key-input';
 import { useEffect } from 'react';
 import { useSelector } from 'settings/store/hooks';
 import { OwnEmailServiceNote } from './own-email-service-note';
+import { navigateToPath } from '../../steps-numbers';
 
 function MSSStepSecondPart(): JSX.Element {
   const history = useHistory();
@@ -15,7 +16,7 @@ function MSSStepSecondPart(): JSX.Element {
 
   useEffect(() => {
     if (state.isKeyValid === true) {
-      history.push(`/steps/${step}/part/3`);
+      void navigateToPath(history, `/steps/${step}/part/3`, true);
     }
   }, [state.isKeyValid, history, step]);
 

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
@@ -16,7 +16,7 @@ function MSSStepSecondPart(): JSX.Element {
 
   useEffect(() => {
     if (state.isKeyValid === true) {
-      void navigateToPath(history, `/steps/${step}/part/3`, true);
+      navigateToPath(history, `/steps/${step}/part/3`, true);
     }
   }, [state.isKeyValid, history, step]);
 

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
@@ -7,7 +7,7 @@ import { KeyInput } from 'common/premium-key/key-input';
 import { useEffect } from 'react';
 import { useSelector } from 'settings/store/hooks';
 import { OwnEmailServiceNote } from './own-email-service-note';
-import { navigateToPath } from '../../steps-numbers';
+import { navigateToPath } from '../../navigate-to-path';
 
 function MSSStepSecondPart(): JSX.Element {
   const history = useHistory();

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -3,6 +3,7 @@ import { useSetting } from 'settings/store/hooks';
 import { Settings } from 'settings/store/types';
 import { partial } from 'underscore';
 
+import { History } from 'history';
 import { WelcomeWizardSenderStep } from './steps/sender-step';
 import { WelcomeWizardUsageTrackingStep } from './steps/usage-tracking-step';
 import { WelcomeWizardPitchMSSStep } from './steps/pitch-mss-step';
@@ -12,7 +13,7 @@ import { WelcomeWizardStepLayout } from './layout/step-layout.jsx';
 import { createSenderSettings } from './create-sender-settings.jsx';
 import {
   getStepsCount,
-  mapStepNumberToStepName,
+  mapStepNumberToStepName, navigateToPath,
   redirectToNextStep,
 } from './steps-numbers';
 import { Steps } from '../common/steps/steps';
@@ -25,7 +26,7 @@ import { updateSettings } from './update-settings';
 
 type WelcomeWizardStepsControllerPropType = {
   match: { params: { step: string } };
-  history: { push: (string) => void };
+  history: History;
 };
 
 function WelcomeWizardStepsController({
@@ -42,7 +43,7 @@ function WelcomeWizardStepsController({
 
   useEffect(() => {
     if (step > stepsCount || step < 1) {
-      history.push('/steps/1');
+      void navigateToPath(history, '/steps/1');
     }
   }, [step, stepsCount, history]);
 

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -14,7 +14,6 @@ import { createSenderSettings } from './create-sender-settings.jsx';
 import {
   getStepsCount,
   mapStepNumberToStepName,
-  navigateToPath,
   redirectToNextStep,
 } from './steps-numbers';
 import { Steps } from '../common/steps/steps';
@@ -24,6 +23,7 @@ import { ErrorBoundary } from '../common';
 import { HideScreenOptions } from '../common/hide-screen-options/hide-screen-options';
 import { finishWizard } from './finish-wizard';
 import { updateSettings } from './update-settings';
+import { navigateToPath } from './navigate-to-path';
 
 type WelcomeWizardStepsControllerPropType = {
   match: { params: { step: string } };

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -13,7 +13,8 @@ import { WelcomeWizardStepLayout } from './layout/step-layout.jsx';
 import { createSenderSettings } from './create-sender-settings.jsx';
 import {
   getStepsCount,
-  mapStepNumberToStepName, navigateToPath,
+  mapStepNumberToStepName,
+  navigateToPath,
   redirectToNextStep,
 } from './steps-numbers';
 import { Steps } from '../common/steps/steps';
@@ -43,7 +44,7 @@ function WelcomeWizardStepsController({
 
   useEffect(() => {
     if (step > stepsCount || step < 1) {
-      void navigateToPath(history, '/steps/1');
+      navigateToPath(history, '/steps/1');
     }
   }, [step, stepsCount, history]);
 

--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -121,7 +121,13 @@ function WelcomeWizardStepsController({
     <>
       <HideScreenOptions />
       <TopBar logoWithLink={false}>
-        <Steps count={stepsCount} current={step} />
+        <Steps
+          count={stepsCount}
+          current={step}
+          doneCallback={(stepString: string) => {
+            navigateToPath(history, `/steps/${stepString}`);
+          }}
+        />
       </TopBar>
       <StepsContent>
         {stepName === 'WelcomeWizardSenderStep' ? (

--- a/mailpoet/assets/js/src/wizard/wizard.tsx
+++ b/mailpoet/assets/js/src/wizard/wizard.tsx
@@ -3,12 +3,17 @@ import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { initStore as initSettingsStore } from 'settings/store';
+import { useSetting } from 'settings/store/hooks';
 import { WooCommerceController } from './woocommerce-controller';
 import { registerTranslations, withBoundary } from '../common';
 import { WelcomeWizardStepsController } from './welcome-wizard-controller';
 
 function App(): JSX.Element {
   let basePath = '/steps/1';
+  const [savedStep] = useSetting('welcome_wizard_current_step');
+  if (typeof savedStep === 'string' && savedStep.startsWith('/steps')) {
+    basePath = savedStep;
+  }
   if (window.location.search.includes('woocommerce-setup')) {
     basePath = '/woocommerce';
   }

--- a/mailpoet/assets/js/src/wizard/wizard.tsx
+++ b/mailpoet/assets/js/src/wizard/wizard.tsx
@@ -3,14 +3,13 @@ import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context';
 import { Notices } from 'notices/notices.jsx';
 import { initStore as initSettingsStore } from 'settings/store';
-import { useSetting } from 'settings/store/hooks';
 import { WooCommerceController } from './woocommerce-controller';
 import { registerTranslations, withBoundary } from '../common';
 import { WelcomeWizardStepsController } from './welcome-wizard-controller';
 
 function App(): JSX.Element {
   let basePath = '/steps/1';
-  const [savedStep] = useSetting('welcome_wizard_current_step');
+  const savedStep = window.mailpoet_welcome_wizard_current_step;
   if (typeof savedStep === 'string' && savedStep.startsWith('/steps')) {
     basePath = savedStep;
   }

--- a/mailpoet/lib/AdminPages/Pages/Landingpage.php
+++ b/mailpoet/lib/AdminPages/Pages/Landingpage.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\Menu;
+use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Landingpage {
@@ -13,17 +14,22 @@ class Landingpage {
   /** @var WPFunctions */
   private $wp;
 
+  private SettingsController $settingsController;
+
   public function __construct(
     PageRenderer $pageRenderer,
-    WPFunctions $wp
+    WPFunctions $wp,
+    SettingsController $settingsController
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->wp = $wp;
+    $this->settingsController = $settingsController;
   }
 
   public function render() {
     $data = [
       'welcome_wizard_url' => $this->wp->adminUrl('admin.php?page=' . Menu::WELCOME_WIZARD_PAGE_SLUG),
+      'welcome_wizard_current_step' => $this->settingsController->get('welcome_wizard_current_step', ''),
     ];
     $this->pageRenderer->displayPage('landingpage.html', $data);
   }

--- a/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
+++ b/mailpoet/lib/AdminPages/Pages/WelcomeWizard.php
@@ -73,6 +73,7 @@ class WelcomeWizard {
       'premium_key_valid' => !empty($premiumKeyValid),
       'mss_key_valid' => !empty($mpApiKeyValid),
       'has_tracking_settings' => $this->settings->hasSavedValue('analytics') && $this->settings->hasSavedValue('3rd_party_libs'),
+      'welcome_wizard_current_step' => $this->settings->get('welcome_wizard_current_step', ''),
     ];
     $this->pageRenderer->displayPage('welcome_wizard.html', $data);
   }

--- a/mailpoet/views/landingpage.html
+++ b/mailpoet/views/landingpage.html
@@ -6,6 +6,7 @@
 <script type="text/javascript">
   <% autoescape 'js' %>
     var mailpoet_welcome_wizard_url = <%= json_encode(welcome_wizard_url) %>;
+    var mailpoet_welcome_wizard_current_step = <%= json_encode(welcome_wizard_current_step) %>;
   <% endautoescape %>
 </script>
 <% endblock %>

--- a/mailpoet/views/welcome_wizard.html
+++ b/mailpoet/views/welcome_wizard.html
@@ -1,6 +1,4 @@
-<% extends 'layout.html' %>
-
-<% block content %>
+<% extends 'layout.html' %> <% block content %>
 <script>
   var mailpoet_logo_url = '<%= cdn_url('welcome-wizard/mailpoet-logo.20200623.png') %>';
   var wizard_sender_illustration_url = '<%= cdn_url('welcome-wizard/sender.20200623.png') %>';
@@ -16,12 +14,18 @@
   var mailpoet_premium_key_valid = <%= json_encode(premium_key_valid) %>;
   var mailpoet_mss_key_valid = <%= json_encode(mss_key_valid) %>;
   var wizard_has_tracking_settings = <%= json_encode(has_tracking_settings) %>;
+  var mailpoet_welcome_wizard_current_step = <%= json_encode(welcome_wizard_current_step) %>;
 </script>
 
 <div id="mailpoet-wizard-container"></div>
 
 <div class="mailpoet-wizard-video">
-    <iframe width="1" height="1" src="https://player.vimeo.com/video/279123953" frameborder="0"></iframe>
+  <iframe
+    width="1"
+    height="1"
+    src="https://player.vimeo.com/video/279123953"
+    frameborder="0"
+  ></iframe>
 </div>
 
 <% include 'mss_pitch_translations.html' %>


### PR DESCRIPTION
## Description

This introduces a new setting to track where a user is in the welcome wizard. If a user closes their browser before completing the welcome wizard and returns via the button on the landing page, they should be taken back to the last step they were looking at.

I also updated the button on the landing page so it will say "Continue setup" instead of "Begin setup" for these cases.

I didn't want it to be impossible to return to a previous step without changing the url manually, so I updated the steps component to allow clicking to return to previous steps.

## Code review notes

I ran into an annoying issue where including `useSetting` in the main welcome wizard app was causing a re-render every time state changed, e.g. typing a letter in an input field. This was causing the input to lose focus. More details in 0d434bb4e411133d5cfadd24e7ad665abd40d7fb, where I modified the behavior. I would really like to figure out if we can stop `useSetting` from triggering re-renders in general because I think it might be causing unnecessary renders wherever we're using it. I tried a few things but ultimately wasn't successful. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-5216

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
