### PR TITLE
New segment filter purchased with attribute [MAILPOET-5467]

### DIFF
--- a/mailpoet/assets/js/src/analytics.js
+++ b/mailpoet/assets/js/src/analytics.js
@@ -123,6 +123,8 @@ export function mapFilterType(filter) {
         return 'used coupon code';
       case 'numberOfOrders':
         return 'number of orders';
+      case 'purchasedWithAttribute':
+        return 'purchased with attribute';
       default:
         return '';
     }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -57,7 +57,7 @@ export function PurchasedWithAttributeFields({
     productAttributeTermsOptionsRef.current = productAttributes[
       segment.attribute_taxonomy_slug
     ].terms.map((term) => ({
-      value: term.term_id,
+      value: term.term_id.toString(),
       label: term.name,
     }));
   }, [segment.attribute_taxonomy_slug, productAttributes]);

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -18,8 +18,9 @@ export function validatePurchasedWithAttribute(
 ): boolean {
   const purchasedProductWithAttributeIsInvalid =
     !formItems.operator ||
-    formItems.attribute_id === undefined ||
-    formItems.attribute_term_ids === undefined;
+    formItems.attribute_taxonomy_slug === undefined ||
+    !Array.isArray(formItems.attribute_term_ids) === undefined ||
+    formItems.attribute_term_ids.length === 0;
 
   return !purchasedProductWithAttributeIsInvalid;
 }
@@ -40,7 +41,7 @@ export function PurchasedWithAttributeFields({
 
   const productAttributesOptions = Object.values(productAttributes).map(
     (attribute) => ({
-      value: attribute.id,
+      value: attribute.taxonomy,
       label: attribute.label,
     }),
   );
@@ -48,18 +49,18 @@ export function PurchasedWithAttributeFields({
   const productAttributeTermsOptionsRef = useRef(null);
 
   useEffect(() => {
-    if (segment.attribute_id === undefined) {
+    if (segment.attribute_taxonomy_slug === undefined) {
       productAttributeTermsOptionsRef.current = null;
       return;
     }
 
     productAttributeTermsOptionsRef.current = productAttributes[
-      segment.attribute_id
+      segment.attribute_taxonomy_slug
     ].terms.map((term) => ({
       value: term.term_id,
       label: term.name,
     }));
-  }, [segment.attribute_id, productAttributes]);
+  }, [segment.attribute_taxonomy_slug, productAttributes]);
 
   useEffect(() => {
     if (
@@ -91,15 +92,17 @@ export function PurchasedWithAttributeFields({
         placeholder={__('Search attributes', 'mailpoet')}
         options={productAttributesOptions}
         value={filter((productAttributeOption) => {
-          if (segment.attribute_id === undefined) {
+          if (segment.attribute_taxonomy_slug === undefined) {
             return undefined;
           }
-          return segment.attribute_id === productAttributeOption.value;
+          return (
+            segment.attribute_taxonomy_slug === productAttributeOption.value
+          );
         }, productAttributesOptions)}
         onChange={(option: SelectOption): void => {
           void updateSegmentFilter(
             {
-              attribute_id: option.value,
+              attribute_taxonomy_slug: option.value,
               attribute_term_ids: [],
             },
             filterIndex,

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -9,6 +9,7 @@ import {
   AnyValueTypes,
   FilterProps,
   SelectOption,
+  WindowLocalProductAttributes,
   WindowProductAttributes,
   WooCommerceFormItem,
 } from '../../../types';
@@ -18,9 +19,15 @@ export function validatePurchasedWithAttribute(
 ): boolean {
   const purchasedProductWithAttributeIsInvalid =
     !formItems.operator ||
-    formItems.attribute_taxonomy_slug === undefined ||
-    !Array.isArray(formItems.attribute_term_ids) === undefined ||
-    formItems.attribute_term_ids.length === 0;
+    (formItems.attribute_type === 'taxonomy' &&
+      (formItems.attribute_taxonomy_slug === undefined ||
+        !Array.isArray(formItems.attribute_term_ids) ||
+        formItems.attribute_term_ids.length === 0)) ||
+    (formItems.attribute_type === 'local' &&
+      (!formItems.attribute_local_name ||
+        formItems.attribute_local_name.length === 0 ||
+        !Array.isArray(formItems.attribute_local_values) ||
+        formItems.attribute_local_values.length === 0));
 
   return !purchasedProductWithAttributeIsInvalid;
 }
@@ -46,21 +53,61 @@ export function PurchasedWithAttributeFields({
     }),
   );
 
+  const localProductAttributes: WindowLocalProductAttributes = useSelect(
+    (select) => select(storeName).getLocalProductAttributes(),
+    [],
+  );
+
+  const localAttributeOptions = Object.values(localProductAttributes).map(
+    (attribute) => ({
+      // Appending @local to avoid conflicts between taxonomy and local attributes with the same name
+      value: `${attribute.name}@local`,
+      label: attribute.name,
+    }),
+  );
+
+  const localAttributeValues = Object.values(localAttributeOptions).map(
+    (option) => option.value,
+  );
+
+  const combinedOptions = [
+    ...productAttributesOptions,
+    ...localAttributeOptions,
+  ];
+
   const productAttributeTermsOptionsRef = useRef(null);
 
   useEffect(() => {
-    if (segment.attribute_taxonomy_slug === undefined) {
+    if (
+      segment.attribute_taxonomy_slug === undefined &&
+      segment.attribute_local_name === undefined
+    ) {
       productAttributeTermsOptionsRef.current = null;
       return;
     }
 
-    productAttributeTermsOptionsRef.current = productAttributes[
-      segment.attribute_taxonomy_slug
-    ].terms.map((term) => ({
-      value: term.term_id.toString(),
-      label: term.name,
-    }));
-  }, [segment.attribute_taxonomy_slug, productAttributes]);
+    if (segment.attribute_type === 'taxonomy') {
+      productAttributeTermsOptionsRef.current = productAttributes[
+        segment.attribute_taxonomy_slug
+      ].terms.map((term) => ({
+        value: term.term_id.toString(),
+        label: term.name,
+      }));
+    } else if (segment.attribute_type === 'local') {
+      productAttributeTermsOptionsRef.current = localProductAttributes[
+        segment.attribute_local_name
+      ].values.map((value) => ({
+        value,
+        label: value,
+      }));
+    }
+  }, [
+    segment.attribute_taxonomy_slug,
+    segment.attribute_type,
+    segment.attribute_local_name,
+    productAttributes,
+    localProductAttributes,
+  ]);
 
   useEffect(() => {
     if (
@@ -90,23 +137,52 @@ export function PurchasedWithAttributeFields({
         dimension="small"
         key="select-segment-product-attribute"
         placeholder={__('Search attributes', 'mailpoet')}
-        options={productAttributesOptions}
-        value={filter((productAttributeOption) => {
-          if (segment.attribute_taxonomy_slug === undefined) {
-            return undefined;
-          }
-          return (
-            segment.attribute_taxonomy_slug === productAttributeOption.value
-          );
-        }, productAttributesOptions)}
+        options={combinedOptions}
+        value={
+          segment.attribute_type === 'local'
+            ? filter((localAttributeOption) => {
+                if (!segment.attribute_local_name) {
+                  return undefined;
+                }
+                return (
+                  `${segment.attribute_local_name}@local` ===
+                  localAttributeOption.value
+                );
+              }, localAttributeOptions)
+            : filter((productAttributeOption) => {
+                if (segment.attribute_taxonomy_slug === undefined) {
+                  return undefined;
+                }
+                return (
+                  segment.attribute_taxonomy_slug ===
+                  productAttributeOption.value
+                );
+              }, productAttributesOptions)
+        }
         onChange={(option: SelectOption): void => {
-          void updateSegmentFilter(
-            {
-              attribute_taxonomy_slug: option.value,
-              attribute_term_ids: [],
-            },
-            filterIndex,
-          );
+          if (localAttributeValues.includes(option.value)) {
+            void updateSegmentFilter(
+              {
+                attribute_type: 'local',
+                attribute_local_name: option.value.replace(/@local$/, ''),
+                attribute_local_values: [],
+                attribute_taxonomy_slug: null,
+                attribute_term_ids: null,
+              },
+              filterIndex,
+            );
+          } else {
+            void updateSegmentFilter(
+              {
+                attribute_type: 'taxonomy',
+                attribute_local_name: null,
+                attribute_local_values: null,
+                attribute_taxonomy_slug: option.value,
+                attribute_term_ids: [],
+              },
+              filterIndex,
+            );
+          }
         }}
       />
       {productAttributeTermsOptionsRef.current && (
@@ -118,26 +194,46 @@ export function PurchasedWithAttributeFields({
           options={productAttributeTermsOptionsRef.current}
           value={filter(
             (productAttributeTermOption: { value: string; label: string }) => {
-              if (segment.attribute_term_ids === undefined) {
-                return undefined;
+              if (segment.attribute_local_values) {
+                return (
+                  segment.attribute_local_values.indexOf(
+                    productAttributeTermOption.value,
+                  ) !== -1
+                );
               }
-              return (
-                segment.attribute_term_ids.indexOf(
-                  productAttributeTermOption.value,
-                ) !== -1
-              );
+              if (segment.attribute_term_ids) {
+                return (
+                  segment.attribute_term_ids.indexOf(
+                    productAttributeTermOption.value,
+                  ) !== -1
+                );
+              }
+              return undefined;
             },
             productAttributeTermsOptionsRef.current,
           )}
           onChange={(options: SelectOption[]): void => {
-            void updateSegmentFilter(
-              {
-                attribute_term_ids: (options || []).map(
-                  (x: SelectOption) => x.value,
-                ),
-              },
-              filterIndex,
-            );
+            if (segment.attribute_type === 'local') {
+              void updateSegmentFilter(
+                {
+                  attribute_term_ids: null,
+                  attribute_local_values: (options || []).map(
+                    (x: SelectOption) => x.value,
+                  ),
+                },
+                filterIndex,
+              );
+            } else {
+              void updateSegmentFilter(
+                {
+                  attribute_term_ids: (options || []).map(
+                    (x: SelectOption) => x.value,
+                  ),
+                  attribute_local_values: null,
+                },
+                filterIndex,
+              );
+            }
           }}
         />
       )}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -48,10 +48,12 @@ export function PurchasedWithAttributeFields({
 
   const productAttributesOptions = useMemo(
     () =>
-      Object.values(productAttributes).map((attribute) => ({
-        value: attribute.taxonomy,
-        label: attribute.label,
-      })),
+      Object.values(productAttributes)
+        .filter((attribute) => attribute.terms.length > 0)
+        .map((attribute) => ({
+          value: attribute.taxonomy,
+          label: attribute.label,
+        })),
     [productAttributes],
   );
 
@@ -62,11 +64,13 @@ export function PurchasedWithAttributeFields({
 
   const localAttributeOptions = useMemo(
     () =>
-      Object.values(localProductAttributes).map((attribute) => ({
-        // Appending @local to avoid conflicts between taxonomy and local attributes with the same name
-        value: `${attribute.name}@local`,
-        label: attribute.name,
-      })),
+      Object.values(localProductAttributes)
+        .filter((attribute) => attribute.values.length > 0)
+        .map((attribute) => ({
+          // Appending @local to avoid conflicts between taxonomy and local attributes with the same name
+          value: `${attribute.name}@local`,
+          label: attribute.name,
+        })),
     [localProductAttributes],
   );
 

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -79,10 +79,10 @@ export function PurchasedWithAttributeFields({
     [localAttributeOptions],
   );
 
-  const combinedOptions = [
-    ...productAttributesOptions,
-    ...localAttributeOptions,
-  ];
+  const combinedOptions = useMemo(
+    () => [...productAttributesOptions, ...localAttributeOptions],
+    [productAttributesOptions, localAttributeOptions],
+  );
 
   const attributeValueOptions = useMemo(() => {
     if (segment.attribute_type === 'taxonomy') {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -149,7 +149,7 @@ export function PurchasedWithAttributeFields({
     [filterIndex, localAttributeValues, updateSegmentFilter],
   );
 
-  const initialAttributeValue = useMemo(
+  const initialAttribute = useMemo(
     () =>
       segment.attribute_type === 'local'
         ? filter((localAttributeOption) => {
@@ -178,6 +178,32 @@ export function PurchasedWithAttributeFields({
     ],
   );
 
+  const initialAttributeValues = useMemo(
+    () =>
+      filter((productAttributeTermOption: { value: string; label: string }) => {
+        if (segment.attribute_local_values) {
+          return (
+            segment.attribute_local_values.indexOf(
+              productAttributeTermOption.value,
+            ) !== -1
+          );
+        }
+        if (segment.attribute_term_ids) {
+          return (
+            segment.attribute_term_ids.indexOf(
+              productAttributeTermOption.value,
+            ) !== -1
+          );
+        }
+        return undefined;
+      }, attributeValueOptions),
+    [
+      segment.attribute_local_values,
+      segment.attribute_term_ids,
+      attributeValueOptions,
+    ],
+  );
+
   return (
     <>
       <Select
@@ -197,7 +223,7 @@ export function PurchasedWithAttributeFields({
         key="select-segment-product-attribute"
         placeholder={__('Search attributes', 'mailpoet')}
         options={combinedOptions}
-        value={initialAttributeValue}
+        value={initialAttribute}
         onChange={attributeOnChange}
       />
       {attributeValueOptions.length > 0 && (
@@ -207,26 +233,7 @@ export function PurchasedWithAttributeFields({
           key="select-segment-product-attribute-terms"
           placeholder={__('Search attributes terms', 'mailpoet')}
           options={attributeValueOptions}
-          value={filter(
-            (productAttributeTermOption: { value: string; label: string }) => {
-              if (segment.attribute_local_values) {
-                return (
-                  segment.attribute_local_values.indexOf(
-                    productAttributeTermOption.value,
-                  ) !== -1
-                );
-              }
-              if (segment.attribute_term_ids) {
-                return (
-                  segment.attribute_term_ids.indexOf(
-                    productAttributeTermOption.value,
-                  ) !== -1
-                );
-              }
-              return undefined;
-            },
-            attributeValueOptions,
-          )}
+          value={initialAttributeValues}
           onChange={(options: SelectOption[]): void => {
             if (segment.attribute_type === 'local') {
               void updateSegmentFilter(

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -19,7 +19,7 @@ export function validatePurchasedWithAttribute(
   const purchasedProductWithAttributeIsInvalid =
     !formItems.operator ||
     formItems.attribute_id === undefined ||
-    formItems.attribute_term_id === undefined;
+    formItems.attribute_term_ids === undefined;
 
   return !purchasedProductWithAttributeIsInvalid;
 }
@@ -100,6 +100,7 @@ export function PurchasedWithAttributeFields({
           void updateSegmentFilter(
             {
               attribute_id: option.value,
+              attribute_term_ids: [],
             },
             filterIndex,
           );
@@ -108,24 +109,29 @@ export function PurchasedWithAttributeFields({
       {productAttributeTermsOptionsRef.current && (
         <ReactSelect
           dimension="small"
+          isMulti
           key="select-segment-product-attribute-terms"
           placeholder={__('Search attributes terms', 'mailpoet')}
           options={productAttributeTermsOptionsRef.current}
           value={filter(
             (productAttributeTermOption: { value: string; label: string }) => {
-              if (segment.attribute_term_id === undefined) {
+              if (segment.attribute_term_ids === undefined) {
                 return undefined;
               }
               return (
-                segment.attribute_term_id === productAttributeTermOption.value
+                segment.attribute_term_ids.indexOf(
+                  productAttributeTermOption.value,
+                ) !== -1
               );
             },
             productAttributeTermsOptionsRef.current,
           )}
-          onChange={(option: SelectOption): void => {
+          onChange={(options: SelectOption[]): void => {
             void updateSegmentFilter(
               {
-                attribute_term_id: option.value,
+                attribute_term_ids: (options || []).map(
+                  (x: SelectOption) => x.value,
+                ),
               },
               filterIndex,
             );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -19,6 +19,7 @@ export function validatePurchasedWithAttribute(
 ): boolean {
   const purchasedProductWithAttributeIsInvalid =
     !formItems.operator ||
+    !formItems.attribute_type ||
     (formItems.attribute_type === 'taxonomy' &&
       (formItems.attribute_taxonomy_slug === undefined ||
         !Array.isArray(formItems.attribute_term_ids) ||

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -204,6 +204,33 @@ export function PurchasedWithAttributeFields({
     ],
   );
 
+  const attributeValuesOnChange = useCallback(
+    (options: SelectOption[]): void => {
+      if (segment.attribute_type === 'local') {
+        void updateSegmentFilter(
+          {
+            attribute_term_ids: null,
+            attribute_local_values: (options || []).map(
+              (x: SelectOption) => x.value,
+            ),
+          },
+          filterIndex,
+        );
+      } else {
+        void updateSegmentFilter(
+          {
+            attribute_term_ids: (options || []).map(
+              (x: SelectOption) => x.value,
+            ),
+            attribute_local_values: null,
+          },
+          filterIndex,
+        );
+      }
+    },
+    [segment.attribute_type, updateSegmentFilter, filterIndex],
+  );
+
   return (
     <>
       <Select
@@ -234,29 +261,7 @@ export function PurchasedWithAttributeFields({
           placeholder={__('Search attributes terms', 'mailpoet')}
           options={attributeValueOptions}
           value={initialAttributeValues}
-          onChange={(options: SelectOption[]): void => {
-            if (segment.attribute_type === 'local') {
-              void updateSegmentFilter(
-                {
-                  attribute_term_ids: null,
-                  attribute_local_values: (options || []).map(
-                    (x: SelectOption) => x.value,
-                  ),
-                },
-                filterIndex,
-              );
-            } else {
-              void updateSegmentFilter(
-                {
-                  attribute_term_ids: (options || []).map(
-                    (x: SelectOption) => x.value,
-                  ),
-                  attribute_local_values: null,
-                },
-                filterIndex,
-              );
-            }
-          }}
+          onChange={attributeValuesOnChange}
         />
       )}
     </>

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -1,0 +1,137 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
+import { Select } from 'common/form/select/select';
+import { ReactSelect } from 'common/form/react-select/react-select';
+import { filter } from 'lodash/fp';
+import { storeName } from '../../../store';
+import {
+  AnyValueTypes,
+  FilterProps,
+  SelectOption,
+  WindowProductAttributes,
+  WooCommerceFormItem,
+} from '../../../types';
+
+export function validatePurchasedWithAttribute(
+  formItems: WooCommerceFormItem,
+): boolean {
+  const purchasedProductWithAttributeIsInvalid =
+    !formItems.operator ||
+    formItems.attribute_id === undefined ||
+    formItems.attribute_term_id === undefined;
+
+  return !purchasedProductWithAttributeIsInvalid;
+}
+
+export function PurchasedWithAttributeFields({
+  filterIndex,
+}: FilterProps): JSX.Element {
+  const segment: WooCommerceFormItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const { updateSegmentFilter } = useDispatch(storeName);
+
+  const productAttributes: WindowProductAttributes = useSelect(
+    (select) => select(storeName).getProductAttributes(),
+    [],
+  );
+
+  const productAttributesOptions = Object.values(productAttributes).map(
+    (attribute) => ({
+      value: attribute.id,
+      label: attribute.label,
+    }),
+  );
+
+  const productAttributeTermsOptionsRef = useRef(null);
+
+  useEffect(() => {
+    if (segment.attribute_id === undefined) {
+      productAttributeTermsOptionsRef.current = null;
+      return;
+    }
+
+    productAttributeTermsOptionsRef.current = productAttributes[
+      segment.attribute_id
+    ].terms.map((term) => ({
+      value: term.term_id,
+      label: term.name,
+    }));
+  }, [segment.attribute_id, productAttributes]);
+
+  useEffect(() => {
+    if (
+      segment.operator !== AnyValueTypes.ALL &&
+      segment.operator !== AnyValueTypes.ANY &&
+      segment.operator !== AnyValueTypes.NONE
+    ) {
+      void updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
+
+  return (
+    <>
+      <Select
+        key="select-operator"
+        value={segment.operator}
+        isMinWidth
+        onChange={(e): void => {
+          void updateSegmentFilter({ operator: e.target.value }, filterIndex);
+        }}
+      >
+        <option value={AnyValueTypes.ANY}>{__('any of', 'mailpoet')}</option>
+        <option value={AnyValueTypes.ALL}>{__('all of', 'mailpoet')}</option>
+        <option value={AnyValueTypes.NONE}>{__('none of', 'mailpoet')}</option>
+      </Select>
+      <ReactSelect
+        dimension="small"
+        key="select-segment-product-attribute"
+        placeholder={__('Search attributes', 'mailpoet')}
+        options={productAttributesOptions}
+        value={filter((productAttributeOption) => {
+          if (segment.attribute_id === undefined) {
+            return undefined;
+          }
+          return segment.attribute_id === productAttributeOption.value;
+        }, productAttributesOptions)}
+        onChange={(option: SelectOption): void => {
+          void updateSegmentFilter(
+            {
+              attribute_id: option.value,
+            },
+            filterIndex,
+          );
+        }}
+      />
+      {productAttributeTermsOptionsRef.current && (
+        <ReactSelect
+          dimension="small"
+          key="select-segment-product-attribute-terms"
+          placeholder={__('Search attributes terms', 'mailpoet')}
+          options={productAttributeTermsOptionsRef.current}
+          value={filter(
+            (productAttributeTermOption: { value: string; label: string }) => {
+              if (segment.attribute_term_id === undefined) {
+                return undefined;
+              }
+              return (
+                segment.attribute_term_id === productAttributeTermOption.value
+              );
+            },
+            productAttributeTermsOptionsRef.current,
+          )}
+          onChange={(option: SelectOption): void => {
+            void updateSegmentFilter(
+              {
+                attribute_term_id: option.value,
+              },
+              filterIndex,
+            );
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
@@ -10,6 +10,7 @@ export enum WooCommerceActionTypes {
   PURCHASED_CATEGORY = 'purchasedCategory',
   PURCHASE_DATE = 'purchaseDate',
   PURCHASED_PRODUCT = 'purchasedProduct',
+  PURCHASED_WITH_ATTRIBUTE = 'purchasedWithAttribute',
   TOTAL_SPENT = 'totalSpent',
   AVERAGE_SPENT = 'averageSpent',
   CUSTOMER_IN_COUNTRY = 'customerInCountry',
@@ -76,6 +77,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.PURCHASED_PRODUCT,
     label: __('purchased product', 'mailpoet'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.PURCHASED_WITH_ATTRIBUTE,
+    label: __('purchased with attribute', 'mailpoet'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
@@ -51,6 +51,10 @@ import {
   UsedCouponCodeFields,
   validateUsedCouponCode,
 } from './fields/woocommerce/used-coupon-code';
+import {
+  PurchasedWithAttributeFields,
+  validatePurchasedWithAttribute,
+} from './fields/woocommerce/purchased-with-attribute';
 
 export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (
@@ -102,6 +106,9 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   if (formItems.action === WooCommerceActionTypes.FIRST_ORDER) {
     return validateDateField(formItems);
   }
+  if (formItems.action === WooCommerceActionTypes.PURCHASED_WITH_ATTRIBUTE) {
+    return validatePurchasedWithAttribute(formItems);
+  }
   if (
     [
       WooCommerceActionTypes.CUSTOMER_IN_POSTAL_CODE,
@@ -123,6 +130,8 @@ const componentsMap = {
   [WooCommerceActionTypes.PURCHASE_DATE]: DateFieldsDefaultBefore,
   [WooCommerceActionTypes.PURCHASED_PRODUCT]: PurchasedProductFields,
   [WooCommerceActionTypes.PURCHASED_CATEGORY]: PurchasedCategoryFields,
+  [WooCommerceActionTypes.PURCHASED_WITH_ATTRIBUTE]:
+    PurchasedWithAttributeFields,
   [WooCommerceActionTypes.SINGLE_ORDER_VALUE]: SingleOrderValueFields,
   [WooCommerceActionTypes.TOTAL_SPENT]: TotalSpentFields,
   [WooCommerceActionTypes.AVERAGE_SPENT]: AverageSpentFields,

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
@@ -27,6 +27,7 @@ export const getInitialState = (): StateType => ({
   staticSegmentsList: window.mailpoet_static_segments_list,
   membershipPlans: window.mailpoet_membership_plans,
   subscriptionProducts: window.mailpoet_subscription_products,
+  productAttributes: window.mailpoet_product_attributes,
   productCategories: window.mailpoet_product_categories,
   newslettersList: window.mailpoet_newsletters_list,
   wordpressRoles: window.wordpress_editable_roles_list,

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
@@ -28,6 +28,7 @@ export const getInitialState = (): StateType => ({
   membershipPlans: window.mailpoet_membership_plans,
   subscriptionProducts: window.mailpoet_subscription_products,
   productAttributes: window.mailpoet_product_attributes,
+  localProductAttributes: window.mailpoet_local_product_attributes,
   productCategories: window.mailpoet_product_categories,
   newslettersList: window.mailpoet_newsletters_list,
   wordpressRoles: window.wordpress_editable_roles_list,

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -14,6 +14,7 @@ import {
   WindowEditableRoles,
   WindowMembershipPlans,
   WindowNewslettersList,
+  WindowProductAttributes,
   WindowProductCategories,
   WindowProducts,
   WindowSubscriptionProducts,
@@ -30,6 +31,9 @@ export const getSubscriptionProducts = (
 ): WindowSubscriptionProducts => state.subscriptionProducts;
 export const getWordpressRoles = (state: StateType): WindowEditableRoles =>
   state.wordpressRoles;
+export const getProductAttributes = (
+  state: StateType,
+): WindowProductAttributes => state.productAttributes;
 export const getProductCategories = (
   state: StateType,
 ): WindowProductCategories => state.productCategories;

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -12,6 +12,7 @@ import {
   Tag,
   WindowCustomFields,
   WindowEditableRoles,
+  WindowLocalProductAttributes,
   WindowMembershipPlans,
   WindowNewslettersList,
   WindowProductAttributes,
@@ -34,6 +35,9 @@ export const getWordpressRoles = (state: StateType): WindowEditableRoles =>
 export const getProductAttributes = (
   state: StateType,
 ): WindowProductAttributes => state.productAttributes;
+export const getLocalProductAttributes = (
+  state: StateType,
+): WindowLocalProductAttributes => state.localProductAttributes;
 export const getProductCategories = (
   state: StateType,
 ): WindowProductCategories => state.productCategories;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -153,7 +153,7 @@ export interface WooCommerceFormItem extends FormItem {
   days?: string;
   coupon_code_ids?: string[];
   attribute_id?: string;
-  attribute_term_id?: string;
+  attribute_term_ids?: string[];
 }
 
 export interface AutomationsFormItem extends FormItem {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -152,7 +152,7 @@ export interface WooCommerceFormItem extends FormItem {
   count?: string;
   days?: string;
   coupon_code_ids?: string[];
-  attribute_id?: string;
+  attribute_taxonomy_slug?: string;
   attribute_term_ids?: string[];
 }
 
@@ -231,6 +231,7 @@ export type WindowSubscriptionProducts = {
 export type WindowProductAttributes = {
   id: string;
   label: string;
+  taxonomy: string;
   terms: [];
 }[];
 

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -152,6 +152,8 @@ export interface WooCommerceFormItem extends FormItem {
   count?: string;
   days?: string;
   coupon_code_ids?: string[];
+  attribute_id?: string;
+  attribute_term_id?: string;
 }
 
 export interface AutomationsFormItem extends FormItem {
@@ -226,6 +228,12 @@ export type WindowSubscriptionProducts = {
   name: string;
 }[];
 
+export type WindowProductAttributes = {
+  id: string;
+  label: string;
+  terms: [];
+}[];
+
 export type WindowProductCategories = {
   id: string;
   name: string;
@@ -264,6 +272,7 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_products: WindowProducts;
   mailpoet_membership_plans: WindowMembershipPlans;
   mailpoet_subscription_products: WindowSubscriptionProducts;
+  mailpoet_product_attributes: WindowProductAttributes;
   mailpoet_product_categories: WindowProductCategories;
   mailpoet_woocommerce_countries: WindowWooCommerceCountries;
   mailpoet_woocommerce_payment_methods: WooPaymentMethod[];
@@ -284,6 +293,7 @@ export interface StateType {
   membershipPlans: WindowMembershipPlans;
   subscriptionProducts: WindowSubscriptionProducts;
   wordpressRoles: WindowEditableRoles;
+  productAttributes: WindowProductAttributes;
   productCategories: WindowProductCategories;
   newslettersList: WindowNewslettersList;
   canUseWooMemberships: boolean;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -152,8 +152,11 @@ export interface WooCommerceFormItem extends FormItem {
   count?: string;
   days?: string;
   coupon_code_ids?: string[];
+  attribute_type?: 'local' | 'taxonomy';
   attribute_taxonomy_slug?: string;
   attribute_term_ids?: string[];
+  attribute_local_name?: string;
+  attribute_local_values?: string[];
 }
 
 export interface AutomationsFormItem extends FormItem {
@@ -235,6 +238,11 @@ export type WindowProductAttributes = {
   terms: [];
 }[];
 
+export type WindowLocalProductAttributes = {
+  name: string;
+  values: string[];
+}[];
+
 export type WindowProductCategories = {
   id: string;
   name: string;
@@ -274,6 +282,7 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_membership_plans: WindowMembershipPlans;
   mailpoet_subscription_products: WindowSubscriptionProducts;
   mailpoet_product_attributes: WindowProductAttributes;
+  mailpoet_local_product_attributes: WindowLocalProductAttributes;
   mailpoet_product_categories: WindowProductCategories;
   mailpoet_woocommerce_countries: WindowWooCommerceCountries;
   mailpoet_woocommerce_payment_methods: WooPaymentMethod[];
@@ -295,6 +304,7 @@ export interface StateType {
   subscriptionProducts: WindowSubscriptionProducts;
   wordpressRoles: WindowEditableRoles;
   productAttributes: WindowProductAttributes;
+  localProductAttributes: WindowLocalProductAttributes;
   productCategories: WindowProductCategories;
   newslettersList: WindowNewslettersList;
   canUseWooMemberships: boolean;

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -231,17 +231,28 @@ export type WindowSubscriptionProducts = {
   name: string;
 }[];
 
-export type WindowProductAttributes = {
-  id: string;
-  label: string;
+export type Term = {
+  term_id: string;
+  name: string;
+  slug: string;
   taxonomy: string;
-  terms: [];
-}[];
+};
+
+export type WindowProductAttributes = {
+  [key: string]: {
+    id: string;
+    label: string;
+    taxonomy: string;
+    terms: Term[];
+  };
+};
 
 export type WindowLocalProductAttributes = {
-  name: string;
-  values: string[];
-}[];
+  [key: string]: {
+    name: string;
+    values: string[];
+  };
+};
 
 export type WindowProductCategories = {
   id: string;

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -126,6 +126,26 @@ class DynamicSegments {
       ];
     }
 
+    $data['product_attributes'] = [];
+    $productAttributes = $this->woocommerceHelper->wcGetAttributeTaxonomies();
+
+    foreach ($productAttributes as $attribute) {
+      $attributeTerms = $this->wp->getTerms(
+        [
+          'taxonomy' => 'pa_' . $attribute->attribute_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          'hide_empty' => false,
+        ]
+      );
+
+      if (!isset($attributeTerms['errors'])) {
+        $data['product_attributes'][$attribute->attribute_id] = [ // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          'id' => $attribute->attribute_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          'label' => $attribute->attribute_label, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          'terms' => $attributeTerms,
+        ];
+      }
+    }
+
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();
 
     $data['products'] = $this->wpPostListLoader->getProducts();

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -130,18 +130,20 @@ class DynamicSegments {
     $productAttributes = $this->woocommerceHelper->wcGetAttributeTaxonomies();
 
     foreach ($productAttributes as $attribute) {
+      $taxonomy = 'pa_' . $attribute->attribute_name;// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       $attributeTerms = $this->wp->getTerms(
         [
-          'taxonomy' => 'pa_' . $attribute->attribute_name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          'taxonomy' => $taxonomy,
           'hide_empty' => false,
         ]
       );
 
       if (!isset($attributeTerms['errors'])) {
-        $data['product_attributes'][$attribute->attribute_id] = [ // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        $data['product_attributes'][$taxonomy] = [ // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
           'id' => $attribute->attribute_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
           'label' => $attribute->attribute_label, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
           'terms' => $attributeTerms,
+          'taxonomy' => $taxonomy,
         ];
       }
     }

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -127,24 +127,26 @@ class DynamicSegments {
     }
 
     $data['product_attributes'] = [];
-    $productAttributes = $this->woocommerceHelper->wcGetAttributeTaxonomies();
+    if ($this->woocommerceHelper->isWooCommerceActive()) {
+      $productAttributes = $this->woocommerceHelper->wcGetAttributeTaxonomies();
 
-    foreach ($productAttributes as $attribute) {
-      $taxonomy = 'pa_' . $attribute->attribute_name;// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $attributeTerms = $this->wp->getTerms(
-        [
-          'taxonomy' => $taxonomy,
-          'hide_empty' => false,
-        ]
-      );
+      foreach ($productAttributes as $attribute) {
+        $taxonomy = 'pa_' . $attribute->attribute_name;// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        $attributeTerms = $this->wp->getTerms(
+          [
+            'taxonomy' => $taxonomy,
+            'hide_empty' => false,
+          ]
+        );
 
-      if (!isset($attributeTerms['errors'])) {
-        $data['product_attributes'][$taxonomy] = [ // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-          'id' => $attribute->attribute_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-          'label' => $attribute->attribute_label, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-          'terms' => $attributeTerms,
-          'taxonomy' => $taxonomy,
-        ];
+        if (!isset($attributeTerms['errors'])) {
+          $data['product_attributes'][$taxonomy] = [ // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+            'id' => $attribute->attribute_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+            'label' => $attribute->attribute_label, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+            'terms' => $attributeTerms,
+            'taxonomy' => $taxonomy,
+          ];
+        }
       }
     }
 

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -34,6 +34,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
@@ -237,6 +238,7 @@ class Reporter {
       'Segment > email' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberTextField::EMAIL),
       'Segment > city' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCustomerTextField::CITY),
       'Segment > postal code' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCustomerTextField::POSTAL_CODE),
+      'Segment > purchased with attribute' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommercePurchasedWithAttribute::ACTION),
       'Segment > used payment method' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedPaymentMethod::ACTION),
       'Segment > used shipping method' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION),
       'Segment > number of reviews' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfReviews::ACTION),

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -502,6 +502,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -54,18 +54,22 @@ class FilterDataMapper {
   /** @var WooCommerceUsedCouponCode */
   private $wooCommerceUsedCouponCode;
 
+  private WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute;
+
   public function __construct(
     WPFunctions $wp,
     DateFilterHelper $dateFilterHelper,
     FilterHelper $filterHelper,
     WooCommerceNumberOfReviews $wooCommerceNumberOfReviews,
-    WooCommerceUsedCouponCode $wooCommerceUsedCouponCode
+    WooCommerceUsedCouponCode $wooCommerceUsedCouponCode,
+    WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute
   ) {
     $this->wp = $wp;
     $this->dateFilterHelper = $dateFilterHelper;
     $this->filterHelper = $filterHelper;
     $this->wooCommerceNumberOfReviews = $wooCommerceNumberOfReviews;
     $this->wooCommerceUsedCouponCode = $wooCommerceUsedCouponCode;
+    $this->wooCommercePurchasedWithAttribute = $wooCommercePurchasedWithAttribute;
   }
 
   /**
@@ -511,6 +515,7 @@ class FilterDataMapper {
       $filterData['days'] = $data['days'];
       $filterData['timeframe'] = $data['timeframe'];
     } elseif ($data['action'] === WooCommercePurchasedWithAttribute::ACTION) {
+      $this->wooCommercePurchasedWithAttribute->validateFilterData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['attribute_taxonomy_slug'] = $data['attribute_taxonomy_slug'];
       $filterData['attribute_term_ids'] = $data['attribute_term_ids'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -29,6 +29,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
@@ -509,6 +510,10 @@ class FilterDataMapper {
       $filterData['coupon_code_ids'] = $data['coupon_code_ids'];
       $filterData['days'] = $data['days'];
       $filterData['timeframe'] = $data['timeframe'];
+    } elseif ($data['action'] === WooCommercePurchasedWithAttribute::ACTION) {
+      $filterData['operator'] = $data['operator'];
+      $filterData['attribute_taxonomy_slug'] = $data['attribute_taxonomy_slug'];
+      $filterData['attribute_term_ids'] = $data['attribute_term_ids'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -519,6 +519,9 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['attribute_taxonomy_slug'] = $data['attribute_taxonomy_slug'];
       $filterData['attribute_term_ids'] = $data['attribute_term_ids'];
+      $filterData['attribute_type'] = $data['attribute_type'];
+      $filterData['attribute_local_name'] = $data['attribute_local_name'];
+      $filterData['attribute_local_values'] = $data['attribute_local_values'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -517,11 +517,11 @@ class FilterDataMapper {
     } elseif ($data['action'] === WooCommercePurchasedWithAttribute::ACTION) {
       $this->wooCommercePurchasedWithAttribute->validateFilterData($data);
       $filterData['operator'] = $data['operator'];
-      $filterData['attribute_taxonomy_slug'] = $data['attribute_taxonomy_slug'];
-      $filterData['attribute_term_ids'] = $data['attribute_term_ids'];
+      $filterData['attribute_taxonomy_slug'] = $data['attribute_taxonomy_slug'] ?? null;
+      $filterData['attribute_term_ids'] = $data['attribute_term_ids'] ?? null;
       $filterData['attribute_type'] = $data['attribute_type'];
-      $filterData['attribute_local_name'] = $data['attribute_local_name'];
-      $filterData['attribute_local_values'] = $data['attribute_local_values'];
+      $filterData['attribute_local_name'] = $data['attribute_local_name'] ?? null;
+      $filterData['attribute_local_values'] = $data['attribute_local_values'] ?? null;
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -30,6 +30,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
@@ -128,6 +129,8 @@ class FilterFactory {
   /** @var NumberOfClicks */
   private $numberOfClicks;
 
+  private WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute;
+
   public function __construct(
     EmailAction $emailAction,
     EmailActionClickAny $emailActionClickAny,
@@ -158,7 +161,8 @@ class FilterFactory {
     SubscriberDateField $subscriberDateField,
     AutomationsEvents $automationsEvents,
     EmailsReceived $emailsReceived,
-    NumberOfClicks $numberOfClicks
+    NumberOfClicks $numberOfClicks,
+    WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute
   ) {
     $this->emailAction = $emailAction;
     $this->userRole = $userRole;
@@ -190,6 +194,7 @@ class FilterFactory {
     $this->wooCommerceFirstOrder = $wooCommerceFirstOrder;
     $this->emailsReceived = $emailsReceived;
     $this->numberOfClicks = $numberOfClicks;
+    $this->wooCommercePurchasedWithAttribute = $wooCommercePurchasedWithAttribute;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -295,6 +300,8 @@ class FilterFactory {
       return $this->wooCommerceUsedCouponCode;
     } elseif ($action === WooCommerceFirstOrder::ACTION) {
       return $this->wooCommerceFirstOrder;
+    } elseif ($action === WooCommercePurchasedWithAttribute::ACTION) {
+      return $this->wooCommercePurchasedWithAttribute;
     }
     return $this->wooCommerceCategory;
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/Filter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/Filter.php
@@ -9,5 +9,15 @@ use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 interface Filter {
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder;
 
+  /**
+   * At sending time, we store the current state of every filter so we can tell in the future how it was configured. This
+   * method should be used to return any data that might change after sending time. For example, if a filter stores IDs
+   * of related entities, we should try to look up descriptive names for those entities in case they get deleted or
+   * renamed later.
+   *
+   * @param DynamicSegmentFilterData $filterData
+   *
+   * @return array
+   */
   public function getLookupData(DynamicSegmentFilterData $filterData): array;
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttribute.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttribute.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\WP\Functions;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+
+class WooCommercePurchasedWithAttribute implements Filter {
+  const ACTION = 'purchasedWithAttribute';
+
+  private WooFilterHelper $wooFilterHelper;
+
+  private FilterHelper $filterHelper;
+
+  private Functions $wp;
+
+  public function __construct(
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper,
+    Functions $wp
+  ) {
+    $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
+    $this->wp = $wp;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $operator = $filterData->getOperator();
+    $attributeTaxonomySlug = $filterData->getStringParam('attribute_taxonomy_slug');
+    $attributeTermIds = $filterData->getArrayParam('attribute_term_ids');
+
+    if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
+      $this->applyForAnyOperator($queryBuilder, $attributeTaxonomySlug, $attributeTermIds);
+    } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
+      $this->applyForAnyOperator($queryBuilder, $attributeTaxonomySlug, $attributeTermIds);
+      $countParam = $this->filterHelper->getUniqueParameterName('count');
+      $queryBuilder
+        ->groupBy('inner_subscriber_id')
+        ->having("COUNT(DISTINCT attribute.term_id) = :$countParam")
+        ->setParameter($countParam, count($attributeTermIds));
+    } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+      $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+      $this->applyForAnyOperator($subQuery, $attributeTaxonomySlug, $attributeTermIds);
+      $subscribersTable = $this->filterHelper->getSubscribersTable();
+      $queryBuilder->where("{$subscribersTable}.id NOT IN ({$this->filterHelper->getInterpolatedSQL($subQuery)})");
+    }
+
+    return $queryBuilder;
+  }
+
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, string $attributeTaxonomySlug, array $attributeTermIds): void {
+    $termIdsParam = $this->filterHelper->getUniqueParameterName('attribute_term_ids');
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $productAlias = $this->applyProductJoin($queryBuilder, $orderStatsAlias);
+    $attributeAlias = $this->applyAttributeJoin($queryBuilder, $productAlias, $attributeTaxonomySlug);
+    $queryBuilder->andWhere("$attributeAlias.term_id IN (:$termIdsParam)");
+    $queryBuilder->setParameter($termIdsParam, $attributeTermIds, Connection::PARAM_STR_ARRAY);
+  }
+
+  private function applyProductJoin(QueryBuilder $queryBuilder, string $orderStatsAlias, string $alias = 'product'): string {
+    $queryBuilder->innerJoin(
+      $orderStatsAlias,
+      $this->filterHelper->getPrefixedTable('wc_order_product_lookup'),
+      $alias,
+      "$orderStatsAlias.order_id = product.order_id"
+    );
+    return $alias;
+  }
+
+  private function applyAttributeJoin(QueryBuilder $queryBuilder, string $productAlias, $taxonomySlug, string $alias = 'attribute'): string {
+    $queryBuilder->innerJoin(
+      $productAlias,
+      $this->filterHelper->getPrefixedTable('wc_product_attributes_lookup'),
+      $alias,
+      "product.product_id = attribute.product_id AND attribute.taxonomy = '$taxonomySlug'"
+    );
+
+    return $alias;
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    $slug = $filterData->getStringParam('attribute_taxonomy_slug');
+
+    $lookupData = [
+      'attribute' => $slug,
+    ];
+
+    $termIds = $filterData->getArrayParam('attribute_term_ids');
+    $terms = $this->wp->getTerms([
+      'taxonomy' => $slug,
+      'include' => $termIds,
+      'hide_empty' => false,
+    ]);
+
+    $lookupData['terms'] = array_map(function($term) {
+      return $term->name;
+    }, $terms);
+
+    return $lookupData;
+  }
+}

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -961,4 +961,8 @@ class Functions {
   public function getTheContent($more_link_text = null, $strip_teaser = false, $post = null) {
     return get_the_content($more_link_text, $strip_teaser, $post);
   }
+
+  public function getTaxonomy($taxonomy) {
+    return get_taxonomy($taxonomy);
+  }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -305,6 +305,10 @@ class Helper {
     return $keyedZones;
   }
 
+  public function wcGetAttributeTaxonomies(): array {
+    return wc_get_attribute_taxonomies();
+  }
+
   protected function formatShippingMethods(array $shippingMethods, string $shippingZoneName): array {
     $formattedShippingMethods = [];
 

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -161,6 +161,12 @@ class IntegrationTester extends \Codeception\Actor {
       do_action('woocommerce_run_product_attribute_lookup_update_callback', $product->get_id(), 1);
     }
 
+    if (isset($data['local_attributes'])) {
+      foreach ($data['local_attributes'] as $name => $value) {
+        update_post_meta($product->get_id(), sprintf('attribute_%s', $name), $value);
+      }
+    }
+
     $this->wooProductIds[] = $product->get_id();
     return $product;
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -1085,4 +1085,60 @@ class FilterDataMapperTest extends \MailPoetTest {
       'timeframe' => 'allTime',
     ]]]);
   }
+
+  public function testItMapsPurchasedWithAttributeForTaxonomyAttributes(): void {
+    $data = ['filters' => [[
+      'segmentType' => 'woocommerce',
+      'action' => 'purchasedWithAttribute',
+      'operator' => 'all',
+      'attribute_type' => 'taxonomy',
+      'attribute_taxonomy_slug' => 'pa_color',
+      'attribute_term_ids' => ['1', '200'],
+    ]]];
+    $filters = $this->mapper->map($data);
+    verify($filters)->isArray();
+    verify($filters)->arrayCount(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter)->instanceOf(DynamicSegmentFilterData::class);
+    verify($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_WOOCOMMERCE);
+    verify($filter->getAction())->equals('purchasedWithAttribute');
+    verify($filter->getData())->equals([
+      'operator' => 'all',
+      'connect' => 'and',
+      'attribute_taxonomy_slug' => 'pa_color',
+      'attribute_term_ids' => ['1', '200'],
+      'attribute_type' => 'taxonomy',
+      'attribute_local_name' => null,
+      'attribute_local_values' => null,
+    ]);
+  }
+
+  public function testItMapsPurchasedWithAttributeForLocalAttributes(): void {
+    $data = ['filters' => [[
+      'segmentType' => 'woocommerce',
+      'action' => 'purchasedWithAttribute',
+      'operator' => 'any',
+      'attribute_type' => 'local',
+      'attribute_local_name' => 'color',
+      'attribute_local_values' => ['red', 'blue'],
+    ]]];
+    $filters = $this->mapper->map($data);
+    verify($filters)->isArray();
+    verify($filters)->arrayCount(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter)->instanceOf(DynamicSegmentFilterData::class);
+    verify($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_WOOCOMMERCE);
+    verify($filter->getAction())->equals('purchasedWithAttribute');
+    verify($filter->getData())->equals([
+      'operator' => 'any',
+      'connect' => 'and',
+      'attribute_taxonomy_slug' => null,
+      'attribute_term_ids' => null,
+      'attribute_type' => 'local',
+      'attribute_local_name' => 'color',
+      'attribute_local_values' => ['red', 'blue'],
+    ]);
+  }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
+
+/**
+ * @group woo
+ */
+class WooCommercePurchasedWithAttributeTest extends \MailPoetTest {
+
+
+  private WooCommercePurchasedWithAttribute $filter;
+
+  public function _before(): void {
+    $this->filter = $this->diContainer->get(WooCommercePurchasedWithAttribute::class);
+  }
+
+  public function testItWorksWithAnyOperator(): void {
+    $product1 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['blue']),
+      ],
+    ]);
+    $product2 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['red']),
+      ],
+    ]);
+
+    $blueTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'blue');
+    $redTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'red');
+
+    $customer1 = $this->tester->createCustomer('customer1@example.com');
+    $customer2 = $this->tester->createCustomer('customer2@example.com');
+    $customer3 = $this->tester->createCustomer('customer3@example.com');
+
+    $this->createOrder($customer1, [$product1]);
+    $this->createOrder($customer2, [$product2]);
+    $this->assertFilterReturnsEmails('any', 'pa_color', [$blueTermId, $redTermId], ['customer1@example.com', 'customer2@example.com']);
+  }
+
+  public function testItWorksWithNoneOperator(): void {
+    $product1 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['blue']),
+      ],
+    ]);
+    $product2 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['red']),
+      ],
+    ]);
+
+    $blueTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'blue');
+    $redTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'red');
+
+    $customer1 = $this->tester->createCustomer('customer1@example.com');
+    $customer2 = $this->tester->createCustomer('customer2@example.com');
+    $customer3 = $this->tester->createCustomer('customer3@example.com');
+
+    $this->createOrder($customer1, [$product1]);
+    $this->createOrder($customer2, [$product2]);
+    $this->assertFilterReturnsEmails('none', 'pa_color', [$blueTermId, $redTermId], ['customer3@example.com']);
+  }
+
+  public function testItWorksWithAllOperator(): void {
+    $product1 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['blue']),
+      ],
+    ]);
+    $product2 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['red']),
+      ],
+    ]);
+
+    $blueTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'blue');
+    $redTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'red');
+
+    $customer1 = $this->tester->createCustomer('customer1@example.com');
+    $customer2 = $this->tester->createCustomer('customer2@example.com');
+    $customer3 = $this->tester->createCustomer('customer3@example.com');
+
+    $this->createOrder($customer1, [$product1, $product2]);
+    $this->createOrder($customer2, [$product2]);
+    $this->assertFilterReturnsEmails('all', 'pa_color', [$blueTermId, $redTermId], ['customer1@example.com']);
+  }
+
+  public function testItRetrievesLookupData(): void {
+    $product1 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['blue']),
+      ],
+    ]);
+    $product2 = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['red']),
+      ],
+    ]);
+
+    $blueTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'blue');
+    $redTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'red');
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommercePurchasedWithAttribute::ACTION, [
+      'operator' => 'any',
+      'attribute_taxonomy_slug' => 'pa_color',
+      'attribute_term_ids' => [$blueTermId, $redTermId],
+    ]);
+
+    $lookupData = $this->filter->getLookupData($filterData);
+
+    $this->assertEqualsCanonicalizing([
+      'attribute' => 'pa_color',
+      'terms' => ['blue', 'red'],
+    ], $lookupData);
+  }
+
+  private function assertFilterReturnsEmails(string $operator, string $attributeTaxonomySlug, array $termIds, array $expectedEmails): void {
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommercePurchasedWithAttribute::ACTION, [
+      'operator' => $operator,
+      'attribute_taxonomy_slug' => $attributeTaxonomySlug,
+      'attribute_term_ids' => $termIds,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  private function createOrder(int $customerId, array $products): int {
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_status('wc-completed');
+    foreach ($products as $product) {
+      $order->add_product($product);
+    }
+    $order->save();
+    $this->tester->updateWooOrderStats($order->get_id());
+
+    return $order->get_id();
+  }
+
+  public function _after() {
+    parent::_after();
+    global $wpdb;
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_product_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_product_attributes_lookup");
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
@@ -3,6 +3,7 @@
 namespace integration\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 
 /**
@@ -124,6 +125,27 @@ class WooCommercePurchasedWithAttributeTest extends \MailPoetTest {
       'attribute' => 'pa_color',
       'terms' => ['blue', 'red'],
     ], $lookupData);
+  }
+
+  public function testItValidatesOperator(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing operator');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_OPERATOR);
+    $this->filter->validateFilterData(['operator' => '', 'attribute_taxonomy_slug' => 'pa_color', 'attribute_term_ids' => ['1']]);
+  }
+
+  public function testItValidatesAttribute(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing attribute');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    $this->filter->validateFilterData(['operator' => 'any', 'attribute_taxonomy_slug' => '', 'attribute_term_ids' => ['1']]);
+  }
+
+  public function testItValidatesTerms(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing attribute terms');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);
+    $this->filter->validateFilterData(['operator' => 'any', 'attribute_taxonomy_slug' => 'pa_color', 'attribute_term_ids' => []]);
   }
 
   private function assertFilterReturnsEmails(string $operator, string $attributeTaxonomySlug, array $termIds, array $expectedEmails): void {

--- a/mailpoet/views/segments/dynamic.html
+++ b/mailpoet/views/segments/dynamic.html
@@ -10,6 +10,7 @@
     var wordpress_editable_roles_list = <%= json_encode(wordpress_editable_roles_list)  %>;
     var mailpoet_newsletters_list = <%= json_encode(newsletters_list)  %>;
     var mailpoet_product_attributes = <%= json_encode(product_attributes)  %>;
+    var mailpoet_local_product_attributes = <%= json_encode(local_product_attributes) %>;
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
     var mailpoet_products = <%= json_encode(products) %>;
     var mailpoet_membership_plans = <%= json_encode(membership_plans) %>;

--- a/mailpoet/views/segments/dynamic.html
+++ b/mailpoet/views/segments/dynamic.html
@@ -9,6 +9,7 @@
     var mailpoet_static_segments_list = <%= json_encode(static_segments_list) %>;
     var wordpress_editable_roles_list = <%= json_encode(wordpress_editable_roles_list)  %>;
     var mailpoet_newsletters_list = <%= json_encode(newsletters_list)  %>;
+    var mailpoet_product_attributes = <%= json_encode(product_attributes)  %>;
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
     var mailpoet_products = <%= json_encode(products) %>;
     var mailpoet_membership_plans = <%= json_encode(membership_plans) %>;


### PR DESCRIPTION
## Description

This PR adds a new dynamic segment filter for "purchased with attribute".

Attributes in WooCommerce can be either global, which are saved as taxonomy/terms, or local, which are specific to a product. This filter accounts for both types, but with the limitation that it will only look at local attributes that were used to create product variations.

When local attributes are used for product variations, a new row is created in the `postmeta` table for each attribute/value pair, which makes it possible to write efficient queries to target them. If a simple product has multiple values for a local attribute, it's also saved in the `postmeta` table, but as a serialized string like this:

```
a:1:{s:15:"local-attribute";a:6:{s:4:"name";s:15:"Local Attribute";s:5:"value";s:31:"One | Two | Three | Four | Five";s:8:"position";i:0;s:10:"is_visible";i:1;s:12:"is_variation";i:0;s:11:"is_taxonomy";i:0;}}
```

Since the `postmeta` table is likely to be massive on any larger site and the `meta_value` column is not indexed, I don't see a way to query for this data in an efficient way.

I don't see this as a major issue because if a product has some unique local attributes, a user could simply use the "purchased product" filter.

## Code review notes

_N/A_

## QA notes

Please make sure to test both global (taxonomy based) and local attributes. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5467](https://mailpoet.atlassian.net/browse/MAILPOET-5467)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5467]: https://mailpoet.atlassian.net/browse/MAILPOET-5467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ