### PR TITLE
Fix invalid email address causing failed validation on subsequent flush

### DIFF
--- a/mailpoet/tests/integration/REST/Automation/AutomationTest.php
+++ b/mailpoet/tests/integration/REST/Automation/AutomationTest.php
@@ -16,7 +16,7 @@ abstract class AutomationTest extends Test {
     $userId = wp_create_user(
       'editor',
       'password',
-      'editor@localhost'
+      'editor@localhost.com'
     );
     $this->assertIsNumeric($userId);
     $user = new \WP_User($userId);


### PR DESCRIPTION
## Description

Fix failing unit test in Premium plugin

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5910]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5910]: https://mailpoet.atlassian.net/browse/MAILPOET-5910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ