### PR TITLE
Fix rendering of multiple enum filter values [MAILPOET-5944]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/filters/enum.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/enum.ts
@@ -17,9 +17,18 @@ export const filter: FilterType = {
       id: string;
       name: string;
     }[];
+    const values = Array.isArray(args.value) ? args.value : [args.value];
+    const labels = values
+      .map((v) => options.find(({ id }) => id === v)?.name)
+      .filter((v) => v !== undefined);
 
-    const label = options.find(({ id }) => id === args.value)?.name;
-    return label ?? __('Unknown value', 'mailpoet');
+    if (labels.length === 0) {
+      return __('Unknown value', 'mailpoet');
+    }
+
+    const suffix =
+      labels.length < values.length ? __('and unknown values', 'mailpoet') : '';
+    return `${labels.join(', ')}${suffix}`;
   },
   formatParams: ({ args }) => formatInTheLastParam(args),
   validateArgs: (args, _, field) => {


### PR DESCRIPTION
## Description

While "enum" field can have only one value (and "enum_array" multiple), both can have multiple filtering values set up, so both need to be able to render lists.

## Code review notes

Easy fix, skipping.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5944]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5944]: https://mailpoet.atlassian.net/browse/MAILPOET-5944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ