### PR TITLE
Add automation templates - remove "beta" [MAILPOET-5934] [MAILPOET-5936]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_separator.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_separator.scss
@@ -63,13 +63,15 @@ $separator-width: 1px;
 
   // add curve leaf ending rounded to the bottom
   &:after {
+    $offset: 0.5px; // vertical offset to prevent artifacts with scale/zoom
     border-left: $separator-width solid #c3c4c7;
     border-top: $separator-width solid #c3c4c7;
     border-top-left-radius: 35px 20px;
     content: '';
     display: block;
-    height: 16px;
-    margin: -$separator-width auto 0 calc(50% - $separator-width / 2);
+    height: 16px + $offset;
+    margin: calc(-1 * ($separator-width + $offset)) auto 0
+      calc(50% - $separator-width / 2);
     transform-origin: left;
     width: calc($width + $separator-width / 2);
   }

--- a/mailpoet/assets/css/src/mailpoet-automation-templates.scss
+++ b/mailpoet/assets/css/src/mailpoet-automation-templates.scss
@@ -94,6 +94,11 @@
     padding-bottom: 32px;
   }
 
+  .mailpoet-automation-editor-separator-curve-leaf-left:before,
+  .mailpoet-automation-editor-separator-curve-leaf-right:before {
+    background: #f6f7f7;
+  }
+
   .mailpoet-automation-editor-step-filters {
     max-height: 200px;
   }

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/delay/edit.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/delay/edit.tsx
@@ -4,6 +4,7 @@ import {
   SelectControl,
   Flex,
   FlexItem,
+  BaseControl,
 } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -25,64 +26,64 @@ export function Edit(): JSX.Element {
   const errorFields = errors?.fields ?? {};
   const delayErrorMessage = errorFields?.delay ?? '';
   const delayTypeErrorMessage = errorFields?.delay_type ?? '';
-  const delayValueInputId = `delay-number-${selectedStep.id}`;
   return (
     <PanelBody opened>
-      <label htmlFor={delayValueInputId}>
-        <PlainBodyTitle
-          title={
-            // translators: A label for a wait delay time selection form field - time unit follows
-            __('Wait for', 'mailpoet')
-          }
-        />
-      </label>
-      <Flex align="top">
-        <FlexItem
-          style={{ flex: '1 1 0' }}
-          className={
-            delayErrorMessage ? 'mailpoet-automation-field__error' : ''
-          }
-        >
-          <TextControl
-            id={delayValueInputId}
-            help={delayErrorMessage}
-            type="number"
-            placeholder={__('Number', 'mailpoet')}
-            value={(selectedStep.args.delay as string) ?? ''}
-            onChange={(rawValue) => {
-              const value: number =
-                rawValue.length === 0 || parseInt(rawValue, 10) < 1
-                  ? 1
-                  : parseInt(rawValue, 10);
-              void dispatch(storeName).updateStepArgs(
-                selectedStep.id,
-                'delay',
-                value,
-              );
-            }}
-          />
-        </FlexItem>
-        <FlexItem
-          style={{ flex: '1 1 0' }}
-          className={
-            delayTypeErrorMessage ? 'mailpoet-automation-field__error' : ''
-          }
-        >
-          <SelectControl
-            label=""
-            help={delayTypeErrorMessage}
-            value={(selectedStep.args.delay_type as string) ?? 'HOURS'}
-            options={DelayTypeOptions}
-            onChange={(value) =>
-              dispatch(storeName).updateStepArgs(
-                selectedStep.id,
-                'delay_type',
-                value,
-              )
+      <PlainBodyTitle title={__('Settings', 'mailpoet')} />
+      <BaseControl
+        label={
+          // translators: A label for a wait delay time selection form field - time unit follows
+          __('Wait for', 'mailpoet')
+        }
+      >
+        <Flex align="top">
+          <FlexItem
+            style={{ flex: '1 1 0' }}
+            className={
+              delayErrorMessage ? 'mailpoet-automation-field__error' : ''
             }
-          />
-        </FlexItem>
-      </Flex>
+          >
+            <TextControl
+              name="delay-number"
+              help={delayErrorMessage}
+              type="number"
+              placeholder={__('Number', 'mailpoet')}
+              value={(selectedStep.args.delay as string) ?? ''}
+              onChange={(rawValue) => {
+                const value: number =
+                  rawValue.length === 0 || parseInt(rawValue, 10) < 1
+                    ? 1
+                    : parseInt(rawValue, 10);
+                void dispatch(storeName).updateStepArgs(
+                  selectedStep.id,
+                  'delay',
+                  value,
+                );
+              }}
+            />
+          </FlexItem>
+          <FlexItem
+            style={{ flex: '1 1 0' }}
+            className={
+              delayTypeErrorMessage ? 'mailpoet-automation-field__error' : ''
+            }
+          >
+            <SelectControl
+              name="delay-value"
+              label=""
+              help={delayTypeErrorMessage}
+              value={(selectedStep.args.delay_type as string) ?? 'HOURS'}
+              options={DelayTypeOptions}
+              onChange={(value) =>
+                dispatch(storeName).updateStepArgs(
+                  selectedStep.id,
+                  'delay_type',
+                  value,
+                )
+              }
+            />
+          </FlexItem>
+        </Flex>
+      </BaseControl>
     </PanelBody>
   );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/hooks/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/hooks/index.tsx
@@ -47,7 +47,7 @@ export function initHooks() {
       if (context !== 'view') {
         return filterValue;
       }
-      return function statisticSeperatorWrapper(
+      return function StatisticSeparatorWrapper(
         previousStepData: StepData,
         index: number,
       ) {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/add-to-list/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/add-to-list/index.tsx
@@ -22,7 +22,7 @@ export const step: StepType = {
   foreground: '#00A32A',
   background: '#EDFAEF',
   icon: () => (
-    <div style={{ width: '100%', height: '100%', scale: '1.12' }}>{list}</div>
+    <div style={{ width: '100%', height: '100%', scale: '1.2' }}>{list}</div>
   ),
   edit: () => (
     <PremiumModalForStepEdit

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/clicks-email-link/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/clicks-email-link/index.tsx
@@ -26,7 +26,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-action/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-action/index.tsx
@@ -23,7 +23,7 @@ export const step: StepType = {
   foreground: '#00A32A',
   background: '#EDFAEF',
   icon: () => (
-    <div style={{ width: '100%', height: '100%', scale: '1.12' }}>{code}</div>
+    <div style={{ width: '100%', height: '100%', scale: '1.2' }}>{code}</div>
   ),
   edit: () => (
     <PremiumModalForStepEdit

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-trigger/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/custom-trigger/index.tsx
@@ -27,9 +27,7 @@ export const step: StepType = {
   foreground: '#2271b1',
   background: '#f0f6fc',
   icon: () => (
-    <div style={{ width: '100%', height: '100%', scale: '1.12' }}>
-      {plugins}
-    </div>
+    <div style={{ width: '100%', height: '100%', scale: '1.4' }}>{plugins}</div>
   ),
   edit: () => (
     <PremiumModalForStepEdit

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/notification-email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/notification-email/index.tsx
@@ -24,7 +24,11 @@ export const step: StepType = {
   keywords,
   foreground: '#996800',
   background: '#FCF9E8',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.12' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove-from-list/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/remove-from-list/index.tsx
@@ -22,7 +22,7 @@ export const step: StepType = {
   foreground: '#00A32A',
   background: '#EDFAEF',
   icon: () => (
-    <div style={{ width: '100%', height: '100%', scale: '1.12' }}>{list}</div>
+    <div style={{ width: '100%', height: '100%', scale: '1.2' }}>{list}</div>
   ),
   edit: () => (
     <PremiumModalForStepEdit

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-added/index.tsx
@@ -29,7 +29,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-removed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/tag-removed/index.tsx
@@ -32,7 +32,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-created/index.tsx
@@ -26,7 +26,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-expired/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-expired/index.tsx
@@ -23,7 +23,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-payment-failed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-payment-failed/index.tsx
@@ -24,7 +24,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-renewed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-renewed/index.tsx
@@ -22,7 +22,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-status-changed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-status-changed/index.tsx
@@ -27,7 +27,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-ended/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-ended/index.tsx
@@ -24,7 +24,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-started/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/subscription-trial-started/index.tsx
@@ -24,7 +24,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.3' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/abandoned-cart/edit/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/abandoned-cart/edit/index.tsx
@@ -13,6 +13,8 @@ export function Edit(): JSX.Element {
     <PanelBody opened>
       <PlainBodyTitle title={__('Settings', 'mailpoet')} />
       <SelectControl
+        // translators: A label for a wait delay time selection form field - time unit follows
+        label={__('Cart abandoned for', 'mailpoet')}
         onChange={(id: string) => {
           void dispatch(storeName).updateStepArgs(
             selectedStep.id,

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
@@ -28,6 +28,10 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.4' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => <Edit />,
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-category/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-category/index.tsx
@@ -33,6 +33,10 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.25' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => <Edit />,
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/made-a-review/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/made-a-review/index.tsx
@@ -30,7 +30,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.25' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
@@ -20,6 +20,10 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.25' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => null,
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-completed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-completed/index.tsx
@@ -20,6 +20,10 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.25' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => null,
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
@@ -22,6 +22,10 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.25' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => null,
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/wordpress/steps/made-a-comment/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/steps/made-a-comment/index.tsx
@@ -19,7 +19,11 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => <Icon />,
+  icon: () => (
+    <div style={{ width: '100%', height: '100%', scale: '1.25' }}>
+      <Icon />
+    </div>
+  ),
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -23,7 +23,7 @@ const initializeHooks = () => {
     'mailpoet.automation.render_step_separator',
     'mailpoet',
     () =>
-      function SeperatorWrapper(previousStepData: StepData, index: number) {
+      function SeparatorWrapper(previousStepData: StepData, index: number) {
         const stepType = useSelect(
           (select) => select(storeName).getStepType(previousStepData.key),
           [],

--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@wordpress/components';
-import { dispatch } from '@wordpress/data';
+import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
 import { Hooks } from 'wp-js-hooks';
@@ -9,6 +9,7 @@ import { createStore, storeName } from '../../editor/store';
 import { AutomationTemplate } from '../config';
 import { Automation } from '../../editor/components/automation';
 import { initializeIntegrations } from '../../editor/integrations';
+import { Step as StepData } from '../../editor/components/automation/types';
 
 const initializeHooks = () => {
   Hooks.addFilter(
@@ -22,8 +23,34 @@ const initializeHooks = () => {
     'mailpoet.automation.render_step_separator',
     'mailpoet',
     () =>
-      function Separator() {
-        return <div className="mailpoet-automation-editor-separator" />;
+      function SeperatorWrapper(previousStepData: StepData, index: number) {
+        const stepType = useSelect(
+          (select) => select(storeName).getStepType(previousStepData.key),
+          [],
+        );
+
+        const BranchBadge =
+          previousStepData.next_steps.length > 1 && stepType?.branchBadge;
+
+        return (
+          <>
+            {previousStepData.next_steps.length > 1 && (
+              <div
+                className={
+                  index < previousStepData.next_steps.length / 2
+                    ? 'mailpoet-automation-editor-separator-curve-leaf-left'
+                    : 'mailpoet-automation-editor-separator-curve-leaf-right'
+                }
+              />
+            )}
+            {BranchBadge && (
+              <div className="mailpoet-automation-editor-branch-badge">
+                <BranchBadge step={previousStepData} index={index} />
+              </div>
+            )}
+            <div className="mailpoet-automation-editor-separator" />
+          </>
+        );
       },
   );
 };

--- a/mailpoet/lib/Automation/Engine/Templates/AutomationBuilder.php
+++ b/mailpoet/lib/Automation/Engine/Templates/AutomationBuilder.php
@@ -104,6 +104,7 @@ class AutomationBuilder {
    *       field: string,
    *       condition: string,
    *       value: mixed,
+   *       params?: array<string, mixed>,
    *     }[],
    *   }[],
    * } $filters
@@ -126,7 +127,7 @@ class AutomationBuilder {
               $field->getType(),
               $filter['field'],
               $filter['condition'],
-              ['value' => $filter['value']]
+              array_merge(['value' => $filter['value']], isset($filter['params']) ? ['params' => $filter['params']] : []),
             );
           },
           $group['filters']

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -234,8 +234,8 @@ class TemplatesFactory {
             [
               'key' => 'mailpoet:send-email',
               'args' => [
-                'name' => 'Abandoned cart',
-                'subject' => 'Looks like you forgot something',
+                'name' => __('Abandoned cart', 'mailpoet'),
+                'subject' => __('Looks like you forgot something', 'mailpoet'),
               ],
             ],
           ]

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -145,11 +145,7 @@ class TemplatesFactory {
           __('Celebrate first-time buyers', 'mailpoet'),
           [
             [
-              'key' => 'woocommerce:order-status-changed',
-              'args' => [
-                'from' => 'any',
-                'to' => 'wc-completed',
-              ],
+              'key' => 'woocommerce:order-completed',
               'filters' => [
                 'operator' => 'and',
                 'groups' => [

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -260,7 +260,7 @@ class TemplatesFactory {
           []
         );
       },
-      AutomationTemplate::TYPE_COMING_SOON
+      AutomationTemplate::TYPE_PREMIUM
     );
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -47,7 +47,7 @@ class TemplatesFactory {
       'welcome',
       __('Welcome new subscribers', 'mailpoet'),
       __(
-        "Send a welcome email when someone subscribes to your list. Optionally, you can choose to send this email after a specified period.",
+        'Send a welcome email when someone subscribes to your list. Optionally, you can choose to send this email after a specified period.',
         'mailpoet'
       ),
       function (): Automation {
@@ -73,7 +73,7 @@ class TemplatesFactory {
       'welcome',
       __('Welcome new WordPress users', 'mailpoet'),
       __(
-        "Send a welcome email when a new WordPress user registers to your website. Optionally, you can choose to send this email after a specified period.",
+        'Send a welcome email when a new WordPress user registers to your website. Optionally, you can choose to send this email after a specified period.',
         'mailpoet'
       ),
       function (): Automation {
@@ -99,7 +99,7 @@ class TemplatesFactory {
       'welcome',
       __('Welcome series for new subscribers', 'mailpoet'),
       __(
-        "Welcome new subscribers and start building a relationship with them. Send an email immediately after someone subscribes to your list to introduce your brand and a follow-up two days later to keep the conversation going.",
+        'Welcome new subscribers and start building a relationship with them. Send an email immediately after someone subscribes to your list to introduce your brand and a follow-up two days later to keep the conversation going.',
         'mailpoet'
       ),
       function (): Automation {
@@ -118,7 +118,7 @@ class TemplatesFactory {
       'welcome',
       __('Welcome series for new WordPress users', 'mailpoet'),
       __(
-        "Welcome new WordPress users to your site. Send an email immediately after a WordPress user registers. Send a follow-up email two days later with more in-depth information.",
+        'Welcome new WordPress users to your site. Send an email immediately after a WordPress user registers. Send a follow-up email two days later with more in-depth information.',
         'mailpoet'
       ),
       function (): Automation {
@@ -137,7 +137,7 @@ class TemplatesFactory {
       'woocommerce',
       __('Celebrate first-time buyers', 'mailpoet'),
       __(
-        "Welcome your first-time customers by sending an email with a special offer for their next purchase. Make them feel appreciated within your brand.",
+        'Welcome your first-time customers by sending an email with a special offer for their next purchase. Make them feel appreciated within your brand.',
         'mailpoet'
       ),
       function (): Automation {
@@ -181,7 +181,7 @@ class TemplatesFactory {
       'woocommerce',
       __('Thank loyal customers', 'mailpoet'),
       __(
-        "These are your most important customers. Make them feel special by sending a thank you note for supporting your brand.",
+        'These are your most important customers. Make them feel special by sending a thank you note for supporting your brand.',
         'mailpoet'
       ),
       function (): Automation {
@@ -200,7 +200,7 @@ class TemplatesFactory {
       'woocommerce',
       __('Win-back customers', 'mailpoet'),
       __(
-        "Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what's new, encouraging a return to your brand.",
+        'Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what’s new, encouraging a return to your brand.',
         'mailpoet'
       ),
       function (): Automation {
@@ -219,7 +219,7 @@ class TemplatesFactory {
       'abandoned-cart',
       __('Abandoned cart reminder', 'mailpoet'),
       __(
-        "Nudge your shoppers to complete the purchase after they have added a product to the cart but haven't completed the order.",
+        'Nudge your shoppers to complete the purchase after they have added a product to the cart but haven’t completed the order.',
         'mailpoet'
       ),
       function (): Automation {
@@ -247,7 +247,7 @@ class TemplatesFactory {
       'abandoned-cart',
       __('Abandoned cart campaign', 'mailpoet'),
       __(
-        "Encourage your potential customers to finalize their purchase when they have added items to their cart but haven't finished the order yet. Offer a coupon code as a last resort to convert them to customers.",
+        'Encourage your potential customers to finalize their purchase when they have added items to their cart but haven’t finished the order yet. Offer a coupon code as a last resort to convert them to customers.',
         'mailpoet'
       ),
       function (): Automation {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -33,6 +33,7 @@ class TemplatesFactory {
     if ($this->woocommerce->isWooCommerceActive()) {
       $templates[] = $this->createFirstPurchaseTemplate();
       $templates[] = $this->createThankLoyalCustomersTemplate();
+      $templates[] = $this->createWinBackCustomersTemplate();
       $templates[] = $this->createAbandonedCartTemplate();
       $templates[] = $this->createAbandonedCartCampaignTemplate();
     }
@@ -190,6 +191,25 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Thank loyal customers', 'mailpoet'),
+          []
+        );
+      },
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createWinBackCustomersTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'win-back-customers',
+      'woocommerce',
+      __('Win-back customers', 'mailpoet'),
+      __(
+        "Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what's new, encouraging a return to your brand.",
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Win-back customers', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -32,7 +32,7 @@ class TemplatesFactory {
 
     if ($this->woocommerce->isWooCommerceActive()) {
       $templates[] = $this->createFirstPurchaseTemplate();
-      $templates[] = $this->createLoyalCustomersTemplate();
+      $templates[] = $this->createThankLoyalCustomersTemplate();
       $templates[] = $this->createAbandonedCartTemplate();
       $templates[] = $this->createAbandonedCartCampaignTemplate();
     }
@@ -178,9 +178,9 @@ class TemplatesFactory {
     );
   }
 
-  private function createLoyalCustomersTemplate(): AutomationTemplate {
+  private function createThankLoyalCustomersTemplate(): AutomationTemplate {
     return new AutomationTemplate(
-      'loyal-customers',
+      'thank-loyal-customers',
       'woocommerce',
       __('Thank loyal customers', 'mailpoet'),
       __(
@@ -193,7 +193,7 @@ class TemplatesFactory {
           []
         );
       },
-      AutomationTemplate::TYPE_COMING_SOON
+      AutomationTemplate::TYPE_PREMIUM
     );
   }
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/AbandonedCartPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/AbandonedCartPayload.php
@@ -45,4 +45,15 @@ class AbandonedCartPayload implements Payload {
   public function getProductIds(): array {
     return $this->productIds;
   }
+
+  public function getTotal(): float {
+    $total = 0.0;
+    foreach ($this->productIds as $productId) {
+      $product = wc_get_product($productId);
+      if ($product) {
+        $total += (float)$product->get_price();
+      }
+    }
+    return $total;
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/AbandonedCartSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/AbandonedCartSubject.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Integrations\WooCommerce\Subjects;
 
+use MailPoet\Automation\Engine\Data\Field;
 use MailPoet\Automation\Engine\Data\Subject as SubjectData;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 use MailPoet\Automation\Engine\Integration\Payload;
@@ -32,7 +33,7 @@ class AbandonedCartSubject implements Subject {
 
   public function getName(): string {
     // translators: automation subject (entity entering automation) title
-    return __('MailPoet Abandoned Cart', 'mailpoet');
+    return __('WooCommerce abandoned cart', 'mailpoet');
   }
 
   public function getArgsSchema(): ObjectSchema {
@@ -58,6 +59,15 @@ class AbandonedCartSubject implements Subject {
   }
 
   public function getFields(): array {
-    return [];
+    return [
+      new Field(
+        'woocommerce:cart:cart-total',
+        Field::TYPE_NUMBER,
+        __('Cart total', 'mailpoet'),
+        function (AbandonedCartPayload $payload) {
+          return $payload->getTotal();
+        }
+      ),
+    ];
   }
 }

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -122,22 +122,6 @@ class Menu {
 
     $this->registerMailPoetMenu();
 
-    // @ToDo Remove Beta once Automation is no longer beta.
-    $this->wp->addAction('admin_head', function () {
-      echo '<style>
-#adminmenu .toplevel_page_mailpoet-homepage a[href="admin.php?page=mailpoet-automation"] {
-  white-space: nowrap;
-}
-.mailpoet-beta-badge {
-  text-transform: uppercase;
-  font-size: 9px;
-  position: relative;
-  top: -5px;
-  color: #ffab66;
-}
-</style>';
-    });
-
     if (!self::isOnMailPoetAdminPage()) {
       return;
     }
@@ -531,8 +515,7 @@ class Menu {
     $automationPage = $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,
       $this->setPageTitle(__('Automations', 'mailpoet')),
-      // @ToDo Remove Beta once Automation is no longer beta.
-      '<span>' . esc_html__('Automations', 'mailpoet') . '</span><span class="mailpoet-beta-badge">Beta</span>',
+      esc_html__('Automations', 'mailpoet'),
       AccessControl::PERMISSION_MANAGE_EMAILS,
       self::AUTOMATIONS_PAGE_SLUG,
       [$this, 'automation']

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -147,6 +147,7 @@ class IntegrationTester extends \Codeception\Actor {
 
     if (isset($data['price'])) {
       $product->set_price($data['price']);
+      $product->set_regular_price($data['price']);
     }
 
     if (isset($data['attributes'])) {

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -36,7 +36,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
     $i->click('Delay');
-    $i->fillField('Wait for', '5');
+    $i->fillField(['name' => 'delay-number'], '5');
 
     $i->wantTo('Leave the page without saving.');
     $i->reloadPage();

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -37,7 +37,7 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
     $i->click('Delay');
-    $i->fillField('Wait for', '5');
+    $i->fillField(['name' => 'delay-number'], '5');
 
     $i->click('Send email');
     $i->fillField('"From" name', 'From');

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CartFieldsTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CartFieldsTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Automation\Integrations\WooCommerce\Fields;
+
+use DateTimeImmutable;
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Integrations\WooCommerce\Payloads\AbandonedCartPayload;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\AbandonedCartSubject;
+use WC_Customer;
+
+/**
+ * @group woo
+ */
+class CartFieldsTest extends \MailPoetTest {
+  public function testCartFields(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $cartTotalField = $fields['woocommerce:cart:cart-total'];
+    $this->assertSame('Cart total', $cartTotalField->getName());
+    $this->assertSame('number', $cartTotalField->getType());
+    $this->assertSame([], $cartTotalField->getArgs());
+
+    // check values (empty cart)
+    $customer = new WC_Customer();
+    $payload = new AbandonedCartPayload($customer, new DateTimeImmutable(), []);
+    $this->assertSame(0.0, $cartTotalField->getValue($payload));
+
+    // check values (with products)
+    $product1 = $this->tester->createWooCommerceProduct(['name' => 'Product 1', 'price' => '123.45']);
+    $product2 = $this->tester->createWooCommerceProduct(['name' => 'Product 2', 'price' => '100.00']);
+    $product3 = $this->tester->createWooCommerceProduct(['name' => 'Product 3']);
+
+    $payload = new AbandonedCartPayload($customer, new DateTimeImmutable(), [$product1->get_id(), $product2->get_id(), $product3->get_id()]);
+    $this->assertSame(223.45, $cartTotalField->getValue($payload));
+  }
+
+  /** @return array<string, Field> */
+  private function getFieldsMap(): array {
+    $factory = $this->diContainer->get(AbandonedCartSubject::class);
+    $fields = [];
+    foreach ($factory->getFields() as $field) {
+      $fields[$field->getKey()] = $field;
+    }
+    return $fields;
+  }
+}

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -15,7 +15,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(8, $result['data']);
+    $this->assertCount(9, $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -23,7 +23,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(8, $data['data']);
+    $this->assertCount(9, $data['data']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -57,6 +57,6 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
         'category' => 'woocommerce',
       ],
     ]);
-    $this->assertCount(2, $result['data']);
+    $this->assertCount(3, $result['data']);
   }
 }


### PR DESCRIPTION
## Description

Added 3 new templates with the new features (if/else & "in the last X days"):

1. Thank loyal customers
2. Win-back customers
3. Abandoned cart campaign

## Code review notes

_N/A_

## QA notes

Please, check that the templates follow [specs](https://mailpoet.atlassian.net/browse/MAILPOET-5934).

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/849

## Linked tickets

[MAILPOET-5934]
[MAILPOET-5936]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5934]: https://mailpoet.atlassian.net/browse/MAILPOET-5934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5936]: https://mailpoet.atlassian.net/browse/MAILPOET-5936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ