### PR TITLE
Rename segments to lists in UI [MAILPOET-5940]

### DIFF
--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -157,7 +157,7 @@
   'blockLastNameDescription': __('Allow your subscribers to select which list(s) they want to subscribe to.'),
   'blockSegmentSelectLabel': __('Select list(s):'),
   'blockSegmentSelectNoLists': __('Please select at least one list'),
-  'blockSegmentSelectListLabel': __('Select the segment that you want to add'),
+  'blockSegmentSelectListLabel': __('Select the list that you want to add'),
   'blockEmail': __('Email'),
   'blockEmailDescription': __('Input field used to catch subscribers’ email addresses.'),
   'blockSubmit': __('Submit button'),

--- a/mailpoet/views/form/templatesLegacy/settings/segment_selection.hbs
+++ b/mailpoet/views/form/templatesLegacy/settings/segment_selection.hbs
@@ -1,7 +1,7 @@
 <ul id="mailpoet_segment_selection" class="clearfix"></ul>
 
 <div id="mailpoet_segment_available_container">
-  <h3><%= __('Select the segment that you want to add:') %></h3>
+  <h3><%= __('Select the list that you want to add:') %></h3>
 
   <select class="mailpoet_segment_available"></select>
 


### PR DESCRIPTION
## Description

While Lists in the database are just a specific type of segment, users would be confused and think they can select Segments that they’ve created under MailPoet > Segments.  However, that’s impossible since you can’t subscribe directly to a segment. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5940]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5940]: https://mailpoet.atlassian.net/browse/MAILPOET-5940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ