### PR TITLE
Fix acceptance test ManageWooCommerceSegmentsCest

### DIFF
--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -58,7 +58,9 @@ class ManageWooCommerceSegmentsCest {
     $i->wantTo('Edit segment and save');
     $editedTitle = 'Segment Woo Category Test Edited';
     $editedDesc = 'Segment description Edited';
+    $i->clearField(['name' => 'name']);
     $i->fillField(['name' => 'name'], $editedTitle);
+    $i->clearField(['name' => 'description']);
     $i->fillField(['name' => 'description'], $editedDesc);
     $i->selectOptionInReactSelect('Category 1', $categorySelectElement);
     $i->selectOptionInReactSelect('Category 3', $categorySelectElement);
@@ -125,7 +127,9 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
+    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
+    $i->clearField($segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->selectOption($operatorSelectElement, 'none of');
     $i->selectOptionInReactSelect('Product 1', $productSelectElement);
@@ -193,7 +197,9 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
+    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
+    $i->clearField($segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->waitForElementVisible('input[value=""]' . $numberOfOrdersCountElement);
     $i->waitForElementVisible('input[value=""]' . $numberOfOrdersDaysElement);
@@ -263,7 +269,9 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
+    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
+    $i->clearField($segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->waitForElementVisible('input[value=""]' . $totalSpentAmountElement);
     $i->waitForElementVisible('input[value=""]' . $totalSpentDaysElement);
@@ -334,7 +342,9 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
+    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
+    $i->clearField($$segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->waitForElementVisible('input[value=""]' . $singleOrderValueAmountElement);
     $i->waitForElementVisible('input[value=""]' . $singleOrderValueDaysElement);

--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -127,9 +127,7 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
-    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
-    $i->clearField($segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->selectOption($operatorSelectElement, 'none of');
     $i->selectOptionInReactSelect('Product 1', $productSelectElement);
@@ -197,9 +195,7 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
-    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
-    $i->clearField($segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->waitForElementVisible('input[value=""]' . $numberOfOrdersCountElement);
     $i->waitForElementVisible('input[value=""]' . $numberOfOrdersDaysElement);
@@ -269,9 +265,7 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
-    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
-    $i->clearField($segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->waitForElementVisible('input[value=""]' . $totalSpentAmountElement);
     $i->waitForElementVisible('input[value=""]' . $totalSpentDaysElement);
@@ -342,9 +336,7 @@ class ManageWooCommerceSegmentsCest {
     $i->clearFormField($segmentDescriptionField);
     $i->waitForElementVisible('input[value=""]' . $segmentNameField);
     $i->waitForElementVisible($segmentDescriptionField . ':empty');
-    $i->clearField($segmentNameField);
     $i->fillField($segmentNameField, $editedTitle);
-    $i->clearField($$segmentDescriptionField);
     $i->fillField($segmentDescriptionField, $editedDesc);
     $i->waitForElementVisible('input[value=""]' . $singleOrderValueAmountElement);
     $i->waitForElementVisible('input[value=""]' . $singleOrderValueDaysElement);


### PR DESCRIPTION
## Description

Added clear fields before filling to avoid flakiness. The other scenarios in this test are already equipped with clearFormField methods, but the first scenario was missing such a method which led to flakiness.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6034]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6034]: https://mailpoet.atlassian.net/browse/MAILPOET-6034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ