### PR TITLE
Add check that the updatedAt value is set before calling format on it [MAILPOET-5860]

### DIFF
--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -76,7 +76,7 @@ class SubscribersResponseBuilder {
       'first_name' => $subscriberEntity->getFirstName(),
       'email' => $subscriberEntity->getEmail(),
       'created_at' => ($createdAt = $subscriberEntity->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $subscriberEntity->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $subscriberEntity->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $subscriberEntity->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'subscribed_ip' => $subscriberEntity->getSubscribedIp(),
       'confirmed_ip' => $subscriberEntity->getConfirmedIp(),


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

This PR adds a simple check that the value is set because we saw an error about calling the format method on the null value.

## QA notes

I think we can skip QA here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5860]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5860]: https://mailpoet.atlassian.net/browse/MAILPOET-5860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ