### PR TITLE
Email editor - color palette support [MAILPOET-5741]

### DIFF
--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -338,6 +338,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\EmailEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\EmailApiController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\SettingsController::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\ThemeController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -3,22 +3,20 @@
 namespace MailPoet\EmailEditor\Engine\Renderer;
 
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Engine\ThemeController;
 use MailPoet\Util\pQuery\DomNode;
 use MailPoetVendor\Html2Text\Html2Text;
 
 class Renderer {
+  private \MailPoetVendor\CSS $cssInliner;
 
-  /** @var \MailPoetVendor\CSS */
-  private $cssInliner;
+  private BlocksRegistry $blocksRegistry;
 
-  /** @var BlocksRegistry */
-  private $blocksRegistry;
+  private ProcessManager $processManager;
 
-  /** @var ProcessManager */
-  private $processManager;
+  private SettingsController $settingsController;
 
-  /** @var SettingsController */
-  private $settingsController;
+  private ThemeController $themeController;
 
   const TEMPLATE_FILE = 'template.html';
   const TEMPLATE_STYLES_FILE = 'styles.css';
@@ -30,12 +28,14 @@ class Renderer {
     \MailPoetVendor\CSS $cssInliner,
     ProcessManager $preprocessManager,
     BlocksRegistry $blocksRegistry,
-    SettingsController $settingsController
+    SettingsController $settingsController,
+    ThemeController $themeController
   ) {
     $this->cssInliner = $cssInliner;
     $this->processManager = $preprocessManager;
     $this->blocksRegistry = $blocksRegistry;
     $this->settingsController = $settingsController;
+    $this->themeController = $themeController;
   }
 
   public function render(\WP_Post $post, string $subject, string $preHeader, string $language, $metaRobots = ''): array {
@@ -50,7 +50,7 @@ class Renderer {
     $renderedBody = $this->renderBlocks($parsedBlocks);
 
     $styles = (string)file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_STYLES_FILE);
-    $styles .= $this->settingsController->getStylesheetForRendering();
+    $styles .= $this->themeController->getStylesheetForRendering();
     $styles = apply_filters('mailpoet_email_renderer_styles', $styles, $post);
 
     $template = (string)file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_FILE);

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -163,6 +163,11 @@ class SettingsController {
     foreach ($emailThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
       $cssPresets .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
     }
+    // Color palette classes
+    foreach ($emailThemeSettings['color']['palette']['default'] as $color) {
+      $cssPresets .= ".has-{$color['slug']}-color { color: {$color['color']}; } \n";
+      $cssPresets .= ".has-{$color['slug']}-background-color { background-color: {$color['color']}; } \n";
+    }
 
     // Block specific styles
     $cssBlocks = '';

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -38,8 +38,6 @@ class SettingsController {
    */
   const FLEX_GAP = '16px';
 
-  private string $availableStylesheets = '';
-
   private ThemeController $themeController;
 
   /**
@@ -93,13 +91,6 @@ class SettingsController {
       'contentSize' => self::EMAIL_WIDTH,
       'layout' => 'constrained',
     ];
-  }
-
-  public function getAvailableStylesheets(): string {
-    if ($this->availableStylesheets) return $this->availableStylesheets;
-    $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
-    $this->availableStylesheets = $coreThemeData->get_stylesheet();
-    return $this->availableStylesheets;
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -188,4 +188,14 @@ class SettingsController {
     }
     return $fontSize;
   }
+
+  public function translateSlugToColor(string $colorSlug): string {
+    $settings = $this->getTheme()->get_settings();
+    foreach ($settings['color']['palette']['default'] as $colorDefinition) {
+      if ($colorDefinition['slug'] === $colorSlug) {
+        return $colorDefinition['color'];
+      }
+    }
+    return $colorSlug;
+  }
 }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -54,7 +54,7 @@ class SettingsController {
   public function getSettings(): array {
     $coreDefaultSettings = get_default_block_editor_settings();
     $editorTheme = $this->getTheme();
-    $themeSettings = $editorTheme->get_settings();
+    $themeSettings = $this->themeController->getSettings();
 
     // body selector is later transformed to .editor-styles-wrapper
     // setting padding for bottom and top is needed because \WP_Theme_JSON::get_stylesheet() set them only for .wp-site-blocks selector

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -38,7 +38,18 @@ class SettingsController {
    */
   const FLEX_GAP = '16px';
 
-  private $availableStylesheets = '';
+  private string $availableStylesheets = '';
+
+  private ThemeController $themeController;
+
+  /**
+   * @param ThemeController $themeController
+   */
+  public function __construct(
+    ThemeController $themeController
+  ) {
+    $this->themeController = $themeController;
+  }
 
   public function getSettings(): array {
     $coreDefaultSettings = get_default_block_editor_settings();
@@ -143,59 +154,14 @@ class SettingsController {
   }
 
   public function getTheme(): \WP_Theme_JSON {
-    $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
-    $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
-    $themeJson = json_decode($themeJson, true);
-    /** @var array $themeJson */
-    $coreThemeData->merge(new \WP_Theme_JSON($themeJson, 'default'));
-    return apply_filters('mailpoet_email_editor_theme_json', $coreThemeData);
-  }
-
-  public function getStylesheetForRendering(): string {
-    $emailThemeSettings = $this->getTheme()->get_settings();
-
-    $cssPresets = '';
-    // Font family classes
-    foreach ($emailThemeSettings['typography']['fontFamilies']['default'] as $fontFamily) {
-      $cssPresets .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
-    }
-    // Font size classes
-    foreach ($emailThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
-      $cssPresets .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
-    }
-    // Color palette classes
-    foreach ($emailThemeSettings['color']['palette']['default'] as $color) {
-      $cssPresets .= ".has-{$color['slug']}-color { color: {$color['color']}; } \n";
-      $cssPresets .= ".has-{$color['slug']}-background-color { background-color: {$color['color']}; } \n";
-    }
-
-    // Block specific styles
-    $cssBlocks = '';
-    $blocks = $this->getTheme()->get_styles_block_nodes();
-    foreach ($blocks as $blockMetadata) {
-      $cssBlocks .= $this->getTheme()->get_styles_for_block($blockMetadata);
-    }
-
-    return $cssPresets . $cssBlocks;
+    return $this->themeController->getTheme();
   }
 
   public function translateSlugToFontSize(string $fontSize): string {
-    $settings = $this->getTheme()->get_settings();
-    foreach ($settings['typography']['fontSizes']['default'] as $fontSizeDefinition) {
-      if ($fontSizeDefinition['slug'] === $fontSize) {
-        return $fontSizeDefinition['size'];
-      }
-    }
-    return $fontSize;
+    return $this->themeController->translateSlugToFontSize($fontSize);
   }
 
   public function translateSlugToColor(string $colorSlug): string {
-    $settings = $this->getTheme()->get_settings();
-    foreach ($settings['color']['palette']['default'] as $colorDefinition) {
-      if ($colorDefinition['slug'] === $colorSlug) {
-        return $colorDefinition['color'];
-      }
-    }
-    return $colorSlug;
+    return $this->themeController->translateSlugToColor($colorSlug);
   }
 }

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -2,18 +2,27 @@
 
 namespace MailPoet\EmailEditor\Engine;
 
+use WP_Theme_JSON;
+use WP_Theme_JSON_Resolver;
+
 /**
  * E-mail editor works with own theme.json which defines settings for the editor and styles for the e-mail.
  * This class is responsible for accessing data defined by the theme.json.
  */
 class ThemeController {
-  public function getTheme(): \WP_Theme_JSON {
-    $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
+  private WP_Theme_JSON $themeJson;
+
+  public function getTheme(): WP_Theme_JSON {
+    if (isset($this->themeJson)) {
+      return $this->themeJson;
+    }
+    $coreThemeData = WP_Theme_JSON_Resolver::get_core_data();
     $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
     $themeJson = json_decode($themeJson, true);
     /** @var array $themeJson */
-    $coreThemeData->merge(new \WP_Theme_JSON($themeJson, 'default'));
-    return apply_filters('mailpoet_email_editor_theme_json', $coreThemeData);
+    $coreThemeData->merge(new WP_Theme_JSON($themeJson, 'default'));
+    $this->themeJson = apply_filters('mailpoet_email_editor_theme_json', $coreThemeData);
+    return $this->themeJson;
   }
 
   public function getStylesheetForRendering(): string {

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine;
+
+/**
+ * E-mail editor works with own theme.json which defines settings for the editor and styles for the e-mail.
+ * This class is responsible for accessing data defined by the theme.json.
+ */
+class ThemeController {
+  public function getTheme(): \WP_Theme_JSON {
+    $coreThemeData = \WP_Theme_JSON_Resolver::get_core_data();
+    $themeJson = (string)file_get_contents(dirname(__FILE__) . '/theme.json');
+    $themeJson = json_decode($themeJson, true);
+    /** @var array $themeJson */
+    $coreThemeData->merge(new \WP_Theme_JSON($themeJson, 'default'));
+    return apply_filters('mailpoet_email_editor_theme_json', $coreThemeData);
+  }
+
+  public function getStylesheetForRendering(): string {
+    $emailThemeSettings = $this->getTheme()->get_settings();
+
+    $cssPresets = '';
+    // Font family classes
+    foreach ($emailThemeSettings['typography']['fontFamilies']['default'] as $fontFamily) {
+      $cssPresets .= ".has-{$fontFamily['slug']}-font-family { font-family: {$fontFamily['fontFamily']}; } \n";
+    }
+    // Font size classes
+    foreach ($emailThemeSettings['typography']['fontSizes']['default'] as $fontSize) {
+      $cssPresets .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
+    }
+    // Color palette classes
+    foreach ($emailThemeSettings['color']['palette']['default'] as $color) {
+      $cssPresets .= ".has-{$color['slug']}-color { color: {$color['color']}; } \n";
+      $cssPresets .= ".has-{$color['slug']}-background-color { background-color: {$color['color']}; } \n";
+    }
+
+    // Block specific styles
+    $cssBlocks = '';
+    $blocks = $this->getTheme()->get_styles_block_nodes();
+    foreach ($blocks as $blockMetadata) {
+      $cssBlocks .= $this->getTheme()->get_styles_for_block($blockMetadata);
+    }
+
+    return $cssPresets . $cssBlocks;
+  }
+
+  public function translateSlugToFontSize(string $fontSize): string {
+    $settings = $this->getTheme()->get_settings();
+    foreach ($settings['typography']['fontSizes']['default'] as $fontSizeDefinition) {
+      if ($fontSizeDefinition['slug'] === $fontSize) {
+        return $fontSizeDefinition['size'];
+      }
+    }
+    return $fontSize;
+  }
+
+  public function translateSlugToColor(string $colorSlug): string {
+    $settings = $this->getTheme()->get_settings();
+    foreach ($settings['color']['palette']['default'] as $colorDefinition) {
+      if ($colorDefinition['slug'] === $colorSlug) {
+        return $colorDefinition['color'];
+      }
+    }
+    return $colorSlug;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -25,8 +25,18 @@ class ThemeController {
     return $this->themeJson;
   }
 
+  public function getSettings(): array {
+    $emailEditorThemeSettings = $this->getTheme()->get_settings();
+    $siteThemeSettings = WP_Theme_JSON_Resolver::get_theme_data()->get_settings();
+    $emailEditorThemeSettings['color']['palette']['theme'] = [];
+    if (isset($siteThemeSettings['color']['palette']['theme'])) {
+      $emailEditorThemeSettings['color']['palette']['theme'] = $siteThemeSettings['color']['palette']['theme'];
+    }
+    return $emailEditorThemeSettings;
+  }
+
   public function getStylesheetForRendering(): string {
-    $emailThemeSettings = $this->getTheme()->get_settings();
+    $emailThemeSettings = $this->getSettings();
 
     $cssPresets = '';
     // Font family classes
@@ -38,7 +48,8 @@ class ThemeController {
       $cssPresets .= ".has-{$fontSize['slug']}-font-size { font-size: {$fontSize['size']}; } \n";
     }
     // Color palette classes
-    foreach ($emailThemeSettings['color']['palette']['default'] as $color) {
+    $colorDefinitions = array_merge($emailThemeSettings['color']['palette']['theme'], $emailThemeSettings['color']['palette']['default']);
+    foreach ($colorDefinitions as $color) {
       $cssPresets .= ".has-{$color['slug']}-color { color: {$color['color']}; } \n";
       $cssPresets .= ".has-{$color['slug']}-background-color { background-color: {$color['color']}; } \n";
     }
@@ -54,7 +65,7 @@ class ThemeController {
   }
 
   public function translateSlugToFontSize(string $fontSize): string {
-    $settings = $this->getTheme()->get_settings();
+    $settings = $this->getSettings();
     foreach ($settings['typography']['fontSizes']['default'] as $fontSizeDefinition) {
       if ($fontSizeDefinition['slug'] === $fontSize) {
         return $fontSizeDefinition['size'];
@@ -64,10 +75,11 @@ class ThemeController {
   }
 
   public function translateSlugToColor(string $colorSlug): string {
-    $settings = $this->getTheme()->get_settings();
-    foreach ($settings['color']['palette']['default'] as $colorDefinition) {
+    $settings = $this->getSettings();
+    $colorDefinitions = array_merge($settings['color']['palette']['theme'], $settings['color']['palette']['default']);
+    foreach ($colorDefinitions as $colorDefinition) {
       if ($colorDefinition['slug'] === $colorSlug) {
-        return $colorDefinition['color'];
+        return strtolower($colorDefinition['color']);
       }
     }
     return $colorSlug;

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -44,7 +44,9 @@ class Button implements BlockRenderer {
     // Background
     $themeData = $settingsController->getTheme()->get_data();
     $defaultColor = $themeData['styles']['blocks']['core/button']['color']['background'] ?? 'transparent';
-    $bgColor = $parsedBlock['attrs']['style']['color']['background'] ?? $defaultColor;
+    $colorSetBySlug = isset($parsedBlock['attrs']['backgroundColor']) ? $settingsController->translateSlugToColor($parsedBlock['attrs']['backgroundColor']) : null;
+    $colorSetByUser = $colorSetBySlug ?: ($parsedBlock['attrs']['style']['color']['background'] ?? null);
+    $bgColor = $colorSetByUser ?? $defaultColor;
     $markup = str_replace('{backgroundColor}', $bgColor, $markup);
 
     // Styles attributes
@@ -55,6 +57,7 @@ class Button implements BlockRenderer {
       'box-sizing' => 'border-box',
     ];
     $linkStyles = [
+      'background-color' => $bgColor,
       'display' => 'block',
       'line-height' => '120%',
       'margin' => '0',
@@ -87,6 +90,10 @@ class Button implements BlockRenderer {
     // Typography + colors
     $typography = $parsedBlock['attrs']['style']['typography'] ?? [];
     $color = $parsedBlock['attrs']['style']['color'] ?? [];
+    $colorSetBySlug = isset($parsedBlock['attrs']['textColor']) ? $settingsController->translateSlugToColor($parsedBlock['attrs']['textColor']) : null;
+    if ($colorSetBySlug) {
+      $color['text'] = $colorSetBySlug;
+    }
     $typography['fontSize'] = $parsedBlock['email_attrs']['font-size'] ?? 'inherit';
     $typography['textDecoration'] = $typography['textDecoration'] ?? ($parsedBlock['email_attrs']['text-decoration'] ?? 'inherit');
     $linkStyles = array_merge($linkStyles, wp_style_engine_get_styles(['typography' => $typography, 'color' => $color])['declarations']);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -21,9 +21,7 @@ class Button implements BlockRenderer {
     $buttonLink = $domHelper->findElement('a');
 
     if (!$buttonLink) return '';
-
-    $buttonOriginalWrapper = $domHelper->findElement('div');
-    $buttonClasses = $buttonOriginalWrapper ? $domHelper->getAttributeValue($buttonOriginalWrapper, 'class') : '';
+    $buttonClasses = $domHelper->getAttributeValueByTagName('div', 'class') ?? '';
 
     $markup = $this->getMarkup();
     $markup = str_replace('{classes}', $buttonClasses, $markup);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -27,7 +27,8 @@ class Button implements BlockRenderer {
     $markup = str_replace('{classes}', $buttonClasses, $markup);
 
     // Add Link Text
-    $markup = str_replace('{linkText}', $this->getElementInnerHTML($buttonLink) ?: '', $markup);
+    // Because the button text can contain highlighted text, we need to get the inner HTML of the button
+    $markup = str_replace('{linkText}', $domHelper->getElementInnerHTML($buttonLink) ?: '', $markup);
     $markup = str_replace('{linkUrl}', $buttonLink->getAttribute('href') ?: '#', $markup);
 
     // Width
@@ -114,20 +115,5 @@ class Button implements BlockRenderer {
           </td>
         </tr>
       </table>';
-  }
-
-  /**
-   * Because the button text can contain highlighted text, we need to get the inner HTML of the button
-   */
-  private function getElementInnerHTML(\DOMElement $element): string {
-    $innerHTML = '';
-    $children = $element->childNodes;
-    foreach ($children as $child) {
-      if (!$child instanceof \DOMNode) continue;
-      $ownerDocument = $child->ownerDocument;
-      if (!$ownerDocument instanceof \DOMDocument) continue;
-      $innerHTML .= $ownerDocument->saveXML($child);
-    }
-    return $innerHTML;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -51,17 +51,15 @@ class Column implements BlockRenderer {
       'width' => $width,
       'vertical-align' => $verticalAlign,
     ];
-    $mainCellClasses = 'email_column_wrap';
 
     // The default column alignment is `stretch to fill` which means that we need to set the background color to the main cell
     // to create a feeling of a stretched column
     if (!isset($parsedBlock['attrs']['verticalAlignment']) || $parsedBlock['attrs']['verticalAlignment'] === 'stretch') {
       $mainCellStyles = array_merge($mainCellStyles, $colorStyles);
-      $mainCellClasses .= ' ' . $classes;
     }
 
     return '
-      <td class="block ' . esc_attr($mainCellClasses) . '" style="' . esc_attr($settingsController->convertStylesToString($mainCellStyles)) . '">
+      <td class="block ' . esc_attr($classes) . '" style="' . esc_attr($settingsController->convertStylesToString($mainCellStyles)) . '">
         <div class="email_column" style="width:100%;max-width:' . esc_attr($width) . ';font-size:0px;text-align:left;display:inline-block;">
           <table class="email_column ' . esc_attr($classes) . '" border="0" cellpadding="0" cellspacing="0" role="presentation" style="' . esc_attr($settingsController->convertStylesToString($colorStyles)) . ';min-width:100%;width:100%;max-width:' . esc_attr($width) . ';vertical-align:top;" width="' . esc_attr($width) . '">
             <tbody>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 
 class Column implements BlockRenderer {
   public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
@@ -38,7 +39,7 @@ class Column implements BlockRenderer {
       $colorStyles['color'] = $parsedBlock['attrs']['style']['color']['text'];
     }
 
-    $classes = $this->getClassesFromElement($blockContent, ['tag_name' => 'div']);
+    $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
 
     $verticalAlign = 'top';
     // Because `stretch` is not a valid value for the `vertical-align` property, we don't override the default value
@@ -74,17 +75,5 @@ class Column implements BlockRenderer {
         </div>
       </td>
     ';
-  }
-
-  /**
-   * @param array{tag_name: string, class_name?: string} $tag
-   */
-  private function getClassesFromElement($blockContent, array $tag): string {
-    $html = new \WP_HTML_Tag_Processor($blockContent);
-    $elementClass = '';
-    if ($html->next_tag($tag)) {
-      $elementClass = $html->get_attribute('class') ?? '';
-    }
-    return $elementClass;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 
 class Columns implements BlockRenderer {
   public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
@@ -31,7 +32,7 @@ class Columns implements BlockRenderer {
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
     $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
 
-    $classes = $this->getClassesFromElement($blockContent, ['tag_name' => 'div']);
+    $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
     $colorStyles = [];
     if (isset($parsedBlock['attrs']['style']['color']['background'])) {
       $colorStyles['background-color'] = $parsedBlock['attrs']['style']['color']['background'];
@@ -77,17 +78,5 @@ class Columns implements BlockRenderer {
       </div>
       <!--[if mso | IE]></td></tr></table><![endif]-->
     ';
-  }
-
-  /**
-   * @param array{tag_name: string, class_name?: string} $tag
-   */
-  private function getClassesFromElement($blockContent, array $tag): string {
-    $html = new \WP_HTML_Tag_Processor($blockContent);
-    $elementClass = '';
-    if ($html->next_tag($tag)) {
-      $elementClass = $html->get_attribute('class') ?? '';
-    }
-    return $elementClass;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -25,7 +25,6 @@ class Columns implements BlockRenderer {
    */
   private function getBlockWrapper(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
-    $backgroundColor = $parsedBlock['attrs']['style']['color']['background'] ?? '';
     $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
     $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
     $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -15,21 +15,31 @@ class Columns implements BlockRenderer {
     return str_replace(
       '{columns_content}',
       $content,
-      $this->getBlockWrapper($parsedBlock, $settingsController)
+      $this->getBlockWrapper($blockContent, $parsedBlock, $settingsController)
     );
   }
 
   /**
    * Based on MJML <mj-section>
    */
-  private function getBlockWrapper(array $parsedBlock, SettingsController $settingsController): string {
+  private function getBlockWrapper(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
-    $backgroundColor = $parsedBlock['attrs']['style']['color']['background'] ?? 'none';
+    $backgroundColor = $parsedBlock['attrs']['style']['color']['background'] ?? '';
     $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
     $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
     $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
     $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
     $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
+
+    $classes = $this->getClassesFromElement($blockContent, ['tag_name' => 'div']);
+    $colorStyles = [];
+    if (isset($parsedBlock['attrs']['style']['color']['background'])) {
+      $colorStyles['background-color'] = $parsedBlock['attrs']['style']['color']['background'];
+      $colorStyles['background'] = $parsedBlock['attrs']['style']['color']['background'];
+    }
+    if (isset($parsedBlock['attrs']['style']['color']['text'])) {
+      $colorStyles['color'] = $parsedBlock['attrs']['style']['color']['text'];
+    }
 
     $align = $parsedBlock['attrs']['align'] ?? null;
     if ($align !== 'full') {
@@ -44,16 +54,17 @@ class Columns implements BlockRenderer {
       <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . $width . ';" width="' . $width . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="margin-top:' . $marginTop . ';max-width:' . $width . ';padding-left:' . $layoutPaddingLeft . ';padding-right:' . $layoutPaddingRight . ';">
         <table
+          class="' . $classes . '"
           align="center"
           border="0"
           cellpadding="0"
           cellspacing="0"
           role="presentation"
-          style="background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';max-width:' . $width . ';width:100%;"
+          style="' . esc_attr($settingsController->convertStylesToString($colorStyles)) . ';max-width:' . $width . ';width:100%;"
         >
           <tbody>
             <tr>
-              <td style="font-size:0px;background:' . $backgroundColor . ';background-color:' . $backgroundColor . ';padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';text-align:left;">
+              <td style="font-size:0px;padding-left:' . $paddingLeft . ';padding-right:' . $paddingRight . ';padding-bottom:' . $paddingBottom . ';padding-top:' . $paddingTop . ';text-align:left;">
                 <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;">
                   <tr>
                     {columns_content}
@@ -66,5 +77,17 @@ class Columns implements BlockRenderer {
       </div>
       <!--[if mso | IE]></td></tr></table><![endif]-->
     ';
+  }
+
+  /**
+   * @param array{tag_name: string, class_name?: string} $tag
+   */
+  private function getClassesFromElement($blockContent, array $tag): string {
+    $html = new \WP_HTML_Tag_Processor($blockContent);
+    $elementClass = '';
+    if ($html->next_tag($tag)) {
+      $elementClass = $html->get_attribute('class') ?? '';
+    }
+    return $elementClass;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 use MailPoet\Util\Helpers;
 
 class Heading implements BlockRenderer {
@@ -20,7 +21,7 @@ class Heading implements BlockRenderer {
   private function getBlockWrapper($blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
     $level = $parsedBlock['attrs']['level'] ?? 2; // default level is 2
-    $classes = $this->getClassesFromElement($blockContent, ['tag_name' => "h$level"]);
+    $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName("h$level", 'class') ?? '';
 
     // Styles for padding need to be set on the wrapping table cell due to support in Outlook
     $styles = [
@@ -95,17 +96,5 @@ class Heading implements BlockRenderer {
     }
 
     return $blockContent;
-  }
-
-  /**
-   * @param array{tag_name: string, class_name?: string} $tag
-   */
-  private function getClassesFromElement($blockContent, array $tag): string {
-    $html = new \WP_HTML_Tag_Processor($blockContent);
-    $elementClass = '';
-    if ($html->next_tag($tag)) {
-      $elementClass = $html->get_attribute('class') ?? '';
-    }
-    return $elementClass;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -13,14 +13,13 @@ class ListBlock implements BlockRenderer {
     if ($html->next_tag(['tag_name' => $tagName])) {
       $styles = $html->get_attribute('style') ?? '';
       $styles = $settingsController->parseStylesToArray($styles);
-      $styles = array_merge($styles, $parsedBlock['email_attrs'] ?? []);
 
-      // List block does not need width specification and it can cause issues for nested lists
-      unset($styles['width'] );
-
-      // Use font-size from email theme when those properties are not set
-      $themeData = $settingsController->getTheme()->get_data();
-      if (!isset($styles['font-size'])) {
+      // Font size
+      if (isset($parsedBlock['email_attrs']['font-size'])) {
+        $styles['font-size'] = $parsedBlock['email_attrs']['font-size'];
+      } else {
+        // Use font-size from email theme when those properties are not set
+        $themeData = $settingsController->getTheme()->get_data();
         $styles['font-size'] = $themeData['styles']['typography']['fontSize'];
       }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 use MailPoet\Util\Helpers;
 
 class Paragraph implements BlockRenderer {
@@ -17,7 +18,7 @@ class Paragraph implements BlockRenderer {
    */
   private function getBlockWrapper(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $themeData = $settingsController->getTheme()->get_data();
-    $classes = $this->getClassesFromElement($blockContent, ['tag_name' => 'p']);
+    $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('p', 'class') ?? '';
 
     $align = $parsedBlock['attrs']['align'] ?? 'left';
     $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
@@ -79,17 +80,5 @@ class Paragraph implements BlockRenderer {
     }
 
     return $blockContent;
-  }
-
-  /**
-   * @param array{tag_name: string, class_name?: string} $tag
-   */
-  private function getClassesFromElement($blockContent, array $tag): string {
-    $html = new \WP_HTML_Tag_Processor($blockContent);
-    $elementClass = '';
-    if ($html->next_tag($tag)) {
-      $elementClass = $html->get_attribute('class') ?? '';
-    }
-    return $elementClass;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Utils/DomDocumentHelper.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Utils/DomDocumentHelper.php
@@ -33,6 +33,17 @@ class DomDocumentHelper {
     return $element->hasAttribute($attribute) ? $element->getAttribute($attribute) : '';
   }
 
+  /**
+   * Searches for the first appearance of the given tag name and returns the value of specified attribute.
+   */
+  public function getAttributeValueByTagName(string $tagName, string $attribute): ?string {
+    $element = $this->findElement($tagName);
+    if (!$element) {
+      return null;
+    }
+    return $this->getAttributeValue($element, $attribute);
+  }
+
   public function getOuterHtml(\DOMElement $element): string {
     return (string)$this->dom->saveHTML($element);
   }

--- a/mailpoet/lib/EmailEditor/Integrations/Utils/DomDocumentHelper.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Utils/DomDocumentHelper.php
@@ -47,4 +47,14 @@ class DomDocumentHelper {
   public function getOuterHtml(\DOMElement $element): string {
     return (string)$this->dom->saveHTML($element);
   }
+
+  public function getElementInnerHTML(\DOMElement $element): string {
+    $innerHTML = '';
+    $children = $element->childNodes;
+    foreach ($children as $child) {
+      if (!$child instanceof \DOMNode) continue;
+      $innerHTML .= $this->dom->saveHTML($child);
+    }
+    return $innerHTML;
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/BlocksRegistryTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/BlocksRegistryTest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\EmailEditor\Engine\Renderer;
 
-use MailPoet\EmailEditor\Engine\SettingsController;
 use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\Paragraph;
 
 require_once __DIR__ . '/DummyBlockRenderer.php';
@@ -14,7 +13,7 @@ class BlocksRegistryTest extends \MailPoetTest {
 
   public function _before() {
     parent::_before();
-    $this->registry = new BlocksRegistry(new SettingsController());
+    $this->registry = $this->diContainer->get(BlocksRegistry::class);
   }
 
   public function testItReturnsNullForUnknownRenderer() {

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/Layout/FlexLayoutRendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/Layout/FlexLayoutRendererTest.php
@@ -21,7 +21,7 @@ class FlexLayoutRendererTest extends \MailPoetTest {
 
   public function _before(): void {
     parent::_before();
-    $this->settingsController = new SettingsController();
+    $this->settingsController = $this->diContainer->get(SettingsController::class);
     $this->registry = new BlocksRegistry($this->settingsController);
     $this->renderer = new FlexLayoutRenderer();
     $this->registry->addBlockRenderer('dummy/block', new DummyBlockRenderer());

--- a/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/SettingsControllerTest.php
@@ -49,4 +49,11 @@ class SettingsControllerTest extends \MailPoetTest {
     verify($this->settingsController->translateSlugToFontSize('x-large'))->equals('42px');
     verify($this->settingsController->translateSlugToFontSize('unknown'))->equals('unknown');
   }
+
+  public function testItCanTranslateColorSlug() {
+    verify($this->settingsController->translateSlugToColor('black'))->equals('#000000');
+    verify($this->settingsController->translateSlugToColor('white'))->equals('#ffffff');
+    verify($this->settingsController->translateSlugToColor('cyan-bluish-gray'))->equals('#abb8c3');
+    verify($this->settingsController->translateSlugToColor('pale-pink'))->equals('#f78da7');
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
@@ -2,17 +2,16 @@
 
 namespace MailPoet\EmailEditor\Engine;
 
-class SettingsControllerTest extends \MailPoetTest {
-  /** @var SettingsController */
-  private $settingsController;
+class ThemeControllerTest extends \MailPoetTest {
+  private ThemeController $themeController;
 
   public function _before() {
     parent::_before();
-    $this->settingsController = $this->diContainer->get(SettingsController::class);
+    $this->themeController = $this->diContainer->get(ThemeController::class);
   }
 
   public function testItGeneratesCssStylesForRenderer() {
-    $css = $this->settingsController->getStylesheetForRendering();
+    $css = $this->themeController->getStylesheetForRendering();
     verify($css)->stringContainsString('.has-arial-font-family');
     verify($css)->stringContainsString('.has-comic-sans-ms-font-family');
     verify($css)->stringContainsString('.has-courier-new-font-family');
@@ -43,17 +42,17 @@ class SettingsControllerTest extends \MailPoetTest {
   }
 
   public function testItCanTranslateFontSizeSlug() {
-    verify($this->settingsController->translateSlugToFontSize('small'))->equals('13px');
-    verify($this->settingsController->translateSlugToFontSize('medium'))->equals('20px');
-    verify($this->settingsController->translateSlugToFontSize('large'))->equals('36px');
-    verify($this->settingsController->translateSlugToFontSize('x-large'))->equals('42px');
-    verify($this->settingsController->translateSlugToFontSize('unknown'))->equals('unknown');
+    verify($this->themeController->translateSlugToFontSize('small'))->equals('13px');
+    verify($this->themeController->translateSlugToFontSize('medium'))->equals('20px');
+    verify($this->themeController->translateSlugToFontSize('large'))->equals('36px');
+    verify($this->themeController->translateSlugToFontSize('x-large'))->equals('42px');
+    verify($this->themeController->translateSlugToFontSize('unknown'))->equals('unknown');
   }
 
   public function testItCanTranslateColorSlug() {
-    verify($this->settingsController->translateSlugToColor('black'))->equals('#000000');
-    verify($this->settingsController->translateSlugToColor('white'))->equals('#ffffff');
-    verify($this->settingsController->translateSlugToColor('cyan-bluish-gray'))->equals('#abb8c3');
-    verify($this->settingsController->translateSlugToColor('pale-pink'))->equals('#f78da7');
+    verify($this->themeController->translateSlugToColor('black'))->equals('#000000');
+    verify($this->themeController->translateSlugToColor('white'))->equals('#ffffff');
+    verify($this->themeController->translateSlugToColor('cyan-bluish-gray'))->equals('#abb8c3');
+    verify($this->themeController->translateSlugToColor('pale-pink'))->equals('#f78da7');
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
@@ -12,6 +12,7 @@ class ThemeControllerTest extends \MailPoetTest {
 
   public function testItGeneratesCssStylesForRenderer() {
     $css = $this->themeController->getStylesheetForRendering();
+    // Font families
     verify($css)->stringContainsString('.has-arial-font-family');
     verify($css)->stringContainsString('.has-comic-sans-ms-font-family');
     verify($css)->stringContainsString('.has-courier-new-font-family');
@@ -39,6 +40,25 @@ class ThemeControllerTest extends \MailPoetTest {
     verify($css)->stringContainsString('.has-medium-font-size');
     verify($css)->stringContainsString('.has-large-font-size');
     verify($css)->stringContainsString('.has-x-large-font-size');
+
+    // Font sizes
+    verify($css)->stringContainsString('.has-small-font-size');
+    verify($css)->stringContainsString('.has-medium-font-size');
+    verify($css)->stringContainsString('.has-large-font-size');
+    verify($css)->stringContainsString('.has-x-large-font-size');
+
+    // Colors
+    verify($css)->stringContainsString('.has-black-color');
+    verify($css)->stringContainsString('.has-black-background-color');
+
+    verify($css)->stringContainsString('.has-black-color');
+    verify($css)->stringContainsString('.has-black-background-color');
+
+    $this->checkCorrectThemeConfiguration();
+    if (wp_get_theme()->get('Name') === 'Twenty Twenty-One') {
+      verify($css)->stringContainsString('.has-yellow-background-color');
+      verify($css)->stringContainsString('.has-yellow-color');
+    }
   }
 
   public function testItCanTranslateFontSizeSlug() {
@@ -54,5 +74,29 @@ class ThemeControllerTest extends \MailPoetTest {
     verify($this->themeController->translateSlugToColor('white'))->equals('#ffffff');
     verify($this->themeController->translateSlugToColor('cyan-bluish-gray'))->equals('#abb8c3');
     verify($this->themeController->translateSlugToColor('pale-pink'))->equals('#f78da7');
+    $this->checkCorrectThemeConfiguration();
+    if (wp_get_theme()->get('Name') === 'Twenty Twenty-One') {
+      verify($this->themeController->translateSlugToColor('yellow'))->equals('#eeeadd');
+    }
+  }
+
+  public function testItLoadsColorPaletteFromSiteTheme() {
+    $this->checkCorrectThemeConfiguration();
+    $settings = $this->themeController->getSettings();
+    if (wp_get_theme()->get('Name') === 'Twenty Twenty-One') {
+      verify($settings['color']['palette']['theme'])->notEmpty();
+    }
+  }
+
+  /**
+   * This test depends on using Twenty Twenty-One or Twenty Nineteen theme.
+   * This method checks if the theme is correctly configured and trigger a failure if not
+   * to prevent silent failures in case we change theme configuration in the test environment.
+   */
+  private function checkCorrectThemeConfiguration() {
+    $expectedThemes = ['Twenty Twenty-One', 'Twenty Nineteen'];
+    if (!in_array(wp_get_theme()->get('Name'), $expectedThemes)) {
+      $this->fail('Test depends on using Twenty Twenty-One or Twenty Nineteen theme. If you changed the theme, please update the test.');
+    }
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -166,4 +166,26 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('bgcolor="#32373c"');
     verify($output)->stringContainsString('background:#32373c;');
   }
+
+  public function testItRendersBackgroundColorSetBySlug(): void {
+    unset($this->parsedButton['attrs']['style']['color']);
+    unset($this->parsedButton['attrs']['style']['spacing']['padding']);
+    $this->parsedButton['attrs']['backgroundColor'] = 'black';
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    // For other blocks this is handled by CSS-inliner, but for button we need to handle it manually
+    // because of special email HTML markup
+    verify($output)->stringContainsString('bgcolor="#000000"');
+    verify($output)->stringContainsString('background:#000000;');
+    verify($output)->stringContainsString('background-color:#000000;');
+  }
+
+  public function testItRendersFontColorSetBySlug(): void {
+    unset($this->parsedButton['attrs']['style']['color']);
+    unset($this->parsedButton['attrs']['style']['spacing']['padding']);
+    $this->parsedButton['attrs']['textColor'] = 'white';
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    // For other blocks this is handled by CSS-inliner, but for button we need to handle it manually
+    // because of special email HTML markup
+    verify($output)->stringContainsString('color:#ffffff');
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
@@ -87,4 +87,24 @@ class ColumnTest extends \MailPoetTest {
     $this->checkValidHTML($rendered);
     $this->assertStringContainsString('vertical-align:bottom;', $rendered);
   }
+
+  public function testItSetsCustomColorAndBackground(): void {
+    $parsedColumn = $this->parsedColumn;
+    $parsedColumn['attrs']['style']['color']['text'] = '#123456';
+    $parsedColumn['attrs']['style']['color']['background'] = '#654321';
+    $rendered = $this->columnRenderer->render('', $parsedColumn, $this->settingsController);
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('color:#123456;', $rendered);
+    $this->assertStringContainsString('background-color:#654321;', $rendered);
+    $this->assertStringContainsString('background:#654321;', $rendered);
+  }
+
+  public function testItPreservesClassesSetByEditor(): void {
+    $parsedColumn = $this->parsedColumn;
+    $content = '<div class="wp-block-column editor-class-1 another-class"></div>';
+    $parsedColumn['attrs']['style']['color']['background'] = '#654321';
+    $rendered = $this->columnRenderer->render($content, $parsedColumn, $this->settingsController);
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('wp-block-column editor-class-1 another-class', $rendered);
+  }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
@@ -16,6 +16,7 @@ class ColumnsTest extends \MailPoetTest {
     'email_attrs' => [
       'width' => '784px',
     ],
+    'innerHTML' => '<div class="wp-block-columns"></div>',
     'innerBlocks' => [
       0 => [
         'blockName' => 'core/column',
@@ -81,5 +82,25 @@ class ColumnsTest extends \MailPoetTest {
     verify($rendered)->stringContainsString('padding-left:15px;');
     verify($rendered)->stringContainsString('padding-right:20px;');
     verify($rendered)->stringContainsString('padding-top:10px;');
+  }
+
+  public function testItSetsCustomColorAndBackground(): void {
+    $parsedColumns = $this->parsedColumns;
+    $parsedColumns['attrs']['style']['color']['text'] = '#123456';
+    $parsedColumns['attrs']['style']['color']['background'] = '#654321';
+    $rendered = $this->columnsRenderer->render('', $parsedColumns, $this->settingsController);
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('color:#123456;', $rendered);
+    $this->assertStringContainsString('background-color:#654321;', $rendered);
+    $this->assertStringContainsString('background:#654321;', $rendered);
+  }
+
+  public function testItPreservesClassesSetByEditor(): void {
+    $parsedColumns = $this->parsedColumns;
+    $content = '<div class="wp-block-columns editor-class-1 another-class"></div>';
+    $parsedColumns['attrs']['style']['color']['background'] = '#654321';
+    $rendered = $this->columnsRenderer->render($content, $parsedColumns, $this->settingsController);
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('wp-block-columns editor-class-1 another-class', $rendered);
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
@@ -54,10 +54,16 @@ class HeadingTest extends \MailPoetTest {
 
   public function testItRendersBlockAttributes(): void {
     $rendered = $this->headingRenderer->render('<h1>This is Heading 1</h1>', $this->parsedHeading, $this->settingsController);
-    verify($rendered)->stringContainsString('background-color:#cf2e2e'); // background color from theme.json matching vivid-red
-    verify($rendered)->stringContainsString('color:#8ed1fc;'); // color from theme.json matching pale-cyan-blue
     verify($rendered)->stringContainsString('text-transform:lowercase;');
     verify($rendered)->stringContainsString('text-align:center;');
+  }
+
+  public function testItRendersCustomSetColors(): void {
+    $this->parsedHeading['attrs']['style']['color']['background'] = '#000000';
+    $this->parsedHeading['attrs']['style']['color']['text'] = '#ff0000';
+    $rendered = $this->headingRenderer->render('<h1>This is Heading 1</h1>', $this->parsedHeading, $this->settingsController);
+    verify($rendered)->stringContainsString('background-color:#000000');
+    verify($rendered)->stringContainsString('color:#ff0000;');
   }
 
   public function testItReplacesFluidFontSizeInContent(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ListBlockTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ListBlockTest.php
@@ -57,19 +57,23 @@ class ListBlockTest extends \MailPoetTest {
     $this->assertStringContainsString('Item 2', $rendered);
   }
 
-  public function testItRendersConfiguredStyles(): void {
+  public function testItRendersFontSizeFromPreprocessor(): void {
     $parsedList = $this->parsedList;
     $parsedList['email_attrs'] = [
       'font-size' => '20px',
-      'font-family' => 'Arial',
-      'color' => '#00aa00',
     ];
     $rendered = $this->listRenderer->render('<ul><li>Item 1</li><li>Item 2</li></ul>', $parsedList, $this->settingsController);
     $this->checkValidHTML($rendered);
     $this->assertStringContainsString('Item 1', $rendered);
     $this->assertStringContainsString('Item 2', $rendered);
     $this->assertStringContainsString('font-size:20px;', $rendered);
-    $this->assertStringContainsString('font-family:Arial;', $rendered);
-    $this->assertStringContainsString('color:#00aa00;', $rendered);
+  }
+
+  public function testItPreservesCustomSetColors(): void {
+    $parsedList = $this->parsedList;
+    $rendered = $this->listRenderer->render('<ul style="color:#ff0000;background-color:#000000"><li>Item 1</li><li>Item 2</li></ul>', $parsedList, $this->settingsController);
+    $this->checkValidHTML($rendered);
+    $this->assertStringContainsString('color:#ff0000;', $rendered);
+    $this->assertStringContainsString('background-color:#000000', $rendered);
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ParagraphTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ParagraphTest.php
@@ -13,7 +13,6 @@ class ParagraphTest extends \MailPoetTest {
   private $parsedParagraph = [
     'blockName' => 'core/paragraph',
     'email_attrs' => [
-      'font-family' => 'Arial',
       'font-size' => '16px',
     ],
     'innerBlocks' => [],
@@ -37,7 +36,6 @@ class ParagraphTest extends \MailPoetTest {
     $this->assertStringContainsString('width:100%', $rendered);
     $this->assertStringContainsString('Lorem Ipsum', $rendered);
     $this->assertStringContainsString('font-size:16px;', $rendered);
-    $this->assertStringContainsString('font-family:Arial;', $rendered);
     $this->assertStringContainsString('text-align:left;', $rendered); // Check the default text-align
     $this->assertStringContainsString('align="left"', $rendered); // Check the default align
   }
@@ -69,7 +67,6 @@ class ParagraphTest extends \MailPoetTest {
       'fontStyle' => 'italic',
       'fontWeight' => 'bold',
       'fontSize' => '20px',
-      'fontFamily' => 'Times New Roman',
     ];
 
     $rendered = $this->paragraphRenderer->render('<p>Lorem Ipsum</p>', $parsedParagraph, $this->settingsController);
@@ -79,7 +76,6 @@ class ParagraphTest extends \MailPoetTest {
     $this->assertStringContainsString('font-style:italic;', $rendered);
     $this->assertStringContainsString('font-weight:bold;', $rendered);
     $this->assertStringContainsString('font-size:20px;', $rendered);
-    $this->assertStringContainsString('font-family:Times New Roman;', $rendered);
     $this->assertStringContainsString('Lorem Ipsum', $rendered);
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -75,6 +75,30 @@ class RendererTest extends \MailPoetTest {
     verify($listStyle)->stringContainsString('background-color:#000000'); // black is #000000
   }
 
+  public function testItInlinesColumnsColors() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:columns {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
+        <div class="wp-block-columns has-black-background-color has-luminous-vivid-orange-color"><!-- wp:column --><!-- /wp:column --><div>
+        <!-- /wp:columns -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $style = $this->extractBlockStyle($rendered['html'], 'wp-block-columns', 'table');
+    verify($style)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
+    verify($style)->stringContainsString('background-color:#000000'); // black is #000000
+  }
+
+  public function testItInlinesColumnColors() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:column {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
+        <div class="wp-block-column has-black-background-color has-luminous-vivid-orange-color"><div>
+        <!-- /wp:column -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column', 'td');
+    verify($style)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
+    verify($style)->stringContainsString('background-color:#000000'); // black is #000000
+  }
+
   private function extractBlockHtml(string $html, string $blockClass, string $tag): string {
     $doc = new \DOMDocument();
     $doc->loadHTML($html);

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -28,6 +28,17 @@ class RendererTest extends \MailPoetTest {
     verify($buttonHtml)->stringContainsString('background:#32373c');
   }
 
+  public function testButtonDefaultStylesDontOverwriteUserSetStyles() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:button {"backgroundColor":"white","textColor":"vivid-cyan-blue"} --><div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button">Button</a></div><!-- /wp:button -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $buttonHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-button', 'td');
+    verify($buttonHtml)->stringContainsString('color:#0693e3');
+    verify($buttonHtml)->stringContainsString('background:#ffffff');
+    verify($buttonHtml)->stringContainsString('background-color:#ffffff');
+  }
+
   public function testItInlinesHeadingFontSize() {
     $emailPost = new \WP_Post((object)[
       'post_content' => '<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"large"}}} --><h1 class="wp-block-heading">Hello</h1><!-- /wp:heading -->',

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -37,6 +37,16 @@ class RendererTest extends \MailPoetTest {
     verify($headingHtml)->stringContainsString('font-size:48px'); // large is 48px
   }
 
+  public function testItInlinesHeadingColors() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:heading {"level":1, "backgroundColor":"black", "textColor":"luminous-vivid-orange"} --><h1 class="wp-block-heading has-luminous-vivid-orange-color has-black-background-color">Hello</h1><!-- /wp:heading -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $headingWrapperStyle = $this->extractBlockStyle($rendered['html'], 'has-luminous-vivid-orange-color', 'td');
+    verify($headingWrapperStyle)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
+    verify($headingWrapperStyle)->stringContainsString('background-color:#000000'); // black is #000000
+  }
+
   public function testItInlinesParagraphColors() {
     $emailPost = new \WP_Post((object)[
       'post_content' => '<!-- wp:paragraph {style":{"color":{"background":"black", "text":"luminous-vivid-orange"}}} --><p class="has-luminous-vivid-orange-color has-black-background-color">Hello</p><!-- /wp:paragraph -->',

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -57,6 +57,24 @@ class RendererTest extends \MailPoetTest {
     verify($paragraphWrapperStyle)->stringContainsString('background-color:#000000'); // black is #000000
   }
 
+  public function testItInlinesListColors() {
+    $emailPost = new \WP_Post((object)[
+      'post_content' => '<!-- wp:list {"backgroundColor":"black","textColor":"luminous-vivid-orange","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}}}} -->
+        <ul class="has-black-background-color has-luminous-vivid-orange-color has-text-color has-background has-link-color"><!-- wp:list-item -->
+        <li>Item 1</li>
+        <!-- /wp:list-item -->
+
+        <!-- wp:list-item -->
+        <li>Item 2</li>
+        <!-- /wp:list-item --></ul>
+        <!-- /wp:list -->',
+    ]);
+    $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
+    $listStyle = $this->extractBlockStyle($rendered['html'], 'has-luminous-vivid-orange-color', 'ul');
+    verify($listStyle)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
+    verify($listStyle)->stringContainsString('background-color:#000000'); // black is #000000
+  }
+
   private function extractBlockHtml(string $html, string $blockClass, string $tag): string {
     $doc = new \DOMDocument();
     $doc->loadHTML($html);

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -3,10 +3,11 @@
 namespace unit\EmailEditor\Engine\Renderer;
 
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Engine\ThemeController;
 
 class SettingsControllerTest extends \MailPoetUnitTest {
   public function testItGetsMainLayoutStyles(): void {
-    $settingsController = new SettingsController();
+    $settingsController = new SettingsController($this->makeEmpty(ThemeController::class));
     $layoutStyles = $settingsController->getEmailLayoutStyles();
     verify($layoutStyles)->arrayHasKey('width');
     verify($layoutStyles)->arrayHasKey('background');
@@ -14,7 +15,7 @@ class SettingsControllerTest extends \MailPoetUnitTest {
   }
 
   public function testItGetsCorrectLayoutWidthWithoutPadding(): void {
-    $settingsController = new SettingsController();
+    $settingsController = new SettingsController($this->makeEmpty(ThemeController::class));
     $layoutWidth = $settingsController->getLayoutWidthWithoutPadding();
     // default width is 660px and if we subtract padding from left and right we must get the correct value
     $expectedWidth = (int)SettingsController::EMAIL_WIDTH - (int)SettingsController::FLEX_GAP * 2;
@@ -22,7 +23,7 @@ class SettingsControllerTest extends \MailPoetUnitTest {
   }
 
   public function testItConvertsStylesToString(): void {
-    $settingsController = new SettingsController();
+    $settingsController = new SettingsController($this->makeEmpty(ThemeController::class));
     $styles = [
       'width' => '600px',
       'background' => '#ffffff',

--- a/mailpoet/tests/unit/EmailEditor/Integrations/Utils/DomDocumentHelperTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/Utils/DomDocumentHelperTest.php
@@ -37,4 +37,11 @@ class DomDocumentHelperTest extends \MailPoetUnitTest {
     $this->assertInstanceOf(\DOMElement::class, $element);
     $this->assertEquals('<img src="https://test.com/DALL%C2%B7E-A%C2%AE%E2%88%91oecas%C6%92-803x1024.jpg">', $domDocumentHelper->getOuterHtml($element));
   }
+
+  public function testItGetsAttributeValueByTagName(): void {
+    $html = '<div><p class="some-class">Some text</p><p class="second-paragraph"></p></div>';
+    $domDocumentHelper = new DomDocumentHelper($html);
+    $this->assertEquals('some-class', $domDocumentHelper->getAttributeValueByTagName('p', 'class'));
+    $this->assertNull($domDocumentHelper->getAttributeValueByTagName('span', 'class'));
+  }
 }


### PR DESCRIPTION
## Description

This PR adds support for colors selected from the color palette. Prior to this change, values from the palette were ignored by the renderer.
As a bonus, I also added support for the site's theme palette (tested with TT4)

![Screenshot 2024-02-22 at 15 45 17](https://github.com/mailpoet/mailpoet/assets/1082140/e7b587ee-a26e-488c-bf5d-a8a2e2d67125)


## Code review notes

This doesn't cover the color palette support for border colors. I created an extra ticket for that.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5741]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5741]: https://mailpoet.atlassian.net/browse/MAILPOET-5741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ