### PR TITLE
Replace ORM::raw_execute usages with Doctrine connection [MAILPOET-5761]

### DIFF
--- a/mailpoet/tests/integration/WP/EmojiTest.php
+++ b/mailpoet/tests/integration/WP/EmojiTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Test\WP;
 use Codeception\Stub\Expected;
 use MailPoet\Config\Env;
 use MailPoet\WP\Emoji;
-use MailPoetVendor\Idiorm\ORM;
 
 class EmojiTest extends \MailPoetTest {
   public $emoji;
@@ -70,7 +69,7 @@ class EmojiTest extends \MailPoetTest {
   }
 
   private function createTable($table, $charset) {
-    ORM::raw_execute(
+    $this->connection->executeStatement(
       'CREATE TABLE IF NOT EXISTS ' . $table
       . ' (' . $this->column . ' TEXT) '
       . 'DEFAULT CHARSET=' . $charset . ';'
@@ -78,6 +77,6 @@ class EmojiTest extends \MailPoetTest {
   }
 
   private function dropTable($table) {
-    ORM::raw_execute('DROP TABLE IF EXISTS ' . $table);
+    $this->connection->executeStatement('DROP TABLE IF EXISTS ' . $table);
   }
 }


### PR DESCRIPTION
## Description

I discovered remaining direct usages of the old ORM class and found a related (probably forgotten) [ticket](https://mailpoet.atlassian.net/browse/MAILPOET-5761).

## Code review notes

Only tests, we can merge without QA.

## QA notes

Only tests, no QA needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5761]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5761]: https://mailpoet.atlassian.net/browse/MAILPOET-5761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ