### PR TITLE
Add List-Unsubscribe-Post header to PHPMailerMethod [MAILPOET-5983]

### DIFF
--- a/mailpoet/lib/Mailer/Methods/PHPMailerMethod.php
+++ b/mailpoet/lib/Mailer/Methods/PHPMailerMethod.php
@@ -75,6 +75,7 @@ abstract class PHPMailerMethod implements MailerMethod {
     }
     $mailer->Sender = $this->returnPath; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     if (!empty($extraParams['unsubscribe_url'])) {
+      $this->mailer->addCustomHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
       $this->mailer->addCustomHeader('List-Unsubscribe', '<' . $extraParams['unsubscribe_url'] . '>');
     }
 

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -129,10 +129,10 @@ class AmazonSESTest extends \MailPoetTest {
     verify($mailer->Subject)->equals($this->newsletter['subject']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->Body)->equals($this->newsletter['body']['html']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->AltBody)->equals($this->newsletter['body']['text']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    verify($mailer->getCustomHeaders())->equals([[
-      'List-Unsubscribe',
-      '<https://www.mailpoet.com>',
-    ]]);
+    verify($mailer->getCustomHeaders())->equals([
+      ['List-Unsubscribe-Post', 'List-Unsubscribe=One-Click'],
+      ['List-Unsubscribe', '<https://www.mailpoet.com>'],
+    ]);
   }
 
   public function testItCanCreateRequest() {

--- a/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -90,14 +90,10 @@ class PHPMailTest extends \MailPoetTest {
       ->equals($this->newsletter['body']['html']);
     verify($mailer->AltBody) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       ->equals($this->newsletter['body']['text']);
-    verify($mailer->getCustomHeaders())->equals(
-      [
-        [
-          'List-Unsubscribe',
-          '<https://www.mailpoet.com>',
-        ],
-      ]
-    );
+    verify($mailer->getCustomHeaders())->equals([
+      ['List-Unsubscribe-Post', 'List-Unsubscribe=One-Click'],
+      ['List-Unsubscribe', '<https://www.mailpoet.com>'],
+    ]);
   }
 
   public function testItCanConfigureMailerWithTextEmail() {

--- a/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
@@ -107,7 +107,10 @@ class SMTPTest extends \MailPoetTest {
     verify($mailer->Subject)->equals($this->newsletter['subject']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->Body)->equals($this->newsletter['body']['html']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->AltBody)->equals($this->newsletter['body']['text']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    verify($mailer->getCustomHeaders())->equals([['List-Unsubscribe', '<https://www.mailpoet.com>']]);
+    verify($mailer->getCustomHeaders())->equals([
+      ['List-Unsubscribe-Post', 'List-Unsubscribe=One-Click'],
+      ['List-Unsubscribe', '<https://www.mailpoet.com>'],
+    ]);
   }
 
   public function testItCanProcessSubscriber() {


### PR DESCRIPTION
## Description

A user reported a missing header `List-Unsubscribe-Post` when it used the Amazon SES sending method. This PR adds this header when the header `List-Unsubscribe` is set.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5983]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5983]: https://mailpoet.atlassian.net/browse/MAILPOET-5983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ