### PR TITLE
Add styles panel to the new email editor [MAILPOET-5638]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -33,7 +33,7 @@ import { Header } from '../header';
 import { ListviewSidebar } from '../listview-sidebar/listview-sidebar';
 import { InserterSidebar } from '../inserter-sidebar/inserter-sidebar';
 import { EditorNotices, EditorSnackbars, SentEmailNotice } from '../notices';
-import { StylesSidebar } from '../styles-sidebar/styles-sidebar';
+import { StylesSidebar } from '../styles-sidebar';
 
 export function BlockEditor() {
   const {

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -48,7 +48,7 @@ export function BlockEditor() {
     canUserEditMedia,
     hasFixedToolbar,
     focusMode,
-    layoutStyles,
+    styles,
     layout,
   } = useSelect(
     (select) => ({
@@ -63,7 +63,7 @@ export function BlockEditor() {
       canUserEditMedia: select(coreStore).canUser('create', 'media'),
       hasFixedToolbar: select(storeName).isFeatureActive('fixedToolbar'),
       focusMode: select(storeName).isFeatureActive('focusMode'),
-      layoutStyles: select(storeName).getLayoutStyles(),
+      styles: select(storeName).getStyles(),
       layout: select(storeName).getLayout(),
     }),
     [],
@@ -86,7 +86,7 @@ export function BlockEditor() {
   );
 
   // This will be set by the user in the future in email or global styles.
-  const layoutBackground = layoutStyles.background;
+  const layoutBackground = styles.layout.background;
 
   let inlineStyles = useResizeCanvas(previewDeviceType);
   // UseResizeCanvas returns null if the previewDeviceType is Desktop.
@@ -94,7 +94,7 @@ export function BlockEditor() {
     inlineStyles = {
       height: 'auto',
       margin: '4rem auto', // 4em top/bottom to place the email document nicely vertically in canvas. Same value is used for title in WP Post editor.
-      width: layoutStyles.width,
+      width: styles.layout.width,
       display: 'flex',
       flexFlow: 'column',
     };

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -33,6 +33,7 @@ import { Header } from '../header';
 import { ListviewSidebar } from '../listview-sidebar/listview-sidebar';
 import { InserterSidebar } from '../inserter-sidebar/inserter-sidebar';
 import { EditorNotices, EditorSnackbars, SentEmailNotice } from '../notices';
+import { StylesSidebar } from '../styles-sidebar/styles-sidebar';
 
 export function BlockEditor() {
   const {
@@ -130,6 +131,7 @@ export function BlockEditor() {
       <AutosaveMonitor />
       <SentEmailNotice />
       <Sidebar />
+      <StylesSidebar />
       <InterfaceSkeleton
         className={className}
         header={<Header />}

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
@@ -1,32 +1,35 @@
-import classnames from 'classnames';
-import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import {
-  mainSidebarEmailKey,
-  mainSidebarBlockKey,
+  mainSidebarBlockTab,
+  mainSidebarEmailTab,
   storeName,
 } from '../../store';
 
-type Props = {
-  sidebarKey: string;
-};
-
-export function Header({ sidebarKey }: Props) {
-  const { openSidebar } = useDispatch(storeName);
+export function Header() {
+  const { toggleSettingsSidebarActiveTab } = useDispatch(storeName);
 
   const selectedBlockId = useSelect(
     (select) => select(blockEditorStore).getSelectedBlockClientId(),
     [],
   );
 
+  const activeTab = useSelect(
+    (select) => select(storeName).getSettingsSidebarActiveTab(),
+    [],
+  );
+
   // Switch tab based on selected block.
   useEffect(() => {
-    void openSidebar(
-      selectedBlockId ? mainSidebarBlockKey : mainSidebarEmailKey,
-    );
-  }, [selectedBlockId, openSidebar]);
+    if (selectedBlockId) {
+      void toggleSettingsSidebarActiveTab(mainSidebarBlockTab);
+    } else {
+      void toggleSettingsSidebarActiveTab(mainSidebarEmailTab);
+    }
+  }, [selectedBlockId, toggleSettingsSidebarActiveTab]);
 
   return (
     <div className="components-panel__header interface-complementary-area-header edit-post-sidebar__panel-tabs">
@@ -34,11 +37,11 @@ export function Header({ sidebarKey }: Props) {
         <li>
           <button
             onClick={() => {
-              void openSidebar(mainSidebarEmailKey);
+              void toggleSettingsSidebarActiveTab(mainSidebarEmailTab);
             }}
             className={classnames(
               'components-button edit-post-sidebar__panel-tab',
-              { 'is-active': sidebarKey === mainSidebarEmailKey },
+              { 'is-active': activeTab === mainSidebarEmailTab },
             )}
             data-automation-id="email_settings_tab"
             type="button"
@@ -49,11 +52,11 @@ export function Header({ sidebarKey }: Props) {
         <li>
           <button
             onClick={() => {
-              void openSidebar(mainSidebarBlockKey);
+              void toggleSettingsSidebarActiveTab(mainSidebarBlockTab);
             }}
             className={classnames(
               'components-button edit-post-sidebar__panel-tab',
-              { 'is-active': sidebarKey === mainSidebarBlockKey },
+              { 'is-active': activeTab === mainSidebarBlockTab },
             )}
             data-automation-id="mailpoet_block_settings_tab"
             type="button"

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/sidebar.tsx
@@ -2,16 +2,14 @@ import { Panel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { BlockInspector } from '@wordpress/block-editor';
-import {
-  ComplementaryArea,
-  store as interfaceStore,
-} from '@wordpress/interface';
+import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { drawerRight } from '@wordpress/icons';
 import {
   storeName,
-  mainSidebarEmailKey,
-  mainSidebarBlockKey,
+  mainSidebarEmailTab,
+  mainSidebarBlockTab,
+  mainSidebarId,
 } from '../../store';
 import { Header } from './header';
 import { EmailSettings } from './email-settings';
@@ -19,25 +17,24 @@ import { EmailSettings } from './email-settings';
 type Props = ComponentProps<typeof ComplementaryArea>;
 
 export function Sidebar(props: Props): JSX.Element {
-  const { sidebarKey } = useSelect((select) => ({
-    sidebarKey:
-      select(interfaceStore).getActiveComplementaryArea(storeName) ??
-      mainSidebarEmailKey,
-  }));
+  const activeTab = useSelect(
+    (select) => select(storeName).getSettingsSidebarActiveTab(),
+    [],
+  );
 
   return (
     <ComplementaryArea
-      identifier={sidebarKey}
+      identifier={mainSidebarId}
       className="edit-post-sidebar"
-      header={<Header sidebarKey={sidebarKey} />}
+      header={<Header />}
       icon={drawerRight}
       scope={storeName}
       smallScreenTitle={__('No title', 'mailpoet')}
       isActiveByDefault
       {...props}
     >
-      {sidebarKey === mainSidebarEmailKey && <EmailSettings />}
-      {sidebarKey === mainSidebarBlockKey && (
+      {activeTab === mainSidebarEmailTab && <EmailSettings />}
+      {activeTab === mainSidebarBlockTab && (
         <Panel>
           <BlockInspector />
         </Panel>

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/index.scss
@@ -1,0 +1,3 @@
+.mailpoet-email-editor__styles-panel .components-navigator-button {
+  width: 100%;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/index.ts
@@ -1,0 +1,3 @@
+import './index.scss';
+
+export * from './styles-sidebar';

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/preview.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/preview.tsx
@@ -1,0 +1,218 @@
+import {
+  __unstableMotion as motion,
+  __experimentalHStack as HStack,
+  __experimentalVStack as VStack,
+} from '@wordpress/components';
+
+const firstFrame = {
+  start: {
+    scale: 1,
+    opacity: 1,
+  },
+  hover: {
+    scale: 0,
+    opacity: 0,
+  },
+};
+
+const midFrame = {
+  hover: {
+    opacity: 1,
+  },
+  start: {
+    opacity: 0.5,
+  },
+};
+
+const secondFrame = {
+  hover: {
+    scale: 1,
+    opacity: 1,
+  },
+  start: {
+    scale: 0,
+    opacity: 0,
+  },
+};
+
+const normalizedHeight = 152;
+const normalizedColorSwatchSize = 32;
+
+/**
+ * Component to render the styles preview based on the component from the site editor:
+ * https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/global-styles/preview.js
+ */
+export function Preview(): JSX.Element {
+  const style = {
+    backgroundColor: '#f3f3f3',
+    headingFontFamily: 'Arial',
+    headingColor: '#000000',
+    headingFontWeight: 'normal',
+    paletteColors: [
+      {
+        name: 'Sample Background',
+        slug: 'Sample-background',
+        color: '#f9f8f3',
+      },
+    ],
+    highlightedColors: [
+      {
+        name: 'Sample primary',
+        slug: 'sample-primary',
+        color: '#e5e2d3',
+      },
+      {
+        name: 'Sample Secondary',
+        slug: 'sample-secondary',
+        color: '#111111',
+      },
+    ],
+  };
+
+  const isFocused = false;
+  const isHovered = false;
+  const disableMotion = false;
+  const label = 'Some Label';
+  const ratio = 1;
+
+  const gradientValue = undefined;
+  const withHoverView = true;
+
+  return (
+    <motion.div
+      style={{
+        height: normalizedHeight * ratio,
+        width: '100%',
+        background: gradientValue ?? style.backgroundColor,
+        cursor: withHoverView ? 'pointer' : undefined,
+      }}
+      initial="start"
+      animate={
+        (isHovered || isFocused) && !disableMotion && label ? 'hover' : 'start'
+      }
+    >
+      <motion.div
+        variants={firstFrame}
+        style={{
+          height: '100%',
+          overflow: 'hidden',
+        }}
+      >
+        <HStack
+          spacing={10 * ratio}
+          justify="center"
+          style={{
+            height: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <motion.div
+            style={{
+              fontFamily: style.headingFontFamily,
+              fontSize: 65 * ratio,
+              color: style.headingColor,
+              fontWeight: style.headingFontWeight,
+            }}
+            animate={{ scale: 1, opacity: 1 }}
+            initial={{ scale: 0.1, opacity: 0 }}
+            transition={{ delay: 0.3, type: 'tween' }}
+          >
+            Aa
+          </motion.div>
+          <VStack spacing={4 * ratio}>
+            {style.highlightedColors.map(({ slug, color }, index) => (
+              <motion.div
+                key={slug}
+                style={{
+                  height: normalizedColorSwatchSize * ratio,
+                  width: normalizedColorSwatchSize * ratio,
+                  background: color,
+                  borderRadius: (normalizedColorSwatchSize * ratio) / 2,
+                }}
+                animate={{
+                  scale: 1,
+                  opacity: 1,
+                }}
+                initial={{
+                  scale: 0.1,
+                  opacity: 0,
+                }}
+                transition={{
+                  delay: index === 1 ? 0.2 : 0.1,
+                }}
+              />
+            ))}
+          </VStack>
+        </HStack>
+      </motion.div>
+      <motion.div
+        variants={withHoverView && midFrame}
+        style={{
+          height: '100%',
+          width: '100%',
+          position: 'absolute',
+          top: 0,
+          overflow: 'hidden',
+          filter: 'blur(60px)',
+          opacity: 0.1,
+        }}
+      >
+        <HStack
+          spacing={0}
+          justify="flex-start"
+          style={{
+            height: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          {style.paletteColors.slice(0, 4).map(({ color }) => (
+            <div
+              key={color}
+              style={{
+                height: '100%',
+                background: color,
+                flexGrow: 1,
+              }}
+            />
+          ))}
+        </HStack>
+      </motion.div>
+      <motion.div
+        variants={secondFrame}
+        style={{
+          height: '100%',
+          width: '100%',
+          overflow: 'hidden',
+          position: 'absolute',
+          top: 0,
+        }}
+      >
+        <VStack
+          spacing={3 * ratio}
+          justify="center"
+          style={{
+            height: '100%',
+            overflow: 'hidden',
+            padding: 10 * ratio,
+            boxSizing: 'border-box',
+          }}
+        >
+          {label && (
+            <div
+              style={{
+                fontSize: 40 * ratio,
+                fontFamily: style.headingFontFamily,
+                color: style.headingColor,
+                fontWeight: style.headingFontWeight,
+                lineHeight: '1em',
+                textAlign: 'center',
+              }}
+            >
+              {label}
+            </div>
+          )}
+        </VStack>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/preview.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/preview.tsx
@@ -1,8 +1,11 @@
 import {
-  __unstableMotion as motion,
   __experimentalHStack as HStack,
   __experimentalVStack as VStack,
+  __unstableMotion as motion,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { storeName } from '../../store';
 
 const firstFrame = {
   start: {
@@ -38,181 +41,191 @@ const secondFrame = {
 const normalizedHeight = 152;
 const normalizedColorSwatchSize = 32;
 
+type Props = {
+  label?: string;
+  isFocused?: boolean;
+  withHoverView?: boolean;
+};
+
 /**
  * Component to render the styles preview based on the component from the site editor:
  * https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/global-styles/preview.js
  */
-export function Preview(): JSX.Element {
-  const style = {
-    backgroundColor: '#f3f3f3',
-    headingFontFamily: 'Arial',
-    headingColor: '#000000',
-    headingFontWeight: 'normal',
-    paletteColors: [
-      {
-        name: 'Sample Background',
-        slug: 'Sample-background',
-        color: '#f9f8f3',
-      },
-    ],
-    highlightedColors: [
-      {
-        name: 'Sample primary',
-        slug: 'sample-primary',
-        color: '#e5e2d3',
-      },
-      {
-        name: 'Sample Secondary',
-        slug: 'sample-secondary',
-        color: '#111111',
-      },
-    ],
-  };
+export function Preview({
+  label,
+  isFocused,
+  withHoverView,
+}: Props): JSX.Element {
+  const styles = useSelect((select) => select(storeName).getStyles());
 
-  const isFocused = false;
-  const isHovered = false;
-  const disableMotion = false;
-  const label = 'Some Label';
+  const backgroundColor = styles.colors.background;
+  const headingFontFamily = styles.elements.h1.fontFamily;
+  const headingColor = styles.elements.h1.color;
+  const headingFontWeight = styles.elements.h1.fontWeight;
+  const paletteColors = [
+    {
+      name: 'Sample primary',
+      slug: 'sample-primary',
+      color: '#a5a2a3',
+    },
+    {
+      name: 'Sample Secondary',
+      slug: 'sample-secondary',
+      color: '#e5e2d3',
+    },
+    {
+      name: 'Sample Background',
+      slug: 'Sample-background',
+      color: '#a8c7a9',
+    },
+  ];
+  // https://github.com/WordPress/gutenberg/blob/7fa03fafeb421ab4c3604564211ce6007cc38e84/packages/edit-site/src/components/global-styles/hooks.js#L68-L73
+  const highlightedColors = paletteColors
+    .filter(({ color }) => color !== backgroundColor && color !== headingColor)
+    .slice(0, 2);
+
   const ratio = 1;
-
-  const gradientValue = undefined;
-  const withHoverView = true;
+  // When is set label, the preview animates the hover state and displays the label
+  const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <motion.div
-      style={{
-        height: normalizedHeight * ratio,
-        width: '100%',
-        background: gradientValue ?? style.backgroundColor,
-        cursor: withHoverView ? 'pointer' : undefined,
-      }}
-      initial="start"
-      animate={
-        (isHovered || isFocused) && !disableMotion && label ? 'hover' : 'start'
-      }
+    <div
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <motion.div
-        variants={firstFrame}
         style={{
-          height: '100%',
-          overflow: 'hidden',
+          height: normalizedHeight * ratio,
+          width: '100%',
+          background: backgroundColor,
+          cursor: withHoverView ? 'pointer' : undefined,
         }}
+        initial="start"
+        animate={(isHovered || isFocused) && label ? 'hover' : 'start'}
       >
-        <HStack
-          spacing={10 * ratio}
-          justify="center"
+        <motion.div
+          variants={firstFrame}
           style={{
             height: '100%',
             overflow: 'hidden',
           }}
         >
-          <motion.div
+          <HStack
+            spacing={10 * ratio}
+            justify="center"
             style={{
-              fontFamily: style.headingFontFamily,
-              fontSize: 65 * ratio,
-              color: style.headingColor,
-              fontWeight: style.headingFontWeight,
+              height: '100%',
+              overflow: 'hidden',
             }}
-            animate={{ scale: 1, opacity: 1 }}
-            initial={{ scale: 0.1, opacity: 0 }}
-            transition={{ delay: 0.3, type: 'tween' }}
           >
-            Aa
-          </motion.div>
-          <VStack spacing={4 * ratio}>
-            {style.highlightedColors.map(({ slug, color }, index) => (
-              <motion.div
-                key={slug}
+            <motion.div
+              style={{
+                fontFamily: headingFontFamily,
+                fontSize: 65 * ratio,
+                color: headingColor,
+                fontWeight: headingFontWeight,
+              }}
+              animate={{ scale: 1, opacity: 1 }}
+              initial={{ scale: 0.1, opacity: 0 }}
+              transition={{ delay: 0.3, type: 'tween' }}
+            >
+              Aa
+            </motion.div>
+            <VStack spacing={4 * ratio}>
+              {highlightedColors.map(({ slug, color }, index) => (
+                <motion.div
+                  key={slug}
+                  style={{
+                    height: normalizedColorSwatchSize * ratio,
+                    width: normalizedColorSwatchSize * ratio,
+                    background: color,
+                    borderRadius: (normalizedColorSwatchSize * ratio) / 2,
+                  }}
+                  animate={{
+                    scale: 1,
+                    opacity: 1,
+                  }}
+                  initial={{
+                    scale: 0.1,
+                    opacity: 0,
+                  }}
+                  transition={{
+                    delay: index === 1 ? 0.2 : 0.1,
+                  }}
+                />
+              ))}
+            </VStack>
+          </HStack>
+        </motion.div>
+        <motion.div
+          variants={withHoverView && midFrame}
+          style={{
+            height: '100%',
+            width: '100%',
+            position: 'absolute',
+            top: 0,
+            overflow: 'hidden',
+            filter: 'blur(60px)',
+            opacity: 0.1,
+          }}
+        >
+          <HStack
+            spacing={0}
+            justify="flex-start"
+            style={{
+              height: '100%',
+              overflow: 'hidden',
+            }}
+          >
+            {paletteColors.slice(0, 4).map(({ color }) => (
+              <div
+                key={color}
                 style={{
-                  height: normalizedColorSwatchSize * ratio,
-                  width: normalizedColorSwatchSize * ratio,
+                  height: '100%',
                   background: color,
-                  borderRadius: (normalizedColorSwatchSize * ratio) / 2,
-                }}
-                animate={{
-                  scale: 1,
-                  opacity: 1,
-                }}
-                initial={{
-                  scale: 0.1,
-                  opacity: 0,
-                }}
-                transition={{
-                  delay: index === 1 ? 0.2 : 0.1,
+                  flexGrow: 1,
                 }}
               />
             ))}
+          </HStack>
+        </motion.div>
+        <motion.div
+          variants={secondFrame}
+          style={{
+            height: '100%',
+            width: '100%',
+            overflow: 'hidden',
+            position: 'absolute',
+            top: 0,
+          }}
+        >
+          <VStack
+            spacing={3 * ratio}
+            justify="center"
+            style={{
+              height: '100%',
+              overflow: 'hidden',
+              padding: 10 * ratio,
+              boxSizing: 'border-box',
+            }}
+          >
+            {label && (
+              <div
+                style={{
+                  fontSize: 40 * ratio,
+                  fontFamily: headingFontFamily,
+                  color: headingColor,
+                  fontWeight: headingFontWeight,
+                  lineHeight: '1em',
+                  textAlign: 'center',
+                }}
+              >
+                {label}
+              </div>
+            )}
           </VStack>
-        </HStack>
+        </motion.div>
       </motion.div>
-      <motion.div
-        variants={withHoverView && midFrame}
-        style={{
-          height: '100%',
-          width: '100%',
-          position: 'absolute',
-          top: 0,
-          overflow: 'hidden',
-          filter: 'blur(60px)',
-          opacity: 0.1,
-        }}
-      >
-        <HStack
-          spacing={0}
-          justify="flex-start"
-          style={{
-            height: '100%',
-            overflow: 'hidden',
-          }}
-        >
-          {style.paletteColors.slice(0, 4).map(({ color }) => (
-            <div
-              key={color}
-              style={{
-                height: '100%',
-                background: color,
-                flexGrow: 1,
-              }}
-            />
-          ))}
-        </HStack>
-      </motion.div>
-      <motion.div
-        variants={secondFrame}
-        style={{
-          height: '100%',
-          width: '100%',
-          overflow: 'hidden',
-          position: 'absolute',
-          top: 0,
-        }}
-      >
-        <VStack
-          spacing={3 * ratio}
-          justify="center"
-          style={{
-            height: '100%',
-            overflow: 'hidden',
-            padding: 10 * ratio,
-            boxSizing: 'border-box',
-          }}
-        >
-          {label && (
-            <div
-              style={{
-                fontSize: 40 * ratio,
-                fontFamily: style.headingFontFamily,
-                color: style.headingColor,
-                fontWeight: style.headingFontWeight,
-                lineHeight: '1em',
-                textAlign: 'center',
-              }}
-            >
-              {label}
-            </div>
-          )}
-        </VStack>
-      </motion.div>
-    </motion.div>
+    </div>
   );
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/preview.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/preview.tsx
@@ -56,32 +56,28 @@ export function Preview({
   isFocused,
   withHoverView,
 }: Props): JSX.Element {
-  const styles = useSelect((select) => select(storeName).getStyles());
+  const { styles, colors } = useSelect(
+    (select) => ({
+      styles: select(storeName).getStyles(),
+      colors: select(storeName).getPaletteColors(),
+    }),
+    [],
+  );
 
   const backgroundColor = styles.colors.background;
   const headingFontFamily = styles.elements.h1.fontFamily;
   const headingColor = styles.elements.h1.color;
   const headingFontWeight = styles.elements.h1.fontWeight;
-  const paletteColors = [
-    {
-      name: 'Sample primary',
-      slug: 'sample-primary',
-      color: '#a5a2a3',
-    },
-    {
-      name: 'Sample Secondary',
-      slug: 'sample-secondary',
-      color: '#e5e2d3',
-    },
-    {
-      name: 'Sample Background',
-      slug: 'Sample-background',
-      color: '#a8c7a9',
-    },
-  ];
+
+  const paletteColors = colors.theme.concat(colors.theme);
+
   // https://github.com/WordPress/gutenberg/blob/7fa03fafeb421ab4c3604564211ce6007cc38e84/packages/edit-site/src/components/global-styles/hooks.js#L68-L73
   const highlightedColors = paletteColors
-    .filter(({ color }) => color !== backgroundColor && color !== headingColor)
+    .filter(
+      ({ color }) =>
+        color.toLowerCase() !== backgroundColor.toLowerCase() &&
+        color.toLowerCase() !== headingColor.toLowerCase(),
+    )
     .slice(0, 2);
 
   const ratio = 1;

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/root-menu.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/root-menu.tsx
@@ -1,0 +1,43 @@
+import {
+  __experimentalItemGroup as ItemGroup,
+  __experimentalItem as Item,
+  __experimentalHStack as HStack,
+  __experimentalNavigatorButton as NavigatorButton,
+  Icon,
+  FlexItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { typography, color, layout } from '@wordpress/icons';
+
+function RootMenu() {
+  return (
+    <ItemGroup>
+      <NavigatorButton path="/typography">
+        <Item>
+          <HStack justify="flex-start">
+            <Icon icon={typography} size={24} />
+            <FlexItem>{__('Typography', 'mailpoet')}</FlexItem>
+          </HStack>
+        </Item>
+      </NavigatorButton>
+      <NavigatorButton path="/colors">
+        <Item>
+          <HStack justify="flex-start">
+            <Icon icon={color} size={24} />
+            <FlexItem>{__('Colors', 'mailpoet')}</FlexItem>
+          </HStack>
+        </Item>
+      </NavigatorButton>
+      <NavigatorButton path="/layout">
+        <Item>
+          <HStack justify="flex-start">
+            <Icon icon={layout} size={24} />
+            <FlexItem>{__('Layout', 'mailpoet')}</FlexItem>
+          </HStack>
+        </Item>
+      </NavigatorButton>
+    </ItemGroup>
+  );
+}
+
+export default RootMenu;

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-root.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-root.tsx
@@ -1,0 +1,29 @@
+import {
+  __experimentalVStack as VStack,
+  Card,
+  CardBody,
+  CardMedia,
+} from '@wordpress/components';
+import RootMenu from './root-menu';
+import { Preview } from './preview';
+
+export function ScreenRoot(): JSX.Element {
+  return (
+    <Card
+      size="small"
+      className="edit-site-global-styles-screen-root"
+      variant="primary"
+    >
+      <CardBody>
+        <VStack spacing={4}>
+          <Card>
+            <CardMedia>
+              <Preview />
+            </CardMedia>
+          </Card>
+          <RootMenu />
+        </VStack>
+      </CardBody>
+    </Card>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
@@ -17,7 +17,7 @@ export function StylesSidebar(props: Props): JSX.Element {
   return (
     <ComplementaryArea
       identifier={stylesSidebarId}
-      className="edit-post-styles"
+      className="mailpoet-email-editor__styles-panel"
       header={__('Styles', 'mailpoet')}
       icon={styles}
       scope={storeName}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
@@ -1,9 +1,10 @@
-import { Panel } from '@wordpress/components';
+import { Card, CardBody, CardMedia, Panel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
 import { storeName, stylesSidebarId } from '../../store';
+import { StylesPreview } from './styles-preview';
 
 type Props = ComponentProps<typeof ComplementaryArea>;
 
@@ -18,7 +19,21 @@ export function StylesSidebar(props: Props): JSX.Element {
       smallScreenTitle={__('No title', 'mailpoet')}
       {...props}
     >
-      <Panel>TODO: Styles panel</Panel>
+      <Panel>
+        <Card
+          size="small"
+          className="edit-site-global-styles-screen-root"
+          variant="primary"
+        >
+          <CardBody>
+            <Card>
+              <CardMedia>
+                <StylesPreview />
+              </CardMedia>
+            </Card>
+          </CardBody>
+        </Card>
+      </Panel>
     </ComplementaryArea>
   );
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
@@ -1,0 +1,24 @@
+import { Panel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { ComplementaryArea } from '@wordpress/interface';
+import { ComponentProps } from 'react';
+import { styles } from '@wordpress/icons';
+import { storeName, stylesSidebarId } from '../../store';
+
+type Props = ComponentProps<typeof ComplementaryArea>;
+
+export function StylesSidebar(props: Props): JSX.Element {
+  return (
+    <ComplementaryArea
+      identifier={stylesSidebarId}
+      className="edit-post-styles"
+      header={__('Styles', 'mailpoet')}
+      icon={styles}
+      scope={storeName}
+      smallScreenTitle={__('No title', 'mailpoet')}
+      {...props}
+    >
+      <Panel>TODO: Styles panel</Panel>
+    </ComplementaryArea>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
@@ -1,10 +1,15 @@
-import { Card, CardBody, CardMedia, Panel } from '@wordpress/components';
+import {
+  Panel,
+  __experimentalNavigatorProvider as NavigatorProvider,
+  __experimentalNavigatorScreen as NavigatorScreen,
+  __experimentalNavigatorToParentButton as NavigatorToParentButton,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
 import { storeName, stylesSidebarId } from '../../store';
-import { StylesPreview } from './styles-preview';
+import { ScreenRoot } from './screen-root';
 
 type Props = ComponentProps<typeof ComplementaryArea>;
 
@@ -20,19 +25,26 @@ export function StylesSidebar(props: Props): JSX.Element {
       {...props}
     >
       <Panel>
-        <Card
-          size="small"
-          className="edit-site-global-styles-screen-root"
-          variant="primary"
-        >
-          <CardBody>
-            <Card>
-              <CardMedia>
-                <StylesPreview />
-              </CardMedia>
-            </Card>
-          </CardBody>
-        </Card>
+        <NavigatorProvider initialPath="/">
+          <NavigatorScreen path="/">
+            <ScreenRoot />
+          </NavigatorScreen>
+
+          <NavigatorScreen path="/typography">
+            <NavigatorToParentButton>Back</NavigatorToParentButton>
+            <div>TODO: Typography screen</div>
+          </NavigatorScreen>
+
+          <NavigatorScreen path="/colors">
+            <NavigatorToParentButton>Back</NavigatorToParentButton>
+            <div>TODO: Typography screen</div>
+          </NavigatorScreen>
+
+          <NavigatorScreen path="/layout">
+            <NavigatorToParentButton>Back</NavigatorToParentButton>
+            <div>TODO: Typography screen</div>
+          </NavigatorScreen>
+        </NavigatorProvider>
       </Panel>
     </ComplementaryArea>
   );

--- a/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
@@ -5,7 +5,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 import { apiFetch } from '@wordpress/data-controls';
-import { storeName, mainSidebarEmailKey } from './constants';
+import { storeName, mainSidebarEmailTab } from './constants';
 import { SendingPreviewStatus, State, Feature } from './types';
 
 export const toggleFeature =
@@ -47,7 +47,7 @@ export function updateSendPreviewEmail(toEmail: string) {
 }
 
 export const openSidebar =
-  (key = mainSidebarEmailKey) =>
+  (key = mainSidebarEmailTab) =>
   ({ registry }): unknown =>
     registry.dispatch(interfaceStore).enableComplementaryArea(storeName, key);
 
@@ -55,6 +55,13 @@ export const closeSidebar =
   () =>
   ({ registry }): unknown =>
     registry.dispatch(interfaceStore).disableComplementaryArea(storeName);
+
+export function toggleSettingsSidebarActiveTab(activeTab: string) {
+  return {
+    type: 'TOGGLE_SETTINGS_SIDEBAR_ACTIVE_TAB',
+    state: { activeTab } as Partial<State['settingsSidebar']>,
+  } as const;
+}
 
 export function* saveEditedEmail() {
   const postId = select(storeName).getEmailPostId();

--- a/mailpoet/assets/js/src/email-editor/engine/store/constants.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/constants.ts
@@ -1,5 +1,5 @@
 export const storeName = 'email-editor/editor';
 
 export const mainSidebarId = 'email-editor/editor/main';
-export const mainSidebarEmailKey = 'email-editor/editor/main/email';
-export const mainSidebarBlockKey = 'email-editor/editor/main/block';
+export const mainSidebarEmailTab = 'email';
+export const mainSidebarBlockTab = 'block';

--- a/mailpoet/assets/js/src/email-editor/engine/store/constants.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/constants.ts
@@ -3,3 +3,4 @@ export const storeName = 'email-editor/editor';
 export const mainSidebarId = 'email-editor/editor/main';
 export const mainSidebarEmailTab = 'email';
 export const mainSidebarBlockTab = 'block';
+export const stylesSidebarId = 'email-editor/editor/styles';

--- a/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
@@ -1,3 +1,4 @@
+import { mainSidebarEmailTab } from './constants';
 import { State } from './types';
 import {
   getEditorLayout,
@@ -14,6 +15,9 @@ export function getInitialState(): State {
     },
     listviewSidebar: {
       isOpened: false,
+    },
+    settingsSidebar: {
+      activeTab: mainSidebarEmailTab,
     },
     postId,
     editorSettings: getEditorSettings(),

--- a/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
@@ -1,10 +1,6 @@
 import { mainSidebarEmailTab } from './constants';
 import { State } from './types';
-import {
-  getEditorLayout,
-  getEditorSettings,
-  getEmailLayoutStyles,
-} from './settings';
+import { getEditorLayout, getEditorSettings, getEmailStyles } from './settings';
 
 export function getInitialState(): State {
   const searchParams = new URLSearchParams(window.location.search);
@@ -21,7 +17,7 @@ export function getInitialState(): State {
     },
     postId,
     editorSettings: getEditorSettings(),
-    layoutStyles: getEmailLayoutStyles(),
+    styles: getEmailStyles(),
     layout: getEditorLayout(),
     autosaveInterval: 60,
     preview: {

--- a/mailpoet/assets/js/src/email-editor/engine/store/reducer.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/reducer.ts
@@ -31,6 +31,14 @@ export function reducer(state: State, action): State {
         ...state,
         preview: { ...state.preview, ...action.state },
       };
+    case 'TOGGLE_SETTINGS_SIDEBAR_ACTIVE_TAB':
+      return {
+        ...state,
+        settingsSidebar: {
+          ...state.settingsSidebar,
+          activeTab: action.state.activeTab,
+        },
+      };
     default:
       return state;
   }

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -111,6 +111,10 @@ export function isListviewSidebarOpened(state: State): boolean {
   return state.listviewSidebar.isOpened;
 }
 
+export function getSettingsSidebarActiveTab(state: State): string {
+  return state.settingsSidebar.activeTab;
+}
+
 export function getInitialEditorSettings(
   state: State,
 ): State['editorSettings'] {

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -125,8 +125,8 @@ export function getPreviewState(state: State): State['preview'] {
   return state.preview;
 }
 
-export function getLayoutStyles(state: State): State['layoutStyles'] {
-  return state.layoutStyles;
+export function getStyles(state: State): State['styles'] {
+  return state.styles;
 }
 
 export function getLayout(state: State): State['layout'] {

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -121,6 +121,13 @@ export function getInitialEditorSettings(
   return state.editorSettings;
 }
 
+export function getPaletteColors(
+  state: State,
+): State['editorSettings']['__experimentalFeatures']['color']['palette'] {
+  // eslint-disable-next-line no-underscore-dangle
+  return state.editorSettings.__experimentalFeatures.color.palette;
+}
+
 export function getPreviewState(state: State): State['preview'] {
   return state.preview;
 }

--- a/mailpoet/assets/js/src/email-editor/engine/store/settings.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/settings.ts
@@ -1,15 +1,11 @@
-import {
-  EmailEditorSettings,
-  EmailLayoutStyles,
-  EmailEditorLayout,
-} from './types';
+import { EmailEditorSettings, EmailStyles, EmailEditorLayout } from './types';
 
 export function getEditorSettings(): EmailEditorSettings {
   return window.MailPoetEmailEditor.editor_settings as EmailEditorSettings;
 }
 
-export function getEmailLayoutStyles(): EmailLayoutStyles {
-  return window.MailPoetEmailEditor.email_layout_styles as EmailLayoutStyles;
+export function getEmailStyles(): EmailStyles {
+  return window.MailPoetEmailEditor.email_styles as EmailStyles;
 }
 
 export function getEditorLayout(): EmailEditorLayout {

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -39,6 +39,13 @@ export type EmailStyles = {
   colors: {
     background: string;
   };
+  elements: {
+    h1: {
+      color: string;
+      fontFamily: string;
+      fontWeight: string;
+    };
+  };
 };
 
 export type EmailEditorLayout = {

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -25,14 +25,19 @@ export type ExperimentalSettings = {
 
 export type EmailEditorSettings = EditorSettings & ExperimentalSettings;
 
-export type EmailLayoutStyles = {
-  width: string;
-  background: string;
-  padding: {
-    bottom: string;
-    left: string;
-    right: string;
-    top: string;
+export type EmailStyles = {
+  layout: {
+    background: string;
+    padding: {
+      bottom: string;
+      left: string;
+      right: string;
+      top: string;
+    };
+    width: string;
+  };
+  colors: {
+    background: string;
   };
 };
 
@@ -53,7 +58,7 @@ export type State = {
   };
   postId: number;
   editorSettings: EmailEditorSettings;
-  layoutStyles: EmailLayoutStyles;
+  styles: EmailStyles;
   layout: EmailEditorLayout;
   autosaveInterval: number;
   preview: {

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -15,6 +15,7 @@ export type ExperimentalSettings = {
       defaultPalette: boolean;
       palette: {
         default: EditorColor[];
+        theme: EditorColor[];
       };
       gradients: {
         default: EditorColor[];

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -48,6 +48,9 @@ export type State = {
   listviewSidebar: {
     isOpened: boolean;
   };
+  settingsSidebar: {
+    activeTab: string;
+  };
   postId: number;
   editorSettings: EmailEditorSettings;
   layoutStyles: EmailLayoutStyles;

--- a/mailpoet/assets/js/src/email-editor/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/global.d.ts
@@ -5,7 +5,7 @@ interface Window {
     api_version: string;
     current_wp_user_email: string;
     editor_settings: unknown; // Can't import type in global.d.ts. Typed in getEditorSettings() in store/settings.ts
-    email_layout_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailLayoutStyles() in store/settings.ts
+    email_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailStyles() in store/settings.ts
     editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts
   };
 }

--- a/mailpoet/lib/AdminPages/Pages/EmailEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/EmailEditor.php
@@ -58,7 +58,7 @@ class EmailEditor {
         'api_version' => esc_js($apiVersion),
         'current_wp_user_email' => esc_js($currentUserEmail),
         'editor_settings' => $this->settingsController->getSettings(),
-        'email_layout_styles' => $this->settingsController->getEmailLayoutStyles(),
+        'email_styles' => $this->settingsController->getEmailStyles(),
         'editor_layout' => $this->settingsController->getLayout(),
       ]
     );

--- a/mailpoet/lib/EmailEditor/Engine/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Engine/EmailApiController.php
@@ -19,7 +19,7 @@ class EmailApiController {
    */
   public function getEmailData(): array {
     return [
-      'layout_styles' => $this->settingsController->getEmailLayoutStyles(),
+      'layout_styles' => $this->settingsController->getEmailStyles(),
     ];
   }
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -42,7 +42,7 @@ class Renderer {
     $parser = new \WP_Block_Parser();
     $parsedBlocks = $parser->parse($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-    $layoutStyles = $this->settingsController->getEmailLayoutStyles();
+    $layoutStyles = $this->settingsController->getEmailStyles()['layout'];
     $themeData = $this->settingsController->getTheme()->get_data();
     $contentBackground = $themeData['styles']['color']['background'] ?? $layoutStyles['background'];
     $contentFontFamily = $themeData['styles']['typography']['fontFamily'];

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -113,9 +113,17 @@ class SettingsController {
         ],
       ],
       'colors' => [
-        'background' => '#000000',
+        'background' => '#ffffff',
       ],
       'typography' => [
+      ],
+      // Value are only for purpose of displaying in the preview component in style sidebar
+      'elements' => [
+        'h1' => [
+          'color' => '#000000',
+          'fontWeight' => 'bold',
+          'fontFamily' => "Arial, 'Helvetica Neue', Helvetica, sans-serif",
+        ],
       ],
     ];
   }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -94,26 +94,37 @@ class SettingsController {
   }
 
   /**
-   * @return array{width: string, background: string, padding: array{bottom: string, left: string, right: string, top: string}}
+   * @return array{
+   *   layout: array{width: string,background: string,padding: array{bottom: string, left: string, right: string, top: string}},
+   *   colors: array{background: string},
+   *   typography: array[]
+   * }
    */
-  public function getEmailLayoutStyles(): array {
+  public function getEmailStyles(): array {
     return [
-      'width' => self::EMAIL_WIDTH,
-      'background' => self::EMAIL_LAYOUT_BACKGROUND,
-      'padding' => [
-        'bottom' => self::FLEX_GAP,
-        'left' => self::FLEX_GAP,
-        'right' => self::FLEX_GAP,
-        'top' => self::FLEX_GAP,
+      'layout' => [
+        'background' => self::EMAIL_LAYOUT_BACKGROUND,
+        'width' => self::EMAIL_WIDTH,
+        'padding' => [
+          'bottom' => self::FLEX_GAP,
+          'left' => self::FLEX_GAP,
+          'right' => self::FLEX_GAP,
+          'top' => self::FLEX_GAP,
+        ],
+      ],
+      'colors' => [
+        'background' => '#000000',
+      ],
+      'typography' => [
       ],
     ];
   }
 
   public function getLayoutWidthWithoutPadding(): string {
-    $layoutStyles = $this->getEmailLayoutStyles();
-    $width = $this->parseNumberFromStringWithPixels($layoutStyles['width']);
-    $width -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['left']);
-    $width -= $this->parseNumberFromStringWithPixels($layoutStyles['padding']['right']);
+    $layoutStyles = $this->getEmailStyles();
+    $width = $this->parseNumberFromStringWithPixels($layoutStyles['layout']['width']);
+    $width -= $this->parseNumberFromStringWithPixels($layoutStyles['layout']['padding']['left']);
+    $width -= $this->parseNumberFromStringWithPixels($layoutStyles['layout']['padding']['right']);
     return "{$width}px";
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -43,8 +43,8 @@ class Columns implements BlockRenderer {
 
     $align = $parsedBlock['attrs']['align'] ?? null;
     if ($align !== 'full') {
-      $layoutPaddingLeft = $settingsController->getEmailLayoutStyles()['padding']['left'];
-      $layoutPaddingRight = $settingsController->getEmailLayoutStyles()['padding']['right'];
+      $layoutPaddingLeft = $settingsController->getEmailStyles()['layout']['padding']['left'];
+      $layoutPaddingRight = $settingsController->getEmailStyles()['layout']['padding']['right'];
     } else {
       $layoutPaddingLeft = '0px';
       $layoutPaddingRight = '0px';

--- a/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/Renderer/RendererTest.php
@@ -88,14 +88,16 @@ class RendererTest extends \MailPoetTest {
       ],
     ]);
     $settingsControllerMock = $this->createMock(SettingsController::class);
-    $settingsControllerMock->method('getEmailLayoutStyles')->willReturn([
-      'width' => '123px',
-      'background' => '#123456',
-      'padding' => [
-        'left' => '1px',
-        'right' => '2px',
-        'top' => '3px',
-        'bottom' => '4px',
+    $settingsControllerMock->method('getEmailStyles')->willReturn([
+      'layout' => [
+        'width' => '123px',
+        'background' => '#123456',
+        'padding' => [
+          'left' => '1px',
+          'right' => '2px',
+          'top' => '3px',
+          'bottom' => '4px',
+        ],
       ],
     ]);
     $settingsControllerMock->method('getTheme')->willReturn($themeJsonMock);

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -8,10 +8,14 @@ use MailPoet\EmailEditor\Engine\ThemeController;
 class SettingsControllerTest extends \MailPoetUnitTest {
   public function testItGetsMainLayoutStyles(): void {
     $settingsController = new SettingsController($this->makeEmpty(ThemeController::class));
-    $layoutStyles = $settingsController->getEmailLayoutStyles();
-    verify($layoutStyles)->arrayHasKey('width');
+    $styles = $settingsController->getEmailStyles();
+    verify($styles)->arrayHasKey('layout');
+    verify($styles)->arrayHasKey('colors');
+    verify($styles)->arrayHasKey('typography');
+    $layoutStyles = $styles['layout'];
     verify($layoutStyles)->arrayHasKey('background');
     verify($layoutStyles)->arrayHasKey('padding');
+    verify($layoutStyles)->arrayHasKey('width');
   }
 
   public function testItGetsCorrectLayoutWidthWithoutPadding(): void {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

- I  needed to refactor the settings sidebar slightly because it was not possible to use the `ComplementaryArea` component properly.
- I tried to prepare the data structure for the styles panel.
- The settings panel contains a few experimental components because I was inspired by the site editor.
- I am opened to discussion about each part of this PR.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5638]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5638]: https://mailpoet.atlassian.net/browse/MAILPOET-5638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ