### PR TITLE
Improve acceptance test for new email editor

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -24,10 +24,10 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Compose an email');
-    $i->waitForElement('.is-root-container');
-    $i->wait(1);
+    $i->waitForElementVisible('.is-root-container');
+    $i->waitForElementClickable('.is-root-container');
     $i->click('.is-root-container');
-    $i->type('Hello world!');
+    $i->fillField('.//p[@data-title="Paragraph"]', 'Sample text');
 
     $i->wantTo('Verify correct WP menu item is highlighted');
     $i->waitForText('Emails', 10, '#toplevel_page_mailpoet-homepage .current');
@@ -46,6 +46,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->wantTo('Send an email and verify it was delivered');
     $i->click('Save Draft');
     $i->waitForText('Saved');
+    $i->waitForText('Email saved!');
     $i->click('Send');
     $i->waitForElement('[name="subject"]');
     $subject = $i->grabValueFrom('[name="subject"]');
@@ -84,20 +85,23 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Edit an email');
-    $i->waitForElement('.is-root-container');
-    $i->wait(1);
+    $i->waitForElementVisible('.is-root-container');
+    $i->waitForElementClickable('.is-root-container');
     $i->click('.is-root-container');
-    $i->type('Hello world!');
+    $i->fillField('.//p[@data-title="Paragraph"]', 'Sample text');
 
     $i->wantTo('Save draft and display preview');
     $i->click('Save Draft');
     $i->waitForText('Saved');
+    $i->waitForText('Email saved!');
+    $i->click('.interface-pinned-items'); // close sidebar
     $i->click('.mailpoet-preview-dropdown button[aria-label="Preview"]');
+    $i->waitForElementVisible('//button[text()="Preview in new tab"]');
     $i->waitForElementClickable('//button[text()="Preview in new tab"]');
     $i->click('//button[text()="Preview in new tab"]');
     $i->switchToNextTab();
     $i->canSeeInCurrentUrl('endpoint=view_in_browser');
-    $i->canSee('Hello world!');
+    $i->canSee('Sample text');
     $i->closeTab();
 
     $i->wantTo('Send preview email and verify it was delivered');


### PR DESCRIPTION
## Description

I investigated and tried to reproduce on both local and online site, using different browsers and WP versions, also older associated plugins with _oldest job in CI and no luck to reproduce issue. Since the email editor is at early phase and still a lot to be tested and reported, if we find issue like this we will report it through manual testing. I added workaround for this popup overlay so the nightly workflow pass.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5923]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5923]: https://mailpoet.atlassian.net/browse/MAILPOET-5923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ