### PR TITLE
Add new k6 performance test forms subscribing

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -26,6 +26,7 @@ import { automationCreateWooCommerce } from './tests/automation-create-woocommer
 import { newsletterPostNotification } from './tests/newsletters-post-notification.js';
 import { newsletterReEngagement } from './tests/newsletter-reengagement.js';
 import { segmentsSelectTemplate } from './tests/segments-select-template.js';
+import { formsSubscribing } from './tests/forms-subscribing.js';
 
 // Scenarios, Thresholds, Tags and Project ID used for K6 Cloud
 export let options = {
@@ -105,7 +106,7 @@ export async function pullRequests() {
 }
 
 // Run those tests against trunk in a nightly build
-// Note: there are 39 checks in total
+// Note: there are 41 checks in total
 export async function nightly() {
   await newsletterListing();
   await newsletterStatistics();
@@ -128,6 +129,7 @@ export async function nightly() {
   await segmentsSelectTemplate();
   await settingsBasic();
   await formsAdding();
+  await formsSubscribing();
 }
 
 // HTML report data saved in performance folder

--- a/mailpoet/tests/performance/tests/forms-subscribing.js
+++ b/mailpoet/tests/performance/tests/forms-subscribing.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+import { browser } from 'k6/experimental/browser';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.1.0/index.js';
+import {
+  expect,
+  describe,
+} from 'https://jslib.k6.io/k6chaijs/4.3.4.2/index.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+  baseURL,
+  thinkTimeMin,
+  thinkTimeMax,
+  formsPageTitle,
+  fullPageSet,
+  screenshotPath,
+} from '../config.js';
+import {
+  login,
+  waitAndType,
+  waitForSelectorToBeVisible,
+} from '../utils/helpers.js';
+
+export async function formsSubscribing() {
+  const page = browser.newPage();
+
+  try {
+    let subscriberEmail = 'blackhole+testform' + Date.now() + '@mailpoet.com';
+
+    // Log in to WP Admin
+    await login(page);
+
+    // Go to the test form page
+    await page.goto(`${baseURL}/sample-page/`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.waitForSelector('.mailpoet_form_below_posts');
+    await page.screenshot({
+      path: screenshotPath + 'Forms_Subscribing_01.png',
+      fullPage: fullPageSet,
+    });
+
+    // Subscribe to a test form
+    await waitAndType(
+      page,
+      '[data-automation-id="form_email"]',
+      subscriberEmail,
+    );
+    await page
+      .locator('[data-automation-id="subscribe-submit-button"]')
+      .click();
+    await waitForSelectorToBeVisible(page, '.mailpoet_validate_success');
+    describe(formsPageTitle, () => {
+      describe('forms-subscribing: should be able to see successfully subscribed message', () => {
+        expect(
+          page.locator('.mailpoet_validate_success').innerText(),
+        ).to.contain('Successfully subscribed!');
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Forms_Subscribing_02.png',
+      fullPage: fullPageSet,
+    });
+
+    // Go to Subscribers page to see subscribed user
+    await page.goto(
+      `${baseURL}/wp-admin/admin.php?page=mailpoet-subscribers#/`,
+      {
+        waitUntil: 'networkidle',
+      },
+    );
+    await page.locator('#search_input').type(subscriberEmail, { delay: 25 });
+    await page.waitForSelector('.mailpoet-listing-no-items');
+    await page.waitForSelector('[data-automation-id="filters_subscribed"]');
+    await page.waitForLoadState('networkidle');
+    describe(formsPageTitle, () => {
+      describe('forms-subscribing: should be able to search for a new subscriber', () => {
+        expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
+          subscriberEmail,
+        );
+      });
+    });
+
+    await page.screenshot({
+      path: screenshotPath + 'Forms_Subscribing_03.png',
+      fullPage: fullPageSet,
+    });
+
+    // Thinking time and closing
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+  } finally {
+    page.close();
+    browser.context().close();
+  }
+}
+
+export default function formsSubscribingTest() {
+  formsSubscribing();
+}


### PR DESCRIPTION
## Description

Added a new k6 test for subscribing to a front-end form.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5874]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5874]: https://mailpoet.atlassian.net/browse/MAILPOET-5874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ