### PR TITLE
Add missing prebuilt segments [MAILPOET-5685]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -283,16 +283,26 @@ export const templates: SegmentTemplate[] = [
       },
     ],
   },
-  // {
-  //   name: __('Clickers', 'mailpoet'),
-  //   slug: 'clickers',
-  //   category: SegmentTemplateCategories.ENGAGEMENT,
-  //   description: __(
-  //     'Contacts who regularly click on your emails in the last 90 days.',
-  //     'mailpoet',
-  //   ),
-  //   isEssential: false,
-  // },
+  {
+    name: __('Clickers', 'mailpoet'),
+    slug: 'clickers',
+    category: SegmentTemplateCategories.ENGAGEMENT,
+    description: __(
+      'Contacts who regularly click on your emails in the last 90 days.',
+      'mailpoet',
+    ),
+    filters: [
+      {
+        segmentType: 'email',
+        action: 'numberOfClicks',
+        operator: 'more',
+        timeframe: Timeframe.IN_THE_LAST,
+        clicks: '2',
+        days: '90',
+      },
+    ],
+    isEssential: false,
+  },
   // {
   //   name: __('Non-Openers', 'mailpoet'),
   //   slug: 'non-openers',

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -331,16 +331,26 @@ export const templates: SegmentTemplate[] = [
       },
     ],
   },
-  // {
-  //   name: __('Recent Clickers', 'mailpoet'),
-  //   slug: 'recent-clickers',
-  //   category: SegmentTemplateCategories.ENGAGEMENT,
-  //   description: __(
-  //     'Contacts who have clicked on an email in the last 7 days.',
-  //     'mailpoet',
-  //   ),
-  //   isEssential: false,
-  // },
+  {
+    name: __('Recent Clickers', 'mailpoet'),
+    slug: 'recent-clickers',
+    category: SegmentTemplateCategories.ENGAGEMENT,
+    description: __(
+      'Contacts who have clicked on an email in the last 7 days.',
+      'mailpoet',
+    ),
+    filters: [
+      {
+        segmentType: 'email',
+        action: 'numberOfClicks',
+        operator: 'more',
+        timeframe: Timeframe.IN_THE_LAST,
+        clicks: '0',
+        days: '7',
+      },
+    ],
+    isEssential: false,
+  },
   {
     name: __('Recent Openers', 'mailpoet'),
     slug: 'recent-openers',

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -6,6 +6,7 @@ import {
   Timeframe,
 } from '../types';
 import { WooCommerceActionTypes } from '../dynamic-segments-filters/woocommerce-options';
+import { DateOperator } from '../dynamic-segments-filters/fields/date-fields';
 
 export const templates: SegmentTemplate[] = [
   {
@@ -168,16 +169,24 @@ export const templates: SegmentTemplate[] = [
     ],
     isEssential: true,
   },
-  // {
-  //   name: __('First-Time Buyers', 'mailpoet'),
-  //   slug: 'first-time-buyers',
-  //   category: SegmentTemplateCategories.PURCHASE_HISTORY,
-  //   description: __(
-  //     'Customers who have made their first purchase in the last 30 days.',
-  //     'mailpoet',
-  //   ),
-  //   isEssential: true,
-  // },
+  {
+    name: __('First-Time Buyers', 'mailpoet'),
+    slug: 'first-time-buyers',
+    category: SegmentTemplateCategories.PURCHASE_HISTORY,
+    description: __(
+      'Customers who have made their first purchase in the last 30 days.',
+      'mailpoet',
+    ),
+    filters: [
+      {
+        segmentType: 'woocommerce',
+        action: 'firstOrder',
+        operator: DateOperator.IN_THE_LAST,
+        value: '30',
+      },
+    ],
+    isEssential: true,
+  },
   {
     name: __('Recent Buyers', 'mailpoet'),
     slug: 'recent-buyers',

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -303,23 +303,34 @@ export const templates: SegmentTemplate[] = [
     ],
     isEssential: false,
   },
-  // {
-  //   name: __('Non-Openers', 'mailpoet'),
-  //   slug: 'non-openers',
-  //   category: SegmentTemplateCategories.ENGAGEMENT,
-  //   description: __('Contacts who have received but haven’t opened an email in the last 90 days.', 'mailpoet'),
-  //   isEssential: false,
-  //   filters: [
-  //     {
-  //       segmentType: 'email',
-  //       action: 'opensAbsoluteCount',
-  //       operator: 'equals',
-  //       timeframe: Timeframe.IN_THE_LAST,
-  //       opens: '0',
-  //       days: '90',
-  //     },
-  //   ],
-  // },
+  {
+    name: __('Non-Openers', 'mailpoet'),
+    slug: 'non-openers',
+    category: SegmentTemplateCategories.ENGAGEMENT,
+    description: __(
+      'Contacts who have received but haven’t opened an email in the last 90 days.',
+      'mailpoet',
+    ),
+    isEssential: false,
+    filters: [
+      {
+        segmentType: 'email',
+        action: 'numberReceived',
+        operator: 'more',
+        timeframe: Timeframe.IN_THE_LAST,
+        emails: '0',
+        days: '90',
+      },
+      {
+        segmentType: 'email',
+        action: 'opensAbsoluteCount',
+        operator: 'equals',
+        timeframe: Timeframe.IN_THE_LAST,
+        opens: '0',
+        days: '90',
+      },
+    ],
+  },
   // {
   //   name: __('Recent Clickers', 'mailpoet'),
   //   slug: 'recent-clickers',

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -5,6 +5,7 @@ import {
   SegmentTemplateCategories,
   Timeframe,
 } from '../types';
+import { WooCommerceActionTypes } from '../dynamic-segments-filters/woocommerce-options';
 
 export const templates: SegmentTemplate[] = [
   {
@@ -329,16 +330,26 @@ export const templates: SegmentTemplate[] = [
       },
     ],
   },
-  // {
-  //   name: __('Used a discount code', 'mailpoet'),
-  //   slug: 'used-a-discount-code',
-  //   category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
-  //   description: __(
-  //     'Customers who made a purchase with a coupon code in the last 30 days.',
-  //     'mailpoet',
-  //   ),
-  //   isEssential: false,
-  // },
+  {
+    name: __('Used a discount code', 'mailpoet'),
+    slug: 'used-a-discount-code',
+    category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
+    description: __(
+      'Customers who made a purchase with a coupon code in the last 30 days.',
+      'mailpoet',
+    ),
+    filters: [
+      {
+        segmentType: 'woocommerce',
+        action: WooCommerceActionTypes.NUMBER_OF_ORDERS_WITH_COUPON,
+        number_of_orders_type: '>',
+        number_of_orders_count: 0,
+        timeframe: Timeframe.IN_THE_LAST,
+        days: '30',
+      },
+    ],
+    isEssential: false,
+  },
   // {
   //   name: __('Frequently uses discounts', 'mailpoet'),
   //   slug: 'frequently-uses-discounts',

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -137,16 +137,37 @@ export const templates: SegmentTemplate[] = [
     ],
     filtersConnect: SegmentConnectTypes.OR,
   },
-  // {
-  //   name: __('Unengaged Subscribers', 'mailpoet'),
-  //   slug: 'unengaged-subscribers',
-  //   category: SegmentTemplateCategories.ENGAGEMENT,
-  //   description: __(
-  //     'Contacts who haven’t interacted with your emails, haven’t made a purchase, or haven’t visited your page in the last 6 months.',
-  //     'mailpoet',
-  //   ),
-  //   isEssential: true,
-  // },
+  {
+    name: __('Unengaged Subscribers', 'mailpoet'),
+    slug: 'unengaged-subscribers',
+    category: SegmentTemplateCategories.ENGAGEMENT,
+    description: __(
+      'Contacts who haven’t interacted with your emails, haven’t made a purchase, or haven’t visited your page in the last 6 months.',
+      'mailpoet',
+    ),
+    filters: [
+      {
+        segmentType: 'userRole',
+        action: 'lastEngagementDate',
+        operator: 'notInTheLast',
+        value: '180',
+      },
+      {
+        segmentType: 'userRole',
+        action: 'subscribedDate',
+        operator: 'notInTheLast',
+        value: '210',
+      },
+      {
+        segmentType: 'email',
+        action: 'numberReceived',
+        operator: 'more',
+        emails: '9',
+        timeframe: Timeframe.ALL_TIME,
+      },
+    ],
+    isEssential: true,
+  },
   // {
   //   name: __('First-Time Buyers', 'mailpoet'),
   //   slug: 'first-time-buyers',

--- a/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/templates/templates.tsx
@@ -350,16 +350,26 @@ export const templates: SegmentTemplate[] = [
     ],
     isEssential: false,
   },
-  // {
-  //   name: __('Frequently uses discounts', 'mailpoet'),
-  //   slug: 'frequently-uses-discounts',
-  //   category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
-  //   description: __(
-  //     'Customers who have regularly used coupons in the last 90 days.',
-  //     'mailpoet',
-  //   ),
-  //   isEssential: false,
-  // },
+  {
+    name: __('Frequently uses discounts', 'mailpoet'),
+    slug: 'frequently-uses-discounts',
+    category: SegmentTemplateCategories.SHOPPING_BEHAVIOR,
+    description: __(
+      'Customers who have regularly used coupons in the last 90 days.',
+      'mailpoet',
+    ),
+    filters: [
+      {
+        segmentType: 'woocommerce',
+        action: WooCommerceActionTypes.NUMBER_OF_ORDERS_WITH_COUPON,
+        number_of_orders_type: '>',
+        number_of_orders_count: 2,
+        timeframe: Timeframe.IN_THE_LAST,
+        days: '90',
+      },
+    ],
+    isEssential: false,
+  },
 ];
 
 export const templateCategories = [


### PR DESCRIPTION
## Description

This adds some prebuilt segments that weren't possible to create when first implemented due to missing filters that have since been implemented.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5685](https://mailpoet.atlassian.net/browse/MAILPOET-5685)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5685]: https://mailpoet.atlassian.net/browse/MAILPOET-5685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ