### PR TITLE
Ensure the parameter is always int [MAILPOET-5895]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SubscribersEmailCount.php
+++ b/mailpoet/lib/Cron/Workers/SubscribersEmailCount.php
@@ -66,7 +66,7 @@ class SubscribersEmailCount extends SimpleWorker {
     $task->setMeta($meta);
 
     while ($lastSubscriberId <= $highestSubscriberId) {
-      [$count, $lastSubscriberId] = $this->subscribersEmailCountsController->updateSubscribersEmailCounts($dateFromLastRun, self::BATCH_SIZE, $lastSubscriberId);
+      [$count, $lastSubscriberId] = $this->subscribersEmailCountsController->updateSubscribersEmailCounts($dateFromLastRun, self::BATCH_SIZE, intval($lastSubscriberId));
       if ($count === 0) {
         break;
       }


### PR DESCRIPTION
## Description

This is a fix for an issue found in an error log.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5895]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5895]: https://mailpoet.atlassian.net/browse/MAILPOET-5895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ