### PR TITLE
Fix acceptance test WooCheckoutAutomateWooSubscriptionsCest and its failing checkoutOptInChecked due to empty cart

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -508,7 +508,8 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function addProductToCart(array $product) {
     $i = $this;
-    $i->amOnPage('/product/?add-to-cart=' . $product['id']);
+    $i->amOnPage('product/' . $product['slug']);
+    $i->click('Add to cart');
     $i->waitForText("“{$product['name']}” has been added to your cart.");
   }
 

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -508,8 +508,7 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function addProductToCart(array $product) {
     $i = $this;
-    $i->amOnPage('product/' . $product['slug']);
-    $i->click('Add to cart');
+    $i->amOnPage('/product/?add-to-cart=' . $product['id']);
     $i->waitForText("“{$product['name']}” has been added to your cart.");
   }
 

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -450,10 +450,12 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   public function orderProductWithoutRegistration(array $product, $userEmail, $doSubscribe = true) {
+    $this->amOnPage('cart/?add-to-cart=' . $product['id']);
     $this->orderProduct($product, $userEmail, false, $doSubscribe);
   }
 
   public function orderProductWithRegistration(array $product, $userEmail, $doSubscribe = true) {
+    $this->amOnPage('cart/?add-to-cart=' . $product['id']);
     $this->orderProduct($product, $userEmail, true, $doSubscribe);
   }
 

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -450,12 +450,10 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   public function orderProductWithoutRegistration(array $product, $userEmail, $doSubscribe = true) {
-    $this->amOnPage('cart/?add-to-cart=' . $product['id']);
     $this->orderProduct($product, $userEmail, false, $doSubscribe);
   }
 
   public function orderProductWithRegistration(array $product, $userEmail, $doSubscribe = true) {
-    $this->amOnPage('cart/?add-to-cart=' . $product['id']);
     $this->orderProduct($product, $userEmail, true, $doSubscribe);
   }
 
@@ -465,8 +463,7 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function orderProduct(array $product, $userEmail, $doRegister = true, $doSubscribe = true) {
     $i = $this;
-    $i->addProductToCart($product);
-    $i->goToCheckout();
+    $i->amOnPage('checkout/?add-to-cart=' . $product['id']);
     $i->fillCustomerInfo($userEmail);
 
     $wooCommerceVersion = $i->getWooCommerceVersion();

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -39,20 +39,24 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->logout();
   }
 
+  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_check@example.com';
+    $i->orderProductWithRegistration($this->product, $customerEmail, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->see($customerEmail, '.automatewoo-content');
+    $i->seeConfirmationEmailWasReceived();
+  }
+
   public function checkoutOptInDisabled(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
     $i->addProductToCart($this->product);
     $i->goToCheckout();
     $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
     $i->dontSee(self::MAILPOET_OPTIN_TEXT);
-  }
-
-  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
-    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $i->addProductToCart($this->product);
-    $i->goToCheckout();
-    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
-    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
   }
 
   public function checkoutOptInUnchecked(\AcceptanceTester $i) {
@@ -67,16 +71,11 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->seeConfirmationEmailWasNotReceived();
   }
 
-  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
+  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $this->settingsFactory->withConfirmationEmailEnabled();
-    $customerEmail = 'woo_guest_check@example.com';
-    $i->addProductToCart($this->product); // to avoid flaky adding to cart from below
-    $i->orderProductWithRegistration($this->product, $customerEmail, true);
-    $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
-    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
-    $i->see($customerEmail, '.automatewoo-content');
-    $i->seeConfirmationEmailWasReceived();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
+    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
   }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -39,24 +39,20 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->logout();
   }
 
-  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
-    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $this->settingsFactory->withConfirmationEmailEnabled();
-    $customerEmail = 'woo_guest_check@example.com';
-    $i->orderProductWithRegistration($this->product, $customerEmail, true);
-    $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
-    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
-    $i->see($customerEmail, '.automatewoo-content');
-    $i->seeConfirmationEmailWasReceived();
-  }
-
   public function checkoutOptInDisabled(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
     $i->addProductToCart($this->product);
     $i->goToCheckout();
     $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
     $i->dontSee(self::MAILPOET_OPTIN_TEXT);
+  }
+
+  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
+    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
   }
 
   public function checkoutOptInUnchecked(\AcceptanceTester $i) {
@@ -71,11 +67,15 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->seeConfirmationEmailWasNotReceived();
   }
 
-  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
+  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $i->addProductToCart($this->product);
-    $i->goToCheckout();
-    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
-    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_check@example.com';
+    $i->orderProductWithRegistration($this->product, $customerEmail, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->see($customerEmail, '.automatewoo-content');
+    $i->seeConfirmationEmailWasReceived();
   }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -39,20 +39,16 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->logout();
   }
 
-  public function checkoutOptInDisabled(\AcceptanceTester $i) {
-    $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
-    $i->addProductToCart($this->product);
-    $i->goToCheckout();
-    $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
-    $i->dontSee(self::MAILPOET_OPTIN_TEXT);
-  }
-
-  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
+  public function checkoutOptInChecked(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $i->addProductToCart($this->product);
-    $i->goToCheckout();
-    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
-    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_check@example.com';
+    $i->orderProductWithRegistration($this->product, $customerEmail, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->see($customerEmail, '.automatewoo-content');
+    $i->seeConfirmationEmailWasReceived();
   }
 
   public function checkoutOptInUnchecked(\AcceptanceTester $i) {
@@ -67,15 +63,19 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->seeConfirmationEmailWasNotReceived();
   }
 
-  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
+  public function checkoutOptInDisabled(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
+    $i->dontSee(self::MAILPOET_OPTIN_TEXT);
+  }
+
+  public function checkoutOptInEnabled(\AcceptanceTester $i) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $this->settingsFactory->withConfirmationEmailEnabled();
-    $customerEmail = 'woo_guest_check@example.com';
-    $i->orderProductWithRegistration($this->product, $customerEmail, true);
-    $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
-    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
-    $i->see($customerEmail, '.automatewoo-content');
-    $i->seeConfirmationEmailWasReceived();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
+    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
   }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -39,16 +39,20 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->logout();
   }
 
-  public function checkoutOptInChecked(\AcceptanceTester $i) {
+  public function checkoutOptInDisabled(\AcceptanceTester $i) {
+    $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
+    $i->dontSee(self::MAILPOET_OPTIN_TEXT);
+  }
+
+  public function checkoutOptInEnabled(\AcceptanceTester $i, $scenario) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $this->settingsFactory->withConfirmationEmailEnabled();
-    $customerEmail = 'woo_guest_check@example.com';
-    $i->orderProductWithRegistration($this->product, $customerEmail, true);
-    $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
-    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
-    $i->see($customerEmail, '.automatewoo-content');
-    $i->seeConfirmationEmailWasReceived();
+    $i->addProductToCart($this->product);
+    $i->goToCheckout();
+    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
+    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
   }
 
   public function checkoutOptInUnchecked(\AcceptanceTester $i) {
@@ -63,19 +67,16 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $i->seeConfirmationEmailWasNotReceived();
   }
 
-  public function checkoutOptInDisabled(\AcceptanceTester $i) {
-    $this->settingsFactory->withWooCommerceCheckoutOptinDisabled();
-    $i->addProductToCart($this->product);
-    $i->goToCheckout();
-    $i->waitForText(self::AUTOMATE_WOO_OPTIN_TEXT, 10);
-    $i->dontSee(self::MAILPOET_OPTIN_TEXT);
-  }
-
-  public function checkoutOptInEnabled(\AcceptanceTester $i) {
+  public function checkoutOptInChecked(\AcceptanceTester $i, $scenario) {
     $this->settingsFactory->withWooCommerceCheckoutOptinEnabled();
-    $i->addProductToCart($this->product);
-    $i->goToCheckout();
-    $i->waitForText(self::MAILPOET_OPTIN_TEXT, 10);
-    $i->dontSee(self::AUTOMATE_WOO_OPTIN_TEXT);
+    $this->settingsFactory->withConfirmationEmailEnabled();
+    $customerEmail = 'woo_guest_check@example.com';
+    $i->addProductToCart($this->product); // to avoid flaky adding to cart from below
+    $i->orderProductWithRegistration($this->product, $customerEmail, true);
+    $i->login();
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WooCommerce Customers']);
+    $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
+    $i->see($customerEmail, '.automatewoo-content');
+    $i->seeConfirmationEmailWasReceived();
   }
 }


### PR DESCRIPTION
## Description

We have failing scenario `checkoutOptInChecked` of the test `WooCheckoutAutomateWooSubscriptionsCest` for a very unknown reason only on CI. The problem is that when adding product to cart and going to checkout, we see the page Checkout with cart block inside which is also empty. If we reorder scenarios inside the test, the scenario `checkoutOptInChecked` will pass but then the other scenario will fail. We didn't encounter this issue locally or when testing manually, so it is unknown why it happens. It could be due to some background glitch on CI.

I will improve the adding to cart method to directly add item to cart and proceed to checkout. This is normal method when you just want to quickly add item to cart or checkout.

## Code review notes

Please ignore all the previous commits as they were different attempts to investigate and fix this.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5933]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5933]: https://mailpoet.atlassian.net/browse/MAILPOET-5933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ