### PR TITLE
Email Editor - WP 6.5 compatibility fixes

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/general-block-support.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/general-block-support.ts
@@ -1,0 +1,33 @@
+import { addFilter } from '@wordpress/hooks';
+import {
+  Block as WPBlock,
+  BlockSupports as WPBlockSupports,
+} from '@wordpress/blocks';
+
+// Extend the BlockSupports type to include shadow
+// The shadow is not included in WP6.4 but it is in WP6.5
+// We can remove it once we upgrade packages to WP6.5
+type BlockSupports = WPBlockSupports & { shadow: boolean };
+type Block = WPBlock & { supports?: BlockSupports };
+
+/**
+ * Disables Shadow Support for all blocks
+ * Currently we are not able to read these styles in renderer
+ */
+function alterSupportConfiguration() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/block-support',
+    (settings: Block) => {
+      if (settings.supports?.shadow) {
+        return {
+          ...settings,
+          supports: { ...settings.supports, shadow: false },
+        };
+      }
+      return settings;
+    },
+  );
+}
+
+export { alterSupportConfiguration };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -9,6 +9,7 @@ import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
 import { enhanceButtonsBlock } from './core/buttons';
+import { alterSupportConfiguration } from './core/general-block-support';
 
 export function initBlocks() {
   disableNestedColumns();
@@ -21,5 +22,6 @@ export function initBlocks() {
   enhanceButtonsBlock();
   enhanceColumnBlock();
   enhanceColumnsBlock();
+  alterSupportConfiguration();
   registerCoreBlocks();
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -90,13 +90,19 @@ export function BlockEditor() {
     inlineStyles = {
       ...inlineStyles,
       height: 'auto',
-      margin: '4rem auto', // 4em top/bottom to place the email document nicely vertically in canvas. Same value is used for title in WP Post editor.
       width: styles.layout.width,
       display: 'flex',
       flexFlow: 'column',
     };
   }
+
   inlineStyles.transition = 'all 0.3s ease 0s';
+  // 72px top/bottom to place the email document nicely vertically in canvas. Same value is used for title in WP Post editor.
+  inlineStyles.margin = '72px auto';
+  delete inlineStyles.marginLeft;
+  delete inlineStyles.marginTop;
+  delete inlineStyles.marginBottom;
+  delete inlineStyles.marginRight;
 
   const contentAreaStyles = {
     background:

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -85,9 +85,10 @@ export function BlockEditor() {
   const layoutBackground = styles.layout.background;
 
   let inlineStyles = useResizeCanvas(previewDeviceType);
-  // UseResizeCanvas returns null if the previewDeviceType is Desktop.
-  if (!inlineStyles) {
+  // Adjust the inline styles for desktop preview. We want to set email width and center it.
+  if (previewDeviceType === 'Desktop') {
     inlineStyles = {
+      ...inlineStyles,
       height: 'auto',
       margin: '4rem auto', // 4em top/bottom to place the email document nicely vertically in canvas. Same value is used for title in WP Post editor.
       width: styles.layout.width,

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -69,13 +69,9 @@ export function BlockEditor() {
     [],
   );
 
-  const className = classnames(
-    'interface-interface-skeleton',
-    'edit-post-layout',
-    {
-      'is-sidebar-opened': isSidebarOpened,
-    },
-  );
+  const className = classnames('edit-post-layout', {
+    'is-sidebar-opened': isSidebarOpened,
+  });
 
   const [blocks, onInput, onChange] = useEntityBlockEditor(
     'postType',

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/block-editor.tsx
@@ -97,8 +97,9 @@ export function BlockEditor() {
   }
 
   inlineStyles.transition = 'all 0.3s ease 0s';
-  // 72px top/bottom to place the email document nicely vertically in canvas. Same value is used for title in WP Post editor.
-  inlineStyles.margin = '72px auto';
+  // 72px top to place the email document nicely vertically in canvas. Same value is used for title in WP Post editor.
+  // We use only 16px bottom to mitigate the issue with inserter popup displaying below the fold.
+  inlineStyles.margin = '72px auto 16px auto';
   delete inlineStyles.marginLeft;
   delete inlineStyles.marginTop;
   delete inlineStyles.marginBottom;

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -34,6 +34,12 @@ const BlockToolbar = WPBlockToolbar as React.FC<
   }
 >;
 
+// In older versions of Gutenberg (e.g. wp-6.4 and < 17.3) the fixed block toolbar is rendered automatically
+// This is a workaround to hide the block toolbar in these versions
+// We will remove this after we drop support for WP 6.4
+const isInlinedBlockToolbarAvailable =
+  window.MailPoetEmailEditor.bc_state.isInlinedBlockToolbarAvailable;
+
 export function Header() {
   const inserterButton = useRef();
   const listviewButton = useRef();
@@ -132,30 +138,33 @@ export function Header() {
             />
           </div>
         </NavigableToolbar>
-        {isFixedToolbarActive && isBlockSelected && (
-          <>
-            <div
-              className={classnames('selected-block-tools-wrapper', {
-                'is-collapsed': isBlockToolsCollapsed,
-              })}
-            >
-              <BlockToolbar hideDragHandle />
-            </div>
-            <Button
-              className="edit-post-header__block-tools-toggle"
-              icon={isBlockToolsCollapsed ? next : previous}
-              onClick={() => {
-                setIsBlockToolsCollapsed((collapsed) => !collapsed);
-              }}
-              label={
-                isBlockToolsCollapsed
-                  ? __('Show block tools')
-                  : __('Hide block tools')
-              }
-            />
-          </>
-        )}
-        {(!isFixedToolbarActive ||
+        {isInlinedBlockToolbarAvailable &&
+          isFixedToolbarActive &&
+          isBlockSelected && (
+            <>
+              <div
+                className={classnames('selected-block-tools-wrapper', {
+                  'is-collapsed': isBlockToolsCollapsed,
+                })}
+              >
+                <BlockToolbar hideDragHandle />
+              </div>
+              <Button
+                className="edit-post-header__block-tools-toggle"
+                icon={isBlockToolsCollapsed ? next : previous}
+                onClick={() => {
+                  setIsBlockToolsCollapsed((collapsed) => !collapsed);
+                }}
+                label={
+                  isBlockToolsCollapsed
+                    ? __('Show block tools')
+                    : __('Hide block tools')
+                }
+              />
+            </>
+          )}
+        {(!isInlinedBlockToolbarAvailable ||
+          !isFixedToolbarActive ||
           !isBlockSelected ||
           isBlockToolsCollapsed) && (
           <div className="edit-post-header__center">

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -1,4 +1,4 @@
-import { useRef } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { PinnedItems } from '@wordpress/interface';
 import { Button, ToolbarItem as WpToolbarItem } from '@wordpress/components';
 import {
@@ -9,7 +9,8 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
-import { plus, listView, undo, redo } from '@wordpress/icons';
+import { plus, listView, undo, redo, next, previous } from '@wordpress/icons';
+import classnames from 'classnames';
 import { storeName } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';
@@ -38,6 +39,8 @@ export function Header() {
   const listviewButton = useRef();
   const undoButton = useRef();
   const redoButton = useRef();
+
+  const [isBlockToolsCollapsed, setIsBlockToolsCollapsed] = useState(false);
 
   const { toggleInserterSidebar, toggleListviewSidebar } =
     useDispatch(storeName);
@@ -129,11 +132,32 @@ export function Header() {
             />
           </div>
         </NavigableToolbar>
-        {isFixedToolbarActive && isBlockSelected ? (
-          <div className="selected-block-tools-wrapper">
-            <BlockToolbar hideDragHandle />
-          </div>
-        ) : (
+        {isFixedToolbarActive && isBlockSelected && (
+          <>
+            <div
+              className={classnames('selected-block-tools-wrapper', {
+                'is-collapsed': isBlockToolsCollapsed,
+              })}
+            >
+              <BlockToolbar hideDragHandle />
+            </div>
+            <Button
+              className="edit-post-header__block-tools-toggle"
+              icon={isBlockToolsCollapsed ? next : previous}
+              onClick={() => {
+                setIsBlockToolsCollapsed((collapsed) => !collapsed);
+              }}
+              label={
+                isBlockToolsCollapsed
+                  ? __('Show block tools')
+                  : __('Hide block tools')
+              }
+            />
+          </>
+        )}
+        {(!isFixedToolbarActive ||
+          !isBlockSelected ||
+          isBlockToolsCollapsed) && (
           <div className="edit-post-header__center">
             <CampaignName />
           </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -51,10 +51,11 @@ export function Header() {
     <div className="edit-post-header">
       <div className="edit-post-header__toolbar">
         <NavigableToolbar
-          className="edit-post-header-toolbar"
+          className="edit-post-header-toolbar is-unstyled editor-document-tools"
           aria-label={__('Email document tools', 'mailpoet')}
         >
-          <div className="edit-post-header-toolbar__left">
+          {/* edit-post-header-toolbar__left can be removed after we drop support of WP 6.4 */}
+          <div className="edit-post-header-toolbar__left editor-document-tools__left">
             <ToolbarItem
               ref={inserterButton}
               as={Button}

--- a/mailpoet/assets/js/src/email-editor/engine/components/preview/preview-dropdown.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/preview/preview-dropdown.tsx
@@ -80,7 +80,7 @@ export function PreviewDropdown() {
               <MenuGroup>
                 <div className="edit-post-header-preview__grouping-external">
                   <Button
-                    className="edit-post-header-preview__button-external"
+                    className="edit-post-header-preview__button-external components-menu-item__button"
                     onClick={() => {
                       openInNewTab(newsletterPreviewUrl);
                     }}

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
@@ -32,39 +32,37 @@ export function Header() {
   }, [selectedBlockId, toggleSettingsSidebarActiveTab]);
 
   return (
-    <div className="components-panel__header interface-complementary-area-header edit-post-sidebar__panel-tabs">
-      <ul>
-        <li>
-          <button
-            onClick={() => {
-              void toggleSettingsSidebarActiveTab(mainSidebarEmailTab);
-            }}
-            className={classnames(
-              'components-button edit-post-sidebar__panel-tab',
-              { 'is-active': activeTab === mainSidebarEmailTab },
-            )}
-            data-automation-id="email_settings_tab"
-            type="button"
-          >
-            {__('Email', 'mailpoet')}
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => {
-              void toggleSettingsSidebarActiveTab(mainSidebarBlockTab);
-            }}
-            className={classnames(
-              'components-button edit-post-sidebar__panel-tab',
-              { 'is-active': activeTab === mainSidebarBlockTab },
-            )}
-            data-automation-id="mailpoet_block_settings_tab"
-            type="button"
-          >
-            {__('Block')}
-          </button>
-        </li>
-      </ul>
-    </div>
+    <ul>
+      <li>
+        <button
+          onClick={() => {
+            void toggleSettingsSidebarActiveTab(mainSidebarEmailTab);
+          }}
+          className={classnames(
+            'components-button edit-post-sidebar__panel-tab',
+            { 'is-active': activeTab === mainSidebarEmailTab },
+          )}
+          data-automation-id="email_settings_tab"
+          type="button"
+        >
+          {__('Email', 'mailpoet')}
+        </button>
+      </li>
+      <li>
+        <button
+          onClick={() => {
+            void toggleSettingsSidebarActiveTab(mainSidebarBlockTab);
+          }}
+          className={classnames(
+            'components-button edit-post-sidebar__panel-tab',
+            { 'is-active': activeTab === mainSidebarBlockTab },
+          )}
+          data-automation-id="mailpoet_block_settings_tab"
+          type="button"
+        >
+          {__('Block')}
+        </button>
+      </li>
+    </ul>
   );
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/index.scss
@@ -8,57 +8,59 @@
   margin: 0;
 }
 
-/**
-  SIDEBAR TABS
-  This CSS cover styles for the sidebar tabs in the header.
-  Post Editor in WP 6.5 uses Tabs component, but it is not available for WP6.4
-  After we drop support for WP6.4, we can remove this CSS and switch sidebar header to the Tabs components.
- */
-.edit-post-sidebar__panel-tabs {
-  padding-left: 0;
-
-  ul {
-    display: flex;
-  }
-  li {
-    margin: 0;
-  }
-}
-.edit-post-sidebar__panel-tab {
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-  cursor: pointer;
-  font-weight: 500;
-  height: 48px;
-  margin-left: 0;
-  padding: 3px 16px;
-  position: relative;
-
-  &:focus:not(:disabled) {
+// Disable focus outline for buttons in the sidebar
+.edit-post-sidebar {
+  .components-button:focus:not(:disabled) {
     box-shadow: none;
     outline: none;
-    position: relative;
   }
 
-  &:after {
-    background: var(--wp-admin-theme-color);
+  /**
+      SIDEBAR TABS
+      This CSS cover styles for the sidebar tabs in the header.
+      Post Editor in WP 6.5 uses Tabs component, but it is not available for WP6.4
+      After we drop support for WP6.4, we can remove this CSS and switch sidebar header to the Tabs components.
+     */
+  .edit-post-sidebar__panel-tabs {
+    padding-left: 0;
+
+    ul {
+      display: flex;
+    }
+    li {
+      margin: 0;
+    }
+  }
+  .edit-post-sidebar__panel-tab {
+    background: transparent;
+    border: none;
     border-radius: 0;
-    bottom: 0;
-    content: '';
-    height: calc(var(--wp-admin-border-width-focus) * 0);
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    transition: all 0.1s linear;
-  }
+    box-shadow: none;
+    cursor: pointer;
+    font-weight: 500;
+    height: 48px;
+    margin-left: 0;
+    padding: 3px 16px;
+    position: relative;
 
-  &.is-active:after {
-    height: calc(var(--wp-admin-border-width-focus) * 1);
-    outline: 2px solid transparent;
-    outline-offset: -1px;
+    &:after {
+      background: var(--wp-admin-theme-color);
+      border-radius: 0;
+      bottom: 0;
+      content: '';
+      height: calc(var(--wp-admin-border-width-focus) * 0);
+      left: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      transition: all 0.1s linear;
+    }
+
+    &.is-active:after {
+      height: calc(var(--wp-admin-border-width-focus) * 1);
+      outline: 2px solid transparent;
+      outline-offset: -1px;
+    }
   }
 }
 /* END OF SIDEBAR TABS */

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/index.scss
@@ -7,3 +7,58 @@
   // resetting margin fits the notice to the full column width
   margin: 0;
 }
+
+/**
+  SIDEBAR TABS
+  This CSS cover styles for the sidebar tabs in the header.
+  Post Editor in WP 6.5 uses Tabs component, but it is not available for WP6.4
+  After we drop support for WP6.4, we can remove this CSS and switch sidebar header to the Tabs components.
+ */
+.edit-post-sidebar__panel-tabs {
+  padding-left: 0;
+
+  ul {
+    display: flex;
+  }
+  li {
+    margin: 0;
+  }
+}
+.edit-post-sidebar__panel-tab {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  font-weight: 500;
+  height: 48px;
+  margin-left: 0;
+  padding: 3px 16px;
+  position: relative;
+
+  &:focus:not(:disabled) {
+    box-shadow: none;
+    outline: none;
+    position: relative;
+  }
+
+  &:after {
+    background: var(--wp-admin-theme-color);
+    border-radius: 0;
+    bottom: 0;
+    content: '';
+    height: calc(var(--wp-admin-border-width-focus) * 0);
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    transition: all 0.1s linear;
+  }
+
+  &.is-active:after {
+    height: calc(var(--wp-admin-border-width-focus) * 1);
+    outline: 2px solid transparent;
+    outline-offset: -1px;
+  }
+}
+/* END OF SIDEBAR TABS */

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/sidebar.tsx
@@ -14,6 +14,8 @@ import {
 import { Header } from './header';
 import { EmailSettings } from './email-settings';
 
+import './index.scss';
+
 type Props = ComponentProps<typeof ComplementaryArea>;
 
 export function Sidebar(props: Props): JSX.Element {
@@ -25,6 +27,7 @@ export function Sidebar(props: Props): JSX.Element {
   return (
     <ComplementaryArea
       identifier={mainSidebarId}
+      headerClassName="edit-post-sidebar__panel-tabs"
       className="edit-post-sidebar"
       header={<Header />}
       icon={drawerRight}

--- a/mailpoet/assets/js/src/email-editor/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/global.d.ts
@@ -4,6 +4,9 @@ interface Window {
     api_token: string;
     api_version: string;
     current_wp_user_email: string;
+    bc_state: {
+      isInlinedBlockToolbarAvailable: boolean;
+    };
     editor_settings: unknown; // Can't import type in global.d.ts. Typed in getEditorSettings() in store/settings.ts
     email_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailStyles() in store/settings.ts
     editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts

--- a/mailpoet/lib/AdminPages/Pages/EmailEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/EmailEditor.php
@@ -60,6 +60,7 @@ class EmailEditor {
         'editor_settings' => $this->settingsController->getSettings(),
         'email_styles' => $this->settingsController->getEmailStyles(),
         'editor_layout' => $this->settingsController->getLayout(),
+        'bc_state' => $this->getBackwardCompatibilityState(),
       ]
     );
 
@@ -72,5 +73,17 @@ class EmailEditor {
     $this->wp->wpEnqueueMedia();
 
     echo '<div id="mailpoet-email-editor" class="block-editor"></div>';
+  }
+
+  /**
+   * Workaround for backward compatibility with WordPress and Gutenberg versions
+   * Hopefully we could get rid of this after we drop support for WP 6.4
+   */
+  private function getBackwardCompatibilityState(): array {
+    global $wp_version;
+    $gutenbergVersion = defined('GUTENBERG_VERSION') ? GUTENBERG_VERSION : '0.0.0';
+    return [
+      'isInlinedBlockToolbarAvailable' => version_compare($wp_version, '6.5', '>=') || version_compare($gutenbergVersion, '17.3', '>='),
+    ];
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -52,6 +52,7 @@ class Button implements BlockRenderer {
       'cursor' => 'auto',
       'word-break' => 'break-word',
       'box-sizing' => 'border-box',
+      'overflow' => 'hidden',
     ];
     $linkStyles = [
       'background-color' => $bgColor,
@@ -62,18 +63,29 @@ class Button implements BlockRenderer {
     ];
 
     // Border
-    if (isset($parsedBlock['attrs']['style']['border']) && !empty($parsedBlock['attrs']['style']['border'])) {
+    $borderAttrs = $parsedBlock['attrs']['style']['border'] ?? [];
+    if (!empty($borderAttrs)) {
       // Use text color if border color is not set. Check for the value in the custom color text property
       // then look also to the text color set from palette
-      if (!($parsedBlock['attrs']['style']['border']['color'] ?? '')) {
+      if (!isset($borderAttrs['color'])) {
         if (isset($parsedBlock['attrs']['style']['color']['text'])) {
-          $parsedBlock['attrs']['style']['border']['color'] = $parsedBlock['attrs']['style']['color']['text'];
+          $borderAttrs['color'] = $parsedBlock['attrs']['style']['color']['text'];
         } elseif ($parsedBlock['attrs']['textColor']) {
           $buttonClasses .= ' has-' . $parsedBlock['attrs']['textColor'] . '-border-color';
         }
       }
-      $wrapperStyles = array_merge($wrapperStyles, wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['declarations']);
-      $wrapperStyles['border-style'] = 'solid';
+      $wrapperStyles = array_merge($wrapperStyles, wp_style_engine_get_styles(['border' => $borderAttrs])['declarations']);
+      // User might set only the border radius without border color and width so in that case we need to set border:none
+      // to avoid rendering 1px border. Let's render the border only when width is set or border top is set separately
+      // which is saved only when there is a side with non-zero width so it is enough to check only top
+      if (
+        (isset($borderAttrs['width']) && $borderAttrs['width'] !== '0px')
+        || isset($borderAttrs['top'])
+      ) {
+        $wrapperStyles['border-style'] = 'solid';
+      } else {
+        $wrapperStyles['border'] = 'none';
+      }
     } else {
       // Some clients render 1px border when not set as none
       $wrapperStyles['border'] = 'none';


### PR DESCRIPTION
## Description

This PR fixes issues found when we tested the plugin with WP 6.5 beta 1. Some the issues in the ticket were addressed in different PRs, but I've also found a couple of new issues.

#### Issues addressed in this PR:

1. The appearance of the toolbar menu
2. Sidebar header (tabs)
3. The main area appearance
4. Inserter goes below the browser window
5. Blocks supporting borders allow shadow configuration - I disabled this for now.
6. Fixed Toolbar was not working

#### Issues I was not able to replicate (I was working with beta 2 so possibly some issues were already fixed)

1. Missing Image settings
2. Image missing in Preview
3. The Button's full-width setting is not working (possibly related to 3) The main area appearance)
4. Column block spacing is not working (possibly related to 3) The main area appearance)

#### Issues solved in different PR/ticket

1. Padding cannot be changed (https://github.com/mailpoet/mailpoet/pull/5450)
2. Button rendering is not working (https://github.com/mailpoet/mailpoet/pull/5450)

## Code review notes

I was not able to replicate all the issues (e.g. the problems with image blocks) and also found that some of those in the ticket were not related to WP 6.5 but they were just issues in the rederer (e.g. problems with padding in button were addressed in https://github.com/mailpoet/mailpoet/pull/5450). 

I fixed the issues with BC in mind so the editor should work in WP 6.4 and WP 6.5.

Two issues worth additional comments are:

1. Problem with Tabs in Sidebar Header - The post editor switched to [Tabs component](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/tabs) but this one is in private APIs and not available in WP 6.4. I was able to make it work for WP 6.5 but since it is still private and not supported in WP6.4 I chose to fix the issue by adding CSS for the current implemantation.
2. Fixed Toolbar Not Working - The fix for WP 6.5 caused that in WP 6.4 we rendered two toolbars in the header. I needed to add a condition based on WP/Gutenberg version. I'm not happy with such a condition, but I hope we can get rid of it as soon as we drop support of WP 6.4.

## QA notes

Please test the editor in WP 6.4 and WP 6.5 Beta. There might be some differences because WP6.5 provides newer Gutenberg packages, but we should not introduce any regression compared to WP 6.4

Veljko's note to Alex: We can use site cloning on InstaWP or creating a new site instance to test the difference.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5907]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5907]: https://mailpoet.atlassian.net/browse/MAILPOET-5907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ