### PR TITLE
Fix popover in automation template modal opening behind the modal [MAILPOET-5953]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
@@ -3,6 +3,7 @@ import {
   __unstableComposite as Composite,
   __unstableUseCompositeState as useCompositeState,
   SlotFillProvider,
+  Popover,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -70,6 +71,9 @@ export function Automation({
                 <Flow stepData={automationData.steps.root} row={0} />
               </div>
               <div />
+              {/* Render popovers within the automation, so they work in modals and other contexts. */}
+              {/* @ts-expect-error Slot is not currently typed on Popover */}
+              <Popover.Slot />
             </div>
             <InserterPopover />
           </Composite>


### PR DESCRIPTION
## Description

When clicking on `Filters: 1`, the popover displays behind the modal instead of within it:

![Screenshot 2024-03-12 at 16 54 34](https://github.com/mailpoet/mailpoet/assets/141436/eff79c7f-bc57-4a70-badc-42ac54d2eb21)


## Code review notes

_N/A_

## QA notes

The issue from description should be fixed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5953]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5953]: https://mailpoet.atlassian.net/browse/MAILPOET-5953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ