### PR TITLE
Allow text highlighting in the email editor [MAILPOET-5809]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/rich-text.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/rich-text.ts
@@ -13,9 +13,6 @@ function disableCertainRichTextFormats() {
 
   // remove support for Language - Not supported for now
   unregisterFormatType('core/language');
-
-  // remove support for Highlight - We can't apply inline text colors yet
-  unregisterFormatType('core/text-color');
 }
 
 export { disableCertainRichTextFormats };

--- a/mailpoet/lib/AdminPages/Pages/EmailEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/EmailEditor.php
@@ -65,6 +65,8 @@ class EmailEditor {
 
     // Load CSS from Post Editor
     $this->wp->wpEnqueueStyle('wp-edit-post');
+    // Load CSS for the format library - used for example in popover
+    $this->wp->wpEnqueueStyle('wp-format-library');
 
     // Enqueue media library scripts
     $this->wp->wpEnqueueMedia();

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -337,6 +337,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\EmailEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\EmailApiController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\SettingsController::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -344,7 +344,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Renderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\BlocksRegistry::class)->setPublic(true);
-    $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\PreprocessManager::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ProcessManager::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\Core\Initializer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailApiController::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/HighlightingPostprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/HighlightingPostprocessor.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Renderer\Postprocessors;
+
+/**
+ * This postprocessor replaces <mark> tags with <span> tags because mark tags are not supported across all email clients
+ */
+class HighlightingPostprocessor implements Postprocessor {
+  public function postprocess(string $html): string {
+    return str_replace(
+      ['<mark', '</mark>'],
+      ['<span', '</span>'],
+      $html
+    );
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/Postprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/Postprocessor.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Renderer\Postprocessors;
+
+interface Postprocessor {
+  public function postprocess(string $html): string;
+}

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ProcessManager.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ProcessManager.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\EmailEditor\Engine\Renderer;
 
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor;
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\Postprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\Preprocessor;
@@ -13,18 +15,23 @@ class ProcessManager {
   /** @var Preprocessor[] */
   private $preprocessors = [];
 
+  /** @var Postprocessor[] */
+  private $postprocessors = [];
+
   public function __construct(
     CleanupPreprocessor $cleanupPreprocessor,
     TopLevelPreprocessor $topLevelPreprocessor,
     BlocksWidthPreprocessor $blocksWidthPreprocessor,
     TypographyPreprocessor $typographyPreprocessor,
-    SpacingPreprocessor $spacingPreprocessor
+    SpacingPreprocessor $spacingPreprocessor,
+    HighlightingPostprocessor $highlightingPostprocessor
   ) {
     $this->registerPreprocessor($cleanupPreprocessor);
     $this->registerPreprocessor($topLevelPreprocessor);
     $this->registerPreprocessor($blocksWidthPreprocessor);
     $this->registerPreprocessor($typographyPreprocessor);
     $this->registerPreprocessor($spacingPreprocessor);
+    $this->registerPostprocessor($highlightingPostprocessor);
   }
 
   /**
@@ -39,7 +46,18 @@ class ProcessManager {
     return $parsedBlocks;
   }
 
+  public function postprocess(string $html): string {
+    foreach ($this->postprocessors as $postprocessor) {
+      $html = $postprocessor->postprocess($html);
+    }
+    return $html;
+  }
+
   public function registerPreprocessor(Preprocessor $preprocessor): void {
     $this->preprocessors[] = $preprocessor;
+  }
+
+  public function registerPostprocessor(Postprocessor $postprocessor): void {
+    $this->postprocessors[] = $postprocessor;
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ProcessManager.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ProcessManager.php
@@ -9,7 +9,7 @@ use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TopLevelPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor;
 
-class PreprocessManager {
+class ProcessManager {
   /** @var Preprocessor[] */
   private $preprocessors = [];
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -15,7 +15,7 @@ class Renderer {
   private $blocksRegistry;
 
   /** @var ProcessManager */
-  private $preprocessManager;
+  private $processManager;
 
   /** @var SettingsController */
   private $settingsController;
@@ -33,7 +33,7 @@ class Renderer {
     SettingsController $settingsController
   ) {
     $this->cssInliner = $cssInliner;
-    $this->preprocessManager = $preprocessManager;
+    $this->processManager = $preprocessManager;
     $this->blocksRegistry = $blocksRegistry;
     $this->settingsController = $settingsController;
   }
@@ -46,7 +46,7 @@ class Renderer {
     $themeData = $this->settingsController->getTheme()->get_data();
     $contentBackground = $themeData['styles']['color']['background'] ?? $layoutStyles['background'];
     $contentFontFamily = $themeData['styles']['typography']['fontFamily'];
-    $parsedBlocks = $this->preprocessManager->preprocess($parsedBlocks, $layoutStyles);
+    $parsedBlocks = $this->processManager->preprocess($parsedBlocks, $layoutStyles);
     $renderedBody = $this->renderBlocks($parsedBlocks);
 
     $styles = (string)file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_STYLES_FILE);
@@ -85,7 +85,7 @@ class Renderer {
 
     $templateWithContentsDom = $this->inlineCSSStyles($templateWithContents);
     $templateWithContents = $this->postProcessTemplate($templateWithContentsDom);
-    $templateWithContents = $this->preprocessManager->postprocess($templateWithContents);
+    $templateWithContents = $this->processManager->postprocess($templateWithContents);
     return [
       'html' => $templateWithContents,
       'text' => $this->renderTextVersion($templateWithContents),

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -85,6 +85,7 @@ class Renderer {
 
     $templateWithContentsDom = $this->inlineCSSStyles($templateWithContents);
     $templateWithContents = $this->postProcessTemplate($templateWithContentsDom);
+    $templateWithContents = $this->preprocessManager->postprocess($templateWithContents);
     return [
       'html' => $templateWithContents,
       'text' => $this->renderTextVersion($templateWithContents),

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -136,10 +136,6 @@ class Renderer {
    * @return string
    */
   private function postProcessTemplate(DomNode $templateDom) {
-    // replace spaces in image tag URLs
-    foreach ($templateDom->query('img') as $image) {
-      $image->src = str_replace(' ', '%20', $image->src);
-    }
     // because tburry/pquery contains a bug and replaces the opening non mso condition incorrectly we have to replace the opening tag with correct value
     $template = $templateDom->__toString();
     $template = str_replace('<!--[if !mso]><![endif]-->', '<!--[if !mso]><!-- -->', $template);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -14,7 +14,7 @@ class Renderer {
   /** @var BlocksRegistry */
   private $blocksRegistry;
 
-  /** @var PreprocessManager */
+  /** @var ProcessManager */
   private $preprocessManager;
 
   /** @var SettingsController */
@@ -28,7 +28,7 @@ class Renderer {
    */
   public function __construct(
     \MailPoetVendor\CSS $cssInliner,
-    PreprocessManager $preprocessManager,
+    ProcessManager $preprocessManager,
     BlocksRegistry $blocksRegistry,
     SettingsController $settingsController
   ) {
@@ -109,7 +109,7 @@ class Renderer {
   }
 
   private function injectContentIntoTemplate($template, array $content) {
-    return preg_replace_callback('/{{\w+}}/', function($matches) use (&$content) {
+    return preg_replace_callback('/{{\w+}}/', function ($matches) use (&$content) {
       return array_shift($content);
     }, $template);
   }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/styles.css
@@ -3,6 +3,7 @@
 /* StyleLint is disabled because some rules contain properties that linter marks as unknown, but they are valid for email rendering */
 /* stylelint-disable property-no-unknown */
 body {
+  line-height: 1.4; /* Recommended line-height that is also used in the email editor */
   margin: 0;
   padding: 0;
   -webkit-text-size-adjust: 100%; /* From MJMJ - Automatic test adjustment on mobile max to 100% */

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -10,7 +10,6 @@ use MailPoet\EmailEditor\Engine\SettingsController;
  * @see https://www.activecampaign.com/blog/email-buttons
  * @see https://documentation.mjml.io/#mj-button
  */
-
 class Button implements BlockRenderer {
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
     // Don't render empty buttons
@@ -32,7 +31,7 @@ class Button implements BlockRenderer {
     $markup = str_replace('{classes}', $buttonClasses, $markup);
 
     // Add Link Text
-    $markup = str_replace('{linkText}', $buttonLink->textContent ?: '', $markup);
+    $markup = str_replace('{linkText}', $this->getElementInnerHTML($buttonLink) ?: '', $markup);
     $markup = str_replace('{linkUrl}', $buttonLink->getAttribute('href') ?: '#', $markup);
 
     // Width
@@ -112,5 +111,20 @@ class Button implements BlockRenderer {
           </td>
         </tr>
       </table>';
+  }
+
+  /**
+   * Because the button text can contain highlighted text, we need to get the inner HTML of the button
+   */
+  private function getElementInnerHTML(\DOMElement $element): string {
+    $innerHTML = '';
+    $children = $element->childNodes;
+    foreach ($children as $child) {
+      if (!$child instanceof \DOMNode) continue;
+      $ownerDocument = $child->ownerDocument;
+      if (!$ownerDocument instanceof \DOMDocument) continue;
+      $innerHTML .= $ownerDocument->saveXML($child);
+    }
+    return $innerHTML;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -53,7 +53,7 @@ class Column implements BlockRenderer {
             <tbody>
               <tr>
                 <td align="left" style="font-size:0px;padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';">
-                  <div style="line-height:1;text-align:left;">{column_content}</div>
+                  <div style="text-align:left;">{column_content}</div>
                 </td>
               </tr>
             </tbody>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -41,7 +41,7 @@ class Columns implements BlockRenderer {
     }
 
     return '
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '"><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin-top:' . $marginTop . ';max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
         <table
           align="center"

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Postprocessors/HighlightingPostprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Postprocessors/HighlightingPostprocessorTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Engine\Renderer\Postprocessors;
+
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor;
+
+class HighlightingPostprocessorTest extends \MailPoetUnitTest {
+  /** @var HighlightingPostprocessor */
+  private $postprocessor;
+
+  public function _before() {
+    parent::_before();
+    $this->postprocessor = new HighlightingPostprocessor();
+  }
+
+  public function testItReplacesHtmlElements(): void {
+    $html = '
+      <mark>Some text</mark>
+      <p>Some <mark style="color:red;">paragraph</mark></p>
+      <a href="http://example.com">Some <mark style="font-weight:bold;">link</mark></a>
+    ';
+    $result = $this->postprocessor->postprocess($html);
+    verify($result)->equals('
+      <span>Some text</span>
+      <p>Some <span style="color:red;">paragraph</span></p>
+      <a href="http://example.com">Some <span style="font-weight:bold;">link</span></a>
+    ');
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/ProcessManagerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/ProcessManagerTest.php
@@ -2,14 +2,14 @@
 
 namespace unit\EmailEditor\Engine\Renderer;
 
-use MailPoet\EmailEditor\Engine\Renderer\PreprocessManager;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TopLevelPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\TypographyPreprocessor;
+use MailPoet\EmailEditor\Engine\Renderer\ProcessManager;
 
-class PreprocessManagerTest extends \MailPoetUnitTest {
+class ProcessManagerTest extends \MailPoetUnitTest {
   public function testItCallsPreprocessorsProperly(): void {
     $layoutStyles = [
       'width' => '600px',
@@ -39,7 +39,7 @@ class PreprocessManagerTest extends \MailPoetUnitTest {
     $secondPreprocessor = $this->createMock(TopLevelPreprocessor::class);
     $secondPreprocessor->expects($this->once())->method('preprocess')->willReturn([]);
 
-    $preprocessManager = new PreprocessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing);
+    $preprocessManager = new ProcessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing);
     $preprocessManager->registerPreprocessor($secondPreprocessor);
     verify($preprocessManager->preprocess([], $layoutStyles))->equals([]);
   }

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/ProcessManagerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/ProcessManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace unit\EmailEditor\Engine\Renderer;
 
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
@@ -39,8 +40,12 @@ class ProcessManagerTest extends \MailPoetUnitTest {
     $secondPreprocessor = $this->createMock(TopLevelPreprocessor::class);
     $secondPreprocessor->expects($this->once())->method('preprocess')->willReturn([]);
 
-    $preprocessManager = new ProcessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing);
-    $preprocessManager->registerPreprocessor($secondPreprocessor);
-    verify($preprocessManager->preprocess([], $layoutStyles))->equals([]);
+    $highlighting = $this->createMock(HighlightingPostprocessor::class);
+    $highlighting->expects($this->once())->method('postprocess')->willReturn('');
+
+    $processManager = new ProcessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing, $highlighting);
+    $processManager->registerPreprocessor($secondPreprocessor);
+    verify($processManager->preprocess([], $layoutStyles))->equals([]);
+    verify($processManager->postprocess(''))->equals('');
   }
 }


### PR DESCRIPTION
## Description

This PR reactivates text highlighting in the new email editor.

## Code review notes

- I decided to use post-processing to replace `mark` tags with `span` because it solves replacing for all blocks.
- I fixed some basic line-height styles.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5809]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5809]: https://mailpoet.atlassian.net/browse/MAILPOET-5809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ