### PR TITLE
Add command for crating testing email [MAILPOET-5971]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1494,6 +1494,10 @@ class RoboFile extends \Robo\Tasks {
     }
   }
 
+  public function emailCreateTemplates() {
+    return $this->taskExec('vendor/bin/wp mailpoet:email-editor:create-templates');
+  }
+
   protected function rsearch($folder, $extensions = []) {
     $dir = new RecursiveDirectoryIterator($folder);
     $iterator = new RecursiveIteratorIterator($dir);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -351,6 +351,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\BlocksRegistry::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\ProcessManager::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\Core\Initializer::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailApiController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Cli.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Cli.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewsletterSaveController;
+use MailPoet\WP\Functions as WPFunctions;
+use WP_CLI;
+
+class Cli {
+  private const TEMPLATES = [
+    [
+      'name' => 'testing-email-with-core-blocks',
+      'subject' => 'Hey [subscriber:firstname | default:subscriber], we test new email editor!',
+      'preheader' => 'This is a testing email containing core blocks with different configurations.',
+    ],
+  ];
+
+  private NewsletterSaveController $newsletterSaveController;
+
+  private WPFunctions $wp;
+
+  public function __construct(
+    NewsletterSaveController $newsletterSaveController,
+    WPFunctions $wp
+  ) {
+    $this->newsletterSaveController = $newsletterSaveController;
+    $this->wp = $wp;
+  }
+
+  public function initialize(): void {
+    if (!class_exists(WP_CLI::class)) {
+      return;
+    }
+
+    WP_CLI::add_command('mailpoet:email-editor:create-templates', [$this, 'createTemplates'], [
+      'shortdesc' => 'Create MailPoet email editor templates',
+    ]);
+  }
+
+  public function createTemplates(): void {
+    WP_CLI::log("Starting creating MailPoet email editor templates.");
+    foreach (self::TEMPLATES as $template) {
+      $content = file_get_contents(__DIR__ . "/templates/{$template['name']}.html");
+      $newsletter = $this->newsletterSaveController->save([
+        'subject' => $template['subject'],
+        'preheader' => $template['preheader'],
+        'type' => NewsletterEntity::TYPE_STANDARD,
+        'new_editor' => true,
+      ]);
+
+      $wpPost = $newsletter->getWpPost();
+      if (!$wpPost) {
+        WP_CLI::error("Failed to create a post for the email template {$template['name']}.");
+      }
+
+      $this->wp->wpUpdatePost([
+        'ID' => $wpPost->getId(),
+        'post_title' => $this->getTemplateName($template['name']),
+        'post_content' => $content,
+      ]);
+      WP_CLI::log("Created a new email template {$template['name']}.");
+    }
+    WP_CLI::log('Finished creating MailPoet email editor templates.');
+  }
+
+  private function getTemplateName(string $templateName): string {
+    $name = str_replace('-', ' ', $templateName);
+    return ucwords($name);
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -3,40 +3,36 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\Features\FeaturesController;
-use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditor {
   const MAILPOET_EMAIL_POST_TYPE = 'mailpoet_email';
 
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
 
-  /** @var FeaturesController */
-  private $featuresController;
+  private FeaturesController $featuresController;
 
-  /** @var EmailApiController */
-  private $emailApiController;
+  private EmailApiController $emailApiController;
 
-  /** @var CdnAssetUrl */
-  private $cdnAssetUrl;
+  private Cli $cli;
 
   public function __construct(
     WPFunctions $wp,
     FeaturesController $featuresController,
     EmailApiController $emailApiController,
-    CdnAssetUrl $cdnAssetUrl
+    Cli $cli
   ) {
     $this->wp = $wp;
     $this->featuresController = $featuresController;
     $this->emailApiController = $emailApiController;
-    $this->cdnAssetUrl = $cdnAssetUrl;
+    $this->cli = $cli;
   }
 
   public function initialize(): void {
     if (!$this->featuresController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR)) {
       return;
     }
+    $this->cli->initialize();
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
     $this->extendEmailPostApi();
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -62,27 +62,4 @@ class EmailEditor {
       'schema' => $this->emailApiController->getEmailDataSchema(),
     ]);
   }
-
-  public function getEmailDefaultContent(): string {
-    return '
-      <!-- wp:image {"width":"130px","sizeSlug":"large"} -->
-      <figure class="wp-block-image size-large is-resized"><img src="' . esc_url($this->cdnAssetUrl->generateCdnUrl("email-editor/your-logo-placeholder.png")) . '" alt="Your Logo" style="width:130px"/></figure>
-      <!-- /wp:image -->
-      <!-- wp:heading {"fontSize":"medium","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <h2 class="wp-block-heading has-medium-font-size" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"></h2>
-      <!-- /wp:heading -->
-      <!-- wp:image -->
-      <figure class="wp-block-image"><img alt=""/></figure>
-      <!-- /wp:image -->
-      <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
-      <p style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"></p>
-      <!-- /wp:paragraph -->
-      <!-- wp:paragraph {"fontSize":"small"} -->
-      <p class="has-small-font-size">' . esc_html__('You received this email because you are subscribed to the [site:title]', 'mailpoet') . '</p>
-      <!-- /wp:paragraph -->
-      <!-- wp:paragraph {"fontSize":"small"} -->
-      <p class="has-small-font-size"><a href="[link:subscription_unsubscribe_url]">' . esc_html__('Unsubscribe', 'mailpoet') . '</a> | <a href="[link:subscription_manage_url]">' . esc_html__('Manage subscription', 'mailpoet') . '</a></p>
-      <!-- /wp:paragraph -->
-    ';
-  }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/testing-email-with-core-blocks.html
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/testing-email-with-core-blocks.html
@@ -69,6 +69,50 @@
 </h2>
 <!-- /wp:heading -->
 
+<!-- wp:paragraph {"fontFamily":"comic-sans-ms"} -->
+<p class="has-comic-sans-ms-font-family">
+  A two-column layout organizes information into sections, making it easier for
+  users to navigate content. Try other layouts by adding or removing columns,
+  drag blocks into them to add content and customize your email styles from the
+  styles panel.
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns">
+  <!-- wp:column -->
+  <div class="wp-block-column">
+    <!-- wp:image {"width":"280px","sizeSlug":"large","align":"left"} -->
+    <figure class="wp-block-image alignleft size-large is-resized">
+      <img
+        src="https://picsum.photos/id/133/300/200"
+        alt=""
+        style="width: 280px"
+      />
+    </figure>
+    <!-- /wp:image -->
+  </div>
+  <!-- /wp:column -->
+
+  <!-- wp:column {"width":"300px","style":{"spacing":{"padding":{"right":"0","left":"0"}}}} -->
+  <div
+    class="wp-block-column"
+    style="padding-right: 0; padding-left: 0; flex-basis: 300px"
+  >
+    <!-- wp:image {"width":"280px","sizeSlug":"large","align":"right"} -->
+    <figure class="wp-block-image alignright size-large is-resized">
+      <img
+        src="https://picsum.photos/id/133/300/200"
+        alt=""
+        style="width: 280px"
+      />
+    </figure>
+    <!-- /wp:image -->
+  </div>
+  <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
 <!-- wp:columns -->
 <div class="wp-block-columns">
   <!-- wp:column -->
@@ -81,10 +125,15 @@
     </h3>
     <!-- /wp:heading -->
 
-    <!-- wp:paragraph -->
-    <p>
-      You can also add text blocks into a column next to an image block to
-      create unique layouts.
+    <!-- wp:paragraph {"style":{"typography":{"fontStyle":"italic","fontWeight":"700"}}} -->
+    <p style="font-style: italic; font-weight: 700">
+      You can also add text blocks into a column next to
+      <mark
+        style="background-color: #dc2d2d"
+        class="has-inline-color has-white-color"
+        >an image block</mark
+      >
+      to create unique layouts.
     </p>
     <!-- /wp:paragraph -->
 
@@ -103,17 +152,17 @@
   </div>
   <!-- /wp:column -->
 
-  <!-- wp:column {"width":"300px","style":{"spacing":{"padding":{"right":"10px","left":"10px"}}}} -->
+  <!-- wp:column {"width":"300px","style":{"spacing":{"padding":{"right":"0","left":"0"}}}} -->
   <div
     class="wp-block-column"
-    style="padding-right: 10px; padding-left: 10px; flex-basis: 300px"
+    style="padding-right: 0; padding-left: 0; flex-basis: 300px"
   >
-    <!-- wp:image {"width":"265px","sizeSlug":"large","align":"right"} -->
+    <!-- wp:image {"width":"280px","height":"auto","sizeSlug":"large","align":"right"} -->
     <figure class="wp-block-image alignright size-large is-resized">
       <img
         src="https://picsum.photos/id/133/300/200"
         alt=""
-        style="width: 265px"
+        style="width: 280px; height: auto"
       />
     </figure>
     <!-- /wp:image -->
@@ -154,7 +203,8 @@
 
       <!-- wp:list-item -->
       <li>
-        Item 2<!-- wp:list {"textColor":"vivid-red","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}},"typography":{"fontStyle":"italic","fontWeight":"400"}}} -->
+        Item 2
+        <!-- wp:list {"textColor":"vivid-red","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}},"typography":{"fontStyle":"italic","fontWeight":"400"}}} -->
         <ul
           style="font-style: italic; font-weight: 400"
           class="has-vivid-red-color has-text-color has-link-color"
@@ -199,7 +249,8 @@
 
       <!-- wp:list-item -->
       <li>
-        Item 2<!-- wp:list {"textColor":"vivid-cyan-blue","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-cyan-blue"}}},"typography":{"textDecoration":"underline"}}} -->
+        Item 2
+        <!-- wp:list {"textColor":"vivid-cyan-blue","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-cyan-blue"}}},"typography":{"textDecoration":"underline"}}} -->
         <ul
           style="text-decoration: underline"
           class="has-vivid-cyan-blue-color has-text-color has-link-color"
@@ -244,7 +295,8 @@
 
       <!-- wp:list-item -->
       <li>
-        Item 2<!-- wp:list {"textColor":"vivid-green-cyan","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-green-cyan"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+        Item 2
+        <!-- wp:list {"textColor":"vivid-green-cyan","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-green-cyan"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
         <ul
           style="font-style: normal; font-weight: 700"
           class="has-vivid-green-cyan-color has-text-color has-link-color"

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/testing-email-with-core-blocks.html
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/testing-email-with-core-blocks.html
@@ -1,0 +1,303 @@
+<!-- wp:heading {"textAlign":"center","level":1,"align":"full","textColor":"luminous-vivid-orange","style":{"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-orange"}}},"color":{"background":"#f0f0f0"}}} -->
+<h1
+  class="wp-block-heading alignfull has-text-align-center has-luminous-vivid-orange-color has-text-color has-background has-link-color"
+  style="background-color: #f0f0f0"
+>
+  Sample Newsletter
+</h1>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns">
+  <!-- wp:column {"style":{"spacing":{"padding":{"right":"10px","left":"10px"}}}} -->
+  <div class="wp-block-column" style="padding-right: 10px; padding-left: 10px">
+    <!-- wp:heading {"backgroundColor":"pale-cyan-blue","style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} -->
+    <h2
+      class="wp-block-heading has-pale-cyan-blue-background-color has-background"
+      style="
+        padding-right: var(--wp--preset--spacing--20);
+        padding-left: var(--wp--preset--spacing--20);
+      "
+    >
+      1 Column Part
+    </h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph -->
+    <p>
+      A one-column layout is great for simplified and concise content, like
+      announcements or newsletters with brief updates. Drag blocks to add
+      content and customize your styles from the styles panel on the top right.
+    </p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:image {"sizeSlug":"large"} -->
+    <figure class="wp-block-image size-large">
+      <img src="https://picsum.photos/id/133/600/300" alt="" />
+    </figure>
+    <!-- /wp:image -->
+
+    <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+    <div class="wp-block-buttons">
+      <!-- wp:button {"backgroundColor":"pale-cyan-blue","textColor":"black","width":100,"style":{"elements":{"link":{"color":{"text":"var:preset|color|black"}}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100">
+        <a
+          class="wp-block-button__link has-black-color has-pale-cyan-blue-background-color has-text-color has-background has-link-color wp-element-button"
+          >Button</a
+        >
+      </div>
+      <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+  </div>
+  <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:heading {"textAlign":"center","align":"full","style":{"color":{"background":"#f0f0f0"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"0","right":"0"}}}} -->
+<h2
+  class="wp-block-heading alignfull has-text-align-center has-background"
+  style="
+    background-color: #f0f0f0;
+    padding-top: var(--wp--preset--spacing--20);
+    padding-right: 0;
+    padding-bottom: var(--wp--preset--spacing--20);
+    padding-left: 0;
+  "
+>
+  2 Columns Part
+</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns">
+  <!-- wp:column -->
+  <div class="wp-block-column">
+    <!-- wp:heading {"level":3,"textColor":"vivid-red","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}}}} -->
+    <h3
+      class="wp-block-heading has-vivid-red-color has-text-color has-link-color"
+    >
+      Heading 2
+    </h3>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph -->
+    <p>
+      You can also add text blocks into a column next to an image block to
+      create unique layouts.
+    </p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:buttons {"layout":{"justifyContent":"right"}} -->
+    <div class="wp-block-buttons">
+      <!-- wp:button {"backgroundColor":"pale-cyan-blue","textColor":"contrast","width":50,"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-50">
+        <a
+          class="wp-block-button__link has-contrast-color has-pale-cyan-blue-background-color has-text-color has-background has-link-color wp-element-button"
+          >Button</a
+        >
+      </div>
+      <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+  </div>
+  <!-- /wp:column -->
+
+  <!-- wp:column {"width":"300px","style":{"spacing":{"padding":{"right":"10px","left":"10px"}}}} -->
+  <div
+    class="wp-block-column"
+    style="padding-right: 10px; padding-left: 10px; flex-basis: 300px"
+  >
+    <!-- wp:image {"width":"265px","sizeSlug":"large","align":"right"} -->
+    <figure class="wp-block-image alignright size-large is-resized">
+      <img
+        src="https://picsum.photos/id/133/300/200"
+        alt=""
+        style="width: 265px"
+      />
+    </figure>
+    <!-- /wp:image -->
+  </div>
+  <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"style":{"spacing":{"padding":{"right":"var:preset|spacing|10","left":"var:preset|spacing|10"}}}} -->
+<div
+  class="wp-block-columns"
+  style="
+    padding-right: var(--wp--preset--spacing--10);
+    padding-left: var(--wp--preset--spacing--10);
+  "
+>
+  <!-- wp:column -->
+  <div class="wp-block-column">
+    <!-- wp:heading {"textAlign":"center","level":4} -->
+    <h4 class="wp-block-heading has-text-align-center">Product 1</h4>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"width":"150px","sizeSlug":"large","align":"center"} -->
+    <figure class="wp-block-image aligncenter size-large is-resized">
+      <img
+        src="https://picsum.photos/id/36/180/200"
+        alt=""
+        style="width: 150px"
+      />
+    </figure>
+    <!-- /wp:image -->
+
+    <!-- wp:list -->
+    <ul>
+      <!-- wp:list-item -->
+      <li>Item 1</li>
+      <!-- /wp:list-item -->
+
+      <!-- wp:list-item -->
+      <li>
+        Item 2<!-- wp:list {"textColor":"vivid-red","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}},"typography":{"fontStyle":"italic","fontWeight":"400"}}} -->
+        <ul
+          style="font-style: italic; font-weight: 400"
+          class="has-vivid-red-color has-text-color has-link-color"
+        >
+          <!-- wp:list-item -->
+          <li>Item A</li>
+          <!-- /wp:list-item -->
+
+          <!-- wp:list-item -->
+          <li>Item B</li>
+          <!-- /wp:list-item -->
+        </ul>
+        <!-- /wp:list -->
+      </li>
+      <!-- /wp:list-item -->
+    </ul>
+    <!-- /wp:list -->
+  </div>
+  <!-- /wp:column -->
+
+  <!-- wp:column -->
+  <div class="wp-block-column">
+    <!-- wp:heading {"textAlign":"center","level":4} -->
+    <h4 class="wp-block-heading has-text-align-center">Product 2</h4>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"width":"150px","sizeSlug":"large","align":"center"} -->
+    <figure class="wp-block-image aligncenter size-large is-resized">
+      <img
+        src="https://picsum.photos/id/36/180/200"
+        alt=""
+        style="width: 150px"
+      />
+    </figure>
+    <!-- /wp:image -->
+
+    <!-- wp:list {"style":{"typography":{"textDecoration":"none"}}} -->
+    <ul style="text-decoration: none">
+      <!-- wp:list-item -->
+      <li>Item 1</li>
+      <!-- /wp:list-item -->
+
+      <!-- wp:list-item -->
+      <li>
+        Item 2<!-- wp:list {"textColor":"vivid-cyan-blue","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-cyan-blue"}}},"typography":{"textDecoration":"underline"}}} -->
+        <ul
+          style="text-decoration: underline"
+          class="has-vivid-cyan-blue-color has-text-color has-link-color"
+        >
+          <!-- wp:list-item -->
+          <li>Item A</li>
+          <!-- /wp:list-item -->
+
+          <!-- wp:list-item -->
+          <li>Item B</li>
+          <!-- /wp:list-item -->
+        </ul>
+        <!-- /wp:list -->
+      </li>
+      <!-- /wp:list-item -->
+    </ul>
+    <!-- /wp:list -->
+  </div>
+  <!-- /wp:column -->
+
+  <!-- wp:column -->
+  <div class="wp-block-column">
+    <!-- wp:heading {"textAlign":"center","level":4} -->
+    <h4 class="wp-block-heading has-text-align-center">Product 3</h4>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"width":"150px","sizeSlug":"large","align":"center"} -->
+    <figure class="wp-block-image aligncenter size-large is-resized">
+      <img
+        src="https://picsum.photos/id/36/180/200"
+        alt=""
+        style="width: 150px"
+      />
+    </figure>
+    <!-- /wp:image -->
+
+    <!-- wp:list {"ordered":true} -->
+    <ol>
+      <!-- wp:list-item -->
+      <li>Item 1</li>
+      <!-- /wp:list-item -->
+
+      <!-- wp:list-item -->
+      <li>
+        Item 2<!-- wp:list {"textColor":"vivid-green-cyan","style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-green-cyan"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}}} -->
+        <ul
+          style="font-style: normal; font-weight: 700"
+          class="has-vivid-green-cyan-color has-text-color has-link-color"
+        >
+          <!-- wp:list-item -->
+          <li>Item A</li>
+          <!-- /wp:list-item -->
+
+          <!-- wp:list-item -->
+          <li>Item B</li>
+          <!-- /wp:list-item -->
+        </ul>
+        <!-- /wp:list -->
+      </li>
+      <!-- /wp:list-item -->
+    </ol>
+    <!-- /wp:list -->
+  </div>
+  <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:buttons {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"justifyContent":"center"}} -->
+<div class="wp-block-buttons alignfull">
+  <!-- wp:button {"width":25} -->
+  <div class="wp-block-button has-custom-width wp-block-button__width-25">
+    <a class="wp-block-button__link wp-element-button">Button 1</a>
+  </div>
+  <!-- /wp:button -->
+
+  <!-- wp:button {"width":25} -->
+  <div class="wp-block-button has-custom-width wp-block-button__width-25">
+    <a class="wp-block-button__link wp-element-button">Button 2</a>
+  </div>
+  <!-- /wp:button -->
+
+  <!-- wp:button {"width":25} -->
+  <div class="wp-block-button has-custom-width wp-block-button__width-25">
+    <a class="wp-block-button__link wp-element-button">Button 3</a>
+  </div>
+  <!-- /wp:button -->
+</div>
+<!-- /wp:buttons -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size">
+  You received this email because you are subscribed to the [site:title]
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size">
+  <a href="[link:subscription_unsubscribe_url]">Unsubscribe</a> |
+  <a href="[link:subscription_manage_url]">Manage subscription</a>
+</p>
+<!-- /wp:paragraph -->

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -23,6 +23,7 @@ use MailPoet\NotFoundException;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
+use MailPoet\Util\CdnAssetUrl;
 use MailPoet\Util\Security;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -78,8 +78,7 @@ class NewsletterSaveController {
   /*** @var NewsletterCoupon */
   private $newsletterCoupon;
 
-  /** @var EmailEditor */
-  private $emailEditor;
+  private CdnAssetUrl $cdnAssetUrl;
 
   public function __construct(
     AuthorizedEmailsController $authorizedEmailsController,
@@ -98,7 +97,7 @@ class NewsletterSaveController {
     ApiDataSanitizer $dataSanitizer,
     Scheduler $scheduler,
     NewsletterCoupon $newsletterCoupon,
-    EmailEditor $emailEditor
+    CdnAssetUrl $cdnAssetUrl
   ) {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->emoji = $emoji;
@@ -116,7 +115,7 @@ class NewsletterSaveController {
     $this->dataSanitizer = $dataSanitizer;
     $this->scheduler = $scheduler;
     $this->newsletterCoupon = $newsletterCoupon;
-    $this->emailEditor = $emailEditor;
+    $this->cdnAssetUrl = $cdnAssetUrl;
   }
 
   public function save(array $data = []): NewsletterEntity {
@@ -463,7 +462,7 @@ class NewsletterSaveController {
     }
 
     $newPostId = $this->wp->wpInsertPost([
-      'post_content' => $this->emailEditor->getEmailDefaultContent(),
+      'post_content' => $this->getEmailDefaultContent(),
       'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
       'post_status' => 'draft',
       'post_author' => $this->wp->getCurrentUserId(),
@@ -471,5 +470,28 @@ class NewsletterSaveController {
     ]);
     $newsletter->setWpPost($this->entityManager->getReference(WpPostEntity::class, $newPostId));
     $this->entityManager->flush();
+  }
+
+  private function getEmailDefaultContent(): string {
+    return '
+      <!-- wp:image {"width":"130px","sizeSlug":"large"} -->
+      <figure class="wp-block-image size-large is-resized"><img src="' . esc_url($this->cdnAssetUrl->generateCdnUrl("email-editor/your-logo-placeholder.png")) . '" alt="Your Logo" style="width:130px"/></figure>
+      <!-- /wp:image -->
+      <!-- wp:heading {"fontSize":"medium","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <h2 class="wp-block-heading has-medium-font-size" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)"></h2>
+      <!-- /wp:heading -->
+      <!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+      <!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}}} -->
+      <p style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"></p>
+      <!-- /wp:paragraph -->
+      <!-- wp:paragraph {"fontSize":"small"} -->
+      <p class="has-small-font-size">' . esc_html__('You received this email because you are subscribed to the [site:title]', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+      <!-- wp:paragraph {"fontSize":"small"} -->
+      <p class="has-small-font-size"><a href="[link:subscription_unsubscribe_url]">' . esc_html__('Unsubscribe', 'mailpoet') . '</a> | <a href="[link:subscription_manage_url]">' . esc_html__('Manage subscription', 'mailpoet') . '</a></p>
+      <!-- /wp:paragraph -->
+    ';
   }
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

1. A new template can be created by using:
   a. `./do email:create-templates` in the project root directory
   b. WP CLI `wp mailpoet:email-editor:create-templates` 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5971]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5971]: https://mailpoet.atlassian.net/browse/MAILPOET-5971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ