### PR TITLE
Add segment page renders "0" after "Add condition" button

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/form.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/form.tsx
@@ -51,6 +51,9 @@ export function Form({ isNewSegment, newsletterId }: Props): JSX.Element {
   );
 
   const segmentFiltersCount = segment.filters.length;
+  const segmentFiltersLimitReached =
+    MailPoet.capabilities.segmentFilters.value > 0 && // 0 is unlimited
+    segmentFiltersCount >= MailPoet.capabilities.segmentFilters.value;
 
   const segmentFilters: GroupFilterValue[] = useSelect(
     (select) => select(storeName).getAvailableFilters(),
@@ -193,9 +196,7 @@ export function Form({ isNewSegment, newsletterId }: Props): JSX.Element {
                 {(!MailPoet.premiumActive ||
                   !MailPoet.hasValidPremiumKey ||
                   MailPoet.subscribersLimitReached ||
-                  (MailPoet.capabilities.segmentFilters.value &&
-                    segmentFiltersCount >=
-                      MailPoet.capabilities.segmentFilters.value)) && (
+                  segmentFiltersLimitReached) && (
                   <LockedBadge text={__('UPGRADE', 'mailpoet')} />
                 )}
 


### PR DESCRIPTION
## Description

Fix the bug where "0" is displayed in "Segment" page after "Add condition" button

## Code review notes

_N/A_

## QA notes

To test you need a 2022 business plan or a 2024 Pro plan key active on the site and premium plugin installed..
Go to Segments > Add New, check that you don't see "0" after "Add Condition" (Screenshot in ticket).
Test that, with free plans or no plan, you see the 'Upgrade' badge next to "Add Condition"

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6025]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6025]: https://mailpoet.atlassian.net/browse/MAILPOET-6025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ