### PR TITLE
Fix clicking selector to close sidebar

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -94,7 +94,9 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('Save Draft');
     $i->waitForText('Saved');
     $i->waitForText('Email saved!');
-    $i->click('.interface-pinned-items'); // close sidebar
+    // there is weird issue in the acceptance env where preview popup goes beyond sidebar
+    // this issue is not confirmed to be real issue but only on the acceptance test site
+    $i->click('div.interface-pinned-items > button'); // close sidebar
     $i->click('.mailpoet-preview-dropdown button[aria-label="Preview"]');
     $i->waitForElementVisible('//button[text()="Preview in new tab"]');
     $i->waitForElementClickable('//button[text()="Preview in new tab"]');


### PR DESCRIPTION
## Description

There is issue in the acceptance test environment where the preview popup in the new email editor goes beyond the sidebar. I will make a workaround to close the sidebar before attempting to open the popup.

## Code review notes

I added this previously but seems the selector wasn't right so I added now pre-class to it and it worked clicking it.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5930]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5930]: https://mailpoet.atlassian.net/browse/MAILPOET-5930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ