### PR TITLE
Fix loading order in customer payload for guest users [MAILPOET-6000]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
@@ -45,8 +45,9 @@ class CustomerSubject implements Subject {
   }
 
   public function getPayload(SubjectData $subjectData): Payload {
-    $customerId = $subjectData->getArgs()['customer_id'];
-    $orderId = $subjectData->getArgs()['order_id'] ?? null;
+    $args = $subjectData->getArgs();
+    $customerId = isset($args['customer_id']) ? (int)$args['customer_id'] : null;
+    $orderId = isset($args['order_id']) ? (int)$args['order_id'] : null;
 
     $order = $orderId === null ? null : wc_get_order($orderId);
     $order = $order instanceof WC_Order ? $order : null;

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
@@ -47,8 +47,12 @@ class CustomerSubject implements Subject {
   public function getPayload(SubjectData $subjectData): Payload {
     $customerId = $subjectData->getArgs()['customer_id'];
     $orderId = $subjectData->getArgs()['order_id'] ?? null;
+
+    $order = $orderId === null ? null : wc_get_order($orderId);
+    $order = $order instanceof WC_Order ? $order : null;
+
     if (!$customerId) {
-      return new CustomerPayload(null, $orderId);
+      return new CustomerPayload(null, $order);
     }
 
     $customer = new WC_Customer($customerId);
@@ -57,8 +61,7 @@ class CustomerSubject implements Subject {
       throw NotFoundException::create()->withMessage(sprintf(__("Customer with ID '%d' not found.", 'mailpoet'), $customerId));
     }
 
-    $order = wc_get_order($orderId);
-    return new CustomerPayload($customer, $order instanceof WC_Order ? $order : null);
+    return new CustomerPayload($customer, $order);
   }
 
   /** @return Field[] */


### PR DESCRIPTION
## Description

We were passing order ID instead of the order itself for guest users.

## Code review notes

_N/A_

## QA notes

1. The error described in the ticket should no longer occur.
2. The automation should be triggered also for guest users, and a transactional email (e.g. "Order completed" -> "Send email") should be delivered.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6000]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6000]: https://mailpoet.atlassian.net/browse/MAILPOET-6000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ