### PR TITLE
Add Satismeter survey to email editor [MAILPOET-5911]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/editor.tsx
@@ -4,6 +4,7 @@ import { StrictMode, createRoot } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import { EntityProvider } from '@wordpress/core-data';
+import { withNpsPoll } from '../../nps-poll';
 import { initBlocks } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { BlockEditor } from './components/block-editor';
@@ -33,6 +34,8 @@ function Editor() {
   );
 }
 
+const EditorWithPool = withNpsPoll(Editor);
+
 export function initialize(elementId: string) {
   const container = document.getElementById(elementId);
   if (!container) {
@@ -43,5 +46,5 @@ export function initialize(elementId: string) {
   initBlocks();
   initHooks();
   const root = createRoot(container);
-  root.render(<Editor />);
+  root.render(<EditorWithPool />);
 }

--- a/mailpoet/assets/js/src/nps-poll.jsx
+++ b/mailpoet/assets/js/src/nps-poll.jsx
@@ -32,8 +32,11 @@ const useNpsPoll = () => {
       const newUsersPollId = '6L479eVPXk7pBn6S';
       const oldUsersPollId = 'k0aJAsQAWI2ERyGv';
       const formPollId = 'EqOgKsgZd832Sz9w';
+      const emailEditorPollId = '9qCj2SJBE1s5OhnX5NYfRXu82pEDUB9x';
       let writeKey;
-      if (window.mailpoet_display_nps_form) {
+      if (window.mailpoet_display_nps_email_editor) {
+        writeKey = emailEditorPollId;
+      } else if (window.mailpoet_display_nps_form) {
         writeKey = formPollId;
       } else if (window.mailpoet_is_new_user) {
         writeKey = newUsersPollId;

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -87,6 +87,15 @@ class NewslettersRepository extends Repository {
       ->getSingleScalarResult());
   }
 
+  public function getCountOfEmailsWithWPPost(): int {
+    return intval($this->entityManager->createQueryBuilder()
+      ->select('COUNT(n.id)')
+      ->from(NewsletterEntity::class, 'n')
+      ->andWhere('n.wpPost IS NOT NULL')
+      ->getQuery()
+      ->getSingleScalarResult());
+  }
+
   /**
    * @return NewsletterEntity[]
    */


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

1. Create and save at least two emails in the new email editor
2. Open one of the new emails in the new email editor
3. A new Satismeter poll should be visible

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5911]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5911]: https://mailpoet.atlassian.net/browse/MAILPOET-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ