### PR TITLE
Add new k6 performance test for re-engagement email

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -24,6 +24,7 @@ import { automationTrashRestore } from './tests/automation-trash-restore.js';
 import { automationTriggerWorkflow } from './tests/automation-trigger-workflow.js';
 import { automationCreateWooCommerce } from './tests/automation-create-woocommerce.js';
 import { newsletterPostNotification } from './tests/newsletters-post-notification.js';
+import { newsletterReEngagement } from './tests/newsletter-reengagement.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -86,12 +87,13 @@ if (scenario) {
 }
 
 // Run those tests against a pull request build
-// Note: there are 20 checks in total
+// Note: there are 21 checks in total
 export async function pullRequests() {
   await onboardingWizard();
   await newsletterListing();
   await newsletterSearching();
   await newsletterPostNotification();
+  await newsletterReEngagement();
   await automationTrashRestore();
   await automationCreateWelcome();
   await automationCreateWooCommerce();
@@ -103,13 +105,14 @@ export async function pullRequests() {
 }
 
 // Run those tests against trunk in a nightly build
-// Note: there are 37 checks in total
+// Note: there are 38 checks in total
 export async function nightly() {
   await newsletterListing();
   await newsletterStatistics();
   await newsletterSearching();
   await newsletterSending();
   await newsletterPostNotification();
+  await newsletterReEngagement();
   await automationTrashRestore();
   await automationCreateCustom();
   await automationCreateWelcome();

--- a/mailpoet/tests/performance/tests/newsletter-reengagement.js
+++ b/mailpoet/tests/performance/tests/newsletter-reengagement.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  defaultListName,
+  emailsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import { login, selectInSelect2 } from '../utils/helpers.js';
+/* global Promise */
+
+export async function newsletterReEngagement() {
+  const page = browser.newPage();
+
+  try {
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the Emails page
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-newsletters#/new/re-engagement`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Newsletter_Re_Engagement_01.png',
+      fullPage: fullPageSet,
+    });
+
+    // Click to add a new re-engagement email and set frequency
+    await page.locator('input[type="text"]').fill('99');
+    await page.locator('.mailpoet-button.mailpoet-full-width').click();
+    await page.waitForSelector('.mailpoet_loading');
+    await page.waitForSelector(
+      '[data-automation-id="templates-re_engagement"]',
+    );
+    await page.waitForLoadState('networkidle');
+
+    // Switch to a Standard templates tab and select the 2nd template
+    await page
+      .locator('[data-automation-id="templates-re_engagement"]')
+      .click();
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('[data-automation-id="select_template_1"]').click(),
+    ]);
+    await page.waitForSelector('.mailpoet_loading');
+    await page.waitForSelector('[data-automation-id="newsletter_title"]');
+    await page.waitForLoadState('networkidle');
+
+    await page.screenshot({
+      path: screenshotPath + 'Newsletter_Re_Engagement_02.png',
+      fullPage: fullPageSet,
+    });
+
+    // Try to close the tutorial video popup
+    try {
+      await page.locator('#mailpoet_modal_close').click({ timeout: 5000 });
+    } catch (error) {
+      console.log("Tutorial video wasn't present, skipping action.");
+    }
+
+    // Click to proceed to the next step (the last one)
+    await Promise.all([
+      page.waitForNavigation(),
+      page
+        .locator('#mailpoet_editor_top > div > div > .mailpoet_save_next')
+        .click(),
+    ]);
+    await page.waitForSelector(
+      '[data-automation-id="newsletter_send_heading"]',
+    );
+    await page.waitForLoadState('networkidle');
+
+    // Select the default list and send the newsletter
+    await selectInSelect2(page, defaultListName);
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('[data-automation-id="email-submit"]').click(),
+    ]);
+    sleep(1);
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Newsletter_Re_Engagement_03.png',
+      fullPage: fullPageSet,
+    });
+
+    // Wait for the success notice message and confirm it
+    const locator =
+      "//div[@class='notice-success'].//p[starts-with(text(),'Your Re-engagement Email is now activated!')]";
+    await page.waitForSelector('#mailpoet_notices');
+    describe(emailsPageTitle, () => {
+      describe('newsletter-re-engagement: should be able to see Re-engagement is active message', () => {
+        expect(page.locator(locator)).to.exist;
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Newsletter_Re_Engagement_04.png',
+      fullPage: fullPageSet,
+    });
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default async function newsletterReEngagementTest() {
+  await newsletterReEngagement();
+}


### PR DESCRIPTION
## Description

Add new k6 performance test Re Engagement email

## Code review notes

Optionally check how much checks are in the CI run, should be 21.
Open [this link directly](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/17487/workflows/af58cc3d-bb3f-47f6-950d-1ff472db0b0a/jobs/297344) and expand Run Performance Tests.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5870]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5870]: https://mailpoet.atlassian.net/browse/MAILPOET-5870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ