### PR TITLE
Automation filters with "in the last X days" [PREMIUM-253]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/filters/value.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/value.tsx
@@ -1,100 +1,18 @@
 import { useSelect } from '@wordpress/data';
-import { getSettings, dateI18n } from '@wordpress/date';
 import { Icon, helpFilled } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
 import { Filter } from '../automation/types';
-import { Registry, storeName } from '../../store';
-
-type Field = Registry['fields'][number];
-
-const getValue = (field: Field, filter: Filter): string | undefined => {
-  const { condition, args } = filter;
-
-  if (args.value === undefined) {
-    return undefined;
-  }
-
-  switch (field?.type) {
-    case 'boolean':
-      return args.value ? __('Yes', 'mailpoet') : __('No', 'mailpoet');
-    case 'number':
-    case 'integer':
-      return Array.isArray(args.value)
-        ? args.value.join(' and ')
-        : args.value.toString();
-    case 'string':
-      return args.value.toString();
-    case 'datetime': {
-      const settings = getSettings();
-
-      // in-the-last/not-in-the-last
-      if (
-        ['in-the-last', 'not-in-the-last'].includes(condition) &&
-        typeof args.value === 'object' &&
-        'number' in args.value &&
-        'unit' in args.value
-      ) {
-        return `${args.value.number as number} ${
-          {
-            days: __('days', 'mailpoet'),
-            weeks: __('weeks', 'mailpoet'),
-            months: __('months', 'mailpoet'),
-          }[args.value.unit as string] ?? __('unknown unit', 'mailpoet')
-        }`;
-      }
-
-      // on-the-days-of-the-week
-      if (condition === 'on-the-days-of-the-week') {
-        return (Array.isArray(args.value) ? args.value : [])
-          .map(
-            (day: number) =>
-              (settings.l10n.weekdays[day] as string) ??
-              __('unknown day', 'mailpoet'),
-          )
-          .join(', ');
-      }
-
-      const isDate = condition === 'on' || condition === 'not-on';
-
-      return dateI18n(
-        isDate ? settings.formats.date : settings.formats.datetime,
-        args.value as string,
-        settings.timezone.string,
-      );
-    }
-    case 'enum':
-    case 'enum_array': {
-      const options = (field.args.options ?? []) as {
-        id: string;
-        name: string;
-      }[];
-      const values = Array.isArray(args.value) ? args.value : [args.value];
-      const labels = values
-        .map((v) => options.find(({ id }) => id === v)?.name)
-        .filter((v) => v !== undefined);
-
-      if (labels.length === 0) {
-        return __('Unknown value', 'mailpoet');
-      }
-
-      const suffix =
-        labels.length < values.length
-          ? __('and unknown values', 'mailpoet')
-          : '';
-      return `${labels.join(', ')}${suffix}`;
-    }
-    default:
-      return __('Unknown value', 'mailpoet');
-  }
-};
+import { storeName } from '../../store';
 
 type Props = {
   filter: Filter;
 };
 
 export function Value({ filter }: Props): JSX.Element | null {
-  const field = useSelect(
-    (select) => select(storeName).getRegistry().fields[filter.field_key],
+  const { field, filterType } = useSelect(
+    (select) => ({
+      field: select(storeName).getRegistry().fields[filter.field_key],
+      filterType: select(storeName).getFilterType(filter.field_type),
+    }),
     [],
   );
 
@@ -109,7 +27,7 @@ export function Value({ filter }: Props): JSX.Element | null {
     return undefined;
   }
 
-  const value = getValue(field, filter);
+  const value = filterType?.formatValue(filter, field);
   if (value === undefined) {
     return expectsValue ? (
       <span className="mailpoet-automation-filters-list-item-value-missing">

--- a/mailpoet/assets/js/src/automation/editor/components/filters/value.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/filters/value.tsx
@@ -28,6 +28,7 @@ export function Value({ filter }: Props): JSX.Element | null {
   }
 
   const value = filterType?.formatValue(filter, field);
+  const params = filterType?.formatParams?.(filter, field);
   if (value === undefined) {
     return expectsValue ? (
       <span className="mailpoet-automation-filters-list-item-value-missing">
@@ -36,6 +37,11 @@ export function Value({ filter }: Props): JSX.Element | null {
     ) : null;
   }
   return (
-    <span className="mailpoet-automation-filters-list-item-value">{value}</span>
+    <>
+      <span className="mailpoet-automation-filters-list-item-value">
+        {value}
+      </span>
+      {params && <span> {params}</span>}
+    </>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/filters/boolean.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/boolean.ts
@@ -1,0 +1,14 @@
+import { __ } from '@wordpress/i18n';
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'boolean',
+  fieldType: 'boolean',
+  formatValue: ({ args }) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+    return args.value ? __('Yes', 'mailpoet') : __('No', 'mailpoet');
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/boolean.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/boolean.ts
@@ -10,5 +10,6 @@ export const filter: FilterType = {
     }
     return args.value ? __('Yes', 'mailpoet') : __('No', 'mailpoet');
   },
+  validateArgs: (args) => typeof args.value === 'boolean',
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/datetime.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/datetime.ts
@@ -1,0 +1,51 @@
+import { dateI18n, getSettings } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'datetime',
+  fieldType: 'datetime',
+  formatValue: ({ args, condition }) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+
+    const settings = getSettings();
+
+    // in-the-last/not-in-the-last
+    if (
+      ['in-the-last', 'not-in-the-last'].includes(condition) &&
+      typeof args.value === 'object' &&
+      'number' in args.value &&
+      'unit' in args.value
+    ) {
+      return `${args.value.number as number} ${
+        {
+          days: __('days', 'mailpoet'),
+          weeks: __('weeks', 'mailpoet'),
+          months: __('months', 'mailpoet'),
+        }[args.value.unit as string] ?? __('unknown unit', 'mailpoet')
+      }`;
+    }
+
+    // on-the-days-of-the-week
+    if (condition === 'on-the-days-of-the-week') {
+      return (Array.isArray(args.value) ? args.value : [])
+        .map(
+          (day: number) =>
+            (settings.l10n.weekdays[day] as string) ??
+            __('unknown day', 'mailpoet'),
+        )
+        .join(', ');
+    }
+
+    const isDate = condition === 'on' || condition === 'not-on';
+
+    return dateI18n(
+      isDate ? settings.formats.date : settings.formats.datetime,
+      args.value as string,
+      settings.timezone.string,
+    );
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/datetime.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/datetime.ts
@@ -47,5 +47,37 @@ export const filter: FilterType = {
       settings.timezone.string,
     );
   },
+  validateArgs: (args, condition) => {
+    const value = args.value;
+
+    if (['in-the-last', 'not-in-the-last'].includes(condition)) {
+      return (
+        typeof value === 'object' &&
+        'number' in value &&
+        'unit' in value &&
+        typeof value.number === 'number' &&
+        typeof value.unit === 'string' &&
+        ['days', 'weeks', 'months'].includes(value.unit)
+      );
+    }
+
+    if (['is-set', 'is-not-set'].includes(condition)) {
+      return value === undefined;
+    }
+
+    if (condition === 'on-the-days-of-the-week') {
+      return (
+        Array.isArray(value) &&
+        value.every(
+          (day) =>
+            typeof day === 'number' && [0, 1, 2, 3, 4, 5, 6].includes(day),
+        )
+      );
+    }
+
+    return (
+      typeof value === 'string' && new Date(value).toString() !== 'Invalid Date'
+    );
+  },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'enum_array',
+  fieldType: 'enum_array',
+  formatValue: ({ args }, field) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+
+    const options = (field.args.options ?? []) as {
+      id: string;
+      name: string;
+    }[];
+    const values = Array.isArray(args.value) ? args.value : [args.value];
+    const labels = values
+      .map((v) => options.find(({ id }) => id === v)?.name)
+      .filter((v) => v !== undefined);
+
+    if (labels.length === 0) {
+      return __('Unknown value', 'mailpoet');
+    }
+
+    const suffix =
+      labels.length < values.length ? __('and unknown values', 'mailpoet') : '';
+    return `${labels.join(', ')}${suffix}`;
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
@@ -26,5 +26,16 @@ export const filter: FilterType = {
       labels.length < values.length ? __('and unknown values', 'mailpoet') : '';
     return `${labels.join(', ')}${suffix}`;
   },
+  validateArgs: (args, _, field) => {
+    const value = args.value;
+    const options = (field.args.options ?? []) as {
+      id: string;
+      name: string;
+    }[];
+    return (
+      Array.isArray(value) &&
+      value.every((item) => options.some(({ id }) => id === item))
+    );
+  },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
@@ -1,5 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import { validateInTheLastParam } from './params/in-the-last';
+import {
+  formatInTheLastParam,
+  validateInTheLastParam,
+} from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -27,6 +30,7 @@ export const filter: FilterType = {
       labels.length < values.length ? __('and unknown values', 'mailpoet') : '';
     return `${labels.join(', ')}${suffix}`;
   },
+  formatParams: ({ args }) => formatInTheLastParam(args),
   validateArgs: (args, _, field) => {
     if (!validateInTheLastParam(args)) {
       return false;

--- a/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum-array.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { validateInTheLastParam } from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -27,6 +28,10 @@ export const filter: FilterType = {
     return `${labels.join(', ')}${suffix}`;
   },
   validateArgs: (args, _, field) => {
+    if (!validateInTheLastParam(args)) {
+      return false;
+    }
+
     const value = args.value;
     const options = (field.args.options ?? []) as {
       id: string;

--- a/mailpoet/assets/js/src/automation/editor/filters/enum.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum.ts
@@ -1,5 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import { validateInTheLastParam } from './params/in-the-last';
+import {
+  formatInTheLastParam,
+  validateInTheLastParam,
+} from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -18,6 +21,7 @@ export const filter: FilterType = {
     const label = options.find(({ id }) => id === args.value)?.name;
     return label ?? __('Unknown value', 'mailpoet');
   },
+  formatParams: ({ args }) => formatInTheLastParam(args),
   validateArgs: (args, _, field) => {
     if (!validateInTheLastParam(args)) {
       return false;

--- a/mailpoet/assets/js/src/automation/editor/filters/enum.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum.ts
@@ -1,0 +1,21 @@
+import { __ } from '@wordpress/i18n';
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'enum',
+  fieldType: 'enum',
+  formatValue: ({ args }, field) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+
+    const options = (field.args.options ?? []) as {
+      id: string;
+      name: string;
+    }[];
+
+    const label = options.find(({ id }) => id === args.value)?.name;
+    return label ?? __('Unknown value', 'mailpoet');
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/enum.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum.ts
@@ -17,5 +17,13 @@ export const filter: FilterType = {
     const label = options.find(({ id }) => id === args.value)?.name;
     return label ?? __('Unknown value', 'mailpoet');
   },
+  validateArgs: (args, _, field) => {
+    const value = args.value;
+    const options = (field.args.options ?? []) as {
+      id: string;
+      name: string;
+    }[];
+    return options.some(({ id }) => id === value);
+  },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/enum.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { validateInTheLastParam } from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -18,6 +19,10 @@ export const filter: FilterType = {
     return label ?? __('Unknown value', 'mailpoet');
   },
   validateArgs: (args, _, field) => {
+    if (!validateInTheLastParam(args)) {
+      return false;
+    }
+
     const value = args.value;
     const options = (field.args.options ?? []) as {
       id: string;

--- a/mailpoet/assets/js/src/automation/editor/filters/enum.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum.ts
@@ -32,7 +32,10 @@ export const filter: FilterType = {
       id: string;
       name: string;
     }[];
-    return options.some(({ id }) => id === value);
+    return (
+      Array.isArray(value) &&
+      value.every((item) => options.some(({ id }) => id === item))
+    );
   },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/index.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/index.ts
@@ -1,0 +1,18 @@
+import { filter as booleanFilter } from './boolean';
+import { filter as numberFilter } from './number';
+import { filter as integerFilter } from './integer';
+import { filter as stringFilter } from './string';
+import { filter as datetimeFilter } from './datetime';
+import { filter as enumFilter } from './enum';
+import { filter as enumArrayFilter } from './enum-array';
+import { registerFilterType } from '../store/register-filter-type';
+
+export const initializeFilters = (): void => {
+  registerFilterType(booleanFilter);
+  registerFilterType(numberFilter);
+  registerFilterType(integerFilter);
+  registerFilterType(stringFilter);
+  registerFilterType(datetimeFilter);
+  registerFilterType(enumFilter);
+  registerFilterType(enumArrayFilter);
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/integer.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/integer.ts
@@ -11,5 +11,21 @@ export const filter: FilterType = {
       ? args.value.join(' and ')
       : args.value.toString();
   },
+  validateArgs: (args, condition) => {
+    const value = args.value;
+    if (['between', 'not-between'].includes(condition)) {
+      return (
+        Array.isArray(value) &&
+        value.length === 2 &&
+        value.every((item) => typeof item === 'number')
+      );
+    }
+
+    if (['is-set', 'is-not-set'].includes(condition)) {
+      return value === undefined;
+    }
+
+    return typeof value === 'number';
+  },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/integer.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/integer.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import {
   formatInTheLastParam,
   validateInTheLastParam,
@@ -12,7 +13,7 @@ export const filter: FilterType = {
       return undefined;
     }
     return Array.isArray(args.value)
-      ? args.value.join(' and ')
+      ? args.value.join(` ${__('and', 'mailpoet')} `)
       : args.value.toString();
   },
   formatParams: ({ args }) => formatInTheLastParam(args),

--- a/mailpoet/assets/js/src/automation/editor/filters/integer.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/integer.ts
@@ -1,4 +1,7 @@
-import { validateInTheLastParam } from './params/in-the-last';
+import {
+  formatInTheLastParam,
+  validateInTheLastParam,
+} from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -12,6 +15,7 @@ export const filter: FilterType = {
       ? args.value.join(' and ')
       : args.value.toString();
   },
+  formatParams: ({ args }) => formatInTheLastParam(args),
   validateArgs: (args, condition) => {
     if (!validateInTheLastParam(args)) {
       return false;

--- a/mailpoet/assets/js/src/automation/editor/filters/integer.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/integer.ts
@@ -1,3 +1,4 @@
+import { validateInTheLastParam } from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -12,6 +13,10 @@ export const filter: FilterType = {
       : args.value.toString();
   },
   validateArgs: (args, condition) => {
+    if (!validateInTheLastParam(args)) {
+      return false;
+    }
+
     const value = args.value;
     if (['between', 'not-between'].includes(condition)) {
       return (

--- a/mailpoet/assets/js/src/automation/editor/filters/integer.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/integer.ts
@@ -1,0 +1,15 @@
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'integer',
+  fieldType: 'integer',
+  formatValue: ({ args }) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+    return Array.isArray(args.value)
+      ? args.value.join(' and ')
+      : args.value.toString();
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/number.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/number.ts
@@ -11,5 +11,21 @@ export const filter: FilterType = {
       ? args.value.join(' and ')
       : args.value.toString();
   },
+  validateArgs: (args, condition) => {
+    const value = args.value;
+    if (['between', 'not-between'].includes(condition)) {
+      return (
+        Array.isArray(value) &&
+        value.length === 2 &&
+        value.every((item) => typeof item === 'number')
+      );
+    }
+
+    if (['is-set', 'is-not-set'].includes(condition)) {
+      return value === undefined;
+    }
+
+    return typeof value === 'number';
+  },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/number.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/number.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import {
   formatInTheLastParam,
   validateInTheLastParam,
@@ -12,7 +13,7 @@ export const filter: FilterType = {
       return undefined;
     }
     return Array.isArray(args.value)
-      ? args.value.join(' and ')
+      ? args.value.join(` ${__('and', 'mailpoet')} `)
       : args.value.toString();
   },
   formatParams: ({ args }) => formatInTheLastParam(args),

--- a/mailpoet/assets/js/src/automation/editor/filters/number.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/number.ts
@@ -1,0 +1,15 @@
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'number',
+  fieldType: 'number',
+  formatValue: ({ args }) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+    return Array.isArray(args.value)
+      ? args.value.join(' and ')
+      : args.value.toString();
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/number.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/number.ts
@@ -1,4 +1,7 @@
-import { validateInTheLastParam } from './params/in-the-last';
+import {
+  formatInTheLastParam,
+  validateInTheLastParam,
+} from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -12,6 +15,7 @@ export const filter: FilterType = {
       ? args.value.join(' and ')
       : args.value.toString();
   },
+  formatParams: ({ args }) => formatInTheLastParam(args),
   validateArgs: (args, condition) => {
     if (!validateInTheLastParam(args)) {
       return false;

--- a/mailpoet/assets/js/src/automation/editor/filters/number.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/number.ts
@@ -1,3 +1,4 @@
+import { validateInTheLastParam } from './params/in-the-last';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -12,6 +13,10 @@ export const filter: FilterType = {
       : args.value.toString();
   },
   validateArgs: (args, condition) => {
+    if (!validateInTheLastParam(args)) {
+      return false;
+    }
+
     const value = args.value;
     if (['between', 'not-between'].includes(condition)) {
       return (

--- a/mailpoet/assets/js/src/automation/editor/filters/params/in-the-last.tsx
+++ b/mailpoet/assets/js/src/automation/editor/filters/params/in-the-last.tsx
@@ -1,0 +1,21 @@
+export const validateInTheLastParam = (
+  args: Record<string, unknown>,
+): boolean => {
+  if (args.params === undefined) {
+    return true;
+  }
+
+  if (typeof args.params !== 'object' || !('in_the_last' in args.params)) {
+    return false;
+  }
+
+  const inTheLast = args.params.in_the_last;
+  return (
+    typeof inTheLast === 'object' &&
+    'number' in inTheLast &&
+    'unit' in inTheLast &&
+    typeof inTheLast.number === 'number' &&
+    inTheLast.number > 0 &&
+    inTheLast.unit === 'days'
+  );
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/params/in-the-last.tsx
+++ b/mailpoet/assets/js/src/automation/editor/filters/params/in-the-last.tsx
@@ -1,3 +1,10 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+type Param = {
+  number: number;
+  unit: 'days';
+};
+
 export const validateInTheLastParam = (
   args: Record<string, unknown>,
 ): boolean => {
@@ -17,5 +24,26 @@ export const validateInTheLastParam = (
     typeof inTheLast.number === 'number' &&
     inTheLast.number > 0 &&
     inTheLast.unit === 'days'
+  );
+};
+
+export const formatInTheLastParam = (
+  args: Record<string, unknown>,
+): string | undefined => {
+  if (args.params === undefined) {
+    return undefined;
+  }
+
+  const isValid = validateInTheLastParam(args);
+  if (!isValid) {
+    return undefined;
+  }
+
+  const params = args.params as { in_the_last: Param };
+  return sprintf(
+    // translators: %d is a number and %s is a unit of time (days, weeks, months, years)
+    __('in the last %d %s', 'mailpoet'),
+    params.in_the_last.number,
+    __('days', 'mailpoet'),
   );
 };

--- a/mailpoet/assets/js/src/automation/editor/filters/string.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/string.ts
@@ -1,0 +1,13 @@
+import { FilterType } from '../store/types';
+
+export const filter: FilterType = {
+  key: 'string',
+  fieldType: 'string',
+  formatValue: ({ args }) => {
+    if (args.value === undefined) {
+      return undefined;
+    }
+    return args.value.toString();
+  },
+  edit: undefined,
+};

--- a/mailpoet/assets/js/src/automation/editor/filters/string.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/string.ts
@@ -9,5 +9,12 @@ export const filter: FilterType = {
     }
     return args.value.toString();
   },
+  validateArgs: (args, condition) => {
+    const value = args.value;
+    if (['is-blank', 'is-not-blank'].includes(condition)) {
+      return value === undefined;
+    }
+    return typeof value === 'string';
+  },
   edit: undefined,
 };

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -241,6 +241,13 @@ export function registerStepType(stepType) {
   };
 }
 
+export function registerFilterType(filterType) {
+  return {
+    type: 'REGISTER_FILTER_TYPE',
+    filterType,
+  };
+}
+
 export function updateStepArgs(stepId, name, value) {
   return {
     type: 'UPDATE_STEP_ARGS',

--- a/mailpoet/assets/js/src/automation/editor/store/initial-state.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/initial-state.ts
@@ -7,6 +7,7 @@ export const getInitialState = (): State => ({
   registry: { ...window.mailpoet_automation_registry },
   context: { ...window.mailpoet_automation_context },
   stepTypes: {},
+  filterTypes: {},
   automationData: { ...window.mailpoet_automation },
   selectedStep: undefined,
   inserterSidebar: {

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -71,6 +71,14 @@ export function reducer(state: State, action): State {
           [action.stepType.key]: action.stepType,
         },
       };
+    case 'REGISTER_FILTER_TYPE':
+      return {
+        ...state,
+        filterTypes: {
+          ...state.filterTypes,
+          [action.filterType.key]: action.filterType,
+        },
+      };
     case 'UPDATE_STEP_ARGS': {
       const prevArgs = state.automationData.steps[action.stepId].args ?? {};
 

--- a/mailpoet/assets/js/src/automation/editor/store/register-filter-type.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/register-filter-type.ts
@@ -1,0 +1,10 @@
+import { dispatch } from '@wordpress/data';
+import { Hooks } from 'wp-js-hooks';
+import { storeName } from './constants';
+import { FilterType } from './types';
+
+export const registerFilterType = (filterType: FilterType): void => {
+  void dispatch(storeName).registerFilterType(
+    Hooks.applyFilters('mailpoet.automation.register_filter_type', filterType),
+  );
+};

--- a/mailpoet/assets/js/src/automation/editor/store/selectors.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/selectors.ts
@@ -10,6 +10,7 @@ import {
   StepErrors,
   StepType,
   State as EditorState,
+  FilterType,
 } from './types';
 import { Item } from '../components/inserter/item';
 import { Step, Automation } from '../components/automation/types';
@@ -91,6 +92,13 @@ export function getStepById(state: State, id: string): Step | undefined {
 
 export function getStepType(state: State, key: string): StepType | undefined {
   return state.stepTypes[key] ?? undefined;
+}
+
+export function getFilterType(
+  state: State,
+  key: string,
+): FilterType | undefined {
+  return state.filterTypes[key] ?? undefined;
 }
 
 export function getSelectedStepType(state: State): StepType | undefined {

--- a/mailpoet/assets/js/src/automation/editor/store/store.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/store.ts
@@ -10,6 +10,7 @@ import { storeName } from './constants';
 import { getInitialState } from './initial-state';
 import { reducer } from './reducer';
 import * as selectors from './selectors';
+import { initializeFilters } from '../filters';
 
 const getConfig = () =>
   ({
@@ -30,6 +31,7 @@ export const createStore = () => {
   ) as EditorStoreConfig;
   const store = createReduxStore(storeName, storeConfig);
   register(store);
+  initializeFilters();
   return store;
 };
 

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -86,7 +86,11 @@ export type FilterType = {
   key: string;
   fieldType: Registry['fields'][string]['type'];
   formatValue: (filter: Filter, field: Registry['fields'][string]) => string;
-  edit: ComponentType;
+  edit: ComponentType<{
+    field: Registry['fields'][string];
+    args: Record<string, unknown>;
+    onChange: (args: unknown) => void;
+  }>;
 };
 
 export type StepErrors = {

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -86,6 +86,11 @@ export type FilterType = {
   key: string;
   fieldType: Registry['fields'][string]['type'];
   formatValue: (filter: Filter, field: Registry['fields'][string]) => string;
+  validateArgs: (
+    args: Record<string, unknown>,
+    condition: string,
+    field: Registry['fields'][string],
+  ) => boolean;
   edit: ComponentType<{
     field: Registry['fields'][string];
     args: Record<string, unknown>;

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react';
-import { Step, Automation } from '../components/automation/types';
+import { Step, Automation, Filter } from '../components/automation/types';
 
 export interface AutomationEditorWindow extends Window {
   mailpoet_automation_registry: Registry;
@@ -82,6 +82,13 @@ export type StepType = {
   createStep?: (step: Step, state: State) => Step;
 };
 
+export type FilterType = {
+  key: string;
+  fieldType: Registry['fields'][string]['type'];
+  formatValue: (filter: Filter, field: Registry['fields'][string]) => string;
+  edit: ComponentType;
+};
+
 export type StepErrors = {
   step_id: string;
   message: string;
@@ -98,6 +105,7 @@ export type State = {
   registry: Registry;
   context: Context;
   stepTypes: Record<string, StepType>;
+  filterTypes: Record<string, FilterType>;
   automationData: Automation;
   selectedStep: Step | undefined;
   inserterSidebar: {

--- a/mailpoet/assets/js/src/automation/editor/store/types.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/types.ts
@@ -86,6 +86,10 @@ export type FilterType = {
   key: string;
   fieldType: Registry['fields'][string]['type'];
   formatValue: (filter: Filter, field: Registry['fields'][string]) => string;
+  formatParams?: (
+    filter: Filter,
+    field: Registry['fields'][string],
+  ) => string | undefined;
   validateArgs: (
     args: Record<string, unknown>,
     condition: string,

--- a/mailpoet/lib/Automation/Engine/Data/Field.php
+++ b/mailpoet/lib/Automation/Engine/Data/Field.php
@@ -60,8 +60,8 @@ class Field {
   }
 
   /** @return mixed */
-  public function getValue(Payload $payload) {
-    return $this->getFactory()($payload);
+  public function getValue(Payload $payload, array $params = []) {
+    return $this->getFactory()($payload, $params);
   }
 
   public function getArgs(): array {

--- a/mailpoet/lib/Automation/Engine/Data/StepRunArgs.php
+++ b/mailpoet/lib/Automation/Engine/Data/StepRunArgs.php
@@ -137,7 +137,7 @@ class StepRunArgs {
   }
 
   /** @return mixed */
-  public function getFieldValue(string $key) {
+  public function getFieldValue(string $key, array $params = []) {
     $field = $this->fields[$key] ?? null;
     $subjectKey = $this->fieldToSubjectMap[$key] ?? null;
     if (!$field || !$subjectKey) {
@@ -146,7 +146,7 @@ class StepRunArgs {
 
     $entry = $this->getSingleSubjectEntry($subjectKey);
     try {
-      $value = $field->getValue($entry->getPayload());
+      $value = $field->getValue($entry->getPayload(), $params);
     } catch (Throwable $e) {
       throw Exceptions::fieldLoadFailed($field->getKey(), $field->getArgs());
     }

--- a/mailpoet/lib/Automation/Engine/Integration/Filter.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Filter.php
@@ -13,6 +13,8 @@ interface Filter {
 
   public function getArgsSchema(string $condition): ObjectSchema;
 
+  public function getFieldParams(FilterData $data): array;
+
   /** @param mixed $value */
   public function matches(FilterData $data, $value): bool;
 }

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
@@ -196,7 +196,7 @@ class AutomationStorage {
       array_merge(
         [$subject->getHash()],
         $runStatus ?? [],
-        isset($inTheLastSeconds) ? [$inTheLastSeconds] : [],
+        isset($inTheLastSeconds) ? [intval($inTheLastSeconds)] : [],
       )
     );
     return array_map('intval', $this->wpdb->get_col($query));

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
@@ -12,8 +12,10 @@ use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
 
 class DelayAction implements Action {
+  public const KEY = 'core:delay';
+
   public function getKey(): string {
-    return 'core:delay';
+    return self::KEY;
   }
 
   public function getName(): string {

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
@@ -13,6 +13,8 @@ use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
 
 class IfElseAction implements Action {
+  public const KEY = 'core:if-else';
+
   /** @var FilterHandler */
   private $filterHandler;
 
@@ -23,7 +25,7 @@ class IfElseAction implements Action {
   }
 
   public function getKey(): string {
-    return 'core:if-else';
+    return self::KEY;
   }
 
   public function getName(): string {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/BooleanFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/BooleanFilter.php
@@ -27,6 +27,10 @@ class BooleanFilter implements Filter {
     ]);
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   public function matches(FilterData $data, $value): bool {
     $filterValue = $data->getArgs()['value'] ?? null;
     if (!is_bool($value) || !is_bool($filterValue)) {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/DateTimeFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/DateTimeFilter.php
@@ -88,6 +88,10 @@ class DateTimeFilter implements Filter {
     }
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   public function matches(FilterData $data, $value): bool {
     $filterValue = $data->getArgs()['value'] ?? null;
     $condition = $data->getCondition();

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -34,6 +34,10 @@ class EnumArrayFilter implements Filter {
     ]);
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   public function matches(FilterData $data, $value): bool {
     $filterValue = $data->getArgs()['value'] ?? null;
     if (!is_array($value) || !is_array($filterValue)) {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -49,7 +49,7 @@ class EnumArrayFilter implements Filter {
     $inTheLastUnit = $paramData['in_the_last']['unit'] ?? null;
     $inTheLastNumber = $paramData['in_the_last']['number'] ?? null;
     if ($inTheLastUnit === 'days' && $inTheLastNumber !== null) {
-      $params['in_the_last_seconds'] = $inTheLastNumber * DAY_IN_SECONDS;
+      $params['in_the_last'] = $inTheLastNumber * DAY_IN_SECONDS;
     }
 
     return $params;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
@@ -47,7 +47,7 @@ class EnumFilter implements Filter {
     $inTheLastUnit = $paramData['in_the_last']['unit'] ?? null;
     $inTheLastNumber = $paramData['in_the_last']['number'] ?? null;
     if ($inTheLastUnit === 'days' && $inTheLastNumber !== null) {
-      $params['in_the_last_seconds'] = $inTheLastNumber * DAY_IN_SECONDS;
+      $params['in_the_last'] = $inTheLastNumber * DAY_IN_SECONDS;
     }
 
     return $params;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
@@ -32,6 +32,10 @@ class EnumFilter implements Filter {
     ]);
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   public function matches(FilterData $data, $value): bool {
     $filterValue = $data->getArgs()['value'] ?? null;
     if (!is_scalar($value) || !is_array($filterValue)) {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumFilter.php
@@ -24,16 +24,33 @@ class EnumFilter implements Filter {
   }
 
   public function getArgsSchema(string $condition): ObjectSchema {
+    $paramsSchema = Builder::object([
+      'in_the_last' => Builder::object([
+        'number' => Builder::integer()->required()->minimum(1),
+        'unit' => Builder::string()->required()->pattern('^(days)$')->default('days'),
+      ]),
+    ]);
+
     return Builder::object([
       'value' => Builder::oneOf([
         Builder::array(Builder::string())->minItems(1),
         Builder::array(Builder::integer())->minItems(1),
       ])->required(),
+      'params' => $paramsSchema,
     ]);
   }
 
   public function getFieldParams(FilterData $data): array {
-    return [];
+    $paramData = $data->getArgs()['params'] ?? [];
+    $params = [];
+
+    $inTheLastUnit = $paramData['in_the_last']['unit'] ?? null;
+    $inTheLastNumber = $paramData['in_the_last']['number'] ?? null;
+    if ($inTheLastUnit === 'days' && $inTheLastNumber !== null) {
+      $params['in_the_last_seconds'] = $inTheLastNumber * DAY_IN_SECONDS;
+    }
+
+    return $params;
   }
 
   public function matches(FilterData $data, $value): bool {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
@@ -27,6 +27,10 @@ class IntegerFilter extends NumberFilter {
     }
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   public function matches(FilterData $data, $value): bool {
     $matches = parent::matches($data, $value);
     if (!$matches) {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
@@ -47,7 +47,7 @@ class IntegerFilter extends NumberFilter {
     $inTheLastUnit = $paramData['in_the_last']['unit'] ?? null;
     $inTheLastNumber = $paramData['in_the_last']['number'] ?? null;
     if ($inTheLastUnit === 'days' && $inTheLastNumber !== null) {
-      $params['in_the_last_seconds'] = $inTheLastNumber * DAY_IN_SECONDS;
+      $params['in_the_last'] = $inTheLastNumber * DAY_IN_SECONDS;
     }
 
     return $params;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/IntegerFilter.php
@@ -13,22 +13,44 @@ class IntegerFilter extends NumberFilter {
   }
 
   public function getArgsSchema(string $condition): ObjectSchema {
+    $paramsSchema = Builder::object([
+      'in_the_last' => Builder::object([
+        'number' => Builder::integer()->required()->minimum(1),
+        'unit' => Builder::string()->required()->pattern('^(days)$')->default('days'),
+      ]),
+    ]);
+
     switch ($condition) {
       case self::CONDITION_BETWEEN:
       case self::CONDITION_NOT_BETWEEN:
         return Builder::object([
           'value' => Builder::array(Builder::integer())->minItems(2)->maxItems(2)->required(),
+          'params' => $paramsSchema,
         ]);
       case self::CONDITION_IS_SET:
       case self::CONDITION_IS_NOT_SET:
-        return Builder::object([]);
+        return Builder::object([
+          'params' => $paramsSchema,
+        ]);
       default:
-        return Builder::object(['value' => Builder::integer()->required()]);
+        return Builder::object([
+          'value' => Builder::integer()->required(),
+          'params' => $paramsSchema,
+        ]);
     }
   }
 
   public function getFieldParams(FilterData $data): array {
-    return [];
+    $paramData = $data->getArgs()['params'] ?? [];
+    $params = [];
+
+    $inTheLastUnit = $paramData['in_the_last']['unit'] ?? null;
+    $inTheLastNumber = $paramData['in_the_last']['number'] ?? null;
+    if ($inTheLastUnit === 'days' && $inTheLastNumber !== null) {
+      $params['in_the_last_seconds'] = $inTheLastNumber * DAY_IN_SECONDS;
+    }
+
+    return $params;
   }
 
   public function matches(FilterData $data, $value): bool {

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
@@ -74,7 +74,7 @@ class NumberFilter implements Filter {
     $inTheLastUnit = $paramData['in_the_last']['unit'] ?? null;
     $inTheLastNumber = $paramData['in_the_last']['number'] ?? null;
     if ($inTheLastUnit === 'days' && $inTheLastNumber !== null) {
-      $params['in_the_last_seconds'] = $inTheLastNumber * DAY_IN_SECONDS;
+      $params['in_the_last'] = $inTheLastNumber * DAY_IN_SECONDS;
     }
 
     return $params;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
@@ -54,6 +54,10 @@ class NumberFilter implements Filter {
     }
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   /**
    * @param float $value
    */

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/StringFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/StringFilter.php
@@ -48,6 +48,10 @@ class StringFilter implements Filter {
     }
   }
 
+  public function getFieldParams(FilterData $data): array {
+    return [];
+  }
+
   public function matches(FilterData $data, $value): bool {
     $filterValue = $data->getArgs()['value'] ?? null;
     if (!is_string($value) || !is_string($filterValue)) {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -48,8 +48,8 @@ class SubscriberAutomationFieldsFactory {
         'mailpoet:subscriber:automations-processing',
         Field::TYPE_ENUM_ARRAY,
         __('Automations — processing', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          return $this->getAutomationIds($payload, [AutomationRun::STATUS_RUNNING]);
+        function (SubscriberPayload $payload, array $params = []) {
+          return $this->getAutomationIds($payload, [AutomationRun::STATUS_RUNNING], $params);
         },
         $args
       ),

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -57,8 +57,8 @@ class SubscriberAutomationFieldsFactory {
         'mailpoet:subscriber:automations-exited',
         Field::TYPE_ENUM_ARRAY,
         __('Automations — exited', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          return $this->getAutomationIds($payload, [AutomationRun::STATUS_COMPLETE]);
+        function (SubscriberPayload $payload, array $params = []) {
+          return $this->getAutomationIds($payload, [AutomationRun::STATUS_COMPLETE], $params);
         },
         $args
       ),

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -39,8 +39,8 @@ class SubscriberAutomationFieldsFactory {
         'mailpoet:subscriber:automations-entered',
         Field::TYPE_ENUM_ARRAY,
         __('Automations — entered', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          return $this->getAutomationIds($payload);
+        function (SubscriberPayload $payload, array $params = []) {
+          return $this->getAutomationIds($payload, null, $params);
         },
         $args
       ),
@@ -65,8 +65,9 @@ class SubscriberAutomationFieldsFactory {
     ];
   }
 
-  private function getAutomationIds(SubscriberPayload $payload, array $status = null): array {
+  private function getAutomationIds(SubscriberPayload $payload, array $status = null, array $params = []): array {
+    $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
     $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => $payload->getId()]);
-    return $this->automationStorage->getAutomationIdsBySubject($subject, $status);
+    return $this->automationStorage->getAutomationIdsBySubject($subject, $status, $inTheLastSeconds);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -32,6 +32,7 @@ class SubscriberAutomationFieldsFactory {
           'name' => $automation->getName() . " (#{$automation->getId()})",
         ];
       }, $automations),
+      'params' => ['in_the_last'],
     ];
 
     return [

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -67,9 +67,6 @@ class SubscriberAutomationFieldsFactory {
 
   private function getAutomationIds(SubscriberPayload $payload, array $status = null): array {
     $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => $payload->getId()]);
-    $automations = $this->automationStorage->getAutomationsBySubject($subject, $status);
-    return array_map(function (Automation $automation) {
-      return $automation->getId();
-    }, $automations);
+    return $this->automationStorage->getAutomationIdsBySubject($subject, $status);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -67,7 +67,7 @@ class SubscriberAutomationFieldsFactory {
   }
 
   private function getAutomationIds(SubscriberPayload $payload, array $status = null, array $params = []): array {
-    $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+    $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
     $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => $payload->getId()]);
     return $this->automationStorage->getAutomationIdsBySubject($subject, $status, $inTheLastSeconds);
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
@@ -27,7 +27,10 @@ class SubscriberStatisticFieldsFactory {
         function (SubscriberPayload $payload, array $params = []) {
           $startTime = $this->getStartTime($params);
           return $this->subscriberStatisticsRepository->getTotalSentCount($payload->getSubscriber(), $startTime);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'mailpoet:subscriber:email-opened-count',
@@ -36,7 +39,10 @@ class SubscriberStatisticFieldsFactory {
         function (SubscriberPayload $payload, array $params = []) {
           $startTime = $this->getStartTime($params);
           return $this->subscriberStatisticsRepository->getStatisticsOpenCount($payload->getSubscriber(), $startTime);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'mailpoet:subscriber:email-machine-opened-count',
@@ -45,7 +51,10 @@ class SubscriberStatisticFieldsFactory {
         function (SubscriberPayload $payload, array $params = []) {
           $startTime = $this->getStartTime($params);
           return $this->subscriberStatisticsRepository->getStatisticsMachineOpenCount($payload->getSubscriber(), $startTime);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'mailpoet:subscriber:email-clicked-count',
@@ -54,7 +63,10 @@ class SubscriberStatisticFieldsFactory {
         function (SubscriberPayload $payload, array $params = []) {
           $startTime = $this->getStartTime($params);
           return $this->subscriberStatisticsRepository->getStatisticsClickCount($payload->getSubscriber(), $startTime);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
     ];
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
@@ -33,9 +33,9 @@ class SubscriberStatisticFieldsFactory {
         'mailpoet:subscriber:email-opened-count',
         Field::TYPE_INTEGER,
         __('Email — opened count', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          $stats = $this->subscriberStatisticsRepository->getStatistics($payload->getSubscriber());
-          return $stats->getOpenCount();
+        function (SubscriberPayload $payload, array $params = []) {
+          $startTime = $this->getStartTime($params);
+          return $this->subscriberStatisticsRepository->getStatisticsOpenCount($payload->getSubscriber(), $startTime);
         }
       ),
       new Field(

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
@@ -51,9 +51,9 @@ class SubscriberStatisticFieldsFactory {
         'mailpoet:subscriber:email-clicked-count',
         Field::TYPE_INTEGER,
         __('Email — clicked count', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          $stats = $this->subscriberStatisticsRepository->getStatistics($payload->getSubscriber());
-          return $stats->getClickCount();
+        function (SubscriberPayload $payload, array $params = []) {
+          $startTime = $this->getStartTime($params);
+          return $this->subscriberStatisticsRepository->getStatisticsClickCount($payload->getSubscriber(), $startTime);
         }
       ),
     ];

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
@@ -72,7 +72,7 @@ class SubscriberStatisticFieldsFactory {
   }
 
   private function getStartTime(array $params): ?Carbon {
-    $inTheLastSeconds = $params['in_the_last_seconds'] ?? null;
+    $inTheLastSeconds = $params['in_the_last'] ?? null;
     return $inTheLastSeconds ? Carbon::now()->subSeconds((int)$inTheLastSeconds) : null;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Integrations\MailPoet\Fields;
 use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Subscribers\Statistics\SubscriberStatisticsRepository;
+use MailPoetVendor\Carbon\Carbon;
 
 class SubscriberStatisticFieldsFactory {
   /** @var SubscriberStatisticsRepository */
@@ -23,9 +24,9 @@ class SubscriberStatisticFieldsFactory {
         'mailpoet:subscriber:email-sent-count',
         Field::TYPE_INTEGER,
         __('Email — sent count', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          $stats = $this->subscriberStatisticsRepository->getStatistics($payload->getSubscriber());
-          return $stats->getTotalSentCount();
+        function (SubscriberPayload $payload, array $params = []) {
+          $startTime = $this->getStartTime($params);
+          return $this->subscriberStatisticsRepository->getTotalSentCount($payload->getSubscriber(), $startTime);
         }
       ),
       new Field(
@@ -56,5 +57,10 @@ class SubscriberStatisticFieldsFactory {
         }
       ),
     ];
+  }
+
+  private function getStartTime(array $params): ?Carbon {
+    $inTheLastSeconds = $params['in_the_last_seconds'] ?? null;
+    return $inTheLastSeconds ? Carbon::now()->subSeconds((int)$inTheLastSeconds) : null;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberStatisticFieldsFactory.php
@@ -42,9 +42,9 @@ class SubscriberStatisticFieldsFactory {
         'mailpoet:subscriber:email-machine-opened-count',
         Field::TYPE_INTEGER,
         __('Email — machine opened count', 'mailpoet'),
-        function (SubscriberPayload $payload) {
-          $stats = $this->subscriberStatisticsRepository->getStatistics($payload->getSubscriber());
-          return $stats->getMachineOpenCount();
+        function (SubscriberPayload $payload, array $params = []) {
+          $startTime = $this->getStartTime($params);
+          return $this->subscriberStatisticsRepository->getStatisticsMachineOpenCount($payload->getSubscriber(), $startTime);
         }
       ),
       new Field(

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -308,8 +308,8 @@ class CustomerOrderFieldsFactory {
       array_merge(
         $statuses,
         [$customer->get_id()],
-        isset($inTheLastSeconds) ? [$inTheLastSeconds] : [],
-        [$taxonomy]
+        isset($inTheLastSeconds) ? [intval($inTheLastSeconds)] : [],
+        [(string)($taxonomy)]
       )
     );
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -58,10 +58,20 @@ class CustomerOrderFieldsFactory {
         'woocommerce:customer:spent-average',
         Field::TYPE_NUMBER,
         __('Average spent', 'mailpoet'),
-        function (CustomerPayload $payload) {
+        function (CustomerPayload $payload, array $params = []) {
           $customer = $payload->getCustomer();
-          $totalSpent = $customer ? (float)$customer->get_total_spent() : 0.0;
-          $orderCount = $customer ? (int)$customer->get_order_count() : 0;
+          if (!$customer) {
+            return 0.0;
+          }
+
+          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          if ($inTheLastSeconds === null) {
+            $totalSpent = (float)$customer->get_total_spent();
+            $orderCount = (int)$customer->get_order_count();
+          } else {
+            $totalSpent = $this->getRecentSpentTotal($customer, $inTheLastSeconds);
+            $orderCount = $this->getRecentOrderCount($customer, $inTheLastSeconds);
+          }
           return $orderCount > 0 ? ($totalSpent / $orderCount) : 0.0;
         }
       ),

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -52,7 +52,10 @@ class CustomerOrderFieldsFactory {
           return $inTheLastSeconds === null
             ? (float)$customer->get_total_spent()
             : $this->getRecentSpentTotal($customer, $inTheLastSeconds);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'woocommerce:customer:spent-average',
@@ -73,7 +76,10 @@ class CustomerOrderFieldsFactory {
             $orderCount = $this->getRecentOrderCount($customer, $inTheLastSeconds);
           }
           return $orderCount > 0 ? ($totalSpent / $orderCount) : 0.0;
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'woocommerce:customer:order-count',
@@ -89,7 +95,10 @@ class CustomerOrderFieldsFactory {
           return $inTheLastSeconds === null
             ? $customer->get_order_count()
             : $this->getRecentOrderCount($customer, $inTheLastSeconds);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'woocommerce:customer:first-paid-order-date',
@@ -132,6 +141,7 @@ class CustomerOrderFieldsFactory {
         },
         [
           'options' => $this->termOptionsBuilder->getTermOptions('product_cat'),
+          'params' => ['in_the_last'],
         ]
       ),
       new Field(
@@ -150,6 +160,7 @@ class CustomerOrderFieldsFactory {
         },
         [
           'options' => $this->termOptionsBuilder->getTermOptions('product_tag'),
+          'params' => ['in_the_last'],
         ]
       ),
     ];

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -48,7 +48,7 @@ class CustomerOrderFieldsFactory {
             return 0.0;
           }
 
-          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
           return $inTheLastSeconds === null
             ? (float)$customer->get_total_spent()
             : $this->getRecentSpentTotal($customer, $inTheLastSeconds);
@@ -67,7 +67,7 @@ class CustomerOrderFieldsFactory {
             return 0.0;
           }
 
-          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
           if ($inTheLastSeconds === null) {
             $totalSpent = (float)$customer->get_total_spent();
             $orderCount = (int)$customer->get_order_count();
@@ -91,7 +91,7 @@ class CustomerOrderFieldsFactory {
             return 0;
           }
 
-          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
           return $inTheLastSeconds === null
             ? $customer->get_order_count()
             : $this->getRecentOrderCount($customer, $inTheLastSeconds);
@@ -133,7 +133,7 @@ class CustomerOrderFieldsFactory {
           if (!$customer) {
             return [];
           }
-          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
           $ids = $this->getOrderProductTermIds($customer, 'product_cat', $inTheLastSeconds);
           $ids = array_merge($ids, $this->termParentsLoader->getParentIds($ids));
           sort($ids);
@@ -153,7 +153,7 @@ class CustomerOrderFieldsFactory {
           if (!$customer) {
             return [];
           }
-          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
           $ids = $this->getOrderProductTermIds($customer, 'product_tag', $inTheLastSeconds);
           sort($ids);
           return $ids;

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -138,9 +138,15 @@ class CustomerOrderFieldsFactory {
         'woocommerce:customer:purchased-tags',
         Field::TYPE_ENUM_ARRAY,
         __('Purchased tags', 'mailpoet'),
-        function (CustomerPayload $payload) {
+        function (CustomerPayload $payload, array $params = []) {
           $customer = $payload->getCustomer();
-          return $customer ? $this->getOrderProductTermIds($customer, 'product_tag') : [];
+          if (!$customer) {
+            return [];
+          }
+          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $ids = $this->getOrderProductTermIds($customer, 'product_tag', $inTheLastSeconds);
+          sort($ids);
+          return $ids;
         },
         [
           'options' => $this->termOptionsBuilder->getTermOptions('product_tag'),

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -68,7 +68,7 @@ class CustomerReviewFieldsFactory {
         $sql,
         array_merge(
           [$customer->get_id(), $customer->get_email()],
-          isset($inTheLastSeconds) ? [$inTheLastSeconds] : []
+          isset($inTheLastSeconds) ? [intval($inTheLastSeconds)] : []
         )
       )
     );

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -55,15 +55,17 @@ class CustomerReviewFieldsFactory {
    */
   private function getUniqueProductReviewCount(WC_Customer $customer, int $inTheLastSeconds = null): int {
     $wpdb = $this->wordPress->getWpdb();
-    $inTheLastFilter = isset($inTheLastSeconds) ? "AND comment_date >= DATE_SUB(current_timestamp, INTERVAL %d SECOND)" : '';
+    $inTheLastFilter = isset($inTheLastSeconds) ? "AND c.comment_date >= DATE_SUB(current_timestamp, INTERVAL %d SECOND)" : '';
 
     /** @var literal-string $sql */
     $sql = "
-      SELECT COUNT(DISTINCT comment_post_ID) FROM {$wpdb->comments}
-      WHERE comment_parent = 0
-      AND comment_approved = 1
-      AND comment_type = 'review'
-      AND (user_ID = %d OR comment_author_email = %s)
+      SELECT COUNT(DISTINCT c.comment_post_ID) FROM {$wpdb->comments} c
+      JOIN {$wpdb->posts} p ON c.comment_post_ID = p.ID
+      WHERE p.post_type = 'product'
+      AND c.comment_parent = 0
+      AND c.comment_approved = 1
+      AND c.comment_type = 'review'
+      AND (c.user_ID = %d OR c.comment_author_email = %s)
       $inTheLastFilter
     ";
     return (int)$wpdb->get_var(
@@ -81,12 +83,14 @@ class CustomerReviewFieldsFactory {
     $wpdb = $this->wordPress->getWpdb();
     /** @var literal-string $sql */
     $sql = "
-      SELECT comment_date FROM {$wpdb->comments}
-      WHERE comment_parent = 0
-      AND comment_approved = 1
-      AND comment_type = 'review'
-      AND (user_ID = %d OR comment_author_email = %s)
-      ORDER BY comment_date DESC
+      SELECT c.comment_date FROM {$wpdb->comments} c
+      JOIN {$wpdb->posts} p ON c.comment_post_ID = p.ID
+      WHERE p.post_type = 'product'
+      AND c.comment_parent = 0
+      AND c.comment_approved = 1
+      AND c.comment_type = 'review'
+      AND (c.user_ID = %d OR c.comment_author_email = %s)
+      ORDER BY c.comment_date DESC
       LIMIT 1
     ";
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -55,7 +55,7 @@ class CustomerReviewFieldsFactory {
    */
   private function getUniqueProductReviewCount(WC_Customer $customer, int $inTheLastSeconds = null): int {
     $wpdb = $this->wordPress->getWpdb();
-    $inTheLastFilter = isset($inTheLastSeconds) ? "AND c.comment_date >= DATE_SUB(current_timestamp, INTERVAL %d SECOND)" : '';
+    $inTheLastFilter = isset($inTheLastSeconds) ? "AND c.comment_date_gmt >= DATE_SUB(current_timestamp, INTERVAL %d SECOND)" : '';
 
     /** @var literal-string $sql */
     $sql = "

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -30,7 +30,7 @@ class CustomerReviewFieldsFactory {
           if (!$customer) {
             return 0;
           }
-          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
           return $this->getUniqueProductReviewCount($customer, $inTheLastSeconds);
         },
         [

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -25,9 +25,13 @@ class CustomerReviewFieldsFactory {
         'woocommerce:customer:review-count',
         Field::TYPE_INTEGER,
         __('Review count', 'mailpoet'),
-        function (CustomerPayload $payload) {
+        function (CustomerPayload $payload, array $params = []) {
           $customer = $payload->getCustomer();
-          return $customer ? $this->getUniqueProductReviewCount($customer) : 0;
+          if (!$customer) {
+            return 0;
+          }
+          $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
+          return $this->getUniqueProductReviewCount($customer, $inTheLastSeconds);
         }
       ),
       new Field(
@@ -46,8 +50,10 @@ class CustomerReviewFieldsFactory {
    * Calculate the customer's review count excluding multiple reviews on the same product.
    * Inspired by AutomateWoo implementation.
    */
-  private function getUniqueProductReviewCount(WC_Customer $customer): int {
+  private function getUniqueProductReviewCount(WC_Customer $customer, int $inTheLastSeconds = null): int {
     $wpdb = $this->wordPress->getWpdb();
+    $inTheLastFilter = isset($inTheLastSeconds) ? "AND comment_date >= DATE_SUB(current_timestamp, INTERVAL %d SECOND)" : '';
+
     /** @var literal-string $sql */
     $sql = "
       SELECT COUNT(DISTINCT comment_post_ID) FROM {$wpdb->comments}
@@ -55,9 +61,16 @@ class CustomerReviewFieldsFactory {
       AND comment_approved = 1
       AND comment_type = 'review'
       AND (user_ID = %d OR comment_author_email = %s)
+      $inTheLastFilter
     ";
     return (int)$wpdb->get_var(
-      (string)$wpdb->prepare($sql, [$customer->get_id(), $customer->get_email()])
+      (string)$wpdb->prepare(
+        $sql,
+        array_merge(
+          [$customer->get_id(), $customer->get_email()],
+          isset($inTheLastSeconds) ? [$inTheLastSeconds] : []
+        )
+      )
     );
   }
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -32,7 +32,10 @@ class CustomerReviewFieldsFactory {
           }
           $inTheLastSeconds = isset($params['in_the_last_seconds']) ? (int)$params['in_the_last_seconds'] : null;
           return $this->getUniqueProductReviewCount($customer, $inTheLastSeconds);
-        }
+        },
+        [
+          'params' => ['in_the_last'],
+        ]
       ),
       new Field(
         'woocommerce:customer:last-review-date',

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermParentsLoader.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermParentsLoader.php
@@ -19,6 +19,9 @@ class TermParentsLoader {
    * @return int[]
    */
   public function getParentIds(array $termIds): array {
+    if (count($termIds) === 0) {
+      return [];
+    }
     $idsPlaceholder = implode(',', array_fill(0, count($termIds), '%s'));
 
     $wpdb = $this->wordPress->getWpdb();

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -76,7 +76,7 @@ parameters:
       path: ../../lib/Logging/PluginVersionProcessor.php
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 3
+      count: 5
       path: ../../lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan.neon
+++ b/mailpoet/tasks/phpstan/phpstan.neon
@@ -76,7 +76,7 @@ parameters:
       path: ../../lib/Logging/PluginVersionProcessor.php
     -
       message: "#^Cannot cast string|void to string\\.$#"
-      count: 5
+      count: 7
       path: ../../lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
     -
       message: "#^Cannot cast string|void to string\\.$#"

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -341,14 +341,8 @@ class IntegrationTester extends \Codeception\Actor {
   }
 
   public function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
-    $trigger = array_filter($automation->getSteps(), function(Step $step): bool { return $step->getType() === Step::TYPE_TRIGGER;
-
-    });
-    $triggerKeys = array_map(function(Step $step): string { return $step->getKey();
-
-    }, $trigger);
-    $triggerKey = count($triggerKeys) > 0 ? current($triggerKeys) : '';
-
+    $trigger = array_values($automation->getTriggers())[0] ?? null;
+    $triggerKey = $trigger ? $trigger->getKey() : '';
     $automationRun = new AutomationRun(
       $automation->getId(),
       $automation->getVersionId(),

--- a/mailpoet/tests/integration/Automation/AutomationFullRunTest.php
+++ b/mailpoet/tests/integration/Automation/AutomationFullRunTest.php
@@ -86,8 +86,10 @@ class AutomationFullRunTest extends \MailPoetTest {
     $noSubscriber = (new Subscriber())->withWpUserId($noCustomer->ID)->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
 
     // reviews
-    $this->tester->createWooProductReview($yesCustomer->ID, '', 1, 5, Carbon::now());
-    $this->tester->createWooProductReview($noCustomer->ID, '', 2, 1, Carbon::now()->subMonth());
+    $product1 = $this->tester->createWooCommerceProduct(['name' => 'Product 1']);
+    $product2 = $this->tester->createWooCommerceProduct(['name' => 'Product 2']);
+    $this->tester->createWooProductReview($yesCustomer->ID, '', $product1->get_id(), 5, Carbon::now());
+    $this->tester->createWooProductReview($noCustomer->ID, '', $product2->get_id(), 1, Carbon::now()->subMonth());
 
     // run triggers
     $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);

--- a/mailpoet/tests/integration/Automation/AutomationFullRunTest.php
+++ b/mailpoet/tests/integration/Automation/AutomationFullRunTest.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation;
+
+use ActionScheduler_QueueRunner;
+use ActionScheduler_Store;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\Core\Actions\IfElseAction;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoet\Test\DataFactories\User;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * @group woo
+ */
+class AutomationFullRunTest extends \MailPoetTest {
+  private AutomationStorage $automationStorage;
+  private AutomationRunStorage $automationRunStorage;
+
+  public function _before(): void {
+    parent::_before();
+    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $this->cleanup();
+  }
+
+  public function testAutomationWithIfElseStepAndInTheLastParam(): void {
+    $automation = (new \MailPoet\Test\DataFactories\Automation())
+      ->withSteps([
+        new Step('root', Step::TYPE_ROOT, 'root', [], [new NextStep('trigger')]),
+        new Step('trigger', Step::TYPE_TRIGGER, SomeoneSubscribesTrigger::KEY, [], [new NextStep('if-else')]),
+        new Step(
+          'if-else',
+          Step::TYPE_ACTION,
+          IfElseAction::KEY,
+          [],
+          [new NextStep('yes'), new NextStep('no')],
+          new Filters(
+            'and',
+            [
+              new FilterGroup(
+                'group',
+                'and',
+                [
+                  // customers with at least one review in the last 7 days
+                  new Filter(
+                    'filter',
+                    Field::TYPE_INTEGER,
+                    'woocommerce:customer:review-count',
+                    'greater-than',
+                    [
+                      'value' => 0,
+                      'params' => ['in_the_last' => ['number' => 7, 'unit' => 'days']],
+                    ]
+                  ),
+                ]
+              ),
+            ]
+          )
+        ),
+        new Step('yes', Step::TYPE_ACTION, DelayAction::KEY, ['delay' => 1, 'delay_type' => 'MINUTES'], []),
+        new Step('no', Step::TYPE_ACTION, DelayAction::KEY, ['delay' => 3, 'delay_type' => 'HOURS'], []),
+      ])
+      ->withStatus(Automation::STATUS_ACTIVE)
+      ->create();
+
+    // customers
+    $yesCustomer = (new User)->createUser('Yes', 'customer', 'yes@test.com');
+    $noCustomer = (new User)->createUser('No', 'customer', 'no@test.com');
+
+    // subscribers & segments
+    $segment = (new Segment())->withName('Test segment')->create();
+    $yesSubscriber = (new Subscriber())->withWpUserId($yesCustomer->ID)->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
+    $noSubscriber = (new Subscriber())->withWpUserId($noCustomer->ID)->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->withSegments([$segment])->create();
+
+    // reviews
+    $this->tester->createWooProductReview($yesCustomer->ID, '', 1, 5, Carbon::now());
+    $this->tester->createWooProductReview($noCustomer->ID, '', 2, 1, Carbon::now()->subMonth());
+
+    // run triggers
+    $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
+    $yesSubscriberSegment = $yesSubscriber->getSubscriberSegments()[0];
+    $noSubscriberSegment = $noSubscriber->getSubscriberSegments()[0];
+    $this->assertNotNull($yesSubscriberSegment);
+    $this->assertNotNull($noSubscriberSegment);
+    $trigger->handleSubscription($yesSubscriberSegment);
+    $trigger->handleSubscription($noSubscriberSegment);
+    $this->assertCount(2, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
+
+    // if-else steps should be scheduled
+    $actions = $this->getScheduledActions();
+    $this->assertCount(2, $actions);
+    [$action1, $action2] = $actions;
+    $this->assertSame('mailpoet/automation/step', $action1->get_hook());
+    $this->assertSame('if-else', $action1->get_args()[0]['step_id']);
+    $this->assertSame('mailpoet/automation/step', $action2->get_hook());
+    $this->assertSame('if-else', $action2->get_args()[0]['step_id']);
+
+    // execute if-else steps
+    $runner = new ActionScheduler_QueueRunner();
+    $runner->run();
+
+    // check yes/no branches
+    $actions = $this->getScheduledActions();
+    $this->assertCount(2, $actions);
+    [$action1, $action2] = $actions;
+
+    $this->assertSame('mailpoet/automation/step', $action1->get_hook());
+    $this->assertSame('yes', $action1->get_args()[0]['step_id']);
+    $run1 = $this->automationRunStorage->getAutomationRun($action1->get_args()[0]['automation_run_id']);
+    $subscriberId1 = $run1 ? $run1->getSubjects('mailpoet:subscriber')[0]->getArgs()['subscriber_id'] : null;
+    $this->assertSame($yesSubscriber->getId(), $subscriberId1);
+
+    $this->assertSame('mailpoet/automation/step', $action2->get_hook());
+    $this->assertSame('no', $action2->get_args()[0]['step_id']);
+    $run2 = $this->automationRunStorage->getAutomationRun($action2->get_args()[0]['automation_run_id']);
+    $subscriberId2 = $run2 ? $run2->getSubjects('mailpoet:subscriber')[0]->getArgs()['subscriber_id'] : null;
+    $this->assertSame($noSubscriber->getId(), $subscriberId2);
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->cleanup();
+  }
+
+  private function getScheduledActions(): array {
+    return array_values(
+      as_get_scheduled_actions([
+        'group' => 'mailpoet-automation',
+        'status' => [ActionScheduler_Store::STATUS_PENDING, ActionScheduler_Store::STATUS_RUNNING],
+      ])
+    );
+  }
+
+  private function cleanup(): void {
+    $this->automationStorage->truncate();
+    $this->automationRunStorage->truncate();
+
+    global $wpdb;
+    $actionsTable = $wpdb->prefix . 'actionscheduler_actions';
+    $wpdb->query('TRUNCATE ' . $actionsTable);
+    $claimsTable = $wpdb->prefix . 'actionscheduler_claims';
+    $wpdb->query('TRUNCATE ' . $claimsTable);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -96,6 +96,7 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
     $payload = new SubscriberPayload($subscriber);
     $entered = $fields['mailpoet:subscriber:automations-entered'];
     $processing = $fields['mailpoet:subscriber:automations-processing'];
+    $exited = $fields['mailpoet:subscriber:automations-exited'];
 
     // all time
     $this->assertSame(
@@ -105,6 +106,10 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
     $this->assertSame(
       [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active1->getId()],
       $processing->getValue($payload)
+    );
+    $this->assertSame(
+      [$active3->getId(), $active2->getId(), $draft2->getId(), $draft1->getId()],
+      $exited->getValue($payload)
     );
 
     // 3 months
@@ -116,6 +121,10 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
       [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active1->getId()],
       $processing->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
     );
+    $this->assertSame(
+      [$active3->getId(), $active2->getId(), $draft2->getId(), $draft1->getId()],
+      $exited->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
+    );
 
     // 3 weeks
     $this->assertSame(
@@ -126,10 +135,15 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
       [$deactivating2->getId(), $active3->getId()],
       $processing->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
     );
+    $this->assertSame(
+      [$active3->getId(), $draft2->getId()],
+      $exited->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
+    );
 
     // 3 days
     $this->assertSame([], $entered->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
     $this->assertSame([], $processing->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame([], $exited->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
   }
 
   private function getFieldsMap(): array {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -118,35 +118,35 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
     // 3 months
     $this->assertSame(
       [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active2->getId(), $active1->getId(), $draft2->getId(), $draft1->getId()],
-      $entered->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
+      $entered->getValue($payload, ['in_the_last' => 3 * MONTH_IN_SECONDS])
     );
     $this->assertSame(
       [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active1->getId()],
-      $processing->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
+      $processing->getValue($payload, ['in_the_last' => 3 * MONTH_IN_SECONDS])
     );
     $this->assertSame(
       [$active3->getId(), $active2->getId(), $draft2->getId(), $draft1->getId()],
-      $exited->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
+      $exited->getValue($payload, ['in_the_last' => 3 * MONTH_IN_SECONDS])
     );
 
     // 3 weeks
     $this->assertSame(
       [$deactivating2->getId(), $active3->getId(), $active2->getId(), $draft2->getId()],
-      $entered->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
+      $entered->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS])
     );
     $this->assertSame(
       [$deactivating2->getId(), $active3->getId()],
-      $processing->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
+      $processing->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS])
     );
     $this->assertSame(
       [$active3->getId(), $draft2->getId()],
-      $exited->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
+      $exited->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS])
     );
 
     // 3 days
-    $this->assertSame([], $entered->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
-    $this->assertSame([], $processing->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
-    $this->assertSame([], $exited->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame([], $entered->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame([], $processing->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame([], $exited->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
   }
 
   private function getFieldsMap(): array {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -36,11 +36,14 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
       $field = $fields[$key];
       $this->assertSame($name, $field->getName());
       $this->assertSame('enum_array', $field->getType());
-      $this->assertSame(['options' => [
-        ['id' => $deactivating->getId(), 'name' => "Deactivating (#{$deactivating->getId()})"],
-        ['id' => $active->getId(), 'name' => "Active (#{$active->getId()})"],
-        ['id' => $draft->getId(), 'name' => "Draft (#{$draft->getId()})"],
-      ]], $field->getArgs());
+      $this->assertSame([
+        'options' => [
+          ['id' => $deactivating->getId(), 'name' => "Deactivating (#{$deactivating->getId()})"],
+          ['id' => $active->getId(), 'name' => "Active (#{$active->getId()})"],
+          ['id' => $draft->getId(), 'name' => "Draft (#{$draft->getId()})"],
+        ],
+        'params' => ['in_the_last'],
+      ], $field->getArgs());
     }
 
     // check values

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -95,11 +95,16 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
 
     $payload = new SubscriberPayload($subscriber);
     $entered = $fields['mailpoet:subscriber:automations-entered'];
+    $processing = $fields['mailpoet:subscriber:automations-processing'];
 
     // all time
     $this->assertSame(
       [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active2->getId(), $active1->getId(), $draft2->getId(), $draft1->getId()],
       $entered->getValue($payload)
+    );
+    $this->assertSame(
+      [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active1->getId()],
+      $processing->getValue($payload)
     );
 
     // 3 months
@@ -107,15 +112,24 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
       [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active2->getId(), $active1->getId(), $draft2->getId(), $draft1->getId()],
       $entered->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
     );
+    $this->assertSame(
+      [$deactivating2->getId(), $deactivating1->getId(), $active3->getId(), $active1->getId()],
+      $processing->getValue($payload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS])
+    );
 
     // 3 weeks
     $this->assertSame(
       [$deactivating2->getId(), $active3->getId(), $active2->getId(), $draft2->getId()],
       $entered->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
     );
+    $this->assertSame(
+      [$deactivating2->getId(), $active3->getId()],
+      $processing->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS])
+    );
 
     // 3 days
     $this->assertSame([], $entered->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame([], $processing->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
   }
 
   private function getFieldsMap(): array {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -37,9 +37,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
-    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
-    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last' => 3 * HOUR_IN_SECONDS]));
   }
 
   public function testItCreatesOpenedCountField(): void {
@@ -69,9 +69,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
-    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
-    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last' => 3 * HOUR_IN_SECONDS]));
   }
 
   public function testItCreatesMachineOpenedCountField(): void {
@@ -101,9 +101,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
-    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
-    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last' => 3 * HOUR_IN_SECONDS]));
   }
 
   public function testItCreatesClickedCountField(): void {
@@ -134,9 +134,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
-    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
-    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last' => 3 * HOUR_IN_SECONDS]));
   }
 
   /** @return array<string, Field> */

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -23,8 +23,8 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     $newsletter2 = (new NewsletterFactory())->withSendingQueue()->create();
     (new NewsletterFactory())->withSendingQueue()->create();
 
-    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->withSentAt(Carbon::now())->create();
-    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->withSentAt(Carbon::now())->create();
+    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->withSentAt(new Carbon('-1 week'))->create();
+    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->withSentAt(new Carbon('-1 day'))->create();
 
     // check definitions
     $field = $fields['mailpoet:subscriber:email-sent-count'];

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -113,6 +113,10 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     (new StatisticsClicksFactory($link1, $subscriber))->create(); // click 1
     (new StatisticsClicksFactory($link2, $subscriber))->create(); // click 2
 
+    // click dates are filtered by newsletter stats dates
+    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->withSentAt(new Carbon('-1 week'))->create();
+    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->withSentAt(new Carbon('-1 day'))->create();
+
     // check definitions
     $field = $fields['mailpoet:subscriber:email-clicked-count'];
     $this->assertSame('Email — clicked count', $field->getName());
@@ -122,6 +126,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
   }
 
   /** @return array<string, Field> */

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -35,6 +35,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
   }
 
   public function testItCreatesOpenedCountField(): void {
@@ -46,8 +49,12 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     (new NewsletterFactory())->withSendingQueue()->create();
 
     (new StatisticsOpensFacctory($newsletter1, $subscriber))->create(); // open
+    (new StatisticsOpensFacctory($newsletter2, $subscriber))->create(); // open
     (new StatisticsOpensFacctory($newsletter1, $subscriber))->withMachineUserAgentType()->create(); // machine open
-    (new StatisticsOpensFacctory($newsletter2, $subscriber))->withMachineUserAgentType()->create(); // machine open
+
+    // open dates are filtered by newsletter stats dates
+    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->withSentAt(new Carbon('-1 week'))->create();
+    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->withSentAt(new Carbon('-1 day'))->create();
 
     // check definitions
     $field = $fields['mailpoet:subscriber:email-opened-count'];
@@ -57,7 +64,10 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
 
     // check values
     $payload = new SubscriberPayload($subscriber);
-    $this->assertSame(1, $field->getValue($payload));
+    $this->assertSame(2, $field->getValue($payload));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
   }
 
   public function testItCreatesMachineOpenedCountField(): void {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -30,7 +30,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     $field = $fields['mailpoet:subscriber:email-sent-count'];
     $this->assertSame('Email — sent count', $field->getName());
     $this->assertSame('integer', $field->getType());
-    $this->assertSame([], $field->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $field->getArgs());
 
     // check values
     $payload = new SubscriberPayload($subscriber);
@@ -60,7 +62,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     $field = $fields['mailpoet:subscriber:email-opened-count'];
     $this->assertSame('Email — opened count', $field->getName());
     $this->assertSame('integer', $field->getType());
-    $this->assertSame([], $field->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $field->getArgs());
 
     // check values
     $payload = new SubscriberPayload($subscriber);
@@ -90,7 +94,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     $field = $fields['mailpoet:subscriber:email-machine-opened-count'];
     $this->assertSame('Email — machine opened count', $field->getName());
     $this->assertSame('integer', $field->getType());
-    $this->assertSame([], $field->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $field->getArgs());
 
     // check values
     $payload = new SubscriberPayload($subscriber);
@@ -121,7 +127,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     $field = $fields['mailpoet:subscriber:email-clicked-count'];
     $this->assertSame('Email — clicked count', $field->getName());
     $this->assertSame('integer', $field->getType());
-    $this->assertSame([], $field->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $field->getArgs());
 
     // check values
     $payload = new SubscriberPayload($subscriber);

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberStatisticsFieldsFactoryTest.php
@@ -82,6 +82,10 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     (new StatisticsOpensFacctory($newsletter1, $subscriber))->withMachineUserAgentType()->create(); // machine open
     (new StatisticsOpensFacctory($newsletter2, $subscriber))->withMachineUserAgentType()->create(); // machine open
 
+    // open dates are filtered by newsletter stats dates
+    (new StatisticsNewslettersFactory($newsletter1, $subscriber))->withSentAt(new Carbon('-1 week'))->create();
+    (new StatisticsNewslettersFactory($newsletter2, $subscriber))->withSentAt(new Carbon('-1 day'))->create();
+
     // check definitions
     $field = $fields['mailpoet:subscriber:email-machine-opened-count'];
     $this->assertSame('Email — machine opened count', $field->getName());
@@ -91,6 +95,9 @@ class SubscriberStatisticsFieldsFactoryTest extends MailPoetTest {
     // check values
     $payload = new SubscriberPayload($subscriber);
     $this->assertSame(2, $field->getValue($payload));
+    $this->assertSame(2, $field->getValue($payload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $field->getValue($payload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(0, $field->getValue($payload, ['in_the_last_seconds' => 3 * HOUR_IN_SECONDS]));
   }
 
   public function testItCreatesClickedCountField(): void {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
@@ -75,14 +75,17 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
 
     // 100 years
     $this->assertSame(162.3, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
+    $this->assertSame(54.1, $spentAverageField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
     $this->assertSame(3, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
 
     // 3 months
     $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
+    $this->assertSame(75.0, $spentAverageField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
     $this->assertSame(2, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
 
     // 3 weeks
     $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(150.0, $spentAverageField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
     $this->assertSame(1, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
   }
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
@@ -22,17 +22,23 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     $spentTotalField = $fields['woocommerce:customer:spent-total'];
     $this->assertSame('Total spent', $spentTotalField->getName());
     $this->assertSame('number', $spentTotalField->getType());
-    $this->assertSame([], $spentTotalField->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $spentTotalField->getArgs());
 
     $spentAverageField = $fields['woocommerce:customer:spent-average'];
     $this->assertSame('Average spent', $spentAverageField->getName());
     $this->assertSame('number', $spentAverageField->getType());
-    $this->assertSame([], $spentAverageField->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $spentAverageField->getArgs());
 
     $orderCountField = $fields['woocommerce:customer:order-count'];
     $this->assertSame('Order count', $orderCountField->getName());
     $this->assertSame('integer', $orderCountField->getType());
-    $this->assertSame([], $orderCountField->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $orderCountField->getArgs());
 
     // check values (guest)
     $this->createOrder(0, 12.3);
@@ -150,6 +156,7 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
         ['id' => $cat3Id, 'name' => 'Cat 3'],
         ['id' => $uncategorizedId, 'name' => 'Uncategorized'],
       ],
+      'params' => ['in_the_last'],
     ], $purchasedCategories->getArgs());
 
     // create products
@@ -225,6 +232,7 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
         ['id' => $tag2Id, 'name' => 'Tag 2'],
         ['id' => $tag3Id, 'name' => 'Tag 3'],
       ],
+      'params' => ['in_the_last'],
     ], $purchasedTags->getArgs());
 
     // create products

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
@@ -75,12 +75,15 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
 
     // 100 years
     $this->assertSame(162.3, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
+    $this->assertSame(3, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
 
     // 3 months
     $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
+    $this->assertSame(2, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
 
     // 3 weeks
     $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
   }
 
   public function testOrderDateFields(): void {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
@@ -56,6 +56,33 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame(3, $orderCountField->getValue($customerPayload));
   }
 
+  public function testOrderStatsFieldsWithInTheLastParameter(): void {
+    $fields = $this->getFieldsMap();
+
+    $spentTotalField = $fields['woocommerce:customer:spent-total'];
+    $spentAverageField = $fields['woocommerce:customer:spent-average'];
+    $orderCountField = $fields['woocommerce:customer:order-count'];
+
+    // check values (registered)
+    $id = $this->tester->createCustomer('customer@example.com');
+    $id2 = $this->tester->createCustomer('other_user@example.com');
+    $this->createOrder($id, 12.3, date('Y-m-d H:i:s', strtotime('-1 year')));
+    $this->createOrder($id, 0, date('Y-m-d H:i:s', strtotime('-1 month')));
+    $this->createOrder($id, 150.0, date('Y-m-d H:i:s', strtotime('-1 week')));
+    $this->createOrder($id2, 12345.0, date('Y-m-d H:i:s', strtotime('-1 day'))); // other user
+
+    $customerPayload = new CustomerPayload(new WC_Customer($id));
+
+    // 100 years
+    $this->assertSame(162.3, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
+
+    // 3 months
+    $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
+
+    // 3 weeks
+    $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+  }
+
   public function testOrderDateFields(): void {
     $fields = $this->getFieldsMap();
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactoryTest.php
@@ -80,19 +80,19 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     $customerPayload = new CustomerPayload(new WC_Customer($id));
 
     // 100 years
-    $this->assertSame(162.3, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
-    $this->assertSame(54.1, $spentAverageField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
-    $this->assertSame(3, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 100 * YEAR_IN_SECONDS]));
+    $this->assertSame(162.3, $spentTotalField->getValue($customerPayload, ['in_the_last' => 100 * YEAR_IN_SECONDS]));
+    $this->assertSame(54.1, $spentAverageField->getValue($customerPayload, ['in_the_last' => 100 * YEAR_IN_SECONDS]));
+    $this->assertSame(3, $orderCountField->getValue($customerPayload, ['in_the_last' => 100 * YEAR_IN_SECONDS]));
 
     // 3 months
-    $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
-    $this->assertSame(75.0, $spentAverageField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
-    $this->assertSame(2, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
+    $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last' => 3 * MONTH_IN_SECONDS]));
+    $this->assertSame(75.0, $spentAverageField->getValue($customerPayload, ['in_the_last' => 3 * MONTH_IN_SECONDS]));
+    $this->assertSame(2, $orderCountField->getValue($customerPayload, ['in_the_last' => 3 * MONTH_IN_SECONDS]));
 
     // 3 weeks
-    $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(150.0, $spentAverageField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(1, $orderCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(150.0, $spentTotalField->getValue($customerPayload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(150.0, $spentAverageField->getValue($customerPayload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(1, $orderCountField->getValue($customerPayload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
   }
 
   public function testOrderDateFields(): void {
@@ -203,15 +203,15 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame([$uncategorizedId, $cat1Id, $cat2Id, $subCat1Id, $subSubCat1Id], $value);
 
     // 3 months
-    $value = $purchasedCategories->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]);
+    $value = $purchasedCategories->getValue($customerPayload, ['in_the_last' => 3 * MONTH_IN_SECONDS]);
     $this->assertSame([$uncategorizedId, $cat1Id, $cat2Id, $subCat1Id, $subSubCat1Id], $value);
 
     // 3 weeks
-    $value = $purchasedCategories->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]);
+    $value = $purchasedCategories->getValue($customerPayload, ['in_the_last' => 3 * WEEK_IN_SECONDS]);
     $this->assertSame([$cat1Id, $cat2Id, $subCat1Id, $subSubCat1Id], $value);
 
     // 3 days
-    $value = $purchasedCategories->getValue($customerPayload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]);
+    $value = $purchasedCategories->getValue($customerPayload, ['in_the_last' => 3 * DAY_IN_SECONDS]);
     $this->assertSame([], $value);
   }
 
@@ -276,15 +276,15 @@ class CustomerOrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame([$tag1Id, $tag2Id], $value);
 
     // 3 months
-    $value = $purchasedTags->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]);
+    $value = $purchasedTags->getValue($customerPayload, ['in_the_last' => 3 * MONTH_IN_SECONDS]);
     $this->assertSame([$tag1Id, $tag2Id], $value);
 
     // 3 weeks
-    $value = $purchasedTags->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]);
+    $value = $purchasedTags->getValue($customerPayload, ['in_the_last' => 3 * WEEK_IN_SECONDS]);
     $this->assertSame([$tag2Id], $value);
 
     // 3 days
-    $value = $purchasedTags->getValue($customerPayload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]);
+    $value = $purchasedTags->getValue($customerPayload, ['in_the_last' => 3 * DAY_IN_SECONDS]);
     $this->assertSame([], $value);
   }
 

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactoryTest.php
@@ -58,9 +58,9 @@ class CustomerReviewFieldsFactoryTest extends \MailPoetTest {
 
     $customerPayload = new CustomerPayload(new WC_Customer($id));
     $this->assertSame(3, $reviewCountField->getValue($customerPayload));
-    $this->assertSame(2, $reviewCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * MONTH_IN_SECONDS]));
-    $this->assertSame(1, $reviewCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * WEEK_IN_SECONDS]));
-    $this->assertSame(0, $reviewCountField->getValue($customerPayload, ['in_the_last_seconds' => 3 * DAY_IN_SECONDS]));
+    $this->assertSame(2, $reviewCountField->getValue($customerPayload, ['in_the_last' => 3 * MONTH_IN_SECONDS]));
+    $this->assertSame(1, $reviewCountField->getValue($customerPayload, ['in_the_last' => 3 * WEEK_IN_SECONDS]));
+    $this->assertSame(0, $reviewCountField->getValue($customerPayload, ['in_the_last' => 3 * DAY_IN_SECONDS]));
   }
 
   public function testLastReviewDateField(): void {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactoryTest.php
@@ -19,7 +19,9 @@ class CustomerReviewFieldsFactoryTest extends \MailPoetTest {
     $reviewCountField = $fields['woocommerce:customer:review-count'];
     $this->assertSame('Review count', $reviewCountField->getName());
     $this->assertSame('integer', $reviewCountField->getType());
-    $this->assertSame([], $reviewCountField->getArgs());
+    $this->assertSame([
+      'params' => ['in_the_last'],
+    ], $reviewCountField->getArgs());
 
     // check values (guest)
     $this->createProductReview(0, '', 1);

--- a/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Control/FilterHandlerTest.php
@@ -286,6 +286,10 @@ class FilterHandlerTest extends MailPoetUnitTest {
         return Builder::object();
       }
 
+      public function getFieldParams(FilterData $data): array {
+        return [];
+      }
+
       public function matches(FilterData $data, $value): bool {
         return $data->getArgs()['value'] === $value;
       }

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepFiltersRuleTest.php
@@ -119,6 +119,10 @@ class ValidStepFiltersRuleTest extends AutomationRuleTest {
         return Builder::object();
       }
 
+      public function getFieldParams(FilterData $data): array {
+        return [];
+      }
+
       public function matches(FilterData $data, $value): bool {
         return true;
       }

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumArrayFilterTest.php
@@ -18,6 +18,19 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
       'matches-none-of' => 'matches none of',
     ], $filter->getConditions());
 
+    $paramsSchema = [
+      'type' => 'object',
+      'properties' => [
+        'in_the_last' => [
+          'type' => 'object',
+          'properties' => [
+            'number' => ['type' => 'integer', 'required' => true, 'minimum' => 1],
+            'unit' => ['type' => 'string', 'required' => true, 'pattern' => '^(days)$', 'default' => 'days'],
+          ],
+        ],
+      ],
+    ];
+
     $argsSchema = [
       'type' => 'object',
       'properties' => [
@@ -28,6 +41,7 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
           ],
           'required' => true,
         ],
+        'params' => $paramsSchema,
       ],
     ];
 
@@ -94,6 +108,19 @@ class EnumArrayFilterTest extends MailPoetUnitTest {
   public function testUnknownCondition(): void {
     $this->assertNotMatches('unknown', [1], [1]);
     $this->assertNotMatches('unknown', [1, 2, 3], [1]);
+  }
+
+  public function testFieldParams(): void {
+    if (!defined('DAY_IN_SECONDS')) {
+      define('DAY_IN_SECONDS', 24 * 60 * 60);
+    }
+
+    $filter = new EnumArrayFilter();
+    $params = ['in_the_last' => ['number' => 123, 'unit' => 'days']];
+    $this->assertSame(
+      ['in_the_last' => 123 * DAY_IN_SECONDS],
+      $filter->getFieldParams(new Filter('f', 'integer', '', 'equals', ['params' => $params]))
+    );
   }
 
   private function assertMatches(string $condition, $filterValue, $value): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/EnumFilterTest.php
@@ -17,6 +17,19 @@ class EnumFilterTest extends MailPoetUnitTest {
       'is-none-of' => 'is none of',
     ], $filter->getConditions());
 
+    $paramsSchema = [
+      'type' => 'object',
+      'properties' => [
+        'in_the_last' => [
+          'type' => 'object',
+          'properties' => [
+            'number' => ['type' => 'integer', 'required' => true, 'minimum' => 1],
+            'unit' => ['type' => 'string', 'required' => true, 'pattern' => '^(days)$', 'default' => 'days'],
+          ],
+        ],
+      ],
+    ];
+
     $argsSchema = [
       'type' => 'object',
       'properties' => [
@@ -27,6 +40,7 @@ class EnumFilterTest extends MailPoetUnitTest {
           ],
           'required' => true,
         ],
+        'params' => $paramsSchema,
       ],
     ];
 
@@ -79,6 +93,19 @@ class EnumFilterTest extends MailPoetUnitTest {
   public function testUnknownCondition(): void {
     $this->assertNotMatches('unknown', [1], 1);
     $this->assertNotMatches('unknown', [1, 2, 3], 1);
+  }
+
+  public function testFieldParams(): void {
+    if (!defined('DAY_IN_SECONDS')) {
+      define('DAY_IN_SECONDS', 24 * 60 * 60);
+    }
+
+    $filter = new EnumFilter();
+    $params = ['in_the_last' => ['number' => 123, 'unit' => 'days']];
+    $this->assertSame(
+      ['in_the_last' => 123 * DAY_IN_SECONDS],
+      $filter->getFieldParams(new Filter('f', 'integer', '', 'equals', ['params' => $params]))
+    );
   }
 
   private function assertMatches(string $condition, $filterValue, $value): void {

--- a/mailpoet/tests/unit/Automation/Integration/Core/Filters/NumberFilterTest.php
+++ b/mailpoet/tests/unit/Automation/Integration/Core/Filters/NumberFilterTest.php
@@ -24,6 +24,19 @@ class NumberFilterTest extends MailPoetUnitTest {
       'is-not-set' => 'is not set',
     ], $filter->getConditions());
 
+    $paramsSchema = [
+      'type' => 'object',
+      'properties' => [
+        'in_the_last' => [
+          'type' => 'object',
+          'properties' => [
+            'number' => ['type' => 'integer', 'required' => true, 'minimum' => 1],
+            'unit' => ['type' => 'string', 'required' => true, 'pattern' => '^(days)$', 'default' => 'days'],
+          ],
+        ],
+      ],
+    ];
+
     $singleValueArgsSchema = [
       'type' => 'object',
       'properties' => [
@@ -31,6 +44,7 @@ class NumberFilterTest extends MailPoetUnitTest {
           'type' => 'number',
           'required' => true,
         ],
+        'params' => $paramsSchema,
       ],
     ];
 
@@ -44,10 +58,16 @@ class NumberFilterTest extends MailPoetUnitTest {
           'maxItems' => 2,
           'required' => true,
         ],
+        'params' => $paramsSchema,
       ],
     ];
 
-    $emptyArgsSchema = ['type' => 'object', 'properties' => []];
+    $emptyArgsSchema = [
+      'type' => 'object',
+      'properties' => [
+        'params' => $paramsSchema,
+      ],
+    ];
 
     $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('equals')->toArray());
     $this->assertSame($singleValueArgsSchema, $filter->getArgsSchema('not-equals')->toArray());
@@ -273,6 +293,19 @@ class NumberFilterTest extends MailPoetUnitTest {
     $this->assertNotMatches('is-not-set', null, -0.5);
     $this->assertNotMatches('is-not-set', null, 1);
     $this->assertNotMatches('is-not-set', null, -1);
+  }
+
+  public function testFieldParams(): void {
+    if (!defined('DAY_IN_SECONDS')) {
+      define('DAY_IN_SECONDS', 24 * 60 * 60);
+    }
+
+    $filter = new NumberFilter();
+    $params = ['in_the_last' => ['number' => 123, 'unit' => 'days']];
+    $this->assertSame(
+      ['in_the_last' => 123 * DAY_IN_SECONDS],
+      $filter->getFieldParams(new Filter('f', 'integer', '', 'equals', ['params' => $params]))
+    );
   }
 
   private function assertMatches(string $condition, $filterValue, $value): void {


### PR DESCRIPTION
## Description

Adds "in the last X days" filter to these fields:

**WooCommerce customer**

1. Average spent
2. Order count
3. Total spent

**MailPoet subscriber**

1. Automations — entered
2. Automations — exited
3. Automations — processing
4. Email — clicked count
5. Email — machine opened count
6. Email — opened count
7. Email — sent count

**WooCommerce customer**

1. Purchased categories
2. Purchased tags
3. Review count

## Code review notes

This includes a refactor that adds a more generic support for organizing and rendering filters. I needed this to be able to properly validate the vales to allow/disable the save button.

As for filter parameters, there is a bit of a code repetition now. I didn't want to over-architect it and introduce new generic abstractions, while we have only a single parameter on 4 different filters for now.

## QA notes

I guess there are two ways to test this:

1. Apply filters with this parameter to a trigger, and see if it triggers an automation or not.
2. Use filters with this parameter in an if/else step, and see which branch the automation goes.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/843

## Linked tickets

[PREMIUM-253]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[PREMIUM-253]: https://mailpoet.atlassian.net/browse/PREMIUM-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ