### PR TITLE
Fix failing multisite acceptance tests [MAILPOET-5925]

### DIFF
--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -165,10 +165,9 @@ wp config set COOKIE_DOMAIN \$_SERVER[\'HTTP_HOST\'] --raw
 wp config set DISABLE_WP_CRON true --raw
 
 # activate theme
+wp theme install twentytwentyone --activate
 if [[ $MULTISITE == "1" ]]; then
   wp theme install twentytwentyone --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG --activate
-else
-  wp theme install twentytwentyone --activate
 fi
 
 # Remove Doctrine Annotations (they are not needed since generated metadata are packed)


### PR DESCRIPTION
## Description

It seems that when we use multisite configuration, the integration tests load the site from `test.local/php7_multisite`, but acceptance tests run on `test.local`

I'm not sure why multisite acceptance tests don't run on  `test.local/php7_multisite`

So, let's activate the correct theme on both to make test green.


## Code review notes

[Testing build on CI](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/17105/workflows/987d7a43-09fa-4a27-8c1e-2d4bcdc6acc7)

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5925]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5925]: https://mailpoet.atlassian.net/browse/MAILPOET-5925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ