### PR TITLE
Email editor - add support for border color selected from palette [MAILPOET-5919]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -52,6 +52,7 @@ class ThemeController {
     foreach ($colorDefinitions as $color) {
       $cssPresets .= ".has-{$color['slug']}-color { color: {$color['color']}; } \n";
       $cssPresets .= ".has-{$color['slug']}-background-color { background-color: {$color['color']}; } \n";
+      $cssPresets .= ".has-{$color['slug']}-border-color { border-color: {$color['color']}; } \n";
     }
 
     // Block specific styles

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -21,10 +21,8 @@ class Button implements BlockRenderer {
     $buttonLink = $domHelper->findElement('a');
 
     if (!$buttonLink) return '';
-    $buttonClasses = $domHelper->getAttributeValueByTagName('div', 'class') ?? '';
-
     $markup = $this->getMarkup();
-    $markup = str_replace('{classes}', $buttonClasses, $markup);
+    $buttonClasses = $domHelper->getAttributeValueByTagName('div', 'class') ?? '';
 
     // Add Link Text
     // Because the button text can contain highlighted text, we need to get the inner HTML of the button
@@ -65,9 +63,14 @@ class Button implements BlockRenderer {
 
     // Border
     if (isset($parsedBlock['attrs']['style']['border']) && !empty($parsedBlock['attrs']['style']['border'])) {
-      // Use text color if border color is not set
+      // Use text color if border color is not set. Check for the value in the custom color text property
+      // then look also to the text color set from palette
       if (!($parsedBlock['attrs']['style']['border']['color'] ?? '')) {
-        $parsedBlock['attrs']['style']['border']['color'] = $parsedBlock['attrs']['style']['color']['text'] ?? null;
+        if (isset($parsedBlock['attrs']['style']['color']['text'])) {
+          $parsedBlock['attrs']['style']['border']['color'] = $parsedBlock['attrs']['style']['color']['text'];
+        } elseif ($parsedBlock['attrs']['textColor']) {
+          $buttonClasses .= ' has-' . $parsedBlock['attrs']['textColor'] . '-border-color';
+        }
       }
       $wrapperStyles = array_merge($wrapperStyles, wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border']])['declarations']);
       $wrapperStyles['border-style'] = 'solid';
@@ -106,6 +109,7 @@ class Button implements BlockRenderer {
 
     $markup = str_replace('{linkStyles}', $settingsController->convertStylesToString($linkStyles), $markup);
     $markup = str_replace('{wrapperStyles}', $settingsController->convertStylesToString($wrapperStyles), $markup);
+    $markup = str_replace('{classes}', $buttonClasses, $markup);
 
     return $markup;
   }

--- a/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Engine/ThemeControllerTest.php
@@ -50,14 +50,17 @@ class ThemeControllerTest extends \MailPoetTest {
     // Colors
     verify($css)->stringContainsString('.has-black-color');
     verify($css)->stringContainsString('.has-black-background-color');
+    verify($css)->stringContainsString('.has-black-border-color');
 
     verify($css)->stringContainsString('.has-black-color');
     verify($css)->stringContainsString('.has-black-background-color');
+    verify($css)->stringContainsString('.has-black-border-color');
 
     $this->checkCorrectThemeConfiguration();
     if (wp_get_theme()->get('Name') === 'Twenty Twenty-One') {
       verify($css)->stringContainsString('.has-yellow-background-color');
       verify($css)->stringContainsString('.has-yellow-color');
+      verify($css)->stringContainsString('.has-yellow-border-color');
     }
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -106,6 +106,18 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-color:#111111;');
   }
 
+  public function testItRendersBorderWithTextColorFallbackForColorsFromPalette(): void {
+    $this->parsedButton['attrs']['style']['border'] = [
+      'width' => '10px',
+    ];
+    // Custom text color is not set so we use the text color from the palette
+    $this->parsedButton['attrs']['style']['color'] = null;
+    $this->parsedButton['attrs']['textColor'] = 'white';
+    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
+    // We set proper class for border color based on the text color slug
+    verify($output)->stringContainsString('has-white-border-color');
+  }
+
   public function testItRendersEachSideSpecificBorder(): void {
     $this->parsedButton['attrs']['style']['border'] = [
       'top' => ['width' => '1px', 'color' => '#111111'],


### PR DESCRIPTION
## Description

This PR adds support for border colors selected from the color palette and fixes border color fallback (to the text color) for the button block.

## Code review notes

Currently, the acceptance build is failing, but it seems to be caused by an unrelated flaky test.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5919]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5919]: https://mailpoet.atlassian.net/browse/MAILPOET-5919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ