### PR TITLE
[Email Editor] Add context to removing notices [MAILPOET-6007]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/notices/notices.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/notices/notices.tsx
@@ -32,7 +32,7 @@ export function EditorNotices() {
       <NoticeList
         notices={dismissibleNotices}
         className="components-editor-notices__dismissible"
-        onRemove={removeNotice}
+        onRemove={(id) => removeNotice(id, 'email-editor')}
       />
       <ValidationNotices />
     </>

--- a/mailpoet/assets/js/src/email-editor/engine/components/notices/snackbars.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/notices/snackbars.tsx
@@ -20,7 +20,7 @@ export function EditorSnackbars() {
     <SnackbarList
       notices={snackbarNotices}
       className="components-editor-notices__snackbar"
-      onRemove={removeNotice}
+      onRemove={(id) => removeNotice(id, 'email-editor')}
     />
   );
 }

--- a/mailpoet/assets/js/src/types/wordpress-modules.ts
+++ b/mailpoet/assets/js/src/types/wordpress-modules.ts
@@ -100,6 +100,7 @@ declare module '@wordpress/notices' {
     };
     selectors: {
       getNotices(state: unknown, context?: string): Notice[];
+      removeNotice(id: string, context?: string): void;
     };
   }>;
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

After refactoring, the notices are created in the context `email-editor`, but calling the `removeNotice` action was not updated.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6007]


## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6007]: https://mailpoet.atlassian.net/browse/MAILPOET-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ