### PR TITLE
Email Editor: Add support for core/group block [MAILPOET-6057]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/group.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/group.tsx
@@ -1,0 +1,25 @@
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Disables layout support for group blocks because the default layout `flex` add gaps between columns that it is not possible to support in emails.
+ */
+function disableGroupVariations() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/disable-group-variations',
+    (settings, name) => {
+      if (name === 'core/group') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return {
+          ...settings,
+          variations: [],
+        };
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return settings;
+    },
+  );
+}
+
+export { disableGroupVariations };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/group.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/group.tsx
@@ -12,10 +12,11 @@ function disableGroupVariations() {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return {
           ...settings,
-          variations: [],
+          variations: settings.variations.filter(
+            (variation) => variation.name === 'group',
+          ),
         };
       }
-
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return settings;
     },

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -6,6 +6,7 @@ import {
   enhanceColumnsBlock,
 } from './core/columns';
 import { enhancePostContentBlock } from './core/post-content';
+import { disableGroupVariations } from './core/group';
 import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
@@ -18,6 +19,7 @@ export function initBlocks() {
   disableImageFilter();
   disableCertainRichTextFormats();
   disableColumnsLayout();
+  disableGroupVariations();
   enhanceButtonBlock();
   enhanceButtonsBlock();
   enhanceColumnBlock();

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/ContentRenderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/ContentRenderer.php
@@ -92,7 +92,7 @@ class ContentRenderer {
     $layout = $this->settingsController->getLayout();
     $styles .= sprintf(
       '
-      .is-layout-constrained > *:not(.alignleft):not(.alignright):not(.alignfull):not(.alignwide) {
+      .is-layout-constrained > *:not(.alignleft):not(.alignright):not(.alignfull) {
         max-width: %1$s;
         margin-left: auto !important;
         margin-right: auto !important;
@@ -109,8 +109,7 @@ class ContentRenderer {
 
     // Get styles from theme.
     $styles .= $this->themeController->getStylesheetForRendering($post);
-
-    $blockSupportStyles = \wp_style_engine_get_stylesheet_from_context('block-supports', []);
+    $blockSupportStyles = $this->themeController->getStylesheetFromContext('block-supports', []);
     // Get styles from block-supports stylesheet. This includes rules such as layout (contentWidth) that some blocks use.
     // @see https://github.com/WordPress/WordPress/blob/3c5da9c74344aaf5bf8097f2e2c6a1a781600e03/wp-includes/script-loader.php#L3134
     // @internal :where is not supported by emogrifier, so we need to replace it with *.

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/content.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/content.css
@@ -35,7 +35,12 @@ h6 {
   margin-top: 0;
 }
 
-/* Wa want ensure the same design for all email clients */
+/* Ensure border style is set when a block has a border */
+.has-border-color {
+  border-style: solid;
+}
+
+/* We want ensure the same design for all email clients */
 ul,
 ol {
   /* When margin attribute is set to zero, Outlook doesn't render the list properly. As a possible workaround, we can reset only margin for top and bottom */

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.css
@@ -45,7 +45,7 @@ body {
 }
 
 @media screen and (max-width: 660px) {
-  .email_column {
+  .email-block-column-content {
     max-width: 100% !important;
   }
   .block {

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -14,6 +14,7 @@ class SettingsController {
     'core/image',
     'core/list',
     'core/list-item',
+    'core/group',
   ];
 
   const DEFAULT_SETTINGS = [
@@ -66,11 +67,13 @@ class SettingsController {
   }
 
   /**
-   * @return array{contentSize: string, layout: string}
+   * @return array{contentSize: string, wideSize: string, layout: string}
    */
   public function getLayout(): array {
+    $settings = $this->getSettings();
     return [
-      'contentSize' => self::EMAIL_WIDTH,
+      'contentSize' => $settings['__experimentalFeatures']['layout']['contentSize'],
+      'wideSize' => $settings['__experimentalFeatures']['layout']['wideSize'],
       'layout' => 'constrained',
     ];
   }

--- a/mailpoet/lib/EmailEditor/Engine/SettingsController.php
+++ b/mailpoet/lib/EmailEditor/Engine/SettingsController.php
@@ -39,7 +39,7 @@ class SettingsController {
   }
 
   public function getSettings(): array {
-    $coreDefaultSettings = get_default_block_editor_settings();
+    $coreDefaultSettings = \get_default_block_editor_settings();
     $themeSettings = $this->themeController->getSettings();
 
     // body selector is later transformed to .editor-styles-wrapper
@@ -70,10 +70,10 @@ class SettingsController {
    * @return array{contentSize: string, wideSize: string, layout: string}
    */
   public function getLayout(): array {
-    $settings = $this->getSettings();
+    $themeSettings = $this->themeController->getSettings();
     return [
-      'contentSize' => $settings['__experimentalFeatures']['layout']['contentSize'],
-      'wideSize' => $settings['__experimentalFeatures']['layout']['wideSize'],
+      'contentSize' => $themeSettings['layout']['contentSize'],
+      'wideSize' => $themeSettings['layout']['wideSize'],
       'layout' => 'constrained',
     ];
   }

--- a/mailpoet/lib/EmailEditor/Engine/Templates/email-general.html
+++ b/mailpoet/lib/EmailEditor/Engine/Templates/email-general.html
@@ -1,2 +1,2 @@
-<!-- wp:core/post-content {"lock":{"move":true,"remove":true},"layout":{"type":"constrained","contentSize":"660px"}} /-->
+<!-- wp:core/post-content {"lock":{"move":true,"remove":true},"layout":{"type":"constrained"}} /-->
 <!-- wp:mailpoet/powered-by-mailpoet {"lock":{"move":true,"remove":true}} /-->

--- a/mailpoet/lib/EmailEditor/Engine/ThemeController.php
+++ b/mailpoet/lib/EmailEditor/Engine/ThemeController.php
@@ -59,6 +59,10 @@ class ThemeController {
     return $emailEditorThemeSettings;
   }
 
+  public function getStylesheetFromContext($context, $options = []): string {
+    return function_exists('gutenberg_style_engine_get_stylesheet_from_context') ? gutenberg_style_engine_get_stylesheet_from_context($context, $options) : wp_style_engine_get_stylesheet_from_context($context, $options);
+  }
+
   public function getStylesheetForRendering($post = null): string {
     $emailThemeSettings = $this->getSettings();
 

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -8,7 +8,8 @@
       "gradients": []
     },
     "layout": {
-      "contentSize": "660px"
+      "contentSize": "660px",
+      "wideSize": "660px"
     },
     "background": {
       "backgroundImage": true

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Initializer.php
@@ -24,6 +24,7 @@ class Initializer {
     $blocksRegistry->addBlockRenderer('core/image', new Renderer\Blocks\Image());
     $blocksRegistry->addBlockRenderer('core/buttons', new Renderer\Blocks\Buttons(new FlexLayoutRenderer()));
     $blocksRegistry->addBlockRenderer('core/button', new Renderer\Blocks\Button());
+    $blocksRegistry->addBlockRenderer('core/group', new Renderer\Blocks\Group());
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/AbstractBlockRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/AbstractBlockRenderer.php
@@ -46,7 +46,7 @@ abstract class AbstractBlockRenderer implements BlockRenderer {
 
     return sprintf(
       '<!--[if mso | IE]><table align="left" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="%2$s"><tr><td style="%3$s"><![endif]-->
-      <div class="block_layout" style="%2$s %3$s">%1$s</div>
+      <div class="email-block-layout" style="%2$s %3$s">%1$s</div>
       <!--[if mso | IE]></td></tr></table><![endif]-->',
       $content,
       esc_attr($gapStyle),

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Column.php
@@ -52,8 +52,8 @@ class Column extends AbstractBlockRenderer {
       $cellStyles['background-size'] = 'cover';
     }
 
-    $wrapperClassname = 'block wp-block-column';
-    $contentClassname = 'email_column';
+    $wrapperClassname = 'block wp-block-column email-block-column';
+    $contentClassname = 'email-block-column-content';
     $wrapperCSS = WP_Style_Engine::compile_css([
       'vertical-align' => $isStretched ? 'top' : $block_attributes['verticalAlignment'],
     ], '');

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Columns.php
@@ -48,8 +48,10 @@ class Columns extends AbstractBlockRenderer {
       $columnsStyles['background-size'] = 'cover';
     }
 
-    $renderedColumns = '<table class="' . esc_attr('email_columns ' . $originalWrapperClassname) . '" style="width:100%;border-collapse:separate;text-align:left;' . esc_attr(WP_Style_Engine::compile_css($columnsStyles, '')) . '" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
-      <tr>{columns_content}</tr>
+    $renderedColumns = '<table class="' . esc_attr('email-block-columns ' . $originalWrapperClassname) . '" style="width:100%;border-collapse:separate;text-align:left;' . esc_attr(WP_Style_Engine::compile_css($columnsStyles, '')) . '" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+      <tbody>
+        <tr>{columns_content}</tr>
+      </tbody>
     </table>';
 
     // Margins are not supported well in outlook for tables, so wrap in another table.
@@ -57,12 +59,14 @@ class Columns extends AbstractBlockRenderer {
 
     if (!empty($margins)) {
       $marginToPaddingStyles = $this->getStylesFromBlock([
-        'spacing' => [ 'padding' => $margins ],
+        'spacing' => [ 'margin' => $margins ],
       ])['css'];
-      $renderedColumns = '<table class="email_columns_wrapper" style="width:100%;border-collapse:separate;text-align:left;' . esc_attr($marginToPaddingStyles) . '" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
-        <tr>
-          <td>' . $renderedColumns . '</td>
-        </tr>
+      $renderedColumns = '<table class="email-block-columns-wrapper" style="width:100%;border-collapse:separate;text-align:left;' . esc_attr($marginToPaddingStyles) . '" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+        <tbody>
+          <tr>
+            <td>' . $renderedColumns . '</td>
+          </tr>
+        </tbody>
       </table>';
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Group.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Group.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks;
+
+use MailPoet\EmailEditor\Engine\SettingsController;
+use MailPoet\EmailEditor\Integrations\Core\Renderer\Blocks\AbstractBlockRenderer;
+use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
+use WP_Style_Engine;
+
+class Group extends AbstractBlockRenderer {
+  protected function renderContent(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    $content = '';
+    $innerBlocks = $parsedBlock['innerBlocks'] ?? [];
+
+    foreach ($innerBlocks as $block) {
+      $content .= render_block($block);
+    }
+
+    return str_replace(
+      '{group_content}',
+      $content,
+      $this->getBlockWrapper($blockContent, $parsedBlock, $settingsController)
+    );
+  }
+
+  private function getBlockWrapper(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
+    $originalClassname = (new DomDocumentHelper($blockContent))->getAttributeValueByTagName('div', 'class') ?? '';
+    $blockAttributes = wp_parse_args($parsedBlock['attrs'] ?? [], [
+      'style' => [],
+      'backgroundColor' => '',
+      'textColor' => '',
+      'borderColor' => '',
+      'layout' => [
+        'justifyContent' => '',
+      ],
+    ]);
+
+    // Layout, background, borders need to be on the outer table element.
+    $tableStyles = $this->getStylesFromBlock([
+      'color' => array_filter([
+        'background' => $blockAttributes['backgroundColor'] ? $settingsController->translateSlugToColor($blockAttributes['backgroundColor']) : null,
+        'text' => $blockAttributes['textColor'] ? $settingsController->translateSlugToColor($blockAttributes['textColor']) : null,
+        'border' => $blockAttributes['borderColor'] ? $settingsController->translateSlugToColor($blockAttributes['borderColor']) : null,
+      ]),
+      'background' => $blockAttributes['style']['background'] ?? [],
+      'border' => $blockAttributes['style']['border'] ?? [],
+      'spacing' => [ 'padding' => $blockAttributes['style']['spacing']['margin'] ?? [] ],
+    ])['declarations'];
+
+    // Padding properties need to be added to the table cell.
+    $cellStyles = $this->getStylesFromBlock([
+      'spacing' => [ 'padding' => $blockAttributes['style']['spacing']['padding'] ?? [] ],
+    ])['declarations'];
+
+    if (empty($tableStyles['background-size'])) {
+      $tableStyles['background-size'] = 'cover';
+    }
+
+    return sprintf(
+      '<table class="email-block-group %3$s" style="%1$s" width="100%%" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+        <tbody>
+          <tr>
+            <td class="email-block-group-content" style="%2$s" align="%4$s" width="%5$s">
+              {group_content}
+            </td>
+          </tr>
+        </tbody>
+      </table>',
+      esc_attr(WP_Style_Engine::compile_css($tableStyles, '')),
+      esc_attr(WP_Style_Engine::compile_css($cellStyles, '')),
+      esc_attr($originalClassname),
+      esc_attr($blockAttributes['layout']['justifyContent'] ?: 'center'),
+      esc_attr($parsedBlock['email_attrs']['width'] ?: '100%'),
+    );
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Text.php
@@ -50,7 +50,6 @@ class Text extends AbstractBlockRenderer {
             border="0"
             cellpadding="0"
             cellspacing="0"
-            style="min-width: 100%%;"
             width="100%%"
           >
             <tr>

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes;
 
 use MailPoet\Config\Env;
+use WP_Style_Engine;
 
 abstract class AbstractBlock {
   protected $namespace = 'mailpoet';
@@ -90,6 +91,24 @@ abstract class AbstractBlock {
         'path' => Env::$assetsUrl . '/dist/js/email-editor-blocks/style-' . $this->blockName . '-block.css',
     ];
     return $key ? $style[$key] : $style;
+  }
+
+  protected function addSpacer($content, $emailAttrs): string {
+    $gapStyle = WP_Style_Engine::compile_css(array_intersect_key($emailAttrs, array_flip(['margin-top'])), '');
+    $paddingStyle = WP_Style_Engine::compile_css(array_intersect_key($emailAttrs, array_flip(['padding-left', 'padding-right'])), '');
+
+    if (!$gapStyle && !$paddingStyle) {
+      return $content;
+    }
+
+    return sprintf(
+      '<!--[if mso | IE]><table align="left" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%%" style="%2$s"><tr><td style="%3$s"><![endif]-->
+      <div class="email-block-layout" style="%2$s %3$s">%1$s</div>
+      <!--[if mso | IE]></td></tr></table><![endif]-->',
+      $content,
+      esc_attr($gapStyle),
+      esc_attr($paddingStyle)
+    );
   }
 
   abstract public function render($attributes, $content, $block);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/PoweredByMailpoet.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/PoweredByMailpoet.php
@@ -26,10 +26,10 @@ class PoweredByMailpoet extends AbstractBlock {
     $logo = $attributes['logo'] ?? 'default';
     $logoUrl = $this->cdnAssetUrl->generateCdnUrl('email-editor/logo-' . $logo . '.png');
 
-    return sprintf(
+    return $this->addSpacer(sprintf(
       '<div class="%1$s" style="text-align:center">%2$s</div>',
       esc_attr('wp-block-' . $this->blockName),
       '<img src="' . esc_attr($logoUrl) . '" alt="Powered by MailPoet" width="100px" />'
-    );
+    ), $block->parsed_block['email_attrs'] ?? []); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integration/Core/Renderer/Blocks/HeadingTest.php
@@ -46,7 +46,7 @@ class HeadingTest extends \MailPoetTest {
   public function testItRendersContent(): void {
     $rendered = $this->headingRenderer->render('<h1>This is Heading 1</h1>', $this->parsedHeading, $this->settingsController);
     verify($rendered)->stringContainsString('This is Heading 1');
-    verify($rendered)->stringContainsString('width: 100%;');
+    verify($rendered)->stringContainsString('width:100%;');
     verify($rendered)->stringContainsString('font-size:24px;');
     verify($rendered)->stringNotContainsString('width:640px;');
   }

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -9,6 +9,12 @@ class SettingsControllerTest extends \MailPoetUnitTest {
   public function testItGetsCorrectLayoutWidthWithoutPadding(): void {
     $themeJsonMock = $this->createMock(\WP_Theme_JSON::class);
     $themeJsonMock->method('get_data')->willReturn([
+      'settings' => [
+        "layout" => [
+          "contentSize" => "660px",
+          "wideSize" => "660px",
+        ],
+      ],
       'styles' => [
         'spacing' => [
           'padding' => [

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -9,12 +9,6 @@ class SettingsControllerTest extends \MailPoetUnitTest {
   public function testItGetsCorrectLayoutWidthWithoutPadding(): void {
     $themeJsonMock = $this->createMock(\WP_Theme_JSON::class);
     $themeJsonMock->method('get_data')->willReturn([
-      'settings' => [
-        "layout" => [
-          "contentSize" => "660px",
-          "wideSize" => "660px",
-        ],
-      ],
       'styles' => [
         'spacing' => [
           'padding' => [
@@ -22,6 +16,12 @@ class SettingsControllerTest extends \MailPoetUnitTest {
             'right' => '10px',
           ],
         ],
+      ],
+    ]);
+    $themeJsonMock->method('get_settings')->willReturn([
+      "layout" => [
+        "contentSize" => "660px",
+        "wideSize" => "660px",
       ],
     ]);
     $themeController = $this->createMock(ThemeController::class);

--- a/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Engine/SettingsControllerTest.php
@@ -18,14 +18,14 @@ class SettingsControllerTest extends \MailPoetUnitTest {
         ],
       ],
     ]);
-    $themeJsonMock->method('get_settings')->willReturn([
+    $themeController = $this->createMock(ThemeController::class);
+    $themeController->method('getTheme')->willReturn($themeJsonMock);
+    $themeController->method('getSettings')->willReturn([
       "layout" => [
         "contentSize" => "660px",
         "wideSize" => "660px",
       ],
     ]);
-    $themeController = $this->createMock(ThemeController::class);
-    $themeController->method('getTheme')->willReturn($themeJsonMock);
     $settingsController = new SettingsController($themeController);
     $layoutWidth = $settingsController->getLayoutWidthWithoutPadding();
     // default width is 660px and if we subtract padding from left and right we must get the correct value

--- a/mailpoet/tests/unit/_stubs.php
+++ b/mailpoet/tests/unit/_stubs.php
@@ -7,5 +7,8 @@ if (!class_exists(\WP_Theme_JSON::class)) {
     public function get_data() {
       return [];
     }
+    public function get_settings() {
+      return [];
+    }
   }
 }


### PR DESCRIPTION
## Description

Adds group to the list of supported blocks. Disables support for group variations because flexbox causes issues in email clients.

While doing this I adjusted how contentSize is applied so groups inherit it correcrly, and I standardised some block class naming.

@costasovo could use your feedback on this one once tests are passing.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6057](https://mailpoet.atlassian.net/browse/MAILPOET-6057)
[MAILPOET-6052](https://mailpoet.atlassian.net/browse/MAILPOET-6052)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6057]: https://mailpoet.atlassian.net/browse/MAILPOET-6057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAILPOET-6052]: https://mailpoet.atlassian.net/browse/MAILPOET-6052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ