### PR TITLE
Add GA params only when tracking is set [MAILPOET-5939]

### DIFF
--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -4,6 +4,7 @@ namespace MailPoet\Statistics;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\Links\Links as NewsletterLinks;
+use MailPoet\Settings\TrackingConfig;
 use MailPoet\Util\Helpers;
 use MailPoet\Util\SecondLevelDomainNames;
 use MailPoet\WP\Functions;
@@ -19,16 +20,24 @@ class GATracking {
   /** @var Functions */
   private $wp;
 
+  /** @var TrackingConfig */
+  private $tackingConfig;
+
   public function __construct(
     NewsletterLinks $newsletterLinks,
-    Functions $wp
+    Functions $wp,
+    TrackingConfig $trackingConfig
   ) {
     $this->secondLevelDomainNames = new SecondLevelDomainNames();
     $this->newsletterLinks = $newsletterLinks;
     $this->wp = $wp;
+    $this->tackingConfig = $trackingConfig;
   }
 
   public function applyGATracking($renderedNewsletter, NewsletterEntity $newsletter, $internalHost = null) {
+    if (!$this->tackingConfig->isEmailTrackingEnabled()) {
+      return $renderedNewsletter;
+    }
     if ($newsletter->getType() == NewsletterEntity::TYPE_NOTIFICATION_HISTORY && $newsletter->getParent() instanceof NewsletterEntity) {
       $parentNewsletter = $newsletter->getParent();
       $field = $parentNewsletter->getGaCampaign();


### PR DESCRIPTION
## Description
[MAILPOET-5939]
This is just a small adjustment and does not need extensive review imo

## Code review notes

can skip

## QA notes

can skip

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5939]: https://mailpoet.atlassian.net/browse/MAILPOET-5939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ