### PR TITLE
Fix Public API method `updateList` - MAILPOET-6056

### DIFF
--- a/doc/api_methods/AddList.md
+++ b/doc/api_methods/AddList.md
@@ -1,6 +1,6 @@
 [back to list](../Readme.md)
 
-# Add Subscriber
+# Add List
 
 ## `array addList(array $list)`
 

--- a/doc/api_methods/UpdateList.md
+++ b/doc/api_methods/UpdateList.md
@@ -1,6 +1,6 @@
 [back to list](../Readme.md)
 
-# Add Subscriber
+# Update List
 
 ## `array updateList(array $list)`
 
@@ -14,11 +14,11 @@ It returns the updated list. See [Get Lists](GetLists.md) for a list data struct
 
 An associative array which contains list data.
 
-| Property               | Type         | Limits    | Description                |
-| ---------------------- | ------------ | --------- | -------------------------- |
-| id (required)          | string       | 11 chars  | A id of the list.          |
-| name (required)        | string       | 90 chars  | A name of the list.        |
-| description (optional) | string\|null | 250 chars | A description of the list. |
+| Property               | Type         | Limits    | Description                                                                |
+| ---------------------- | ------------ | --------- | -------------------------------------------------------------------------- |
+| id (required)          | string       | 11 chars  | A id of the list.                                                          |
+| name (required)        | string       | 90 chars  | A name of the list.                                                        |
+| description (optional) | string\|null | 250 chars | A description of the list. This will reset the list description when empty |
 
 ## Error handling
 

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -163,7 +163,8 @@ class Segments {
       );
     }
 
-    if (!$this->segmentsRepository->isNameUnique($data['name'], null)) {
+    $segmentId = isset($data['id']) ? (int)$data['id'] : null;
+    if (!$this->segmentsRepository->isNameUnique($data['name'], $segmentId)) {
       throw new APIException(
         __('This list already exists.', 'mailpoet'),
         APIException::LIST_EXISTS

--- a/mailpoet/tests/integration/API/MP/SegmentsTest.php
+++ b/mailpoet/tests/integration/API/MP/SegmentsTest.php
@@ -164,6 +164,62 @@ class SegmentsTest extends \MailPoetTest {
     verify($result['description'])->equals($data['description']);
   }
 
+  public function testItUpdatesListName(): void {
+    $segment = $this->createOrUpdateSegment(
+      'Current Segment name',
+      SegmentEntity::TYPE_DEFAULT,
+      'Description'
+    );
+
+    $data = [
+      'id' => (string)$segment->getId(),
+      'name' => 'new Segment name',
+    ];
+    $result = $this->getApi()->updateList($data);
+    verify($result['id'])->equals($data['id']);
+    verify($result['name'])->equals($data['name']);
+    verify($result['description'])->equals(''); // documenting this. We probably should not reset the segment description if it wasn't provided
+  }
+
+  public function testItUpdatesListDescription(): void {
+    $segment = $this->createOrUpdateSegment(
+      'Segment name',
+      SegmentEntity::TYPE_DEFAULT,
+      'Current Segment Description'
+    );
+
+    $data = [
+      'id' => (string)$segment->getId(),
+      'name' => $segment->getName(),
+      'description' => 'updated segment description',
+    ];
+    $result = $this->getApi()->updateList($data);
+    verify($result['id'])->equals($data['id']);
+    verify($result['name'])->equals($data['name']);
+    verify($result['description'])->equals($data['description']);
+  }
+
+  public function testItDoesNotAllowOnlyListDescriptionUpdate(): void {
+    // we currently cannot update only segment description
+    $segment = $this->createOrUpdateSegment(
+      'Segment name only',
+      SegmentEntity::TYPE_DEFAULT,
+      'Current Segment Description only'
+    );
+
+    $data = [
+      'id' => (string)$segment->getId(),
+      'description' => 'newly updated segment description',
+    ];
+
+    try {
+      $this->getApi()->updateList($data);
+      $this->fail('Segment description requires name for updating');
+    } catch (\Exception $e) {
+      verify($e->getMessage())->equals('List name is required.');
+    }
+  }
+
   public function testItDoesNotAllowUpdateWPSegment(): void {
     $wpSegment = $this->segmentsRepository->getWPUsersSegment();
     $this->assertInstanceOf(SegmentEntity::class, $wpSegment);


### PR DESCRIPTION
## Description

Allow Public API method `updateList` update segment description with the same segment name

Closes https://github.com/mailpoet/mailpoet/issues/5547

## Code review notes

_N/A_

## QA notes

This should work now
```php
// Get MailPoet API instance
$mailpoet_api = \MailPoet\API\API::MP('v1');

try {
  // create a new list
  $theNewList = $mailpoet_api->addList([
    'name' => 'new-api-list',
    'description' => 'new list created from the api'
  ]);
} catch (\Exception $e) {
  $error_message = $e->getMessage();
}

try {
  // update list description
  $mailpoet_api->updateList([
    'description' => 'a new description',
    'id' => $theNewList['id'],
    'name' => $theNewList['name'],
  ]);
} catch (\Exception $e) {
  $error_message = $e->getMessage();
}
	
```

## Linked PRs

Recreating this [PR](https://github.com/mailpoet/mailpoet/pull/5548) because of CircleCI issues 

## Linked tickets

[MAILPOET-6056](https://mailpoet.atlassian.net/browse/MAILPOET-6056)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6056]: https://mailpoet.atlassian.net/browse/MAILPOET-6056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ