### PR TITLE
Add new k6 test automation trash and restore

### DIFF
--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
 
   wordpress:
-    image: mailpoet/wordpress:wp-6.3_php8.1_20230811.1
+    image: mailpoet/wordpress:wp-6.4_php8.2_20231120.1
     container_name: performance_wordpress
     depends_on:
       mysql: { condition: service_healthy }

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -20,6 +20,7 @@ import { subscribersTrashingRestoring } from './tests/subscribers-trashing-resto
 import { automationCreateCustom } from './tests/automation-create-custom.js';
 import { automationCreateWelcome } from './tests/automation-create-welcome.js';
 import { automationAnalytics } from './tests/automation-analytics.js';
+import { automationTrashRestore } from './tests/automation-trash-restore.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -86,6 +87,7 @@ export async function pullRequests() {
   await onboardingWizard();
   await newsletterListing();
   await newsletterSearching();
+  await automationTrashRestore();
   await automationCreateWelcome();
   await listsViewSubscribers();
   await subscribersListing();
@@ -100,6 +102,7 @@ export async function nightly() {
   await newsletterStatistics();
   await newsletterSearching();
   await newsletterSending();
+  await automationTrashRestore();
   await automationCreateCustom();
   await automationCreateWelcome();
   await automationAnalytics();

--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -20,7 +20,7 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login } from '../utils/helpers.js';
+import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function automationAnalytics() {
   const page = browser.newPage();
@@ -89,16 +89,19 @@ export async function automationAnalytics() {
     await page.locator('//span[contains(text(),"Today")]').click();
     await page.locator('.woocommerce-filters-date__button').click();
     await page.waitForLoadState('networkidle');
+    await waitForSelectorToBeVisible(page, '.woocommerce-table__table > table');
 
     // Filter results by date range Year to date
     await page.locator('.woocommerce-dropdown-button').click();
     await page.locator('//span[contains(text(),"Year to date")]').click();
     await page.locator('.woocommerce-filters-date__button').click();
     await page.waitForLoadState('networkidle');
+    await waitForSelectorToBeVisible(page, '.woocommerce-table__table > table');
 
     describe(automationsPageTitle, () => {
       describe('automation-analytics: should be able to see items in the listing', () => {
-        expect(page.$$('.mailpoet-analytics-orders__customer')[0]).to.exist;
+        expect(page.locator('.woocommerce-table__table > table > tbody > tr'))
+          .to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -44,10 +44,9 @@ export async function automationTrashRestore() {
     await page.$$('.mailpoet-automation-listing-more-button')[0].click(); // click More
     await page.locator('.components-popover__content').click(); // click Trash
     await page.waitForLoadState('networkidle');
-    sleep(1); // this is to avoid false-positive
-    await page.$$('.is-primary')[1].focus();
-    await page.$$('.is-primary')[1].click(); // click Move to trash
-    await waitForSelectorToBeVisible(page, '.notice-success');
+    await page.locator('div.components-flex > button.is-primary').focus();
+    await page.locator('div.components-flex > button.is-primary').click(); // click Move to trash
+    await page.waitForLoadState('networkidle');
 
     // Wait for the success notice message and confirm it
     const movedToTrashNotice =
@@ -71,10 +70,9 @@ export async function automationTrashRestore() {
     await waitForSelectorToBeVisible(page, '.mailpoet-tab-trash.is-active');
     await page.$$('.mailpoet-automation-listing-more-button')[0].click(); // click More
     await page.waitForLoadState('networkidle');
-    sleep(1); // this is to avoid false-positive
     await page.$$('.components-dropdown-menu__menu-item')[0].focus();
     await page.$$('.components-dropdown-menu__menu-item')[0].click(); // click Restore
-    await waitForSelectorToBeVisible(page, '.notice-success');
+    await page.waitForLoadState('networkidle');
 
     // Wait for the success notice message and confirm it
     const restoredFromTrashNotice =

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  automationsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
+
+export async function automationTrashRestore() {
+  const page = browser.newPage();
+
+  try {
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the Automations page
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-automation`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Trash_Restore_01.png',
+      fullPage: fullPageSet,
+    });
+
+    // Move to trash one of the existing automation listing
+    await page.$$('.mailpoet-automation-listing-more-button')[0].click(); // click More
+    await page.locator('.components-popover__content').click(); // click Trash
+    await page.waitForLoadState('networkidle');
+    sleep(1); // this is to avoid false-positive
+    await page.$$('.is-primary')[1].focus();
+    await page.$$('.is-primary')[1].click(); // click Move to trash
+    await waitForSelectorToBeVisible(page, '.notice-success');
+
+    // Wait for the success notice message and confirm it
+    const movedToTrashNotice =
+      "//div[@class='notice-success'].//p[contains(text(),'was moved to the trash')]";
+    describe(automationsPageTitle, () => {
+      describe('automation-trash-restore: should be able to see moved to trash notice', () => {
+        expect(page.locator(movedToTrashNotice)).to.exist;
+      });
+    });
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Trash_Restore_02.png',
+      fullPage: fullPageSet,
+    });
+
+    // Restore from the trash one of trashed automation items
+    await waitForSelectorToBeVisible(page, '.mailpoet-tab-trash');
+    await page.locator('.mailpoet-tab-trash').click(); // click Trash tab
+    await page.waitForLoadState('networkidle');
+    await waitForSelectorToBeVisible(page, '.mailpoet-tab-trash.is-active');
+    await page.$$('.mailpoet-automation-listing-more-button')[0].click(); // click More
+    await page.waitForLoadState('networkidle');
+    sleep(1); // this is to avoid false-positive
+    await page.$$('.components-dropdown-menu__menu-item')[0].focus();
+    await page.$$('.components-dropdown-menu__menu-item')[0].click(); // click Restore
+    await waitForSelectorToBeVisible(page, '.notice-success');
+
+    // Wait for the success notice message and confirm it
+    const restoredFromTrashNotice =
+      "//div[@class='notice-success'].//p[contains(text(),'was restored from the trash')]";
+    describe(automationsPageTitle, () => {
+      describe('automation-trash-restore: should be able to see restored from trash notice', () => {
+        expect(page.locator(restoredFromTrashNotice)).to.exist;
+      });
+    });
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Trash_Restore_03.png',
+      fullPage: fullPageSet,
+    });
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default function automationTrashRestoreTest() {
+  automationTrashRestore();
+}

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -89,7 +89,7 @@ export async function designEmailInWorkflow(page) {
   await page.locator('input[type="email"]').fill(adminEmail);
 
   await page.screenshot({
-    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,
+    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}.png`,
     fullPage: fullPageSet,
   });
 
@@ -102,7 +102,7 @@ export async function designEmailInWorkflow(page) {
   await page.waitForLoadState('networkidle');
 
   await page.screenshot({
-    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,
+    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}.png`,
     fullPage: fullPageSet,
   });
 
@@ -119,7 +119,7 @@ export async function designEmailInWorkflow(page) {
   await page.waitForLoadState('networkidle');
 
   await page.screenshot({
-    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}`,
+    path: screenshotPath + `Design_Email_In_Workflow_${Date.now()}.png`,
     fullPage: fullPageSet,
   });
 


### PR DESCRIPTION
## Description

Adding new k6 test to cover moving automation to trash and restoring it.

Additionally updated WordPress image and fixed screenshot issue in the helper (missing .png).

## Code review notes

I tested this locally many times to make sure there is no flakiness. It worked well for both local and nightly test execution.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5866]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5866]: https://mailpoet.atlassian.net/browse/MAILPOET-5866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ