### PR TITLE
Keep on-save email validation only in SubscriberSaveController [MAILPOET-5878]

### DIFF
--- a/mailpoet/lib/Doctrine/EntityTraits/ValidationGroupsTrait.php
+++ b/mailpoet/lib/Doctrine/EntityTraits/ValidationGroupsTrait.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Doctrine\EntityTraits;
+
+trait ValidationGroupsTrait {
+  /**
+   * @var array|null
+   */
+  private $validationGroups;
+
+  public function getValidationGroups(): ?array {
+    return $this->validationGroups;
+  }
+
+  public function setValidationGroups(?array $validationGroups): void {
+    $this->validationGroups = $validationGroups;
+  }
+}

--- a/mailpoet/lib/Doctrine/EventListeners/ValidationListener.php
+++ b/mailpoet/lib/Doctrine/EventListeners/ValidationListener.php
@@ -29,9 +29,17 @@ class ValidationListener {
   }
 
   private function validate($entity) {
-    $violations = $this->validator->validate($entity);
+    $groups = $this->getValidationGroups($entity);
+    $violations = $this->validator->validate($entity, null, $groups);
     if ($violations->count() > 0) {
       throw new ValidationException(get_class($entity), $violations);
     }
+  }
+
+  private function getValidationGroups($entity) {
+    if (is_object($entity) && method_exists($entity, 'getValidationGroups')) {
+      return $entity->getValidationGroups();
+    }
+    return null;
   }
 }

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -7,6 +7,7 @@ use MailPoet\Doctrine\EntityTraits\AutoincrementedIdTrait;
 use MailPoet\Doctrine\EntityTraits\CreatedAtTrait;
 use MailPoet\Doctrine\EntityTraits\DeletedAtTrait;
 use MailPoet\Doctrine\EntityTraits\UpdatedAtTrait;
+use MailPoet\Doctrine\EntityTraits\ValidationGroupsTrait;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\Common\Collections\ArrayCollection;
 use MailPoetVendor\Doctrine\Common\Collections\Collection;
@@ -44,6 +45,7 @@ class SubscriberEntity {
   use CreatedAtTrait;
   use UpdatedAtTrait;
   use DeletedAtTrait;
+  use ValidationGroupsTrait;
 
   /**
    * @ORM\Column(type="bigint", nullable=true)
@@ -71,7 +73,7 @@ class SubscriberEntity {
 
   /**
    * @ORM\Column(type="string")
-   * @Assert\Email()
+   * @Assert\Email(groups={"Saving"})
    * @Assert\NotBlank()
    * @var string
    */

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -229,6 +229,9 @@ class SubscriberSaveController {
     // wipe any unconfirmed data at this point
     $subscriber->setUnconfirmedData(null);
 
+    // Validate the email (Saving group) + everything else (Default group)
+    $subscriber->setValidationGroups(['Saving', 'Default']);
+
     try {
       $this->subscribersRepository->persist($subscriber);
       $this->subscribersRepository->flush();

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -772,7 +772,7 @@ parameters:
 
 		-
 			message: "#^Dead catch \\- MailPoet\\\\Doctrine\\\\Validator\\\\ValidationException is never thrown in the try block\\.$#"
-			count: 2
+			count: 4
 			path: ../../tests/integration/Doctrine/EventListeners/ValidationTest.php
 
 		-

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -767,7 +767,7 @@ parameters:
 
 		-
 			message: "#^Dead catch \\- MailPoet\\\\Doctrine\\\\Validator\\\\ValidationException is never thrown in the try block\\.$#"
-			count: 2
+			count: 4
 			path: ../../tests/integration/Doctrine/EventListeners/ValidationTest.php
 
 		-

--- a/mailpoet/tests/integration/Doctrine/EventListeners/ValidatedEntity.php
+++ b/mailpoet/tests/integration/Doctrine/EventListeners/ValidatedEntity.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Doctrine\EventListeners;
 
+use MailPoet\Doctrine\EntityTraits\ValidationGroupsTrait;
 use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
 use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
 
@@ -10,6 +11,8 @@ use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Table(name="test_validated_entity")
  */
 class ValidatedEntity {
+  use ValidationGroupsTrait;
+
   /**
    * @ORM\Column(type="integer")
    * @ORM\Id
@@ -26,6 +29,13 @@ class ValidatedEntity {
    */
   private $name;
 
+  /**
+   * @ORM\Column(type="string")
+   * @Assert\Email(groups={"Saving"})
+   * @var string
+   */
+  private $email;
+
   /** @return int|null */
   public function getId() {
     return $this->id;
@@ -39,5 +49,15 @@ class ValidatedEntity {
   /** @param string $name */
   public function setName($name) {
     $this->name = $name;
+  }
+
+  /** @return string */
+  public function getEmail() {
+    return $this->email;
+  }
+
+  /** @param string $email */
+  public function setEmail($email) {
+    $this->email = $email;
   }
 }


### PR DESCRIPTION
## Description

The email validation in question was added as part of the [refactoring of Subscribers::save() to SubscriberSaveController](https://github.com/mailpoet/mailpoet/pull/3408). I decided to disable it by default and only turn it on in the aforementioned controller for which it was originally introduced. I think this controller deals with all cases of saving emails from user input. Cron workers and other internal services that may work with `SubscriberEntity`  won't trip up on that validation anymore.

To implement this fix, I added the support of the Symfony `Validator` [validation groups](https://symfony.com/doc/current/validation/groups.html) to our `ValidationListener`.

## Code review notes

If you think on-save email validation needs to be kept somewhere else besides `SubscriberSaveController`, please let me know.

## QA notes

Please check that it didn't break email validation in the plugin forms (front-end and admin UI) and smoke-test that other types of form validation are working.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5878]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5878]: https://mailpoet.atlassian.net/browse/MAILPOET-5878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ