### PR TITLE
Update all places with new WP 6.5 and Woo 8.8 rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.6.0
+            ./do download:woo-commerce-zip 8.6.1
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
             ./do download:automate-woo-zip 6.0.10
@@ -947,7 +947,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
-          woo_core_version: 8.6.0
+          woo_core_version: 8.6.1
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           automate_woo_version: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.8.0-rc.1
+            ./do download:woo-commerce-zip 8.6.0
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
             ./do download:automate-woo-zip 6.0.10
@@ -947,7 +947,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
-          woo_core_version: 8.8.0-rc.1
+          woo_core_version: 8.6.0
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           automate_woo_version: latest
@@ -998,7 +998,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 8.8.0-rc.1
+          woo_core_version: 8.6.0
           woo_subscriptions_version: 5.6.0
           woo_memberships_version: 1.24.0
           automate_woo_version: 5.8.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -965,7 +965,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-6.3_php8.0_20230811.1
+          wordpress_image_version: wp-6.4_php8.0_20231114.1
           requires:
             - build
       - performance_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.6.1
+            ./do download:woo-commerce-zip 8.6.0
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
             ./do download:automate-woo-zip 6.0.10
@@ -947,7 +947,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
-          woo_core_version: 8.6.1
+          woo_core_version: 8.6.0
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           automate_woo_version: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.6.1
+            ./do download:woo-commerce-zip 8.8.0-rc.1
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
             ./do download:automate-woo-zip 6.0.10
@@ -947,7 +947,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
-          woo_core_version: 8.6.1
+          woo_core_version: 8.8.0-rc.1
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           automate_woo_version: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.6.0
+            ./do download:woo-commerce-zip 8.8.0-rc.1
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
             ./do download:automate-woo-zip 6.0.10
@@ -947,7 +947,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
-          woo_core_version: 8.6.0
+          woo_core_version: 8.8.0-rc.1
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           automate_woo_version: latest
@@ -998,7 +998,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 8.6.0
+          woo_core_version: 8.8.0-rc.1
           woo_subscriptions_version: 5.6.0
           woo_memberships_version: 1.24.0
           automate_woo_version: 5.8.5

--- a/mailpoet/lib/Cron/DaemonHttpRunner.php
+++ b/mailpoet/lib/Cron/DaemonHttpRunner.php
@@ -95,7 +95,7 @@ class DaemonHttpRunner {
       // pause daemon execution to ensure that daemon runs only once every X seconds
       $elapsedTime = microtime(true) - $this->timer;
       if ($elapsedTime < $this->cronHelper->getDaemonExecutionLimit()) {
-        $this->pauseExecution($this->cronHelper->getDaemonExecutionLimit() - $elapsedTime);
+        $this->pauseExecution((int)ceil($this->cronHelper->getDaemonExecutionLimit() - $elapsedTime));
       }
     }
     // after each execution, re-read daemon data in case it changed
@@ -106,7 +106,7 @@ class DaemonHttpRunner {
     return $this->callSelf();
   }
 
-  public function pauseExecution($pauseTime) {
+  public function pauseExecution(int $pauseTime) {
     return sleep($pauseTime);
   }
 

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -107,8 +107,8 @@ class SystemReportCollector {
   protected function maskApiKey($key) {
     // the length of this particular key is an even number.
     // for odd lengths this method will change the total number of characters (which shouldn't be a problem in this context).
-    $halfKeyLength = (int)(strlen($key) / 2);
+    $halfKeyLength = (int)(strlen($key ?? '') / 2);
 
-    return substr($key, 0, $halfKeyLength) . str_repeat('*', $halfKeyLength);
+    return substr($key ?? '', 0, $halfKeyLength) . str_repeat('*', $halfKeyLength);
   }
 }

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -27,7 +27,7 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.3';
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.4';
 const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '7.9';// Older versions lead to fatal errors
 
 function mailpoet_deactivate_plugin() {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,9 +1,9 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
-Requires at least: 6.3
-Tested up to: 6.4
-Stable tag: 4.48.2
+Requires at least: 6.4
+Tested up to: 6.5
+Stable tag: 4.48.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
 Requires at least: 6.4
 Tested up to: 6.5
-Stable tag: 4.48.1
+Stable tag: 4.48.2
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -22,9 +22,6 @@ class CheckSkippedTestsExtension extends Extension {
       'testAllSubscribersFoundWithOperatorAllOf',
       'automationTriggeredByRegistrationWitConfirmationNeeded',
       'automationTriggeredByRegistrationWithoutConfirmationNeeded',
-      // The next two tests can be removed after dropping support for WP 6.3
-      'createAndSendStandardNewsletter',
-      'displayNewsletterPreview',
     ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -7,9 +7,7 @@ use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Settings;
 
 class CreateAndSendEmailUsingGutenbergCest {
-  public function createAndSendStandardNewsletter(\AcceptanceTester $i, $scenario) {
-    if (!$this->checkMinimalWordpressVersion($i))
-      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4');
+  public function createAndSendStandardNewsletter(\AcceptanceTester $i) {
 
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
@@ -72,9 +70,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->checkEmailWasReceived('My New Subject');
   }
 
-  public function displayNewsletterPreview(\AcceptanceTester $i, $scenario) {
-    if (!$this->checkMinimalWordpressVersion($i))
-      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4');
+  public function displayNewsletterPreview(\AcceptanceTester $i) {
 
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
@@ -119,14 +115,5 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForText('Test email sent successfully!');
     $i->click('//button[text()="Close"]');
     $i->waitForElementNotVisible('//button[text()="Send test email"]');
-  }
-
-  private function checkMinimalWordpressVersion(\AcceptanceTester $i): bool {
-    $wordPressVersion = $i->getWordPressVersion();
-    // New email editor is not compatible with WP versions below 6.4
-    if (version_compare($wordPressVersion, '6.4', '<')) {
-      return false;
-    }
-    return true;
   }
 }

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use Facebook\WebDriver\WebDriverKeys;
+use Codeception\Util\Locator;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
@@ -26,7 +26,7 @@ class GutenbergFormBlockCest {
     $this->lastName = 'Last Name';
   }
 
-  public function _before(\AcceptanceTester $i) {
+  public function _before() {
     $settings = new Settings();
     $settings
       ->withConfirmationEmailSubject()
@@ -117,11 +117,14 @@ class GutenbergFormBlockCest {
     $i->wantTo('Add Gutenberg form block to the post manually');
     $i->login();
     $i->amEditingPostWithId($postId);
+    $this->closeDialog($i);
     $i->waitForText('My Gutenberg form');
-    $i->pressKey('body', WebDriverKeys::ESCAPE);
-    $i->click('.block-editor-inserter');
-    $i->fillField('.components-search-control__input', 'MailPoet Subscription Form');
-    $i->click('.editor-block-list-item-mailpoet-subscription-form-block');
+    $i->click('[aria-label="Add title"]');
+    $i->click('[aria-label="Add block"]');
+    $i->fillField('[placeholder="Search"]', 'MailPoet Subscription Form');
+    $i->waitForElement(Locator::contains('button', 'MailPoet Subscription Form'));
+    $i->click(Locator::contains('button', 'MailPoet Subscription Form'));
+    $i->waitForElement('[aria-label="Block: MailPoet Subscription Form"]');
     $i->selectOption('.mailpoet-block-create-forms-list', 'Acceptance Test Block Form');
     $i->waitForElementVisible('[data-automation-id="form_email"]');
     $i->waitForElementVisible('[data-automation-id="form_first_name"]');
@@ -158,5 +161,17 @@ class GutenbergFormBlockCest {
       'post_content' => '',
       'post_status' => 'publish',
     ]);
+  }
+
+  /**
+   * Close dialog when is visible.
+   */
+  private function closeDialog(\AcceptanceTester $i): void {
+    $closeButton = $i->executeJS('return document.querySelectorAll("button[aria-label=\'Close\']");');
+
+    if ($closeButton) {
+      $i->click('button[aria-label="Close"]');
+      $i->waitForElementNotVisible('button[aria-label="Close"]');
+    }
   }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -210,10 +210,12 @@ class WooCheckoutBlocksCest {
 
     // Close welcome in block editor dialog
     $this->closeDialog($i);
-    $i->click('button[aria-label="Toggle block inserter"]');
+    $i->click('[aria-label="Add title"]'); // For block inserter to show up
+    $i->click('[aria-label="Add block"]');
     $i->fillField('[placeholder="Search"]', 'Checkout');
     $i->waitForElement(Locator::contains('button', 'Checkout'));
     $i->click(Locator::contains('button', 'Checkout')); // Select Checkout block
+    $i->waitForElement('[aria-label="Block: Checkout"]');
     // Close dialog with Compatibility notice
     $this->closeDialog($i);
 
@@ -225,9 +227,6 @@ class WooCheckoutBlocksCest {
       // Starting from WC 7.2 this option is removed and only controlled from the settings page -> Accounts & Privacy tab
       $i->click(Locator::contains('label', 'Allow shoppers to sign up for a user account during checkout'));
     }
-
-    // Close dialog if any
-    $this->closeDialog($i);
 
     $i->click('Update');
     $i->waitForText('Page updated.');

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -68,9 +68,9 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     cd /wp-core/wp-content/plugins
     WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
     if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
-      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.8.0-rc.1 zip"
+      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.0 zip"
       cd /project
-      ./do download:woo-commerce-zip 8.8.0-rc.1
+      ./do download:woo-commerce-zip 8.6.0
       cd /wp-core/wp-content/plugins
     fi
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -68,9 +68,9 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     cd /wp-core/wp-content/plugins
     WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
     if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
-      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.0 zip"
+      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.8.0-rc.1 zip"
       cd /project
-      ./do download:woo-commerce-zip 8.6.0
+      ./do download:woo-commerce-zip 8.8.0-rc.1
       cd /wp-core/wp-content/plugins
     fi
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -68,9 +68,9 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     cd /wp-core/wp-content/plugins
     WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
     if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
-      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.0 zip"
+      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.1 zip"
       cd /project
-      ./do download:woo-commerce-zip 8.6.0
+      ./do download:woo-commerce-zip 8.6.1
       cd /wp-core/wp-content/plugins
     fi
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -68,9 +68,9 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     cd /wp-core/wp-content/plugins
     WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
     if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
-      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.1 zip"
+      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.0 zip"
       cd /project
-      ./do download:woo-commerce-zip 8.6.1
+      ./do download:woo-commerce-zip 8.6.0
       cd /wp-core/wp-content/plugins
     fi
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -68,9 +68,9 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     cd /wp-core/wp-content/plugins
     WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
     if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
-      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.6.1 zip"
+      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.8.0-rc.1 zip"
       cd /project
-      ./do download:woo-commerce-zip 8.6.1
+      ./do download:woo-commerce-zip 8.8.0-rc.1
       cd /wp-core/wp-content/plugins
     fi
 

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.4_php8.0_20231114.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.5_php8.1_20240405.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.5_php8.2_20240405.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.5_php8.1_20240405.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.5_php8.1_20240405.1}
+    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.5_php8.2_20240405.1}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -101,7 +101,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
     $daemon = $this->makeEmpty(Daemon::class);
     $daemonHttpRunner = $this->make(DaemonHttpRunner::class, [
       'pauseExecution' => Expected::exactly(1, function($pauseDelay) {
-        verify($pauseDelay)->lessThan($this->cronHelper->getDaemonExecutionLimit());
+        verify($pauseDelay)->lessThan($this->cronHelper->getDaemonExecutionLimit() + 1);
         verify($pauseDelay)->greaterThan($this->cronHelper->getDaemonExecutionLimit() - 1);
       }),
       'callSelf' => null,

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
 
   wordpress:
-    image: mailpoet/wordpress:wp-6.5_php8.1_20240405.1
+    image: mailpoet/wordpress:wp-6.5_php8.2_20240405.1
     container_name: performance_wordpress
     depends_on:
       mysql: { condition: service_healthy }

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
 
   wordpress:
-    image: mailpoet/wordpress:wp-6.4_php8.2_20231120.1
+    image: mailpoet/wordpress:wp-6.5_php8.1_20240405.1
     container_name: performance_wordpress
     depends_on:
       mysql: { condition: service_healthy }


### PR DESCRIPTION
## Description

Update all places where necessary after the new WordPress CMS version is released (in this case 6.5).

Just because we skipped testing against Woo 8.7 due to known bug they fixed in 8.8, we can still test against Woo 8.8 RC build until they release the final version. Better to test against Woo RC latest then 2 versions back.

I will make another PR updating to Woo latest when they release the next 8.8 version.

Additionally, reverted 2 skipped tests [as per this PR](https://github.com/mailpoet/mailpoet/pull/5524), they are now testable against WP 6.5

## Code review notes

2 tests were failing due to false-positive outcome. I refactored them and improved, previously debugged and confirmed what was wrong.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6003]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6003]: https://mailpoet.atlassian.net/browse/MAILPOET-6003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ