### PR TITLE
Display upgrade page for Tier 1

### DIFF
--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -28,7 +28,6 @@ use MailPoet\AdminPages\Pages\WooCommerceSetup;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Util\License\Features\CapabilitiesManager;
-use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Menu {
@@ -467,8 +466,7 @@ class Menu {
     );
 
     // Upgrade page
-    // Only show this page in menu if the Premium plugin is not activated
-    if (!License::getLicense() || $this->capabilitiesManager->showUpgradePage()) {
+    if ($this->capabilitiesManager->showUpgradePage()) {
       $this->wp->addSubmenuPage(
         self::MAIN_PAGE_SLUG,
         $this->setPageTitle(__('Upgrade', 'mailpoet')),

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -27,6 +27,7 @@ use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceSetup;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Form\Util\CustomFonts;
+use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\License\License;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -83,13 +84,16 @@ class Menu {
   /** @var CustomFonts  */
   private $customFonts;
 
+  private CapabilitiesManager $capabilitiesManager;
+
   public function __construct(
     AccessControl $accessControl,
     WPFunctions $wp,
     ServicesChecker $servicesChecker,
     ContainerWrapper $container,
     Router $router,
-    CustomFonts $customFonts
+    CustomFonts $customFonts,
+    CapabilitiesManager $capabilitiesManager
   ) {
     $this->accessControl = $accessControl;
     $this->wp = $wp;
@@ -97,6 +101,7 @@ class Menu {
     $this->container = $container;
     $this->router = $router;
     $this->customFonts = $customFonts;
+    $this->capabilitiesManager = $capabilitiesManager;
   }
 
   public function init() {
@@ -463,7 +468,7 @@ class Menu {
 
     // Upgrade page
     // Only show this page in menu if the Premium plugin is not activated
-    if (!License::getLicense()) {
+    if (!License::getLicense() || $this->capabilitiesManager->showUpgradePage()) {
       $this->wp->addSubmenuPage(
         self::MAIN_PAGE_SLUG,
         $this->setPageTitle(__('Upgrade', 'mailpoet')),

--- a/mailpoet/lib/Util/License/Features/CapabilitiesManager.php
+++ b/mailpoet/lib/Util/License/Features/CapabilitiesManager.php
@@ -16,6 +16,7 @@ class CapabilitiesManager {
   // Product capabilities mapping
   const MIN_TIER_LOGO_NOT_REQUIRED = 1;
   const MIN_TIER_ANALYTICS_ENABLED = 1;
+  const MIN_TIER_NO_UPGRADE_PAGE = 2;
   const MIN_TIER_UNLIMITED_AUTOMATION_STEPS = 2;
   const MIN_TIER_UNLIMITED_SEGMENT_FILTERS = 2;
 
@@ -114,5 +115,13 @@ class CapabilitiesManager {
       $this->getAutomationStepsLimit(),
       $this->getSegmentFiltersLimit(),
     );
+  }
+
+  public function showUpgradePage(): bool {
+    $tier = $this->getTier();
+    if ($this->subscribersFeature->hasValidPremiumKey() && isset($tier) && $tier < self::MIN_TIER_NO_UPGRADE_PAGE) {
+      return true;
+    }
+    return false;
   }
 }

--- a/mailpoet/lib/Util/License/Features/CapabilitiesManager.php
+++ b/mailpoet/lib/Util/License/Features/CapabilitiesManager.php
@@ -117,9 +117,12 @@ class CapabilitiesManager {
     );
   }
 
+  /**
+   * Returns true if there is no valid premium key or the product tier can be upgraded
+   */
   public function showUpgradePage(): bool {
     $tier = $this->getTier();
-    if ($this->subscribersFeature->hasValidPremiumKey() && isset($tier) && $tier < self::MIN_TIER_NO_UPGRADE_PAGE) {
+    if (!$this->subscribersFeature->hasValidPremiumKey() || (isset($tier) && $tier < self::MIN_TIER_NO_UPGRADE_PAGE)) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Description

Display the upgrade page also if Tier 1

## Code review notes

_N/A_

## QA notes

Check that the upgrade page is displayed if:
- premium is not installed
- key is valid but they have a Starter plan or they don't have premium
- key is not valid

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5905]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5905]: https://mailpoet.atlassian.net/browse/MAILPOET-5905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ