### PR TITLE
Track sent campaigns [MAILPOET-5629]

### DIFF
--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -440,14 +440,6 @@ class Reporter {
       'Number of automations campaigns sent in the last 30 days' => [],
       'Number of automations campaigns sent in the last 3 months' => [],
 
-      'Number of automations campaigns sent to segment in the last 7 days' => [],
-      'Number of automations campaigns sent to segment in the last 30 days' => [],
-      'Number of automations campaigns sent to segment in the last 3 months' => [],
-
-      'Number of automations campaigns filtered by segment in the last 7 days' => [],
-      'Number of automations campaigns filtered by segment in the last 30 days' => [],
-      'Number of automations campaigns filtered by segment in the last 3 months' => [],
-
       'Number of re-engagement campaigns sent in the last 7 days' => [],
       'Number of re-engagement campaigns sent in the last 30 days' => [],
       'Number of re-engagement campaigns sent in the last 3 months' => [],
@@ -675,23 +667,11 @@ class Reporter {
             $matchingCampaignIds['Number of automations campaigns sent in the last 7 days'][] = $campaignId;
             $matchingCampaignIds['Number of automations campaigns sent in the last 30 days'][] = $campaignId;
             $matchingCampaignIds['Number of automations campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of automations campaigns filtered by segment in the last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of automations campaigns filtered by segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of automations campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
           } elseif ($isNewerThan30DaysAgo) {
             $matchingCampaignIds['Number of automations campaigns sent in the last 30 days'][] = $campaignId;
             $matchingCampaignIds['Number of automations campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of automations campaigns filtered by segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of automations campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
           } elseif ($isNewerThan3MonthsAgo) {
             $matchingCampaignIds['Number of automations campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of automations campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
           }
           break;
         // Legacy automatic emails.

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -785,6 +785,9 @@ class Reporter {
         if ($sendingInfo['sentLast3Months']) {
           $processedResults[$campaignId]['sentLast3Months'] = true;
         }
+        if ($sendingInfo['sentToSegment']) {
+          $processedResults[$campaignId]['sentToSegment'] = true;
+        }
       }
     }
 

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -175,9 +175,6 @@ class Reporter {
       'Tracking level' => $this->settings->get('tracking.level', TrackingConfig::LEVEL_FULL),
       'Premium key valid' => $this->servicesChecker->isPremiumKeyValid(),
       'New subscriber notifications' => NewSubscriberNotificationMailer::isDisabled($this->settings->get(NewSubscriberNotificationMailer::SETTINGS_KEY)),
-      'Number of standard newsletters sent in last 7 days' => $newsletters['sent_newsletters_7_days'],
-      'Number of standard newsletters sent in last 3 months' => $newsletters['sent_newsletters_3_months'],
-      'Number of standard newsletters sent in last 30 days' => $newsletters['sent_newsletters_30_days'],
       'Number of active post notifications' => $newsletters['notifications_count'],
       'Number of active welcome emails' => $newsletters['welcome_newsletters_count'],
       'Total number of standard newsletters sent' => $newsletters['sent_newsletters_count'],
@@ -267,6 +264,7 @@ class Reporter {
       $result,
       $this->subscriberProperties(),
       $this->automationProperties(),
+      $this->getCampaignAnalyticsProperties(),
       $this->unsubscribeReporter->getProperties()
     );
     if ($hasWc) {
@@ -424,7 +422,7 @@ class Reporter {
     ];
   }
 
-  public function getCampaignAnalyticsData(): array {
+  public function getCampaignAnalyticsProperties(): array {
     $matchingCampaignIds = [
       'Number of standard newsletters sent in last 7 days' => [],
       'Number of standard newsletters sent in last 3 months' => [],
@@ -799,7 +797,6 @@ class Reporter {
           }
         }
       } else {
-        $existingData = $processedResults[$campaignId];
         if ($sendingInfo['segmentType'] === 'dynamic') {
           $processedResults[$campaignId]['sentToSegment'] = true;
         }

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -775,6 +775,16 @@ class Reporter {
             // Ignore this error, the `automatic` email type won't be counted
           }
         }
+      } else {
+        if ($sendingInfo['sentLast7Days']) {
+          $processedResults[$campaignId]['sentLast7Days'] = true;
+        }
+        if ($sendingInfo['sentLast30Days']) {
+          $processedResults[$campaignId]['sentLast30Days'] = true;
+        }
+        if ($sendingInfo['sentLast3Months']) {
+          $processedResults[$campaignId]['sentLast3Months'] = true;
+        }
       }
     }
 

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -773,7 +773,7 @@ class Reporter {
           'campaignId' => $campaignId,
           'newsletterType' => $newsletterType,
           'automaticSubType' => null,
-          'sentToSegment' => $sendingInfo['segmentType'] === 'dynamic',
+          'sentToSegment' => (bool)$sendingInfo['sentToSegment'],
           'sentLast7Days' => (bool)$sendingInfo['sentLast7Days'],
           'sentLast30Days' => (bool)$sendingInfo['sentLast30Days'],
           'sentLast3Months' => (bool)$sendingInfo['sentLast3Months'],
@@ -789,10 +789,6 @@ class Reporter {
           } catch (UnexpectedValueException $e) {
             // Ignore this error, the `automatic` email type won't be counted
           }
-        }
-      } else {
-        if ($sendingInfo['segmentType'] === 'dynamic') {
-          $processedResults[$campaignId]['sentToSegment'] = true;
         }
       }
     }

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -11,6 +11,7 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository;
 use MailPoet\Segments\DynamicSegments\Filters\AutomationsEvents;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
@@ -103,6 +104,8 @@ class Reporter {
   /*** @var DotcomHelperFunctions */
   private $dotcomHelperFunctions;
 
+  private SendingQueuesRepository $sendingQueuesRepository;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
     SegmentsRepository $segmentsRepository,
@@ -117,7 +120,8 @@ class Reporter {
     SubscriberListingRepository $subscriberListingRepository,
     AutomationStorage $automationStorage,
     UnsubscribeReporter $unsubscribeReporter,
-    DotcomHelperFunctions $dotcomHelperFunctions
+    DotcomHelperFunctions $dotcomHelperFunctions,
+    SendingQueuesRepository $sendingQueuesRepository
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsRepository = $segmentsRepository;
@@ -133,6 +137,7 @@ class Reporter {
     $this->automationStorage = $automationStorage;
     $this->unsubscribeReporter = $unsubscribeReporter;
     $this->dotcomHelperFunctions = $dotcomHelperFunctions;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
   }
 
   public function getData() {
@@ -736,7 +741,7 @@ class Reporter {
   }
 
   public function getProcessedCampaignAnalytics(): array {
-    $rawData = $this->newslettersRepository->getCampaignAnalyticsQuery()->getArrayResult();
+    $rawData = $this->sendingQueuesRepository->getCampaignAnalyticsQuery()->getArrayResult();
     $processedResults = [];
 
     foreach ($rawData as $sendingInfo) {

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -8,10 +8,8 @@ use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\Entities\DynamicSegmentFilterData;
-use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Newsletter\NewslettersRepository;
-use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\DynamicSegments\DynamicSegmentFilterRepository;
 use MailPoet\Segments\DynamicSegments\Filters\AutomationsEvents;
 use MailPoet\Segments\DynamicSegments\Filters\EmailAction;
@@ -54,7 +52,6 @@ use MailPoet\Subscribers\ConfirmationEmailCustomizer;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\SubscriberListingRepository;
 use MailPoet\Tags\TagRepository;
-use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
@@ -104,7 +101,8 @@ class Reporter {
   /*** @var DotcomHelperFunctions */
   private $dotcomHelperFunctions;
 
-  private SendingQueuesRepository $sendingQueuesRepository;
+  /*** @var ReporterCampaignData */
+  private $reporterCampaignData;
 
   public function __construct(
     NewslettersRepository $newslettersRepository,
@@ -121,7 +119,7 @@ class Reporter {
     AutomationStorage $automationStorage,
     UnsubscribeReporter $unsubscribeReporter,
     DotcomHelperFunctions $dotcomHelperFunctions,
-    SendingQueuesRepository $sendingQueuesRepository
+    ReporterCampaignData $reporterCampaignData
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->segmentsRepository = $segmentsRepository;
@@ -137,7 +135,7 @@ class Reporter {
     $this->automationStorage = $automationStorage;
     $this->unsubscribeReporter = $unsubscribeReporter;
     $this->dotcomHelperFunctions = $dotcomHelperFunctions;
-    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->reporterCampaignData = $reporterCampaignData;
   }
 
   public function getData() {
@@ -269,7 +267,7 @@ class Reporter {
       $result,
       $this->subscriberProperties(),
       $this->automationProperties(),
-      $this->getCampaignAnalyticsProperties(),
+      $this->reporterCampaignData->getCampaignAnalyticsProperties(),
       $this->unsubscribeReporter->getProperties()
     );
     if ($hasWc) {
@@ -425,390 +423,6 @@ class Reporter {
       'sendingMethod' => isset($mta['method']) ? $mta['method'] : null,
       'woocommerceIsInstalled' => $this->woocommerceHelper->isWooCommerceActive(),
     ];
-  }
-
-  public function getCampaignAnalyticsProperties(): array {
-    $matchingCampaignIds = [
-      'Number of standard newsletters sent in last 7 days' => [],
-      'Number of standard newsletters sent in last 3 months' => [],
-      'Number of standard newsletters sent in last 30 days' => [],
-
-      'Number of standard newsletters sent to segment in last 7 days' => [],
-      'Number of standard newsletters sent to segment in last 30 days' => [],
-      'Number of standard newsletters sent to segment in last 3 months' => [],
-
-      'Number of standard newsletters filtered by segment in last 7 days' => [],
-      'Number of standard newsletters filtered by segment in last 30 days' => [],
-      'Number of standard newsletters filtered by segment in last 3 months' => [],
-
-      'Number of automations campaigns sent in the last 7 days' => [],
-      'Number of automations campaigns sent in the last 30 days' => [],
-      'Number of automations campaigns sent in the last 3 months' => [],
-
-      'Number of re-engagement campaigns sent in the last 7 days' => [],
-      'Number of re-engagement campaigns sent in the last 30 days' => [],
-      'Number of re-engagement campaigns sent in the last 3 months' => [],
-      'Number of re-engagement campaigns sent to segment in the last 7 days' => [],
-      'Number of re-engagement campaigns sent to segment in the last 30 days' => [],
-      'Number of re-engagement campaigns sent to segment in the last 3 months' => [],
-      'Number of re-engagement campaigns filtered by segment in the last 7 days' => [],
-      'Number of re-engagement campaigns filtered by segment in the last 30 days' => [],
-      'Number of re-engagement campaigns filtered by segment in the last 3 months' => [],
-
-      'Number of post notification campaigns sent in the last 7 days' => [],
-      'Number of post notification campaigns sent in the last 30 days' => [],
-      'Number of post notification campaigns sent in the last 3 months' => [],
-      'Number of post notification campaigns sent to segment in the last 7 days' => [],
-      'Number of post notification campaigns sent to segment in the last 30 days' => [],
-      'Number of post notification campaigns sent to segment in the last 3 months' => [],
-      'Number of post notification campaigns filtered by segment in the last 7 days' => [],
-      'Number of post notification campaigns filtered by segment in the last 30 days' => [],
-      'Number of post notification campaigns filtered by segment in the last 3 months' => [],
-
-      // Legacy
-      'Number of legacy welcome email campaigns sent in the last 7 days' => [],
-      'Number of legacy welcome email campaigns sent in the last 30 days' => [],
-      'Number of legacy welcome email campaigns sent in the last 3 months' => [],
-
-      'Number of legacy abandoned cart campaigns sent in the last 7 days' => [],
-      'Number of legacy abandoned cart campaigns sent in the last 30 days' => [],
-      'Number of legacy abandoned cart campaigns sent in the last 3 months' => [],
-
-      'Number of legacy first purchase campaigns sent in the last 7 days' => [],
-      'Number of legacy first purchase campaigns sent in the last 30 days' => [],
-      'Number of legacy first purchase campaigns sent in the last 3 months' => [],
-
-      'Number of legacy purchased in category campaigns sent in the last 7 days' => [],
-      'Number of legacy purchased in category campaigns sent in the last 30 days' => [],
-      'Number of legacy purchased in category campaigns sent in the last 3 months' => [],
-
-      'Number of legacy purchased product campaigns sent in the last 7 days' => [],
-      'Number of legacy purchased product campaigns sent in the last 30 days' => [],
-      'Number of legacy purchased product campaigns sent in the last 3 months' => [],
-
-      // Totals
-      'Number of campaigns sent in the last 7 days' => [],
-      'Number of campaigns sent in the last 30 days' => [],
-      'Number of campaigns sent in the last 3 months' => [],
-      'Number of campaigns sent to segment in the last 7 days' => [],
-      'Number of campaigns sent to segment in the last 30 days' => [],
-      'Number of campaigns sent to segment in the last 3 months' => [],
-      'Number of campaigns filtered by segment in the last 7 days' => [],
-      'Number of campaigns filtered by segment in the last 30 days' => [],
-      'Number of campaigns filtered by segment in the last 3 months' => [],
-    ];
-
-    $processedResults = $this->getProcessedCampaignAnalytics();
-
-    foreach ($processedResults as $campaignId => $processedResult) {
-      $isNewerThan7DaysAgo = $processedResult['sentLast7Days'] ?? false;
-      $isNewerThan30DaysAgo = $processedResult['sentLast30Days'] ?? false;
-      $isNewerThan3MonthsAgo = $processedResult['sentLast3Months'] ?? false;
-
-      $newsletterType = $processedResult['newsletterType'];
-
-      $wasSentToDynamicSegment = $processedResult['sentToSegment'] ?? false;
-      $wasFilteredBySegment = $processedResult['filteredBySegment'] ?? false;
-
-      // Totals
-      if ($isNewerThan7DaysAgo) {
-        $matchingCampaignIds['Number of campaigns sent in the last 7 days'][] = $campaignId;
-        $matchingCampaignIds['Number of campaigns sent in the last 30 days'][] = $campaignId;
-        $matchingCampaignIds['Number of campaigns sent in the last 3 months'][] = $campaignId;
-        if ($wasSentToDynamicSegment) {
-          $matchingCampaignIds['Number of campaigns sent to segment in the last 7 days'][] = $campaignId;
-          $matchingCampaignIds['Number of campaigns sent to segment in the last 30 days'][] = $campaignId;
-          $matchingCampaignIds['Number of campaigns sent to segment in the last 3 months'][] = $campaignId;
-        }
-        if ($wasFilteredBySegment) {
-          $matchingCampaignIds['Number of campaigns filtered by segment in the last 7 days'][] = $campaignId;
-          $matchingCampaignIds['Number of campaigns filtered by segment in the last 30 days'][] = $campaignId;
-          $matchingCampaignIds['Number of campaigns filtered by segment in the last 3 months'][] = $campaignId;
-        }
-      } elseif ($isNewerThan30DaysAgo) {
-        $matchingCampaignIds['Number of campaigns sent in the last 30 days'][] = $campaignId;
-        $matchingCampaignIds['Number of campaigns sent in the last 3 months'][] = $campaignId;
-        if ($wasSentToDynamicSegment) {
-          $matchingCampaignIds['Number of campaigns sent to segment in the last 30 days'][] = $campaignId;
-          $matchingCampaignIds['Number of campaigns sent to segment in the last 3 months'][] = $campaignId;
-        }
-        if ($wasFilteredBySegment) {
-          $matchingCampaignIds['Number of campaigns filtered by segment in the last 30 days'][] = $campaignId;
-          $matchingCampaignIds['Number of campaigns filtered by segment in the last 3 months'][] = $campaignId;
-        }
-      } elseif ($isNewerThan3MonthsAgo) {
-        $matchingCampaignIds['Number of campaigns sent in the last 3 months'][] = $campaignId;
-        if ($wasSentToDynamicSegment) {
-          $matchingCampaignIds['Number of campaigns sent to segment in the last 3 months'][] = $campaignId;
-        }
-        if ($wasFilteredBySegment) {
-          $matchingCampaignIds['Number of campaigns filtered by segment in the last 3 months'][] = $campaignId;
-        }
-      }
-
-      switch ($newsletterType) {
-        case NewsletterEntity::TYPE_STANDARD:
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of standard newsletters sent in last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of standard newsletters sent in last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of standard newsletters sent in last 3 months'][] = $campaignId;
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of standard newsletters filtered by segment in last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of standard newsletters filtered by segment in last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of standard newsletters filtered by segment in last 3 months'][] = $campaignId;
-            }
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of standard newsletters sent to segment in last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of standard newsletters sent to segment in last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of standard newsletters sent to segment in last 3 months'][] = $campaignId;
-            }
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of standard newsletters sent in last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of standard newsletters sent in last 3 months'][] = $campaignId;
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of standard newsletters filtered by segment in last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of standard newsletters filtered by segment in last 3 months'][] = $campaignId;
-            }
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of standard newsletters sent to segment in last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of standard newsletters sent to segment in last 3 months'][] = $campaignId;
-            }
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of standard newsletters sent in last 3 months'][] = $campaignId;
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of standard newsletters filtered by segment in last 3 months'][] = $campaignId;
-            }
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of standard newsletters sent to segment in last 3 months'][] = $campaignId;
-            }
-          }
-          break;
-        case NewsletterEntity::TYPE_NOTIFICATION_HISTORY:
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of post notification campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of post notification campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of post notification campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of post notification campaigns sent to segment in the last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of post notification campaigns sent to segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of post notification campaigns sent to segment in the last 3 months'][] = $campaignId;
-            }
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of post notification campaigns filtered by segment in the last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of post notification campaigns filtered by segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of post notification campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of post notification campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of post notification campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of post notification campaigns sent to segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of post notification campaigns sent to segment in the last 3 months'][] = $campaignId;
-            }
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of post notification campaigns filtered by segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of post notification campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of post notification campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of post notification campaigns sent to segment in the last 3 months'][] = $campaignId;
-            }
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of post notification campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
-          }
-          break;
-        case NewsletterEntity::TYPE_RE_ENGAGEMENT:
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of re-engagement campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of re-engagement campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of re-engagement campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of re-engagement campaigns sent to segment in the last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of re-engagement campaigns sent to segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of re-engagement campaigns sent to segment in the last 3 months'][] = $campaignId;
-            }
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of re-engagement campaigns filtered by segment in the last 7 days'][] = $campaignId;
-              $matchingCampaignIds['Number of re-engagement campaigns filtered by segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of re-engagement campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of re-engagement campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of re-engagement campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of re-engagement campaigns sent to segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of re-engagement campaigns sent to segment in the last 3 months'][] = $campaignId;
-            }
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of re-engagement campaigns filtered by segment in the last 30 days'][] = $campaignId;
-              $matchingCampaignIds['Number of re-engagement campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of re-engagement campaigns sent in the last 3 months'][] = $campaignId;
-            if ($wasSentToDynamicSegment) {
-              $matchingCampaignIds['Number of re-engagement campaigns sent to segment in the last 3 months'][] = $campaignId;
-            }
-            if ($wasFilteredBySegment) {
-              $matchingCampaignIds['Number of re-engagement campaigns filtered by segment in the last 3 months'][] = $campaignId;
-            }
-          }
-          break;
-        case NewsletterEntity::TYPE_WELCOME:
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of legacy welcome email campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy welcome email campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy welcome email campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of legacy welcome email campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy welcome email campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of legacy welcome email campaigns sent in the last 3 months'][] = $campaignId;
-          }
-          break;
-        case NewsletterEntity::TYPE_AUTOMATION:
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of automations campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of automations campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of automations campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of automations campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of automations campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of automations campaigns sent in the last 3 months'][] = $campaignId;
-          }
-          break;
-        // Legacy automatic emails.
-        case 'purchasedProduct':
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of legacy purchased product campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy purchased product campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy purchased product campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of legacy purchased product campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy purchased product campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of legacy purchased product campaigns sent in the last 3 months'][] = $campaignId;
-          }
-          break;
-        case 'purchasedInCategory':
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of legacy purchased in category campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy purchased in category campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy purchased in category campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of legacy purchased in category campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy purchased in category campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of legacy purchased in category campaigns sent in the last 3 months'][] = $campaignId;
-          }
-          break;
-        case 'abandonedCart':
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of legacy abandoned cart campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy abandoned cart campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy abandoned cart campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of legacy abandoned cart campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy abandoned cart campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of legacy abandoned cart campaigns sent in the last 3 months'][] = $campaignId;
-          }
-          break;
-        case 'firstPurchase':
-          if ($isNewerThan7DaysAgo) {
-            $matchingCampaignIds['Number of legacy first purchase campaigns sent in the last 7 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy first purchase campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy first purchase campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan30DaysAgo) {
-            $matchingCampaignIds['Number of legacy first purchase campaigns sent in the last 30 days'][] = $campaignId;
-            $matchingCampaignIds['Number of legacy first purchase campaigns sent in the last 3 months'][] = $campaignId;
-          } elseif ($isNewerThan3MonthsAgo) {
-            $matchingCampaignIds['Number of legacy first purchase campaigns sent in the last 3 months'][] = $campaignId;
-          }
-          break;
-      }
-    }
-
-    $returnData = [];
-
-    foreach ($matchingCampaignIds as $key => $campaignIds) {
-      $returnData[$key] = count(array_unique($campaignIds));
-    }
-
-    return $returnData;
-  }
-
-  public function getProcessedCampaignAnalytics(): array {
-    $rawData = $this->sendingQueuesRepository->getCampaignAnalyticsQuery()->getArrayResult();
-    $processedResults = [];
-
-    foreach ($rawData as $sendingInfo) {
-      $meta = $sendingInfo['sendingQueueMeta'];
-      $campaignId = $meta['campaignId'] ?? null;
-
-      if (!is_string($campaignId)) {
-        continue;
-      }
-
-      if (!isset($processedResults[$campaignId])) {
-        $newsletterType = $sendingInfo['newsletterType'];
-        $processedData = [
-          'campaignId' => $campaignId,
-          'newsletterType' => $newsletterType,
-          'automaticSubType' => null,
-          'sentToSegment' => (bool)$sendingInfo['sentToSegment'],
-          'sentLast7Days' => (bool)$sendingInfo['sentLast7Days'],
-          'sentLast30Days' => (bool)$sendingInfo['sentLast30Days'],
-          'sentLast3Months' => (bool)$sendingInfo['sentLast3Months'],
-          'filteredBySegment' => !!($meta['filterSegment'] ?? null),
-        ];
-        $processedResults[$campaignId] = $processedData;
-        if ($newsletterType === NewsletterEntity::TYPE_AUTOMATIC) {
-          try {
-            // Although we could determine the subtype by joining the appropriate newsletter option field, using
-            // the meta should be just as reliable, and we need the meta anyway, so this keeps our query simpler.
-            $subType = $this->getLegacyAutomaticEmailSubtypeFromMeta($meta);
-            $processedResults[$campaignId]['newsletterType'] = $subType;
-          } catch (UnexpectedValueException $e) {
-            // Ignore this error, the `automatic` email type won't be counted
-          }
-        }
-      } else {
-        if ($sendingInfo['sentLast7Days']) {
-          $processedResults[$campaignId]['sentLast7Days'] = true;
-        }
-        if ($sendingInfo['sentLast30Days']) {
-          $processedResults[$campaignId]['sentLast30Days'] = true;
-        }
-        if ($sendingInfo['sentLast3Months']) {
-          $processedResults[$campaignId]['sentLast3Months'] = true;
-        }
-        if ($sendingInfo['sentToSegment']) {
-          $processedResults[$campaignId]['sentToSegment'] = true;
-        }
-      }
-    }
-
-    return $processedResults;
-  }
-
-  private function getLegacyAutomaticEmailSubtypeFromMeta(array $meta): string {
-    if (array_key_exists('orderedProducts', $meta)) {
-      return 'purchasedProduct';
-    }
-    if (array_key_exists('orderedProductCategories', $meta)) {
-      return 'purchasedInCategory';
-    }
-    if (array_key_exists('cart_product_ids', $meta)) {
-      return 'abandonedCart';
-    }
-    if (array_key_exists('order_amount', $meta) && array_key_exists('order_date', $meta) && array_key_exists('order_id', $meta)) {
-      return 'firstPurchase';
-    }
-
-    throw new UnexpectedValueException('Unknown automatic email type based on meta data');
   }
 
   private function isFilterTypeActive(string $filterType, string $action): bool {

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -759,10 +759,6 @@ class Reporter {
     $rawData = $this->newslettersRepository->getCampaignAnalyticsQuery()->getArrayResult();
     $processedResults = [];
 
-    $sevenDaysAgo = Carbon::now()->subDays(7);
-    $thirtyDaysAgo = Carbon::now()->subDays(30);
-    $threeMonthsAgo = Carbon::now()->subMonths(3);
-
     foreach ($rawData as $sendingInfo) {
       $meta = $sendingInfo['sendingQueueMeta'];
       $campaignId = $meta['campaignId'] ?? null;
@@ -770,8 +766,6 @@ class Reporter {
       if (!is_string($campaignId)) {
         continue;
       }
-      /** @var \DateTime $processedAt */
-      $processedAt = $sendingInfo['processedAt'];
 
       if (!isset($processedResults[$campaignId])) {
         $newsletterType = $sendingInfo['newsletterType'];
@@ -780,9 +774,9 @@ class Reporter {
           'newsletterType' => $newsletterType,
           'automaticSubType' => null,
           'sentToSegment' => $sendingInfo['segmentType'] === 'dynamic',
-          'sentLast7Days' => $processedAt > $sevenDaysAgo,
-          'sentLast30Days' => $processedAt > $thirtyDaysAgo,
-          'sentLast3Months' => $processedAt > $threeMonthsAgo,
+          'sentLast7Days' => (bool)$sendingInfo['sentLast7Days'],
+          'sentLast30Days' => (bool)$sendingInfo['sentLast30Days'],
+          'sentLast3Months' => (bool)$sendingInfo['sentLast3Months'],
           'filteredBySegment' => !!($meta['filterSegment'] ?? null),
         ];
         $processedResults[$campaignId] = $processedData;
@@ -799,15 +793,6 @@ class Reporter {
       } else {
         if ($sendingInfo['segmentType'] === 'dynamic') {
           $processedResults[$campaignId]['sentToSegment'] = true;
-        }
-        if ($processedAt > $sevenDaysAgo) {
-          $processedResults[$campaignId]['sentLast7Days'] = true;
-        }
-        if ($processedAt > $thirtyDaysAgo) {
-          $processedResults[$campaignId]['sentLast30Days'] = true;
-        }
-        if ($processedAt > $threeMonthsAgo) {
-          $processedResults[$campaignId]['sentLast3Months'] = true;
         }
       }
     }

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -173,6 +173,7 @@ class Reporter {
       'Tracking level' => $this->settings->get('tracking.level', TrackingConfig::LEVEL_FULL),
       'Premium key valid' => $this->servicesChecker->isPremiumKeyValid(),
       'New subscriber notifications' => NewSubscriberNotificationMailer::isDisabled($this->settings->get(NewSubscriberNotificationMailer::SETTINGS_KEY)),
+      'Number of standard newsletters sent in last 7 days' => $newsletters['sent_newsletters_7_days'],
       'Number of standard newsletters sent in last 3 months' => $newsletters['sent_newsletters_3_months'],
       'Number of standard newsletters sent in last 30 days' => $newsletters['sent_newsletters_30_days'],
       'Number of active post notifications' => $newsletters['notifications_count'],

--- a/mailpoet/lib/Analytics/ReporterCampaignData.php
+++ b/mailpoet/lib/Analytics/ReporterCampaignData.php
@@ -1,0 +1,466 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Analytics;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\UnexpectedValueException;
+
+class ReporterCampaignData {
+
+
+  const STANDARD_7_DAYS = 'Number of standard newsletters sent in last 7 days';
+  const STANDARD_30_DAYS = 'Number of standard newsletters sent in last 30 days';
+  const STANDARD_3_MONTHS = 'Number of standard newsletters sent in last 3 months';
+  const STANDARD_SEGMENT_7_DAYS = 'Number of standard newsletters sent to segment in last 7 days';
+  const STANDARD_SEGMENT_30_DAYS = 'Number of standard newsletters sent to segment in last 30 days';
+  const STANDARD_SEGMENT_3_MONTHS = 'Number of standard newsletters sent to segment in last 3 months';
+  const STANDARD_FILTERED_SEGMENT_7_DAYS = 'Number of standard newsletters filtered by segment in last 7 days';
+  const STANDARD_FILTERED_SEGMENT_30_DAYS = 'Number of standard newsletters filtered by segment in last 30 days';
+  const STANDARD_FILTERED_SEGMENT_3_MONTHS = 'Number of standard newsletters filtered by segment in last 3 months';
+  const AUTOMATION_7_DAYS = 'Number of automations campaigns sent in the last 7 days';
+  const AUTOMATION_30_DAYS = 'Number of automations campaigns sent in the last 30 days';
+  const AUTOMATION_3_MONTHS = 'Number of automations campaigns sent in the last 3 months';
+  const RE_ENGAGEMENT_7_DAYS = 'Number of re-engagement campaigns sent in the last 7 days';
+  const RE_ENGAGEMENT_30_DAYS = 'Number of re-engagement campaigns sent in the last 30 days';
+  const RE_ENGAGEMENT_3_MONTHS = 'Number of re-engagement campaigns sent in the last 3 months';
+  const RE_ENGAGEMENT_SEGMENT_7_DAYS = 'Number of re-engagement campaigns sent to segment in the last 7 days';
+  const RE_ENGAGEMENT_SEGMENT_30_DAYS = 'Number of re-engagement campaigns sent to segment in the last 30 days';
+  const RE_ENGAGEMENT_SEGMENT_3_MONTHS = 'Number of re-engagement campaigns sent to segment in the last 3 months';
+  const RE_ENGAGEMENT_FILTERED_SEGMENT_7_DAYS = 'Number of re-engagement campaigns filtered by segment in the last 7 days';
+  const RE_ENGAGEMENT_FILTERED_SEGMENT_30_DAYS = 'Number of re-engagement campaigns filtered by segment in the last 30 days';
+  const RE_ENGAGEMENT_FILTERED_SEGMENT_3_MONTHS = 'Number of re-engagement campaigns filtered by segment in the last 3 months';
+  const POST_NOTIFICATION_7_DAYS = 'Number of post notification campaigns sent in the last 7 days';
+  const POST_NOTIFICATION_30_DAYS = 'Number of post notification campaigns sent in the last 30 days';
+  const POST_NOTIFICATION_3_MONTHS = 'Number of post notification campaigns sent in the last 3 months';
+  const POST_NOTIFICATION_SEGMENT_7_DAYS = 'Number of post notification campaigns sent to segment in the last 7 days';
+  const POST_NOTIFICATION_SEGMENT_30_DAYS = 'Number of post notification campaigns sent to segment in the last 30 days';
+  const POST_NOTIFICATION_SEGMENT_3_MONTHS = 'Number of post notification campaigns sent to segment in the last 3 months';
+  const POST_NOTIFICATION_FILTERED_SEGMENT_7_DAYS = 'Number of post notification campaigns filtered by segment in the last 7 days';
+  const POST_NOTIFICATION_FILTERED_SEGMENT_30_DAYS = 'Number of post notification campaigns filtered by segment in the last 30 days';
+  const POST_NOTIFICATION_FILTERED_SEGMENT_3_MONTHS = 'Number of post notification campaigns filtered by segment in the last 3 months';
+
+  const LEGACY_WELCOME_7_DAYS = 'Number of legacy welcome email campaigns sent in the last 7 days';
+  const LEGACY_WELCOME_30_DAYS = 'Number of legacy welcome email campaigns sent in the last 30 days';
+  const LEGACY_WELCOME_3_MONTHS = 'Number of legacy welcome email campaigns sent in the last 3 months';
+
+  const LEGACY_ABANDONED_CART_7_DAYS = 'Number of legacy abandoned cart campaigns sent in the last 7 days';
+  const LEGACY_ABANDONED_CART_30_DAYS = 'Number of legacy abandoned cart campaigns sent in the last 30 days';
+  const LEGACY_ABANDONED_CART_3_MONTHS = 'Number of legacy abandoned cart campaigns sent in the last 3 months';
+
+  const LEGACY_FIRST_PURCHASE_7_DAYS = 'Number of legacy first purchase campaigns sent in the last 7 days';
+  const LEGACY_FIRST_PURCHASE_30_DAYS = 'Number of legacy first purchase campaigns sent in the last 30 days';
+  const LEGACY_FIRST_PURCHASE_3_MONTHS = 'Number of legacy first purchase campaigns sent in the last 3 months';
+
+  const LEGACY_PURCHASED_IN_CATEGORY_7_DAYS = 'Number of legacy purchased in category campaigns sent in the last 7 days';
+  const LEGACY_PURCHASED_IN_CATEGORY_30_DAYS = 'Number of legacy purchased in category campaigns sent in the last 30 days';
+  const LEGACY_PURCHASED_IN_CATEGORY_3_MONTHS = 'Number of legacy purchased in category campaigns sent in the last 3 months';
+
+  const LEGACY_PURCHASED_PRODUCT_7_DAYS = 'Number of legacy purchased product campaigns sent in the last 7 days';
+  const LEGACY_PURCHASED_PRODUCT_30_DAYS = 'Number of legacy purchased product campaigns sent in the last 30 days';
+  const LEGACY_PURCHASED_PRODUCT_3_MONTHS = 'Number of legacy purchased product campaigns sent in the last 3 months';
+
+  const TOTAL_CAMPAIGNS_7_DAYS = 'Number of campaigns sent in the last 7 days';
+  const TOTAL_CAMPAIGNS_30_DAYS = 'Number of campaigns sent in the last 30 days';
+  const TOTAL_CAMPAIGNS_3_MONTHS = 'Number of campaigns sent in the last 3 months';
+
+
+  const TOTAL_CAMPAIGNS_SEGMENT_7_DAYS = 'Number of campaigns sent to segment in the last 7 days';
+  const TOTAL_CAMPAIGNS_SEGMENT_30_DAYS = 'Number of campaigns sent to segment in the last 30 days';
+  const TOTAL_CAMPAIGNS_SEGMENT_3_MONTHS = 'Number of campaigns sent to segment in the last 3 months';
+
+  const TOTAL_CAMPAIGNS_FILTERED_SEGMENT_7_DAYS = 'Number of campaigns filtered by segment in the last 7 days';
+  const TOTAL_CAMPAIGNS_FILTERED_SEGMENT_30_DAYS = 'Number of campaigns filtered by segment in the last 30 days';
+  const TOTAL_CAMPAIGNS_FILTERED_SEGMENT_3_MONTHS = 'Number of campaigns filtered by segment in the last 3 months';
+
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
+  public function __construct(
+    SendingQueuesRepository $sendingQueuesRepository
+  ) {
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+  }
+
+  public function getCampaignAnalyticsProperties(): array {
+    $returnData = [
+      self::STANDARD_7_DAYS => 0,
+      self::STANDARD_30_DAYS => 0,
+      self::STANDARD_3_MONTHS => 0,
+
+      self::STANDARD_SEGMENT_7_DAYS => 0,
+      self::STANDARD_SEGMENT_30_DAYS => 0,
+      self::STANDARD_SEGMENT_3_MONTHS => 0,
+
+      self::STANDARD_FILTERED_SEGMENT_7_DAYS => 0,
+      self::STANDARD_FILTERED_SEGMENT_30_DAYS => 0,
+      self::STANDARD_FILTERED_SEGMENT_3_MONTHS => 0,
+
+      self::AUTOMATION_7_DAYS => 0,
+      self::AUTOMATION_30_DAYS => 0,
+      self::AUTOMATION_3_MONTHS => 0,
+
+      self::RE_ENGAGEMENT_7_DAYS => 0,
+      self::RE_ENGAGEMENT_30_DAYS => 0,
+      self::RE_ENGAGEMENT_3_MONTHS => 0,
+
+      self::RE_ENGAGEMENT_SEGMENT_7_DAYS => 0,
+      self::RE_ENGAGEMENT_SEGMENT_30_DAYS => 0,
+      self::RE_ENGAGEMENT_SEGMENT_3_MONTHS => 0,
+
+      self::RE_ENGAGEMENT_FILTERED_SEGMENT_7_DAYS => 0,
+      self::RE_ENGAGEMENT_FILTERED_SEGMENT_30_DAYS => 0,
+      self::RE_ENGAGEMENT_FILTERED_SEGMENT_3_MONTHS => 0,
+
+      self::POST_NOTIFICATION_7_DAYS => 0,
+      self::POST_NOTIFICATION_30_DAYS => 0,
+      self::POST_NOTIFICATION_3_MONTHS => 0,
+
+      self::POST_NOTIFICATION_SEGMENT_7_DAYS => 0,
+      self::POST_NOTIFICATION_SEGMENT_30_DAYS => 0,
+      self::POST_NOTIFICATION_SEGMENT_3_MONTHS => 0,
+
+      self::POST_NOTIFICATION_FILTERED_SEGMENT_7_DAYS => 0,
+      self::POST_NOTIFICATION_FILTERED_SEGMENT_30_DAYS => 0,
+      self::POST_NOTIFICATION_FILTERED_SEGMENT_3_MONTHS => 0,
+
+      // Legacy
+      self::LEGACY_WELCOME_7_DAYS => 0,
+      self::LEGACY_WELCOME_30_DAYS => 0,
+      self::LEGACY_WELCOME_3_MONTHS => 0,
+
+      self::LEGACY_ABANDONED_CART_7_DAYS => 0,
+      self::LEGACY_ABANDONED_CART_30_DAYS => 0,
+      self::LEGACY_ABANDONED_CART_3_MONTHS => 0,
+
+      self::LEGACY_FIRST_PURCHASE_7_DAYS => 0,
+      self::LEGACY_FIRST_PURCHASE_30_DAYS => 0,
+      self::LEGACY_FIRST_PURCHASE_3_MONTHS => 0,
+
+      self::LEGACY_PURCHASED_IN_CATEGORY_7_DAYS => 0,
+      self::LEGACY_PURCHASED_IN_CATEGORY_30_DAYS => 0,
+      self::LEGACY_PURCHASED_IN_CATEGORY_3_MONTHS => 0,
+
+      self::LEGACY_PURCHASED_PRODUCT_7_DAYS => 0,
+      self::LEGACY_PURCHASED_PRODUCT_30_DAYS => 0,
+      self::LEGACY_PURCHASED_PRODUCT_3_MONTHS => 0,
+
+      // Totals
+      self::TOTAL_CAMPAIGNS_7_DAYS => 0,
+      self::TOTAL_CAMPAIGNS_30_DAYS => 0,
+      self::TOTAL_CAMPAIGNS_3_MONTHS => 0,
+      self::TOTAL_CAMPAIGNS_SEGMENT_7_DAYS => 0,
+      self::TOTAL_CAMPAIGNS_SEGMENT_30_DAYS => 0,
+      self::TOTAL_CAMPAIGNS_SEGMENT_3_MONTHS => 0,
+      self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_7_DAYS => 0,
+      self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_30_DAYS => 0,
+      self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_3_MONTHS => 0,
+    ];
+
+    $processedResults = $this->getProcessedCampaignAnalytics();
+
+    foreach ($processedResults as $campaignId => $processedResult) {
+      $isNewerThan7DaysAgo = $processedResult['sentLast7Days'] ?? false;
+      $isNewerThan30DaysAgo = $processedResult['sentLast30Days'] ?? false;
+      $isNewerThan3MonthsAgo = $processedResult['sentLast3Months'] ?? false;
+
+      $newsletterType = $processedResult['newsletterType'];
+
+      $wasSentToDynamicSegment = $processedResult['sentToSegment'] ?? false;
+      $wasFilteredBySegment = $processedResult['filteredBySegment'] ?? false;
+
+      // Totals
+      if ($isNewerThan7DaysAgo) {
+        $returnData[self::TOTAL_CAMPAIGNS_7_DAYS]++;
+        $returnData[self::TOTAL_CAMPAIGNS_30_DAYS]++;
+        $returnData[self::TOTAL_CAMPAIGNS_3_MONTHS]++;
+        if ($wasSentToDynamicSegment) {
+          $returnData[self::TOTAL_CAMPAIGNS_SEGMENT_7_DAYS]++;
+          $returnData[self::TOTAL_CAMPAIGNS_SEGMENT_30_DAYS]++;
+          $returnData[self::TOTAL_CAMPAIGNS_SEGMENT_3_MONTHS]++;
+        }
+        if ($wasFilteredBySegment) {
+          $returnData[self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_7_DAYS]++;
+          $returnData[self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_30_DAYS]++;
+          $returnData[self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_3_MONTHS]++;
+        }
+      } elseif ($isNewerThan30DaysAgo) {
+        $returnData[self::TOTAL_CAMPAIGNS_30_DAYS]++;
+        $returnData[self::TOTAL_CAMPAIGNS_3_MONTHS]++;
+        if ($wasSentToDynamicSegment) {
+          $returnData[self::TOTAL_CAMPAIGNS_SEGMENT_30_DAYS]++;
+          $returnData[self::TOTAL_CAMPAIGNS_SEGMENT_3_MONTHS]++;
+        }
+        if ($wasFilteredBySegment) {
+          $returnData[self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_30_DAYS]++;
+          $returnData[self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_3_MONTHS]++;
+        }
+      } elseif ($isNewerThan3MonthsAgo) {
+        $returnData[self::TOTAL_CAMPAIGNS_3_MONTHS]++;
+        if ($wasSentToDynamicSegment) {
+          $returnData[self::TOTAL_CAMPAIGNS_SEGMENT_3_MONTHS]++;
+        }
+        if ($wasFilteredBySegment) {
+          $returnData[self::TOTAL_CAMPAIGNS_FILTERED_SEGMENT_3_MONTHS]++;
+        }
+      }
+
+      switch ($newsletterType) {
+        case NewsletterEntity::TYPE_STANDARD:
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::STANDARD_7_DAYS]++;
+            $returnData[self::STANDARD_30_DAYS]++;
+            $returnData[self::STANDARD_3_MONTHS]++;
+            if ($wasFilteredBySegment) {
+              $returnData[self::STANDARD_FILTERED_SEGMENT_7_DAYS]++;
+              $returnData[self::STANDARD_FILTERED_SEGMENT_30_DAYS]++;
+              $returnData[self::STANDARD_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::STANDARD_SEGMENT_7_DAYS]++;
+              $returnData[self::STANDARD_SEGMENT_30_DAYS]++;
+              $returnData[self::STANDARD_SEGMENT_3_MONTHS]++;
+            }
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::STANDARD_30_DAYS]++;
+            $returnData[self::STANDARD_3_MONTHS]++;
+            if ($wasFilteredBySegment) {
+              $returnData[self::STANDARD_FILTERED_SEGMENT_30_DAYS]++;
+              $returnData[self::STANDARD_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::STANDARD_SEGMENT_30_DAYS]++;
+              $returnData[self::STANDARD_SEGMENT_3_MONTHS]++;
+            }
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::STANDARD_3_MONTHS]++;
+            if ($wasFilteredBySegment) {
+              $returnData[self::STANDARD_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::STANDARD_SEGMENT_3_MONTHS]++;
+            }
+          }
+          break;
+        case NewsletterEntity::TYPE_NOTIFICATION_HISTORY:
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::POST_NOTIFICATION_7_DAYS]++;
+            $returnData[self::POST_NOTIFICATION_30_DAYS]++;
+            $returnData[self::POST_NOTIFICATION_3_MONTHS]++;
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::POST_NOTIFICATION_SEGMENT_7_DAYS]++;
+              $returnData[self::POST_NOTIFICATION_SEGMENT_30_DAYS]++;
+              $returnData[self::POST_NOTIFICATION_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasFilteredBySegment) {
+              $returnData[self::POST_NOTIFICATION_FILTERED_SEGMENT_7_DAYS]++;
+              $returnData[self::POST_NOTIFICATION_FILTERED_SEGMENT_30_DAYS]++;
+              $returnData[self::POST_NOTIFICATION_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::POST_NOTIFICATION_30_DAYS]++;
+            $returnData[self::POST_NOTIFICATION_3_MONTHS]++;
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::POST_NOTIFICATION_SEGMENT_30_DAYS]++;
+              $returnData[self::POST_NOTIFICATION_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasFilteredBySegment) {
+              $returnData[self::POST_NOTIFICATION_FILTERED_SEGMENT_30_DAYS]++;
+              $returnData[self::POST_NOTIFICATION_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::POST_NOTIFICATION_3_MONTHS]++;
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::POST_NOTIFICATION_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasFilteredBySegment) {
+              $returnData[self::POST_NOTIFICATION_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+          }
+          break;
+        case NewsletterEntity::TYPE_RE_ENGAGEMENT:
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::RE_ENGAGEMENT_7_DAYS]++;
+            $returnData[self::RE_ENGAGEMENT_30_DAYS]++;
+            $returnData[self::RE_ENGAGEMENT_3_MONTHS]++;
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::RE_ENGAGEMENT_SEGMENT_7_DAYS]++;
+              $returnData[self::RE_ENGAGEMENT_SEGMENT_30_DAYS]++;
+              $returnData[self::RE_ENGAGEMENT_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasFilteredBySegment) {
+              $returnData[self::RE_ENGAGEMENT_FILTERED_SEGMENT_7_DAYS]++;
+              $returnData[self::RE_ENGAGEMENT_FILTERED_SEGMENT_30_DAYS]++;
+              $returnData[self::RE_ENGAGEMENT_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::RE_ENGAGEMENT_30_DAYS]++;
+            $returnData[self::RE_ENGAGEMENT_3_MONTHS]++;
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::RE_ENGAGEMENT_SEGMENT_30_DAYS]++;
+              $returnData[self::RE_ENGAGEMENT_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasFilteredBySegment) {
+              $returnData[self::RE_ENGAGEMENT_FILTERED_SEGMENT_30_DAYS]++;
+              $returnData[self::RE_ENGAGEMENT_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::RE_ENGAGEMENT_3_MONTHS]++;
+            if ($wasSentToDynamicSegment) {
+              $returnData[self::RE_ENGAGEMENT_SEGMENT_3_MONTHS]++;
+            }
+            if ($wasFilteredBySegment) {
+              $returnData[self::RE_ENGAGEMENT_FILTERED_SEGMENT_3_MONTHS]++;
+            }
+          }
+          break;
+        case NewsletterEntity::TYPE_WELCOME:
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::LEGACY_WELCOME_7_DAYS]++;
+            $returnData[self::LEGACY_WELCOME_30_DAYS]++;
+            $returnData[self::LEGACY_WELCOME_3_MONTHS]++;
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::LEGACY_WELCOME_30_DAYS]++;
+            $returnData[self::LEGACY_WELCOME_3_MONTHS]++;
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::LEGACY_WELCOME_3_MONTHS]++;
+          }
+          break;
+        case NewsletterEntity::TYPE_AUTOMATION:
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::AUTOMATION_7_DAYS]++;
+            $returnData[self::AUTOMATION_30_DAYS]++;
+            $returnData[self::AUTOMATION_3_MONTHS]++;
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::AUTOMATION_30_DAYS]++;
+            $returnData[self::AUTOMATION_3_MONTHS]++;
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::AUTOMATION_3_MONTHS]++;
+          }
+          break;
+        // Legacy automatic emails.
+        case 'purchasedProduct':
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::LEGACY_PURCHASED_PRODUCT_7_DAYS]++;
+            $returnData[self::LEGACY_PURCHASED_PRODUCT_30_DAYS]++;
+            $returnData[self::LEGACY_PURCHASED_PRODUCT_3_MONTHS]++;
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::LEGACY_PURCHASED_PRODUCT_30_DAYS]++;
+            $returnData[self::LEGACY_PURCHASED_PRODUCT_3_MONTHS]++;
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::LEGACY_PURCHASED_PRODUCT_3_MONTHS]++;
+          }
+          break;
+        case 'purchasedInCategory':
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::LEGACY_PURCHASED_IN_CATEGORY_7_DAYS]++;
+            $returnData[self::LEGACY_PURCHASED_IN_CATEGORY_30_DAYS]++;
+            $returnData[self::LEGACY_PURCHASED_IN_CATEGORY_3_MONTHS]++;
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::LEGACY_PURCHASED_IN_CATEGORY_30_DAYS]++;
+            $returnData[self::LEGACY_PURCHASED_IN_CATEGORY_3_MONTHS]++;
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::LEGACY_PURCHASED_IN_CATEGORY_3_MONTHS]++;
+          }
+          break;
+        case 'abandonedCart':
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::LEGACY_ABANDONED_CART_7_DAYS]++;
+            $returnData[self::LEGACY_ABANDONED_CART_30_DAYS]++;
+            $returnData[self::LEGACY_ABANDONED_CART_3_MONTHS]++;
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::LEGACY_ABANDONED_CART_30_DAYS]++;
+            $returnData[self::LEGACY_ABANDONED_CART_3_MONTHS]++;
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::LEGACY_ABANDONED_CART_3_MONTHS]++;
+          }
+          break;
+        case 'firstPurchase':
+          if ($isNewerThan7DaysAgo) {
+            $returnData[self::LEGACY_FIRST_PURCHASE_7_DAYS]++;
+            $returnData[self::LEGACY_FIRST_PURCHASE_30_DAYS]++;
+            $returnData[self::LEGACY_FIRST_PURCHASE_3_MONTHS]++;
+          } elseif ($isNewerThan30DaysAgo) {
+            $returnData[self::LEGACY_FIRST_PURCHASE_30_DAYS]++;
+            $returnData[self::LEGACY_FIRST_PURCHASE_3_MONTHS]++;
+          } elseif ($isNewerThan3MonthsAgo) {
+            $returnData[self::LEGACY_FIRST_PURCHASE_3_MONTHS]++;
+          }
+          break;
+      }
+    }
+
+    return $returnData;
+  }
+
+  public function getProcessedCampaignAnalytics(): array {
+    $rawData = $this->sendingQueuesRepository->getCampaignAnalyticsQuery()->getArrayResult();
+    $processedResults = [];
+
+    foreach ($rawData as $sendingInfo) {
+      $meta = $sendingInfo['sendingQueueMeta'];
+      $campaignId = $meta['campaignId'] ?? null;
+
+      if (!is_string($campaignId)) {
+        continue;
+      }
+
+      if (!isset($processedResults[$campaignId])) {
+        $newsletterType = $sendingInfo['newsletterType'];
+        $processedData = [
+          'campaignId' => $campaignId,
+          'newsletterType' => $newsletterType,
+          'automaticSubType' => null,
+          'sentToSegment' => (bool)$sendingInfo['sentToSegment'],
+          'sentLast7Days' => (bool)$sendingInfo['sentLast7Days'],
+          'sentLast30Days' => (bool)$sendingInfo['sentLast30Days'],
+          'sentLast3Months' => (bool)$sendingInfo['sentLast3Months'],
+          'filteredBySegment' => !!($meta['filterSegment'] ?? null),
+        ];
+        $processedResults[$campaignId] = $processedData;
+        if ($newsletterType === NewsletterEntity::TYPE_AUTOMATIC) {
+          try {
+            // Although we could determine the subtype by joining the appropriate newsletter option field, using
+            // the meta should be just as reliable, and we need the meta anyway, so this keeps our query simpler.
+            $subType = $this->getLegacyAutomaticEmailSubtypeFromMeta($meta);
+            $processedResults[$campaignId]['newsletterType'] = $subType;
+          } catch (UnexpectedValueException $e) {
+            // Ignore this error, the `automatic` email type won't be counted
+          }
+        }
+      } else {
+        if ($sendingInfo['sentLast7Days']) {
+          $processedResults[$campaignId]['sentLast7Days'] = true;
+        }
+        if ($sendingInfo['sentLast30Days']) {
+          $processedResults[$campaignId]['sentLast30Days'] = true;
+        }
+        if ($sendingInfo['sentLast3Months']) {
+          $processedResults[$campaignId]['sentLast3Months'] = true;
+        }
+        if ($sendingInfo['sentToSegment']) {
+          $processedResults[$campaignId]['sentToSegment'] = true;
+        }
+      }
+    }
+
+    return $processedResults;
+  }
+
+  private function getLegacyAutomaticEmailSubtypeFromMeta(array $meta): string {
+    if (array_key_exists('orderedProducts', $meta)) {
+      return 'purchasedProduct';
+    }
+    if (array_key_exists('orderedProductCategories', $meta)) {
+      return 'purchasedInCategory';
+    }
+    if (array_key_exists('cart_product_ids', $meta)) {
+      return 'abandonedCart';
+    }
+    if (array_key_exists('order_amount', $meta) && array_key_exists('order_date', $meta) && array_key_exists('order_id', $meta)) {
+      return 'firstPurchase';
+    }
+
+    throw new UnexpectedValueException('Unknown automatic email type based on meta data');
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -58,6 +58,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Analytics
     $container->autowire(\MailPoet\Analytics\Analytics::class)->setPublic(true);
     $container->autowire(\MailPoet\Analytics\Reporter::class)->setPublic(true);
+    $container->autowire(\MailPoet\Analytics\ReporterCampaignData::class)->setPublic(true);
     $container->autowire(\MailPoet\Analytics\UnsubscribeReporter::class)->setPublic(true);
     // API
     $container->autowire(\MailPoet\API\JSON\API::class)

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -194,7 +194,7 @@ class NewslettersRepository extends Repository {
       ->setParameter('threeMonthsAgo', $threeMonthsAgo)
       ->setParameter('taskStatus', ScheduledTaskEntity::STATUS_COMPLETED)
       ->setParameter('dynamicType', SegmentEntity::TYPE_DYNAMIC)
-      ->setParameter('since', Carbon::now()->subMonths(3))
+      ->setParameter('since', $threeMonthsAgo)
       ->groupBy('n.id')
       ->getQuery();
   }

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -196,6 +196,7 @@ class NewslettersRepository extends Repository {
       'automation_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATION] ?? 0,
       're-engagement_emails_count' => $analyticsMap[NewsletterEntity::TYPE_RE_ENGAGEMENT] ?? 0,
       'sent_newsletters_count' => $analyticsMap[NewsletterEntity::TYPE_STANDARD] ?? 0,
+      'sent_newsletters_7_days' => $this->getStandardNewsletterSentCount(Carbon::now()->subDays(7)),
       'sent_newsletters_3_months' => $this->getStandardNewsletterSentCount(Carbon::now()->subMonths(3)),
       'sent_newsletters_30_days' => $this->getStandardNewsletterSentCount(Carbon::now()->subDays(30)),
       'first_purchase_emails_count' => $analyticsMap[NewsletterEntity::TYPE_AUTOMATIC][FirstPurchase::SLUG] ?? 0,

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -194,7 +194,7 @@ class NewslettersRepository extends Repository {
       ->setParameter('threeMonthsAgo', $threeMonthsAgo)
       ->setParameter('taskStatus', ScheduledTaskEntity::STATUS_COMPLETED)
       ->setParameter('dynamicType', SegmentEntity::TYPE_DYNAMIC)
-      ->setParameter('since', Carbon::now()->subDays(90))
+      ->setParameter('since', Carbon::now()->subMonths(3))
       ->groupBy('n.id')
       ->getQuery();
   }

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -158,8 +158,7 @@ class SendingQueuesRepository extends Repository {
         CASE 
             WHEN t.processedAt >= :threeMonthsAgo THEN true
             ELSE false
-        END as sentLast3Months'
-      )
+        END as sentLast3Months')
       ->join('q.task', 't')
       ->leftJoin('q.newsletter', 'n')
       ->leftJoin('n.newsletterSegments', 'ns')

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -360,6 +360,7 @@ class Newsletter {
       'count_total' => 1,
       'created_at' => null,
       'updated_at' => null,
+      'meta' => null,
     ];
     $this->queues[] = array_merge($queue, $options);
     return $this;

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -484,6 +484,9 @@ class Newsletter {
       if ($queue['processed_at'] ?? null) {
         $scheduledTask->setProcessedAt($queue['processed_at']);
       }
+      if ($queue['meta']) {
+        $sendingQueue->setMeta($queue['meta']);
+      }
       $entityManager->persist($sendingQueue);
       $sendingQueue->setNewsletter($newsletter);
       $scheduledTask->setStatus($queue['status']);

--- a/mailpoet/tests/integration/Analytics/ReporterTest.php
+++ b/mailpoet/tests/integration/Analytics/ReporterTest.php
@@ -21,7 +21,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
     $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
@@ -33,7 +33,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
     $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
@@ -48,7 +48,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
     $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
@@ -66,7 +66,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
@@ -78,7 +78,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
@@ -93,7 +93,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['not' => 'relevant']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['not' => 'relevant']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['not' => 'relevant']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
@@ -111,7 +111,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
@@ -123,7 +123,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
@@ -138,7 +138,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
@@ -155,7 +155,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
     $this->assertSame(1, $processed['Number of legacy welcome email campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy welcome email campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy welcome email campaigns sent in the last 3 months']);
@@ -165,7 +165,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'cart_product_ids' => ['123']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'cart_product_ids' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'cart_product_ids' => ['1235']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
     $this->assertSame(1, $processed['Number of legacy abandoned cart campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy abandoned cart campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy abandoned cart campaigns sent in the last 3 months']);
@@ -175,7 +175,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProducts' => ['123']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProducts' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProducts' => ['1235']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
     $this->assertSame(1, $processed['Number of legacy purchased product campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy purchased product campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy purchased product campaigns sent in the last 3 months']);
@@ -185,7 +185,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProductCategories' => ['123']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProductCategories' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProductCategories' => ['1235']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
     $this->assertSame(1, $processed['Number of legacy purchased in category campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy purchased in category campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy purchased in category campaigns sent in the last 3 months']);
@@ -195,7 +195,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
     $this->assertSame(1, $processed['Number of legacy first purchase campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy first purchase campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy first purchase campaigns sent in the last 3 months']);
@@ -206,7 +206,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProductCategories' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProductCategories' => ['1235']]]]);
 
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertSame(1, $processed['Number of automations campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of automations campaigns sent in the last 30 days']);
@@ -228,7 +228,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '8', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '9', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
 
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
     $this->assertEquals(3, $processed['Number of campaigns sent in the last 7 days']);
     $this->assertEquals(6, $processed['Number of campaigns sent in the last 30 days']);
     $this->assertEquals(9, $processed['Number of campaigns sent in the last 3 months']);
@@ -247,7 +247,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
-    $processed = $this->reporter->getCampaignAnalyticsData();
+    $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 30 days']);

--- a/mailpoet/tests/integration/Analytics/ReporterTest.php
+++ b/mailpoet/tests/integration/Analytics/ReporterTest.php
@@ -1,0 +1,276 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Analytics;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\Segment;
+use MailPoetVendor\Carbon\Carbon;
+
+class ReporterTest extends \MailPoetTest {
+  private Reporter $reporter;
+
+  public function _before() {
+    parent::_before();
+    $this->reporter = $this->diContainer->get(Reporter::class);
+  }
+
+  public function testItWorksWithStandardNewslettersAndStandardSegments(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
+    $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
+    $this->assertEquals(3, $processed['Number of standard newsletters sent in last 3 months']);
+  }
+
+  public function testItWorksWithStandardNewslettersAndDynamicSegments(): void {
+    $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
+    $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
+    $this->assertEquals(3, $processed['Number of standard newsletters sent in last 3 months']);
+    $this->assertEquals(1, $processed['Number of standard newsletters sent to segment in last 7 days']);
+    $this->assertEquals(2, $processed['Number of standard newsletters sent to segment in last 30 days']);
+    $this->assertEquals(3, $processed['Number of standard newsletters sent to segment in last 3 months']);
+  }
+
+  public function testItWorksWithStandardNewslettersAndFilterSegments(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
+    $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
+    $this->assertEquals(3, $processed['Number of standard newsletters sent in last 3 months']);
+    $this->assertEquals(1, $processed['Number of standard newsletters filtered by segment in last 7 days']);
+    $this->assertEquals(2, $processed['Number of standard newsletters filtered by segment in last 30 days']);
+    $this->assertEquals(3, $processed['Number of standard newsletters filtered by segment in last 3 months']);
+    $this->assertEquals(0, $processed['Number of standard newsletters sent to segment in last 7 days']);
+    $this->assertEquals(0, $processed['Number of standard newsletters sent to segment in last 30 days']);
+    $this->assertEquals(0, $processed['Number of standard newsletters sent to segment in last 3 months']);
+  }
+
+  public function testItWorksWithNotificationHistoryNewsletters(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of post notification campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksWithNotificationHistoryNewslettersSentToSegments(): void {
+    $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of post notification campaigns sent in the last 3 months']);
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent to segment in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of post notification campaigns sent to segment in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of post notification campaigns sent to segment in the last 3 months']);
+  }
+
+  public function testItWorksWithNotificationHistoryNewslettersFilteredBySegment(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['not' => 'relevant']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['not' => 'relevant']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['not' => 'relevant']]]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of post notification campaigns sent in the last 3 months']);
+    $this->assertEquals(1, $processed['Number of post notification campaigns filtered by segment in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of post notification campaigns filtered by segment in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of post notification campaigns filtered by segment in the last 3 months']);
+    $this->assertEquals(0, $processed['Number of post notification campaigns sent to segment in the last 7 days']);
+    $this->assertEquals(0, $processed['Number of post notification campaigns sent to segment in the last 30 days']);
+    $this->assertEquals(0, $processed['Number of post notification campaigns sent to segment in the last 3 months']);
+  }
+
+  public function testItWorksWithReEngagementEmails(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of re-engagement campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksWithReEngagementEmailsSentToSegment(): void {
+    $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of re-engagement campaigns sent in the last 3 months']);
+    $this->assertEquals(1, $processed['Number of re-engagement campaigns sent to segment in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of re-engagement campaigns sent to segment in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of re-engagement campaigns sent to segment in the last 3 months']);
+  }
+
+  public function testItWorksWithReEngagementEmailsFilteredBySegment(): void {
+    $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of re-engagement campaigns sent in the last 3 months']);
+    $this->assertEquals(1, $processed['Number of re-engagement campaigns filtered by segment in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of re-engagement campaigns filtered by segment in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of re-engagement campaigns filtered by segment in the last 3 months']);
+    $this->assertEquals(0, $processed['Number of re-engagement campaigns sent to segment in the last 7 days']);
+    $this->assertEquals(0, $processed['Number of re-engagement campaigns sent to segment in the last 30 days']);
+    $this->assertEquals(0, $processed['Number of re-engagement campaigns sent to segment in the last 3 months']);
+  }
+
+  public function testItWorksWithLegacyWelcomeEmails(): void {
+    $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+    $this->assertSame(1, $processed['Number of legacy welcome email campaigns sent in the last 7 days']);
+    $this->assertSame(2, $processed['Number of legacy welcome email campaigns sent in the last 30 days']);
+    $this->assertSame(3, $processed['Number of legacy welcome email campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksWithLegacyAbandonedCartEmails(): void {
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'cart_product_ids' => ['123']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'cart_product_ids' => ['1234']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'cart_product_ids' => ['1235']]]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+    $this->assertSame(1, $processed['Number of legacy abandoned cart campaigns sent in the last 7 days']);
+    $this->assertSame(2, $processed['Number of legacy abandoned cart campaigns sent in the last 30 days']);
+    $this->assertSame(3, $processed['Number of legacy abandoned cart campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksWithLegacyPurchasedProductEmails(): void {
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProducts' => ['123']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProducts' => ['1234']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProducts' => ['1235']]]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+    $this->assertSame(1, $processed['Number of legacy purchased product campaigns sent in the last 7 days']);
+    $this->assertSame(2, $processed['Number of legacy purchased product campaigns sent in the last 30 days']);
+    $this->assertSame(3, $processed['Number of legacy purchased product campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksWithLegacyPurchasedInCategoryEmails(): void {
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProductCategories' => ['123']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProductCategories' => ['1234']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProductCategories' => ['1235']]]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+    $this->assertSame(1, $processed['Number of legacy purchased in category campaigns sent in the last 7 days']);
+    $this->assertSame(2, $processed['Number of legacy purchased in category campaigns sent in the last 30 days']);
+    $this->assertSame(3, $processed['Number of legacy purchased in category campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksWithLegacyFirstPurchaseEmails(): void {
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '3']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+    $this->assertSame(1, $processed['Number of legacy first purchase campaigns sent in the last 7 days']);
+    $this->assertSame(2, $processed['Number of legacy first purchase campaigns sent in the last 30 days']);
+    $this->assertSame(3, $processed['Number of legacy first purchase campaigns sent in the last 3 months']);
+  }
+
+  public function testItWorksForAutomationEmails(): void {
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProductCategories' => ['123']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProductCategories' => ['1234']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProductCategories' => ['1235']]]]);
+
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertSame(1, $processed['Number of automations campaigns sent in the last 7 days']);
+    $this->assertSame(2, $processed['Number of automations campaigns sent in the last 30 days']);
+    $this->assertSame(3, $processed['Number of automations campaigns sent in the last 3 months']);
+  }
+
+  public function testItReportsSentCampaignTotals(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $dynamicSegment = (new Segment())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
+
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$defaultSegment, $dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '4']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$defaultSegment, $dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '5']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$defaultSegment, $dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '6']]]);
+
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '7', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '8', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '9', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
+
+    $processed = $this->reporter->getCampaignAnalyticsData();
+    $this->assertEquals(3, $processed['Number of campaigns sent in the last 7 days']);
+    $this->assertEquals(6, $processed['Number of campaigns sent in the last 30 days']);
+    $this->assertEquals(9, $processed['Number of campaigns sent in the last 3 months']);
+
+    $this->assertEquals(1, $processed['Number of campaigns sent to segment in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of campaigns sent to segment in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of campaigns sent to segment in the last 3 months']);
+
+    $this->assertEquals(1, $processed['Number of campaigns filtered by segment in the last 7 days']);
+    $this->assertEquals(2, $processed['Number of campaigns filtered by segment in the last 30 days']);
+    $this->assertEquals(3, $processed['Number of campaigns filtered by segment in the last 3 months']);
+  }
+
+  public function testItDoesNotDoubleCountDuplicateCampaignIds(): void {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $processed = $this->reporter->getCampaignAnalyticsData();
+
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 30 days']);
+    $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 3 months']);
+  }
+
+  public function testItCanDetermineIfAnAutomationWasFilteredBySegment(): void {
+  }
+
+  private function createSentNewsletter(string $type, Carbon $sentAt, array $segments, array $otherOptions = []): void {
+    $sendingQueueOptions = ['processed_at' => $sentAt];
+
+    $extraSendingQueueOptions = $otherOptions['sendingQueueOptions'] ?? null;
+
+    if (is_array($extraSendingQueueOptions)) {
+      $sendingQueueOptions = array_merge($sendingQueueOptions, $extraSendingQueueOptions);
+    }
+
+    (new NewsletterFactory())
+      ->withType($type)
+      ->withSegments($segments)
+      ->withSendingQueue($sendingQueueOptions)
+      ->withStatus(NewsletterEntity::STATUS_SENT)
+      ->create();
+  }
+}

--- a/mailpoet/tests/integration/Analytics/ReporterTest.php
+++ b/mailpoet/tests/integration/Analytics/ReporterTest.php
@@ -254,9 +254,6 @@ class ReporterTest extends \MailPoetTest {
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 3 months']);
   }
 
-  public function testItCanDetermineIfAnAutomationWasFilteredBySegment(): void {
-  }
-
   private function createSentNewsletter(string $type, Carbon $sentAt, array $segments, array $otherOptions = []): void {
     $sendingQueueOptions = ['processed_at' => $sentAt];
 

--- a/mailpoet/tests/integration/Analytics/ReporterTest.php
+++ b/mailpoet/tests/integration/Analytics/ReporterTest.php
@@ -21,7 +21,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
     $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
@@ -33,7 +33,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
     $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
@@ -48,7 +48,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of standard newsletters sent in last 7 days']);
     $this->assertEquals(2, $processed['Number of standard newsletters sent in last 30 days']);
@@ -66,7 +66,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
@@ -78,7 +78,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
@@ -93,7 +93,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['not' => 'relevant']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['not' => 'relevant']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['not' => 'relevant']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of post notification campaigns sent in the last 30 days']);
@@ -111,7 +111,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
@@ -123,7 +123,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
@@ -138,7 +138,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(2), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(8), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_RE_ENGAGEMENT, Carbon::now()->subDays(89), [$dynamicSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of re-engagement campaigns sent in the last 7 days']);
     $this->assertEquals(2, $processed['Number of re-engagement campaigns sent in the last 30 days']);
@@ -155,7 +155,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_WELCOME, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
     $this->assertSame(1, $processed['Number of legacy welcome email campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy welcome email campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy welcome email campaigns sent in the last 3 months']);
@@ -165,7 +165,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'cart_product_ids' => ['123']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'cart_product_ids' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'cart_product_ids' => ['1235']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
     $this->assertSame(1, $processed['Number of legacy abandoned cart campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy abandoned cart campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy abandoned cart campaigns sent in the last 3 months']);
@@ -175,7 +175,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProducts' => ['123']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProducts' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProducts' => ['1235']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
     $this->assertSame(1, $processed['Number of legacy purchased product campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy purchased product campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy purchased product campaigns sent in the last 3 months']);
@@ -185,7 +185,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'orderedProductCategories' => ['123']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProductCategories' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProductCategories' => ['1235']]]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
     $this->assertSame(1, $processed['Number of legacy purchased in category campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy purchased in category campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy purchased in category campaigns sent in the last 3 months']);
@@ -195,7 +195,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(2), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '2']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATIC, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'order_amount' => 123, 'order_date' => '2024-03-01', 'order_id' => '3']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
     $this->assertSame(1, $processed['Number of legacy first purchase campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of legacy first purchase campaigns sent in the last 30 days']);
     $this->assertSame(3, $processed['Number of legacy first purchase campaigns sent in the last 3 months']);
@@ -206,7 +206,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(8), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '2', 'orderedProductCategories' => ['1234']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_AUTOMATION, Carbon::now()->subDays(89), [], ['sendingQueueOptions' => ['meta' => ['campaignId' => '3', 'orderedProductCategories' => ['1235']]]]);
 
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertSame(1, $processed['Number of automations campaigns sent in the last 7 days']);
     $this->assertSame(2, $processed['Number of automations campaigns sent in the last 30 days']);
@@ -228,7 +228,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '8', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_STANDARD, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '9', 'filterSegment' => ['theDataDoesNot' => 'matter']]]]);
 
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
     $this->assertEquals(3, $processed['Number of campaigns sent in the last 7 days']);
     $this->assertEquals(6, $processed['Number of campaigns sent in the last 30 days']);
     $this->assertEquals(9, $processed['Number of campaigns sent in the last 3 months']);
@@ -247,7 +247,7 @@ class ReporterTest extends \MailPoetTest {
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
-    $processed = $this->reporter->getCampaignAnalyticsProperties();
+    $processed = $this->reporter->getData();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 30 days']);

--- a/mailpoet/tests/integration/Analytics/ReporterTest.php
+++ b/mailpoet/tests/integration/Analytics/ReporterTest.php
@@ -244,9 +244,9 @@ class ReporterTest extends \MailPoetTest {
 
   public function testItDoesNotDoubleCountDuplicateCampaignIds(): void {
     $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
-    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
-    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(89), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(8), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
+    $this->createSentNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, Carbon::now()->subDays(2), [$defaultSegment], ['sendingQueueOptions' => ['meta' => ['campaignId' => '1']]]);
     $processed = $this->reporter->getCampaignAnalyticsProperties();
 
     $this->assertEquals(1, $processed['Number of post notification campaigns sent in the last 7 days']);


### PR DESCRIPTION
## Description

This PR adds a lot of data to the reporter about campaigns sent in the last 90 days.

## Code review notes

I intentionally left out the "sent to segment" and "filtered by segment" stats for automations because I don't think it's feasible to do it efficiently without making some bigger changes. I know we want to have more stats about automations (e.g. other trigger filter usage), which will run into a similar issue, so I think it's best to leave these stats for that work.

I'm not thrilled about the structure of the code and may update it before requesting review.

My one big question is if it's reasonable to fetch all the data at once or if I should handle it in batches. It seems like a site would need to have a ton of sending queues in a 3 month period to run into performance issues with this query, but it could happen.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
