### PR TITLE
Move component PremiumModalForStepEdit from common to automations [MAILPOET-5932]

### DIFF
--- a/mailpoet/assets/js/src/automation/components/premium-modal-steps-edit/index.tsx
+++ b/mailpoet/assets/js/src/automation/components/premium-modal-steps-edit/index.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { dispatch } from '@wordpress/data';
+import { PremiumModal, PremiumModalProps } from 'common/premium-modal';
+import { withBoundary } from 'common/error-boundary';
+import { storeName } from '../../editor/store';
+
+type EditProps = Omit<PremiumModalProps, 'onRequestClose'>;
+
+function PremiumModalForStepEdit({
+  children,
+  ...props
+}: EditProps): JSX.Element {
+  const [showModal, setShowModal] = useState(true);
+  useEffect(() => {
+    if (showModal) {
+      return;
+    }
+    const { selectStep } = dispatch(storeName);
+    void selectStep(undefined);
+    setShowModal(true);
+  }, [showModal]);
+  if (!showModal) {
+    return null;
+  }
+  return (
+    <PremiumModal
+      onRequestClose={() => {
+        setShowModal(false);
+      }}
+      {...props}
+    >
+      {children}
+    </PremiumModal>
+  );
+}
+
+PremiumModalForStepEdit.displayName = 'PremiumModalForStepEdit';
+const PremiumModalForStepEditWithBoundary = withBoundary(
+  PremiumModalForStepEdit,
+);
+export { PremiumModalForStepEditWithBoundary as PremiumModalForStepEdit };

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/add-tags/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/add-tags/index.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { tag } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Add tag" automation action

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/add-to-list/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/add-to-list/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { list } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store/types';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/clicks-email-link/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/clicks-email-link/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { Icon } from './icon';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-action/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-action/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { code } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store/types';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-trigger/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-trigger/index.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { plugins } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Custom trigger" in automation

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/notification-email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/notification-email/index.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
 import { StepType } from '../../../../editor/store/types';
 import { Icon } from './icon';

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove-from-list/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove-from-list/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { list } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store/types';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove-tags/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove-tags/index.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { tag } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Remove tag" automation action

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-added/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { Icon } from './icon';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-removed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-removed/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { Icon } from './icon';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/unsubscribe/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/unsubscribe/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { Icon } from './icon';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/update-subscriber/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/update-subscriber/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { postAuthor } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store/types';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
 
 const keywords = [

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-created/index.tsx
@@ -1,7 +1,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription started" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-expired/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-expired/index.tsx
@@ -1,7 +1,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription expired" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-payment-failed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-payment-failed/index.tsx
@@ -1,7 +1,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription payment failed" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-renewed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-renewed/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription renewed" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-status-changed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-status-changed/index.tsx
@@ -1,7 +1,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription status changed" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-ended/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-ended/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription trial ended" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-started/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-started/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Woo Subscription trial started" trigger

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/made-a-review/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/made-a-review/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { Icon } from './icon';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
   // translators: noun, used as a search keyword for "Customer makes a review" trigger

--- a/mailpoet/assets/js/src/automation/integrations/wordpress/steps/made-a-comment/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/steps/made-a-comment/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { StepType } from '../../../../editor/store';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
-import { PremiumModalForStepEdit } from '../../../../../common/premium-modal';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { Icon } from './icon';
 
 const keywords = [

--- a/mailpoet/assets/js/src/common/premium-modal/index.tsx
+++ b/mailpoet/assets/js/src/common/premium-modal/index.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   Modal,
 } from '@wordpress/components';
-import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import {
@@ -23,8 +22,6 @@ import {
   useUpgradeInfo,
   UtmParams,
 } from './upgrade-info';
-import { storeName } from '../../automation/editor/store';
-import { withBoundary } from '../error-boundary';
 
 export const premiumValidAndActive =
   premiumFeaturesEnabled && MailPoet.premiumActive;
@@ -137,42 +134,4 @@ function PremiumModal({
 }
 
 PremiumModal.displayName = 'PremiumModal';
-
-type EditProps = Omit<Props, 'onRequestClose'>;
-
-function PremiumModalForStepEdit({
-  children,
-  ...props
-}: EditProps): JSX.Element {
-  const [showModal, setShowModal] = useState(true);
-  useEffect(() => {
-    if (showModal) {
-      return;
-    }
-    const { selectStep } = dispatch(storeName);
-    void selectStep(undefined);
-    setShowModal(true);
-  }, [showModal]);
-  if (!showModal) {
-    return null;
-  }
-  return (
-    <PremiumModal
-      onRequestClose={() => {
-        setShowModal(false);
-      }}
-      {...props}
-    >
-      {children}
-    </PremiumModal>
-  );
-}
-
-PremiumModalForStepEdit.displayName = 'PremiumModalForStepEdit';
-const PremiumModalForStepEditWithBoundary = withBoundary(
-  PremiumModalForStepEdit,
-);
-export {
-  PremiumModal,
-  PremiumModalForStepEditWithBoundary as PremiumModalForStepEdit,
-};
+export { PremiumModal, Props as PremiumModalProps };


### PR DESCRIPTION
## Description

This caused common components to be dependent on the automation store and caused subsequent issues when the original premium modal was used in the email editor.

## Code review notes

Currently, the acceptance build is failing, but it seems to be caused by an unrelated flaky test.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5932]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5932]: https://mailpoet.atlassian.net/browse/MAILPOET-5932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ