### PR TITLE
Remove escapeHtml when rendering list titles in React [MAILPOET-5842]

### DIFF
--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -284,14 +284,12 @@ class SegmentListComponent extends Component<RouteComponentProps> {
       // the WP users and WooCommerce customers segments
       // are not editable so just display their names
       segmentName = (
-        <span className="mailpoet-listing-title">
-          {escapeHTML(segment.name)}
-        </span>
+        <span className="mailpoet-listing-title">{segment.name}</span>
       );
     } else {
       segmentName = (
         <Link className="mailpoet-listing-title" to={`/edit/${segment.id}`}>
-          {escapeHTML(segment.name)}
+          {segment.name}
         </Link>
       );
     }
@@ -306,7 +304,7 @@ class SegmentListComponent extends Component<RouteComponentProps> {
           {actions}
         </td>
         <td data-colname={MailPoet.I18n.t('description')}>
-          <abbr>{escapeHTML(segment.description)}</abbr>
+          <abbr>{segment.description}</abbr>
         </td>
         {mailpoetTrackingEnabled ? (
           <td


### PR DESCRIPTION
Escaping is not required when rendering titles in react components. HTML is escaped automatically unless you use a component like `RawHTML` or the `dangerouslySetInnerHTML` attribute.

[MAILPOET-5842]

Fixes #5384

## Description

Removes usages of `escapeHtml` when rendering data inside React components. `escapeHtml` is still required when rendering notices—I left these as is.

This issue was introduced in https://github.com/mailpoet/mailpoet/commit/d52dfa215c46e370f875680f1a14db77f97da589.

## Code review notes

_N/A_

## QA notes

To test:

1. Go to MailPoet > Lists
2. Edit a list
3. Add the `&` character to the list title and the list description. Save the list.
4. Back on MailPoet > Lists, look at the items in the table. The `&` should be rendered as `&`, not `&amp;`.
5. Trash the list. The `&` should be rendered as `&`, not `&amp;` in the notice.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5842](https://mailpoet.atlassian.net/browse/MAILPOET-5842)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5842]: https://mailpoet.atlassian.net/browse/MAILPOET-5842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5842]: https://mailpoet.atlassian.net/browse/MAILPOET-5842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ