### PR TITLE
Email Editor: Add missing textdomains [MAILPOET-6061]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -90,7 +90,9 @@ export function Header() {
     event.preventDefault();
   };
 
-  const shortLabelInserter = !isInserterSidebarOpened ? __('Add') : __('Close');
+  const shortLabelInserter = !isInserterSidebarOpened
+    ? __('Add', 'mailpoet')
+    : __('Close', 'mailpoet');
 
   return (
     <div className="edit-post-header">
@@ -124,7 +126,7 @@ export function Header() {
               onClick={undoAction}
               disabled={!hasUndo}
               icon={undo}
-              label={__('Undo')}
+              label={__('Undo', 'mailpoet')}
               showTooltip
             />
             <ToolbarItem
@@ -136,7 +138,7 @@ export function Header() {
               onClick={redoAction}
               disabled={!hasRedo}
               icon={redo}
-              label={__('Redo')}
+              label={__('Redo', 'mailpoet')}
               showTooltip
             />
             <ToolbarItem
@@ -173,8 +175,8 @@ export function Header() {
                 }}
                 label={
                   isBlockToolsCollapsed
-                    ? __('Show block tools')
-                    : __('Hide block tools')
+                    ? __('Show block tools', 'mailpoet')
+                    : __('Hide block tools', 'mailpoet')
                 }
               />
             </>

--- a/mailpoet/assets/js/src/email-editor/engine/components/preview/preview-dropdown.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/preview/preview-dropdown.tsx
@@ -55,14 +55,14 @@ export function PreviewDropdown() {
                 onClick={() => changeDeviceType('Desktop')}
                 icon={previewDeviceType === 'Desktop' && check}
               >
-                {__('Desktop')}
+                {__('Desktop', 'mailpoet')}
               </MenuItem>
               <MenuItem
                 className="block-editor-post-preview__button-resize"
                 onClick={() => changeDeviceType('Mobile')}
                 icon={previewDeviceType === 'Mobile' && check}
               >
-                {__('Mobile')}
+                {__('Mobile', 'mailpoet')}
               </MenuItem>
             </MenuGroup>
             <MenuGroup>
@@ -85,7 +85,7 @@ export function PreviewDropdown() {
                       openInNewTab(newsletterPreviewUrl);
                     }}
                   >
-                    {__('Preview in new tab')}
+                    {__('Preview in new tab', 'mailpoet')}
                     <Icon icon={external} />
                   </Button>
                 </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
@@ -65,7 +65,7 @@ export function Header() {
           data-automation-id="mailpoet_block_settings_tab"
           type="button"
         >
-          {__('Block')}
+          {__('Block', 'mailpoet')}
         </button>
       </li>
     </ul>

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/template-info.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/template-info.tsx
@@ -19,7 +19,7 @@ export function TemplateInfo() {
           </span>
           <div className="mailpoet-email-type-info__content">
             {/* @ts-expect-error Todo template type is not defined */}
-            <h2>{template?.title || __('Template')}</h2>
+            <h2>{template?.title || __('Template', 'mailpoet')}</h2>
             {/* @ts-expect-error Todo template type is not defined */}
             <span>{template?.description || ''}</span>
           </div>

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/templates-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/templates-panel.tsx
@@ -85,7 +85,7 @@ export function TemplatesPanel() {
       void createSuccessNotice(
         sprintf(
           /* translators: The template/part's name. */
-          __('"%s" reset.'),
+          __('"%s" reset.', 'mailpoet'),
           // @ts-expect-error template type is not defined
           decodeEntities(template.title as string),
         ),
@@ -96,7 +96,7 @@ export function TemplatesPanel() {
       );
     } catch (error) {
       void createErrorNotice(
-        __('An error occurred while reverting the template.'),
+        __('An error occurred while reverting the template.', 'mailpoet'),
         {
           type: 'snackbar',
         },

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/panels/dimensions-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/panels/dimensions-panel.tsx
@@ -32,7 +32,7 @@ export function DimensionsPanel() {
         hasValue={() =>
           !isEqual(styles.spacing.padding, defaultStyles.spacing.padding)
         }
-        label={__('Padding')}
+        label={__('Padding', 'mailpoet')}
         onDeselect={() =>
           updateStyleProp(['spacing', 'padding'], defaultStyles.spacing.padding)
         }
@@ -44,14 +44,14 @@ export function DimensionsPanel() {
           onChange={(value) => {
             updateStyleProp(['spacing', 'padding'], value);
           }}
-          label={__('Padding')}
+          label={__('Padding', 'mailpoet')}
           sides={['horizontal', 'vertical', 'top', 'left', 'right', 'bottom']}
           units={units}
         />
       </ToolsPanelItem>
       <ToolsPanelItem
         isShownByDefault
-        label={__('Block spacing')}
+        label={__('Block spacing', 'mailpoet')}
         hasValue={() =>
           styles.spacing.blockGap !== defaultStyles.spacing.blockGap
         }
@@ -64,7 +64,7 @@ export function DimensionsPanel() {
         className="tools-panel-item-spacing"
       >
         <SpacingSizesControl
-          label={__('Block spacing')}
+          label={__('Block spacing', 'mailpoet')}
           min={0}
           onChange={(value) => {
             updateStyleProp(['spacing', 'blockGap'], value.top);

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/panels/typography-element-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/panels/typography-element-panel.tsx
@@ -144,7 +144,7 @@ export function TypographyElementPanel({
   return (
     <ToolsPanel label={__('Typography', 'mailpoet')} resetAll={resetAll}>
       <ToolsPanelItem
-        label={__('Font family')}
+        label={__('Font family', 'mailpoet')}
         hasValue={hasFontFamily}
         onDeselect={() => setFontFamily(defaultFontFamily)}
         isShownByDefault={defaultControls.fontFamily}
@@ -159,7 +159,7 @@ export function TypographyElementPanel({
       </ToolsPanelItem>
       {showToolFontSize && (
         <ToolsPanelItem
-          label={__('Font size')}
+          label={__('Font size', 'mailpoet')}
           hasValue={hasFontSize}
           onDeselect={() => setFontSize(defaultFontSize)}
           isShownByDefault={defaultControls.fontSize}
@@ -178,7 +178,7 @@ export function TypographyElementPanel({
       )}
       <ToolsPanelItem
         className="single-column"
-        label={__('Appearance')}
+        label={__('Appearance', 'mailpoet')}
         hasValue={hasFontAppearance}
         onDeselect={() => {
           setFontAppearance({
@@ -202,7 +202,7 @@ export function TypographyElementPanel({
       </ToolsPanelItem>
       <ToolsPanelItem
         className="single-column"
-        label={__('Line height')}
+        label={__('Line height', 'mailpoet')}
         hasValue={hasLineHeight}
         onDeselect={() => setLineHeight(defaultLineHeight)}
         isShownByDefault={defaultControls.lineHeight}
@@ -217,7 +217,7 @@ export function TypographyElementPanel({
       </ToolsPanelItem>
       <ToolsPanelItem
         className="single-column"
-        label={__('Letter spacing')}
+        label={__('Letter spacing', 'mailpoet')}
         hasValue={hasLetterSpacing}
         onDeselect={() => setLetterSpacing(defaultLetterSpacing)}
         isShownByDefault={defaultControls.letterSpacing}
@@ -231,7 +231,7 @@ export function TypographyElementPanel({
       </ToolsPanelItem>
       <ToolsPanelItem
         className="single-column"
-        label={__('Text decoration')}
+        label={__('Text decoration', 'mailpoet')}
         hasValue={hasTextDecoration}
         onDeselect={() => setTextDecoration(defaultTextDecoration)}
         isShownByDefault={defaultControls.textDecoration}
@@ -244,7 +244,7 @@ export function TypographyElementPanel({
         />
       </ToolsPanelItem>
       <ToolsPanelItem
-        label={__('Letter case')}
+        label={__('Letter case', 'mailpoet')}
         hasValue={hasTextTransform}
         onDeselect={() => setTextTransform(defaultTextTransform)}
         isShownByDefault={defaultControls.textTransform}

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/panels/typography-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/panels/typography-panel.tsx
@@ -33,7 +33,7 @@ function ElementItem({ element, label }: { element: string; label: string }) {
   const background = elementStyles.color?.background || '#f0f0f0';
   const navigationButtonLabel = sprintf(
     // translators: %s: is a subset of Typography, e.g., 'text' or 'links'.
-    __('Typography %s styles'),
+    __('Typography %s styles', 'mailpoet'),
     label,
   );
 
@@ -58,7 +58,7 @@ function ElementItem({ element, label }: { element: string; label: string }) {
               textTransform: textTransform ?? 'none',
             }}
           >
-            {__('Aa')}
+            Aa
           </FlexItem>
           <FlexItem>{label}</FlexItem>
         </HStack>
@@ -73,13 +73,13 @@ export function TypographyPanel() {
       <CardBody>
         <VStack spacing={3}>
           <Heading level={3} className="edit-site-global-styles-subtitle">
-            {__('Elements')}
+            {__('Elements', 'mailpoet')}
           </Heading>
           <ItemGroup isBordered isSeparated size="small">
-            <ElementItem element="text" label={__('Text')} />
-            <ElementItem element="link" label={__('Links')} />
-            <ElementItem element="heading" label={__('Headings')} />
-            <ElementItem element="button" label={__('Buttons')} />
+            <ElementItem element="text" label={__('Text', 'mailpoet')} />
+            <ElementItem element="link" label={__('Links', 'mailpoet')} />
+            <ElementItem element="heading" label={__('Headings', 'mailpoet')} />
+            <ElementItem element="button" label={__('Buttons', 'mailpoet')} />
           </ItemGroup>
         </VStack>
       </CardBody>

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/screen-header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/screen-header.tsx
@@ -29,7 +29,7 @@ export function ScreenHeader({ title, description, onBack }: Props) {
               style={{ minWidth: 24, padding: 0 }}
               icon={chevronLeft}
               size="small"
-              aria-label={__('Navigate to the previous view')}
+              aria-label={__('Navigate to the previous view', 'mailpoet')}
               onClick={onBack}
             />
             <Spacer>

--- a/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/screen-typography-element.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/styles-sidebar/screens/screen-typography-element.tsx
@@ -19,7 +19,7 @@ export function ScreenTypographyElement({
   const [headingLevel, setHeadingLevel] = useState('heading');
   const panels = {
     text: {
-      title: __('Text'),
+      title: __('Text', 'mailpoet'),
       description: __(
         'Manage the fonts and typography used on text.',
         'mailpoet',
@@ -27,7 +27,7 @@ export function ScreenTypographyElement({
       defaultControls: DEFAULT_CONTROLS,
     },
     link: {
-      title: __('Links'),
+      title: __('Links', 'mailpoet'),
       description: __(
         'Manage the fonts and typography used on links.',
         'mailpoet',
@@ -38,7 +38,7 @@ export function ScreenTypographyElement({
       },
     },
     heading: {
-      title: __('Headings'),
+      title: __('Headings', 'mailpoet'),
       description: __(
         'Manage the fonts and typography used on headings.',
         'mailpoet',
@@ -49,7 +49,7 @@ export function ScreenTypographyElement({
       },
     },
     button: {
-      title: __('Buttons'),
+      title: __('Buttons', 'mailpoet'),
       description: __(
         'Manage the fonts and typography used on buttons.',
         'mailpoet',
@@ -69,7 +69,7 @@ export function ScreenTypographyElement({
       {element === 'heading' && (
         <Spacer marginX={4} marginBottom="1em">
           <ToggleGroupControl
-            label={__('Select heading level')}
+            label={__('Select heading level', 'mailpoet')}
             hideLabelFromVision
             value={headingLevel}
             onChange={(value) => setHeadingLevel(value.toString())}
@@ -79,12 +79,24 @@ export function ScreenTypographyElement({
           >
             <ToggleGroupControlOption
               value="heading"
-              label={_x('All', 'heading levels')}
+              label={_x('All', 'heading levels', 'mailpoet')}
             />
-            <ToggleGroupControlOption value="h1" label={__('H1')} />
-            <ToggleGroupControlOption value="h2" label={__('H2')} />
-            <ToggleGroupControlOption value="h3" label={__('H3')} />
-            <ToggleGroupControlOption value="h4" label={__('H4')} />
+            <ToggleGroupControlOption
+              value="h1"
+              label={_x('H1', 'Heading Level', 'mailpoet')}
+            />
+            <ToggleGroupControlOption
+              value="h2"
+              label={_x('H2', 'Heading Level', 'mailpoet')}
+            />
+            <ToggleGroupControlOption
+              value="h3"
+              label={_x('H3', 'Heading Level', 'mailpoet')}
+            />
+            <ToggleGroupControlOption
+              value="h4"
+              label={_x('H4', 'Heading Level', 'mailpoet')}
+            />
           </ToggleGroupControl>
         </Spacer>
       )}

--- a/mailpoet/assets/js/src/email-editor/engine/layouts/flex-email.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/layouts/flex-email.tsx
@@ -43,17 +43,17 @@ function JustificationControls({
     {
       value: 'left',
       icon: justifyLeft,
-      label: __('Justify items left'),
+      label: __('Justify items left', 'mailpoet'),
     },
     {
       value: 'center',
       icon: justifyCenter,
-      label: __('Justify items center'),
+      label: __('Justify items center', 'mailpoet'),
     },
     {
       value: 'right',
       icon: justifyRight,
-      label: __('Justify items right'),
+      label: __('Justify items right', 'mailpoet'),
     },
   ];
 
@@ -74,7 +74,7 @@ function JustificationControls({
   return (
     <ToggleGroupControl
       __nextHasNoMarginBottom
-      label={__('Justification')}
+      label={__('Justification', 'mailpoet')}
       value={justificationValue}
       onChange={onChange}
       className="block-editor-hooks__flex-layout-justification-controls"
@@ -118,7 +118,7 @@ function LayoutControls({ setAttributes, attributes, name: blockName }) {
   return (
     <>
       <InspectorControls>
-        <PanelBody title={__('Layout')}>
+        <PanelBody title={__('Layout', 'mailpoet')}>
           <Flex>
             <FlexItem>
               <JustificationControls


### PR DESCRIPTION
## Description

Adds missing textdomains (uses MailPoet instead of default). I searched only within EmailEditor code.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6061](https://mailpoet.atlassian.net/browse/MAILPOET-6061)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6061]: https://mailpoet.atlassian.net/browse/MAILPOET-6061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ