### PR TITLE
Handle shop unavailable when checking the sender domain authentication during sending

### DIFF
--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -170,6 +170,11 @@ class AuthorizedEmailsController {
       ? $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache()
       : $this->senderDomainController->getVerifiedSenderDomains();
 
+    // The shop is not returning data, so we allow sending and let the Sending Service block the campaign if needed.
+    if ($context === 'sending' && empty($verifiedDomains) && !$this->senderDomainController->isCacheAvailable()) {
+      return true;
+    }
+
     return $this->validateEmailDomainIsVerified($verifiedDomains, $newsletter->getSenderAddress());
   }
 

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -243,6 +243,10 @@ class AuthorizedSenderDomainController {
     $this->wp->setTransient(self::SENDER_DOMAINS_KEY, $this->currentRawData, 60 * 60 * 24 * 7);
   }
 
+  public function isCacheAvailable(): bool {
+    return is_array($this->wp->getTransient(self::SENDER_DOMAINS_KEY));
+  }
+
   private function getAllRawData(): array {
     if ($this->currentRawData === null) {
       $currentData = $this->wp->getTransient(self::SENDER_DOMAINS_KEY);

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -236,7 +236,10 @@ class AuthorizedSenderDomainController {
   }
 
   private function reloadCache() {
-    $this->currentRawData = $this->bridge->getRawSenderDomainData();
+    $currentRawData = $this->bridge->getRawSenderDomainData();
+    if (!$currentRawData) return; // Do not modify cache if there is no data from the API
+
+    $this->currentRawData = $currentRawData;
     $this->wp->setTransient(self::SENDER_DOMAINS_KEY, $this->currentRawData, 60 * 60 * 24);
   }
 
@@ -246,11 +249,10 @@ class AuthorizedSenderDomainController {
       if (is_array($currentData)) {
         $this->currentRawData = $currentData;
       } else {
-        $this->currentRawData = $this->bridge->getRawSenderDomainData();
-        $this->wp->setTransient(self::SENDER_DOMAINS_KEY, $this->currentRawData, 60 * 60 * 24);
+        $this->reloadCache();
       }
     }
-    return $this->currentRawData;
+    return is_array($this->currentRawData) ? $this->currentRawData : [];
   }
 
   private function getAllRecords(): array {

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -240,7 +240,7 @@ class AuthorizedSenderDomainController {
     if (!$currentRawData) return; // Do not modify cache if there is no data from the API
 
     $this->currentRawData = $currentRawData;
-    $this->wp->setTransient(self::SENDER_DOMAINS_KEY, $this->currentRawData, 60 * 60 * 24);
+    $this->wp->setTransient(self::SENDER_DOMAINS_KEY, $this->currentRawData, 60 * 60 * 24 * 7);
   }
 
   private function getAllRawData(): array {

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -158,6 +158,9 @@ class Bridge {
 
     $allSenderDomains = [];
     $data = $this->getRawSenderDomainData();
+    if ($data === null) {
+      return [];
+    }
 
     foreach ($data as $subarray) {
       if (isset($subarray['domain'])) {
@@ -173,11 +176,10 @@ class Bridge {
     return $allSenderDomains;
   }
 
-  public function getRawSenderDomainData(): array {
-    $data = $this
+  public function getRawSenderDomainData(): ?array {
+    return $this
       ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
       ->getAuthorizedSenderDomains();
-    return $data ?? [];
   }
 
   /**

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -300,6 +300,27 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     verify($controller->isSenderAddressValid($newsletter, 'sending'))->true();
   }
 
+  public function testSenderAddressIsValidForSendingIfRestrictionsApplyAndShopDoesNotReturnData() {
+    $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
+    $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
+      'isAuthorizedDomainRequiredForExistingCampaigns' => Expected::once(true),
+      'getVerifiedSenderDomains' => Expected::once([]),
+      'isCacheAvailable' => Expected::once(false),
+    ]);
+
+    $newsletter = new NewsletterEntity();
+    $newsletter->setSubject('Subject');
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
+    $newsletter->setSenderAddress('contact@email.com');
+
+    $mocks = [
+      'AuthorizedSenderDomainController' => $senderDomainMock,
+    ];
+    $controller = $this->getControllerWithCustomMocks($mocks);
+    verify($controller->isSenderAddressValid($newsletter, 'sending'))->true();
+  }
+
   public function testSenderAddressIsValidForActivationIfNotACampaign() {
     $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
 


### PR DESCRIPTION
## Description

This PR:
- When retrieving the sender domains from the shop, if the data is not available, we do not overwrite the transient that stores the sender domains with an empty array
- Extends the life of the transient from 1 day to 1 week.
- If during sending, an authenticated domain is required and the shop does not return data, we allow sending. If the domain had already been verified, the sending service will have it stored and the email will be sent. If not, it will be rejected and the campaign will be paused.

## Code review notes

I chose the option to send anyways when the shop is not available. I think that the changes with the transient will cover most of the cases and the sending service has the additional storage of the domains.

## QA notes

Can't be tested on QA but regression testing would be good:
- authenticate a domain
- Import a list with >200 subscribers so that you are a big sender (or reduce the limits in the code)
- Send a campaign (newsletter or post notification)
- Check that sending works as expected

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5921]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations -> NA
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes -> NA


[MAILPOET-5921]: https://mailpoet.atlassian.net/browse/MAILPOET-5921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ