### PR TITLE
Email Editor: Fix button rendering in Outlook [MAILPOET-5836]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template.css
@@ -64,6 +64,7 @@ td {
 
   .layout-flex-item table,
   .layout-flex-item td {
+    box-sizing: border-box !important;
     display: block !important;
     width: 100% !important;
   }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -9,6 +9,7 @@ class Initializer {
   public function initialize(): void {
     add_action('mailpoet_blocks_renderer_initialized', [$this, 'registerCoreBlocksRenderers'], 10, 1);
     add_filter('mailpoet_email_editor_theme_json', [$this, 'adjustThemeJson'], 10, 1);
+    add_filter('safe_style_css', [$this, 'allowStyles']);
   }
 
   /**
@@ -34,5 +35,16 @@ class Initializer {
     /** @var array $themeJson */
     $editorThemeJson->merge(new \WP_Theme_JSON($themeJson, 'default'));
     return $editorThemeJson;
+  }
+
+  /**
+   * Allow styles for the email editor.
+   */
+  public function allowStyles(array $allowedStyles): array {
+    $allowedStyles[] = 'display';
+    $allowedStyles[] = 'mso-padding-alt';
+    $allowedStyles[] = 'mso-font-width';
+    $allowedStyles[] = 'mso-text-raise';
+    return $allowedStyles;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/AbstractBlockRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/AbstractBlockRenderer.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\BlockRenderer;
+use WP_Style_Engine;
+
+/**
+ * Shared functionality for block renderers.
+ */
+abstract class AbstractBlockRenderer implements BlockRenderer {
+  /**
+   * Wrapper for wp_style_engine_get_styles which ensures all values are returned.
+   *
+   * @param array $block_styles Array of block styles.
+   * @param bool $skip_convert_vars If true, --wp_preset--spacing--x type values will be left in the original var:preset:spacing:x format.
+   * @return array
+   */
+  protected function getStylesFromBlock(array $block_styles, $skip_convert_vars = false) {
+    $styles = wp_style_engine_get_styles( $block_styles, [ 'convert_vars_to_classnames' => $skip_convert_vars ] );
+    return wp_parse_args($styles, [
+      'css' => '',
+      'declarations' => [],
+      'classnames' => '',
+    ]);
+  }
+
+  /**
+   * Compile objects containing CSS properties to a string.
+   *
+   * @param array ...$styles Style arrays to compile.
+   * @return string
+   */
+  protected function compileCss(...$styles): string {
+    return WP_Style_Engine::compile_css( array_merge(...$styles), '' );
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/AbstractBlockRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/AbstractBlockRenderer.php
@@ -17,7 +17,7 @@ abstract class AbstractBlockRenderer implements BlockRenderer {
    * @return array
    */
   protected function getStylesFromBlock(array $block_styles, $skip_convert_vars = false) {
-    $styles = wp_style_engine_get_styles( $block_styles, [ 'convert_vars_to_classnames' => $skip_convert_vars ] );
+    $styles = wp_style_engine_get_styles($block_styles, ['convert_vars_to_classnames' => $skip_convert_vars]);
     return wp_parse_args($styles, [
       'css' => '',
       'declarations' => [],
@@ -32,6 +32,6 @@ abstract class AbstractBlockRenderer implements BlockRenderer {
    * @return string
    */
   protected function compileCss(...$styles): string {
-    return WP_Style_Engine::compile_css( array_merge(...$styles), '' );
+    return WP_Style_Engine::compile_css(array_merge(...$styles), '');
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -16,7 +16,7 @@ class Button extends AbstractBlockRenderer {
     $properties = ['border', 'color', 'typography', 'spacing'];
     $styles = $this->getStylesFromBlock(array_intersect_key($blockStyles, array_flip($properties)));
     return (object)[
-      'css' => $this->compileCss($styles['declarations'], [ 'word-break' => 'break-word' ]),
+      'css' => $this->compileCss($styles['declarations'], [ 'word-break' => 'break-word', 'display' => 'block' ]),
       'classname' => $styles['classnames'],
     ];
   }
@@ -74,7 +74,7 @@ class Button extends AbstractBlockRenderer {
       $blockAttributes['style'] ?? []
     );
 
-    if (isset($blockStyles['border']['width']) && empty($blockStyles['border']['style'])) {
+    if (!empty($blockStyles['border']) && empty($blockStyles['border']['style'])) {
       $blockStyles['border']['style'] = 'solid';
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -3,7 +3,6 @@
 namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use MailPoet\EmailEditor\Engine\SettingsController;
-use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\AbstractBlockRenderer;
 use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 
 /**

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -2,92 +2,36 @@
 
 namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
-use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\AbstractBlockRenderer;
 use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
-use WP_Style_Engine;
 
 /**
  * Renders a button block.
  * @see https://www.activecampaign.com/blog/email-buttons
  * @see https://documentation.mjml.io/#mj-button
  */
-class Button implements BlockRenderer {
-  private function getStylesFromBlock(array $block_styles, $skip_convert_vars = false) {
-    $styles = wp_style_engine_get_styles($block_styles, ['convert_vars_to_classnames' => $skip_convert_vars]);
-    return (object)wp_parse_args($styles, [
-      'css' => '',
-      'declarations' => [],
-      'classnames' => '',
+class Button extends AbstractBlockRenderer {
+  private function getWrapperStyles(array $blockStyles) {
+    $properties = ['border', 'color', 'typography', 'spacing'];
+    $styles = $this->getStylesFromBlock(array_intersect_key($blockStyles, array_flip($properties)));
+    return (object)[
+      'css' => $this->compileCss($styles['declarations'], [ 'word-break' => 'break-word' ]),
+      'classname' => $styles['classnames'],
+    ];
+  }
+
+  private function getLinkStyles(array $blockStyles) {
+    $styles = $this->getStylesFromBlock([
+      'color' => [
+        'text' => $blockStyles['color']['text'] ?? '',
+      ],
+      'typography' => $blockStyles['typography'],
     ]);
-  }
-
-  private function replaceSpacingPresets($styles, $presets) {
-    $replaced = [];
-    foreach ($styles as $key => $value) {
-      if (strstr($value, 'var:preset|spacing|')) {
-        $slug = str_replace('var:preset|spacing|', '', $value);
-        $replaced[$key] = $presets[$slug] ?? $value;
-      } else {
-        $replaced[$key] = $value;
-      }
-    }
-    return $replaced;
-  }
-
-  private function convertToPixels($size, $baseFontSize) {
-    $unit = '';
-    $value = '';
-
-    // Extract unit and value from the size
-    preg_match('/^([\d\.]+)(px|em|%)$/', $size, $matches);
-    if (count($matches) == 3) {
-        $value = absint($matches[1]);
-        $unit = $matches[2];
-    } else {
-        return 0;
-    }
-
-    // Convert size to pixels
-    switch ($unit) {
-      case 'px':
-        return $value;
-      case 'em':
-        return $value * $baseFontSize;
-      case '%':
-        return ($value / 100) * $baseFontSize;
-      default:
-        return 0;
-    }
-  }
-
-  /**
-   * We need to space using em units, so calculate the percentage of 1em for padding values.
-   *
-   * @param string|float|int $value Size in pixels.
-   * @return string
-   */
-  private function msoPaddingPercentage($value, $baseFontSize = 16) {
-    return round((floatval($value) / $baseFontSize), 2) * 100 . '%';
-  }
-
-  private function msoPadding($wrapContent, $padding, $baseFontSize = 16) {
-    // Convert padding to pixels.
-    $paddingTop = $this->convertToPixels($padding['padding-top'], $baseFontSize);
-    $paddingBottom = $this->convertToPixels($padding['padding-bottom'], $baseFontSize);
-    $paddingLeft = $this->convertToPixels($padding['padding-left'], $baseFontSize);
-    $paddingRight = $this->convertToPixels($padding['padding-right'], $baseFontSize);
-
-    return sprintf(
-      '<!--[if mso]><i style="%s" hidden>&emsp;</i><span style="%s"><![endif]-->%s<!--[if mso]></span><i style="%s" hidden>&emsp;&#8203;</i><![endif]-->',
-      // Top and left padding.
-      esc_attr(WP_Style_Engine::compile_css(['mso-font-width' => $this->msoPaddingPercentage($paddingLeft, $baseFontSize), 'mso-text-raise' => $this->msoPaddingPercentage($paddingTop + $paddingBottom, $baseFontSize)], '')),
-      // Bottom padding.
-      esc_attr(WP_Style_Engine::compile_css(['mso-text-raise' => $this->msoPaddingPercentage($paddingBottom, $baseFontSize)], '')),
-      $wrapContent,
-      // Right padding.
-      esc_attr(WP_Style_Engine::compile_css(['mso-font-width' => $this->msoPaddingPercentage($paddingRight, $baseFontSize)], '')),
-    );
+    return (object)[
+      'css' => $this->compileCss($styles['declarations'], [ 'display' => 'block' ]),
+      'classname' => $styles['classnames'],
+    ];
   }
 
   public function render($blockContent, array $parsedBlock, SettingsController $settingsController): string {
@@ -95,9 +39,9 @@ class Button implements BlockRenderer {
       return '';
     }
 
-    $themeSettings = $settingsController->getTheme()->get_settings();
     $themeData = $settingsController->getTheme()->get_data();
     $domHelper = new DomDocumentHelper($parsedBlock['innerHTML']);
+    $blockClassname = $domHelper->getAttributeValueByTagName('div', 'class') ?? '';
     $buttonLink = $domHelper->findElement('a');
 
     if (!$buttonLink) {
@@ -106,10 +50,9 @@ class Button implements BlockRenderer {
 
     $buttonText = $domHelper->getElementInnerHTML($buttonLink) ?: '';
     $buttonUrl = $buttonLink->getAttribute('href') ?: '#';
-    $buttonClasses = $domHelper->getAttributeValueByTagName('div', 'class') ?? '';
 
     $blockAttributes = wp_parse_args($parsedBlock['attrs'] ?? [], [
-      'width' => '100%',
+      'width' => '',
       'style' => [],
       'textAlign' => 'center',
       'backgroundColor' => '',
@@ -117,19 +60,17 @@ class Button implements BlockRenderer {
     ]);
 
     $blockStyles = array_replace_recursive(
-      array_replace_recursive(
-        $themeData['styles']['blocks']['core/button'] ?? [],
-        [
-          'color' => array_filter([
-            'background' => $blockAttributes['backgroundColor'] ? $settingsController->translateSlugToColor($blockAttributes['backgroundColor']) : null,
-            'text' => $blockAttributes['textColor'] ? $settingsController->translateSlugToColor($blockAttributes['textColor']) : null,
-          ]),
-          'typography' => [
-            'fontSize' => $parsedBlock['email_attrs']['font-size'] ?? 'inherit',
-            'textDecoration' => $parsedBlock['email_attrs']['text-decoration'] ?? 'none',
-          ],
-        ]
-      ),
+      $themeData['styles']['blocks']['core/button'] ?? [],
+      [
+        'color' => array_filter([
+          'background' => $blockAttributes['backgroundColor'] ? $settingsController->translateSlugToColor($blockAttributes['backgroundColor']) : null,
+          'text' => $blockAttributes['textColor'] ? $settingsController->translateSlugToColor($blockAttributes['textColor']) : null,
+        ]),
+        'typography' => [
+          'fontSize' => $parsedBlock['email_attrs']['font-size'] ?? 'inherit',
+          'textDecoration' => $parsedBlock['email_attrs']['text-decoration'] ?? 'none',
+        ],
+      ],
       $blockAttributes['style'] ?? []
     );
 
@@ -137,48 +78,25 @@ class Button implements BlockRenderer {
       $blockStyles['border']['style'] = 'solid';
     }
 
-    $wrapperStyles = $this->getStylesFromBlock([
-      'border' => $blockStyles['border'] ?? [],
-      'typography' => $blockStyles['typography'] ?? [],
-      'color' => [
-        'text' => $blockStyles['color']['text'] ?? '',
-        'background' => $blockStyles['color']['background'] ?? '',
-      ],
-    ]);
-
-    $linkStyles = $this->getStylesFromBlock([
-      'color' => [
-        'text' => $blockStyles['color']['text'] ?? '',
-      ],
-      'typography' => $blockStyles['typography'],
-      'spacing' => [
-        'padding' => $blockStyles['spacing']['padding'] ?? [],
-      ],
-    ]);
-
-    $paddingStyles = wp_parse_args(
-      $this->replaceSpacingPresets(
-        $this->getStylesFromBlock(['spacing' => ['padding' => $blockStyles['spacing']['padding'] ?? []]], true)->declarations,
-        wp_list_pluck($themeSettings['spacing']['spacingSizes']['default'] ?? [], 'size', 'slug')
-      ),
-      [
-        'padding-top' => '0px',
-        'padding-right' => '0px',
-        'padding-bottom' => '0px',
-        'padding-left' => '0px',
-      ]
-    );
+    $wrapperStyles = $this->getWrapperStyles($blockStyles);
+    $linkStyles = $this->getLinkStyles($blockStyles);
 
     return sprintf(
-      '<div class="%s" style="%stext-align:%s;width:%s;"><a rel="noopener" class="%s" style="display:block;word-break:break-word;%s" href="%s" target="_blank">%s</a></div>',
-      esc_attr($buttonClasses . ' ' . $wrapperStyles->classnames),
+      '<table border="0" cellspacing="0" cellpadding="0" role="presentation" style="width:%1$s;">
+        <tr>
+          <td align="%2$s" valign="middle" role="presentation" class="%3$s" style="%4$s">
+            <a class="%5$s" style="%6$s" href="%7$s" target="_blank">%8$s</a>
+          </td>
+        </tr>
+      </table>',
+      esc_attr($blockAttributes['width'] ? '100%' : 'auto'),
+      esc_attr($blockAttributes['textAlign']),
+      esc_attr($wrapperStyles->classname . ' ' . $blockClassname),
       esc_attr($wrapperStyles->css),
-      esc_attr($blockAttributes['textAlign'] ?? 'center'),
-      esc_attr(isset($blockAttributes['width']) ? '100%' : 'auto'),
-      esc_attr($linkStyles->classnames),
+      esc_attr($linkStyles->classname),
       esc_attr($linkStyles->css),
       esc_url($buttonUrl),
-      $this->msoPadding($buttonText, $paddingStyles, absint($linkStyles->declarations['font-size']) ?? 16)
+      wp_kses_post($buttonText),
     );
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -16,7 +16,7 @@ class Button extends AbstractBlockRenderer {
     $properties = ['border', 'color', 'typography', 'spacing'];
     $styles = $this->getStylesFromBlock(array_intersect_key($blockStyles, array_flip($properties)));
     return (object)[
-      'css' => $this->compileCss($styles['declarations'], [ 'word-break' => 'break-word', 'display' => 'block' ]),
+      'css' => $this->compileCss($styles['declarations'], ['word-break' => 'break-word', 'display' => 'block']),
       'classname' => $styles['classnames'],
     ];
   }
@@ -29,7 +29,7 @@ class Button extends AbstractBlockRenderer {
       'typography' => $blockStyles['typography'],
     ]);
     return (object)[
-      'css' => $this->compileCss($styles['declarations'], [ 'display' => 'block' ]),
+      'css' => $this->compileCss($styles['declarations'], ['display' => 'block']),
       'classname' => $styles['classnames'],
     ];
   }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -2,12 +2,12 @@
 
 namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
-use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\AbstractBlockRenderer;
 use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 use WP_Style_Engine;
 
-class Column implements BlockRenderer {
+class Column extends AbstractBlockRenderer {
   public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $content = '';
     foreach ($parsedBlock['innerBlocks'] ?? [] as $block) {
@@ -19,15 +19,6 @@ class Column implements BlockRenderer {
       $content,
       $this->getBlockWrapper($blockContent, $parsedBlock, $settingsController)
     );
-  }
-
-  private function getStylesFromBlock(array $block_styles) {
-    $styles = wp_style_engine_get_styles($block_styles);
-    return (object)wp_parse_args($styles, [
-      'css' => '',
-      'declarations' => [],
-      'classnames' => '',
-    ]);
   }
 
   /**
@@ -45,13 +36,13 @@ class Column implements BlockRenderer {
     // to create a feeling of a stretched column. This also needs to apply to CSS classnames which can also apply styles.
     $isStretched = empty($block_attributes['verticalAlignment']) || $block_attributes['verticalAlignment'] === 'stretch';
 
-    $paddingCSS = $this->getStylesFromBlock(['spacing' => ['padding' => $block_attributes['style']['spacing']['padding'] ?? []]])->css;
+    $paddingCSS = $this->getStylesFromBlock(['spacing' => ['padding' => $block_attributes['style']['spacing']['padding'] ?? []]])['css'];
     $cellStyles = $this->getStylesFromBlock([
         'color' => $block_attributes['style']['color'] ?? [],
         'background' => $block_attributes['style']['background'] ?? [],
-      ])->declarations;
+      ])['declarations'];
 
-    $borderStyles = $this->getStylesFromBlock(['border' => $block_attributes['style']['border'] ?? []])->declarations;
+    $borderStyles = $this->getStylesFromBlock(['border' => $block_attributes['style']['border'] ?? []])['declarations'];
 
     if (!empty($borderStyles)) {
       $cellStyles = array_merge($cellStyles, ['border-style' => 'solid'], $borderStyles);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -2,12 +2,12 @@
 
 namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
 
-use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\BlockRenderer;
 use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\AbstractBlockRenderer;
 use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 use WP_Style_Engine;
 
-class Columns implements BlockRenderer {
+class Columns extends AbstractBlockRenderer {
   public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
     $content = '';
     foreach ($parsedBlock['innerBlocks'] ?? [] as $block) {
@@ -19,15 +19,6 @@ class Columns implements BlockRenderer {
       $content,
       $this->getBlockWrapper($blockContent, $parsedBlock, $settingsController)
     );
-  }
-
-  private function getStylesFromBlock(array $block_styles) {
-    $styles = wp_style_engine_get_styles($block_styles);
-    return (object)wp_parse_args($styles, [
-      'css' => '',
-      'declarations' => [],
-      'classnames' => '',
-    ]);
   }
 
   /**
@@ -45,9 +36,9 @@ class Columns implements BlockRenderer {
       'spacing' => [ 'padding' => $block_attributes['style']['spacing']['padding'] ?? [] ],
       'color' => $block_attributes['style']['color'] ?? [],
       'background' => $block_attributes['style']['background'] ?? [],
-    ])->declarations;
+    ])['declarations'];
 
-    $borderStyles = $this->getStylesFromBlock(['border' => $block_attributes['style']['border'] ?? []])->declarations;
+    $borderStyles = $this->getStylesFromBlock(['border' => $block_attributes['style']['border'] ?? []])['declarations'];
 
     if (!empty($borderStyles)) {
       $cellStyles = array_merge($cellStyles, ['border-style' => 'solid'], $borderStyles);

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -73,7 +73,7 @@ class ButtonTest extends \MailPoetTest {
       'text' => '#111111',
     ];
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
-    verify($output)->stringContainsString('background:#000000;');
+    verify($output)->stringContainsString('background-color:#000000;');
     verify($output)->stringContainsString('color:#111111;');
   }
 
@@ -145,7 +145,7 @@ class ButtonTest extends \MailPoetTest {
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     // Verify default background colors theme.json for email editor
     // These can't be set via CSS inliner because of special email HTML markup
-    verify($output)->stringContainsString('background:#32373c;');
+    verify($output)->stringContainsString('background-color:#32373c;');
   }
 
   public function testItRendersBackgroundColorSetBySlug(): void {
@@ -155,7 +155,6 @@ class ButtonTest extends \MailPoetTest {
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     // For other blocks this is handled by CSS-inliner, but for button we need to handle it manually
     // because of special email HTML markup
-    verify($output)->stringContainsString('background:#000000;');
     verify($output)->stringContainsString('background-color:#000000;');
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -73,7 +73,6 @@ class ButtonTest extends \MailPoetTest {
       'text' => '#111111',
     ];
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
-    verify($output)->stringContainsString('bgcolor="#000000"');
     verify($output)->stringContainsString('background:#000000;');
     verify($output)->stringContainsString('color:#111111;');
   }
@@ -87,35 +86,6 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-color:#111111;');
     verify($output)->stringContainsString('border-width:10px;');
     verify($output)->stringContainsString('border-style:solid;');
-  }
-
-  public function testItRendersBorderNone(): void {
-    $this->parsedButton['attrs']['style']['border'] = [];
-    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
-    verify($output)->stringContainsString('border:none;');
-  }
-
-  public function testItRendersBorderWithTextColorFallback(): void {
-    $this->parsedButton['attrs']['style']['border'] = [
-      'width' => '10px',
-    ];
-    $this->parsedButton['attrs']['style']['color'] = [
-      'text' => '#111111',
-    ];
-    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
-    verify($output)->stringContainsString('border-color:#111111;');
-  }
-
-  public function testItRendersBorderWithTextColorFallbackForColorsFromPalette(): void {
-    $this->parsedButton['attrs']['style']['border'] = [
-      'width' => '10px',
-    ];
-    // Custom text color is not set so we use the text color from the palette
-    $this->parsedButton['attrs']['style']['color'] = null;
-    $this->parsedButton['attrs']['textColor'] = 'white';
-    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
-    // We set proper class for border color based on the text color slug
-    verify($output)->stringContainsString('has-white-border-color');
   }
 
   public function testItRendersEachSideSpecificBorder(): void {
@@ -175,7 +145,6 @@ class ButtonTest extends \MailPoetTest {
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     // Verify default background colors theme.json for email editor
     // These can't be set via CSS inliner because of special email HTML markup
-    verify($output)->stringContainsString('bgcolor="#32373c"');
     verify($output)->stringContainsString('background:#32373c;');
   }
 
@@ -186,7 +155,6 @@ class ButtonTest extends \MailPoetTest {
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     // For other blocks this is handled by CSS-inliner, but for button we need to handle it manually
     // because of special email HTML markup
-    verify($output)->stringContainsString('bgcolor="#000000"');
     verify($output)->stringContainsString('background:#000000;');
     verify($output)->stringContainsString('background-color:#000000;');
   }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -24,7 +24,10 @@ class RendererTest extends \MailPoetTest {
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $buttonHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-button', 'td');
     verify($buttonHtml)->stringContainsString('color:#ffffff');
-    verify($buttonHtml)->stringContainsString('padding:.7em 1.4em');
+    verify($buttonHtml)->stringContainsString('padding-bottom:0.7em;');
+    verify($buttonHtml)->stringContainsString('padding-left:1.4em;');
+    verify($buttonHtml)->stringContainsString('padding-right:1.4em;');
+    verify($buttonHtml)->stringContainsString('padding-top:0.7em;');
     verify($buttonHtml)->stringContainsString('background:#32373c');
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -28,7 +28,7 @@ class RendererTest extends \MailPoetTest {
     verify($buttonHtml)->stringContainsString('padding-left:1.4em;');
     verify($buttonHtml)->stringContainsString('padding-right:1.4em;');
     verify($buttonHtml)->stringContainsString('padding-top:0.7em;');
-    verify($buttonHtml)->stringContainsString('background:#32373c');
+    verify($buttonHtml)->stringContainsString('background-color:#32373c');
   }
 
   public function testButtonDefaultStylesDontOverwriteUserSetStyles() {
@@ -38,7 +38,6 @@ class RendererTest extends \MailPoetTest {
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $buttonHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-button', 'td');
     verify($buttonHtml)->stringContainsString('color:#0693e3');
-    verify($buttonHtml)->stringContainsString('background:#ffffff');
     verify($buttonHtml)->stringContainsString('background-color:#ffffff');
   }
 


### PR DESCRIPTION
## Description

Fixes button rendering in outlook and across other email clients using inline styles (globally and from block settings) using table based markup.

I've included a new `AbstractBlockRenderer` class to house shared logic across renderers, and I've simplified the render logic as much as I think possible.

## Code review notes

- `safe_style_css` lets us define some non-standard properties so WordPress will still compile them.
- `AbstractBlockRenderer` has some utility for getting block styles and compiling CSS to save repetition.
- The original class had a `getMarkup` method with placeholders, but it seemed to make more sense to inline this using `sprintf`.
- I attempted using the conditional padding method from https://www.litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design before going back to tables which worked across most clients except the newer Outlook versions where no padding was present at all. Using a table for all seemed like the simplest approach given the requirements.
- The previous code had `mso-padding-alt` usage to allow the links to have padding in modern clients but the wrapper to have padding in outlook. This did not work on latest Outlook 365 and resulted in no padding being applied at all. Because of this I've opted to use padding only on the wrapper. cc @costasovo 
- I removed the border fallbacks which didn't appear to be needed. Border style solid only gets forced when borders are enabled, otherwise no border styles are added. I didn't notice any problems when testing email clients with this approach. Test coverage was updated to reflect this change.

I tested the rendered output using Email On Acid. Some examples:

![o365_w10_lm_dt](https://github.com/mailpoet/mailpoet/assets/90977/5de209dc-83f2-49b7-a208-0eac8543dafe)
![gmailw10_chr26_win](https://github.com/mailpoet/mailpoet/assets/90977/ab7317ab-855f-4586-bb77-eba788ddf5a2)

Full report:

[Button testing_jHf8MtQzvSnZ5nSpA2owmXns5w06nWwwLl0rq6kP2k8Rh_2024-03-20 07.21.14.AM.zip](https://github.com/mailpoet/mailpoet/files/14667892/Button.testing_jHf8MtQzvSnZ5nSpA2owmXns5w06nWwwLl0rq6kP2k8Rh_2024-03-20.07.21.14.AM.zip)

## QA notes

Go to MailPoet > Emails > New Email > Create using new editor.

Test adding buttons with various colors, background colors, padding, and typography options. You can check the rendering by previewing the email.

To test other clients you can use Email on Acid as I did above.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5836](https://mailpoet.atlassian.net/browse/MAILPOET-5836)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5836]: https://mailpoet.atlassian.net/browse/MAILPOET-5836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ