### PR TITLE
Use large instance for zip build [MAILPOET-5714]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -757,7 +757,7 @@ jobs:
           destination: mailhog-data
   build_release_zip:
     executor: wpcli_php_mysql_latest
-    resource_class: medium+
+    resource_class: large
     steps:
       - attach_workspace:
           at: /home/circleci


### PR DESCRIPTION
## Description

After the update of Gutenberg packages, builds started failing with an exit code 1 without any other information.
Increasing the instance helps. I'm not entirely sure what's causing the issue. I suspect memory consumption during the build. In the past, we had to increase from medium to medium+ after updating the webpack to v5 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5714]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5714]: https://mailpoet.atlassian.net/browse/MAILPOET-5714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ