### PR TITLE
Fix flaky performance test automation trigger workflow

### DIFF
--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -20,7 +20,11 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2 } from '../utils/helpers.js';
+import {
+  login,
+  selectInSelect2,
+  waitForSelectorToBeVisible,
+} from '../utils/helpers.js';
 
 export async function automationTriggerWorkflow() {
   const page = browser.newPage();
@@ -100,13 +104,16 @@ export async function automationTriggerWorkflow() {
     );
 
     // Filter subscribers by subscribed email and completed status
+    await waitForSelectorToBeVisible(page, '.components-text-control__input');
+    await page.selectOption('#inspector-select-control-1', 'complete');
     await page.waitForLoadState('networkidle');
     await page
       .locator('.components-text-control__input')
       .type(subscriberEmail, { delay: 25 });
-    await page.selectOption('#inspector-select-control-1', 'complete');
-    await page.locator('.components-text-control__input').click();
-    await page.keyboard.press('Enter');
+    await page.waitForLoadState('networkidle');
+    await page
+      .locator('.mailpoet-analytics-filter > div > button.is-primary')
+      .click();
 
     await page.screenshot({
       path: screenshotPath + 'Automation_Trigger_Workflow_03.png',


### PR DESCRIPTION
## Description

Fix flakiness in k6 performance test Automation Trigger Workflow.

## Code review notes

I tested it locally and reproduced it then with the fix I executed 5/5 and it worked greatly. Previously failing in 3 consequence runs.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5990]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5990]: https://mailpoet.atlassian.net/browse/MAILPOET-5990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ