### PR TITLE
Fix display of upgrade banner on subscribers stats page

### DIFF
--- a/mailpoet/assets/js/src/subscribers/stats/no-access-info.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/no-access-info.tsx
@@ -42,46 +42,48 @@ export function NoAccessInfo(): JSX.Element {
   );
 
   return (
-    <table
-      className="mailpoet-listing-table"
-      data-automation-id="subscriber-stats-no-access"
-    >
-      <thead>
-        <tr>
-          <th>{__('E-mail', 'mailpoet')}</th>
-          <th>
-            {
-              // translators: Table column label for subscriber actions e.g. email open, link clicked
-              __('Action', 'mailpoet')
-            }
-          </th>
-          <th>
-            {
-              // translators: Table column label for count of subscriber actions
-              __('Count', 'mailpoet')
-            }
-          </th>
-          <th>
-            {
-              // translators: Table column label for date when subscriber action happened
-              __('Action on', 'mailpoet')
-            }
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td colSpan={4}>
-            <div className="mailpoet-subscriber-stats-no-access-content">
-              <PremiumBannerWithUpgrade
-                message={getBannerMessage({})}
-                actionButton={getCtaButton({})}
-                capabilities={{ detailedAnalytics: true }}
-              />
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div className="mailpoet-listing">
+      <table
+        className="mailpoet-listing-table"
+        data-automation-id="subscriber-stats-no-access"
+      >
+        <thead>
+          <tr>
+            <th>{__('E-mail', 'mailpoet')}</th>
+            <th>
+              {
+                // translators: Table column label for subscriber actions e.g. email open, link clicked
+                __('Action', 'mailpoet')
+              }
+            </th>
+            <th>
+              {
+                // translators: Table column label for count of subscriber actions
+                __('Count', 'mailpoet')
+              }
+            </th>
+            <th>
+              {
+                // translators: Table column label for date when subscriber action happened
+                __('Action on', 'mailpoet')
+              }
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colSpan={4}>
+              <div className="mailpoet-subscriber-stats-no-access-content">
+                <PremiumBannerWithUpgrade
+                  message={getBannerMessage({})}
+                  actionButton={getCtaButton({})}
+                  capabilities={{ detailedAnalytics: true }}
+                />
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

Fix the table on Subscribers stats page when displaying the upgrade banner.

## Code review notes

_N/A_

## QA notes

To test:
- Deactivate the premium plugin
- Go to MailPoet > Subscribers, click on the Statistics of one of the subscribers
- Check the table that displays the banner expands on the page, has margins and border.

<img width="1867" alt="Screenshot 2024-05-03 at 3 59 48 PM" src="https://github.com/mailpoet/mailpoet/assets/8002881/ca6a0e66-418c-4e15-8bba-756c8bff25f6">


## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5968]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5968]: https://mailpoet.atlassian.net/browse/MAILPOET-5968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ