### PR TITLE
Fix acceptance test itCanCreateMailPoetCampaigns

### DIFF
--- a/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/MPMarketingChannelCest.php
@@ -91,7 +91,8 @@ class MPMarketingChannelCest {
       $i->see('MailPoet Post notifications');
       $i->see('MailPoet Automations');
       $i->click('Create', '.woocommerce-marketing-new-campaign-type');
-      $i->seeInCurrentUrl('page=mailpoet-newsletters&loadedvia=woo_multichannel_dashboard#/new/standard'); // will be redirected to page=mailpoet-newsletters#/template
+      $i->waitForElement('[data-automation-id="templates-standard"]');
+      $i->seeInCurrentUrl('page=mailpoet-newsletters&loadedvia=woo_multichannel_dashboard#'); // will be redirected to page=mailpoet-newsletters#/template
       $i->waitForText('Simple text'); // on template selection page
       $i->see('Template'); // on template selection page
       $i->see('Newsletters');


### PR DESCRIPTION
## Description

Fixed acceptance test that was recently seen as flaky. The test required waiting for element before assertion and a bit reduced url assertion.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6046]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6046]: https://mailpoet.atlassian.net/browse/MAILPOET-6046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ