### PR TITLE
Optimize and cache term loading [MAILPOET-5942]

### DIFF
--- a/mailpoet/tests/integration/_bootstrap.php
+++ b/mailpoet/tests/integration/_bootstrap.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types = 1);
 
 use Codeception\Stub;
+use MailPoet\Automation\Integrations\WooCommerce\Fields\TermOptionsBuilder;
 use MailPoet\Cache\TransientCache;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\DI\ContainerWrapper;
@@ -113,6 +114,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
     // Reset caches
     $this->diContainer->get(FeaturesController::class)->resetCache();
     $this->diContainer->get(SettingsController::class)->resetCache();
+    $this->diContainer->get(TermOptionsBuilder::class)->resetCache();
 
     $this->entityManager->clear();
     $this->clearSubscribersCountCache();


### PR DESCRIPTION
## Description

A refactor of https://github.com/mailpoet/mailpoet/pull/5492.

## Code review notes

_N/A_

## QA notes
This PR is concerned with the automation filters, more particularly the filters with which you can limit the triggers to only trigger for certain product categories or product tags.
![image](https://github.com/mailpoet/mailpoet/assets/6458412/d9943a0e-2987-4c42-b65c-d0ebd2ce9125)

The goal is to improve performance when you have a lot of categories or tags. It is important that we do not add any regressions.

1. Can I select all product tags or are some missing?
2. Can I select all product categories or are some missing?
3. The product categories are organized hierarchically. A child category should be underneath its parent and its name should look like "Parentname | Childname"

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5942]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5942]: https://mailpoet.atlassian.net/browse/MAILPOET-5942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ