### PR TITLE
Fix acceptance tests flakiness ManageWooCommerceSegmentsCest & CreateAndSendEmailUsingGutenbergCest

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -25,7 +25,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Compose an email');
-    $i->waitForElementVisible('.is-root-container');
+    $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');
@@ -88,7 +88,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('//button[text()="Continue"]');
 
     $i->wantTo('Edit an email');
-    $i->waitForElementVisible('.is-root-container');
+    $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
     $i->waitForElementVisible('[aria-label="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');

--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -28,6 +28,8 @@ class ManageWooCommerceSegmentsCest {
     $categorySelectElement = '[data-automation-id="select-segment-category"]';
     $actionSelectElement = '[data-automation-id="select-segment-action"]';
     $operatorSelectElement = '[data-automation-id="select-operator"]';
+    $segmentNameField = '[data-automation-id="input-name"]';
+    $segmentDescriptionField = '[data-automation-id="input-description"]';
 
     $i->wantTo('Create a new WooCommerce purchased in category segment');
     $segmentTitle = 'Segment Woo Category Test';
@@ -37,8 +39,8 @@ class ManageWooCommerceSegmentsCest {
     $i->click('[data-automation-id="new-segment"]');
     $i->waitForElement('[data-automation-id="new-custom-segment"]');
     $i->click('[data-automation-id="new-custom-segment"]');
-    $i->fillField(['name' => 'name'], $segmentTitle);
-    $i->fillField(['name' => 'description'], $segmentDesc);
+    $i->fillField($segmentNameField, $segmentTitle);
+    $i->fillField($segmentDescriptionField, $segmentDesc);
     $i->selectOptionInReactSelect('purchased in category', $actionSelectElement);
     $i->waitForElement($categorySelectElement);
     $i->selectOptionInReactSelect('Category 2', $categorySelectElement);
@@ -49,8 +51,8 @@ class ManageWooCommerceSegmentsCest {
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
     $i->waitForElement($categorySelectElement);
-    $i->seeInField(['name' => 'name'], $segmentTitle);
-    $i->seeInField(['name' => 'description'], $segmentDesc);
+    $i->seeInField($segmentNameField, $segmentTitle);
+    $i->seeInField($segmentDescriptionField, $segmentDesc);
     $i->see('purchased in category', $actionSelectElement);
     $i->see('Category 2', $categorySelectElement);
     $i->seeOptionIsSelected($operatorSelectElement, 'any of'); // default value should be selected
@@ -58,10 +60,12 @@ class ManageWooCommerceSegmentsCest {
     $i->wantTo('Edit segment and save');
     $editedTitle = 'Segment Woo Category Test Edited';
     $editedDesc = 'Segment description Edited';
-    $i->clearField(['name' => 'name']);
-    $i->fillField(['name' => 'name'], $editedTitle);
-    $i->clearField(['name' => 'description']);
-    $i->fillField(['name' => 'description'], $editedDesc);
+    $i->clearFormField($segmentNameField);
+    $i->clearFormField($segmentDescriptionField);
+    $i->waitForElementVisible('input[value=""]' . $segmentNameField);
+    $i->waitForElementVisible($segmentDescriptionField . ':empty');
+    $i->fillField($segmentNameField, $editedTitle);
+    $i->fillField($segmentDescriptionField, $editedDesc);
     $i->selectOptionInReactSelect('Category 1', $categorySelectElement);
     $i->selectOptionInReactSelect('Category 3', $categorySelectElement);
     $i->selectOption($operatorSelectElement, 'none of');
@@ -72,8 +76,8 @@ class ManageWooCommerceSegmentsCest {
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($editedTitle, 'Edit');
     $i->waitForElement($categorySelectElement);
-    $i->seeInField(['name' => 'name'], $editedTitle);
-    $i->seeInField(['name' => 'description'], $editedDesc);
+    $i->seeInField($segmentNameField, $editedTitle);
+    $i->seeInField($segmentDescriptionField, $editedDesc);
     $i->see('purchased in category', $actionSelectElement);
     $i->see('Category 1', $categorySelectElement);
     $i->see('Category 3', $categorySelectElement);


### PR DESCRIPTION
## Description

Flaky tests were due to improperly clearing form fields. The other test was rarely flaky in case when the new email editor takes more than 10s to load.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6050]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6050]: https://mailpoet.atlassian.net/browse/MAILPOET-6050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ