### PR TITLE
Fix encoding issue after using DOMDocument to parse HTML [MAILPOET-5831]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 
 /**
  * Renders a button block.
@@ -17,16 +18,13 @@ class Button implements BlockRenderer {
     if (empty($parsedBlock['innerHTML'])) {
       return '';
     }
-    $buttonDom = new \DOMDocument();
-    $buttonDom->loadHTML($parsedBlock['innerHTML']);
-    $buttonLink = $buttonDom->getElementsByTagName('a')->item(0);
+    $domHelper = new DomDocumentHelper($parsedBlock['innerHTML']);
+    $buttonLink = $domHelper->findElement('a');
 
-    if (!$buttonLink instanceof \DOMElement) {
-      return '';
-    }
+    if (!$buttonLink) return '';
 
-    $buttonOriginalWrapper = $buttonDom->getElementsByTagName('div')->item(0);
-    $buttonClasses = $buttonOriginalWrapper instanceof \DOMElement ? $buttonOriginalWrapper->getAttribute('class') : '';
+    $buttonOriginalWrapper = $domHelper->findElement('div');
+    $buttonClasses = $buttonOriginalWrapper ? $domHelper->getAttributeValue($buttonOriginalWrapper, 'class') : '';
 
     $markup = $this->getMarkup();
     $markup = str_replace('{classes}', $buttonClasses, $markup);

--- a/mailpoet/lib/EmailEditor/Integrations/Utils/DomDocumentHelper.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Utils/DomDocumentHelper.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Utils;
+
+/**
+ * This class should guarantee that our work with the DOMDocument is unified and safe.
+ */
+class DomDocumentHelper {
+  private \DOMDocument $dom;
+
+  public function __construct(
+    string $htmlContent
+  ) {
+    $this->loadHtml($htmlContent);
+  }
+
+  private function loadHtml(string $htmlContent): void {
+    libxml_use_internal_errors(true);
+    $this->dom = new \DOMDocument();
+    if (!empty($htmlContent)) {
+      // prefixing the content with the XML declaration to force the input encoding to UTF-8
+      $this->dom->loadHTML('<?xml encoding="UTF-8">' . $htmlContent, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+    }
+    libxml_clear_errors();
+  }
+
+  public function findElement(string $tagName): ?\DOMElement {
+    $elements = $this->dom->getElementsByTagName($tagName);
+    return $elements->item(0) ?: null;
+  }
+
+  public function getAttributeValue(\DOMElement $element, string $attribute): string {
+    return $element->hasAttribute($attribute) ? $element->getAttribute($attribute) : '';
+  }
+
+  public function getOuterHtml(\DOMElement $element): string {
+    return (string)$this->dom->saveHTML($element);
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Integrations/Utils/DomDocumentHelperTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/Utils/DomDocumentHelperTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Integrations\Utils;
+
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
+
+class DomDocumentHelperTest extends \MailPoetUnitTest {
+  public function testItFindsElement(): void {
+    $html = '<div><p>Some text</p></div>';
+    $domDocumentHelper = new DomDocumentHelper($html);
+    $element = $domDocumentHelper->findElement('p');
+    $empty = $domDocumentHelper->findElement('span');
+    $this->assertInstanceOf(\DOMElement::class, $element);
+    $this->assertEquals('p', $element->tagName);
+    $this->assertNull($empty);
+  }
+
+  public function testItGetsAttributeValue(): void {
+    $html = '<div><p class="some-class">Some text</p></div>';
+    $domDocumentHelper = new DomDocumentHelper($html);
+    $element = $domDocumentHelper->findElement('p');
+    $this->assertInstanceOf(\DOMElement::class, $element);
+    $this->assertEquals('some-class', $domDocumentHelper->getAttributeValue($element, 'class'));
+  }
+
+  public function testItGetsOuterHtml(): void {
+    $html = '<div><span>Some <strong>text</strong></span></div>';
+    $domDocumentHelper = new DomDocumentHelper($html);
+    $element = $domDocumentHelper->findElement('span');
+    $this->assertInstanceOf(\DOMElement::class, $element);
+    $this->assertEquals('<span>Some <strong>text</strong></span>', $domDocumentHelper->getOuterHtml($element));
+
+    // testings encoding of special characters
+    $html = '<div><img src="https://test.com/DALL·E-A®∑oecasƒ-803x1024.jpg"></div>';
+    $domDocumentHelper = new DomDocumentHelper($html);
+    $element = $domDocumentHelper->findElement('img');
+    $this->assertInstanceOf(\DOMElement::class, $element);
+    $this->assertEquals('<img src="https://test.com/DALL%C2%B7E-A%C2%AE%E2%88%91oecas%C6%92-803x1024.jpg">', $domDocumentHelper->getOuterHtml($element));
+  }
+}


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

This PR adds a new class `DomDocumentHelper` that should guarantee unified manipulation with `\DOMDocument` class.
I was also considering a static class, but this solution should offer a better readability and developer experience.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5831]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5831]: https://mailpoet.atlassian.net/browse/MAILPOET-5831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ