### PR TITLE
Revert testing against latest WooCommerce

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 8.8.0-rc.1
+            ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 5.7.0
             ./do download:woo-commerce-memberships-zip 1.25.2
             ./do download:automate-woo-zip 6.0.10
@@ -947,7 +947,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
-          woo_core_version: 8.8.0-rc.1
+          woo_core_version: latest
           woo_subscriptions_version: latest
           woo_memberships_version: latest
           automate_woo_version: latest

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -68,9 +68,9 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     cd /wp-core/wp-content/plugins
     WOOCOMMERCE_CORE_ZIP="/wp-core/wp-content/plugins/mailpoet/tests/plugins/woocommerce.zip"
     if [ ! -f "$WOOCOMMERCE_CORE_ZIP" ]; then
-      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin 8.8.0-rc.1 zip"
+      echo "WooCommerce plugin zip not found. Downloading WooCommerce plugin latest zip"
       cd /project
-      ./do download:woo-commerce-zip 8.8.0-rc.1
+      ./do download:woo-commerce-zip latest
       cd /wp-core/wp-content/plugins
     fi
 


### PR DESCRIPTION
## Description

Revert testing against WooCommerce latest build.

What's left is testing against WooCommece 8.6.0 in the `acceptance_oldest` job, because testing against 8.7.0 is not recommended due to known issue we found which they decided to fix in 8.8.0.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6033]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6033]: https://mailpoet.atlassian.net/browse/MAILPOET-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ