### PR TITLE
Email editor - select template after editor starts [MAILPOET-6049]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -32,6 +32,7 @@ import { InserterSidebar } from '../inserter-sidebar/inserter-sidebar';
 import { EditorNotices, EditorSnackbars, SentEmailNotice } from '../notices';
 import { StylesSidebar } from '../styles-sidebar';
 import { unlock } from '../../../lock-unlock';
+import { TemplateSelection } from '../template-select';
 
 const { EditorCanvas } = unlock(editorPrivateApis);
 
@@ -115,6 +116,7 @@ export function Layout() {
       <SentEmailNotice />
       <Sidebar />
       <StylesSidebar />
+      <TemplateSelection />
       <InterfaceSkeleton
         className={className}
         header={<Header />}

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/templates-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/templates-panel.tsx
@@ -1,9 +1,7 @@
 import { PanelBody, Button } from '@wordpress/components';
 import { useSelect, useDispatch, dispatch, select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
-import { SelectTemplateModal } from 'email-editor/engine/components/template-select';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -67,8 +65,6 @@ export function TemplatesPanel() {
     [],
   );
 
-  const [isTemplateSelectModalOpen, setIsTemplateSelectModalOpen] =
-    useState(false);
   const { saveEditedEntityRecord } = useDispatch(coreStore);
   const { createSuccessNotice, createErrorNotice } = useDispatch(noticesStore);
   async function revertAndSaveTemplate() {
@@ -130,19 +126,6 @@ export function TemplatesPanel() {
         >
           {__('Edit template', 'mailpoet')}
         </Button>
-      )}
-      <hr />
-      <h3>Select Template</h3>
-      <Button
-        variant="primary"
-        onClick={() => {
-          setIsTemplateSelectModalOpen(true);
-        }}
-      >
-        {__('Select initial template', 'mailpoet')}
-      </Button>
-      {isTemplateSelectModalOpen && (
-        <SelectTemplateModal setIsOpen={setIsTemplateSelectModalOpen} />
       )}
       <hr />
       <h3>Revert Template</h3>

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/index.scss
@@ -7,3 +7,7 @@
 .block-editor-block-patterns-list__item .block-editor-block-preview__container {
   align-items: flex-start !important;
 }
+
+.block-editor-block-patterns-list__list-item {
+  overflow: hidden;
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/index.ts
@@ -1,3 +1,4 @@
 import './index.scss';
 
 export * from './select-modal';
+export * from './template-selection';

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/select-modal.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/select-modal.tsx
@@ -11,24 +11,32 @@ import { Async } from './async';
 import { usePreviewTemplates } from '../../hooks';
 import { storeName } from '../../store/constants';
 
-export function SelectTemplateModal({ setIsOpen }) {
+const BLANK_TEMPLATE = 'email-general';
+
+export function SelectTemplateModal({ onSelectCallback }) {
   const [templates] = usePreviewTemplates();
 
   const handleTemplateSelection = (template) => {
-    setIsOpen(false);
     void dispatch(editorStore).resetEditorBlocks(template.patternParsed);
     void dispatch(storeName).setTemplateToPost(
       template.slug,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       template.template.mailpoet_email_theme ?? {},
     );
+    onSelectCallback();
+  };
+
+  const handleCloseWithoutSelection = () => {
+    const blankTemplate = templates.find(
+      (template) => template.slug === BLANK_TEMPLATE,
+    );
+    handleTemplateSelection(blankTemplate);
   };
 
   return (
     <Modal
       title="Select a template"
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      onRequestClose={() => setIsOpen(false)}
+      onRequestClose={() => handleCloseWithoutSelection()}
       isFullScreen
     >
       <div className="block-editor-block-patterns-explorer">

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/select-modal.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/select-modal.tsx
@@ -30,6 +30,7 @@ export function SelectTemplateModal({ onSelectCallback }) {
     const blankTemplate = templates.find(
       (template) => template.slug === BLANK_TEMPLATE,
     );
+    if (!blankTemplate) return; // Prevent close if blank template is still not loaded
     handleTemplateSelection(blankTemplate);
   };
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/template-selection.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/template-selection.tsx
@@ -1,0 +1,22 @@
+import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { storeName } from 'email-editor/engine/store';
+import { SelectTemplateModal } from './select-modal';
+
+export function TemplateSelection() {
+  const [templateSelected, setTemplateSelected] = useState(false);
+  const { emailContentIsEmpty } = useSelect(
+    (select) => ({
+      emailContentIsEmpty: select(storeName).hasEmptyContent(),
+    }),
+    [],
+  );
+
+  if (!emailContentIsEmpty || templateSelected) {
+    return null;
+  }
+
+  return (
+    <SelectTemplateModal onSelectCallback={() => setTemplateSelected(true)} />
+  );
+}

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/template-selection.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/template-selection.tsx
@@ -5,14 +5,14 @@ import { SelectTemplateModal } from './select-modal';
 
 export function TemplateSelection() {
   const [templateSelected, setTemplateSelected] = useState(false);
-  const { emailContentIsEmpty } = useSelect(
+  const { emailContentIsEmpty, emailHasEdits } = useSelect(
     (select) => ({
       emailContentIsEmpty: select(storeName).hasEmptyContent(),
+      emailHasEdits: select(storeName).hasEdits(),
     }),
     [],
   );
-
-  if (!emailContentIsEmpty || templateSelected) {
+  if (!emailContentIsEmpty || emailHasEdits || templateSelected) {
     return null;
   }
 

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Newsletter;
 
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter as NewsletterQueueTask;
-use MailPoet\EmailEditor\Engine\Patterns\Library\DefaultContent;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
@@ -24,7 +23,6 @@ use MailPoet\NotFoundException;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
-use MailPoet\Util\CdnAssetUrl;
 use MailPoet\Util\Security;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -80,8 +78,6 @@ class NewsletterSaveController {
   /*** @var NewsletterCoupon */
   private $newsletterCoupon;
 
-  private CdnAssetUrl $cdnAssetUrl;
-
   public function __construct(
     AuthorizedEmailsController $authorizedEmailsController,
     Emoji $emoji,
@@ -98,8 +94,7 @@ class NewsletterSaveController {
     WPFunctions $wp,
     ApiDataSanitizer $dataSanitizer,
     Scheduler $scheduler,
-    NewsletterCoupon $newsletterCoupon,
-    CdnAssetUrl $cdnAssetUrl
+    NewsletterCoupon $newsletterCoupon
   ) {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->emoji = $emoji;
@@ -117,7 +112,6 @@ class NewsletterSaveController {
     $this->dataSanitizer = $dataSanitizer;
     $this->scheduler = $scheduler;
     $this->newsletterCoupon = $newsletterCoupon;
-    $this->cdnAssetUrl = $cdnAssetUrl;
   }
 
   public function save(array $data = []): NewsletterEntity {
@@ -464,7 +458,7 @@ class NewsletterSaveController {
     }
 
     $newPostId = $this->wp->wpInsertPost([
-      'post_content' => $this->getEmailDefaultContent(),
+      'post_content' => '',
       'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
       'post_status' => 'draft',
       'post_author' => $this->wp->getCurrentUserId(),
@@ -472,10 +466,5 @@ class NewsletterSaveController {
     ]);
     $newsletter->setWpPost($this->entityManager->getReference(WpPostEntity::class, $newPostId));
     $this->entityManager->flush();
-  }
-
-  private function getEmailDefaultContent(): string {
-    $defaultPattern = new DefaultContent($this->cdnAssetUrl);
-    return $defaultPattern->getProperties()['content'];
   }
 }

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -26,6 +26,8 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForText('Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.');
     $i->click('//button[text()="Continue"]');
 
+    $this->closeTemplateSelectionModal($i);
+
     $i->wantTo('Compose an email');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
@@ -91,6 +93,8 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForText('Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.');
     $i->click('//button[text()="Continue"]');
 
+    $this->closeTemplateSelectionModal($i);
+
     $i->wantTo('Edit an email');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
@@ -130,5 +134,11 @@ class CreateAndSendEmailUsingGutenbergCest {
       return false;
     }
     return true;
+  }
+
+  private function closeTemplateSelectionModal(\AcceptanceTester $i): void {
+    $i->wantTo('Close template selector');
+    $i->waitForElementVisible('.block-editor-block-preview__container');
+    $i->click('[aria-label="Close"]');
   }
 }

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -384,7 +384,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($postEntity->getPostTitle())->equals('New Email');
     $wpPost = $postEntity->getWpPostInstance();
     $this->assertInstanceOf(\WP_Post::class, $wpPost);
-    $this->assertStringContainsString('You received this email because you are subscribed to the [site:title]', $wpPost->post_content); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $this->assertEmpty($wpPost->post_content); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($wpPost->post_author)->equals($wp->getCurrentUserId()); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($wpPost->post_status)->equals('draft'); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }


### PR DESCRIPTION
## Description

This PR replaces the experimental button for opening the template selection modal with the proper behavior of opening the modal when the editor starts with empty content.

## Code review notes

_N/A_

## QA notes

#### Testing instructions

1. Create a new email
2. Template selection modal should open immediately after editor is loaded (please ignore some slowness in loading templates)
3. A) after selecting template modal closes and template and content is applied in editor
    B) when closing modal without selecting the "General Email" template is used

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6049]

## After-merge notes

_N/A_

## Tasks

- [x ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6049]: https://mailpoet.atlassian.net/browse/MAILPOET-6049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ