### PR TITLE
Add new k6 test Select Segment Tempalte and update existing Complex Segment to Custom Segment

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -13,7 +13,7 @@ import { formsAdding } from './tests/forms-adding.js';
 import { newsletterSearching } from './tests/newsletter-searching.js';
 import { newsletterSending } from './tests/newsletter-sending.js';
 import { listsViewSubscribers } from './tests/lists-view-subscribers.js';
-import { listsComplexSegment } from './tests/lists-complex-segment.js';
+import { segmentsCreateCustom } from './tests/segments-create-custom.js';
 import { newsletterStatistics } from './tests/newsletter-statistics.js';
 import { onboardingWizard } from './tests/onboarding-wizard.js';
 import { subscribersTrashingRestoring } from './tests/subscribers-trashing-restoring.js';
@@ -25,6 +25,7 @@ import { automationTriggerWorkflow } from './tests/automation-trigger-workflow.j
 import { automationCreateWooCommerce } from './tests/automation-create-woocommerce.js';
 import { newsletterPostNotification } from './tests/newsletters-post-notification.js';
 import { newsletterReEngagement } from './tests/newsletter-reengagement.js';
+import { segmentsSelectTemplate } from './tests/segments-select-template.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -85,7 +86,7 @@ if (scenario) {
 }
 
 // Run those tests against a pull request build
-// Note: there are 21 checks in total
+// Note: there are 22 checks in total
 export async function pullRequests() {
   await onboardingWizard();
   await newsletterListing();
@@ -100,10 +101,11 @@ export async function pullRequests() {
   await subscribersFiltering();
   await subscribersAdding();
   await formsAdding();
+  await segmentsSelectTemplate();
 }
 
 // Run those tests against trunk in a nightly build
-// Note: there are 38 checks in total
+// Note: there are 39 checks in total
 export async function nightly() {
   await newsletterListing();
   await newsletterStatistics();
@@ -122,7 +124,8 @@ export async function nightly() {
   await subscribersAdding();
   await subscribersTrashingRestoring();
   await listsViewSubscribers();
-  await listsComplexSegment();
+  await segmentsCreateCustom();
+  await segmentsSelectTemplate();
   await settingsBasic();
   await formsAdding();
 }

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -17,13 +17,13 @@ import {
   thinkTimeMin,
   thinkTimeMax,
   defaultListName,
-  listsPageTitle,
+  segmentsPageTitle,
   fullPageSet,
   screenshotPath,
 } from '../config.js';
 import { login, selectInReact } from '../utils/helpers.js';
 
-export async function listsComplexSegment() {
+export async function segmentsCreateCustom() {
   const page = browser.newPage();
 
   try {
@@ -40,7 +40,7 @@ export async function listsComplexSegment() {
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({
-      path: screenshotPath + 'Lists_Complex_Segment_01.png',
+      path: screenshotPath + 'Segments_Create_Custom_01.png',
       fullPage: fullPageSet,
     });
 
@@ -57,8 +57,8 @@ export async function listsComplexSegment() {
     await selectInReact(page, '#react-select-2-input', 'subscribed to list');
     await selectInReact(page, '#react-select-4-input', defaultListName);
     await page.waitForSelector('.mailpoet-form-notice-message');
-    describe(listsPageTitle, () => {
-      describe('lists-complex-segment: should be able to see calculating message 1st time', () => {
+    describe(segmentsPageTitle, () => {
+      describe('segments-create-custom: should be able to see calculating message 1st time', () => {
         expect(
           page.locator('.mailpoet-form-notice-message').innerText(),
         ).to.contain('Calculating segment size…');
@@ -67,7 +67,7 @@ export async function listsComplexSegment() {
     await page.waitForLoadState('networkidle');
 
     await page.screenshot({
-      path: screenshotPath + 'Lists_Complex_Segment_02.png',
+      path: screenshotPath + 'Segments_Create_Custom_02.png',
       fullPage: fullPageSet,
     });
 
@@ -79,8 +79,8 @@ export async function listsComplexSegment() {
     // Select "Subscribed date" action
     await selectInReact(page, '#react-select-5-input', 'subscribed date');
     await page.waitForSelector('.mailpoet-form-notice-message');
-    describe(listsPageTitle, () => {
-      describe('lists-complex-segment: should be able to see calculating message 2nd time', () => {
+    describe(segmentsPageTitle, () => {
+      describe('segments-create-custom: should be able to see calculating message 2nd time', () => {
         expect(
           page.locator('.mailpoet-form-notice-message').innerText(),
         ).to.contain('Calculating segment size…');
@@ -88,7 +88,7 @@ export async function listsComplexSegment() {
     });
 
     await page.screenshot({
-      path: screenshotPath + 'Lists_Complex_Segment_03.png',
+      path: screenshotPath + 'Segments_Create_Custom_03.png',
       fullPage: fullPageSet,
     });
 
@@ -102,8 +102,8 @@ export async function listsComplexSegment() {
     await selectInReact(page, '#react-select-8-input', 'Administrator');
     await page.waitForSelector('.mailpoet-form-notice-message');
     await page.waitForLoadState('networkidle');
-    describe(listsPageTitle, () => {
-      describe('lists-complex-segment: should be able to see Calculating message 3rd time', () => {
+    describe(segmentsPageTitle, () => {
+      describe('segments-create-custom: should be able to see Calculating message 3rd time', () => {
         expect(
           page.locator('.mailpoet-form-notice-message').innerText(),
         ).to.contain('Calculating segment size…');
@@ -116,7 +116,7 @@ export async function listsComplexSegment() {
     await page.waitForLoadState('networkidle');
 
     await page.screenshot({
-      path: screenshotPath + 'Lists_Complex_Segment_04.png',
+      path: screenshotPath + 'Segments_Create_Custom_04.png',
       fullPage: fullPageSet,
     });
 
@@ -127,15 +127,15 @@ export async function listsComplexSegment() {
     });
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
-    describe(listsPageTitle, () => {
-      describe('lists-complex-segment: should be able to see Segment Updated message', () => {
+    describe(segmentsPageTitle, () => {
+      describe('segments-create-custom: should be able to see Segment Updated message', () => {
         expect(page.locator(locator)).to.exist;
       });
     });
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({
-      path: screenshotPath + 'Lists_Complex_Segment_05.png',
+      path: screenshotPath + 'Segments_Create_Custom_05.png',
       fullPage: fullPageSet,
     });
 
@@ -147,6 +147,6 @@ export async function listsComplexSegment() {
   }
 }
 
-export default async function listsComplexSegmentTest() {
-  await listsComplexSegment();
+export default async function segmentsCreateCustomTest() {
+  await segmentsCreateCustom();
 }

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  segmentsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import { login } from '../utils/helpers.js';
+
+export async function segmentsSelectTemplate() {
+  const page = browser.newPage();
+
+  try {
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the segments page
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-segments#/segment-templates`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+
+    await page.waitForSelector('.wp-heading-inline');
+    await page.screenshot({
+      path: screenshotPath + 'Segments_Select_Template_01.png',
+      fullPage: fullPageSet,
+    });
+
+    // Select any segment's template on page
+    await page.$$('.mailpoet-templates-card')[0].click(); // this will randomly pick
+    await page.waitForSelector('[data-automation-id="select-segment-action"]');
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Segments_Select_Template_02.png',
+      fullPage: fullPageSet,
+    });
+
+    // Save the segment
+    await page.locator('button[type="submit"]').click();
+    await page.waitForSelector('[data-automation-id="filters_all"]', {
+      state: 'visible',
+    });
+    const locator =
+      "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
+    describe(segmentsPageTitle, () => {
+      describe('segments-select-template: should be able to see Segment saved message', () => {
+        expect(page.locator(locator)).to.exist;
+      });
+    });
+
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({
+      path: screenshotPath + 'Segments_Select_Template_03.png',
+      fullPage: fullPageSet,
+    });
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default async function segmentsSelectTemplateTest() {
+  await segmentsSelectTemplate();
+}


### PR DESCRIPTION
## Description

- Added a new k6 performance test for selecting any segment template
- Update existing segment's test to better reflect there's a different between lists and segments. It is a leftover from the time when we named segments as lists.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5875]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5875]: https://mailpoet.atlassian.net/browse/MAILPOET-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ