### PR TITLE
Remove flaky assesment [MAILPOET-5941]

### DIFF
--- a/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
+++ b/mailpoet/tests/integration/Cron/ActionScheduler/Actions/DaemonRunTest.php
@@ -45,7 +45,6 @@ class DaemonRunTest extends \MailPoetTest {
       'name' => 'John',
       'address' => 'john@example.com',
     ]);
-    verify($this->daemonRun->getDaemonExecutionLimit())->equals(20); // Verify initial execution limit
     $this->daemonRun->init();
     verify($this->daemonRun->getDaemonExecutionLimit())->greaterThan(19); // It can be a bit lower as action scheduler may take some time to process actions
 


### PR DESCRIPTION
## Description
This is a follow up for https://github.com/mailpoet/mailpoet/pull/5483

Somehow, placing the 20s before the init did not solve the issue. I removed the 20s now completely. The statement that `getDaemonExecutionLimit` should be  `>19s` is sufficient imo.
## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-5941]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5941]: https://mailpoet.atlassian.net/browse/MAILPOET-5941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ