### PR TITLE
Add background image support to Column/Columns Blocks [MAILPOET-5650]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/column.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/column.ts
@@ -47,4 +47,25 @@ function disableNestedColumns() {
   );
 }
 
-export { disableNestedColumns };
+function enhanceColumnBlock() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/change-column',
+    (settings: Block, name) => {
+      if (name === 'core/column') {
+        return {
+          ...settings,
+          supports: {
+            ...settings.supports,
+            background: {
+              backgroundImage: true,
+            },
+          },
+        };
+      }
+      return settings;
+    },
+  );
+}
+
+export { disableNestedColumns, enhanceColumnBlock };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/columns.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/columns.tsx
@@ -1,5 +1,6 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { Block } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 
 const columnsEditCallback = createHigherOrderComponent(
@@ -62,4 +63,25 @@ function disableColumnsLayout() {
   );
 }
 
-export { deactivateStackOnMobile, disableColumnsLayout };
+function enhanceColumnsBlock() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/change-column',
+    (settings: Block, name) => {
+      if (name === 'core/columns') {
+        return {
+          ...settings,
+          supports: {
+            ...settings.supports,
+            background: {
+              backgroundImage: true,
+            },
+          },
+        };
+      }
+      return settings;
+    },
+  );
+}
+
+export { deactivateStackOnMobile, disableColumnsLayout, enhanceColumnsBlock };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/columns.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/columns.tsx
@@ -66,7 +66,7 @@ function disableColumnsLayout() {
 function enhanceColumnsBlock() {
   addFilter(
     'blocks.registerBlockType',
-    'mailpoet-email-editor/change-column',
+    'mailpoet-email-editor/change-columns',
     (settings: Block, name) => {
       if (name === 'core/columns') {
         return {

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -1,6 +1,10 @@
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { disableNestedColumns } from './core/column';
-import { disableColumnsLayout, deactivateStackOnMobile } from './core/columns';
+import { disableNestedColumns, enhanceColumnBlock } from './core/column';
+import {
+  disableColumnsLayout,
+  deactivateStackOnMobile,
+  enhanceColumnsBlock,
+} from './core/columns';
 import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
@@ -15,5 +19,7 @@ export function initBlocks() {
   disableColumnsLayout();
   enhanceButtonBlock();
   enhanceButtonsBlock();
+  enhanceColumnBlock();
+  enhanceColumnsBlock();
   registerCoreBlocks();
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/block-compatibility-warnings.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/block-compatibility-warnings.tsx
@@ -1,7 +1,18 @@
-import { hasBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport, getBlockSupport } from '@wordpress/blocks';
 import { Fill, Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+
+export const hasBackgroundImageSupport = (nameOrType: string) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore not yet supported in the types
+  const backgroundSupport = getBlockSupport(nameOrType, 'background') as Record<
+    string,
+    boolean
+  >;
+
+  return backgroundSupport && backgroundSupport?.backgroundImage !== false;
+};
 
 export function BlockCompatibilityWarnings(): JSX.Element {
   // Select the currently selected block
@@ -19,18 +30,36 @@ export function BlockCompatibilityWarnings(): JSX.Element {
     false,
   );
 
-  return hasBorderSupport ? (
-    <Fill name="InspectorControlsBorder">
-      <Notice
-        className="mailpoet__grid-full-width"
-        status="warning"
-        isDismissible={false}
-      >
-        {__(
-          'Border display may vary or be unsupported in some email clients.',
-          'mailpoet',
-        )}
-      </Notice>
-    </Fill>
-  ) : null;
+  return (
+    <>
+      {hasBorderSupport && (
+        <Fill name="InspectorControlsBorder">
+          <Notice
+            className="mailpoet__grid-full-width"
+            status="warning"
+            isDismissible={false}
+          >
+            {__(
+              'Border display may vary or be unsupported in some email clients.',
+              'mailpoet',
+            )}
+          </Notice>
+        </Fill>
+      )}
+      {hasBackgroundImageSupport(selectedBlock?.name) && (
+        <Fill name="InspectorControlsBackground">
+          <Notice
+            className="mailpoet__grid-full-width"
+            status="warning"
+            isDismissible={false}
+          >
+            {__(
+              'Select a background color for email clients that do not support background images.',
+              'mailpoet',
+            )}
+          </Notice>
+        </Fill>
+      )}
+    </>
+  );
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/index.scss
@@ -1,5 +1,6 @@
 @import '~@wordpress/base-styles/colors';
 
+.background-block-support-panel .mailpoet__grid-full-width,
 .border-block-support-panel .mailpoet__grid-full-width {
   // setting the grid to 100% width because border block contains two grid columns
   grid-column: 1/3;

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -52,6 +52,7 @@ class ThemeController {
     foreach ($colorDefinitions as $color) {
       $cssPresets .= ".has-{$color['slug']}-color { color: {$color['color']}; } \n";
       $cssPresets .= ".has-{$color['slug']}-background-color { background-color: {$color['color']}; } \n";
+      $cssPresets .= ".has-{$color['slug']}-border-color { border-color: {$color['color']}; } \n";
     }
 
     // Block specific styles

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -10,6 +10,9 @@
     "layout": {
       "contentSize": "660px"
     },
+    "background": {
+      "backgroundImage": true
+    },
     "spacing": {
       "units": ["px"],
       "blockGap": true,

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -56,10 +56,7 @@ class Column implements BlockRenderer {
       $cellStyles['background-size'] = 'cover';
     }
 
-    if (!empty($cellStyles['border-width'])) {
-      $cellStyles['border-style'] = 'solid';
-      $cellStyles['box-sizing'] = 'border-box';
-    }
+    $cellStyles['border-style'] = 'solid';
 
     $wrapperClassname = 'block wp-block-column ';
     $contentClassname = 'email_column ';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -49,18 +49,17 @@ class Column implements BlockRenderer {
     $cellStyles = $this->getStylesFromBlock( [
         'color' => $block_attributes['style']['color'] ?? [],
         'background' => $block_attributes['style']['background'] ?? [],
-        'border' => $block_attributes['style']['border'] ?? [],
       ] )->declarations;
+
+    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_attributes['style']['border'] ?? [] ] )->declarations;
+
+    if (!empty($borderStyles)) {
+      $cellStyles = array_merge( $cellStyles, ['border-style' => 'solid'], $borderStyles );
+    }
 
     if (!empty($cellStyles['background-image']) && empty($cellStyles['background-size'])) {
       $cellStyles['background-size'] = 'cover';
     }
-
-    // Prepend default border styles to ensure borders are solid and 0px by default.
-    $cellStyles = array_merge( [
-      'border-width' => '0',
-      'border-style' => 'solid',
-    ], $cellStyles );
 
     $wrapperClassname = 'block wp-block-column';
     $contentClassname = 'email_column';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -22,7 +22,11 @@ class Column implements BlockRenderer {
 
   private function getStylesFromBlock(array $block_styles) {
     $styles = wp_style_engine_get_styles( $block_styles );
-    return $styles['declarations'] ?? [];
+    return (object)wp_parse_args($styles['declarations'], [
+      'css' => '',
+      'declarations' => [],
+      'classnames' => '',
+    ]);
   }
 
   /**
@@ -34,14 +38,10 @@ class Column implements BlockRenderer {
     $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
 
     $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
-    $paddingBottom = $block_attributes['style']['spacing']['padding']['bottom'] ?? '0px';
-    $paddingLeft = $block_attributes['style']['spacing']['padding']['left'] ?? '0px';
-    $paddingRight = $block_attributes['style']['spacing']['padding']['right'] ?? '0px';
-    $paddingTop = $block_attributes['style']['spacing']['padding']['top'] ?? '0px';
-
-    $colorStyles = $this->getStylesFromBlock( [ 'color' => $block_styles['color'] ?? [] ] );
-    $backgroundStyles = $this->getStylesFromBlock( [ 'background' => $block_styles['background'] ?? [] ] );
-    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_styles['border'] ?? [] ] );
+    $paddingStyles = $this->getStylesFromBlock( [ 'spacing' => ['padding' => $block_styles['spacing']['padding'] ?? [] ] ] )->css;
+    $colorStyles = $this->getStylesFromBlock( [ 'color' => $block_styles['color'] ?? [] ] )->declarations;
+    $backgroundStyles = $this->getStylesFromBlock( [ 'background' => $block_styles['background'] ?? [] ] )->declarations;
+    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_styles['border'] ?? [] ] )->declarations;
 
     if (!empty($backgroundStyles['background-image']) && empty($backgroundStyles['background-size'])) {
       $backgroundStyles['background-size'] = 'cover';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -56,9 +56,11 @@ class Column implements BlockRenderer {
       $cellStyles['background-size'] = 'cover';
     }
 
-    if (isset( $cellStyles['border-width'] ) && !isset( $cellStyles['border-style'] )) {
-      $cellStyles['border-style'] = 'solid';
-    }
+    // Prepend default border styles to ensure borders are solid and 0px by default.
+    $cellStyles = array_merge( [
+      'border-width' => '0',
+      'border-style' => 'solid',
+    ], $cellStyles );
 
     $wrapperClassname = 'block wp-block-column';
     $contentClassname = 'email_column';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -36,7 +36,7 @@ class Column implements BlockRenderer {
   private function getBlockWrapper(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $originalWrapperClassname = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
     $block_attributes = wp_parse_args($parsedBlock['attrs'] ?? [], [
-      'verticalAlignment' => 'top',
+      'verticalAlignment' => 'stretch',
       'width' => $settingsController->getLayoutWidthWithoutPadding(),
       'style' => [],
     ]);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -56,7 +56,9 @@ class Column implements BlockRenderer {
       $cellStyles['background-size'] = 'cover';
     }
 
-    $cellStyles['border-style'] = 'solid';
+    if (isset( $cellStyles['border-width'] ) && !isset( $cellStyles['border-style'] )) {
+      $cellStyles['border-style'] = 'solid';
+    }
 
     $wrapperClassname = 'block wp-block-column';
     $contentClassname = 'email_column';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -58,18 +58,18 @@ class Column implements BlockRenderer {
 
     $cellStyles['border-style'] = 'solid';
 
-    $wrapperClassname = 'block wp-block-column ';
-    $contentClassname = 'email_column ';
+    $wrapperClassname = 'block wp-block-column';
+    $contentClassname = 'email_column';
     $wrapperCSS = WP_Style_Engine::compile_css( [
       'vertical-align' => $isStretched ? 'top' : $block_attributes['verticalAlignment'],
     ], '' );
     $contentCSS = 'vertical-align: top;';
 
     if ($isStretched) {
-      $wrapperClassname .= $originalWrapperClassname;
+      $wrapperClassname .= ' ' . $originalWrapperClassname;
       $wrapperCSS .= ' ' . WP_Style_Engine::compile_css( $cellStyles, '' );
     } else {
-      $contentClassname .= $originalWrapperClassname;
+      $contentClassname .= ' ' . $originalWrapperClassname;
       $contentCSS .= ' ' . WP_Style_Engine::compile_css( $cellStyles, '' );
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -61,7 +61,6 @@ class Columns implements BlockRenderer {
     $contentClassname = 'email_columns ' . $originalWrapperClassname;
     $contentCSS = WP_Style_Engine::compile_css( $cellStyles, '' );
     $layoutCSS = WP_Style_Engine::compile_css( [
-      'max-width' => $block_attributes['width'],
       'margin-top' => $parsedBlock['email_attrs']['margin-top'] ?? '0px',
       'padding-left' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['left'] : '0px',
       'padding-right' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['right'] : '0px',

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -22,7 +22,11 @@ class Columns implements BlockRenderer {
 
   private function getStylesFromBlock(array $block_styles) {
     $styles = wp_style_engine_get_styles( $block_styles );
-    return $styles['declarations'] ?? [];
+    return (object)wp_parse_args($styles['declarations'], [
+      'css' => '',
+      'declarations' => [],
+      'classnames' => '',
+    ]);
   }
 
   /**
@@ -35,10 +39,10 @@ class Columns implements BlockRenderer {
 
     $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
     $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
-    $paddingStyles = $this->getStylesFromBlock( ['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]] );
-    $colorStyles = $this->getStylesFromBlock( [ 'color' => $block_styles['color'] ?? [] ] );
-    $backgroundStyles = $this->getStylesFromBlock( [ 'background' => $block_styles['background'] ?? [] ] );
-    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_styles['border'] ?? [] ] );
+    $paddingStyles = $this->getStylesFromBlock( ['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]] )->declarations;
+    $colorStyles = $this->getStylesFromBlock( [ 'color' => $block_styles['color'] ?? [] ] )->declarations;
+    $backgroundStyles = $this->getStylesFromBlock( [ 'background' => $block_styles['background'] ?? [] ] )->declarations;
+    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_styles['border'] ?? [] ] )->declarations;
 
     if (!empty($backgroundStyles['background-image']) && empty($backgroundStyles['background-size'])) {
       $backgroundStyles['background-size'] = 'cover';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -5,6 +5,7 @@ namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 use MailPoet\EmailEditor\Engine\Renderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
 use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
+use WP_Style_Engine;
 
 class Columns implements BlockRenderer {
   public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
@@ -22,7 +23,7 @@ class Columns implements BlockRenderer {
 
   private function getStylesFromBlock(array $block_styles) {
     $styles = wp_style_engine_get_styles( $block_styles );
-    return (object)wp_parse_args($styles['declarations'], [
+    return (object)wp_parse_args($styles, [
       'css' => '',
       'declarations' => [],
       'classnames' => '',
@@ -33,68 +34,54 @@ class Columns implements BlockRenderer {
    * Based on MJML <mj-section>
    */
   private function getBlockWrapper(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    $block_attributes = isset( $parsedBlock['attrs'] ) && is_array( $parsedBlock['attrs'] ) ? $parsedBlock['attrs'] : [];
-    $block_styles = isset( $block_attributes['style'] ) && is_array( $block_attributes['style'] ) ? $block_attributes['style'] : [];
-    $classes = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
+    $originalWrapperClassname = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
+    $block_attributes = wp_parse_args($parsedBlock['attrs'] ?? [], [
+      'align' => null,
+      'width' => $settingsController->getLayoutWidthWithoutPadding(),
+      'style' => [],
+    ]);
 
-    $width = $parsedBlock['email_attrs']['width'] ?? $settingsController->getLayoutWidthWithoutPadding();
-    $marginTop = $parsedBlock['email_attrs']['margin-top'] ?? '0px';
-    $paddingStyles = $this->getStylesFromBlock( ['spacing' => ['padding' => $parsedBlock['attrs']['style']['spacing']['padding'] ?? null ]] )->declarations;
-    $colorStyles = $this->getStylesFromBlock( [ 'color' => $block_styles['color'] ?? [] ] )->declarations;
-    $backgroundStyles = $this->getStylesFromBlock( [ 'background' => $block_styles['background'] ?? [] ] )->declarations;
-    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_styles['border'] ?? [] ] )->declarations;
+    $cellStyles = $this->getStylesFromBlock( [
+      'spacing' => [ 'padding' => $block_attributes['style']['spacing']['padding'] ?? [] ],
+      'color' => $block_attributes['style']['color'] ?? [],
+      'background' => $block_attributes['style']['background'] ?? [],
+      'border' => $block_attributes['style']['border'] ?? [],
+    ] )->declarations;
 
-    if (!empty($backgroundStyles['background-image']) && empty($backgroundStyles['background-size'])) {
-      $backgroundStyles['background-size'] = 'cover';
+    if (!empty($cellStyles['background-image']) && empty($cellStyles['background-size'])) {
+      $cellStyles['background-size'] = 'cover';
     }
 
-    if (!empty($borderStyles['border-width'])) {
-      $borderStyles['border-style'] = 'solid';
-      $borderStyles['box-sizing'] = 'border-box';
+    if (!empty($cellStyles['border-width'])) {
+      $cellStyles['border-style'] = 'solid';
+      $cellStyles['box-sizing'] = 'border-box';
     }
 
-    $align = $block_attributes['align'] ?? null;
-    if ($align !== 'full') {
-      $layoutPaddingLeft = $settingsController->getEmailStyles()['layout']['padding']['left'];
-      $layoutPaddingRight = $settingsController->getEmailStyles()['layout']['padding']['right'];
-    } else {
-      $layoutPaddingLeft = '0px';
-      $layoutPaddingRight = '0px';
-    }
+    $contentClassname = 'email_columns ' . $originalWrapperClassname;
+    $contentCSS = WP_Style_Engine::compile_css( $cellStyles, '' );
+    $layoutCSS = WP_Style_Engine::compile_css( [
+      'max-width' => $block_attributes['width'],
+      'margin-top' => $parsedBlock['email_attrs']['margin-top'] ?? '0px',
+      'padding-left' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['left'] : '0px',
+      'padding-right' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['right'] : '0px',
+    ], '' );
 
     return '
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . esc_attr( $width ) . ';" width="' . esc_attr( $width ) . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-      <div style="' . esc_attr($settingsController->convertStylesToString([
-        'margin-top' => $marginTop,
-        'max-width' => $width,
-        'padding-left' => $layoutPaddingLeft,
-        'padding-right' => $layoutPaddingRight,
-      ])) . '">
-        <table
-          class="' . esc_attr( $classes ) . '"
-          align="center"
-          border="0"
-          cellpadding="0"
-          cellspacing="0"
-          role="presentation"
-          style="' . esc_attr($settingsController->convertStylesToString(array_merge($colorStyles, $backgroundStyles, $borderStyles))) . ';max-width:' . esc_attr( $width ) . ';width:100%;border-collapse:separate;"
-        >
-          <tbody>
-            <tr>
-              <td style="
-              ' . esc_attr($settingsController->convertStylesToString(array_merge($paddingStyles, [
-                'text-align' => 'left',
-                'font-size' => '0px',
-              ]))) . '">
-                <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:separate;">
-                  <tr>
-                    {columns_content}
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . esc_attr( $block_attributes['width'] ) . ';" width="' . esc_attr( $block_attributes['width'] ) . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <div style="' . esc_attr($layoutCSS) . '">
+      <table style="width:100%;border-collapse:separate;" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+        <tbody>
+          <tr>
+            <td class="' . esc_attr( $contentClassname ) . '" style="text-align:left;width:100%;' . esc_attr($contentCSS) . '">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:separate;">
+                <tr>
+                  {columns_content}
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
       </div>
       <!--[if mso | IE]></td></tr></table><![endif]-->
     ';

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -64,10 +64,10 @@ class Columns implements BlockRenderer {
       'padding-left' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['left'] : '0px',
       'padding-right' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['right'] : '0px',
     ], '' );
-    $ieWidth = $block_attributes['align'] !== 'full' ? $block_attributes['width'] : '100%';
+    $tableWidth = $block_attributes['align'] !== 'full' ? $block_attributes['width'] : '100%';
 
     return '
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . esc_attr( $ieWidth ) . ';" width="' . esc_attr( $ieWidth ) . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . esc_attr( $tableWidth ) . ';" width="' . esc_attr( $tableWidth ) . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="' . esc_attr($layoutCSS) . '">
       <table style="width:100%;border-collapse:separate;" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
         <tbody>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -52,9 +52,11 @@ class Columns implements BlockRenderer {
       $cellStyles['background-size'] = 'cover';
     }
 
-    if (isset( $cellStyles['border-width'] ) && !isset( $cellStyles['border-style'] )) {
-      $cellStyles['border-style'] = 'solid';
-    }
+    // Prepend default border styles to ensure borders are solid and 0px by default.
+    $cellStyles = array_merge( [
+      'border-width' => '0',
+      'border-style' => 'solid',
+    ], $cellStyles );
 
     $contentClassname = 'email_columns ' . $originalWrapperClassname;
     $contentCSS = WP_Style_Engine::compile_css( $cellStyles, '' );

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -48,14 +48,11 @@ class Columns implements BlockRenderer {
       'border' => $block_attributes['style']['border'] ?? [],
     ] )->declarations;
 
-    if (!empty($cellStyles['background-image']) && empty($cellStyles['background-size'])) {
+    if (empty($cellStyles['background-size'])) {
       $cellStyles['background-size'] = 'cover';
     }
 
-    if (!empty($cellStyles['border-width'])) {
-      $cellStyles['border-style'] = 'solid';
-      $cellStyles['box-sizing'] = 'border-box';
-    }
+    $cellStyles['border-style'] = 'solid';
 
     $contentClassname = 'email_columns ' . $originalWrapperClassname;
     $contentCSS = WP_Style_Engine::compile_css( $cellStyles, '' );

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -52,7 +52,9 @@ class Columns implements BlockRenderer {
       $cellStyles['background-size'] = 'cover';
     }
 
-    $cellStyles['border-style'] = 'solid';
+    if (isset( $cellStyles['border-width'] ) && !isset( $cellStyles['border-style'] )) {
+      $cellStyles['border-style'] = 'solid';
+    }
 
     $contentClassname = 'email_columns ' . $originalWrapperClassname;
     $contentCSS = WP_Style_Engine::compile_css( $cellStyles, '' );

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -45,18 +45,17 @@ class Columns implements BlockRenderer {
       'spacing' => [ 'padding' => $block_attributes['style']['spacing']['padding'] ?? [] ],
       'color' => $block_attributes['style']['color'] ?? [],
       'background' => $block_attributes['style']['background'] ?? [],
-      'border' => $block_attributes['style']['border'] ?? [],
     ] )->declarations;
+
+    $borderStyles = $this->getStylesFromBlock( [ 'border' => $block_attributes['style']['border'] ?? [] ] )->declarations;
+
+    if (!empty($borderStyles)) {
+      $cellStyles = array_merge( $cellStyles, ['border-style' => 'solid'], $borderStyles );
+    }
 
     if (empty($cellStyles['background-size'])) {
       $cellStyles['background-size'] = 'cover';
     }
-
-    // Prepend default border styles to ensure borders are solid and 0px by default.
-    $cellStyles = array_merge( [
-      'border-width' => '0',
-      'border-style' => 'solid',
-    ], $cellStyles );
 
     $contentClassname = 'email_columns ' . $originalWrapperClassname;
     $contentCSS = WP_Style_Engine::compile_css( $cellStyles, '' );

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -64,9 +64,10 @@ class Columns implements BlockRenderer {
       'padding-left' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['left'] : '0px',
       'padding-right' => $block_attributes['align'] !== 'full' ? $settingsController->getEmailStyles()['layout']['padding']['right'] : '0px',
     ], '' );
+    $ieWidth = $block_attributes['align'] !== 'full' ? $block_attributes['width'] : '100%';
 
     return '
-      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . esc_attr( $block_attributes['width'] ) . ';" width="' . esc_attr( $block_attributes['width'] ) . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="width:' . esc_attr( $ieWidth ) . ';" width="' . esc_attr( $ieWidth ) . '"><tr><td style="font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
       <div style="' . esc_attr($layoutCSS) . '">
       <table style="width:100%;border-collapse:separate;" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
         <tbody>

--- a/mailpoet/lib/Newsletter/Renderer/EscapeHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/EscapeHelper.php
@@ -26,7 +26,7 @@ class EscapeHelper {
    * @return string
    */
   public static function escapeHtmlStyleAttr($string) {
-    return htmlspecialchars((string)$string, ENT_COMPAT, 'UTF-8');
+    return esc_attr((string)$string);
   }
 
   /**
@@ -34,7 +34,8 @@ class EscapeHelper {
    * @return string
    */
   public static function unescapeHtmlStyleAttr($string) {
-    return htmlspecialchars_decode((string)$string, ENT_COMPAT);
+    // This decodes entities which may have been added by esc_attr.
+    return htmlspecialchars_decode((string)$string, ENT_QUOTES);
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Renderer/EscapeHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/EscapeHelper.php
@@ -20,13 +20,14 @@ class EscapeHelper {
   }
 
   /**
-   * Similar to escapeHtmlAttr just this one keeps single quotes since some email clients
-   * (e.g. Yahoo webmail) don't support encoded quoted font names
+   * Escapes Style attributes, but preserves single quotes. Some email clients
+   * (e.g. Yahoo webmail) don't support encoded quoted font names.
+   * Previously used htmlspecialchars but switched to esc_attr which is more appropriate.
    * @param string $string
    * @return string
    */
   public static function escapeHtmlStyleAttr($string) {
-    return esc_attr((string)$string);
+    return str_replace( '&#039;', "'", esc_attr((string)$string));
   }
 
   /**

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnTest.php
@@ -48,8 +48,6 @@ class ColumnTest extends \MailPoetTest {
     $rendered = $this->columnRenderer->render('', $this->parsedColumn, $this->settingsController);
     $this->checkValidHTML($rendered);
     $this->assertStringContainsString('Column content', $rendered);
-    $this->assertStringContainsString('width:300px;', $rendered);
-    $this->assertStringContainsString('max-width:300px;', $rendered);
   }
 
   public function testItContainsColumnsStyles(): void {
@@ -95,7 +93,6 @@ class ColumnTest extends \MailPoetTest {
     ];
     $rendered = $this->columnRenderer->render('', $parsedColumn, $this->settingsController);
     $this->checkValidHTML($rendered);
-    $this->assertStringContainsString('background:#abcdef;', $rendered);
     $this->assertStringContainsString('background-color:#abcdef;', $rendered);
     $this->assertStringContainsString('border-bottom-left-radius:5px;', $rendered);
     $this->assertStringContainsString('border-bottom-right-radius:10px;', $rendered);
@@ -133,7 +130,6 @@ class ColumnTest extends \MailPoetTest {
     $this->checkValidHTML($rendered);
     $this->assertStringContainsString('color:#123456;', $rendered);
     $this->assertStringContainsString('background-color:#654321;', $rendered);
-    $this->assertStringContainsString('background:#654321;', $rendered);
   }
 
   public function testItPreservesClassesSetByEditor(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
@@ -81,7 +81,6 @@ class ColumnsTest extends \MailPoetTest {
       ],
     ];
     $rendered = $this->columnsRenderer->render('', $parsedColumns, $this->settingsController);
-    verify($rendered)->stringContainsString('background:#abcdef;');
     verify($rendered)->stringContainsString('background-color:#abcdef;');
     verify($rendered)->stringContainsString('border-color:#123456;border-radius:10px;border-width:2px;border-style:solid;');
     verify($rendered)->stringContainsString('padding-bottom:5px;');

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
@@ -98,7 +98,6 @@ class ColumnsTest extends \MailPoetTest {
     $this->checkValidHTML($rendered);
     $this->assertStringContainsString('color:#123456;', $rendered);
     $this->assertStringContainsString('background-color:#654321;', $rendered);
-    $this->assertStringContainsString('background:#654321;', $rendered);
   }
 
   public function testItPreservesClassesSetByEditor(): void {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ColumnsTest.php
@@ -54,8 +54,6 @@ class ColumnsTest extends \MailPoetTest {
   public function testItRendersInnerColumn() {
     $rendered = $this->columnsRenderer->render('', $this->parsedColumns, $this->settingsController);
     verify($rendered)->stringContainsString('Column 1');
-    verify($rendered)->stringContainsString('width:784px;');
-    verify($rendered)->stringContainsString('max-width:784px;');
   }
 
   public function testItContainsColumnsStyles(): void {
@@ -82,7 +80,10 @@ class ColumnsTest extends \MailPoetTest {
     ];
     $rendered = $this->columnsRenderer->render('', $parsedColumns, $this->settingsController);
     verify($rendered)->stringContainsString('background-color:#abcdef;');
-    verify($rendered)->stringContainsString('border-color:#123456;border-radius:10px;border-width:2px;border-style:solid;');
+    verify($rendered)->stringContainsString('border-color:#123456;');
+    verify($rendered)->stringContainsString('border-radius:10px;');
+    verify($rendered)->stringContainsString('border-width:2px;');
+    verify($rendered)->stringContainsString('border-style:solid;');
     verify($rendered)->stringContainsString('padding-bottom:5px;');
     verify($rendered)->stringContainsString('padding-left:15px;');
     verify($rendered)->stringContainsString('padding-right:20px;');

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -106,8 +106,10 @@ class RendererTest extends \MailPoetTest {
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column', 'td');
-    verify($style)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
-    verify($style)->stringContainsString('background-color:#000000'); // black is #000000
+    // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+    verify($style)->stringContainsString('color:#ff6900', print_r($rendered['html'], true)); // luminous-vivid-orange is #ff6900
+    // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+    verify($style)->stringContainsString('background-color:#000000', print_r($rendered['html'], true)); // black is #000000
   }
 
   private function extractBlockHtml(string $html, string $blockClass, string $tag): string {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -100,9 +100,10 @@ class RendererTest extends \MailPoetTest {
 
   public function testItInlinesColumnColors() {
     $emailPost = new \WP_Post((object)[
-      'post_content' => '<!-- wp:column {"backgroundColor":"vivid-green-cyan", "textColor":"black", "verticalAlignment":"stretch"} -->
-        <div class="wp-block-column has-black-background-color has-luminous-vivid-orange-color"><div>
-        <!-- /wp:column -->',
+      'post_content' => '
+      <!-- wp:column {"backgroundColor":"black","textColor":"luminous-vivid-orange"} -->
+      <div class="wp-block-column has-luminous-vivid-orange-color has-black-background-color has-text-color has-background"></div>
+      <!-- /wp:column -->',
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column', 'td');

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -93,14 +93,14 @@ class RendererTest extends \MailPoetTest {
         <!-- /wp:columns -->',
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
-    $style = $this->extractBlockStyle($rendered['html'], 'wp-block-columns', 'table');
+    $style = $this->extractBlockStyle($rendered['html'], 'wp-block-columns', 'td');
     verify($style)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
     verify($style)->stringContainsString('background-color:#000000'); // black is #000000
   }
 
   public function testItInlinesColumnColors() {
     $emailPost = new \WP_Post((object)[
-      'post_content' => '<!-- wp:column {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
+      'post_content' => '<!-- wp:column {"backgroundColor":"vivid-green-cyan", "textColor":"black", "verticalAlign":"stretch"} -->
         <div class="wp-block-column has-black-background-color has-luminous-vivid-orange-color"><div>
         <!-- /wp:column -->',
     ]);

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -100,7 +100,7 @@ class RendererTest extends \MailPoetTest {
 
   public function testItInlinesColumnColors() {
     $emailPost = new \WP_Post((object)[
-      'post_content' => '<!-- wp:column {"backgroundColor":"vivid-green-cyan", "textColor":"black", "verticalAlign":"stretch"} -->
+      'post_content' => '<!-- wp:column {"backgroundColor":"vivid-green-cyan", "textColor":"black", "verticalAlignment":"stretch"} -->
         <div class="wp-block-column has-black-background-color has-luminous-vivid-orange-color"><div>
         <!-- /wp:column -->',
     ]);

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -101,16 +101,15 @@ class RendererTest extends \MailPoetTest {
   public function testItInlinesColumnColors() {
     $emailPost = new \WP_Post((object)[
       'post_content' => '
-      <!-- wp:column {"backgroundColor":"black","textColor":"luminous-vivid-orange"} -->
-      <div class="wp-block-column has-luminous-vivid-orange-color has-black-background-color has-text-color has-background"></div>
+      <!-- wp:column {"verticalAlignment":"stretch","backgroundColor":"black","textColor":"luminous-vivid-orange"} -->
+      <div class="wp-block-column is-vertically-aligned-stretch has-luminous-vivid-orange-color has-black-background-color has-text-color has-background"></div>
       <!-- /wp:column -->',
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column', 'td');
     // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
     verify($style)->stringContainsString('color:#ff6900', print_r($rendered['html'], true)); // luminous-vivid-orange is #ff6900
-    // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
-    verify($style)->stringContainsString('background-color:#000000', print_r($rendered['html'], true)); // black is #000000
+    verify($style)->stringContainsString('background-color:#000000'); // black is #000000
   }
 
   private function extractBlockHtml(string $html, string $blockClass, string $tag): string {

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -107,8 +107,7 @@ class RendererTest extends \MailPoetTest {
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column-test', 'td');
-    // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
-    verify($style)->stringContainsString('color:#ff6900', print_r($rendered['html'], true)); // luminous-vivid-orange is #ff6900
+    verify($style)->stringContainsString('color:#ff6900'); // luminous-vivid-orange is #ff6900
     verify($style)->stringContainsString('background-color:#000000'); // black is #000000
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -89,7 +89,7 @@ class RendererTest extends \MailPoetTest {
   public function testItInlinesColumnsColors() {
     $emailPost = new \WP_Post((object)[
       'post_content' => '<!-- wp:columns {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
-        <div class="wp-block-columns has-black-background-color has-luminous-vivid-orange-color"><!-- wp:column --><!-- /wp:column --><div>
+        <div class="wp-block-columns has-black-background-color has-luminous-vivid-orange-color"><!-- wp:column --><!-- /wp:column --></div>
         <!-- /wp:columns -->',
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
@@ -102,11 +102,11 @@ class RendererTest extends \MailPoetTest {
     $emailPost = new \WP_Post((object)[
       'post_content' => '
       <!-- wp:column {"verticalAlignment":"stretch","backgroundColor":"black","textColor":"luminous-vivid-orange"} -->
-      <div class="wp-block-column is-vertically-aligned-stretch has-luminous-vivid-orange-color has-black-background-color has-text-color has-background"></div>
+      <div class="wp-block-column-test wp-block-column is-vertically-aligned-stretch has-luminous-vivid-orange-color has-black-background-color has-text-color has-background"></div>
       <!-- /wp:column -->',
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
-    $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column', 'td');
+    $style = $this->extractBlockStyle($rendered['html'], 'wp-block-column-test', 'td');
     // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
     verify($style)->stringContainsString('color:#ff6900', print_r($rendered['html'], true)); // luminous-vivid-orange is #ff6900
     verify($style)->stringContainsString('background-color:#000000'); // black is #000000

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -532,11 +532,8 @@ class RendererTest extends \MailPoetTest {
     $template = $newsletter['content']['blocks'][0]['blocks'][0]['blocks'][5];
     $template['styles']['block']['fontFamily'] = 'Lucida';
     $DOM = $this->dOMParser->parseStr((new Button)->render($template, self::COLUMN_BASE_WIDTH));
-    verify(
-      preg_match(
-        '/font-family: \'Lucida Sans Unicode\', \'Lucida Grande\', sans-serif/',
-        $DOM('a.mailpoet_button', 0)->attr('style'))
-    )->equals(1, print_r( $DOM('a.mailpoet_button', 0), true)); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+    $style = $DOM('a.mailpoet_button', 0)->attr('style');
+    verify($style)->stringContainsString('font-family: \'Lucida Sans Unicode\', \'Lucida Grande\', sans-serif');
   }
 
   public function testItRendersSocialIcons() {

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -536,7 +536,7 @@ class RendererTest extends \MailPoetTest {
       preg_match(
         '/font-family: \'Lucida Sans Unicode\', \'Lucida Grande\', sans-serif/',
         $DOM('a.mailpoet_button', 0)->attr('style'))
-    )->equals(1);
+    )->equals(1, print_r( $DOM('a.mailpoet_button', 0), true)); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
   }
 
   public function testItRendersSocialIcons() {


### PR DESCRIPTION
## Description

Enhances the `core/column` and `core/columns` block types with support for background images.

As well as adding support for images, this PR also fixes and refactors how styles are generated and applied to columns using `wp_style_engine_get_styles` and `WP_Style_Engine::compile_css`.

I used _Email on Acid_ to check the column layouts worked across clients. Background images do not render in older versions of Outlook. 

![Screenshot 2024-03-04 at 16 56 02](https://github.com/mailpoet/mailpoet/assets/90977/0c8b221a-576b-4ea1-8e77-6aa8d990d070)

## Code review notes

To test you need the new email editor enabled.

1. Go to Emails > New email > Create using beta editor
2. Insert a columns block layout. 
3. Add content to each column.
4. Select the columns block. In the inspector there is a background image section. Upload an image there.
5. Select a column block. In the inspector there is a background image section. Upload an image there.
6. Save and preview the email and check it renders correctly.
7. Select one of the columns and change the alignment from stretch to middle. check the background only covers the block and does not stretch the entire height.
8. Resize preview window to simulate mobile browser. The columns should wrap.

Test coverage was updated as some tests were checking for specific widths; in this PR I made it take the widths from the block itself. I also made it move some of the styles so that they apply to the wrapper with the correct classnames, so some tests were updated to target the correct element.

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5450

## Linked tickets

[MAILPOET-5650](https://mailpoet.atlassian.net/browse/MAILPOET-5650)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5650]: https://mailpoet.atlassian.net/browse/MAILPOET-5650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ