### PR TITLE
Add skipping new email editor acceptance test on WP 6.4 [MAILPOET-6055]

### DIFF
--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -22,6 +22,9 @@ class CheckSkippedTestsExtension extends Extension {
       'testAllSubscribersFoundWithOperatorAllOf',
       'automationTriggeredByRegistrationWitConfirmationNeeded',
       'automationTriggeredByRegistrationWithoutConfirmationNeeded',
+      // The next two tests can be removed after dropping support for WP 6.4
+      'createAndSendStandardNewsletter',
+      'displayNewsletterPreview',
     ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -7,8 +7,10 @@ use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Settings;
 
 class CreateAndSendEmailUsingGutenbergCest {
-  public function createAndSendStandardNewsletter(\AcceptanceTester $i) {
-
+  public function createAndSendStandardNewsletter(\AcceptanceTester $i, $scenario) {
+    if (!$this->checkMinimalWordpressVersion($i)) {
+      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4');
+    }
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
     $settings->withSender('John Doe', 'john@doe.com');
@@ -71,7 +73,9 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->checkEmailWasReceived('My New Subject');
   }
 
-  public function displayNewsletterPreview(\AcceptanceTester $i) {
+  public function displayNewsletterPreview(\AcceptanceTester $i, $scenario) {
+    if (!$this->checkMinimalWordpressVersion($i))
+      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4');
 
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
@@ -117,5 +121,14 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForText('Test email sent successfully!');
     $i->click('//button[text()="Close"]');
     $i->waitForElementNotVisible('//button[text()="Send test email"]');
+  }
+
+  private function checkMinimalWordpressVersion(\AcceptanceTester $i): bool {
+    $wordPressVersion = $i->getWordPressVersion();
+    // New email editor is not compatible with WP versions below 6.5
+    if (version_compare($wordPressVersion, '6.5', '<')) {
+      return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6055]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6055]: https://mailpoet.atlassian.net/browse/MAILPOET-6055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ