### PR TITLE
Change status for all associated purchases with an order [MAILPOET-5584]

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20240322_110443_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20240322_110443_App.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\WooCommerce\Helper;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+
+class Migration_20240322_110443_App extends AppMigration {
+  public function run(): void {
+    $wooCommerceHelper = $this->container->get(Helper::class);
+
+    // If Woo is not active and the table doesn't exist, we can skip this migration
+    if (!$wooCommerceHelper->isWooCommerceActive()) {
+      return;
+    }
+
+    $purchaseStatisticsTable = $this->getTableName(StatisticsWooCommercePurchaseEntity::class);
+    $purchaseStatistics = $this->entityManager->getConnection()->fetchAllAssociative("
+      SELECT order_id
+      FROM {$purchaseStatisticsTable}
+    ");
+
+    global $wpdb;
+    if ($wooCommerceHelper->isWooCommerceCustomOrdersTableEnabled()) {
+      $ordersTable = $wooCommerceHelper->getOrdersTableName();
+      $query = "
+        SELECT id AS order_id, status AS status
+        FROM `{$ordersTable}`
+        WHERE type = 'shop_order' AND id in (:orderIds)
+        ";
+    } else {
+      $query = "
+        SELECT wpp.id AS order_id, wpp.post_status AS status
+        FROM `{$wpdb->posts}` wpp
+        WHERE wpp.post_type = 'shop_order'
+        AND wpp.ID in (:orderIds)
+      ";
+    }
+
+    foreach (array_chunk($purchaseStatistics, 2) as $chunk) {
+      $orderIds = array_column($chunk, 'order_id');
+
+      /** @var array{order_id: int, status: string}[] $orders */
+      $orders = $this->entityManager->getConnection()->executeQuery(
+        $query,
+        ['orderIds' => $orderIds],
+        ['orderIds' => Connection::PARAM_INT_ARRAY],
+      )->fetchAllAssociative();
+
+      foreach ($orders as $order) {
+        $this->entityManager->getConnection()->executeStatement("
+          UPDATE {$purchaseStatisticsTable}
+          SET status = :status
+          WHERE order_id = :orderId
+        ", [
+          'orderId' => $order['order_id'],
+          'status' => str_replace('wc-', '', $order['status']), // WC order status in DB is prefixed with 'wc-'
+        ]);
+      }
+    }
+  }
+
+  /**
+   * @param class-string $entityClassName
+   */
+  private function getTableName(string $entityClassName): string {
+    return $this->entityManager->getClassMetadata($entityClassName)->getTableName();
+  }
+}

--- a/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
+++ b/mailpoet/lib/Statistics/Track/WooCommercePurchases.php
@@ -52,7 +52,7 @@ class WooCommercePurchases {
   public function trackPurchase($id, $useCookies = true) {
 
     $order = $this->woocommerceHelper->wcGetOrder($id);
-    if (!$order instanceof WC_Order || $this->trackExistingStatistic($order)) {
+    if (!$order instanceof WC_Order || $this->trackExistingStatistics($order)) {
       return;
     }
 
@@ -97,22 +97,27 @@ class WooCommercePurchases {
     if (!$order instanceof WC_Order) {
       return;
     }
-    $this->trackExistingStatistic($order);
+    $this->trackExistingStatistics($order);
   }
 
   /**
-   * Returns true when a valid purchase statistic for an order was found.
+   * Returns true when valid purchase statistics for an order were found.
    *
    * @param WC_Order $order
    * @return bool
    */
-  private function trackExistingStatistic(\WC_Order $order): bool {
-    $statistics = $this->statisticsWooCommercePurchasesRepository->findOneBy(['orderId' => $order->get_id()]);
-    if ($statistics && $statistics->getClick()) {
-      $this->statisticsWooCommercePurchasesRepository->createOrUpdateByClickDataAndOrder(
-        $statistics->getClick(),
-        $order
-      );
+  private function trackExistingStatistics(\WC_Order $order): bool {
+    $statistics = $this->statisticsWooCommercePurchasesRepository->findBy(['orderId' => $order->get_id()]);
+    if ($statistics) {
+      foreach ($statistics as $statistic) {
+        if (!$statistic->getClick()) {
+          continue;
+        }
+        $this->statisticsWooCommercePurchasesRepository->createOrUpdateByClickDataAndOrder(
+          $statistic->getClick(),
+          $order
+        );
+      }
       return true;
     }
     return false;

--- a/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/WooCommercePurchasesTest.php
@@ -95,13 +95,28 @@ class WooCommercePurchasesTest extends \MailPoetTest {
     $order->set_status('processing');
     $order->save();
 
+    $order2 = wc_create_order();
+    $this->assertInstanceOf(WC_Order::class, $order2);
+    $order2->set_billing_email($this->subscriber->getEmail());
+    $order2->set_total('12');
+    $order2->set_status('processing');
+    $order2->save();
+
     $statistic = $this->statisticsWooCommercePurchasesRepository->findOneBy(['orderId' => $order->get_id()]);
     $this->assertInstanceOf(StatisticsWooCommercePurchaseEntity::class, $statistic);
+    $this->assertEquals("processing", $statistic->getStatus());
+
+    $statistic2 = $this->statisticsWooCommercePurchasesRepository->findOneBy(['orderId' => $order2->get_id()]);
+    $this->assertInstanceOf(StatisticsWooCommercePurchaseEntity::class, $statistic2);
     $this->assertEquals("processing", $statistic->getStatus());
 
     $order->set_status('completed');
     $order->save();
     $this->assertEquals("completed", $statistic->getStatus());
+
+    $order2->set_status('completed');
+    $order2->save();
+    $this->assertEquals("completed", $statistic2->getStatus());
   }
 
   public function testItDoesNotTrackPaymentForWrongSubscriber() {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

This PR fixes changing the status of WC purchase statistics because when an order has more related statistics, we should change the state for all of them and not only for one of them.

## QA notes

1. Send two emails to a subscriber
2. Click on a link in both of them
3. Create an order in WC
4. Change the status of the order to `completed`
5. Check in subscriber statistics that the order is associated with both emails

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5584]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5584]: https://mailpoet.atlassian.net/browse/MAILPOET-5584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ