### PR TITLE
Only show tutorial icon on the editor [MAILPOET-5735]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/listings/heading-steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading-steps.tsx
@@ -119,9 +119,8 @@ const stepsListingHeading = (
         {' '}
       </h1>
       <div className="mailpoet-flex-grow" />
-      {!['automation', 'automation_transactional'].includes(emailType) && (
-        <TutorialIcon />
-      )}
+      {!['automation', 'automation_transactional'].includes(emailType) &&
+        step === 3 && <TutorialIcon />}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This is a very quick fix to prevent the tutorial icon from being shown in the header when viewing the templates or the send page.

## Code review notes

This relies on fact that the "Design" step is step 3 for all emails where we want to show the tutorial. I tried passing in the `location` as a prop but it was coming through as undefined and I didn't have time at the end of my week to figure out why.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5735](https://mailpoet.atlassian.net/browse/MAILPOET-5735)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5735]: https://mailpoet.atlassian.net/browse/MAILPOET-5735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ