### PR TITLE
Fix failing build [MAILPOET-5925][MAILPOET-5741]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,6 @@ jobs:
             ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
-            ./do download:woo-commerce-blocks-zip 11.7.0
             ./do download:automate-woo-zip 6.0.10
       - run:
           name: Dump tests ENV variables for acceptance tests
@@ -374,9 +373,6 @@ jobs:
       woo_memberships_version:
         type: string
         default: ''
-      woo_blocks_version:
-        type: string
-        default: ''
       automate_woo_version:
         type: string
         default: ''
@@ -437,14 +433,6 @@ jobs:
                 command: |
                   cd tests/docker
                   docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
-      - when:
-          condition: << parameters.woo_blocks_version >>
-          steps:
-            - run:
-                name: Download WooCommerce Blocks
-                command: |
-                  cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-blocks-zip << parameters.woo_blocks_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -644,9 +632,6 @@ jobs:
       woo_memberships_version:
         type: string
         default: ''
-      woo_blocks_version:
-        type: string
-        default: ''
       automate_woo_version:
         type: string
         default: ''
@@ -693,14 +678,6 @@ jobs:
                 command: |
                   cd tests/docker
                   docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
-      - when:
-          condition: << parameters.woo_blocks_version >>
-          steps:
-            - run:
-                name: Download WooCommerce Blocks
-                command: |
-                  cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-blocks-zip << parameters.woo_blocks_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -973,7 +950,6 @@ workflows:
           woo_core_version: latest
           woo_subscriptions_version: latest
           woo_memberships_version: latest
-          woo_blocks_version: latest
           automate_woo_version: latest
           mysql_image: mysql:8.3
           mysql_command: --default-authentication-plugin=mysql_native_password
@@ -985,7 +961,6 @@ workflows:
           woo_core_version: 8.5.0
           woo_subscriptions_version: 5.6.0
           woo_memberships_version: 1.23.1
-          woo_blocks_version: 11.6.0
           automate_woo_version: 5.8.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
@@ -1026,7 +1001,6 @@ workflows:
           woo_core_version: 8.5.0
           woo_subscriptions_version: 5.6.0
           woo_memberships_version: 1.24.0
-          woo_blocks_version: 11.6.0
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1367,11 +1367,6 @@ class RoboFile extends \Robo\Tasks {
     }
   }
 
-  public function downloadWooCommerceBlocksZip($tag = null) {
-    $this->createWpOrgDownloader('woo-gutenberg-products-block')
-      ->downloadPluginZip('woo-gutenberg-products-block.zip', __DIR__ . '/tests/plugins/', $tag);
-  }
-
   public function downloadWooCommerceMembershipsZip($tag = null) {
     if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
       $this->yell("Skipping download of WooCommerce Memberships", 40, 'red');

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -397,16 +397,6 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_PLUGIN]);
   }
 
-  public function activateWooCommerceBlocks() {
-    $i = $this;
-    $i->cli(['plugin', 'activate', self::WOO_COMMERCE_BLOCKS_PLUGIN]);
-  }
-
-  public function deactivateWooCommerceBlocks() {
-    $i = $this;
-    $i->cli(['plugin', 'deactivate', self::WOO_COMMERCE_BLOCKS_PLUGIN]);
-  }
-
   public function activateWooCommerceMemberships() {
     $i = $this;
     $i->cli(['plugin', 'activate', self::WOO_COMMERCE_MEMBERSHIPS_PLUGIN]);

--- a/mailpoet/tests/_support/PluginsExtension.php
+++ b/mailpoet/tests/_support/PluginsExtension.php
@@ -13,7 +13,6 @@ class PluginsExtension extends Extension {
 
   public function setupInitialPluginsState() {
     exec('wp plugin deactivate automatewoo --allow-root');
-    exec('wp plugin deactivate woo-gutenberg-products-block --allow-root');
     exec('wp plugin deactivate woocommerce-memberships --allow-root');
     exec('wp plugin deactivate woocommerce-subscriptions --allow-root');
     exec('wp plugin deactivate woocommerce --allow-root');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -32,7 +32,6 @@ class WooCheckoutBlocksCest {
 
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();
-    $i->activateWooCommerceBlocks();
     $this->product = (new WooCommerceProduct($i))->create();
     $this->settingsFactory = new Settings();
     $this->settingsFactory->withWooCommerceListImportPageDisplayed(true);
@@ -285,10 +284,6 @@ class WooCheckoutBlocksCest {
   private function checkMinimalPluginVersions(\AcceptanceTester $i): bool {
     $wooCommerceVersion = $i->getWooCommerceVersion();
     if (version_compare($wooCommerceVersion, '6.8.0', '<')) {
-      return false;
-    }
-    $wooCommerceBlocksVersion = $i->getWooCommerceBlocksVersion();
-    if (version_compare($wooCommerceBlocksVersion, '8.0.0', '<')) {
       return false;
     }
     $wordPressVersion = $i->getWordPressVersion();

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -171,14 +171,6 @@ else
   wp theme install twentytwentyone --activate
 fi
 
-
-if [[ $CIRCLE_JOB == *"_oldest"* ]]; then
-  wp theme activate twentynineteen
-  if [[ $MULTISITE == "1" ]]; then
-    wp theme activate twentynineteen --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG
-  fi
-fi
-
 # Remove Doctrine Annotations (they are not needed since generated metadata are packed)
 # We want to remove them for tests to make sure they are really not needed
 if [[ $TEST_TYPE == "acceptance" ]] && [[ $CIRCLE_JOB ]]; then

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -104,19 +104,6 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     unzip -q -o "$WOOCOMMERCE_MEMBERSHIPS_ZIP" -d /wp-core/wp-content/plugins/
   fi
 
-  # Install WooCommerce Blocks
-  if [[ ! -d "/wp-core/wp-content/plugins/woo-gutenberg-products-block" ]]; then
-    WOOCOMMERCE_BLOCKS_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woo-gutenberg-products-block.zip"
-    if [ ! -f "$WOOCOMMERCE_BLOCKS_ZIP" ]; then
-      echo "WooCommerce Blocks plugin zip not found. Downloading WooCommerce Blocks plugin latest zip"
-      cd /project
-      ./do download:woo-commerce-blocks-zip latest
-      cd /wp-core/wp-content/plugins
-    fi
-    echo "Unzip Woocommerce Blocks plugin from $WOOCOMMERCE_BLOCKS_ZIP"
-    unzip -q -o "$WOOCOMMERCE_BLOCKS_ZIP" -d /wp-core/wp-content/plugins/
-  fi
-
   # Install AutomateWoo
   if [[ ! -d "/wp-core/wp-content/plugins/automatewoo" ]]; then
     AUTOMATEWOO_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/automatewoo.zip"
@@ -146,14 +133,12 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
   wp plugin activate woocommerce --url=$ACTIVATION_CONTEXT
   wp plugin activate woocommerce-subscriptions --url=$ACTIVATION_CONTEXT
   wp plugin activate woocommerce-memberships --url=$ACTIVATION_CONTEXT
-  wp plugin activate woo-gutenberg-products-block --url=$ACTIVATION_CONTEXT
   wp plugin activate automatewoo --url=$ACTIVATION_CONTEXT
 
   # print info about activated plugins
   wp plugin get woocommerce --url=$ACTIVATION_CONTEXT
   wp plugin get woocommerce-subscriptions --url=$ACTIVATION_CONTEXT
   wp plugin get woocommerce-memberships --url=$ACTIVATION_CONTEXT
-  wp plugin get woo-gutenberg-products-block --url=$ACTIVATION_CONTEXT
   wp plugin get automatewoo --url=$ACTIVATION_CONTEXT
 
    # Activate helper plugin for WooCommerce COT and create tables in DB

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -180,10 +180,18 @@ wp config set COOKIE_DOMAIN \$_SERVER[\'HTTP_HOST\'] --raw
 wp config set DISABLE_WP_CRON true --raw
 
 # activate theme
-wp theme install twentytwentyone --activate
+if [[ $MULTISITE == "1" ]]; then
+  wp theme install twentytwentyone --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG --activate
+else
+  wp theme install twentytwentyone --activate
+fi
+
 
 if [[ $CIRCLE_JOB == *"_oldest"* ]]; then
   wp theme activate twentynineteen
+  if [[ $MULTISITE == "1" ]]; then
+    wp theme activate twentynineteen --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG
+  fi
 fi
 
 # Remove Doctrine Annotations (they are not needed since generated metadata are packed)

--- a/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
@@ -94,7 +94,7 @@ class ThemeControllerTest extends \MailPoetTest {
    * to prevent silent failures in case we change theme configuration in the test environment.
    */
   private function checkCorrectThemeConfiguration() {
-    $expectedThemes = ['Twenty Twenty-One', 'Twenty Nineteen'];
+    $expectedThemes = ['Twenty Twenty-One'];
     if (!in_array(wp_get_theme()->get('Name'), $expectedThemes)) {
       $this->fail('Test depends on using Twenty Twenty-One or Twenty Nineteen theme. If you changed the theme, please update the test.');
     }


### PR DESCRIPTION
## Description

This PR fixes two issues.

1) There was a failing test testing integration with a theme. It depends on values from The Twenty-One theme, which we activate for the test environment. The problem was that for the multisite setup theme was not activated properly. [[commit](https://github.com/mailpoet/mailpoet/commit/b7f659326e082e249f8792639ddbe3e72b129365)]

2) The WooCommerce Blocks plugin is [no longer available for download](https://wordpress.org/plugins/woo-gutenberg-products-block/). This causes build failures when we attempt to download the plugin. The functionality from the plugin was integrated to WooCommerce Core so we don't need to download it to test the integration with the block-based checkout page.

## Code review notes

Here is [a testing build ](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/17100/workflows/bc41fd93-cdc1-4dc7-83e7-4ee341ea2730)containing passing multisite tests and integration test jobs with the oldest supported versions.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5925][MAILPOET-5741]

## After-merge notes

_N/A_

## Tasks

- [ ] 🚫  I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫  I added sufficient test coverage
- [ ] 🚫  I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5925]: https://mailpoet.atlassian.net/browse/MAILPOET-5925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ