### PR TITLE
Add layout screen with dimension panel [MAILPOET-5640]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/dimensions-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/dimensions-panel.tsx
@@ -1,6 +1,6 @@
 import {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // We can remove the ts-expect-error comments once the types are available.
+  // @ts-expect-error TS7016: Could not find a declaration file for module '@wordpress/block-editor'.
   __experimentalSpacingSizesControl as SpacingSizesControl,
   useSetting,
 } from '@wordpress/block-editor';
@@ -12,9 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 
 export function DimensionsPanel() {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const availableUnits: string[] = useSetting('spacing.units');
+  const availableUnits = useSetting('spacing.units') as string[];
   const units = useCustomUnits({
     availableUnits,
   });
@@ -48,20 +46,20 @@ export function DimensionsPanel() {
           allowReset
           values={paddingValues}
           onChange={setPaddingValues}
-          label={__('Padding', 'mailpoet')}
+          label={__('Padding')}
           sides={['horizontal', 'vertical', 'top', 'left', 'right', 'bottom']}
           units={units}
         />
       </ToolsPanelItem>
       <ToolsPanelItem
         isShownByDefault
-        label={__('Block spacing', 'mailpoet')}
+        label={__('Block spacing')}
         hasValue={() => true}
         onDeselect={() => resetBlockGap()}
         className="tools-panel-item-spacing"
       >
         <SpacingSizesControl
-          label={__('Block spacing', 'mailpoet')}
+          label={__('Block spacing')}
           min={0}
           onChange={setBlockGapValue}
           showSideInLabel={false}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/dimensions-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/dimensions-panel.tsx
@@ -1,0 +1,75 @@
+import {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  __experimentalSpacingSizesControl as SpacingSizesControl,
+  useSetting,
+} from '@wordpress/block-editor';
+import {
+  __experimentalToolsPanel as ToolsPanel,
+  __experimentalToolsPanelItem as ToolsPanelItem,
+  __experimentalUseCustomUnits as useCustomUnits,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export function DimensionsPanel() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const availableUnits: string[] = useSetting('spacing.units');
+  const units = useCustomUnits({
+    availableUnits,
+  });
+
+  // Padding
+  const paddingValues = {
+    top: '20px',
+    right: '20px',
+    bottom: '20px',
+    left: '20px',
+  };
+  const resetPadding = () => {};
+  const setPaddingValues = () => {};
+
+  // Block spacing
+  const blockGapValue = '16px';
+  const resetBlockGap = () => {};
+  const setBlockGapValue = () => {};
+  const resetAll = () => {};
+
+  return (
+    <ToolsPanel label={__('Dimensions', 'mailpoet')} resetAll={resetAll}>
+      <ToolsPanelItem
+        isShownByDefault
+        hasValue={() => true}
+        label={__('Padding')}
+        onDeselect={() => resetPadding()}
+        className="tools-panel-item-spacing"
+      >
+        <SpacingSizesControl
+          allowReset
+          values={paddingValues}
+          onChange={setPaddingValues}
+          label={__('Padding', 'mailpoet')}
+          sides={['horizontal', 'vertical', 'top', 'left', 'right', 'bottom']}
+          units={units}
+        />
+      </ToolsPanelItem>
+      <ToolsPanelItem
+        isShownByDefault
+        label={__('Block spacing', 'mailpoet')}
+        hasValue={() => true}
+        onDeselect={() => resetBlockGap()}
+        className="tools-panel-item-spacing"
+      >
+        <SpacingSizesControl
+          label={__('Block spacing', 'mailpoet')}
+          min={0}
+          onChange={setBlockGapValue}
+          showSideInLabel={false}
+          sides={['top']} // Use 'top' as the shorthand property in non-axial configurations.
+          values={{ top: blockGapValue }}
+          allowReset
+        />
+      </ToolsPanelItem>
+    </ToolsPanel>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/index.scss
@@ -1,3 +1,13 @@
-.mailpoet-email-editor__styles-panel .components-navigator-button {
-  width: 100%;
+.mailpoet-email-editor__styles-panel {
+  .components-navigator-button {
+    width: 100%;
+  }
+
+  .mailpoet-email-editor__styles-header {
+    margin-bottom: 0;
+  }
+
+  .mailpoet-email-editor__styles-header-description {
+    padding: 0 16px;
+  }
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-header.tsx
@@ -1,0 +1,56 @@
+import {
+  __experimentalHStack as HStack,
+  __experimentalVStack as VStack,
+  __experimentalSpacer as Spacer,
+  __experimentalHeading as Heading,
+  __experimentalView as View,
+  __experimentalNavigatorToParentButton as NavigatorToParentButton,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
+
+type Props = {
+  title: string;
+  description?: string;
+  onBack?: () => void;
+};
+
+/**
+ * Component for displaying the screen header and optional description based on site editor component:
+ * https://github.com/WordPress/gutenberg/blob/7fa03fafeb421ab4c3604564211ce6007cc38e84/packages/edit-site/src/components/global-styles/header.js
+ */
+export function ScreenHeader({ title, description, onBack }: Props) {
+  return (
+    <VStack spacing={0}>
+      <View>
+        <Spacer marginBottom={0} paddingX={4} paddingY={3}>
+          <HStack spacing={2}>
+            <NavigatorToParentButton
+              style={{ minWidth: 24, padding: 0 }}
+              icon={chevronLeft}
+              size="small"
+              aria-label={__('Navigate to the previous view')}
+              onClick={onBack}
+            />
+            <Spacer>
+              {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+              {/* @ts-ignore */}
+              <Heading
+                className="mailpoet-email-editor__styles-header"
+                level={2}
+                size={13}
+              >
+                {title}
+              </Heading>
+            </Spacer>
+          </HStack>
+        </Spacer>
+      </View>
+      {description && (
+        <p className="mailpoet-email-editor__styles-header-description">
+          {description}
+        </p>
+      )}
+    </VStack>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-header.tsx
@@ -33,8 +33,7 @@ export function ScreenHeader({ title, description, onBack }: Props) {
               onClick={onBack}
             />
             <Spacer>
-              {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-              {/* @ts-ignore */}
+              {/* @ts-expect-error Heading component it's not typed properly in the current components version. */}
               <Heading
                 className="mailpoet-email-editor__styles-header"
                 level={2}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-layout.tsx
@@ -1,6 +1,12 @@
 import { __ } from '@wordpress/i18n';
+import { DimensionsPanel } from './dimensions-panel';
 import { ScreenHeader } from './screen-header';
 
 export function ScreenLayout(): JSX.Element {
-  return <ScreenHeader title={__('Layout', 'mailpoet')} />;
+  return (
+    <>
+      <ScreenHeader title={__('Layout', 'mailpoet')} />
+      <DimensionsPanel />
+    </>
+  );
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screen-layout.tsx
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+import { ScreenHeader } from './screen-header';
+
+export function ScreenLayout(): JSX.Element {
+  return <ScreenHeader title={__('Layout', 'mailpoet')} />;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
@@ -9,6 +9,7 @@ import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
 import { storeName, stylesSidebarId } from '../../store';
+import { ScreenLayout } from './screen-layout';
 import { ScreenRoot } from './screen-root';
 
 type Props = ComponentProps<typeof ComplementaryArea>;
@@ -41,8 +42,7 @@ export function StylesSidebar(props: Props): JSX.Element {
           </NavigatorScreen>
 
           <NavigatorScreen path="/layout">
-            <NavigatorToParentButton>Back</NavigatorToParentButton>
-            <div>TODO: Typography screen</div>
+            <ScreenLayout />
           </NavigatorScreen>
         </NavigatorProvider>
       </Panel>


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

This PR is the first of more PRs to add complex functionality to email-specific styles set in the new styles sidebar.
- There is only a new screen component with a dimension panel. Callbacks, actions, and selectors will be part of the next pull requests.

## QA notes

We can definitely skip QA here. Maybe a reviewer can check the UI components after branch checkout.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5640]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5640]: https://mailpoet.atlassian.net/browse/MAILPOET-5640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ