### PR TITLE
Fix guest customer incorrect subscription status - MAILPOET-5963

### DIFF
--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -167,7 +167,7 @@ class WooCommerce {
 
     if (!$wcOrder instanceof \WC_Order) return;
     $signupConfirmation = $this->settings->get('signup_confirmation');
-    $status = SubscriberEntity::STATUS_UNCONFIRMED;
+    $status = SubscriberEntity::STATUS_UNSUBSCRIBED;
     if ((bool)$signupConfirmation['enabled'] === false) {
       $status = SubscriberEntity::STATUS_SUBSCRIBED;
     }

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -61,7 +61,7 @@ class WooCheckoutAutomateWooSubscriptionsCest {
     $customerEmail = 'woo_guest_uncheck@example.com';
     $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, null, ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
     $i->amOnPage('/wp-admin/admin.php?page=automatewoo-opt-ins');
     $i->dontSee($customerEmail, '.automatewoo-content');
     $i->seeConfirmationEmailWasNotReceived();

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -66,7 +66,7 @@ class WooCheckoutBlocksCest {
     $i->logOut();
     $this->orderProduct($i, $customerEmail, true, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 
@@ -94,7 +94,7 @@ class WooCheckoutBlocksCest {
     $customerEmail = 'woo_customer_uncheck@example.com';
     $this->orderProduct($i, $customerEmail, true, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
@@ -35,7 +35,7 @@ class WooCheckoutCustomerSubscriptionsCest {
     $customerEmail = 'woo_customer_noptin@example.com';
     $i->orderProductWithRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 
@@ -55,7 +55,7 @@ class WooCheckoutCustomerSubscriptionsCest {
     $customerEmail = 'woo_customer_uncheck@example.com';
     $i->orderProductWithRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, ['WordPress Users'], ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, ['WordPress Users'], ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
@@ -35,7 +35,7 @@ class WooCheckoutGuestSubscriptionsCest {
     $customerEmail = 'woo_guest_noptin@example.com';
     $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, null, ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 
@@ -55,7 +55,7 @@ class WooCheckoutGuestSubscriptionsCest {
     $customerEmail = 'woo_guest_uncheck@example.com';
     $i->orderProductWithoutRegistration($this->product, $customerEmail, false);
     $i->login();
-    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNCONFIRMED, null, ['WooCommerce Customers']);
+    $i->checkSubscriberStatusAndLists($customerEmail, SubscriberEntity::STATUS_UNSUBSCRIBED, null, ['WooCommerce Customers']);
     $i->seeConfirmationEmailWasNotReceived();
   }
 


### PR DESCRIPTION
## Description

This PR updates the behavior of guest `checkout` with OptIn Unchecked.

Previously, when a Woo customer checks out without registration and leaves OptIn Unchecked, MailPoet creates a subscriber with the status `UNCONFIRMED` without any list.

These subscribers cannot be sent newsletters and are only counted toward the user's plan limits.

This is corrected in this PR ensuring the other features are working as expected.



## Code review notes

_N/A_

## QA notes

### Please test the following flows

#### Scenario 1 

* withWooCommerceCheckoutOptinEnabled
* withConfirmationEmailEnabled

**Test**: Check out a Woo product and leave optin **unchecked**.
-> A subscriber should be created with status `UNSUBSCRIBED`

**Test**: Check out a Woo product and leave optin **checked**.
-> A subscriber should be created with status `UNCONFIRMED`


#### Scenario 2
* withWooCommerceCheckoutOptinEnabled
* withConfirmationEmailDisabled

**Test**: Check out a Woo product and leave optin **unchecked**.
-> A subscriber should be created with status `UNSUBSCRIBED`

**Test**: Check out a Woo product and leave optin **checked**.
-> A subscriber should be created with status `SUBSCRIBED`


#### Scenario 3
* withWooCommerceCheckoutOptinDisabled
* withConfirmationEmailEnabled

**Test**: Check out a Woo product and leave optin **unchecked**.
-> A subscriber should be created with status `UNSUBSCRIBED`


#### Scenario 4
* withWooCommerceCheckoutOptinDisabled
* withConfirmationEmailDisabled

**Test**: Check out a Woo product and leave optin **unchecked**.
-> A subscriber should be created with status `UNSUBSCRIBED`
*** How was this even allowed?


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5963](https://mailpoet.atlassian.net/browse/MAILPOET-5963)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5963]: https://mailpoet.atlassian.net/browse/MAILPOET-5963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ