### PR TITLE
Email editor - padding rendering refactor [MAILPOET-5918]

### DIFF
--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -340,6 +340,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\SettingsController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\ThemeController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Postprocessors\VariablesPostprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/VariablesPostprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/VariablesPostprocessor.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Renderer\Postprocessors;
+
+use MailPoet\EmailEditor\Engine\ThemeController;
+
+/**
+ * In some case the blocks HTML contains CSS variables.
+ * For example when spacing is set from a preset the inline styles contain var(--wp--preset--spacing--10), var(--wp--preset--spacing--20) etc.
+ * This postprocessor uses variables from theme.json and replaces the CSS variables with their values in final email HTML.
+ */
+class VariablesPostprocessor implements Postprocessor {
+  private ThemeController $themeController;
+
+  public function __construct(
+    ThemeController $themeController
+  ) {
+    $this->themeController = $themeController;
+  }
+
+  public function postprocess(string $html): string {
+    $variables = $this->themeController->getVariablesValuesMap();
+    // Pattern to match style attributes and their values.
+    //We want to replace the CSS variables only in the style attributes to avoid replacing the actual content.
+    $stylePattern = '/style="(.*?)"/i';
+    $callback = function ($matches) use ($variables) {
+      // For each match, replace CSS variables with their values
+      $style = $matches[1];
+      foreach ($variables as $varName => $varValue) {
+        $varPattern = '/var\(' . preg_quote($varName, '/') . '\)/i';
+        $style = preg_replace($varPattern, $varValue, $style);
+      }
+      return 'style="' . $style . '"';
+    };
+
+    $html = preg_replace_callback($stylePattern, $callback, $html);
+
+    return (string)$html;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/VariablesPostprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Postprocessors/VariablesPostprocessor.php
@@ -30,7 +30,7 @@ class VariablesPostprocessor implements Postprocessor {
         $varPattern = '/var\(' . preg_quote($varName, '/') . '\)/i';
         $style = preg_replace($varPattern, $varValue, $style);
       }
-      return 'style="' . $style . '"';
+      return 'style="' . esc_attr($style) . '"';
     };
 
     $html = preg_replace_callback($stylePattern, $callback, $html);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ProcessManager.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ProcessManager.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Engine\Renderer;
 
 use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\Postprocessor;
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\VariablesPostprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\Preprocessor;
@@ -24,7 +25,8 @@ class ProcessManager {
     BlocksWidthPreprocessor $blocksWidthPreprocessor,
     TypographyPreprocessor $typographyPreprocessor,
     SpacingPreprocessor $spacingPreprocessor,
-    HighlightingPostprocessor $highlightingPostprocessor
+    HighlightingPostprocessor $highlightingPostprocessor,
+    VariablesPostprocessor $variablesPostprocessor
   ) {
     $this->registerPreprocessor($cleanupPreprocessor);
     $this->registerPreprocessor($topLevelPreprocessor);
@@ -32,6 +34,7 @@ class ProcessManager {
     $this->registerPreprocessor($typographyPreprocessor);
     $this->registerPreprocessor($spacingPreprocessor);
     $this->registerPostprocessor($highlightingPostprocessor);
+    $this->registerPostprocessor($variablesPostprocessor);
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -84,4 +84,20 @@ class ThemeController {
     }
     return $colorSlug;
   }
+
+  public function getVariablesValuesMap(): array {
+    $variablesCss = $this->getTheme()->get_stylesheet(['variables']);
+    $map = [];
+    // Regular expression to match CSS variable definitions
+    $pattern = '/--(.*?):\s*(.*?);/';
+
+    if (preg_match_all($pattern, $variablesCss, $matches, PREG_SET_ORDER)) {
+      foreach ($matches as $match) {
+        // '--' . $match[1] is the variable name, $match[2] is the variable value
+        $map['--' . $match[1]] = $match[2];
+      }
+    }
+
+    return $map;
+  }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -77,13 +77,16 @@ class Button implements BlockRenderer {
     }
 
     // Spacing
-    if (isset($parsedBlock['attrs']['style']['spacing']['padding'])) {
-      $padding = $parsedBlock['attrs']['style']['spacing']['padding'];
-      $wrapperStyles['mso-padding-alt'] = "{$padding['top']} {$padding['right']} {$padding['bottom']} {$padding['left']}";
-      $linkStyles['padding-top'] = $padding['top'];
-      $linkStyles['padding-right'] = $padding['right'];
-      $linkStyles['padding-bottom'] = $padding['bottom'];
-      $linkStyles['padding-left'] = $padding['left'];
+    $paddingStyles = wp_style_engine_get_styles(['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]]);
+    $linkStyles = array_merge($linkStyles, $paddingStyles['declarations'] ?? []);
+    // In most clients we want to render padding on the link element so that the full button is clickable
+    // Outlook doesn't support padding on the link element, so we need to set padding on the wrapper table cell and to have it only for Outlook we use mso-padding-alt
+    if (isset($paddingStyles['declarations'])) {
+      $paddingTop = $paddingStyles['declarations']['padding-top'] ?? '0px';
+      $paddingRight = $paddingStyles['declarations']['padding-right'] ?? '0px';
+      $paddingBottom = $paddingStyles['declarations']['padding-bottom'] ?? '0px';
+      $paddingLeft = $paddingStyles['declarations']['padding-left'] ?? '0px';
+      $wrapperStyles['mso-padding-alt'] = "$paddingTop $paddingRight $paddingBottom $paddingLeft";
     }
 
     // Typography + colors

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -33,10 +33,9 @@ class Column implements BlockRenderer {
     }
 
     $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
-    $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
-    $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
-    $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
-    $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
+
+    $paddingStyles = wp_style_engine_get_styles(['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]]);
+    $paddingStyles = $paddingStyles['css'] ?? '';
 
     $colorStyles = [];
     if (isset($parsedBlock['attrs']['style']['color']['background'])) {
@@ -72,7 +71,7 @@ class Column implements BlockRenderer {
           <table class="email_column ' . esc_attr($classes) . '" border="0" cellpadding="0" cellspacing="0" role="presentation" style="' . esc_attr($settingsController->convertStylesToString($colorStyles)) . ';min-width:100%;width:100%;max-width:' . esc_attr($width) . ';vertical-align:top;" width="' . esc_attr($width) . '">
             <tbody>
               <tr>
-                <td align="left" style="font-size:0px;padding-left:' . esc_attr($paddingLeft) . ';padding-right:' . esc_attr($paddingRight) . ';padding-bottom:' . esc_attr($paddingBottom) . ';padding-top:' . esc_attr($paddingTop) . ';">
+                <td align="left" style="font-size:0px;' . esc_attr($paddingStyles) . '">
                   <div style="text-align:left;">{column_content}</div>
                 </td>
               </tr>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -33,11 +33,10 @@ class Columns implements BlockRenderer {
     }
 
     $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
-    $paddingBottom = $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px';
-    $paddingLeft = $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px';
-    $paddingRight = $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px';
-    $paddingTop = $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px';
     $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
+
+    $paddingStyles = wp_style_engine_get_styles(['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]]);
+    $paddingStyles = $paddingStyles['css'] ?? '';
 
     $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
     $colorStyles = [];
@@ -74,11 +73,8 @@ class Columns implements BlockRenderer {
             <tr>
               <td style="
               ' . esc_attr($settingsController->convertStylesToString($borderStyles)) . '
+              ' . esc_attr($paddingStyles) . '
                 font-size:0px;
-                padding-left:' . $paddingLeft . ';
-                padding-right:' . $paddingRight . ';
-                padding-bottom:' . $paddingBottom . ';
-                padding-top:' . $paddingTop . ';
                 text-align:left;
               ">
                 <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:separate;">

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Heading.php
@@ -26,11 +26,10 @@ class Heading implements BlockRenderer {
     // Styles for padding need to be set on the wrapping table cell due to support in Outlook
     $styles = [
       'min-width' => '100%', // prevent Gmail App from shrinking the table on mobile devices
-      'padding-bottom' => $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px',
-      'padding-left' => $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px',
-      'padding-right' => $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px',
-      'padding-top' => $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px',
     ];
+
+    $paddingStyles = wp_style_engine_get_styles(['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]]);
+    $styles = array_merge($styles, $paddingStyles['declarations'] ?? []);
 
     if (isset($parsedBlock['attrs']['textAlign'])) {
       $styles['text-align'] = $parsedBlock['attrs']['textAlign'];
@@ -89,7 +88,8 @@ class Heading implements BlockRenderer {
 
     if ($html->next_tag($tag)) {
       $elementStyle = $html->get_attribute('style') ?? '';
-      $elementStyle = preg_replace('/padding.*:.?[0-9]+px;?/', '', $elementStyle);
+      // Padding may contain value like 10px or variable like var(--spacing-10)
+      $elementStyle = preg_replace('/padding.*:.?[0-9a-z-()]+;?/', '', $elementStyle);
       $elementStyle = preg_replace('/font-size:[^;]+;?/', $fontSize, $elementStyle);
       $html->set_attribute('style', $elementStyle);
       $blockContent = $html->get_updated_html();

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Paragraph.php
@@ -25,11 +25,10 @@ class Paragraph implements BlockRenderer {
 
     $styles = [
       'text-align' => $align,
-      'padding-bottom' => $parsedBlock['attrs']['style']['spacing']['padding']['bottom'] ?? '0px',
-      'padding-left' => $parsedBlock['attrs']['style']['spacing']['padding']['left'] ?? '0px',
-      'padding-right' => $parsedBlock['attrs']['style']['spacing']['padding']['right'] ?? '0px',
-      'padding-top' => $parsedBlock['attrs']['style']['spacing']['padding']['top'] ?? '0px',
     ];
+
+    $paddingStyles = wp_style_engine_get_styles(['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]]);
+    $styles = array_merge($styles, $paddingStyles['declarations'] ?? []);
 
     if (isset($parsedBlock['attrs']['style']['color']['text'])) {
       $styles['color'] = $parsedBlock['attrs']['style']['color']['text'];
@@ -74,7 +73,8 @@ class Paragraph implements BlockRenderer {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag($tag)) {
       $elementStyle = $html->get_attribute('style') ?? '';
-      $elementStyle = preg_replace('/padding.*:.?[0-9]+px;?/', '', $elementStyle);
+      // Padding may contain value like 10px or variable like var(--spacing-10)
+      $elementStyle = preg_replace('/padding.*:.?[0-9a-z-()]+;?/', '', $elementStyle);
       $html->set_attribute('style', $elementStyle);
       $blockContent = $html->get_updated_html();
     }

--- a/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
@@ -88,6 +88,12 @@ class ThemeControllerTest extends \MailPoetTest {
     }
   }
 
+  public function testItReturnsCorrectPresetVariablesMap() {
+    $variableMap = $this->themeController->getVariablesValuesMap();
+    verify($variableMap['--wp--preset--color--black'])->equals('#000000');
+    verify($variableMap['--wp--preset--spacing--20'])->equals('20px');
+  }
+
   /**
    * This test depends on using Twenty Twenty-One or Twenty Nineteen theme.
    * This method checks if the theme is correctly configured and trigger a failure if not

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Postprocessors/VariablesPostprocessorTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/Postprocessors/VariablesPostprocessorTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace unit\EmailEditor\Engine\Renderer\Postprocessors;
+
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\VariablesPostprocessor;
+use MailPoet\EmailEditor\Engine\ThemeController;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class VariablesPostprocessorTest extends \MailPoetUnitTest {
+  private VariablesPostprocessor $postprocessor;
+
+  /** @var ThemeController & MockObject */
+  private $themeControllerMock;
+
+  public function _before() {
+    parent::_before();
+    $this->themeControllerMock = $this->createMock(ThemeController::class);
+    $this->postprocessor = new VariablesPostprocessor($this->themeControllerMock);
+  }
+
+  public function testItReplacesVariablesInStyleAttributes(): void {
+    $variablesMap = [
+      '--wp--preset--spacing--10' => '10px',
+      '--wp--preset--spacing--20' => '20px',
+      '--wp--preset--spacing--30' => '30px',
+    ];
+    $this->themeControllerMock->method('getVariablesValuesMap')->willReturn($variablesMap);
+    $html = '<div style="padding:var(--wp--preset--spacing--10);margin:var(--wp--preset--spacing--20)"><p style="color:white;padding-left:var(--wp--preset--spacing--10);">Helloo I have padding var(--wp--preset--spacing--10); </p></div>';
+    $result = $this->postprocessor->postprocess($html);
+    verify($result)->equals('<div style="padding:10px;margin:20px"><p style="color:white;padding-left:10px;">Helloo I have padding var(--wp--preset--spacing--10); </p></div>');
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Engine/Renderer/ProcessManagerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/Renderer/ProcessManagerTest.php
@@ -3,6 +3,7 @@
 namespace unit\EmailEditor\Engine\Renderer;
 
 use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\HighlightingPostprocessor;
+use MailPoet\EmailEditor\Engine\Renderer\Postprocessors\VariablesPostprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\BlocksWidthPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\CleanupPreprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\Preprocessors\SpacingPreprocessor;
@@ -43,7 +44,10 @@ class ProcessManagerTest extends \MailPoetUnitTest {
     $highlighting = $this->createMock(HighlightingPostprocessor::class);
     $highlighting->expects($this->once())->method('postprocess')->willReturn('');
 
-    $processManager = new ProcessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing, $highlighting);
+    $variables = $this->createMock(VariablesPostprocessor::class);
+    $variables->expects($this->once())->method('postprocess')->willReturn('');
+
+    $processManager = new ProcessManager($cleanup, $topLevel, $blocksWidth, $typography, $spacing, $highlighting, $variables);
     $processManager->registerPreprocessor($secondPreprocessor);
     verify($processManager->preprocess([], $layoutStyles))->equals([]);
     verify($processManager->postprocess(''))->equals('');

--- a/mailpoet/tests/unit/_bootstrap.php
+++ b/mailpoet/tests/unit/_bootstrap.php
@@ -10,6 +10,11 @@ if (!function_exists('_x')) {
     return $text;
   }
 }
+if (!function_exists('esc_attr')) {
+  function esc_attr($attr) {
+    return $attr;
+  }
+}
 
 // Fix for mocking WPFunctions
 // [PHPUnit\Framework\Exception] Use of undefined constant OBJECT - assumed 'OBJECT' (this will throw an Error in a future version of PHP)


### PR DESCRIPTION
## Description

In the Gutenberg update, we added a stepped padding control, but the renderer ignores values set in the control. This PR fixes that.

![Screenshot 2024-03-01 at 8 48 18](https://github.com/mailpoet/mailpoet/assets/1082140/b0ebbbdf-c601-4d03-bb7e-0a2294fdb5e4)


This PR contains a small refactor of how we handle paddings in the renderers. We are moving from custom code to WP native function for generating block styles.

## Code review notes

_N/A_

## QA notes

1. Go to the email editor
2. Add column, paragraph, and button and set padding using stepped padding control and also by manual value
3. Open the email preview and check the padding was applied

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5918]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5918]: https://mailpoet.atlassian.net/browse/MAILPOET-5918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ