### PR TITLE
"Purchased with tag" dynamic segment filter [MAILPOET-4985]

### DIFF
--- a/mailpoet/assets/js/src/analytics.js
+++ b/mailpoet/assets/js/src/analytics.js
@@ -99,6 +99,8 @@ export function mapFilterType(filter) {
         return 'city';
       case 'purchasedCategory':
         return 'purchased in category';
+      case 'purchasedTag':
+        return 'purchased with tag';
       case 'purchasedProduct':
         return 'purchased product';
       case 'subscribedDate':

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-tag.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-tag.tsx
@@ -15,12 +15,12 @@ import {
 } from '../../../types';
 
 export function validatePurchasedTag(formItems: WooCommerceFormItem): boolean {
-  const purchasedCategoryIsInvalid =
+  const purchasedTagIsInvalid =
     formItems.tag_ids === undefined ||
     formItems.tag_ids.length === 0 ||
     !formItems.operator;
 
-  return !purchasedCategoryIsInvalid;
+  return !purchasedTagIsInvalid;
 }
 
 export function PurchasedTagFields({ filterIndex }: FilterProps): JSX.Element {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-tag.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-tag.tsx
@@ -1,0 +1,92 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { filter } from 'lodash/fp';
+import { Select } from 'common/form/select/select';
+import { MailPoet } from 'mailpoet';
+import { ReactSelect } from 'common/form/react-select/react-select';
+import { __ } from '@wordpress/i18n';
+import { storeName } from '../../../store';
+import {
+  AnyValueTypes,
+  FilterProps,
+  SelectOption,
+  WindowProductCategories,
+  WooCommerceFormItem,
+} from '../../../types';
+
+export function validatePurchasedTag(formItems: WooCommerceFormItem): boolean {
+  const purchasedCategoryIsInvalid =
+    formItems.tag_ids === undefined ||
+    formItems.tag_ids.length === 0 ||
+    !formItems.operator;
+
+  return !purchasedCategoryIsInvalid;
+}
+
+export function PurchasedTagFields({ filterIndex }: FilterProps): JSX.Element {
+  const segment: WooCommerceFormItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const { updateSegmentFilter } = useDispatch(storeName);
+
+  const productTags: WindowProductCategories = useSelect(
+    (select) => select(storeName).getProductTags(),
+    [],
+  );
+
+  const tagOptions = productTags.map((product) => ({
+    value: product.id,
+    label: product.name,
+  }));
+
+  useEffect(() => {
+    if (
+      segment.operator !== AnyValueTypes.ALL &&
+      segment.operator !== AnyValueTypes.ANY &&
+      segment.operator !== AnyValueTypes.NONE
+    ) {
+      void updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment, filterIndex]);
+
+  return (
+    <>
+      <Select
+        key="select-operator"
+        value={segment.operator}
+        isMinWidth
+        onChange={(e): void => {
+          void updateSegmentFilter({ operator: e.target.value }, filterIndex);
+        }}
+        automationId="select-operator"
+      >
+        <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+        <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+        <option value={AnyValueTypes.NONE}>{MailPoet.I18n.t('noneOf')}</option>
+      </Select>
+      <ReactSelect
+        isMulti
+        dimension="small"
+        key="select-segment-tag"
+        placeholder={__('Search tags', 'mailpoet')}
+        options={tagOptions}
+        value={filter((tagOption) => {
+          if (segment.tag_ids === undefined || segment.tag_ids.length === 0) {
+            return undefined;
+          }
+          return segment.tag_ids.indexOf(tagOption.value) !== -1;
+        }, tagOptions)}
+        onChange={(options: SelectOption[]): void => {
+          void updateSegmentFilter(
+            {
+              tag_ids: (options || []).map((x: SelectOption) => x.value),
+            },
+            filterIndex,
+          );
+        }}
+        automationId="select-segment-tags"
+      />
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
@@ -8,6 +8,7 @@ export enum WooCommerceActionTypes {
   NUMBER_OF_ORDERS_WITH_COUPON = 'numberOfOrdersWithCoupon',
   NUMBER_OF_REVIEWS = 'numberOfReviews',
   PURCHASED_CATEGORY = 'purchasedCategory',
+  PURCHASED_TAG = 'purchasedTag',
   PURCHASE_DATE = 'purchaseDate',
   PURCHASED_PRODUCT = 'purchasedProduct',
   PURCHASED_WITH_ATTRIBUTE = 'purchasedWithAttribute',
@@ -67,6 +68,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.PURCHASED_CATEGORY,
     label: __('purchased in category', 'mailpoet'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.PURCHASED_TAG,
+    label: __('purchased with tag', 'mailpoet'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
@@ -15,6 +15,10 @@ import {
   validatePurchasedCategory,
 } from './fields/woocommerce/purchased-category';
 import {
+  PurchasedTagFields,
+  validatePurchasedTag,
+} from './fields/woocommerce/purchased-tag';
+import {
   CustomerInCountryFields,
   validateCustomerInCountry,
 } from './fields/woocommerce/customer-in-country';
@@ -117,6 +121,9 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   ) {
     return validateTextField(formItems);
   }
+  if (formItems.action === WooCommerceActionTypes.PURCHASED_TAG) {
+    return validatePurchasedTag(formItems);
+  }
   return true;
 }
 
@@ -132,6 +139,7 @@ const componentsMap = {
   [WooCommerceActionTypes.PURCHASED_CATEGORY]: PurchasedCategoryFields,
   [WooCommerceActionTypes.PURCHASED_WITH_ATTRIBUTE]:
     PurchasedWithAttributeFields,
+  [WooCommerceActionTypes.PURCHASED_TAG]: PurchasedTagFields,
   [WooCommerceActionTypes.SINGLE_ORDER_VALUE]: SingleOrderValueFields,
   [WooCommerceActionTypes.TOTAL_SPENT]: TotalSpentFields,
   [WooCommerceActionTypes.AVERAGE_SPENT]: AverageSpentFields,

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
@@ -30,6 +30,7 @@ export const getInitialState = (): StateType => ({
   productAttributes: window.mailpoet_product_attributes,
   localProductAttributes: window.mailpoet_local_product_attributes,
   productCategories: window.mailpoet_product_categories,
+  productTags: window.mailpoet_product_tags,
   newslettersList: window.mailpoet_newsletters_list,
   wordpressRoles: window.wordpress_editable_roles_list,
   canUseWooMemberships: window.mailpoet_can_use_woocommerce_memberships,

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -41,6 +41,8 @@ export const getLocalProductAttributes = (
 export const getProductCategories = (
   state: StateType,
 ): WindowProductCategories => state.productCategories;
+export const getProductTags = (state: StateType): WindowProductCategories =>
+  state.productTags;
 export const getNewslettersList = (state: StateType): WindowNewslettersList =>
   state.newslettersList;
 export const canUseWooSubscriptions = (state: StateType): boolean =>

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -157,6 +157,7 @@ export interface WooCommerceFormItem extends FormItem {
   attribute_term_ids?: string[];
   attribute_local_name?: string;
   attribute_local_values?: string[];
+  tag_ids?: string[];
 }
 
 export interface AutomationsFormItem extends FormItem {
@@ -259,6 +260,11 @@ export type WindowProductCategories = {
   name: string;
 }[];
 
+export type WindowProductTags = {
+  id: string;
+  name: string;
+}[];
+
 export type WindowNewslettersList = {
   sent_at: string;
   subject: string;
@@ -295,6 +301,7 @@ export interface SegmentFormDataWindow extends Window {
   mailpoet_product_attributes: WindowProductAttributes;
   mailpoet_local_product_attributes: WindowLocalProductAttributes;
   mailpoet_product_categories: WindowProductCategories;
+  mailpoet_product_tags: WindowProductTags;
   mailpoet_woocommerce_countries: WindowWooCommerceCountries;
   mailpoet_woocommerce_payment_methods: WooPaymentMethod[];
   mailpoet_woocommerce_shipping_methods: WooShippingMethod[];
@@ -317,6 +324,7 @@ export interface StateType {
   productAttributes: WindowProductAttributes;
   localProductAttributes: WindowLocalProductAttributes;
   productCategories: WindowProductCategories;
+  productTags: WindowProductTags;
   newslettersList: WindowNewslettersList;
   canUseWooMemberships: boolean;
   canUseWooSubscriptions: boolean;

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -161,6 +161,7 @@ class DynamicSegments {
     }
 
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();
+    $data['product_tags'] = $this->wpPostListLoader->getWooCommerceTags();
 
     $data['products'] = $this->wpPostListLoader->getProducts();
     $data['membership_plans'] = $this->wpPostListLoader->getMembershipPlans();

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -33,6 +33,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceFirstOrder;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
@@ -218,7 +219,7 @@ class Reporter {
       'Segment > is in country' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCountry::ACTION_CUSTOMER_COUNTRY),
       'Segment > MailPoet custom field' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE),
       'Segment > purchased in category' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCategory::ACTION_CATEGORY),
-      'Segment > purchased product' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCategory::ACTION_PRODUCT),
+      'Segment > purchased product' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceProduct::ACTION_PRODUCT),
       'Segment > purchased with tag' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTag::ACTION),
       'Segment > subscribed date' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberDateField::SUBSCRIBED_DATE),
       'Segment > total spent' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT),

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -37,6 +37,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedCouponCode;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod;
@@ -218,6 +219,7 @@ class Reporter {
       'Segment > MailPoet custom field' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE),
       'Segment > purchased in category' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCategory::ACTION_CATEGORY),
       'Segment > purchased product' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceCategory::ACTION_PRODUCT),
+      'Segment > purchased with tag' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTag::ACTION),
       'Segment > subscribed date' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_USER_ROLE, SubscriberDateField::SUBSCRIBED_DATE),
       'Segment > total spent' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT),
       'Segment > first order' => $this->isFilterTypeActive(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceFirstOrder::ACTION),

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -509,6 +509,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedCouponCode::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooFilterHelper::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\SegmentSaveController::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\FilterDataMapper::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -32,6 +32,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedCouponCode;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod;
@@ -39,20 +40,17 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
 use MailPoet\WP\Functions as WPFunctions;
 
 class FilterDataMapper {
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
 
-  /** @var DateFilterHelper */
-  private $dateFilterHelper;
+  private DateFilterHelper $dateFilterHelper;
 
-  /** @var WooCommerceNumberOfReviews */
-  private $wooCommerceNumberOfReviews;
+  private WooCommerceNumberOfReviews $wooCommerceNumberOfReviews;
 
-  /** @var FilterHelper */
-  private $filterHelper;
+  private FilterHelper $filterHelper;
 
-  /** @var WooCommerceUsedCouponCode */
-  private $wooCommerceUsedCouponCode;
+  private WooCommerceUsedCouponCode $wooCommerceUsedCouponCode;
+
+  private WooCommerceTag $wooCommerceTag;
 
   private WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute;
 
@@ -62,7 +60,8 @@ class FilterDataMapper {
     FilterHelper $filterHelper,
     WooCommerceNumberOfReviews $wooCommerceNumberOfReviews,
     WooCommerceUsedCouponCode $wooCommerceUsedCouponCode,
-    WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute
+    WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute,
+    WooCommerceTag $wooCommerceTag
   ) {
     $this->wp = $wp;
     $this->dateFilterHelper = $dateFilterHelper;
@@ -70,6 +69,7 @@ class FilterDataMapper {
     $this->wooCommerceNumberOfReviews = $wooCommerceNumberOfReviews;
     $this->wooCommerceUsedCouponCode = $wooCommerceUsedCouponCode;
     $this->wooCommercePurchasedWithAttribute = $wooCommercePurchasedWithAttribute;
+    $this->wooCommerceTag = $wooCommerceTag;
   }
 
   /**
@@ -522,6 +522,10 @@ class FilterDataMapper {
       $filterData['attribute_type'] = $data['attribute_type'];
       $filterData['attribute_local_name'] = $data['attribute_local_name'] ?? null;
       $filterData['attribute_local_values'] = $data['attribute_local_values'] ?? null;
+    } elseif ($data['action'] === WooCommerceTag::ACTION) {
+      $this->wooCommerceTag->validateFilterData($data);
+      $filterData['operator'] = $data['operator'];
+      $filterData['tag_ids'] = $data['tag_ids'];
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -33,6 +33,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTotalSpent;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedCouponCode;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedPaymentMethod;
@@ -131,6 +132,8 @@ class FilterFactory {
 
   private WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute;
 
+  private WooCommerceTag $wooCommerceTag;
+
   public function __construct(
     EmailAction $emailAction,
     EmailActionClickAny $emailActionClickAny,
@@ -154,6 +157,7 @@ class FilterFactory {
     SubscriberSubscribedViaForm $subscribedViaForm,
     WooCommerceSingleOrderValue $wooCommerceSingleOrderValue,
     WooCommerceAverageSpent $wooCommerceAverageSpent,
+    WooCommerceTag $wooCommerceTag,
     WooCommerceUsedCouponCode $wooCommerceUsedCouponCode,
     WooCommerceUsedPaymentMethod $wooCommerceUsedPaymentMethod,
     WooCommerceUsedShippingMethod $wooCommerceUsedShippingMethod,
@@ -195,6 +199,7 @@ class FilterFactory {
     $this->emailsReceived = $emailsReceived;
     $this->numberOfClicks = $numberOfClicks;
     $this->wooCommercePurchasedWithAttribute = $wooCommercePurchasedWithAttribute;
+    $this->wooCommerceTag = $wooCommerceTag;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -302,6 +307,8 @@ class FilterFactory {
       return $this->wooCommerceFirstOrder;
     } elseif ($action === WooCommercePurchasedWithAttribute::ACTION) {
       return $this->wooCommercePurchasedWithAttribute;
+    } elseif ($action == WooCommerceTag::ACTION) {
+      return $this->wooCommerceTag;
     }
     return $this->wooCommerceCategory;
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -15,8 +15,6 @@ use WP_Term;
 class WooCommerceCategory implements Filter {
   const ACTION_CATEGORY = 'purchasedCategory';
 
-  const ACTION_PRODUCT = 'purchasedProduct';
-
   /** @var EntityManager */
   private $entityManager;
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTag.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTag.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use WP_Term;
+
+class WooCommerceTag implements Filter {
+  const ACTION = 'purchasedTag';
+
+  private WPFunctions $wp;
+  private WooFilterHelper $wooFilterHelper;
+  private FilterHelper $filterHelper;
+
+  public function __construct(
+    FilterHelper $filterHelper,
+    WooFilterHelper $wooFilterHelper,
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+    $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $this->validateFilterData((array)$filterData->getData());
+
+    $operator = $filterData->getOperator();
+
+    if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
+      $this->applyForAnyOperator($queryBuilder, $filterData);
+    } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
+      $this->applyForAnyOperator($queryBuilder, $filterData);
+      $countParam = $this->filterHelper->getUniqueParameterName('tagCount');
+      $queryBuilder->groupBy('inner_subscriber_id')
+        ->having("COUNT(DISTINCT term_taxonomy.term_id) = :$countParam")
+        ->setParameter($countParam, count($filterData->getArrayParam('tag_ids')));
+    } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+      $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+      $this->applyForAnyOperator($subQuery, $filterData);
+      $subscribersTable = $this->filterHelper->getSubscribersTable();
+      $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
+    }
+
+    return $queryBuilder;
+  }
+
+  public function applyForAnyOperator(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData): void {
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $tagIdsParam = $this->filterHelper->getUniqueParameterName('tagIds');
+    $productAlias = $this->applyProductJoin($queryBuilder, $orderStatsAlias);
+    $queryBuilder->join(
+      $productAlias,
+      $this->filterHelper->getPrefixedTable('term_relationships'),
+      'term_relationships',
+      'product.product_id = term_relationships.object_id'
+    );
+    $queryBuilder->innerJoin(
+      'term_relationships',
+      $this->filterHelper->getPrefixedTable('term_taxonomy'),
+      'term_taxonomy',
+      "term_taxonomy.term_taxonomy_id = term_relationships.term_taxonomy_id
+      AND
+      term_taxonomy.term_id IN (:$tagIdsParam)"
+    );
+    $queryBuilder->setParameter($tagIdsParam, $filterData->getArrayParam('tag_ids'), Connection::PARAM_STR_ARRAY);
+  }
+
+  private function applyProductJoin(QueryBuilder $queryBuilder, string $orderStatsAlias, string $productAlias = 'product'): string {
+    $queryBuilder->innerJoin(
+      $orderStatsAlias,
+      $this->filterHelper->getPrefixedTable('wc_order_product_lookup'),
+      $productAlias,
+      "$orderStatsAlias.order_id = product.order_id"
+    );
+    return $productAlias;
+  }
+
+  public function validateFilterData(array $data): void {
+    $operator = $data['operator'] ?? null;
+
+    if (
+      !in_array($operator, [
+        DynamicSegmentFilterData::OPERATOR_ANY,
+        DynamicSegmentFilterData::OPERATOR_ALL,
+        DynamicSegmentFilterData::OPERATOR_NONE,
+      ])
+    ) {
+      throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+    }
+
+    if (!is_array($data['tag_ids'] ?? null) || count($data['tag_ids']) === 0) {
+      throw new InvalidFilterException('Missing tag ids');
+    }
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    $lookupData = [
+      'tags' => [],
+    ];
+    $tagIds = $filterData->getArrayParam('tag_ids');
+    $terms = $this->wp->getTerms('product_tag', ['include' => $tagIds, 'hide_empty' => false]);
+    /** @var WP_Term[] $terms */
+    foreach ($terms as $term) {
+      $lookupData['tags'][$term->term_id] = $term->name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
+
+    return $lookupData;
+  }
+}

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -107,6 +107,10 @@ class IntegrationTester extends \Codeception\Actor {
     return $term['term_id'];
   }
 
+  public function createWooTag(string $name): int {
+    return $this->createWordPressTerm($name, 'product_tag');
+  }
+
   public function createCustomer(string $email, string $role = 'customer'): int {
     return $this->createWordPressUser($email, $role);
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -22,6 +22,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
 
 class FilterDataMapperTest extends \MailPoetTest {
   /** @var FilterDataMapper */
@@ -1139,6 +1140,28 @@ class FilterDataMapperTest extends \MailPoetTest {
       'attribute_type' => 'local',
       'attribute_local_name' => 'color',
       'attribute_local_values' => ['red', 'blue'],
+    ]);
+  }
+
+  public function testItMapsWooCommercePurchaseTag(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => WooCommerceTag::ACTION,
+      'tag_ids' => ['1', '3'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+    ]]];
+    $filters = $this->mapper->map($data);
+    verify($filters)->isArray();
+    verify($filters)->arrayCount(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter)->instanceOf(DynamicSegmentFilterData::class);
+    verify($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_WOOCOMMERCE);
+    verify($filter->getAction())->equals(WooCommerceTag::ACTION);
+    verify($filter->getData())->equals([
+      'tag_ids' => ['1', '3'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTagTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTagTest.php
@@ -1,0 +1,205 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
+
+/**
+ * @group woo
+ */
+class WooCommerceTagTest extends \MailPoetTest {
+  private WooCommerceTag $filter;
+
+  public function _before(): void {
+    $this->filter = $this->diContainer->get(WooCommerceTag::class);
+
+    $this->cleanUp();
+  }
+
+  public function testItWorksForAnyOperator(): void {
+    $customer1 = $this->tester->createCustomer('customer1@example.com');
+    $customer2 = $this->tester->createCustomer('customer2@example.com');
+    $customer3 = $this->tester->createCustomer('customer3@example.com');
+
+    $tag1 = $this->tester->createWooTag('tag1');
+    $tag2 = $this->tester->createWooTag('tag2');
+
+    $product1 = $this->tester->createWooCommerceProduct([
+      'tag_ids' => [$tag1],
+    ]);
+
+    $product2 = $this->tester->createWooCommerceProduct([
+      'tag_ids' => [$tag2],
+    ]);
+
+    $this->createOrder($customer1, [$product1]);
+    $this->createOrder($customer2, [$product2]);
+
+    $this->assertFilterReturnsEmails('any', [$tag1], ['customer1@example.com']);
+    $this->assertFilterReturnsEmails('any', [$tag2], ['customer2@example.com']);
+  }
+
+  public function testItWorksForAllOperator(): void {
+    $customer1 = $this->tester->createCustomer('customer1@example.com');
+    $customer2 = $this->tester->createCustomer('customer2@example.com');
+    $customer3 = $this->tester->createCustomer('customer3@example.com');
+
+    $tag1 = $this->tester->createWooTag('tag1');
+    $tag2 = $this->tester->createWooTag('tag2');
+
+    $product1 = $this->tester->createWooCommerceProduct([
+      'tag_ids' => [$tag1],
+    ]);
+
+    $product2 = $this->tester->createWooCommerceProduct([
+      'tag_ids' => [$tag2],
+    ]);
+
+    $this->createOrder($customer1, [$product1]);
+    $this->createOrder($customer2, [$product2]);
+    $this->createOrder($customer3, [$product1, $product2]);
+
+    $this->assertFilterReturnsEmails('all', [$tag1, $tag2], ['customer3@example.com']);
+  }
+
+  public function testItWorksForNoneOperator(): void {
+    $customer1 = $this->tester->createCustomer('customer1@example.com');
+    $customer2 = $this->tester->createCustomer('customer2@example.com');
+    $customer3 = $this->tester->createCustomer('customer3@example.com');
+
+    $tag1 = $this->tester->createWooTag('tag1');
+    $tag2 = $this->tester->createWooTag('tag2');
+
+    $product1 = $this->tester->createWooCommerceProduct([
+      'tag_ids' => [$tag1],
+    ]);
+
+    $product2 = $this->tester->createWooCommerceProduct([
+      'tag_ids' => [$tag2],
+    ]);
+
+    $this->createOrder($customer1, [$product1]);
+    $this->createOrder($customer2, [$product2]);
+
+    $this->assertFilterReturnsEmails('none', [$tag1], ['customer2@example.com', 'customer3@example.com']);
+    $this->assertFilterReturnsEmails('none', [$tag2], ['customer1@example.com', 'customer3@example.com']);
+    $this->assertFilterReturnsEmails('none', [$tag1, $tag2], ['customer3@example.com']);
+  }
+
+  public function testItRetrievesLookupData(): void {
+    $tagId1 = $this->tester->createWooTag('tag50');
+    $tagId2 = $this->tester->createWooTag('tag51');
+
+    $data = $this->getSegmentFilterData('none', [$tagId1, $tagId2]);
+    $lookupData = $this->filter->getLookupData($data);
+
+    $this->assertEqualsCanonicalizing([
+      'tags' => [
+        (string)$tagId1 => 'tag50',
+        (string)$tagId2 => 'tag51',
+      ],
+    ], $lookupData);
+  }
+
+  /**
+   * @dataProvider filterDataProvider
+   */
+  public function testItValidatesFilterData(array $data, bool $isValid): void {
+    if (!$isValid) {
+      $this->expectException(InvalidFilterException::class);
+    }
+    $this->filter->validateFilterData($data);
+  }
+
+  public function filterDataProvider(): array {
+    return [
+      'missing operator' =>
+        [
+          [
+            'tag_ids' => ['1', '2'],
+          ],
+          false,
+        ],
+      'invalid operator' =>
+        [
+          [
+            'operator' => 'invalid',
+            'tag_ids' => ['1', '2'],
+          ],
+          false,
+        ],
+      'missing tag ids' =>
+        [
+          [
+            'operator' => 'any',
+          ],
+          false,
+        ],
+      'empty tag ids' =>
+        [
+          [
+            'operator' => 'any',
+            'tag_ids' => [],
+          ],
+          false,
+        ],
+      'valid filter' =>
+        [
+          [
+            'operator' => 'any',
+            'tag_ids' => ['1', '2'],
+          ],
+          true,
+        ],
+    ];
+  }
+
+  private function createOrder(int $customerId, array $products = []): int {
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_status('wc-completed');
+    foreach ($products as $product) {
+      $order->add_product($product);
+    }
+    $order->save();
+    $orderId = $order->get_id();
+    $this->tester->updateWooOrderStats($orderId);
+
+    return $orderId;
+  }
+
+  private function getSegmentFilterData(string $operator, array $tagIds): DynamicSegmentFilterData {
+    $filterData = [
+      'tag_ids' => array_map(function($tagId) {
+        return (string)$tagId;
+      }, $tagIds),
+      'operator' => $operator,
+    ];
+    return new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceTag::ACTION,
+      $filterData
+    );
+  }
+
+  private function assertFilterReturnsEmails(string $operator, array $tagIds, array $expectedEmails): void {
+    $filterData = $this->getSegmentFilterData($operator, $tagIds);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->cleanUp();
+  }
+
+  private function cleanUp(): void {
+    global $wpdb;
+
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_product_lookup");
+  }
+}

--- a/mailpoet/views/segments/dynamic.html
+++ b/mailpoet/views/segments/dynamic.html
@@ -12,6 +12,7 @@
     var mailpoet_product_attributes = <%= json_encode(product_attributes)  %>;
     var mailpoet_local_product_attributes = <%= json_encode(local_product_attributes) %>;
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
+    var mailpoet_product_tags = <%= json_encode(product_tags) %>;
     var mailpoet_products = <%= json_encode(products) %>;
     var mailpoet_membership_plans = <%= json_encode(membership_plans) %>;
     var mailpoet_subscription_products = <%= json_encode(subscription_products) %>;


### PR DESCRIPTION
## Description

This PR adds a new filter for "purchased with tag" for dynamic segments. It works very similarly to the "purchased in category" filter.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4985]](https://mailpoet.atlassian.net/browse/MAILPOET-4985)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4985]: https://mailpoet.atlassian.net/browse/MAILPOET-4985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ