### PR TITLE
Fix checking whether an email should contain an abandoned cart block [MAILPOET-5999]

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
@@ -49,8 +49,10 @@ class AbandonedCartContent {
       return $optionField && $optionField->getName() === 'event';
     })->first();
     if (
-      ($groupOption instanceof NewsletterOptionEntity && $groupOption->getValue() !== WooCommerceEmail::SLUG)
-      || ($eventOption instanceof NewsletterOptionEntity && $eventOption->getValue() !== AbandonedCart::SLUG)
+      !$groupOption
+      || $groupOption->getValue() !== WooCommerceEmail::SLUG
+      || !$eventOption
+      || $eventOption->getValue() !== AbandonedCart::SLUG
     ) {
       // Do not display the block if not an AbandonedCart email
       return [];


### PR DESCRIPTION
## Description

The problem with the current conditions is that when any of these options doesn't exist at all, the condition will not pass (= it will render the block, but it shouldn't).

## Code review notes

_N/A_

## QA notes

**Before this fix:**

1. Have WooCommerce set up with some existing products.
2. Create an automation, e.g. from Purchased a product template.
3. Add an email and use Abandoned Cart – Fitness template from the WooCommerce Emails templates tab.
4. You won’t see any Abandoned cart block in the email editor.
5. Preview the email, you will see an Abandoned cart block with example products in it — **this is wrong**.

**After the fix:**
In 5, no abandoned cart block should be rendered in the preview.

## Linked PRs

[MAILPOET-5999]

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5999]: https://mailpoet.atlassian.net/browse/MAILPOET-5999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ