### PR TITLE
Enable typography appearance in the email editor [MAILPOET-5840]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -24,7 +24,7 @@
     },
     "typography": {
       "dropCap": false,
-      "fontWeight": false,
+      "fontWeight": true,
       "fontFamilies": [
         {
           "name": "Arial",


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

I tested the enabled typography appearance via Email on Acid, and it seemed to me that everything worked properly.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5840]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5840]: https://mailpoet.atlassian.net/browse/MAILPOET-5840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ