### PR TITLE
Update Ubuntu images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,7 +264,7 @@ jobs:
   security_analysis:
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: default
       docker_layer_caching: false
     steps:
       - attach_workspace:
@@ -343,7 +343,7 @@ jobs:
     parallelism: 20
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: default
       docker_layer_caching: false
     parameters:
       multisite:
@@ -490,7 +490,7 @@ jobs:
   performance_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: default
       docker_layer_caching: false
     parameters:
       mysql_command:
@@ -589,7 +589,7 @@ jobs:
   integration_tests:
     working_directory: /home/circleci/mailpoet/mailpoet
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: default
       docker_layer_caching: false
     environment:
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>


### PR DESCRIPTION
## Description

The Ubuntu images will be deprecated and they became temporarily unavailable today (2024-03-04) during a scheduled brownout: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

We can update them already and avoid disruptions.

## Code review notes

_N/A_

## QA notes

No QA needed

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5931]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5931]: https://mailpoet.atlassian.net/browse/MAILPOET-5931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ