### PR TITLE
Email Editor: Add color styles panel [MAILPOET-5641]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -105,8 +105,6 @@ export function Layout() {
     return null;
   }
 
-  const disableIframe = !isEditingTemplate;
-
   return (
     <>
       <FullscreenMode isActive={isFullscreenActive} />
@@ -146,7 +144,7 @@ export function Layout() {
                 style={contentWrapperStyles}
               >
                 <EditorCanvas
-                  disableIframe={disableIframe}
+                  disableIframe={false}
                   styles={[...settings.styles, ...emailCss]}
                   autoFocus
                   className="has-global-padding"

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/index.ts
@@ -2,3 +2,4 @@ export * from './screen-typography';
 export * from './screen-layout';
 export * from './screen-root';
 export * from './screen-typography-element';
+export * from './screen-colors';

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/screen-colors.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/screen-colors.tsx
@@ -1,0 +1,35 @@
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import {
+  // @ts-expect-error No types for this exist yet.
+  privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import ScreenHeader from './screen-header';
+import { unlock } from '../../../../lock-unlock';
+import { useEmailStyles } from '../../../hooks';
+import { storeName } from '../../../store';
+
+export function ScreenColors(): JSX.Element {
+  const { ColorPanel: StylesColorPanel } = unlock(blockEditorPrivateApis);
+  const { styles, defaultStyles, updateStyles } = useEmailStyles();
+  const theme = useSelect((select) => select(storeName).getTheme(), []);
+
+  return (
+    <>
+      <ScreenHeader
+        title={__('Colors', 'mailpoet')}
+        description={__(
+          'Manage palettes and the default color of different global elements.',
+          'mailpoet',
+        )}
+      />
+      <StylesColorPanel
+        value={styles}
+        inheritValue={defaultStyles}
+        onChange={updateStyles}
+        settings={theme?.settings}
+        panelId="colors"
+      />
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/styles-sidebar.tsx
@@ -1,7 +1,6 @@
 import {
   __experimentalNavigatorProvider as NavigatorProvider,
   __experimentalNavigatorScreen as NavigatorScreen,
-  __experimentalNavigatorToParentButton as NavigatorToParentButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ComplementaryArea } from '@wordpress/interface';
@@ -13,6 +12,7 @@ import {
   ScreenTypographyElement,
   ScreenLayout,
   ScreenRoot,
+  ScreenColors,
 } from './screens';
 
 type Props = ComponentProps<typeof ComplementaryArea>;
@@ -54,8 +54,7 @@ export function StylesSidebar(props: Props): JSX.Element {
         </NavigatorScreen>
 
         <NavigatorScreen path="/colors">
-          <NavigatorToParentButton>Back</NavigatorToParentButton>
-          <div>TODO: Colors screen</div>
+          <ScreenColors />
         </NavigatorScreen>
 
         <NavigatorScreen path="/layout">

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-css.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-css.ts
@@ -1,6 +1,6 @@
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { merge } from 'lodash';
+import deepmerge from 'deepmerge';
 import {
   // @ts-expect-error No types for this exist yet.
   privateApis as blockEditorPrivateApi,
@@ -21,7 +21,12 @@ export function useEmailCss() {
   );
 
   const mergedConfig = useMemo(
-    () => merge({}, editorTheme, templateTheme) as EmailStyles,
+    () =>
+      deepmerge.all([
+        {},
+        editorTheme || {},
+        templateTheme || {},
+      ]) as EmailStyles,
     [editorTheme, templateTheme],
   );
 

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-styles.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-styles.ts
@@ -29,6 +29,7 @@ interface EmailStylesData {
   styles: StyleProperties;
   defaultStyles: StyleProperties;
   updateStyleProp: (path, newValue) => void;
+  updateStyles: (newStyles: StyleProperties) => void;
 }
 
 /**
@@ -76,6 +77,18 @@ export const useEmailStyles = (): EmailStylesData => {
   }));
 
   // Update email styles.
+  const updateStyles = useCallback(
+    (newStyles) => {
+      const newTheme = {
+        ...templateTheme,
+        styles: newStyles,
+      };
+      updateTemplateTheme(newTheme);
+    },
+    [updateTemplateTheme, templateTheme],
+  );
+
+  // Update an email style prop.
   const updateStyleProp = useCallback(
     (path, newValue) => {
       const newTheme = setImmutably(
@@ -89,21 +102,9 @@ export const useEmailStyles = (): EmailStylesData => {
   );
 
   return {
-    styles: {
-      spacing: {
-        ...defaultStyles.spacing,
-        ...styles?.spacing,
-      },
-      typography: {
-        ...defaultStyles.typography,
-        ...styles?.typography,
-      },
-      elements: deepmerge.all([
-        defaultStyles.elements || {},
-        styles?.elements || {},
-      ]) as Record<string, ElementProperties>,
-    },
+    styles: deepmerge.all([defaultStyles, styles]),
     defaultStyles,
     updateStyleProp,
+    updateStyles,
   };
 };

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-styles.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-styles.ts
@@ -102,7 +102,7 @@ export const useEmailStyles = (): EmailStylesData => {
   );
 
   return {
-    styles: deepmerge.all([defaultStyles, styles]),
+    styles: deepmerge.all([defaultStyles || {}, styles || {}]),
     defaultStyles,
     updateStyleProp,
     updateStyles,

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-theme.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-theme.ts
@@ -5,7 +5,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { EmailTheme, storeName } from '../store';
 
 export function useEmailTheme() {
-  const { templateTheme, templateId, templateContent } = useSelect((select) => {
+  const { templateTheme, templateId } = useSelect((select) => {
     // @ts-expect-error Property 'getCurrentPostType' has no types
     const currentPostType = select(editorStore).getCurrentPostType();
     let templateThemeData: EmailTheme = {};
@@ -49,12 +49,10 @@ export function useEmailTheme() {
         templateId as string,
         {
           mailpoet_email_theme: newTheme,
-          // Add space to trigger content update. /template endpoint requires content otherwise it removes form the post.
-          content: `${templateContent} `,
         },
       );
     },
-    [templateId, templateContent],
+    [templateId],
   );
 
   return {

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -29,6 +29,88 @@ export type EmailEditorSettings = EditorSettings & ExperimentalSettings;
 export type EmailTheme = {
   version?: number;
   styles?: EmailStyles;
+  // Ref: https://github.com/WordPress/gutenberg/blob/38d0a4351105e6ba4b72c4dcb90985305aacf921/packages/block-editor/src/components/global-styles/hooks.js#L24C7-L24C21
+  settings?: {
+    appearanceTools?: boolean;
+    useRootPaddingAwareAlignments?: boolean;
+    background?: {
+      backgroundImage?: boolean;
+      backgroundRepeat?: boolean;
+      backgroundSize?: boolean;
+      backgroundPosition?: boolean;
+    };
+    border?: {
+      radius?: boolean;
+      width?: boolean;
+      style?: boolean;
+      color?: boolean;
+    };
+    shadow?: {
+      presets?: boolean;
+      defaultPresets?: boolean;
+    };
+    color?: {
+      background?: boolean;
+      button?: boolean;
+      caption?: boolean;
+      custom?: boolean;
+      customDuotone?: boolean;
+      customGradient?: boolean;
+      defaultDuotone?: boolean;
+      defaultGradients?: boolean;
+      defaultPalette?: boolean;
+      duotone?: boolean;
+      gradients?: {
+        default?: boolean;
+        theme?: boolean;
+        custom?: boolean;
+      };
+      heading?: boolean;
+      link?: boolean;
+      palette?: boolean;
+      text?: boolean;
+    };
+    dimensions?: {
+      aspectRatio?: boolean;
+      minHeight?: boolean;
+    };
+    layout?: {
+      contentSize?: string;
+      wideSize?: string;
+    };
+    spacing?: {
+      customSpacingSize?: number;
+      blockGap?: number;
+      margin?: boolean;
+      padding?: boolean;
+      spacingSizes?: number[];
+      spacingScale?: number;
+      units?: string[];
+    };
+    position?: {
+      fixed?: boolean;
+      sticky?: boolean;
+    };
+    typography?: {
+      customFontSize?: boolean;
+      defaultFontSizes?: boolean;
+      dropCap?: boolean;
+      fontFamilies?: boolean;
+      fontSizes?: boolean;
+      fontStyle?: boolean;
+      fontWeight?: boolean;
+      letterSpacing?: boolean;
+      lineHeight?: boolean;
+      textColumns?: boolean;
+      textDecoration?: boolean;
+      textTransform?: boolean;
+      writingMode?: boolean;
+    };
+    lightbox?: {
+      enabled?: boolean;
+      allowEditing?: boolean;
+    };
+  };
 };
 
 export interface TypographyProperties {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -349,6 +349,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors\TypographyPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Renderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Templates\Templates::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Templates\Utils::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Templates\TemplatePreview::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Patterns\Patterns::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\ContentRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\BlocksRegistry::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Engine;
 
 use MailPoet\EmailEditor\Engine\Patterns\Patterns;
+use MailPoet\EmailEditor\Engine\Templates\TemplatePreview;
 use MailPoet\EmailEditor\Engine\Templates\Templates;
 use MailPoet\Entities\NewsletterEntity;
 use WP_Post;
@@ -17,15 +18,18 @@ class EmailEditor {
 
   private EmailApiController $emailApiController;
   private Templates $templates;
+  private TemplatePreview $templatePreview;
   private Patterns $patterns;
 
   public function __construct(
     EmailApiController $emailApiController,
     Templates $templates,
+    TemplatePreview $templatePreview,
     Patterns $patterns
   ) {
     $this->emailApiController = $emailApiController;
     $this->templates = $templates;
+    $this->templatePreview = $templatePreview;
     $this->patterns = $patterns;
   }
 
@@ -40,7 +44,11 @@ class EmailEditor {
   }
 
   private function registerBlockTemplates(): void {
-    $this->templates->initialize();
+    // Since we cannot currently disable blocks in the editor for specific templates, disable templates when viewing site editor. @see https://github.com/WordPress/gutenberg/issues/41062
+    if (strstr(wp_unslash($_SERVER['REQUEST_URI'] ?? ''), 'site-editor.php') === false) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+      $this->templates->initialize();
+      $this->templatePreview->initialize();
+    }
   }
 
   private function registerBlockPatterns(): void {

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -37,6 +37,20 @@ class Renderer {
     return self::$theme;
   }
 
+  public static function maybeConvertPreset($value, $variables) {
+    if (is_string($value) && str_contains($value, 'var:preset|color|')) {
+        $value = str_replace('var:preset|color|', '', $value);
+        $value = sprintf('var(--wp--preset--color--%s)', $value);
+    }
+
+    foreach ($variables as $varName => $varValue) {
+      $varPattern = '/var\(' . preg_quote($varName, '/') . '\)/i';
+      $value = preg_replace($varPattern, $varValue, $value);
+    }
+
+    return $value;
+  }
+
   public function render(\WP_Post $post, string $subject, string $preHeader, string $language, $metaRobots = ''): array {
     $templateId = 'mailpoet/mailpoet//' . (get_page_template_slug($post) ?: 'email-general');
     $template = $this->templates->getBlockTemplate($templateId);
@@ -45,20 +59,23 @@ class Renderer {
     // Set the theme for the template. This is merged with base theme.json and core json before rendering.
     self::$theme = new WP_Theme_JSON($theme, 'default');
 
-    $emailStyles = $this->themeController->getStyles();
+    $emailStyles = $this->themeController->getStyles($post, $template);
+    $variables = $this->themeController->getVariablesValuesMap();
     $templateHtml = $this->contentRenderer->render($post, $template);
 
     ob_start();
     include self::TEMPLATE_FILE;
     $renderedTemplate = (string)ob_get_clean();
 
-    $templateStyles = WP_Style_Engine::compile_css(
+    $templateStyles =
+    WP_Style_Engine::compile_css(
       [
-        'background-color' => $emailStyles['color']['background'] ?? 'inherit',
-        'padding-top' => $emailStyles['spacing']['padding']['top'] ?? '0px',
-        'padding-bottom' => $emailStyles['spacing']['padding']['bottom'] ?? '0px',
-        'font-family' => $emailStyles['typography']['fontFamily'] ?? 'inherit',
-      ],
+            'background-color' => $this->maybeConvertPreset($emailStyles['color']['background'] ?? 'inherit', $variables),
+            'color' => $this->maybeConvertPreset($emailStyles['color']['text'] ?? 'inherit', $variables),
+            'padding-top' => $emailStyles['spacing']['padding']['top'] ?? '0px',
+            'padding-bottom' => $emailStyles['spacing']['padding']['bottom'] ?? '0px',
+            'font-family' => $emailStyles['typography']['fontFamily'] ?? 'inherit',
+          ],
       'body, .email_layout_wrapper'
     );
     $templateStyles .= file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_STYLES_FILE);

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -38,7 +38,7 @@ class Renderer {
   }
 
   public static function maybeConvertPreset($value, $variables) {
-    if (is_string($value) && str_contains($value, 'var:preset|color|')) {
+    if (is_string($value) && strstr($value, 'var:preset|color|')) {
         $value = str_replace('var:preset|color|', '', $value);
         $value = sprintf('var(--wp--preset--color--%s)', $value);
     }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -37,20 +37,6 @@ class Renderer {
     return self::$theme;
   }
 
-  public static function maybeConvertPreset($value, $variables) {
-    if (is_string($value) && strstr($value, 'var:preset|color|')) {
-        $value = str_replace('var:preset|color|', '', $value);
-        $value = sprintf('var(--wp--preset--color--%s)', $value);
-    }
-
-    foreach ($variables as $varName => $varValue) {
-      $varPattern = '/var\(' . preg_quote($varName, '/') . '\)/i';
-      $value = preg_replace($varPattern, $varValue, $value);
-    }
-
-    return $value;
-  }
-
   public function render(\WP_Post $post, string $subject, string $preHeader, string $language, $metaRobots = ''): array {
     $templateId = 'mailpoet/mailpoet//' . (get_page_template_slug($post) ?: 'email-general');
     $template = $this->templates->getBlockTemplate($templateId);
@@ -59,8 +45,7 @@ class Renderer {
     // Set the theme for the template. This is merged with base theme.json and core json before rendering.
     self::$theme = new WP_Theme_JSON($theme, 'default');
 
-    $emailStyles = $this->themeController->getStyles($post, $template);
-    $variables = $this->themeController->getVariablesValuesMap();
+    $emailStyles = $this->themeController->getStyles($post, $template, true);
     $templateHtml = $this->contentRenderer->render($post, $template);
 
     ob_start();
@@ -70,8 +55,8 @@ class Renderer {
     $templateStyles =
     WP_Style_Engine::compile_css(
       [
-            'background-color' => $this->maybeConvertPreset($emailStyles['color']['background'] ?? 'inherit', $variables),
-            'color' => $this->maybeConvertPreset($emailStyles['color']['text'] ?? 'inherit', $variables),
+            'background-color' => $emailStyles['color']['background'] ?? 'inherit',
+            'color' => $emailStyles['color']['text'] ?? 'inherit',
             'padding-top' => $emailStyles['spacing']['padding']['top'] ?? '0px',
             'padding-bottom' => $emailStyles['spacing']['padding']['bottom'] ?? '0px',
             'font-family' => $emailStyles['typography']['fontFamily'] ?? 'inherit',

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -67,6 +67,12 @@ class Renderer {
     $templateStyles = '<style>' . wp_strip_all_tags((string)apply_filters('mailpoet_email_renderer_styles', $templateStyles, $post)) . '</style>';
     $renderedTemplate = $this->inlineCSSStyles($templateStyles . $renderedTemplate);
 
+    // This is a workaround to support link :hover in some clients. Ideally we would remove the ability to set :hover
+    // however this is not possible using the color panel from Gutenberg.
+    if (isset($emailStyles['elements']['link'][':hover']['color']['text'])) {
+      $renderedTemplate = str_replace('<!-- Forced Styles -->', '<style>a:hover { color: ' . esc_attr($emailStyles['elements']['link'][':hover']['color']['text']) . ' !important; }</style>', $renderedTemplate);
+    }
+
     return [
       'html' => $renderedTemplate,
       'text' => $this->renderTextVersion($renderedTemplate),

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -40,7 +40,7 @@ class Renderer {
   public function render(\WP_Post $post, string $subject, string $preHeader, string $language, $metaRobots = ''): array {
     $templateId = 'mailpoet/mailpoet//' . (get_page_template_slug($post) ?: 'email-general');
     $template = $this->templates->getBlockTemplate($templateId);
-    $theme = $this->templates->getBlockTheme($templateId, $template->wp_id); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $theme = $this->templates->getBlockTemplateTheme($templateId, $template->wp_id); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
     // Set the theme for the template. This is merged with base theme.json and core json before rendering.
     self::$theme = new WP_Theme_JSON($theme, 'default');

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.css
@@ -11,6 +11,10 @@ body {
   word-spacing: normal;
 }
 
+a {
+  text-decoration: none;
+}
+
 .email_layout_wrapper {
   margin: 0 auto;
   padding: 20px 0;

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.php
@@ -16,6 +16,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="format-detection" content="telephone=no" />
   <?php echo $metaRobots; // HTML defined by MailPoet--do not escape ?>
+  <!-- Forced Styles -->
 </head>
 <body>
     <div class="email_layout_wrapper">

--- a/mailpoet/lib/EmailEditor/Engine/Templates/TemplatePreview.php
+++ b/mailpoet/lib/EmailEditor/Engine/Templates/TemplatePreview.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Templates;
+
+use MailPoet\EmailEditor\Engine\ThemeController;
+use MailPoet\Validator\Builder;
+use WP_Theme_JSON;
+
+class TemplatePreview {
+  private ThemeController $themeController;
+  private Templates $templates;
+
+  public function __construct(
+    ThemeController $themeController,
+    Templates $templates
+  ) {
+    $this->themeController = $themeController;
+    $this->templates = $templates;
+  }
+
+  public function initialize(): void {
+    register_rest_field(
+      'wp_template',
+      'email_theme_css',
+      [
+        'get_callback' => [$this, 'getEmailThemePreviewCss'],
+        'update_callback' => null,
+        'schema' => Builder::string()->toArray(),
+      ]
+    );
+  }
+
+  /**
+   * Generates CSS for preview of email theme
+   * They are applied in the preview BLockPreview in template selection
+   */
+  public function getEmailThemePreviewCss($template): string {
+    $editorTheme = clone $this->themeController->getTheme();
+    $templateTheme = $this->templates->getBlockTemplateTheme($template['id'], $template['wp_id']);
+    if (is_array($templateTheme)) {
+      $editorTheme->merge(new WP_Theme_JSON($templateTheme, 'custom'));
+    }
+    $additionalCSS = file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'preview.css');
+    return $editorTheme->get_stylesheet() . $additionalCSS;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/Templates/Templates.php
+++ b/mailpoet/lib/EmailEditor/Engine/Templates/Templates.php
@@ -12,6 +12,7 @@ use WP_Error;
 // phpcs:disable Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 class Templates {
   const MAILPOET_EMAIL_META_THEME_TYPE = 'mailpoet_email_theme';
+  const MAILPOET_TEMPLATE_EMPTY_THEME = ['version' => 2]; // The version 2 is important to merge themes correctly
 
   private string $templateDirectory;
   private string $pluginSlug;
@@ -95,7 +96,7 @@ class Templates {
       }
     }
 
-    return $this->themeJson[$templateSlug] ?? [];
+    return $this->themeJson[$templateSlug] ?? self::MAILPOET_TEMPLATE_EMPTY_THEME;
   }
 
   public function getBlockFileTemplate($return, $templateId, $template_type) {
@@ -261,7 +262,7 @@ class Templates {
         ],
         'single' => true,
         'type' => 'object',
-        'default' => ['version' => 2], // The version 2 is important to merge themes correctly
+        'default' => self::MAILPOET_TEMPLATE_EMPTY_THEME,
       ]
     );
 

--- a/mailpoet/lib/EmailEditor/Engine/Templates/Utils.php
+++ b/mailpoet/lib/EmailEditor/Engine/Templates/Utils.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Templates;
+
+use WP_Block_Template;
+use WP_Error;
+
+// phpcs:disable Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+class Utils {
+  /**
+   * Gets the prefix and slug from the template ID.
+   *
+   * @param string $templateId Id of the template in prefix//slug format.
+   * @return array Associative array with keys 'prefix' and 'slug'.
+   */
+  public function getTemplateIdParts($templateId) {
+    $template_name_parts = explode('//', $templateId);
+
+    if (count($template_name_parts) < 2) {
+      return [
+        'prefix' => '',
+        'slug' => '',
+      ];
+    }
+
+    return [
+      'prefix' => $template_name_parts[0],
+      'slug' => $template_name_parts[1],
+    ];
+  }
+
+  public static function getBlockTemplateSlugFromPath($path) {
+    return basename($path, '.html');
+  }
+
+  public function buildBlockTemplateFromPost($post) {
+    $terms = get_the_terms($post, 'wp_theme');
+
+    if (is_wp_error($terms)) {
+        return $terms;
+    }
+
+    if (!$terms) {
+      return new WP_Error('template_missing_theme', 'No theme is defined for this template.');
+    }
+
+    $templatePrefix = $terms[0]->name;
+    $templateSlug = $post->post_name;
+    $templateId = $templatePrefix . '//' . $templateSlug;
+
+    $template = new WP_Block_Template();
+    $template->wp_id = $post->ID;
+    $template->id = $templateId;
+    $template->theme = $templatePrefix;
+    $template->content = $post->post_content ? $post->post_content : '<p>empty</p>';
+    $template->slug = $templateSlug;
+    $template->source = 'custom';
+    $template->type = $post->post_type;
+    $template->description = $post->post_excerpt;
+    $template->title = $post->post_title;
+    $template->status = $post->post_status;
+    $template->has_theme_file = false;
+    $template->is_custom = true;
+    $template->post_types = [];
+
+    if ('wp_template_part' === $post->post_type) {
+      $type_terms = get_the_terms($post, 'wp_template_part_area');
+
+      if (!is_wp_error($type_terms) && false !== $type_terms) {
+        $template->area = $type_terms[0]->name;
+      }
+    }
+
+    return $template;
+  }
+
+  public function buildBlockTemplateFromFile($templateObject): WP_Block_Template {
+    $template = new WP_Block_Template();
+    $template->id = $templateObject->id;
+    $template->theme = $templateObject->theme;
+    $template->content = (string)file_get_contents($templateObject->path);
+    $template->source = $templateObject->source;
+    $template->slug = $templateObject->slug;
+    $template->type = $templateObject->type;
+    $template->title = $templateObject->title;
+    $template->description = $templateObject->description;
+    $template->status = 'publish';
+    $template->has_theme_file = false;
+    $template->post_types = $templateObject->post_types;
+    $template->is_custom = false; // Templates are only custom if they are loaded from the DB.
+    $template->area = 'uncategorized';
+    return $template;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -19,6 +19,11 @@ class ThemeController {
     $this->baseTheme = new WP_Theme_JSON((array)json_decode((string)file_get_contents(dirname(__FILE__) . '/theme.json'), true), 'default');
   }
 
+  /**
+   * Gets combined theme data from the core and base theme, merged with the currently rendered template.
+   *
+   * @return WP_Theme_JSON
+   */
   public function getTheme(): WP_Theme_JSON {
     $theme = new WP_Theme_JSON();
     $theme->merge($this->coreTheme);

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -170,17 +170,21 @@ class ThemeController {
     foreach ($elementsStyles as $key => $elementsStyle) {
       $selector = $key;
 
-      if ($key === 'heading') {
-        $selector = 'h1, h2, h3, h4, h5, h6';
-      }
-
-      if ($key === 'link') {
-        // Target direct decendants of blocks to avoid styling buttons. :not() is not supported by the inliner.
-        $selector = 'p > a, div > a, li > a';
-      }
-
       if ($key === 'button') {
         $selector = '.wp-block-button';
+        $cssElements .= wp_style_engine_get_styles($elementsStyle, ['selector' => '.wp-block-button'])['css'];
+        // Add color to link element.
+        $cssElements .= wp_style_engine_get_styles(['color' => ['text' => $elementsStyle['color']['text'] ?? '']], ['selector' => '.wp-block-button a'])['css'];
+        continue;
+      }
+
+      switch ($key) {
+        case 'heading':
+          $selector = 'h1, h2, h3, h4, h5, h6';
+          break;
+        case 'link':
+          $selector = 'a:not(.button-link)';
+          break;
       }
 
       $cssElements .= wp_style_engine_get_styles($elementsStyle, ['selector' => $selector])['css'];

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -5,7 +5,9 @@
     "color": {
       "customGradient": false,
       "defaultGradients": false,
-      "gradients": []
+      "gradients": [],
+      "background": true,
+      "text": true
     },
     "layout": {
       "contentSize": "660px",

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -7,7 +7,8 @@
       "defaultGradients": false,
       "gradients": [],
       "background": true,
-      "text": true
+      "text": true,
+      "link": true
     },
     "layout": {
       "contentSize": "660px",

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Button.php
@@ -33,12 +33,15 @@ class Button extends AbstractBlockRenderer {
     ];
   }
 
+  public function render(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    return $this->renderContent($blockContent, $parsedBlock, $settingsController);
+  }
+
   protected function renderContent($blockContent, array $parsedBlock, SettingsController $settingsController): string {
     if (empty($parsedBlock['innerHTML'])) {
       return '';
     }
 
-    $themeData = $settingsController->getTheme()->get_data();
     $domHelper = new DomDocumentHelper($parsedBlock['innerHTML']);
     $blockClassname = $domHelper->getAttributeValueByTagName('div', 'class') ?? '';
     $buttonLink = $domHelper->findElement('a');
@@ -59,7 +62,6 @@ class Button extends AbstractBlockRenderer {
     ]);
 
     $blockStyles = array_replace_recursive(
-      $themeData['styles']['blocks']['core/button'] ?? [],
       [
         'color' => array_filter([
           'background' => $blockAttributes['backgroundColor'] ? $settingsController->translateSlugToColor($blockAttributes['backgroundColor']) : null,
@@ -80,7 +82,7 @@ class Button extends AbstractBlockRenderer {
       '<table border="0" cellspacing="0" cellpadding="0" role="presentation" style="width:%1$s;">
         <tr>
           <td align="%2$s" valign="middle" role="presentation" class="%3$s" style="%4$s">
-            <a class="%5$s" style="%6$s" href="%7$s" target="_blank">%8$s</a>
+            <a class="button-link %5$s" style="%6$s" href="%7$s" target="_blank">%8$s</a>
           </td>
         </tr>
       </table>',

--- a/mailpoet/lib/EmailEditor/Integrations/Core/theme.json
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/theme.json
@@ -4,7 +4,11 @@
   "styles": {
     "blocks": {
       "core/button": {
-        "variations": {},
+        "variations": {}
+      }
+    },
+    "elements": {
+      "button": {
         "color": {
           "background": "#32373c",
           "text": "#ffffff"

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -27,7 +27,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Compose an email');
-    $i->waitForElementVisible('.is-root-container', 20);
+    $i->waitForElementVisible('.editor-canvas__iframe', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');
@@ -92,7 +92,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Edit an email');
-    $i->waitForElementVisible('.is-root-container', 20);
+    $i->waitForElementVisible('.editor-canvas__iframe', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -27,11 +27,13 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Compose an email');
-    $i->waitForElementVisible('.editor-canvas__iframe', 20);
+    $i->switchToIFrame('.editor-canvas__iframe');
+    $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');
     $i->type('Sample text');
+    $i->switchToIFrame();
 
     $i->wantTo('Verify correct WP menu item is highlighted');
     $i->waitForText('Emails', 10, '#toplevel_page_mailpoet-homepage .current');
@@ -92,11 +94,13 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Edit an email');
-    $i->waitForElementVisible('.editor-canvas__iframe', 20);
+    $i->switchToIFrame('.editor-canvas__iframe');
+    $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');
     $i->type('Sample text');
+    $i->switchToIFrame();
 
     $i->wantTo('Save draft and display preview');
     $i->click('Save Draft');

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -27,6 +27,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Compose an email');
+    $i->waitForElement('.editor-canvas__iframe');
     $i->switchToIFrame('.editor-canvas__iframe');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
@@ -94,6 +95,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Edit an email');
+    $i->waitForElement('.editor-canvas__iframe');
     $i->switchToIFrame('.editor-canvas__iframe');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/ButtonTest.php
@@ -139,15 +139,6 @@ class ButtonTest extends \MailPoetTest {
     verify($output)->stringContainsString('border-bottom-right-radius:4px;');
   }
 
-  public function testItRendersDefaultBackgroundColor(): void {
-    unset($this->parsedButton['attrs']['style']['color']);
-    unset($this->parsedButton['attrs']['style']['spacing']['padding']);
-    $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
-    // Verify default background colors theme.json for email editor
-    // These can't be set via CSS inliner because of special email HTML markup
-    verify($output)->stringContainsString('background-color:#32373c;');
-  }
-
   public function testItRendersBackgroundColorSetBySlug(): void {
     unset($this->parsedButton['attrs']['style']['color']);
     unset($this->parsedButton['attrs']['style']['spacing']['padding']);
@@ -165,6 +156,6 @@ class ButtonTest extends \MailPoetTest {
     $output = $this->buttonRenderer->render($this->parsedButton['innerHTML'], $this->parsedButton, $this->settingsController);
     // For other blocks this is handled by CSS-inliner, but for button we need to handle it manually
     // because of special email HTML markup
-    verify($output)->stringContainsString('color:#ffffff');
+    verify($output)->stringContainsString('color:#fff');
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -23,7 +23,7 @@ class RendererTest extends \MailPoetTest {
     ]);
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $buttonHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-button', 'td');
-    verify($buttonHtml)->stringContainsString('color: #ffffff');
+    verify($buttonHtml)->stringContainsString('color: #fff');
     verify($buttonHtml)->stringContainsString('padding-bottom: 0.7em;');
     verify($buttonHtml)->stringContainsString('padding-left: 1.4em;');
     verify($buttonHtml)->stringContainsString('padding-right: 1.4em;');

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/RendererTest.php
@@ -24,10 +24,10 @@ class RendererTest extends \MailPoetTest {
     $rendered = $this->renderer->render($emailPost, 'Subject', '', 'en');
     $buttonHtml = $this->extractBlockHtml($rendered['html'], 'wp-block-button', 'td');
     verify($buttonHtml)->stringContainsString('color: #fff');
-    verify($buttonHtml)->stringContainsString('padding-bottom: 0.7em;');
+    verify($buttonHtml)->stringContainsString('padding-bottom: .7em;');
     verify($buttonHtml)->stringContainsString('padding-left: 1.4em;');
     verify($buttonHtml)->stringContainsString('padding-right: 1.4em;');
-    verify($buttonHtml)->stringContainsString('padding-top: 0.7em;');
+    verify($buttonHtml)->stringContainsString('padding-top: .7em;');
     verify($buttonHtml)->stringContainsString('background-color: #32373c');
   }
 


### PR DESCRIPTION
## Description

Adds color options to the styles panel:

![Screenshot 2024-05-01 at 15 00 53](https://github.com/mailpoet/mailpoet/assets/90977/d1154a4d-05b9-4f57-9ca9-ee374761dbd9)

Selections are saved with the current template globally. This PR also ensures that the frontend renderer loads these styles and merges them with post + theme styles, as well as fixing some issues that the renderer had replacing color presets. 

In the ticket ([MAILPOET-5641](https://mailpoet.atlassian.net/browse/MAILPOET-5641)) we also mention palettes, but there is a separate ticket to build the palette UI.

The designs also include 2 background, but we no longer need this because content background is at block level. We also should avoid using custom components where possible, so I've used the Color Panel from Guternberg—we should just use that design for consistency.

## Code review notes

To test:

1. Create a new email using the new editor
2. Open the styles panel, top right of the screen
3. Change some options, for example, layout background
4. Save
5. Preview. Ensure styles persist.

## QA notes

Please test using the instructions above. The changes may also affect other style settings, so please test briefly also other style sections.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5641](https://mailpoet.atlassian.net/browse/MAILPOET-5641)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5641]: https://mailpoet.atlassian.net/browse/MAILPOET-5641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5641]: https://mailpoet.atlassian.net/browse/MAILPOET-5641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ