### PR TITLE
Add new k6 performance test for Automation Analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -971,7 +971,7 @@ workflows:
       - performance_tests:
           <<: *slack-fail-post-step
           name: performance_latest
-          url: https://mpperftesting.mystagingwebsite.com
+          url: https://mpperftesting.com
           us: $WP_TEST_PERFORMANCE_US
           pw: $WP_TEST_PERFORMANCE_PW
           scenario: nightlytests

--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -19,6 +19,7 @@ import { onboardingWizard } from './tests/onboarding-wizard.js';
 import { subscribersTrashingRestoring } from './tests/subscribers-trashing-restoring.js';
 import { automationCreateCustom } from './tests/automation-create-custom.js';
 import { automationCreateWelcome } from './tests/automation-create-welcome.js';
+import { automationAnalytics } from './tests/automation-analytics.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -101,6 +102,7 @@ export async function nightly() {
   await newsletterSending();
   await automationCreateCustom();
   await automationCreateWelcome();
+  await automationAnalytics();
   await subscribersListing();
   await subscribersFiltering();
   await subscribersAdding();

--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  automationsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import { login } from '../utils/helpers.js';
+
+export async function automationAnalytics() {
+  const page = browser.newPage();
+
+  try {
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the Automation Analytics page
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-analytics&id=142`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Analytics_01.png',
+      fullPage: fullPageSet,
+    });
+
+    // Check Emails tab
+    await page.locator('.mailpoet-analytics-tab-emails').click();
+    await page.waitForSelector('.mailpoet-automation-analytics-email-name');
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-analytics: should be able to see Emails tab loaded', () => {
+        expect(page.$$('.mailpoet-automation-analytics-email-name')).to.exist;
+      });
+    });
+
+    // Check Orders tab
+    await page.locator('.mailpoet-analytics-tab-orders').click();
+    await page.waitForSelector('.mailpoet-analytics-filter-controls');
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-analytics: should be able to see Orders tab loaded', () => {
+        expect(page.$$('.mailpoet-analytics-filter-controls')).to.exist;
+      });
+    });
+
+    // Check Subscribers tab
+    await page.locator('.mailpoet-analytics-tab-subscribers').click();
+    await page.waitForSelector('.mailpoet-analytics-multiselect');
+    // Switch to second page using pagination
+    await page.locator('.woocommerce-pagination__page-picker-input').fill('2');
+    await page.locator('.components-text-control__input').click();
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-analytics: should be able to see Subscribers items loaded', () => {
+        expect(page.$$('.woocommerce-table__item')[0]).to.exist;
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Automation_Analytics_02.png',
+      fullPage: fullPageSet,
+    });
+
+    // Filter results by date range Today
+    await page.locator('.woocommerce-dropdown-button').click();
+    await page.locator('//span[contains(text(),"Today")]').click();
+    await page.locator('.woocommerce-filters-date__button').click();
+    await page.waitForLoadState('networkidle');
+
+    // Filter results by date range Year to date
+    await page.locator('.woocommerce-dropdown-button').click();
+    await page.locator('//span[contains(text(),"Year to date")]').click();
+    await page.locator('.woocommerce-filters-date__button').click();
+    await page.waitForLoadState('networkidle');
+
+    describe(automationsPageTitle, () => {
+      describe('automation-analytics: should be able to see items in the listing', () => {
+        expect(page.$$('.mailpoet-analytics-orders__customer')[0]).to.exist;
+      });
+    });
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default function automationAnalyticsTest() {
+  automationAnalytics();
+}


### PR DESCRIPTION
## Description

Add a new k6 performance test to cover accessing automation statistics pages and filtering results there

The test is capable only for the nightlies due to requirement of the premium plugin.

As a small change I included update to the nightly test site to `mpperftesting.com`

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5865]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5865]: https://mailpoet.atlassian.net/browse/MAILPOET-5865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ