### PR TITLE
Improve term loading

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermOptionsBuilder.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/TermOptionsBuilder.php
@@ -10,6 +10,9 @@ class TermOptionsBuilder {
   /** @var WordPress */
   private $wordPress;
 
+  /** @var array<string, array<array{id: int, name: string}>> */
+  private $terms = [];
+
   public function __construct(
     WordPress $wordPress
   ) {
@@ -18,11 +21,16 @@ class TermOptionsBuilder {
 
   /** @return array<array{id: int, name: string}> */
   public function getTermOptions(string $taxonomy): array {
+    if (isset($this->terms[$taxonomy])) {
+      return $this->terms[$taxonomy];
+    }
     $terms = $this->wordPress->getTerms(['taxonomy' => $taxonomy, 'hide_empty' => false, 'orderby' => 'name']);
     if ($terms instanceof WP_Error) {
-      return [];
+      $this->terms[$taxonomy] = [];
+      return $this->terms[$taxonomy];
     }
-    return $this->buildTermsList((array)$terms);
+    $this->terms[$taxonomy] = $this->buildTermsList((array)$terms);
+    return $this->terms[$taxonomy];
   }
 
   /** @return array<array{id: int, name: string}> */


### PR DESCRIPTION
## Description
This is a follow up for https://github.com/mailpoet/mailpoet/pull/5484 and further improves the loading of terms.

## Code review notes
This PR improves the performance of the term loading. Two major improvements are suggested
1. When we loaded the terms of a taxonomy already, we do not need to load it again
2. We can improve the list building with a.) a lookup table, which limits the arrays we need to walk through in the recursive calls and b.) by not attempting to build a hierarchical list for non-hierarchical taxonomies.

## QA notes
This PR is concerned with the automation filters, more particularly the filters with which you can limit the triggers to only trigger for certain product categories or product tags.
![image](https://github.com/mailpoet/mailpoet/assets/6458412/d9943a0e-2987-4c42-b65c-d0ebd2ce9125)

The goal is to improve performance when you have a lot of categories or tags. It is important that we do not add any regressions.

1. Can I select all product tags or are some missing?
2. Can I select all product categories or are some missing?
3. The product categories are organized hierarchically. A child category should be underneath its parent and its name should look like "Parentname | Childname"

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5942]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5942]: https://mailpoet.atlassian.net/browse/MAILPOET-5942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ