### PR TITLE
Revert accidental reformatting of performance tests [MAILPOET-5946]

### DIFF
--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -31,7 +31,7 @@ export async function automationAnalytics() {
 
     // Go to the Automation Analytics page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - automation - analytics & id = 142`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-analytics&id=142`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/automation-create-custom.js
+++ b/mailpoet/tests/performance/tests/automation-create-custom.js
@@ -39,7 +39,7 @@ export async function automationCreateCustom() {
 
     // Go to the Automations page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - automation - templates`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-templates`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -36,7 +36,7 @@ export async function automationCreateWelcome() {
 
     // Go to the Automations page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - automation - templates`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-templates`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -30,12 +30,9 @@ export async function automationTrashRestore() {
     await login(page);
 
     // Go to the Automations page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - automation`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-automation`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -36,7 +36,7 @@ export async function automationTriggerWorkflow() {
 
     // Go to the Add New Subscriber
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - subscribers# / new`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers#/new`,
       {
         waitUntil: 'networkidle',
       },
@@ -69,7 +69,7 @@ export async function automationTriggerWorkflow() {
 
     // Go to Scheduled Action to trigger the workflow
     await page.goto(
-      `${baseURL} / wp - admin / tools.php ? page = action - scheduler & status = pending`,
+      `${baseURL}/wp-admin/tools.php?page=action-scheduler&status=pending`,
       {
         waitUntil: 'networkidle',
       },
@@ -93,7 +93,7 @@ export async function automationTriggerWorkflow() {
 
     // Go to the Automation Analytics page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - automation - analytics & id = 151 & tab = automation - subscribers`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-automation-analytics&id=151&tab=automation-subscribers`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -31,12 +31,9 @@ export async function formsAdding() {
     await login(page);
 
     // Go to the Forms page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - forms`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-forms`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/lists-complex-segment.js
+++ b/mailpoet/tests/performance/tests/lists-complex-segment.js
@@ -34,12 +34,9 @@ export async function listsComplexSegment() {
     await login(page);
 
     // Go to the segments page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - segments`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-segments`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -32,12 +32,9 @@ export async function listsViewSubscribers() {
     await login(page);
 
     // Go to the Lists page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - lists`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-lists`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -31,12 +31,9 @@ export async function newsletterListing() {
     await login(page);
 
     // Go to the Emails page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - newsletters`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -31,12 +31,9 @@ export async function newsletterSearching() {
     await login(page);
 
     // Go to the Newsletters page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - newsletters`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -32,12 +32,9 @@ export async function newsletterSending() {
     await login(page);
 
     // Go to the Emails page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - newsletters`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -32,7 +32,7 @@ export async function newsletterStatistics() {
 
     // Go to the Newsletter Statistics page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - newsletters# / stats / 2`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters#/stats/2`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -33,7 +33,7 @@ export async function onboardingWizard() {
 
     // Go to the MailPoet Welcome Wizard page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - welcome - wizard# / steps / 1`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-welcome-wizard#/steps/1`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -31,7 +31,7 @@ export async function settingsBasic() {
 
     // Go to the Settings page
     await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - settings# / basics`,
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-settings#/basics`,
       {
         waitUntil: 'networkidle',
       },

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -39,12 +39,9 @@ export async function subscribersAdding() {
     await login(page);
 
     // Go to the Subscribers page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - subscribers`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -31,12 +31,9 @@ export async function subscribersFiltering() {
     await login(page);
 
     // Go to the Subscribers page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - subscribers`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -31,12 +31,9 @@ export async function subscribersListing() {
     await login(page);
 
     // Go to the Subscribers page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - subscribers`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -30,12 +30,9 @@ export async function subscribersTrashingRestoring() {
     await login(page);
 
     // Go to the Subscribers page
-    await page.goto(
-      `${baseURL} / wp - admin / admin.php ? page = mailpoet - subscribers`,
-      {
-        waitUntil: 'networkidle',
-      },
-    );
+    await page.goto(`${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers`, {
+      waitUntil: 'networkidle',
+    });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -16,7 +16,7 @@ import {
 export async function login(page) {
   // Go to WP Admin login page
   await Promise.all([
-    page.goto(`${baseURL} / wp - login.php`, { waitUntil: 'networkidle' }),
+    page.goto(`${baseURL}/wp-login.php`, { waitUntil: 'networkidle' }),
     page.waitForSelector('#user_login'),
   ]);
   // Enter login credentials and login


### PR DESCRIPTION
[MAILPOET-5946]

## Description

Caused by: https://github.com/mailpoet/mailpoet/pull/5503

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5946]: https://mailpoet.atlassian.net/browse/MAILPOET-5946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ