### PR TITLE
Use the value of lastSubscribedAt instead of createdAt in subscribers listing [MAILPOET-5894]

### DIFF
--- a/doc/api_methods/GetSubscriber.md
+++ b/doc/api_methods/GetSubscriber.md
@@ -31,6 +31,7 @@ This method throws an `\Exception` in the event a subscriber with a given email 
 | created_at               | string\|null | -         | UTC time of creation in 'Y-m-d H:i:s' format                                                                                   |
 | updated_at               | string       | -         | UTC time of last update in 'Y-m-d H:i:s' format                                                                                |
 | deleted_at               | string\|null | -         | This property in not null in case that list is in trash and contains UTC time in 'Y-m-d H:i:s' format.                         |
+| last_subscribed_at       | string\|null | -         | UTC time of last confirmed subscription in 'Y-m-d H:i:s' format.                                                               |
 | unconfirmed_data         | string\|null | 65K chars | May contain serialized subscriber data in case when there are pending changes waiting for a confirmation from a subscriber     |
 | source                   | string\|null | -         | Possible values: `form`,`imported`,`administrator`,`api`,`wordpress_user`,`woocommerce_user`,`woocommerce_checkout`,`unknown`) |
 | count_confirmations      | string       | 11 chars  | Counter for confirmation emails                                                                                                |

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -567,9 +567,13 @@ function SubscriberList({ match }) {
           className="column-date mailpoet-hide-on-mobile"
           data-colname={MailPoet.I18n.t('subscribedOn')}
         >
-          {MailPoet.Date.short(subscriber.last_subscribed_at)}
-          <br />
-          {MailPoet.Date.time(subscriber.last_subscribed_at)}
+          {subscriber.last_subscribed_at ? (
+            <>
+              {MailPoet.Date.short(subscriber.last_subscribed_at)}
+              <br />
+              {MailPoet.Date.time(subscriber.last_subscribed_at)}
+            </>
+          ) : null}
         </td>
       </div>
     );

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -31,6 +31,7 @@ type Subscriber = {
   last_name: string;
   engagement_score: number;
   created_at: string;
+  last_subscribed_at: string;
   subscriptions: Array<{
     id: number;
     status: string;
@@ -79,7 +80,7 @@ const columns = [
     display: mailpoetTrackingEnabled,
   },
   {
-    name: 'created_at',
+    name: 'last_subscribed_at',
     label: MailPoet.I18n.t('subscribedOn'),
     sortable: true,
   },
@@ -566,9 +567,9 @@ function SubscriberList({ match }) {
           className="column-date mailpoet-hide-on-mobile"
           data-colname={MailPoet.I18n.t('subscribedOn')}
         >
-          {MailPoet.Date.short(subscriber.created_at)}
+          {MailPoet.Date.short(subscriber.last_subscribed_at)}
           <br />
-          {MailPoet.Date.time(subscriber.created_at)}
+          {MailPoet.Date.time(subscriber.last_subscribed_at)}
         </td>
       </div>
     );

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -59,6 +59,7 @@ class SubscribersResponseBuilder {
       'wp_user_id' => $subscriber->getWpUserId(),
       'is_woocommerce_user' => $subscriber->getIsWoocommerceUser(),
       'created_at' => ($createdAt = $subscriber->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
+      'last_subscribed_at' => ($lastSubscribedAt = $subscriber->getLastSubscribedAt()) ? $lastSubscribedAt->format(self::DATE_FORMAT) : null,
       'engagement_score' => $subscriber->getEngagementScore(),
       'tags' => $this->buildTags($subscriber),
     ];

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -105,7 +105,7 @@ class SubscriberListingRepository extends ListingRepository {
   }
 
   protected function applySelectClause(QueryBuilder $queryBuilder) {
-    $queryBuilder->select("PARTIAL s.{id,email,firstName,lastName,status,createdAt,updatedAt,countConfirmations,wpUserId,isWoocommerceUser,engagementScore}");
+    $queryBuilder->select("PARTIAL s.{id,email,firstName,lastName,status,createdAt,updatedAt,countConfirmations,wpUserId,isWoocommerceUser,engagementScore,lastSubscribedAt}");
   }
 
   protected function applyFromClause(QueryBuilder $queryBuilder) {

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
@@ -110,6 +110,7 @@ class SubscribersResponseBuilderTest extends \MailPoetTest {
       $this->assertEquals($subscriber->getIsWoocommerceUser(), $item['is_woocommerce_user']);
       $this->assertEquals($subscriber->getStatus(), $item['status']);
       $this->assertArrayHasKey('created_at', $item);
+      $this->assertArrayHasKey('last_subscribed_at', $item);
       $this->assertArrayHasKey('count_confirmations', $item);
       $this->assertArrayHasKey('engagement_score', $item);
       // check subscriptions


### PR DESCRIPTION
## Description

Because the plugin uses the column `lastSubscribedAt` in the segment conditions, it was confusing to display values from the column `createdAt` as Subscribed on, so a user reported it as an issue. This PR replaces the rendering `createdAt` by `lastSubscribedAt`.
## Code review notes

_N/A_

## QA notes

1. Visit the subscribers' admin page
2. Check that the values in the column "Subscribed on" are equal to the values in the lastSubscribedAt in the DB
3. Try ordering by the column "Subscribed on"

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5894]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5894]: https://mailpoet.atlassian.net/browse/MAILPOET-5894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ