### PR TITLE
Subscribe from admin trigger [MAILPOET-5992]

### DIFF
--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -165,6 +165,20 @@ class SubscriberSaveController {
       $this->welcomeScheduler->scheduleSubscriberWelcomeNotification($subscriber->getId(), $newSegments);
     }
 
+    // when global status changes to subscribed, fire subscribed hook for all subscribed segments
+    if (
+      $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED
+      && $oldStatus !== null // don't trigger for new subscribers (handled in subscriber segments repository)
+      && $oldStatus !== SubscriberEntity::STATUS_SUBSCRIBED
+    ) {
+      $segments = $subscriber->getSubscriberSegments();
+      foreach ($segments as $subscriberSegment) {
+        if ($subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED) {
+          $this->wp->doAction('mailpoet_segment_subscribed', $subscriberSegment);
+        }
+      }
+    }
+
     return $subscriber;
   }
 


### PR DESCRIPTION
## Description

When list status is `subscribed`, and global status is changed to `subscribed` via admin, automations don't trigger.

## Code review notes

_N/A_

## QA notes

1. Create an automation with `Someone subscribes` trigger.
2. Create a subscriber, subscribe them to a list or two.
3. Change the subscriber's status to sth like `Unconfirmed` or `Unsubscribed` via admin.
4. Changing the status back to `Subscribed` via admin doesn't trigger the automation on `trunk`. On this branch, it should trigger.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5992]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5992]: https://mailpoet.atlassian.net/browse/MAILPOET-5992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ