### PR TITLE
Wait for email sent in send automation step [MAILPOET-4977]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use ActionScheduler_Action;
+
 class ActionScheduler {
   private const GROUP_ID = 'mailpoet-automation';
 
@@ -15,5 +17,14 @@ class ActionScheduler {
 
   public function hasScheduledAction(string $hook, array $args = []): bool {
     return as_has_scheduled_action($hook, $args, self::GROUP_ID);
+  }
+
+  /** @return ActionScheduler_Action[] */
+  public function getScheduledActions(array $args = []): array {
+    return as_get_scheduled_actions(array_merge($args, ['group' => self::GROUP_ID]));
+  }
+
+  public function unscheduleAction(string $hook, array $args = []): ?int {
+    return as_unschedule_action($hook, $args, self::GROUP_ID);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/AutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Control/AutomationController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use ActionScheduler_CanceledAction;
 use MailPoet\Automation\Engine\Data\AutomationRunLog;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Hooks;
@@ -35,6 +36,19 @@ class AutomationController {
       'step_id' => $stepId,
       'run_number' => $runNumber,
     ];
+
+    // if a pending action exists, unschedule it
+    $this->actionScheduler->unscheduleAction(Hooks::AUTOMATION_STEP, [$args]);
+
+    // if an action still exists (pending, in-progress, complete, failed), it's an error
+    $actions = $this->actionScheduler->getScheduledActions(['hook' => Hooks::AUTOMATION_STEP, 'args' => [$args]]);
+    $processedActions = array_filter($actions, function ($action) {
+      return !$action instanceof ActionScheduler_CanceledAction;
+    });
+    if (count($processedActions) > 0) {
+      throw Exceptions::stepActionProcessed($stepId, $runId, $runNumber);
+    }
+
     $this->actionScheduler->enqueue(Hooks::AUTOMATION_STEP, [$args]);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/AutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Control/AutomationController.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Data\AutomationRunLog;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
+
+class AutomationController {
+  private ActionScheduler $actionScheduler;
+  private AutomationRunLogStorage $automationRunLogStorage;
+
+  public function __construct(
+    ActionScheduler $actionScheduler,
+    AutomationRunLogStorage $automationRunLogStorage
+  ) {
+    $this->actionScheduler = $actionScheduler;
+    $this->automationRunLogStorage = $automationRunLogStorage;
+  }
+
+  public function enqueueProgress(int $runId, string $stepId): void {
+    $log = $this->automationRunLogStorage->getAutomationRunLogByRunAndStepId($runId, $stepId);
+    if (!$log) {
+      throw Exceptions::stepNotStarted($stepId, $runId);
+    }
+
+    if ($log->getStatus() !== AutomationRunLog::STATUS_RUNNING) {
+      throw Exceptions::stepNotRunning($stepId, $log->getStatus(), $runId);
+    }
+
+    $runNumber = $log->getRunNumber() + 1;
+    $args = [
+      'automation_run_id' => $runId,
+      'step_id' => $stepId,
+      'run_number' => $runNumber,
+    ];
+    $this->actionScheduler->enqueue(Hooks::AUTOMATION_STEP, [$args]);
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
@@ -64,7 +64,10 @@ class StepRunLogger {
   }
 
   public function logStart(): void {
-    $this->getLog();
+    $log = $this->getLog();
+    $log->setStatus(AutomationRunLog::STATUS_RUNNING);
+    $log->setUpdatedAt(new DateTimeImmutable());
+    $this->automationRunLogStorage->updateAutomationRunLog($log);
   }
 
   public function logStepData(Step $step): void {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -39,6 +39,7 @@ class Exceptions {
   private const AUTOMATION_HAS_ACTIVE_RUNS = 'mailpoet_automation_has_active_runs';
   private const AUTOMATION_STEP_NOT_STARTED = 'mailpoet_automation_step_not_started';
   private const AUTOMATION_STEP_NOT_RUNNING = 'mailpoet_automation_step_not_running';
+  private const AUTOMATION_STEP_ACTION_PROCESSED = 'mailpoet_automation_step_action_processed';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -289,5 +290,12 @@ class Exceptions {
       ->withErrorCode(self::AUTOMATION_STEP_NOT_RUNNING)
       // translators: %1$s is the ID of the automation step, %2$s its current status, %3$d is the automation run ID.
       ->withMessage(sprintf(__("Automation step with ID '%1\$s' is not running in automation run with ID '%2\$d'. Status: '%3\$s'", 'mailpoet'), $id, $runId, $status));
+  }
+
+  public static function stepActionProcessed(string $id, int $runId, int $runNumber): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::AUTOMATION_STEP_ACTION_PROCESSED)
+      // translators: %1$d is the automation run ID, %2$s is the ID of the automation step, %3$d is the run number.
+      ->withMessage(sprintf(__("Automation run with ID '%1\$d' already has a processed action for step with ID '%2\$s' and run number '%3\$d'.", 'mailpoet'), $runId, $id, $runNumber));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -37,6 +37,8 @@ class Exceptions {
   private const AUTOMATION_NOT_TRASHED = 'mailpoet_automation_not_trashed';
   private const AUTOMATION_TEMPLATE_NOT_FOUND = 'mailpoet_automation_template_not_found';
   private const AUTOMATION_HAS_ACTIVE_RUNS = 'mailpoet_automation_has_active_runs';
+  private const AUTOMATION_STEP_NOT_STARTED = 'mailpoet_automation_step_not_started';
+  private const AUTOMATION_STEP_NOT_RUNNING = 'mailpoet_automation_step_not_running';
 
   public function __construct() {
     throw new InvalidStateException(
@@ -273,5 +275,19 @@ class Exceptions {
       ->withErrorCode(self::AUTOMATION_HAS_ACTIVE_RUNS)
       // translators: %d is the ID of the automation.
       ->withMessage(sprintf(__("Can not update automation with ID '%d' because users are currently active.", 'mailpoet'), $id));
+  }
+
+  public static function stepNotStarted(string $id, int $runId): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::AUTOMATION_STEP_NOT_STARTED)
+      // translators: %1$s is the ID of the automation step, %2$d is the automation run ID.
+      ->withMessage(sprintf(__("Automation step with ID '%1\$s' was not started in automation run with ID '%2\$d'.", 'mailpoet'), $id, $runId));
+  }
+
+  public static function stepNotRunning(string $id, string $status, int $runId): InvalidStateException {
+    return InvalidStateException::create()
+      ->withErrorCode(self::AUTOMATION_STEP_NOT_RUNNING)
+      // translators: %1$s is the ID of the automation step, %2$s its current status, %3$d is the automation run ID.
+      ->withMessage(sprintf(__("Automation step with ID '%1\$s' is not running in automation run with ID '%2\$d'. Status: '%3\$s'", 'mailpoet'), $id, $runId, $status));
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -79,7 +79,7 @@ class Exceptions {
     return InvalidStateException::create()
       ->withErrorCode(self::AUTOMATION_NOT_ACTIVE)
       // translators: %1$s is the ID of the automation.
-      ->withMessage(sprintf(__('Automation with ID "%1$s" in no longer active.', 'mailpoet'), $automation));
+      ->withMessage(sprintf(__('Automation with ID "%1$s" is no longer active.', 'mailpoet'), $automation));
   }
 
   public static function automationRunNotFound(int $id): NotFoundException {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -203,12 +203,21 @@ class SendEmailAction implements Action {
   }
 
   private function getNewsletterMeta(StepRunArgs $args): array {
-    if (!$this->automationHasAbandonedCartTrigger($args->getAutomation())) {
-      return [];
+    $meta = [
+      'automation' => [
+        'id' => $args->getAutomation()->getId(),
+        'run_id' => $args->getAutomationRun()->getId(),
+        'step_id' => $args->getStep()->getId(),
+        'run_number' => $args->getRunNumber(),
+      ],
+    ];
+
+    if ($this->automationHasAbandonedCartTrigger($args->getAutomation())) {
+      $payload = $args->getSinglePayloadByClass(AbandonedCartPayload::class);
+      $meta[AbandonedCart::TASK_META_NAME] = $payload->getProductIds();
     }
 
-    $payload = $args->getSinglePayloadByClass(AbandonedCartPayload::class);
-    return [AbandonedCart::TASK_META_NAME => $payload->getProductIds()];
+    return $meta;
   }
 
   private function getSubscriber(StepRunArgs $args): SubscriberEntity {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/MailPoetIntegration.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Integrations\MailPoet;
 
 use MailPoet\Automation\Engine\Integration;
 use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Automation\Integrations\MailPoet\Analytics\Analytics;
 use MailPoet\Automation\Integrations\MailPoet\Hooks\AutomationEditorLoadingHooks;
@@ -65,6 +66,9 @@ class MailPoetIntegration implements Integration {
   /** @var Analytics */
   private $registerAnalytics;
 
+  /** @var WordPress */
+  private $wordPress;
+
   public function __construct(
     ContextFactory $contextFactory,
     SegmentSubject $segmentSubject,
@@ -80,7 +84,8 @@ class MailPoetIntegration implements Integration {
     AutomationEditorLoadingHooks $automationEditorLoadingHooks,
     CreateAutomationRunHook $createAutomationRunHook,
     TemplatesFactory $templatesFactory,
-    Analytics $registerAnalytics
+    Analytics $registerAnalytics,
+    WordPress $wordPress
   ) {
     $this->contextFactory = $contextFactory;
     $this->segmentSubject = $segmentSubject;
@@ -97,6 +102,7 @@ class MailPoetIntegration implements Integration {
     $this->createAutomationRunHook = $createAutomationRunHook;
     $this->templatesFactory = $templatesFactory;
     $this->registerAnalytics = $registerAnalytics;
+    $this->wordPress = $wordPress;
   }
 
   public function register(Registry $registry): void {
@@ -124,6 +130,9 @@ class MailPoetIntegration implements Integration {
       [$this->sendEmailAction, 'saveEmailSettings'],
       $this->sendEmailAction->getKey()
     );
+
+    // execute send email step progress when email is sent
+    $this->wordPress->addAction('mailpoet_automation_email_sent', [$this->sendEmailAction, 'handleEmailSent']);
 
     $this->automationEditorLoadingHooks->init();
     $this->createAutomationRunHook->init();

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -128,6 +128,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateStepsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Builder\UpdateAutomationController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\ActionScheduler::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Control\AutomationController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\RootStep::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\FilterHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Control\StepHandler::class)->setPublic(true);

--- a/mailpoet/tests/integration/Automation/Engine/Control/AutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/AutomationControllerTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Control;
+
+use ActionScheduler_NullSchedule;
+use ActionScheduler_Store;
+use MailPoet\Automation\Engine\Control\AutomationController;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\AutomationRunLog;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\AutomationRunLogStorage;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Test\DataFactories;
+use MailPoetTest;
+
+class AutomationControllerTest extends MailPoetTest {
+  public function testItEnqueuesProgress(): void {
+    $this->createAutomationWithStepRunAndLog(AutomationRun::STATUS_RUNNING, AutomationRunLog::STATUS_RUNNING);
+
+    $controller = $this->diContainer->get(AutomationController::class);
+    $controller->enqueueProgress(1, 'abc');
+
+    $actions = $this->getActions(['status' => [ActionScheduler_Store::STATUS_PENDING]]);
+    $this->assertCount(1, $actions);
+    $this->assertSame('mailpoet-automation', $actions[0]->get_group());
+    $this->assertSame('mailpoet/automation/step', $actions[0]->get_hook());
+    $this->assertSame([['automation_run_id' => 1, 'step_id' => 'abc', 'run_number' => 2]], $actions[0]->get_args());
+    $this->assertInstanceOf(ActionScheduler_NullSchedule::class, $actions[0]->get_schedule());
+  }
+
+  public function testItFailsWhenStepWasNotStarted(): void {
+    $this->expectException(InvalidStateException::class);
+    $this->expectExceptionMessage("Automation step with ID 'abc' was not started in automation run with ID '1'.");
+
+    $controller = $this->diContainer->get(AutomationController::class);
+    $controller->enqueueProgress(1, 'abc');
+  }
+
+  public function testItFailsWhenStepIsComplete(): void {
+    $this->createAutomationWithStepRunAndLog(AutomationRun::STATUS_RUNNING, AutomationRunLog::STATUS_COMPLETE);
+
+    $this->expectException(InvalidStateException::class);
+    $this->expectExceptionMessage("Automation step with ID 'abc' is not running in automation run with ID '1'. Status: 'complete'");
+
+    $controller = $this->diContainer->get(AutomationController::class);
+    $controller->enqueueProgress(1, 'abc');
+  }
+
+  public function testItFailsWhenStepFailed(): void {
+    $this->createAutomationWithStepRunAndLog(AutomationRun::STATUS_RUNNING, AutomationRunLog::STATUS_FAILED);
+
+    $this->expectException(InvalidStateException::class);
+    $this->expectExceptionMessage("Automation step with ID 'abc' is not running in automation run with ID '1'. Status: 'failed'");
+
+    $controller = $this->diContainer->get(AutomationController::class);
+    $controller->enqueueProgress(1, 'abc');
+  }
+
+  private function createAutomationWithStepRunAndLog(string $runStatus, string $logStatus): void {
+    $step = new Step('abc', Step::TYPE_ACTION, 'key', [], []);
+    $automation = (new DataFactories\Automation())
+      ->withStatus(Automation::STATUS_ACTIVE)
+      ->withStep($step)
+      ->create();
+
+    $run = (new DataFactories\AutomationRun())
+      ->withAutomation($automation)
+      ->withStatus($runStatus)
+      ->create();
+
+    // automation run log (running)
+    (new DataFactories\AutomationRunLog($run->getId(), $step))
+      ->setStatus($logStatus)
+      ->create();
+  }
+
+  private function getActions(array $args = []): array {
+    return array_values(
+      as_get_scheduled_actions(
+        array_merge(['hook' => Hooks::AUTOMATION_STEP, 'group' => 'mailpoet-automation'], $args)
+      )
+    );
+  }
+
+  public function _before(): void {
+    $this->cleanup();
+  }
+
+  public function _after(): void {
+    $this->cleanup();
+  }
+
+  private function cleanup() {
+    $this->diContainer->get(AutomationStorage::class)->truncate();
+    $this->diContainer->get(AutomationRunStorage::class)->truncate();
+    $this->diContainer->get(AutomationRunLogStorage::class)->truncate();
+
+    global $wpdb;
+    $actionsTable = $wpdb->prefix . 'actionscheduler_actions';
+    $wpdb->query('TRUNCATE ' . $actionsTable);
+    $claimsTable = $wpdb->prefix . 'actionscheduler_claims';
+    $wpdb->query('TRUNCATE ' . $claimsTable);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepRunLoggerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepRunLoggerTest.php
@@ -203,7 +203,7 @@ class StepRunLoggerTest extends MailPoetTest {
       'status' => $data['status'] ?? 'running',
       'started_at' => $data['started_at'] ?? $log->getStartedAt()->format(DateTimeImmutable::W3C),
       'updated_at' => $data['updated_at'] ?? $log->getUpdatedAt()->format(DateTimeImmutable::W3C),
-      'run_number' => $data['row_number'] ?? 1,
+      'run_number' => $data['run_number'] ?? 1,
       'data' => $data['data'] ?? '{}',
       'error' => $error ? Json::encode($error) : null,
     ];

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -114,8 +114,8 @@ class SendEmailActionTest extends \MailPoetTest {
     $email = (new Newsletter())->withAutomationType()->create();
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
-    $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User());
-    $run = new AutomationRun(1, 1, 'trigger-key', $subjects);
+    $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User(), 1);
+    $run = new AutomationRun(1, 1, 'trigger-key', $subjects, 1);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
     verify($scheduled)->arrayCount(0);
@@ -385,9 +385,10 @@ class SendEmailActionTest extends \MailPoetTest {
         $trigger->getId() => $trigger,
         $step->getId() => $step,
       ],
-      new \WP_User()
+      new \WP_User(),
+      1
     );
-    $run = new AutomationRun(1, 1, 'trigger-key', $subjects);
+    $run = new AutomationRun(1, 1, 'trigger-key', $subjects, 1);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
     verify($scheduled)->arrayCount(0);

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -122,9 +122,14 @@ class SendEmailActionTest extends \MailPoetTest {
     $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
     $this->action->run($args, $controller);
 
+    // scheduled task
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
     verify($scheduled)->arrayCount(1);
+    $this->assertSame([
+      'automation' => ['id' => 1, 'run_id' => 1, 'step_id' => 'step-id', 'run_number' => 1],
+    ], $scheduled[0]->getMeta());
 
+    // scheduled task subscriber
     $this->scheduledTasksRepository->refresh($scheduled[0]);
     $scheduledTaskSubscribers = $scheduled[0]->getSubscribers();
     $this->assertCount(1, $scheduledTaskSubscribers);


### PR DESCRIPTION
## Description

Note that the large timeout (1 month) is for cases such as when solving a ban or sending issues takes more than a week.

## Code review notes

_N/A_

## QA notes

The "Send email" automation step should now be "running" until it is really sent. The automation will continue only after the email will be successfully sent and the step completed. If sending fails, the step should fail as well. If no sending is successful for a long time (1 month), the step will fail.

## Linked PRs

[MAILPOET-4977]

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4977]: https://mailpoet.atlassian.net/browse/MAILPOET-4977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ