### PR TITLE
Fix W3C standard violation [MAILPOET-5993]

### DIFF
--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -141,7 +141,7 @@ class BlockRendererHelper {
         . $forId
         . $labelClass
         . $this->renderFontStyle($formSettings, $block['styles'] ?? [])
-        . ($automationId ?? '')
+        . ($automationId ? " $automationId" : '')
         . '>';
       $html .= htmlspecialchars($block['params']['label']);
 


### PR DESCRIPTION
## Description

Reported in https://wordpress.org/support/topic/w3c-standard-violation/#post-17543406.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5993]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5993]: https://mailpoet.atlassian.net/browse/MAILPOET-5993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ