### PR TITLE
Add new k6 performance tests covering two create automation scenarios welcome & custom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -992,6 +992,7 @@ workflows:
           <<: *slack-fail-post-step
           name: performance_latest
           url: https://mpperftesting.mystagingwebsite.com
+          us: $WP_TEST_PERFORMANCE_US
           pw: $WP_TEST_PERFORMANCE_PW
           scenario: nightlytests
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,6 +517,9 @@ jobs:
       url:
         type: string
         default: 'http://localhost:9500'
+      us:
+        type: string
+        default: 'admin'
       pw:
         type: string
         default: 'password'

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -411,7 +411,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->runTestsInContainer($opts);
   }
 
-  public function testPerformance($path = null, $opts = ['url' => null, 'pw' => null, 'head' => false, 'scenario' => null]) {
+  public function testPerformance($path = null, $opts = ['url' => null, 'us' => null, 'pw' => null, 'head' => false, 'scenario' => null]) {
     $dir = __DIR__;
     if ((getenv('K6_CLOUD_TOKEN')) === false) {
       return $this->collectionBuilder()
@@ -420,6 +420,7 @@ class RoboFile extends \Robo\Tasks {
       ->arg('run')
       ->option('env', 'K6_BROWSER_ENABLED=1')
       ->option('env', 'URL=' . $opts['url'])
+      ->option('env', 'US=' . $opts['us'])
       ->option('env', 'PW=' . $opts['pw'])
       ->option('env', 'K6_BROWSER_HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
       ->option('env', 'K6_BROWSER_TIMEOUT=120s')
@@ -433,6 +434,7 @@ class RoboFile extends \Robo\Tasks {
       ->arg('run')
       ->option('env', 'K6_BROWSER_ENABLED=1')
       ->option('env', 'URL=' . $opts['url'])
+      ->option('env', 'US=' . $opts['us'])
       ->option('env', 'PW=' . $opts['pw'])
       ->option('env', 'HEADLESS=' . ($opts['head'] ? 'false' : 'true'))
       ->option('env', 'SCENARIO=' . $opts['scenario'])

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -8,6 +8,7 @@ export const k6CloudID = __ENV.K6_CLOUD_ID; // eslint-disable-line
 export const fullPageSet = 'true';
 export const screenshotPath = 'tests/performance/_screenshots/';
 
+export const fromName = 'MP Perf Testing';
 export const adminUsername = 'admin';
 export const adminPassword = __ENV.PW || 'password'; // eslint-disable-line
 export const adminEmail = 'test@test.com';

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -9,7 +9,7 @@ export const fullPageSet = 'true';
 export const screenshotPath = 'tests/performance/_screenshots/';
 
 export const fromName = 'MP Perf Testing';
-export const adminUsername = 'admin';
+export const adminUsername = __ENV.US || 'admin'; // eslint-disable-line
 export const adminPassword = __ENV.PW || 'password'; // eslint-disable-line
 export const adminEmail = 'test@test.com';
 

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -23,5 +23,6 @@ export const emailsPageTitle = 'Emails Page';
 export const automationsPageTitle = 'Automations Page';
 export const formsPageTitle = 'Forms Page';
 export const subscribersPageTitle = 'Subscribers Page';
+export const segmentsPageTitle = 'Segments Page';
 export const listsPageTitle = 'Lists Page';
 export const settingsPageTitle = 'Settings Page';

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -31,7 +31,7 @@ export let options = {
   thresholds: {
     browser_web_vital_lcp: ['p(75) < 8000'],
     browser_web_vital_fid: ['p(75) < 300'],
-    browser_web_vital_cls: ['p(75) < 0.25'],
+    browser_web_vital_cls: ['p(75) < 0.60'],
     browser_web_vital_ttfb: ['p(75) < 4000'],
     browser_web_vital_fcp: ['p(75) < 4000'],
     browser_web_vital_inp: ['p(75) < 300'],
@@ -97,6 +97,7 @@ export async function nightly() {
   await newsletterStatistics();
   await newsletterSearching();
   await newsletterSending();
+  await automationCreateCustom();
   await subscribersListing();
   await subscribersFiltering();
   await subscribersAdding();

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -18,6 +18,7 @@ import { newsletterStatistics } from './tests/newsletter-statistics.js';
 import { onboardingWizard } from './tests/onboarding-wizard.js';
 import { subscribersTrashingRestoring } from './tests/subscribers-trashing-restoring.js';
 import { automationCreateCustom } from './tests/automation-create-custom.js';
+import { automationCreateWelcome } from './tests/automation-create-welcome.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -84,6 +85,7 @@ export async function pullRequests() {
   await onboardingWizard();
   await newsletterListing();
   await newsletterSearching();
+  await automationCreateWelcome();
   await listsViewSubscribers();
   await subscribersListing();
   await subscribersFiltering();
@@ -98,6 +100,7 @@ export async function nightly() {
   await newsletterSearching();
   await newsletterSending();
   await automationCreateCustom();
+  await automationCreateWelcome();
   await subscribersListing();
   await subscribersFiltering();
   await subscribersAdding();

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -17,6 +17,7 @@ import { listsComplexSegment } from './tests/lists-complex-segment.js';
 import { newsletterStatistics } from './tests/newsletter-statistics.js';
 import { onboardingWizard } from './tests/onboarding-wizard.js';
 import { subscribersTrashingRestoring } from './tests/subscribers-trashing-restoring.js';
+import { automationCreateCustom } from './tests/automation-create-custom.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {

--- a/mailpoet/tests/performance/tests/automation-create-custom.js
+++ b/mailpoet/tests/performance/tests/automation-create-custom.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  defaultListName,
+  automationsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import { login } from '../utils/helpers.js';
+
+export async function automationCreateCustom() {
+  const page = browser.newPage();
+
+  try {
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the Automations page
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-templates`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Custom_01.png',
+      fullPage: fullPageSet,
+    });
+
+    await page.waitForSelector('.mailpoet-templates-card-grid');
+    await page
+      .locator('//button[text()="Create custom automation"]')
+      .first()
+      .click();
+    await page.waitForSelector(
+      '.mailpoet-automation-editor-step-transition-wrapper',
+    );
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-create-custom: should be able to see Add Trigger button', () => {
+        expect(page.locator('.mailpoet-automation-add-trigger')).to.exist;
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Custom_02.png',
+      fullPage: fullPageSet,
+    });
+
+    await page.locator('.mailpoet-automation-add-trigger').click();
+    await page
+      .locator('.editor-block-list-item-mailpoet:someone-subscribes')
+      .click();
+
+    await page.locator('[placeholder="Any list"]').type(defaultListName);
+    await page.keyboard.press('Enter');
+
+    await page.locator('.mailpoet-automation-editor-add-step-button').click();
+    await page.locator('.editor-block-list-item-mailpoet:add-tag').click();
+
+    await page.locator('[placeholder="Please select a tag"]').type('test');
+    await page.keyboard.press('Enter');
+
+    await page.locator('//button[text()="Activate"]');
+    await page.locator('//button[text()="Activate"]');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-create-custom: should be able to see Automation added message', () => {
+        expect(page.locator('.mailpoet-automation-add-trigger')).to.exist;
+      });
+    });
+
+    page
+      .locator('.components-snackbar__content')
+      .innerText()
+      .to.contain('Automation is now activated!');
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default function automationCreateCustomTest() {
+  automationCreateCustom();
+}

--- a/mailpoet/tests/performance/tests/automation-create-custom.js
+++ b/mailpoet/tests/performance/tests/automation-create-custom.js
@@ -112,8 +112,6 @@ export async function automationCreateCustom() {
     // Activate the automation workflow
     await activateWorkflow(page);
 
-    await page.waitForLoadState('networkidle');
-
     describe(automationsPageTitle, () => {
       describe('automation-create-custom: should be able to see Automation added message', () => {
         expect(

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -79,8 +79,9 @@ export async function automationCreateWelcome() {
     });
 
     // Click Send Email actionable item
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    await page.$$('.mailpoet-automation-editor-step')[1].click();
+    await activateWorkflow(page);
+    await page.waitForSelector('.mailpoet-automation-step-error');
+    await page.$$('.mailpoet-automation-step-error')[0].click();
 
     await designEmailInWorkflow(page);
 
@@ -90,8 +91,9 @@ export async function automationCreateWelcome() {
     });
 
     // Click Follow up email actionable item
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
-    await page.$$('.mailpoet-automation-editor-step')[3].click();
+    await activateWorkflow(page);
+    await page.waitForSelector('.mailpoet-automation-step-error');
+    await page.locator('.mailpoet-automation-step-error').click();
 
     await designEmailInWorkflow(page);
 
@@ -102,8 +104,6 @@ export async function automationCreateWelcome() {
 
     // Activate the automation workflow
     await activateWorkflow(page);
-
-    await page.waitForLoadState('networkidle');
 
     describe(automationsPageTitle, () => {
       describe('automation-create-welcome: should be able to see Automation added message', () => {
@@ -117,11 +117,6 @@ export async function automationCreateWelcome() {
       path: screenshotPath + 'Automation_Create_Welcome_05.png',
       fullPage: fullPageSet,
     });
-
-    // Go to Automations listing to measure performance from workflow to listing
-    await page.locator('.is-secondary').click();
-    await waitForSelectorToBeVisible(page, '.wp-heading-inline');
-    await page.waitForLoadState('networkidle');
 
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -78,27 +78,28 @@ export async function automationCreateWelcome() {
       fullPage: fullPageSet,
     });
 
-    // Click Send Email actionable item
-    await activateWorkflow(page);
-    await page.waitForSelector('.mailpoet-automation-step-error');
-    await page.$$('.mailpoet-automation-step-error')[0].click();
+    if (page.url().includes('localhost')) {
+      // Click Send Email actionable item and design it
+      await activateWorkflow(page);
+      await page.waitForSelector('.mailpoet-automation-errors-header');
+      await page.locator('.mailpoet-automation-step-error').click();
+      await designEmailInWorkflow(page);
+    } else {
+      // Click Send Email actionable item and design it
+      await activateWorkflow(page);
+      await page.waitForSelector('.mailpoet-automation-errors-header');
+      await page.$$('.mailpoet-automation-step-error')[0].click();
+      await designEmailInWorkflow(page);
 
-    await designEmailInWorkflow(page);
+      // Click Follow up email actionable item and design it
+      await activateWorkflow(page);
+      await page.waitForSelector('.mailpoet-automation-errors-header');
+      await page.locator('.mailpoet-automation-step-error').click();
+      await designEmailInWorkflow(page);
+    }
 
     await page.screenshot({
       path: screenshotPath + 'Automation_Create_Welcome_03.png',
-      fullPage: fullPageSet,
-    });
-
-    // Click Follow up email actionable item
-    await activateWorkflow(page);
-    await page.waitForSelector('.mailpoet-automation-step-error');
-    await page.locator('.mailpoet-automation-step-error').click();
-
-    await designEmailInWorkflow(page);
-
-    await page.screenshot({
-      path: screenshotPath + 'Automation_Create_Welcome_04.png',
       fullPage: fullPageSet,
     });
 
@@ -114,7 +115,7 @@ export async function automationCreateWelcome() {
     });
 
     await page.screenshot({
-      path: screenshotPath + 'Automation_Create_Welcome_05.png',
+      path: screenshotPath + 'Automation_Create_Welcome_04.png',
       fullPage: fullPageSet,
     });
 

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  automationsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import {
+  login,
+  activateWorkflow,
+  waitForSelectorToBeVisible,
+  designEmailInWorkflow,
+} from '../utils/helpers.js';
+
+export async function automationCreateWelcome() {
+  const page = browser.newPage();
+
+  try {
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the Automations page
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-templates`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    // Wait for page to load and for template to show up
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('.mailpoet-templates-card-grid');
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Welcome_01.png',
+      fullPage: fullPageSet,
+    });
+
+    // Click on the Welcome tab and then choose the first template
+    await page.locator('#tab-panel-0-welcome').click();
+    await page.waitForLoadState('networkidle');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await waitForSelectorToBeVisible(
+      page,
+      '.mailpoet-automation-template-detail-content',
+    );
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('.components-button.is-primary').click(),
+    ]);
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-create-welcome: should be able to see items in the workflow', () => {
+        expect(page.locator('.mailpoet-automation-editor-automation-row')).to
+          .exist;
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Welcome_02.png',
+      fullPage: fullPageSet,
+    });
+
+    // Click Send Email actionable item
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await page.$$('.mailpoet-automation-editor-step')[1].click();
+
+    await designEmailInWorkflow(page);
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Welcome_03.png',
+      fullPage: fullPageSet,
+    });
+
+    // Click Follow up email actionable item
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await page.$$('.mailpoet-automation-editor-step')[3].click();
+
+    await designEmailInWorkflow(page);
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Welcome_04.png',
+      fullPage: fullPageSet,
+    });
+
+    // Activate the automation workflow
+    await activateWorkflow(page);
+
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-create-welcome: should be able to see Automation added message', () => {
+        expect(
+          page.locator('.components-snackbar__content').innerText(),
+        ).to.contain('Well done! Automation is now activated!');
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Create_Welcome_05.png',
+      fullPage: fullPageSet,
+    });
+
+    // Go to Automations listing to measure performance from workflow to listing
+    await page.locator('.is-secondary').click();
+    await waitForSelectorToBeVisible(page, '.wp-heading-inline');
+    await page.waitForLoadState('networkidle');
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default function automationCreateWelcomeTest() {
+  automationCreateWelcome();
+}

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -19,6 +19,8 @@ import {
   settingsPageTitle,
   fullPageSet,
   screenshotPath,
+  fromName,
+  adminEmail
 } from '../config.js';
 import { login } from '../utils/helpers.js';
 
@@ -38,6 +40,9 @@ export async function onboardingWizard() {
     );
 
     await page.waitForLoadState('networkidle');
+    await page.waitForSelector('#mailpoet_sender_form');
+    await page.locator('input[name="senderName"]').fill(fromName);
+    await page.locator('input[name="senderAddress"]').fill(adminEmail);
     await page.screenshot({
       path: screenshotPath + 'Onboarding_Wizard_01.png',
       fullPage: fullPageSet,

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -20,7 +20,7 @@ import {
   fullPageSet,
   screenshotPath,
   fromName,
-  adminEmail
+  adminEmail,
 } from '../config.js';
 import { login } from '../utils/helpers.js';
 

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -68,14 +68,8 @@ export async function activateWorkflow(page) {
     page
       .locator('.mailpoet-automation-activate-panel__header-activate-button')
       .click(),
-    page.waitForSelector('.components-snackbar__content'),
+    page.waitForLoadState('networkidle'),
   ]);
-}
-
-// Click button with text
-export async function buttonWithText(page, buttonText) {
-  const button = page.locator(`//button[text()="${buttonText}"]`);
-  await button.click();
 }
 
 // Click to design email in the workflow and save it

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -110,9 +110,7 @@ export async function designEmailInWorkflow(page) {
     .locator('input[value="Save and continue"')
     .waitFor({ state: 'visible' });
   try {
-    await page
-      .locator('#mailpoet_modal_close')
-      .click({ timeout: 5000 });
+    await page.locator('#mailpoet_modal_close').click({ timeout: 5000 });
   } catch (error) {
     console.log("Newsletter tutorial video wasn't present.");
   }

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { baseURL, adminUsername, adminPassword, fromName, adminEmail } from '../config.js';
+import {
+  baseURL,
+  adminUsername,
+  adminPassword,
+  fromName,
+  adminEmail,
+} from '../config.js';
 /* global Promise */
 
 // WordPress login authorization

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -79,17 +79,16 @@ export async function designEmailInWorkflow(page) {
     page.waitForNavigation(),
     page.locator('.mailpoet-automation-button-sidebar-primary').click(),
   ]);
-  await page.waitForLoadState('networkidle');
-  await page.waitForSelector('[data-automation-id="templates-standard"]');
 
   // Switch to a Standard templates tab and select the 2nd template
+  await page.waitForLoadState('networkidle');
   await page.locator('[data-automation-id="templates-standard"]').click();
   await Promise.all([
     page.waitForNavigation(),
     page.locator('[data-automation-id="select_template_1"]').click(),
   ]);
-  await page.waitForSelector('.mailpoet_loading');
   await page.waitForLoadState('networkidle');
+  await page.waitForSelector('input[value="Save and continue"');
 
   // Click to save and get back to the workflow
   await Promise.all([

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { baseURL, adminUsername, adminPassword } from '../config.js';
+import { baseURL, adminUsername, adminPassword, fromName, adminEmail } from '../config.js';
 /* global Promise */
 
 // WordPress login authorization
@@ -74,6 +74,10 @@ export async function activateWorkflow(page) {
 
 // Click to design email in the workflow and save it
 export async function designEmailInWorkflow(page) {
+  // Fill the sender email and name
+  await page.locator('input[type="text"]').fill(fromName);
+  await page.locator('input[type="email"]').fill(adminEmail);
+
   // Click Design automation email button
   await Promise.all([
     page.waitForNavigation(),

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -83,8 +83,17 @@ export async function activateWorkflow(page) {
 // Click to design email in the workflow and save it
 export async function designEmailInWorkflow(page) {
   // Fill the sender email and name
+  await page.locator('input[type="text"]').waitFor({ state: 'visible' });
+  await page.locator('input[type="text"]').dblclick();
   await page.locator('input[type="text"]').fill(fromName);
+  await page.locator('input[type="email"]').dblclick();
   await page.locator('input[type="email"]').fill(adminEmail);
+  await page.locator('input[type="text"]').click();
+
+  await page.screenshot({
+    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,
+    fullPage: fullPageSet,
+  });
 
   // Click Design automation email button
   await Promise.all([
@@ -92,8 +101,14 @@ export async function designEmailInWorkflow(page) {
     page.locator('.mailpoet-automation-button-sidebar-primary').click(),
   ]);
 
-  // Switch to a Standard templates tab and select the 2nd template
   await page.waitForLoadState('networkidle');
+
+  await page.screenshot({
+    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,
+    fullPage: fullPageSet,
+  });
+
+  // Switch to a Standard templates tab and select the 2nd template
   await page
     .locator('[data-automation-id="templates-standard"]')
     .waitFor({ state: 'visible' });
@@ -105,12 +120,17 @@ export async function designEmailInWorkflow(page) {
 
   await page.waitForLoadState('networkidle');
 
+  await page.screenshot({
+    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,
+    fullPage: fullPageSet,
+  });
+
   // Click to save and get back to the workflow
   await page
     .locator('input[value="Save and continue"')
     .waitFor({ state: 'visible' });
   try {
-    await page.locator('#mailpoet_modal_close').click({ timeout: 5000 });
+    await page.locator('#mailpoet_modal_close').click({ timeout: 3000 });
   } catch (error) {
     console.log("Newsletter tutorial video wasn't present.");
   }

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -84,11 +84,9 @@ export async function activateWorkflow(page) {
 export async function designEmailInWorkflow(page) {
   // Fill the sender email and name
   await page.locator('input[type="text"]').waitFor({ state: 'visible' });
-  await page.locator('input[type="text"]').dblclick();
   await page.locator('input[type="text"]').fill(fromName);
-  await page.locator('input[type="email"]').dblclick();
+  await page.locator('input[type="text"]').type(' '); // to avoid flakiness
   await page.locator('input[type="email"]').fill(adminEmail);
-  await page.locator('input[type="text"]').click();
 
   await page.screenshot({
     path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -46,3 +46,28 @@ export async function waitAndClick(page, elementName) {
 export async function waitForSelectorToBeVisible(page, element) {
   await page.locator(element).waitFor({ state: 'visible' });
 }
+
+// Add an item to the automation workflow
+export async function addActionTriggerItemToWorkflow(page, actionName) {
+  await page.locator('.components-search-control__input').type(actionName);
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Enter');
+}
+
+// Add value to an action in automations workflow
+export async function addValueToActionInWorkflow(page, actionValue) {
+  await page.locator('.components-form-token-field__input').type(actionValue);
+  await page.keyboard.press('Enter');
+}
+
+// Activate the automation workflow while in the workflow
+export async function activateWorkflow(page) {
+  await Promise.all([
+    page.locator('.editor-post-publish-button').click(),
+    page
+      .locator('.mailpoet-automation-activate-panel__header-activate-button')
+      .click(),
+    page.waitForSelector('.components-snackbar__content'),
+  ]);
+}

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -7,6 +7,8 @@ import {
   adminPassword,
   fromName,
   adminEmail,
+  fullPageSet,
+  screenshotPath,
 } from '../config.js';
 /* global Promise */
 
@@ -100,12 +102,19 @@ export async function designEmailInWorkflow(page) {
     page.waitForNavigation(),
     page.locator('[data-automation-id="select_template_1"]').click(),
   ]);
+
   await page.waitForLoadState('networkidle');
+
+  // Click to save and get back to the workflow
   await page
     .locator('input[value="Save and continue"')
     .waitFor({ state: 'visible' });
 
-  // Click to save and get back to the workflow
+  await page.screenshot({
+    path: screenshotPath + `Design_Email_In_Workflow_${Math.random()}.png`,
+    fullPage: fullPageSet,
+  });
+
   await Promise.all([
     page.waitForNavigation(),
     page.locator('input[value="Save and continue"').click(),

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -109,11 +109,13 @@ export async function designEmailInWorkflow(page) {
   await page
     .locator('input[value="Save and continue"')
     .waitFor({ state: 'visible' });
-
-  await page.screenshot({
-    path: screenshotPath + `Design_Email_In_Workflow_${Math.random()}.png`,
-    fullPage: fullPageSet,
-  });
+  try {
+    await page
+      .locator('#mailpoet_modal_close')
+      .click({ timeout: 5000 });
+  } catch (error) {
+    console.log("Newsletter tutorial video wasn't present.");
+  }
 
   await Promise.all([
     page.waitForNavigation(),

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -71,3 +71,36 @@ export async function activateWorkflow(page) {
     page.waitForSelector('.components-snackbar__content'),
   ]);
 }
+
+// Click button with text
+export async function buttonWithText(page, buttonText) {
+  const button = page.locator(`//button[text()="${buttonText}"]`);
+  await button.click();
+}
+
+// Click to design email in the workflow and save it
+export async function designEmailInWorkflow(page) {
+  // Click Design automation email button
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('.mailpoet-automation-button-sidebar-primary').click(),
+  ]);
+  await page.waitForLoadState('networkidle');
+  await page.waitForSelector('[data-automation-id="templates-standard"]');
+
+  // Switch to a Standard templates tab and select the 2nd template
+  await page.locator('[data-automation-id="templates-standard"]').click();
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('[data-automation-id="select_template_1"]').click(),
+  ]);
+  await page.waitForSelector('.mailpoet_loading');
+  await page.waitForLoadState('networkidle');
+
+  // Click to save and get back to the workflow
+  await Promise.all([
+    page.waitForNavigation(),
+    page.locator('input[value="Save and continue"').click(),
+  ]);
+  await page.waitForLoadState('networkidle');
+}

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -92,13 +92,18 @@ export async function designEmailInWorkflow(page) {
 
   // Switch to a Standard templates tab and select the 2nd template
   await page.waitForLoadState('networkidle');
+  await page
+    .locator('[data-automation-id="templates-standard"]')
+    .waitFor({ state: 'visible' });
   await page.locator('[data-automation-id="templates-standard"]').click();
   await Promise.all([
     page.waitForNavigation(),
     page.locator('[data-automation-id="select_template_1"]').click(),
   ]);
   await page.waitForLoadState('networkidle');
-  await page.waitForSelector('input[value="Save and continue"');
+  await page
+    .locator('input[value="Save and continue"')
+    .waitFor({ state: 'visible' });
 
   // Click to save and get back to the workflow
   await Promise.all([

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.48.0';
+$version = 'v0.49.0';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Add new performance tests to cover 2 scenarios from the project thread.
- Creating a new automation using custom template button
- Creating a new automation using Welcome template

## Code review notes

I also updated k6 to latest build 0.49 and added `user` parameter to test execution.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5863] & [MAILPOET-5867]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5863]: https://mailpoet.atlassian.net/browse/MAILPOET-5863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5867]: https://mailpoet.atlassian.net/browse/MAILPOET-5867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ