### PR TITLE
Respect capabilities in automation template selection [MAILPOET-6002]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
@@ -58,7 +58,7 @@ export function InserterPopover(): JSX.Element | null {
             utm_medium: 'upsell_modal',
             utm_campaign: 'add_automation_step',
           }}
-          data={{ capabilityName: 'automationSteps' }}
+          data={{ capabilities: { automationSteps: 0 } }}
         >
           {__('You cannot add a new step to the automation.', 'mailpoet')}
         </PremiumModal>

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/filter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/filter.tsx
@@ -72,7 +72,7 @@ export function Filter(): JSX.Element {
             utm_medium: 'upsell_modal',
             utm_campaign: 'automation_analytics_date_range_filter',
           }}
-          data={{ capabilityName: 'detailedAnalytics' }}
+          data={{ capabilities: { detailedAnalytics: true } }}
           onRequestClose={() => setShowUpsell(false)}
         >
           {__('Changing the date range is a premium feature.', 'mailpoet')}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/orders/upgrade.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/orders/upgrade.tsx
@@ -27,7 +27,7 @@ const getCta = (state: State, upgradeInfo: UpgradeInfo): string => {
 
 export function Upgrade(): JSX.Element {
   const upgradeInfo = useUpgradeInfo(
-    { capabilityName: 'detailedAnalytics' },
+    { capabilities: { detailedAnalytics: true } },
     {
       utm_medium: 'upsell_modal',
       utm_campaign: 'automation-analytics',

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/actions/index.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/actions/index.ts
@@ -139,7 +139,7 @@ export function openPremiumModalForSampleData() {
     type: 'OPEN_PREMIUM_MODAL',
     content: __("You're viewing sample data.", 'mailpoet'),
     utmCampaign: 'automation_analytics_sample_data',
-    data: { capabilityName: 'detailedAnalytics' },
+    data: { capabilities: { detailedAnalytics: true } },
   };
 }
 

--- a/mailpoet/assets/js/src/automation/templates/components/template-list-item.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-list-item.tsx
@@ -74,9 +74,7 @@ export function TemplateListItem({ template, onSelect }: Props): JSX.Element {
           onRequestClose={() => {
             setShowPremium(false);
           }}
-          data={{
-            capabilityName: 'automationSteps',
-          }}
+          data={{ capabilities: template.required_capabilities }}
           tracking={{
             utm_medium: 'upsell_modal',
             utm_campaign: 'automation_premium_template',

--- a/mailpoet/assets/js/src/automation/templates/config.ts
+++ b/mailpoet/assets/js/src/automation/templates/config.ts
@@ -4,6 +4,7 @@ export type AutomationTemplate = {
   description: string;
   category: string;
   type: 'default' | 'free-only' | 'premium' | 'coming-soon';
+  required_capabilities: Record<string, boolean | number>;
 };
 
 export type AutomationTemplateCategory = {

--- a/mailpoet/assets/js/src/common/premium-banner-with-upgrade/premium-banner-with-upgrade.tsx
+++ b/mailpoet/assets/js/src/common/premium-banner-with-upgrade/premium-banner-with-upgrade.tsx
@@ -9,7 +9,7 @@ import { PremiumMessageWithModal } from 'common/premium-key/key-messages';
 type Props = {
   message: ReactNode;
   actionButton: ReactNode;
-  capabilityName?: string;
+  capabilities?: Record<string, boolean | number>;
 };
 
 const {
@@ -49,7 +49,7 @@ const getPremiumCtaButton = (buttonText: string) => (
 export function PremiumBannerWithUpgrade({
   message,
   actionButton,
-  capabilityName = undefined,
+  capabilities = {},
 }: Props): JSX.Element {
   let bannerMessage: ReactNode;
   let ctaButton: ReactNode;
@@ -88,17 +88,15 @@ export function PremiumBannerWithUpgrade({
   } else if (
     (hasValidApiKey && !hasValidPremiumKey) || // ex. Starter plan
     (hasValidPremiumKey &&
-      capabilityName &&
-      MailPoet.capabilities[capabilityName].isRestricted)
+      Object.keys(capabilities).some(
+        (name) => MailPoet.capabilities[name].isRestricted,
+      ))
   ) {
     title = __('Upgrade your plan', 'mailpoet');
     bannerMessage = message;
-    const upgradeParams = capabilityName
-      ? { capability: capabilityName, s: subscribersCount }
-      : {};
     const link = MailPoet.MailPoetComUrlFactory.getUpgradeUrl(
       pluginPartialKey,
-      upgradeParams,
+      { s: subscribersCount, capabilities },
     );
     ctaButton = getCtaButton(__('Upgrade', 'mailpoet'), link);
   } else {

--- a/mailpoet/assets/js/src/common/premium-modal/upgrade-info.ts
+++ b/mailpoet/assets/js/src/common/premium-modal/upgrade-info.ts
@@ -34,7 +34,7 @@ export type Data = {
   pluginPartialKey?: string;
   subscribersCount?: number;
   subscribersLimitReached?: boolean;
-  capabilityName?: string;
+  capabilities?: Record<string, boolean | number>;
 };
 
 export type UtmParams = {
@@ -59,15 +59,14 @@ export const getUpgradeInfo = (
     pluginPartialKey = MailPoet.pluginPartialKey,
     subscribersCount = MailPoet.subscribersCount,
     subscribersLimitReached = MailPoet.subscribersLimitReached,
-    capabilityName = undefined,
+    capabilities = {},
   }: Data = {},
   utmParams: UtmParams = undefined,
   onPremiumInstalled?: () => void,
 ): UpgradeInfo => {
   const utm = utmParams ? { utm_source: 'plugin', ...utmParams } : undefined;
-  const upgradeParams = capabilityName
-    ? { capability: capabilityName, s: subscribersCount }
-    : {};
+  const upgradeParams = { s: subscribersCount, capabilities };
+
   // a. User doesn't have a valid license.
   if (!hasValidPremiumKey && !hasValidApiKey) {
     return {
@@ -143,10 +142,13 @@ export const getUpgradeInfo = (
   }
 
   // f. User has a license but the feature is not available for the plan.
-  if (capabilityName && MailPoet.capabilities[capabilityName]?.isRestricted) {
+  const restrictedCapabilityName = Object.keys(capabilities).find(
+    (name) => MailPoet.capabilities[name]?.isRestricted,
+  );
+  if (restrictedCapabilityName) {
     let info: string;
 
-    switch (capabilityName) {
+    switch (restrictedCapabilityName) {
       case 'detailedAnalytics':
         info = __(
           'Upgrade your MailPoet plan to gain detailed insights into how your subscribers engage with your automations and their purchasing behaviors.',

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -153,6 +153,7 @@ interface Window {
   mailpoet_email_volume_limit: string;
   mailpoet_email_volume_limit_reached: boolean;
   mailpoet_capabilities: Capabilities;
+  mailpoet_tier: number | null;
   mailpoet_current_wp_user_email: string;
   mailpoet_current_time?: string;
   mailpoet_current_date?: string;

--- a/mailpoet/assets/js/src/mailpoet-com-url-factory.js
+++ b/mailpoet/assets/js/src/mailpoet-com-url-factory.js
@@ -8,9 +8,15 @@ export const MailPoetComUrlFactory = (referralId) => {
       finalParams.ref = referralId;
     }
     const url = new URL(path, base);
-    Object.keys(finalParams).map((key) =>
-      url.searchParams.set(key, finalParams[key]),
-    );
+    Object.keys(finalParams).forEach((key) => {
+      if (typeof finalParams[key] === 'object') {
+        Object.entries(finalParams[key]).forEach(([subKey, subValue]) => {
+          url.searchParams.set(`${key}[${subKey}]`, subValue);
+        });
+      } else {
+        url.searchParams.set(key, finalParams[key]);
+      }
+    });
     return url.toString();
   };
 

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -69,6 +69,7 @@ export const MailPoet = {
   emailVolumeLimit: window.mailpoet_email_volume_limit,
   emailVolumeLimitReached: window.mailpoet_email_volume_limit_reached,
   capabilities: window.mailpoet_capabilities,
+  tier: window.mailpoet_tier,
   currentWpUserEmail: window.mailpoet_current_wp_user_email,
   freeMailDomains: window.mailpoet_free_domains || [],
   installedAt: window.mailpoet_installed_at,

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/premium-banner.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/premium-banner.tsx
@@ -38,7 +38,7 @@ function SkipDisplayingDetailedStats() {
       <PremiumBannerWithUpgrade
         message={description}
         actionButton={ctaButton}
-        capabilityName="detailedAnalytics"
+        capabilities={{ detailedAnalytics: true }}
       />
     </div>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/form.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/form.tsx
@@ -202,7 +202,7 @@ export function Form({ isNewSegment, newsletterId }: Props): JSX.Element {
                 {showPremiumModal && (
                   <PremiumModal
                     onRequestClose={closePremiumModal}
-                    data={{ capabilityName: 'segmentFilters' }}
+                    data={{ capabilities: { segmentFilters: 0 } }}
                   >
                     {__(
                       'Multiple conditions per segment are not available in the free version of the MailPoet plugin.',

--- a/mailpoet/assets/js/src/subscribers/stats/no-access-info.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/no-access-info.tsx
@@ -76,7 +76,7 @@ export function NoAccessInfo(): JSX.Element {
               <PremiumBannerWithUpgrade
                 message={getBannerMessage({})}
                 actionButton={getCtaButton({})}
-                capabilityName="detailedAnalytics"
+                capabilities={{ detailedAnalytics: true }}
               />
             </div>
           </td>

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -194,6 +194,7 @@ class PageRenderer {
       'email_volume_limit' => $this->subscribersFeature->getEmailVolumeLimit(),
       'email_volume_limit_reached' => $this->subscribersFeature->checkEmailVolumeLimitIsReached(),
       'capabilities' => $this->capabilitiesManager->getCapabilities(),
+      'tier' => $this->capabilitiesManager->getTier(),
       'urls' => [
         'automationListing' => admin_url('admin.php?page=mailpoet-automation'),
         'automationEditor' => admin_url('admin.php?page=mailpoet-automation-editor'),

--- a/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
@@ -4,7 +4,6 @@ namespace MailPoet\Automation\Engine\Data;
 
 class AutomationTemplate {
   public const TYPE_DEFAULT = 'default';
-  public const TYPE_FREE_ONLY = 'free-only';
   public const TYPE_PREMIUM = 'premium';
   public const TYPE_COMING_SOON = 'coming-soon';
 

--- a/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
@@ -22,16 +22,23 @@ class AutomationTemplate {
   /** @var callable(): Automation */
   private $automationFactory;
 
+  /** @var array<string, int|bool> */
+  private $requiredCapabilities;
+
   /** @var string */
   private $type;
 
-  /** @param callable(): Automation $automationFactory */
+  /**
+   * @param callable(): Automation $automationFactory
+   * @param array<string, int|bool> $requiredCapabilities
+   */
   public function __construct(
     string $slug,
     string $category,
     string $name,
     string $description,
     callable $automationFactory,
+    array $requiredCapabilities = [],
     string $type = self::TYPE_DEFAULT
   ) {
     $this->slug = $slug;
@@ -39,6 +46,7 @@ class AutomationTemplate {
     $this->name = $name;
     $this->description = $description;
     $this->automationFactory = $automationFactory;
+    $this->requiredCapabilities = $requiredCapabilities;
     $this->type = $type;
   }
 
@@ -62,6 +70,11 @@ class AutomationTemplate {
     return $this->description;
   }
 
+  /** @return array<string, int|bool> */
+  public function getRequiredCapabilities(): array {
+    return $this->requiredCapabilities;
+  }
+
   public function createAutomation(): Automation {
     return ($this->automationFactory)();
   }
@@ -72,6 +85,7 @@ class AutomationTemplate {
       'name' => $this->getName(),
       'category' => $this->getCategory(),
       'type' => $this->getType(),
+      'required_capabilities' => $this->getRequiredCapabilities(),
       'description' => $this->getDescription(),
     ];
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -66,6 +66,9 @@ class TemplatesFactory {
           ]
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -92,6 +95,9 @@ class TemplatesFactory {
           ]
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -111,6 +117,9 @@ class TemplatesFactory {
           []
         );
       },
+      [
+        'automationSteps' => 2,
+      ],
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -130,6 +139,9 @@ class TemplatesFactory {
           []
         );
       },
+      [
+        'automationSteps' => 2,
+      ],
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -174,6 +186,9 @@ class TemplatesFactory {
           ]
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -193,6 +208,9 @@ class TemplatesFactory {
           []
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -212,6 +230,9 @@ class TemplatesFactory {
           []
         );
       },
+      [
+        'automationSteps' => 4,
+      ],
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -240,6 +261,9 @@ class TemplatesFactory {
           ]
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -259,6 +283,9 @@ class TemplatesFactory {
           []
         );
       },
+      [
+        'automationSteps' => 5,
+      ],
       AutomationTemplate::TYPE_PREMIUM
     );
   }
@@ -278,6 +305,9 @@ class TemplatesFactory {
           $this->createPurchasedTemplateBody('woocommerce:order:products')
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -297,6 +327,9 @@ class TemplatesFactory {
           $this->createPurchasedTemplateBody('woocommerce:order:tags')
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }
@@ -316,6 +349,9 @@ class TemplatesFactory {
           $this->createPurchasedTemplateBody('woocommerce:order:categories')
         );
       },
+      [
+        'automationSteps' => 1,
+      ],
       AutomationTemplate::TYPE_DEFAULT
     );
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -36,6 +36,9 @@ class TemplatesFactory {
       $templates[] = $this->createWinBackCustomersTemplate();
       $templates[] = $this->createAbandonedCartTemplate();
       $templates[] = $this->createAbandonedCartCampaignTemplate();
+      $templates[] = $this->createPurchasedProductTemplate();
+      $templates[] = $this->createPurchasedProductWithTagTemplate();
+      $templates[] = $this->createPurchasedInCategoryTemplate();
     }
 
     return $templates;
@@ -258,5 +261,88 @@ class TemplatesFactory {
       },
       AutomationTemplate::TYPE_PREMIUM
     );
+  }
+
+  private function createPurchasedProductTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'purchased-product',
+      'woocommerce',
+      __('Purchased a product', 'mailpoet'),
+      __(
+        'Share care instructions or simply thank the customer for making an order.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Purchased a product', 'mailpoet'),
+          $this->createPurchasedTemplateBody('woocommerce:order:products')
+        );
+      },
+      AutomationTemplate::TYPE_DEFAULT
+    );
+  }
+
+  private function createPurchasedProductWithTagTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'purchased-product-with-tag',
+      'woocommerce',
+      __('Purchased a product with a tag', 'mailpoet'),
+      __(
+        'Share care instructions or simply thank the customer for making an order.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Purchased a product with a tag', 'mailpoet'),
+          $this->createPurchasedTemplateBody('woocommerce:order:tags')
+        );
+      },
+      AutomationTemplate::TYPE_DEFAULT
+    );
+  }
+
+  private function createPurchasedInCategoryTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'purchased-in-category',
+      'woocommerce',
+      __('Purchased in a category', 'mailpoet'),
+      __(
+        'Share care instructions or simply thank the customer for making an order.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Purchased in a category', 'mailpoet'),
+          $this->createPurchasedTemplateBody('woocommerce:order:categories')
+        );
+      },
+      AutomationTemplate::TYPE_DEFAULT
+    );
+  }
+
+  private function createPurchasedTemplateBody(string $filterField): array {
+    return [
+      [
+        'key' => 'woocommerce:order-completed',
+        'filters' => [
+          'operator' => 'and',
+          'groups' => [
+            [
+              'operator' => 'and',
+              'filters' => [
+                ['field' => $filterField, 'condition' => 'matches-any-of', 'value' => null],
+              ],
+            ],
+          ],
+        ],
+      ],
+      [
+        'key' => 'mailpoet:send-email',
+        'args' => [
+          'name' => __('Important information about your order', 'mailpoet'),
+          'subject' => __('Important information about your order', 'mailpoet'),
+        ],
+      ],
+    ];
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -63,7 +63,7 @@ class TemplatesFactory {
           ]
         );
       },
-      AutomationTemplate::TYPE_FREE_ONLY
+      AutomationTemplate::TYPE_DEFAULT
     );
   }
 
@@ -89,7 +89,7 @@ class TemplatesFactory {
           ]
         );
       },
-      AutomationTemplate::TYPE_FREE_ONLY
+      AutomationTemplate::TYPE_DEFAULT
     );
   }
 

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -15,7 +15,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(9, $result['data']);
+    $this->assertCount(12, $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -23,7 +23,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(9, $data['data']);
+    $this->assertCount(12, $data['data']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -44,19 +44,20 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
         'category' => 'welcome',
       ],
     ]);
-
     $this->assertCount(4, $result['data']);
+
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
         'category' => 'abandoned-cart',
       ],
     ]);
     $this->assertCount(2, $result['data']);
+
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
         'category' => 'woocommerce',
       ],
     ]);
-    $this->assertCount(3, $result['data']);
+    $this->assertCount(6, $result['data']);
   }
 }

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -98,6 +98,7 @@
   var mailpoet_email_volume_limit = <%= json_encode(email_volume_limit) %>;
   var mailpoet_email_volume_limit_reached = <%= json_encode(email_volume_limit_reached) %>;
   var mailpoet_capabilities = <%= json_encode(capabilities) %>;
+  var mailpoet_tier = <%= json_encode(tier) %>;
   var mailpoet_cdn_url = <%= json_encode(cdn_url("")) %>;
   var mailpoet_tags = <%= json_encode(tags) %>;
 


### PR DESCRIPTION
## Description

Respect plan capabilities in automation template selection.

## Code review notes

Note that to fully test this with the shop, https://github.com/mailpoet/shop/pull/1204 must be released.

## QA notes

Note that to fully test this with the shop, https://github.com/mailpoet/shop/pull/1204 must be released.

1. Older 2002 plans should behave as before, except that purchased product/tag/category templates are now free, and there are no free-only templates (we don't hide any templates when premium is activated).
2. Newer 2024 plans should behave based on capabilities/tiers (see the specs).

Upgrade URLs should lead to `https://account.mailpoet.com/orders/upgrade/<key>?s=<number-of-subscribers>&capabilities%5BautomationSteps%5D=<number-of-required-automation-steps>`.

Please, also smoke-check other upgrade modals and banners and verify they link to correct plans.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/861

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
