### PR TITLE
Simplify and fix Engaged Subscribers segments [MAILPOET-5760]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -37,30 +37,11 @@ export const templates: SegmentTemplate[] = [
     filters: [
       {
         segmentType: 'userRole',
-        action: 'lastClickDate',
-        operator: 'inTheLast',
-        value: '30',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastOpenDate',
-        operator: 'inTheLast',
-        value: '30',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastPurchaseDate',
-        operator: 'inTheLast',
-        value: '30',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastSendingDate',
+        action: 'lastEngagementDate',
         operator: 'inTheLast',
         value: '30',
       },
     ],
-    filtersConnect: SegmentConnectTypes.OR,
   },
   {
     name: __('Engaged Subscribers (3 months)', 'mailpoet'),
@@ -74,30 +55,11 @@ export const templates: SegmentTemplate[] = [
     filters: [
       {
         segmentType: 'userRole',
-        action: 'lastClickDate',
-        operator: 'inTheLast',
-        value: '90',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastOpenDate',
-        operator: 'inTheLast',
-        value: '90',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastPurchaseDate',
-        operator: 'inTheLast',
-        value: '90',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastSendingDate',
+        action: 'lastEngagementDate',
         operator: 'inTheLast',
         value: '90',
       },
     ],
-    filtersConnect: SegmentConnectTypes.OR,
   },
   {
     name: __('Engaged Subscribers (6 months)', 'mailpoet'),

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -73,25 +73,7 @@ export const templates: SegmentTemplate[] = [
     filters: [
       {
         segmentType: 'userRole',
-        action: 'lastClickDate',
-        operator: 'inTheLast',
-        value: '180',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastOpenDate',
-        operator: 'inTheLast',
-        value: '180',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastPurchaseDate',
-        operator: 'inTheLast',
-        value: '180',
-      },
-      {
-        segmentType: 'userRole',
-        action: 'lastSendingDate',
+        action: 'lastEngagementDate',
         operator: 'inTheLast',
         value: '180',
       },


### PR DESCRIPTION
## Description

It was never correct to include last sending date as engagement. `lastEngagementDate` automatically includes all the conditions that we care about.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5760](https://mailpoet.atlassian.net/browse/MAILPOET-5760)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5760]: https://mailpoet.atlassian.net/browse/MAILPOET-5760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ