### PR TITLE
Restore trashed subscribers when using public API method subscribeToLists - MAILPOET-6023

### DIFF
--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -182,6 +182,11 @@ class Subscribers {
     $subscriber = $this->findSubscriber($subscriberId);
     $foundSegments = $this->getAndValidateSegments($listIds, self::CONTEXT_SUBSCRIBE);
 
+    // restore trashed subscriber
+    if ($subscriber->getDeletedAt()) {
+      $subscriber->setDeletedAt(null);
+    }
+
     $this->subscribersSegmentRepository->subscribeToSegments($subscriber, $foundSegments);
 
     // set status depending on signup confirmation setting

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -232,6 +232,17 @@ class SubscribersTest extends \MailPoetTest {
     verify($result['subscriptions'][0]['segment_id'])->equals($segment->getId());
   }
 
+  public function testItSubscribesSubscriberAndRestoreTrashedSubscribers() {
+    $subscriber = $this->subscriberFactory
+      ->withDeletedAt(new Carbon())
+      ->create();
+    $segment = $this->getSegment();
+
+    $result = $this->getApi()->subscribeToList($subscriber->getEmail(), $segment->getId());
+    verify($result['id'])->equals($subscriber->getId());
+    verify($result['deleted_at'])->null();
+  }
+
   public function testItSchedulesWelcomeNotificationByDefaultAfterSubscriberSubscriberToLists() {
     $subscriber = $this->subscriberFactory
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)


### PR DESCRIPTION
## Description

Restore trashed subscribers when using public API method subscribeToLists 

We do this as well when adding a new subscriber using the form method. We check and restore trashed subscribers ([GitHub link](https://github.com/mailpoet/mailpoet/blob/150042f6702a7c991c3f7ea55ddfb88713b02c13/mailpoet/lib/Subscribers/SubscriberActions.php#L89-L92))

## Code review notes

_N/A_

## QA notes

* Trash and disable your `WordPress Users` list
* Add a new WordPress user. Any user role is fine
* Check the MailPoet subscribers page (`/wp-admin/admin.php?page=mailpoet-subscribers`). Ensure the user is in Trash

You need to call the API method manually. 
Here is an example code you can add to your `functions.php` file.
NOTE: Please remove this code after your test

```php
add_action('profile_update', function (int $wpUserId){
	$wpUser = \get_userdata($wpUserId);

	if (!$wpUser) {
		// wpUser does not exist
		return;
	}

	$wpUserEmail = $wpUser->user_email;

	if (class_exists(\MailPoet\API\API::class)) {
		// Get MailPoet API instance
		$mailpoet_api = \MailPoet\API\API::MP('v1');

		// Get available list so that a subscriber can choose in which to subscribe
		$lists = $mailpoet_api->getLists();

		if (empty($lists)) {
			// no available list
			return;
		}

		// pick any available list
		$anyListId = $lists[0]['id'];

		$subscriber_email = $wpUserEmail;
		$list_id = $anyListId; 

		if (empty($subscriber_email)) {
			// No subscriber_email
			return;
		}

		try {
			$subscriber = $mailpoet_api->subscribeToList($subscriber_email, $list_id);
		} catch (\Exception $e) {
			$error_message = $e->getMessage();
		}
	}

},6, 2);
``` 

**After**
* Update the previous WordPress user. You may update the first or last name
* Check the MailPoet subscribers page; the subscriber should **not be** in the trash.


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6023](https://mailpoet.atlassian.net/browse/MAILPOET-6023)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6023]: https://mailpoet.atlassian.net/browse/MAILPOET-6023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ