### PR TITLE
Add specific permission for help page and filter on system info - MAILPOET-6013

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+<?php declare(strict_types = 1);
 
 namespace MailPoet\AdminPages\Pages;
 
@@ -16,6 +16,7 @@ use MailPoet\Router\Endpoints\CronDaemon;
 use MailPoet\Services\Bridge;
 use MailPoet\SystemReport\SystemReportCollector;
 use MailPoet\WP\DateTime;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Help {
   /** @var PageRenderer */
@@ -58,7 +59,12 @@ class Help {
   }
 
   public function render() {
-    $systemInfoData = $this->systemReportCollector->getData(true);
+    /**
+     * Filter the system info.
+     *
+     * @param array<string, string> $systemInfoData The system info data array.
+     */
+    $systemInfoData = WPFunctions::get()->applyFilters('mailpoet_system_info_data', $this->systemReportCollector->getData(true));
     try {
       $cronPingUrl = $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING);
       $cronPingResponse = $this->cronHelper->pingDaemon();

--- a/mailpoet/lib/Config/AccessControl.php
+++ b/mailpoet/lib/Config/AccessControl.php
@@ -14,6 +14,7 @@ class AccessControl {
   const PERMISSION_MANAGE_FORMS = 'mailpoet_manage_forms';
   const PERMISSION_MANAGE_SEGMENTS = 'mailpoet_manage_segments';
   const PERMISSION_MANAGE_AUTOMATIONS = Engine::CAPABILITY_MANAGE_AUTOMATIONS;
+  const PERMISSION_MANAGE_HELP = 'mailpoet_manage_help';
   const NO_ACCESS_RESTRICTION = 'mailpoet_no_access_restriction';
   const ALL_ROLES_ACCESS = 'mailpoet_all_roles_access';
 
@@ -70,6 +71,13 @@ class AccessControl {
           'editor',
         ]
       ),
+      self::PERMISSION_MANAGE_HELP => WPFunctions::get()->applyFilters(
+        'mailpoet_permission_manage_help',
+        [
+          'administrator',
+          'editor',
+        ]
+      ),
     ];
   }
 
@@ -83,6 +91,7 @@ class AccessControl {
       self::PERMISSION_MANAGE_FORMS => __('Manage forms', 'mailpoet'),
       self::PERMISSION_MANAGE_SEGMENTS => __('Manage segments', 'mailpoet'),
       self::PERMISSION_MANAGE_AUTOMATIONS => __('Manage automations', 'mailpoet'),
+      self::PERMISSION_MANAGE_HELP => __('Manage help', 'mailpoet'),
     ];
   }
 

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -457,7 +457,7 @@ class Menu {
       self::MAIN_PAGE_SLUG,
       $this->setPageTitle(__('Help', 'mailpoet')),
       esc_html__('Help', 'mailpoet'),
-      AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN,
+      AccessControl::PERMISSION_MANAGE_HELP,
       self::HELP_PAGE_SLUG,
       [
         $this,

--- a/mailpoet/tests/integration/Config/AccessControlTest.php
+++ b/mailpoet/tests/integration/Config/AccessControlTest.php
@@ -67,6 +67,13 @@ class AccessControlTest extends \MailPoetTest {
       }
     );
 
+    $wp->addFilter(
+      'mailpoet_permission_manage_help',
+      function() {
+        return ['custom_manage_help_role'];
+      }
+    );
+
     verify($this->accessControl->getDefaultPermissions())->equals(
       [
         AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN => [
@@ -92,6 +99,9 @@ class AccessControlTest extends \MailPoetTest {
         ],
         AccessControl::PERMISSION_MANAGE_AUTOMATIONS => [
           'custom_manage_automations_role',
+        ],
+        AccessControl::PERMISSION_MANAGE_HELP => [
+          'custom_manage_help_role',
         ],
       ]
     );


### PR DESCRIPTION
## Description

This PR:
- adds a new permission level to access the help page
- adds a filter `mailpoet_system_info_data` to filter the info displayed on MailPoet -> Help > System Info


## Code review notes

_NA_

## QA notes

To test:
- Deactivate and activate the plugin
- Check that admins and editors can still access MailPoet > Help
- Add the following filter (for instance using [Code Snippets](https://wordpress.org/plugins/code-snippets/)) and check that Web Server and Server OS are not displayed on system info.
```
add_filter( 'mailpoet_system_info_data', 'hide_info' );
function hide_info( $system_info ) { 
	$keysToRemove = ['Web server', 'Server OS'];
	
	foreach ( $keysToRemove as $key) {
		if (array_key_exists( $key, $system_info )) {
			unset( $system_info[$key] );
		}
    }
    return $system_info;
}
```
Note: If returning an empty array, no information will be displayed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6013]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6013]: https://mailpoet.atlassian.net/browse/MAILPOET-6013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ