### PR TITLE
Backfill WC customer fields for guests from order [MAILPOET-5378]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactory.php
@@ -29,8 +29,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Billing company', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_billing_company() : null;
+            return $payload->getBillingCompany();
           }
         ),
         new Field(
@@ -38,8 +37,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Billing phone', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_billing_phone() : null;
+            return $payload->getBillingPhone();
           }
         ),
         new Field(
@@ -47,8 +45,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Billing city', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_billing_city() : null;
+            return $payload->getBillingCity();
           }
         ),
         new Field(
@@ -56,8 +53,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Billing postcode', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_billing_postcode() : null;
+            return $payload->getBillingPostcode();
           }
         ),
         new Field(
@@ -65,8 +61,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Billing state/county', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_billing_state() : null;
+            return $payload->getBillingState();
           }
         ),
         new Field(
@@ -74,8 +69,7 @@ class CustomerFieldsFactory {
           Field::TYPE_ENUM,
           __('Billing country', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_billing_country() : null;
+            return $payload->getBillingCountry();
           },
           [
             'options' => $this->getBillingCountryOptions(),
@@ -86,8 +80,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Shipping company', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_shipping_company() : null;
+            return $payload->getShippingCompany();
           }
         ),
         new Field(
@@ -95,8 +88,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Shipping phone', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_shipping_phone() : null;
+            return $payload->getShippingPhone();
           }
         ),
         new Field(
@@ -104,8 +96,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Shipping city', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_shipping_city() : null;
+            return $payload->getShippingCity();
           }
         ),
         new Field(
@@ -113,8 +104,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Shipping postcode', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_shipping_postcode() : null;
+            return $payload->getShippingPostcode();
           }
         ),
         new Field(
@@ -122,8 +112,7 @@ class CustomerFieldsFactory {
           Field::TYPE_STRING,
           __('Shipping state/county', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_shipping_state() : null;
+            return $payload->getShippingState();
           }
         ),
         new Field(
@@ -131,8 +120,7 @@ class CustomerFieldsFactory {
           Field::TYPE_ENUM,
           __('Shipping country', 'mailpoet'),
           function (CustomerPayload $payload) {
-            $customer = $payload->getCustomer();
-            return $customer ? $customer->get_shipping_country() : null;
+            return $payload->getShippingCountry();
           },
           [
             'options' => $this->getShippingCountryOptions(),

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -94,7 +94,8 @@ class CustomerOrderFieldsFactory {
         function (CustomerPayload $payload) {
           $customer = $payload->getCustomer();
           if (!$customer) {
-            return null;
+            $order = $payload->getOrder();
+            return $order && $order->is_paid() ? $order->get_date_created() : null;
           }
           return $this->getPaidOrderDate($customer, true);
         }
@@ -106,7 +107,8 @@ class CustomerOrderFieldsFactory {
         function (CustomerPayload $payload) {
           $customer = $payload->getCustomer();
           if (!$customer) {
-            return null;
+            $order = $payload->getOrder();
+            return $order && $order->is_paid() ? $order->get_date_created() : null;
           }
           return $this->getPaidOrderDate($customer, false);
         }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -44,13 +44,9 @@ class CustomerOrderFieldsFactory {
         __('Total spent', 'mailpoet'),
         function (CustomerPayload $payload, array $params = []) {
           $customer = $payload->getCustomer();
-          if (!$customer) {
-            return 0.0;
-          }
-
           $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
-          return $inTheLastSeconds === null
-            ? (float)$customer->get_total_spent()
+          return $inTheLastSeconds === null || !$customer
+            ? $payload->getTotalSpent()
             : $this->getRecentSpentTotal($customer, $inTheLastSeconds);
         },
         [
@@ -63,19 +59,14 @@ class CustomerOrderFieldsFactory {
         __('Average spent', 'mailpoet'),
         function (CustomerPayload $payload, array $params = []) {
           $customer = $payload->getCustomer();
-          if (!$customer) {
-            return 0.0;
-          }
-
           $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
-          if ($inTheLastSeconds === null) {
-            $totalSpent = (float)$customer->get_total_spent();
-            $orderCount = (int)$customer->get_order_count();
+          if ($inTheLastSeconds === null || !$customer) {
+            return $payload->getAverageSpent();
           } else {
             $totalSpent = $this->getRecentSpentTotal($customer, $inTheLastSeconds);
             $orderCount = $this->getRecentOrderCount($customer, $inTheLastSeconds);
+            return $orderCount > 0 ? ($totalSpent / $orderCount) : 0.0;
           }
-          return $orderCount > 0 ? ($totalSpent / $orderCount) : 0.0;
         },
         [
           'params' => ['in_the_last'],
@@ -87,13 +78,9 @@ class CustomerOrderFieldsFactory {
         __('Order count', 'mailpoet'),
         function (CustomerPayload $payload, array $params = []) {
           $customer = $payload->getCustomer();
-          if (!$customer) {
-            return 0;
-          }
-
           $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
-          return $inTheLastSeconds === null
-            ? $customer->get_order_count()
+          return $inTheLastSeconds === null || !$customer
+            ? $payload->getOrderCount()
             : $this->getRecentOrderCount($customer, $inTheLastSeconds);
         },
         [

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -18,6 +18,90 @@ class CustomerPayload implements Payload {
     $this->order = $order;
   }
 
+  public function getBillingCompany(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_billing_company() : null;
+    }
+    return $this->customer->get_billing_company();
+  }
+
+  public function getBillingPhone(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_billing_phone() : null;
+    }
+    return $this->customer->get_billing_phone();
+  }
+
+  public function getBillingCity(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_billing_city() : null;
+    }
+    return $this->customer->get_billing_city();
+  }
+
+  public function getBillingPostcode(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_billing_postcode() : null;
+    }
+    return $this->customer->get_billing_postcode();
+  }
+
+  public function getBillingState(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_billing_state() : null;
+    }
+    return $this->customer->get_billing_state();
+  }
+
+  public function getBillingCountry(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_billing_country() : null;
+    }
+    return $this->customer->get_billing_country();
+  }
+
+  public function getShippingCompany(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_shipping_company() : null;
+    }
+    return $this->customer->get_shipping_company();
+  }
+
+  public function getShippingPhone(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_shipping_phone() : null;
+    }
+    return $this->customer->get_shipping_phone();
+  }
+
+  public function getShippingCity(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_shipping_city() : null;
+    }
+    return $this->customer->get_shipping_city();
+  }
+
+  public function getShippingPostcode(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_shipping_postcode() : null;
+    }
+    return $this->customer->get_shipping_postcode();
+  }
+
+  public function getShippingState(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_shipping_state() : null;
+    }
+    return $this->customer->get_shipping_state();
+  }
+
+  public function getShippingCountry(): ?string {
+    if ($this->isGuest()) {
+      return $this->order ? $this->order->get_shipping_country() : null;
+    }
+    return $this->customer->get_shipping_country();
+  }
+
   public function getCustomer(): ?WC_Customer {
     return $this->customer;
   }
@@ -26,6 +110,7 @@ class CustomerPayload implements Payload {
     return $this->customer ? $this->customer->get_id() : 0;
   }
 
+  /** @phpstan-assert-if-true null $this->customer */
   public function isGuest(): bool {
     return $this->customer === null;
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -102,6 +102,26 @@ class CustomerPayload implements Payload {
     return $this->customer->get_shipping_country();
   }
 
+  public function getTotalSpent(): float {
+    if ($this->isGuest()) {
+      return $this->order && $this->order->is_paid() ? (float)$this->order->get_total() : 0.0;
+    }
+    return (float)$this->customer->get_total_spent();
+  }
+
+  public function getAverageSpent(): float {
+    $totalSpent = $this->getTotalSpent();
+    $orderCount = $this->getOrderCount();
+    return $orderCount > 0 ? ($totalSpent / $orderCount) : 0.0;
+  }
+
+  public function getOrderCount(): int {
+    if ($this->isGuest()) {
+      return $this->order ? 1 : 0;
+    }
+    return $this->customer->get_order_count();
+  }
+
   public function getCustomer(): ?WC_Customer {
     return $this->customer;
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -3,19 +3,22 @@
 namespace MailPoet\Automation\Integrations\WooCommerce\Payloads;
 
 use MailPoet\Automation\Engine\Integration\Payload;
+use WC_Customer;
+use WC_Order;
 
 class CustomerPayload implements Payload {
-
-  /** @var \WC_Customer | null */
-  private $customer;
+  private ?WC_Customer $customer;
+  private ?WC_Order $order;
 
   public function __construct(
-    \WC_Customer $customer = null
+    WC_Customer $customer = null,
+    WC_Order $order = null
   ) {
     $this->customer = $customer;
+    $this->order = $order;
   }
 
-  public function getCustomer(): ?\WC_Customer {
+  public function getCustomer(): ?WC_Customer {
     return $this->customer;
   }
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -126,6 +126,10 @@ class CustomerPayload implements Payload {
     return $this->customer;
   }
 
+  public function getOrder(): ?WC_Order {
+    return $this->order;
+  }
+
   public function getId(): int {
     return $this->customer ? $this->customer->get_id() : 0;
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -20,86 +20,86 @@ class CustomerPayload implements Payload {
 
   public function getBillingCompany(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_billing_company() : null;
+      return $this->order ? (string)$this->order->get_billing_company() : null;
     }
-    return $this->customer->get_billing_company();
+    return (string)$this->customer->get_billing_company();
   }
 
   public function getBillingPhone(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_billing_phone() : null;
+      return $this->order ? (string)$this->order->get_billing_phone() : null;
     }
-    return $this->customer->get_billing_phone();
+    return (string)$this->customer->get_billing_phone();
   }
 
   public function getBillingCity(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_billing_city() : null;
+      return $this->order ? (string)$this->order->get_billing_city() : null;
     }
-    return $this->customer->get_billing_city();
+    return (string)$this->customer->get_billing_city();
   }
 
   public function getBillingPostcode(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_billing_postcode() : null;
+      return $this->order ? (string)$this->order->get_billing_postcode() : null;
     }
-    return $this->customer->get_billing_postcode();
+    return (string)$this->customer->get_billing_postcode();
   }
 
   public function getBillingState(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_billing_state() : null;
+      return $this->order ? (string)$this->order->get_billing_state() : null;
     }
-    return $this->customer->get_billing_state();
+    return (string)$this->customer->get_billing_state();
   }
 
   public function getBillingCountry(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_billing_country() : null;
+      return $this->order ? (string)$this->order->get_billing_country() : null;
     }
-    return $this->customer->get_billing_country();
+    return (string)$this->customer->get_billing_country();
   }
 
   public function getShippingCompany(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_shipping_company() : null;
+      return $this->order ? (string)$this->order->get_shipping_company() : null;
     }
-    return $this->customer->get_shipping_company();
+    return (string)$this->customer->get_shipping_company();
   }
 
   public function getShippingPhone(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_shipping_phone() : null;
+      return $this->order ? (string)$this->order->get_shipping_phone() : null;
     }
-    return $this->customer->get_shipping_phone();
+    return (string)$this->customer->get_shipping_phone();
   }
 
   public function getShippingCity(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_shipping_city() : null;
+      return $this->order ? (string)$this->order->get_shipping_city() : null;
     }
-    return $this->customer->get_shipping_city();
+    return (string)$this->customer->get_shipping_city();
   }
 
   public function getShippingPostcode(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_shipping_postcode() : null;
+      return $this->order ? (string)$this->order->get_shipping_postcode() : null;
     }
-    return $this->customer->get_shipping_postcode();
+    return (string)$this->customer->get_shipping_postcode();
   }
 
   public function getShippingState(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_shipping_state() : null;
+      return $this->order ? (string)$this->order->get_shipping_state() : null;
     }
-    return $this->customer->get_shipping_state();
+    return (string)$this->customer->get_shipping_state();
   }
 
   public function getShippingCountry(): ?string {
     if ($this->isGuest()) {
-      return $this->order ? $this->order->get_shipping_country() : null;
+      return $this->order ? (string)$this->order->get_shipping_country() : null;
     }
-    return $this->customer->get_shipping_country();
+    return (string)$this->customer->get_shipping_country();
   }
 
   public function getTotalSpent(): float {
@@ -119,7 +119,7 @@ class CustomerPayload implements Payload {
     if ($this->isGuest()) {
       return $this->order ? 1 : 0;
     }
-    return $this->customer->get_order_count();
+    return (int)$this->customer->get_order_count();
   }
 
   public function getCustomer(): ?WC_Customer {

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/BuysAProductTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/BuysAProductTrigger.php
@@ -103,7 +103,7 @@ class BuysAProductTrigger implements Trigger {
     }
     $this->wp->doAction(Hooks::TRIGGER, $this, [
       new Subject(OrderSubject::KEY, ['order_id' => $orderId]),
-      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id()]),
+      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id(), 'order_id' => $orderId]),
       new Subject(OrderStatusChangeSubject::KEY, ['from' => $from, 'to' => $to]),
     ]);
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderCreatedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderCreatedTrigger.php
@@ -77,7 +77,7 @@ class OrderCreatedTrigger implements Trigger {
     $this->processedOrders[] = $orderId;
     $this->wp->doAction(Hooks::TRIGGER, $this, [
       new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
-      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id()]),
+      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id(), 'order_id' => $order->get_id()]),
     ]);
   }
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderStatusChangedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderStatusChangedTrigger.php
@@ -80,7 +80,7 @@ class OrderStatusChangedTrigger implements Trigger {
     $this->wp->doAction(Hooks::TRIGGER, $this, [
       new Subject(OrderStatusChangeSubject::KEY, ['from' => $oldStatus, 'to' => $newStatus]),
       new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
-      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id()]),
+      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id(), 'order_id' => $order->get_id()]),
     ]);
   }
 


### PR DESCRIPTION
## Description

Some customer fields in automations will now get values from order for `guest` users.

## Code review notes

_N/A_

## QA notes

Using automation filters (trigger or if/else condition) on the following fields should now work even for `guest` orders:

- Billing company
- Billing phone
- Billing city
- Billing postcode
- Billing state
- Billing country
- Shipping company
- Shipping phone
- Shipping city
- Shipping postcode
- Shipping state
- Shipping country
- Total spent
- Average spent
- Order count
- First paid order date
- Last paid order date
- Purchased categories
- Purchased tags

The fields will be backfilled as follows:

- Billing and shipping info will get the same values as filled in the order.
- Total and average spent will equal the order value, in case the order was already paid.
- Order count will be `1`.
- First and last paid order date will equal the order creation date, in case the order was already paid.
- Purchased categories and tags will get values from product in the order, in case the order was already paid.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5378]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5378]: https://mailpoet.atlassian.net/browse/MAILPOET-5378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ