### PR TITLE
Fix columns width is not respected in the renderer [MAILPOET-5945]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -73,7 +73,7 @@ class Columns implements BlockRenderer {
         <tbody>
           <tr>
             <td class="' . esc_attr($contentClassname) . '" style="text-align:left;width:100%;' . esc_attr($contentCSS) . '">
-              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:separate;">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse:separate;">
                 <tr>
                   {columns_content}
                 </tr>

--- a/mailpoet/lib/EmailEditor/README.md
+++ b/mailpoet/lib/EmailEditor/README.md
@@ -10,3 +10,7 @@ Bot PHP and JS code are divided into `engine` and `integrations` subdirectories.
 Anything MailPoet specific is in the integrations/MailPoet folder.
 
 For the core stuff that goes to the engine folder, avoid using other MailPoet-specific services and modules. The code in the Engine folder should work only with WP code or other stuff from the engine.
+
+## Known rendering issues
+
+- In some (not all) Outlook versions the width of columns is not respected. The columns will be rendered with the full width.


### PR DESCRIPTION
## Description

If a user changed the width of columns, it was not respected in the renderer, and the columns were rendered at full width. It was because the wrapping table set the width to 100%, and the inner columns couldn't change the width anymore.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5945]

## After-merge notes

Once this is merged, we need to write a P2 about the decision to document the rendering exceptions: https://mailpoetdev.wordpress.com/2024/03/21/ballade-team-meeting-march-21-2024/#comment-2829

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5945]: https://mailpoet.atlassian.net/browse/MAILPOET-5945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ