### PR TITLE
Fix performance test for saving segment after calculating segmentsCreateCustom

### DIFF
--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -21,7 +21,7 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInReact } from '../utils/helpers.js';
+import { login, selectInReact, focusAndClick } from '../utils/helpers.js';
 
 export async function segmentsCreateCustom() {
   const page = browser.newPage();
@@ -121,15 +121,18 @@ export async function segmentsCreateCustom() {
     });
 
     // Save the segment
-    await page.locator('div.mailpoet-form-actions > button').click();
+    const calculatedMessage =
+      "//div[@class='mailpoet-form-field'].//span[starts-with(text(),'This segment has')]";
+    await calculatedMessage.waitFor();
+    await focusAndClick(page, 'div.mailpoet-form-actions > button');
     await page.waitForSelector('[data-automation-id="filters_all"]', {
       state: 'visible',
     });
-    const locator =
+    const segmentUpdatedMessage =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
     describe(segmentsPageTitle, () => {
       describe('segments-create-custom: should be able to see Segment Updated message', () => {
-        expect(page.locator(locator)).to.exist;
+        expect(page.locator(segmentUpdatedMessage)).to.exist;
       });
     });
 


### PR DESCRIPTION
## Description

Fix performance test in the nightly tests.
There is a race condition before calculating segment and saving it.
Added wait for text before clicking save button.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6062]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6062]: https://mailpoet.atlassian.net/browse/MAILPOET-6062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ