### PR TITLE
Email Editor: Add custom placeholder to post content during registration [MAILPOET-6051]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/blocks/core/post-content.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/core/post-content.tsx
@@ -1,0 +1,58 @@
+import { addFilter } from '@wordpress/hooks';
+import { Block } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+function Placeholder({ layoutClassNames }) {
+  const blockProps = useBlockProps({ className: layoutClassNames });
+  return (
+    <div {...blockProps}>
+      <p>{__('This is the Content block.', 'mailpoet')}</p>
+      <p>
+        {__(
+          'It will display all the blocks in the email content, which might be only simple text paragraphs. You can enrich your message with images, incorporate data through tables, explore different layout designs with columns, or use any other block type.',
+          'mailpoet',
+        )}
+      </p>
+    </div>
+  );
+}
+
+// Curried function to add a custom placeholder to the post content block, or just use the original Edit component.
+function PostContentEdit(OriginalEditComponent) {
+  return function Edit({
+    context,
+    __unstableLayoutClassNames: layoutClassNames,
+  }) {
+    const { postId: contextPostId, postType: contextPostType } = context;
+    const hasContent = contextPostId && contextPostType;
+
+    if (hasContent) {
+      return (
+        <OriginalEditComponent
+          {...{ context, __unstableLayoutClassNames: layoutClassNames }}
+        />
+      );
+    }
+
+    return <Placeholder layoutClassNames={layoutClassNames} />;
+  };
+}
+
+function enhancePostContentBlock() {
+  addFilter(
+    'blocks.registerBlockType',
+    'mailpoet-email-editor/change-post-content',
+    (settings: Block, name) => {
+      if (name === 'core/post-content') {
+        return {
+          ...settings,
+          edit: PostContentEdit(settings.edit),
+        };
+      }
+      return settings;
+    },
+  );
+}
+
+export { enhancePostContentBlock };

--- a/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/blocks/index.ts
@@ -5,6 +5,7 @@ import {
   deactivateStackOnMobile,
   enhanceColumnsBlock,
 } from './core/columns';
+import { enhancePostContentBlock } from './core/post-content';
 import { disableImageFilter, hideExpandOnClick } from './core/image';
 import { disableCertainRichTextFormats } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
@@ -21,6 +22,7 @@ export function initBlocks() {
   enhanceButtonsBlock();
   enhanceColumnBlock();
   enhanceColumnsBlock();
+  enhancePostContentBlock();
   alterSupportConfiguration();
   registerCoreBlocks();
 }


### PR DESCRIPTION
## Description

Replaces the Placeholder component in `core/post-content` during registration.

![Screenshot 2024-05-13 at 16 33 58](https://github.com/mailpoet/mailpoet/assets/90977/10a6159f-c3f0-466b-8f2c-b27e17bb4286)

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6051](https://mailpoet.atlassian.net/browse/MAILPOET-6051)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6051]: https://mailpoet.atlassian.net/browse/MAILPOET-6051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ