### PR TITLE
[Email Editor] Add move to trash button [MAILPOET-5947] 

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/header/more-menu.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/more-menu.tsx
@@ -27,7 +27,8 @@ export function MoreMenu(): JSX.Element {
     'mailpoet_email',
     'status',
   );
-  const { saveEditedEmail } = useDispatch(storeName);
+  const { saveEditedEmail, updateEmailMailPoetProperty } =
+    useDispatch(storeName);
   const goToListings = () => {
     window.location.href = urls.listings;
   };
@@ -83,6 +84,7 @@ export function MoreMenu(): JSX.Element {
                 <MenuItem
                   onClick={async () => {
                     await setStatus('draft');
+                    await updateEmailMailPoetProperty('deleted_at', '');
                     await saveEditedEmail();
                   }}
                 >

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/more-menu.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/more-menu.tsx
@@ -1,10 +1,11 @@
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { displayShortcut } from '@wordpress/keycodes';
+import { useEntityProp } from '@wordpress/core-data';
 import { __, _x } from '@wordpress/i18n';
 import { MoreMenuDropdown } from '@wordpress/interface';
 import { PreferenceToggleMenuItem } from '@wordpress/preferences';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { storeName } from '../../store';
 import { TrashModal } from './trash-modal';
 
@@ -21,6 +22,12 @@ export function MoreMenu(): JSX.Element {
     }),
     [],
   );
+  const [status, setStatus] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'status',
+  );
+  const { saveEditedEmail } = useDispatch(storeName);
   const goToListings = () => {
     window.location.href = urls.listings;
   };
@@ -72,9 +79,20 @@ export function MoreMenu(): JSX.Element {
               />
             </MenuGroup>
             <MenuGroup>
-              <MenuItem onClick={() => setShowTrashModal(true)} isDestructive>
-                {__('Move to trash', 'mailpoet')}
-              </MenuItem>
+              {status === 'trash' ? (
+                <MenuItem
+                  onClick={async () => {
+                    await setStatus('draft');
+                    await saveEditedEmail();
+                  }}
+                >
+                  {__('Restore from trash', 'mailpoet')}
+                </MenuItem>
+              ) : (
+                <MenuItem onClick={() => setShowTrashModal(true)} isDestructive>
+                  {__('Move to trash', 'mailpoet')}
+                </MenuItem>
+              )}
             </MenuGroup>
           </>
         )}

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/more-menu.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/more-menu.tsx
@@ -1,54 +1,91 @@
-import { MenuGroup } from '@wordpress/components';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { displayShortcut } from '@wordpress/keycodes';
 import { __, _x } from '@wordpress/i18n';
 import { MoreMenuDropdown } from '@wordpress/interface';
 import { PreferenceToggleMenuItem } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 import { storeName } from '../../store';
+import { TrashModal } from './trash-modal';
 
 // See:
 //   https://github.com/WordPress/gutenberg/blob/9601a33e30ba41bac98579c8d822af63dd961488/packages/edit-post/src/components/header/more-menu/index.js
 //   https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/header/more-menu/index.js
 
 export function MoreMenu(): JSX.Element {
+  const [showTrashModal, setShowTrashModal] = useState(false);
+  const { urls, postId } = useSelect(
+    (select) => ({
+      urls: select(storeName).getUrls(),
+      postId: select(storeName).getEmailPostId(),
+    }),
+    [],
+  );
+  const goToListings = () => {
+    window.location.href = urls.listings;
+  };
+
   return (
-    <MoreMenuDropdown
-      className="edit-site-more-menu"
-      popoverProps={{
-        className: 'edit-site-more-menu__content',
-      }}
-    >
-      {() => (
-        <MenuGroup label={_x('View', 'noun', 'mailpoet')}>
-          <PreferenceToggleMenuItem
-            scope={storeName}
-            name="fixedToolbar"
-            label={__('Top toolbar', 'mailpoet')}
-            info={__(
-              'Access all block and document tools in a single place',
-              'mailpoet',
-            )}
-            messageActivated={__('Top toolbar activated', 'mailpoet')}
-            messageDeactivated={__('Top toolbar deactivated', 'mailpoet')}
-          />
-          <PreferenceToggleMenuItem
-            scope={storeName}
-            name="focusMode"
-            label={__('Spotlight mode', 'mailpoet')}
-            info={__('Focus at one block at a time', 'mailpoet')}
-            messageActivated={__('Spotlight mode activated', 'mailpoet')}
-            messageDeactivated={__('Spotlight mode deactivated', 'mailpoet')}
-          />
-          <PreferenceToggleMenuItem
-            scope={storeName}
-            name="fullscreenMode"
-            label={__('Fullscreen mode', 'mailpoet')}
-            info={__('Work without distraction', 'mailpoet')}
-            messageActivated={__('Fullscreen mode activated', 'mailpoet')}
-            messageDeactivated={__('Fullscreen mode deactivated', 'mailpoet')}
-            shortcut={displayShortcut.secondary('f')}
-          />
-        </MenuGroup>
+    <>
+      <MoreMenuDropdown
+        className="edit-site-more-menu"
+        popoverProps={{
+          className: 'edit-site-more-menu__content',
+        }}
+      >
+        {() => (
+          <>
+            <MenuGroup label={_x('View', 'noun', 'mailpoet')}>
+              <PreferenceToggleMenuItem
+                scope={storeName}
+                name="fixedToolbar"
+                label={__('Top toolbar', 'mailpoet')}
+                info={__(
+                  'Access all block and document tools in a single place',
+                  'mailpoet',
+                )}
+                messageActivated={__('Top toolbar activated', 'mailpoet')}
+                messageDeactivated={__('Top toolbar deactivated', 'mailpoet')}
+              />
+              <PreferenceToggleMenuItem
+                scope={storeName}
+                name="focusMode"
+                label={__('Spotlight mode', 'mailpoet')}
+                info={__('Focus at one block at a time', 'mailpoet')}
+                messageActivated={__('Spotlight mode activated', 'mailpoet')}
+                messageDeactivated={__(
+                  'Spotlight mode deactivated',
+                  'mailpoet',
+                )}
+              />
+              <PreferenceToggleMenuItem
+                scope={storeName}
+                name="fullscreenMode"
+                label={__('Fullscreen mode', 'mailpoet')}
+                info={__('Work without distraction', 'mailpoet')}
+                messageActivated={__('Fullscreen mode activated', 'mailpoet')}
+                messageDeactivated={__(
+                  'Fullscreen mode deactivated',
+                  'mailpoet',
+                )}
+                shortcut={displayShortcut.secondary('f')}
+              />
+            </MenuGroup>
+            <MenuGroup>
+              <MenuItem onClick={() => setShowTrashModal(true)} isDestructive>
+                {__('Move to trash', 'mailpoet')}
+              </MenuItem>
+            </MenuGroup>
+          </>
+        )}
+      </MoreMenuDropdown>
+      {showTrashModal && (
+        <TrashModal
+          onClose={() => setShowTrashModal(false)}
+          onRemove={goToListings}
+          postId={postId}
+        />
       )}
-    </MoreMenuDropdown>
+    </>
   );
 }

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/trash-modal.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/trash-modal.tsx
@@ -35,17 +35,22 @@ export function TrashModal({
         'mailpoet_email',
         postId,
       );
-      const errorMessage = lastError?.message
-        ? (lastError.message as string)
-        : __(
-            'An error occurred while moving the email to the trash.',
-            'mailpoet',
-          );
-      await createErrorNotice(errorMessage, {
-        type: 'snackbar',
-        isDismissible: true,
-        context: 'email-editor',
-      });
+      // Already deleted.
+      if (lastError?.code === 410) {
+        onRemove();
+      } else {
+        const errorMessage = lastError?.message
+          ? (lastError.message as string)
+          : __(
+              'An error occurred while moving the email to the trash.',
+              'mailpoet',
+            );
+        await createErrorNotice(errorMessage, {
+          type: 'snackbar',
+          isDismissible: true,
+          context: 'email-editor',
+        });
+      }
     }
   };
   return (

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/trash-modal.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/trash-modal.tsx
@@ -1,0 +1,73 @@
+import { __ } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+
+export function TrashModal({
+  onClose,
+  onRemove,
+  postId,
+}: {
+  onClose: () => void;
+  onRemove: () => void;
+  postId: number;
+}) {
+  const { getLastEntityDeleteError } = useSelect(coreStore);
+  const { deleteEntityRecord } = useDispatch(coreStore);
+  const { createErrorNotice } = useDispatch(noticesStore);
+  const closeCallback = () => {
+    onClose();
+  };
+  const trashCallback = async () => {
+    const success = await deleteEntityRecord(
+      'postType',
+      'mailpoet_email',
+      postId as unknown as string,
+      {},
+      { throwOnError: false },
+    );
+    if (success) {
+      onRemove();
+    } else {
+      const lastError = getLastEntityDeleteError(
+        'postType',
+        'mailpoet_email',
+        postId,
+      );
+      const errorMessage = lastError?.message
+        ? (lastError.message as string)
+        : __(
+            'An error occurred while moving the email to the trash.',
+            'mailpoet',
+          );
+      await createErrorNotice(errorMessage, {
+        type: 'snackbar',
+        isDismissible: true,
+        context: 'email-editor',
+      });
+    }
+  };
+  return (
+    <Modal
+      className="mailpoet-move-to-trash-modal"
+      title={__('Move to trash', 'mailpoet')}
+      onRequestClose={closeCallback}
+      focusOnMount="firstContentElement"
+    >
+      <p>
+        {__('Are you sure you want to move this email to trash?', 'mailpoet')}
+      </p>
+      <div className="mailpoet-send-preview-modal-footer">
+        <Button variant="tertiary" onClick={closeCallback}>
+          {__('Cancel', 'mailpoet')}
+        </Button>
+        <Button variant="primary" onClick={trashCallback}>
+          {__('Move to trash', 'mailpoet')}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default TrashModal;

--- a/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/initial-state.ts
@@ -6,6 +6,7 @@ import {
   getCdnUrl,
   isPremiumPluginActive,
   getEditorTheme,
+  getUrls,
 } from './settings';
 
 export function getInitialState(): State {
@@ -28,6 +29,7 @@ export function getInitialState(): State {
     autosaveInterval: 60,
     cdnUrl: getCdnUrl(),
     isPremiumPluginActive: isPremiumPluginActive(),
+    urls: getUrls(),
     preview: {
       deviceType: 'Desktop',
       toEmail: window.MailPoetEmailEditor.current_wp_user_email,

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -187,3 +187,7 @@ export function isPremiumPluginActive(state: State): boolean {
 export function getTheme(state: State): State['theme'] {
   return state.theme;
 }
+
+export function getUrls(state: State): State['urls'] {
+  return state.urls;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/store/settings.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/settings.ts
@@ -1,4 +1,9 @@
-import { EmailEditorSettings, EmailEditorLayout, EmailTheme } from './types';
+import {
+  EmailEditorSettings,
+  EmailEditorLayout,
+  EmailTheme,
+  EmailEditorUrls,
+} from './types';
 
 export function getEditorSettings(): EmailEditorSettings {
   return window.MailPoetEmailEditor.editor_settings as EmailEditorSettings;
@@ -18,4 +23,8 @@ export function isPremiumPluginActive(): boolean {
 
 export function getEditorTheme(): EmailTheme {
   return window.MailPoetEmailEditor.editor_theme as EmailTheme;
+}
+
+export function getUrls(): EmailEditorUrls {
+  return window.MailPoetEmailEditor.urls as EmailEditorUrls;
 }

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -81,6 +81,10 @@ export type EmailEditorLayout = {
   contentSize: string;
 };
 
+export type EmailEditorUrls = {
+  listings: string;
+};
+
 export type State = {
   inserterSidebar: {
     isOpened: boolean;
@@ -97,6 +101,7 @@ export type State = {
   theme: EmailTheme;
   autosaveInterval: number;
   cdnUrl: string;
+  urls: EmailEditorUrls;
   isPremiumPluginActive: boolean;
   preview: {
     deviceType: string;

--- a/mailpoet/assets/js/src/email-editor/global.d.ts
+++ b/mailpoet/assets/js/src/email-editor/global.d.ts
@@ -9,6 +9,9 @@ interface Window {
     bc_state: {
       isInlinedBlockToolbarAvailable: boolean;
     };
+    urls: {
+      listings: string;
+    };
     editor_settings: unknown; // Can't import type in global.d.ts. Typed in getEditorSettings() in store/settings.ts
     email_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailStyles() in store/settings.ts
     editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts

--- a/mailpoet/lib/AdminPages/Pages/EmailEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/EmailEditor.php
@@ -92,6 +92,9 @@ class EmailEditor {
         'editor_layout' => $this->settingsController->getLayout(),
         'editor_theme' => $this->themeController->getTheme()->get_raw_data(),
         'bc_state' => $this->getBackwardCompatibilityState(),
+        'urls' => [
+          'listings' => admin_url('admin.php?page=mailpoet-newsletters'),
+        ],
       ]
     );
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -54,6 +54,17 @@ class EmailApiController {
     $this->newsletterRepository->flush();
   }
 
+  public function trashEmail(\WP_Post $wpPost) {
+    $newsletter = $this->newsletterRepository->findOneBy(['wpPost' => $wpPost->ID]);
+    if (!$newsletter) {
+      throw new NotFoundException('Newsletter was not found');
+    }
+    if ($newsletter->getWpPostId() !== $wpPost->ID) {
+      throw new UnexpectedValueException('Newsletter ID does not match the post ID');
+    }
+    $this->newsletterRepository->bulkTrash([$newsletter->getId()]);
+  }
+
   public function getEmailDataSchema(): array {
     return Builder::object([
       'id' => Builder::integer()->nullable(),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -82,7 +82,7 @@ class EmailApiController {
       'subject' => Builder::string(),
       'preheader' => Builder::string(),
       'preview_url' => Builder::string(),
-      'deleted_at' => Builder::string(),
+      'deleted_at' => Builder::string()->nullable(),
     ])->toArray();
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -34,6 +34,7 @@ class EmailApiController {
       'subject' => $newsletter ? $newsletter->getSubject() : '',
       'preheader' => $newsletter ? $newsletter->getPreheader() : '',
       'preview_url' => $this->newsletterUrl->getViewInBrowserUrl($newsletter),
+      'deleted_at' => $newsletter && $newsletter->getDeletedAt() !== null ? $newsletter->getDeletedAt()->format('c') : null,
     ];
   }
 
@@ -51,6 +52,16 @@ class EmailApiController {
 
     $newsletter->setSubject($data['subject']);
     $newsletter->setPreheader($data['preheader']);
+
+    if (isset($data['deleted_at'])) {
+      if (empty($data['deleted_at'])) {
+        $data['deleted_at'] = null;
+      } else {
+        $data['deleted_at'] = new \DateTime($data['deleted_at']);
+      }
+      $newsletter->setDeletedAt($data['deleted_at']);
+    }
+
     $this->newsletterRepository->flush();
   }
 
@@ -71,6 +82,7 @@ class EmailApiController {
       'subject' => Builder::string(),
       'preheader' => Builder::string(),
       'preview_url' => Builder::string(),
+      'deleted_at' => Builder::string(),
     ])->toArray();
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -34,6 +34,7 @@ class EmailEditor {
     }
     $this->cli->initialize();
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
+    $this->wp->addAction('rest_delete_mailpoet_email', [$this->emailApiController, 'trashEmail'], 10, 1);
     $this->extendEmailPostApi();
   }
 


### PR DESCRIPTION
## Description

Adds trash functionality to the email editor via the options menu.

![Screenshot 2024-04-03 at 15 23 42](https://github.com/mailpoet/mailpoet/assets/90977/350e3f5d-6d01-44fd-9b07-5f9adcbea35b)

## Code review notes

- When a WP Post is trashed, the newsletter is also trashed
- Bulk trash/bulk restore at newsletter level will trash/untrash the WP Post.

## QA notes

Testing instructions:

1. Go to Emails > Create new > Create using new email editor
2. Click the options (...) top right of the interface and choose "move to trash"
3. Confirm and the page should redirect to the listing. The email should not be listed; it should be under `trash` status.
4. Navigate to `trash`
5. Restore the email
6. Edit it again. Confirm you can edit, and move to trash again successfully. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5947](https://mailpoet.atlassian.net/browse/MAILPOET-5947)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5947]: https://mailpoet.atlassian.net/browse/MAILPOET-5947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ