### PR TITLE
Use MySQL 8 in nightly latest tests [MAILPOET-5888]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,6 +972,8 @@ workflows:
           woo_memberships_version: latest
           woo_blocks_version: latest
           automate_woo_version: latest
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
           requires:
             - build
       - acceptance_tests:
@@ -1010,6 +1012,8 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_latest
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
           requires:
             - build
       - integration_tests:

--- a/mailpoet/lib/WP/Emoji.php
+++ b/mailpoet/lib/WP/Emoji.php
@@ -48,7 +48,9 @@ class Emoji {
   public function encodeForUTF8Column($table, $field, $value) {
     global $wpdb;
     $charset = $wpdb->get_col_charset($table, $field);
-    if ($charset === 'utf8') {
+    // utf8 doesn't support emojis, so we need to encode them
+    // utf8 was an alias for utf8mb3, but it was dropped in MySQL 8.0.28 so we need to check both
+    if ($charset === 'utf8' || $charset === 'utf8mb3') {
       $value = $this->wp->wpEncodeEmoji($value);
     }
     return $value;


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Here is [a passing nighly test build](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/16972/workflows/7474ac95-f373-4137-9b4f-73d76f0c551b)

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5888]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5888]: https://mailpoet.atlassian.net/browse/MAILPOET-5888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ