### PR TITLE
Fix scheduled task entity having the same association twice [MAILPOET-6047]

### DIFF
--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -95,15 +95,8 @@ class ScheduledTaskEntity {
    */
   private $sendingQueue;
 
-  /**
-   * @ORM\OneToMany(targetEntity="MailPoet\Entities\ScheduledTaskSubscriberEntity", mappedBy="task", orphanRemoval=true)
-   * @var Collection<int, ScheduledTaskSubscriberEntity>
-   */
-  private $scheduledTaskSubscribers;
-
   public function __construct() {
     $this->subscribers = new ArrayCollection();
-    $this->scheduledTaskSubscribers = new ArrayCollection();
   }
 
   /**

--- a/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
@@ -45,7 +45,7 @@ class ScheduledTaskSubscriberEntity {
   private $error;
 
   /**
-   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\ScheduledTaskEntity", inversedBy="scheduledTaskSubscribers")
+   * @ORM\Id @ORM\ManyToOne(targetEntity="MailPoet\Entities\ScheduledTaskEntity", inversedBy="subscribers")
    * @var ScheduledTaskEntity|null
    */
   private $task;


### PR DESCRIPTION
## Description

Fix scheduled task entity having the same association twice
It also seems that `orphanRemoval` doesn't play well with our explicit `detachAll` logic.

I realized that it would be better to remove cascades and orphan removals anyway because they always need to load the whole collection into memory and then delete/update the entities one by one.

## Code review notes

I think this doesn't need QA.

## QA notes

I think this doesn't need QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6047]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6047]: https://mailpoet.atlassian.net/browse/MAILPOET-6047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ