### PR TITLE
Fix acceptance test in the new email editor createAndSendStandardNewsletter

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -26,8 +26,8 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Compose an email');
     $i->waitForElementVisible('.is-root-container');
-    $i->waitForElement('[aria-label="Block: Image');
-    $i->waitForElement('[aria-label="Block: Heading');
+    $i->waitForElementVisible('[aria-label="Block: Image"]');
+    $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
     $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
 
@@ -89,8 +89,8 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Edit an email');
     $i->waitForElementVisible('.is-root-container');
-    $i->waitForElement('[aria-label="Block: Image');
-    $i->waitForElement('[aria-label="Block: Heading');
+    $i->waitForElementVisible('[aria-label="Block: Image"]');
+    $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
     $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
 

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -26,9 +26,10 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Compose an email');
     $i->waitForElementVisible('.is-root-container');
-    $i->waitForElementClickable('.is-root-container');
-    $i->click('.is-root-container');
-    $i->fillField('.//p[@data-title="Paragraph"]', 'Sample text');
+    $i->waitForElementVisible('[aria-label="Block: Image');
+    $i->waitForElementVisible('[aria-label="Block: Heading');
+    $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
+    $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
 
     $i->wantTo('Verify correct WP menu item is highlighted');
     $i->waitForText('Emails', 10, '#toplevel_page_mailpoet-homepage .current');
@@ -88,9 +89,10 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Edit an email');
     $i->waitForElementVisible('.is-root-container');
-    $i->waitForElementClickable('.is-root-container');
-    $i->click('.is-root-container');
-    $i->fillField('.//p[@data-title="Paragraph"]', 'Sample text');
+    $i->waitForElementVisible('[aria-label="Block: Image');
+    $i->waitForElementVisible('[aria-label="Block: Heading');
+    $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
+    $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
 
     $i->wantTo('Save draft and display preview');
     $i->click('Save Draft');

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -26,8 +26,8 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Compose an email');
     $i->waitForElementVisible('.is-root-container');
-    $i->waitForElementVisible('[aria-label="Block: Image');
-    $i->waitForElementVisible('[aria-label="Block: Heading');
+    $i->waitForElement('[aria-label="Block: Image');
+    $i->waitForElement('[aria-label="Block: Heading');
     $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
     $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
 
@@ -89,8 +89,8 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Edit an email');
     $i->waitForElementVisible('.is-root-container');
-    $i->waitForElementVisible('[aria-label="Block: Image');
-    $i->waitForElementVisible('[aria-label="Block: Heading');
+    $i->waitForElement('[aria-label="Block: Image');
+    $i->waitForElement('[aria-label="Block: Heading');
     $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
     $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
 

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -29,7 +29,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
-    $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
+    $i->type('Sample text');
 
     $i->wantTo('Verify correct WP menu item is highlighted');
     $i->waitForText('Emails', 10, '#toplevel_page_mailpoet-homepage .current');
@@ -92,7 +92,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Empty block; start writing or type forward slash to choose a block"]');
-    $i->type('[aria-label="Empty block; start writing or type forward slash to choose a block"]', 'Sample text');
+    $i->type('Sample text');
 
     $i->wantTo('Save draft and display preview');
     $i->click('Save Draft');


### PR DESCRIPTION
## Description

Refactor existing email editor acceptance test to have more waits and use those waits as assertions.
The problem was the page wasn't loaded and it attempted to fill the empty block. With those waits we could also assert them they are present on the page and wait for the whole page to load before typing the sample text.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6031]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6031]: https://mailpoet.atlassian.net/browse/MAILPOET-6031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ