### PR TITLE
Display when subscriber was created in listings [MAILPOET-6042]

### DIFF
--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -82,12 +82,12 @@ const columns = [
   },
   {
     name: 'last_subscribed_at',
-    label: MailPoet.I18n.t('confirmedOn'),
+    label: MailPoet.I18n.t('subscribedOn'),
     sortable: true,
   },
   {
     name: 'created_at',
-    label: MailPoet.I18n.t('subscribedOn'),
+    label: MailPoet.I18n.t('createdOn'),
     sortable: true,
   },
 ];

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -82,6 +82,11 @@ const columns = [
   },
   {
     name: 'last_subscribed_at',
+    label: MailPoet.I18n.t('confirmedOn'),
+    sortable: true,
+  },
+  {
+    name: 'created_at',
     label: MailPoet.I18n.t('subscribedOn'),
     sortable: true,
   },
@@ -566,13 +571,25 @@ function SubscriberList({ match }) {
         ) : null}
         <td
           className="column-date mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('subscribedOn')}
+          data-colname={MailPoet.I18n.t('confirmedOn')}
         >
           {subscriber.last_subscribed_at ? (
             <>
               {MailPoet.Date.short(subscriber.last_subscribed_at)}
               <br />
               {MailPoet.Date.time(subscriber.last_subscribed_at)}
+            </>
+          ) : null}
+        </td>
+        <td
+          className="column-date mailpoet-hide-on-mobile"
+          data-colname={MailPoet.I18n.t('subscribedOn')}
+        >
+          {subscriber.created_at ? (
+            <>
+              {MailPoet.Date.short(subscriber.created_at)}
+              <br />
+              {MailPoet.Date.time(subscriber.created_at)}
             </>
           ) : null}
         </td>

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -74,6 +74,7 @@
     'lists': __('Lists'),
     'statisticsColumn': __('Score'),
     'subscribedOn': __('Subscribed on'),
+    'confirmedOn': __('Confirmed on'),
     'lastModifiedOn': __('Last modified on'),
     'oneSubscriberTrashed': __('1 subscriber was moved to the trash.'),
     'multipleSubscribersTrashed': __('%1$d subscribers were moved to the trash.'),

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -74,7 +74,7 @@
     'lists': __('Lists'),
     'statisticsColumn': __('Score'),
     'subscribedOn': __('Subscribed on'),
-    'confirmedOn': __('Confirmed on'),
+    'createdOn': __('Created on'),
     'lastModifiedOn': __('Last modified on'),
     'oneSubscriberTrashed': __('1 subscriber was moved to the trash.'),
     'multipleSubscribersTrashed': __('%1$d subscribers were moved to the trash.'),


### PR DESCRIPTION

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6042]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6042]: https://mailpoet.atlassian.net/browse/MAILPOET-6042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ