### PR TITLE
Update xdebug to 3.3.1 for PHP 8.x docker images [MAILPOET-5924]

### DIFF
--- a/dev/php80/Dockerfile
+++ b/dev/php80/Dockerfile
@@ -27,7 +27,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
-RUN git clone -b "3.0.2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+RUN git clone -b "3.3.1" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug

--- a/dev/php81/Dockerfile
+++ b/dev/php81/Dockerfile
@@ -27,7 +27,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
-RUN git clone -b "3.1.1" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+RUN git clone -b "3.3.1" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug

--- a/dev/php82/Dockerfile
+++ b/dev/php82/Dockerfile
@@ -27,7 +27,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
-RUN git clone -b "3.2.0RC2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+RUN git clone -b "3.3.1" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug


### PR DESCRIPTION
## Description

The older versions fail to compile during the build. Updating to the newest debug release fixed the issue. 
I assume this was caused by an incompatibility of the never-compiler and older XDebug code.


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5924]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5924]: https://mailpoet.atlassian.net/browse/MAILPOET-5924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ