### PR TITLE
Do not run cron when a plugin update is running - MAILPOET-6021

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -554,6 +554,11 @@ class Hooks {
       10,
       2
     );
+
+    $this->wp->addAction(
+      'action_scheduler_before_process_queue',
+      [$this, 'deactivateCronWhenInMaintenanceMode']
+    );
   }
 
   /**
@@ -582,5 +587,19 @@ class Hooks {
     $this->cronTrigger->disable();
 
     return $response;
+  }
+
+  public function deactivateCronWhenInMaintenanceMode(): void {
+    if (!$this->wp->wpIsMaintenanceMode()) {
+      return;
+    }
+
+    $this->wp->addFilter('action_scheduler_queue_runner_batch_size', function () {
+      // return 0 batch sizes to prevent the queue runner from running;
+      // this is the fastest way to stop the current running cron
+      return 0;
+    });
+
+    $this->cronTrigger->disable();
   }
 }

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -45,6 +45,11 @@ class Daemon {
 
     $errors = [];
     foreach ($this->getWorkers() as $worker) {
+      if (wp_is_maintenance_mode()) {
+        // stop execution when in maintenance mode
+        break;
+      }
+
       try {
         // Clear the entity manager memory for every cron run.
         // This avoids using stale data and prevents memory leaks.

--- a/mailpoet/lib/Cron/Triggers/WordPress.php
+++ b/mailpoet/lib/Cron/Triggers/WordPress.php
@@ -102,6 +102,12 @@ class WordPress {
   }
 
   public function checkExecutionRequirements(): bool {
+    if ($this->wp->wpIsMaintenanceMode()) {
+      // Skip if WP is currently in maintenance mode
+      // The maintenance mode is activated when WP core or a plugin update is in progress
+      return false;
+    }
+
     $this->loadTasksCounts();
 
     // Because a lot of workers has the same pattern for check if it's active we can use a loop here

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -972,4 +972,8 @@ class Functions {
   public function getTaxonomy($taxonomy) {
     return get_taxonomy($taxonomy);
   }
+
+  public function wpIsMaintenanceMode(): bool {
+    return wp_is_maintenance_mode();
+  }
 }

--- a/mailpoet/mailpoet-cron.php
+++ b/mailpoet/mailpoet-cron.php
@@ -33,6 +33,11 @@ if (!is_plugin_active('mailpoet/mailpoet.php')) {
   exit(1);
 }
 
+if (wp_is_maintenance_mode()) {
+  echo 'WordPress site in maintenance mode.';
+  exit(1);
+}
+
 // Check for minimum supported PHP version
 if (version_compare(phpversion(), '7.4.0', '<')) {
   echo 'MailPoet requires PHP version 7.4 or newer (version 8.1 recommended).';


### PR DESCRIPTION
## Description

Do not run cron when a plugin update is running.

The ticket description mentioned this: `We need to notify a user if the cron is stuck due to ongoing update`, but that's not necessary again at this point since we are stopping all cron actions before plugin update.

## Code review notes

I have no clue how QA can test this, but Devs can test the PR by adding `error_log` or `var_dump` to the required functions.
You can imitate the plugin update process by switching the [version of the plugin ](https://github.com/mailpoet/mailpoet/blob/b440a791f954e4da34267f5bf998ebfc0f11a568/mailpoet/mailpoet.php#L5) to a lower version. WordPress should prompt you to update the plugin.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6021](https://mailpoet.atlassian.net/browse/MAILPOET-6021)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6021]: https://mailpoet.atlassian.net/browse/MAILPOET-6021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ