### PR TITLE
Invalid API endpoint exception improvement - MAILPOET-6022

### DIFF
--- a/mailpoet/assets/js/src/common/subscribers-cache-message.tsx
+++ b/mailpoet/assets/js/src/common/subscribers-cache-message.tsx
@@ -32,8 +32,17 @@ export function SubscribersCacheMessage({
         window.location.reload();
       })
       .fail((response: ErrorResponse) => {
-        setErrors(response.errors.map((error) => error.message));
         setLoading(false);
+        if (!(response && response.errors && response.errors.length)) return;
+
+        if (JSON.stringify(response.errors).includes('reinstall_plugin')) {
+          MailPoet.Notice.showApiErrorNotice(response, {
+            static: true,
+            scroll: true,
+          });
+        } else {
+          setErrors(response.errors.map((error) => error.message));
+        }
       });
   };
 

--- a/mailpoet/assets/js/src/context/use-notices.jsx
+++ b/mailpoet/assets/js/src/context/use-notices.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 export const useNotices = () => {
   const [state, setState] = useState({
@@ -67,15 +67,12 @@ export const useNotices = () => {
             <p key={err.message}>
               {err.error === 'reinstall_plugin'
                 ? createInterpolateElement(
-                    sprintf(
-                      __(
-                        'The plugin has encountered an unexpected error. Please reload the page. If that does not help, re-install the MailPoet Plugin. See: %s for more information',
-                        'mailpoet',
-                      ),
-                      '<a> https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp </a>',
+                    __(
+                      'The plugin has encountered an unexpected error. Please reload the page. If that does not help, <link>re-install the MailPoet Plugin.</link>',
+                      'mailpoet',
                     ),
                     {
-                      a: (
+                      link: (
                         <a
                           aria-label={err.error}
                           href="https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp"

--- a/mailpoet/assets/js/src/context/use-notices.jsx
+++ b/mailpoet/assets/js/src/context/use-notices.jsx
@@ -75,13 +75,15 @@ export const useNotices = () => {
                       '<a> https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp </a>',
                     ),
                     {
-                      // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
                       a: (
                         <a
+                          aria-label={err.error}
                           href="https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp"
                           target="_blank"
                           rel="noopener noreferrer"
-                        />
+                        >
+                          &nbsp;
+                        </a>
                       ),
                     },
                   )

--- a/mailpoet/assets/js/src/experimental-features/experimental-features.jsx
+++ b/mailpoet/assets/js/src/experimental-features/experimental-features.jsx
@@ -24,7 +24,11 @@ function ExperimentalFeatures() {
         setFlags(flagsMap);
       })
       .fail((response) => {
-        if (response.errors.length > 0) {
+        if (!(response && response.errors && response.errors.length)) return;
+
+        if (JSON.stringify(response.errors).includes('reinstall_plugin')) {
+          MailPoet.Notice.showApiErrorNotice(response);
+        } else {
           showError(
             <>
               {response.errors.map((error) => (
@@ -59,7 +63,11 @@ function ExperimentalFeatures() {
         contextValue.notices.success(<p>{message}</p>);
       })
       .fail((response) => {
-        if (response.errors.length > 0) {
+        if (!(response && response.errors && response.errors.length)) return;
+
+        if (JSON.stringify(response.errors).includes('reinstall_plugin')) {
+          MailPoet.Notice.showApiErrorNotice(response);
+        } else {
           showError(
             response.errors.map((error) => (
               <p key={error.message}>{error.message}</p>

--- a/mailpoet/assets/js/src/form/form.jsx
+++ b/mailpoet/assets/js/src/form/form.jsx
@@ -156,7 +156,11 @@ class FormComponent extends Component {
         }
       })
       .fail((response) => {
-        if (response.errors.length > 0) {
+        if (!(response && response.errors && response.errors.length)) return;
+
+        if (JSON.stringify(response.errors).includes('reinstall_plugin')) {
+          MailPoet.Notice.showApiErrorNotice(response);
+        } else {
           this.setState({ errors: response.errors });
         }
       });

--- a/mailpoet/assets/js/src/forms/list.jsx
+++ b/mailpoet/assets/js/src/forms/list.jsx
@@ -165,10 +165,7 @@ const itemActions = [
         })
         .fail((response) => {
           if (response.errors.length > 0) {
-            MailPoet.Notice.error(
-              response.errors.map((error) => error.message),
-              { scroll: true },
-            );
+            MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           }
         });
     },

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -197,7 +197,7 @@ class ListingComponent extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.apiError(response, { scroll: true });
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         }
       });
   };

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -16,6 +16,11 @@ import { withRouter } from 'react-router-dom';
 import { GlobalContext } from 'context';
 import { withBoundary } from '../common';
 
+const getErrorObject = (errorResponse) =>
+  JSON.stringify(errorResponse.errors).includes('reinstall_plugin')
+    ? { static: true }
+    : {};
+
 class ListingComponent extends Component {
   constructor(props) {
     super(props);
@@ -201,7 +206,7 @@ class ListingComponent extends Component {
             response.errors.map((error) => (
               <p key={error.message}>{error.message}</p>
             )),
-            { scroll: true },
+            { scroll: true, ...getErrorObject(response) },
           );
         }
       });
@@ -281,7 +286,7 @@ class ListingComponent extends Component {
           response.errors.map((error) => (
             <p key={error.message}>{error.message}</p>
           )),
-          { scroll: true },
+          { scroll: true, ...getErrorObject(response) },
         );
       });
   };
@@ -314,7 +319,7 @@ class ListingComponent extends Component {
           response.errors.map((error) => (
             <p key={error.message}>{error.message}</p>
           )),
-          { scroll: true },
+          { scroll: true, ...getErrorObject(response) },
         );
         this.setState({ loading: false });
       });
@@ -348,7 +353,7 @@ class ListingComponent extends Component {
           response.errors.map((error) => (
             <p key={error.message}>{error.message}</p>
           )),
-          { scroll: true },
+          { scroll: true, ...getErrorObject(response) },
         );
       });
   };
@@ -373,7 +378,7 @@ class ListingComponent extends Component {
           response.errors.map((error) => (
             <p key={error.message}>{error.message}</p>
           )),
-          { scroll: true },
+          { scroll: true, ...getErrorObject(response) },
         );
       });
 
@@ -423,7 +428,7 @@ class ListingComponent extends Component {
             response.errors.map((error) => (
               <p key={error.message}>{error.message}</p>
             )),
-            { scroll: true },
+            { scroll: true, ...getErrorObject(response) },
           );
         }
       });

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -16,11 +16,6 @@ import { withRouter } from 'react-router-dom';
 import { GlobalContext } from 'context';
 import { withBoundary } from '../common';
 
-const getErrorObject = (errorResponse) =>
-  JSON.stringify(errorResponse.errors).includes('reinstall_plugin')
-    ? { static: true }
-    : {};
-
 class ListingComponent extends Component {
   constructor(props) {
     super(props);
@@ -202,12 +197,7 @@ class ListingComponent extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true, ...getErrorObject(response) },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       });
   };
@@ -282,12 +272,7 @@ class ListingComponent extends Component {
         this.getItems();
       })
       .fail((response) => {
-        this.context.notices.error(
-          response.errors.map((error) => (
-            <p key={error.message}>{error.message}</p>
-          )),
-          { scroll: true, ...getErrorObject(response) },
-        );
+        this.context.notices.apiError(response, { scroll: true });
       });
   };
 
@@ -315,12 +300,7 @@ class ListingComponent extends Component {
         this.getItems();
       })
       .fail((response) => {
-        this.context.notices.error(
-          response.errors.map((error) => (
-            <p key={error.message}>{error.message}</p>
-          )),
-          { scroll: true, ...getErrorObject(response) },
-        );
+        this.context.notices.apiError(response, { scroll: true });
         this.setState({ loading: false });
       });
   };
@@ -349,12 +329,7 @@ class ListingComponent extends Component {
         this.getItems();
       })
       .fail((response) => {
-        this.context.notices.error(
-          response.errors.map((error) => (
-            <p key={error.message}>{error.message}</p>
-          )),
-          { scroll: true, ...getErrorObject(response) },
-        );
+        this.context.notices.apiError(response, { scroll: true });
       });
   };
 
@@ -374,12 +349,7 @@ class ListingComponent extends Component {
         this.handleGroup('all');
       })
       .fail((response) => {
-        this.context.notices.error(
-          response.errors.map((error) => (
-            <p key={error.message}>{error.message}</p>
-          )),
-          { scroll: true, ...getErrorObject(response) },
-        );
+        this.context.notices.apiError(response, { scroll: true });
       });
 
   handleBulkAction = (selectedIds, params) => {
@@ -424,12 +394,7 @@ class ListingComponent extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true, ...getErrorObject(response) },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       });
   };

--- a/mailpoet/assets/js/src/newsletters/automatic-emails/events-conditions.jsx
+++ b/mailpoet/assets/js/src/newsletters/automatic-emails/events-conditions.jsx
@@ -144,12 +144,7 @@ class EventsConditions extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       });
   }

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -96,10 +96,7 @@ const duplicateNewsletter = (
     })
     .fail((response) => {
       if (response.errors.length > 0) {
-        MailPoet.Notice.error(
-          response.errors.map((error) => error.message),
-          { scroll: true },
-        );
+        MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
       }
     })
     .always(() => {
@@ -127,10 +124,7 @@ const trashNewsletter = (
     })
     .fail((response) => {
       if (response.errors.length > 0) {
-        MailPoet.Notice.error(
-          response.errors.map((error) => error.message),
-          { scroll: true },
-        );
+        MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
       }
     })
     .always(() => {

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -65,10 +65,7 @@ function CampaignStatsPageComponent({ match, history, location }: Props) {
           });
         })
         .fail((response: ErrorResponse) => {
-          MailPoet.Notice.error(
-            response.errors.map((error) => error.message),
-            { scroll: true },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           setState({
             loading: false,
           });

--- a/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
+++ b/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
@@ -37,12 +37,7 @@ export function EditorSelectModal({
         setIsLoading(false);
         onClose();
         if (response.errors.length > 0) {
-          notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          notices.apiError(response, { scroll: true });
         }
       });
   }, [notices, onClose]);

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -158,10 +158,7 @@ const newsletterActions = [
         })
         .fail((response) => {
           if (response.errors.length > 0) {
-            MailPoet.Notice.error(
-              response.errors.map((error) => error.message),
-              { scroll: true },
-            );
+            MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           }
         });
     },

--- a/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
@@ -148,10 +148,7 @@ let newsletterActions = [
         })
         .fail((response) => {
           if (response.errors.length > 0) {
-            MailPoet.Notice.error(
-              response.errors.map((error) => error.message),
-              { scroll: true },
-            );
+            MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           }
         }),
   },

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -184,10 +184,7 @@ let newsletterActions = [
         })
         .fail((response) => {
           if (response.errors.length > 0) {
-            MailPoet.Notice.error(
-              response.errors.map((error) => error.message),
-              { scroll: true },
-            );
+            MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           }
         });
     },

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -661,15 +661,7 @@ class NewsletterSendComponent extends Component<
 
   showError = (response) => {
     if (response.errors.length > 0) {
-      this.context.notices.error(
-        response.errors.map((error) => (
-          <p key={error.message}>{error.message}</p>
-        )),
-        {
-          scroll: true,
-          timeout: false,
-        },
-      );
+      this.context.notices.apiError(response, { scroll: true, timeout: false });
     }
   };
 

--- a/mailpoet/assets/js/src/newsletters/templates.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates.jsx
@@ -108,12 +108,7 @@ class NewsletterTemplates extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       })
       .always(() => {
@@ -214,12 +209,7 @@ class NewsletterTemplates extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       })
       .always(() => {

--- a/mailpoet/assets/js/src/newsletters/templates/import-template.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates/import-template.jsx
@@ -84,12 +84,7 @@ class ImportTemplate extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
         afterImport(false);
       });

--- a/mailpoet/assets/js/src/newsletters/templates/template-box.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates/template-box.jsx
@@ -39,12 +39,7 @@ class TemplateBox extends Component {
         })
         .fail((response) => {
           if (response.errors.length > 0) {
-            this.context.notices.error(
-              response.errors.map((error) => (
-                <p key={error.message}>{error.message}</p>
-              )),
-              { scroll: true },
-            );
+            this.context.notices.apiError(response, { scroll: true });
           }
           afterDelete(false);
         });
@@ -89,12 +84,7 @@ class TemplateBox extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
         afterSelect(false);
       });

--- a/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/notification/notification.jsx
@@ -70,12 +70,7 @@ class NewsletterNotificationComponent extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       });
   };

--- a/mailpoet/assets/js/src/newsletters/types/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/standard.jsx
@@ -36,12 +36,7 @@ class NewsletterStandardComponent extends Component {
       })
       .fail((response) => {
         if (response.errors.length > 0) {
-          this.context.notices.error(
-            response.errors.map((error) => (
-              <p key={error.message}>{error.message}</p>
-            )),
-            { scroll: true },
-          );
+          this.context.notices.apiError(response, { scroll: true });
         }
       });
   }

--- a/mailpoet/assets/js/src/notice.js
+++ b/mailpoet/assets/js/src/notice.js
@@ -245,9 +245,13 @@ export const MailPoetNotice = {
     );
   },
   showApiErrorNotice: function showApiErrorNotice(response, options) {
-    var errorMessage = I18n.t('ajaxFailedErrorMessage');
+    let errorMessage = I18n.t('ajaxFailedErrorMessage');
+    let optionsObj = options;
     if (response && response.errors && response.errors.length > 0) {
       errorMessage = response.errors.map((error) => error.message);
+      optionsObj = JSON.stringify(response.errors).includes('reinstall_plugin')
+        ? { ...options, static: true, scroll: true }
+        : options;
     }
     this.show(
       jQuery.extend(
@@ -256,7 +260,7 @@ export const MailPoetNotice = {
           type: 'error',
           message: errorMessage,
         },
-        options,
+        optionsObj,
       ),
     );
   },

--- a/mailpoet/assets/js/src/notices/mailer-error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer-error.tsx
@@ -19,10 +19,7 @@ const resumeMailerSending = () =>
     })
     .fail((response) => {
       if (response.errors.length > 0) {
-        MailPoet.Notice.error(
-          response.errors.map((error) => error.message),
-          { scroll: true },
-        );
+        MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
       }
     });
 

--- a/mailpoet/assets/js/src/segments/dynamic/list/action-confirm.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list/action-confirm.tsx
@@ -36,7 +36,9 @@ async function bulkAction(
     });
 
     if (response.meta.errors && response.meta.errors.length > 0) {
-      MailPoet.Notice.showApiErrorNotice(response.meta.errors);
+      response.meta.errors.forEach(
+        (error: string) => void dispatch(noticesStore).createErrorNotice(error),
+      );
     }
 
     const count = response.meta.count;

--- a/mailpoet/assets/js/src/segments/dynamic/list/action-confirm.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list/action-confirm.tsx
@@ -36,9 +36,7 @@ async function bulkAction(
     });
 
     if (response.meta.errors && response.meta.errors.length > 0) {
-      response.meta.errors.forEach(
-        (error: string) => void dispatch(noticesStore).createErrorNotice(error),
-      );
+      MailPoet.Notice.showApiErrorNotice(response.meta.errors);
     }
 
     const count = response.meta.count;
@@ -86,11 +84,7 @@ async function bulkAction(
     if (isErrorResponse(errorResponse)) {
       let errorMessage = '';
       if (errorResponse.errors) {
-        errorResponse.errors.forEach(
-          (error) =>
-            void dispatch(noticesStore).createErrorNotice(error.message),
-          { explicitDismiss: true },
-        );
+        MailPoet.Notice.showApiErrorNotice(errorResponse);
       } else {
         switch (action) {
           case 'trash':

--- a/mailpoet/assets/js/src/segments/dynamic/list/get-row.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list/get-row.tsx
@@ -29,9 +29,7 @@ async function duplicateDynamicSegment(segment: DynamicSegment) {
     void dispatch(storeName).loadDynamicSegments();
   } catch (errorResponse: unknown) {
     if (isErrorResponse(errorResponse)) {
-      errorResponse.errors.forEach((e: { error: string; message: string }) => {
-        void dispatch(noticesStore).createErrorNotice(e.message);
-      });
+      MailPoet.Notice.showApiErrorNotice(errorResponse);
     }
   }
 }

--- a/mailpoet/assets/js/src/segments/dynamic/store/actions.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/actions.ts
@@ -1,6 +1,5 @@
 import { ChangeEvent } from 'react';
 import { select, dispatch } from '@wordpress/data';
-import { store as noticesStore } from '@wordpress/notices';
 import { MailPoet } from 'mailpoet';
 
 import * as ROUTES from '../../routes';
@@ -269,8 +268,7 @@ export async function loadDynamicSegments(query?: Query) {
       return { type: 'NOOP' };
     }
     if (isErrorResponse(res)) {
-      const errors = res.errors.map((error) => error.message).join(', ');
-      void dispatch(noticesStore).createErrorNotice(errors);
+      MailPoet.Notice.showApiErrorNotice(res);
     }
   }
 

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -172,10 +172,7 @@ const itemActions = [
           refresh();
         })
         .fail((response) => {
-          MailPoet.Notice.error(
-            response.errors.map((error) => error.message),
-            { scroll: true },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         }),
     display: function display(segment: Segment) {
       return !isSpecialSegment(segment);
@@ -229,10 +226,7 @@ const itemActions = [
         .fail((response) => {
           MailPoet.Modal.loading(false);
           if (response.errors.length > 0) {
-            MailPoet.Notice.error(
-              response.errors.map((error) => error.message),
-              { scroll: true },
-            );
+            MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           }
         });
     },

--- a/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
+++ b/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
@@ -51,10 +51,7 @@ const resumeMailerSending = () => {
     })
     .fail((response: ErrorResponse) => {
       if (response.errors.length > 0) {
-        MailPoet.Notice.error(
-          response.errors.map((error) => error.message),
-          { scroll: true },
-        );
+        MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
       }
     });
 };

--- a/mailpoet/assets/js/src/subscribers/import-export/export.ts
+++ b/mailpoet/assets/js/src/subscribers/import-export/export.ts
@@ -192,10 +192,7 @@ jQuery(document).ready(() => {
       })
       .fail((response: ErrorResponse) => {
         if (response.errors.length > 0) {
-          MailPoet.Notice.error(
-            response.errors.map((error) => error.message),
-            { scroll: true },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         }
       });
   });

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.jsx
@@ -37,10 +37,9 @@ export const createNewSegment = (onCreateSegment) => {
       .fail((response) => {
         if (response.errors.length > 0) {
           MailPoet.Notice.hide();
-          MailPoet.Notice.error(
-            response.errors.map((error) => error.message),
-            { positionAfter: '#new_segment_name' },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, {
+            positionAfter: '#new_segment_name',
+          });
         }
       });
   });

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/do-import.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/do-import.jsx
@@ -83,10 +83,7 @@ export const doImport = (
         .fail((response) => {
           MailPoet.Modal.progress(false);
           if (response.errors.length > 0) {
-            MailPoet.Notice.error(
-              response.errors.map((error) => error.message),
-              { scroll: true },
-            );
+            MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
           }
         });
       batchNumber += 1;

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/generate-column-selection.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/generate-column-selection.jsx
@@ -64,10 +64,9 @@ export const generateColumnSelection = () => {
               })
               .fail((response) => {
                 if (response.errors.length > 0) {
-                  MailPoet.Notice.error(
-                    response.errors.map((error) => error.message),
-                    { positionAfter: '#field_name' },
-                  );
+                  MailPoet.Notice.showApiErrorNotice(response, {
+                    positionAfter: '#field_name',
+                  });
                 }
               });
             return false;

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-method-selection/method-mailchimp.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-method-selection/method-mailchimp.jsx
@@ -35,10 +35,7 @@ function MethodMailChimp({ onFinish, onPrevious }) {
       .done((response) => setMailChimpLoadedLists(response.data))
       .fail((response) => {
         if (response.errors.length > 0) {
-          MailPoet.Notice.error(
-            response.errors.map((error) => error.message),
-            { scroll: true },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         }
       });
   };
@@ -60,10 +57,7 @@ function MethodMailChimp({ onFinish, onPrevious }) {
       .done((response) => onFinish(response.data))
       .fail((response) => {
         if (response.errors.length > 0) {
-          MailPoet.Notice.error(
-            response.errors.map((error) => error.message),
-            { scroll: true },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         }
       });
   };

--- a/mailpoet/assets/js/src/subscribers/stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useLocation, useRouteMatch } from 'react-router-dom';
 import { MailPoet } from 'mailpoet';
 import { Loading } from 'common/loading';
-import { useGlobalContextValue } from 'context';
 
 import { StatsHeading } from './stats/heading';
 import { Summary } from './stats/summary';
@@ -16,8 +15,6 @@ export function SubscriberStats(): JSX.Element {
   const location = useLocation();
   const [stats, setStats] = useState<StatsType | null>(null);
   const [loading, setLoading] = useState(true);
-  const contextValue = useGlobalContextValue(window);
-  const showError = contextValue.notices.error;
 
   useEffect(() => {
     void MailPoet.Ajax.post({
@@ -35,21 +32,16 @@ export function SubscriberStats(): JSX.Element {
       .fail((response) => {
         setLoading(false);
         if (response.errors.length > 0) {
-          showError(
-            <>
-              {response.errors.map((error) => (
-                <p key={error.message}>{error.message}</p>
-              ))}
-            </>,
-            { scroll: true },
-          );
+          MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
         }
       });
-  }, [match.params.id, showError]);
+  }, [match.params.id]);
 
   if (loading) {
     return <Loading />;
   }
+
+  if (!stats) return null;
 
   return (
     <div className="mailpoet-subscriber-stats">

--- a/mailpoet/assets/js/src/wizard/update-settings.ts
+++ b/mailpoet/assets/js/src/wizard/update-settings.ts
@@ -8,10 +8,7 @@ export async function updateSettings(data) {
     data,
   }).fail((response: ErrorResponse) => {
     if (response.errors.length > 0) {
-      MailPoet.Notice.error(
-        response.errors.map((error) => error.message),
-        { scroll: true },
-      );
+      MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
     }
   });
 }

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -269,10 +269,17 @@ class API {
   }
 
   public function createErrorResponse($errorType, $errorMessage, $responseStatus) {
+    $errorMessages = [
+      $errorType => $errorMessage,
+    ];
+
+    if ($errorType === Error::BAD_REQUEST) {
+      $mpReinstallErrorMessage = __('The plugin has encountered an unexpected error. Please reload the page. If that does not help, re-install the MailPoet Plugin. See: https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp', 'mailpoet');
+      $errorMessages[Error::REINSTALL_PLUGIN] = $mpReinstallErrorMessage; // not all places on the frontend accept html for an error message. we want this to be backwards compatible
+    }
+
     $errorResponse = new ErrorResponse(
-      [
-        $errorType => $errorMessage,
-      ],
+      $errorMessages,
       [],
       $responseStatus
     );

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -274,8 +274,13 @@ class API {
     ];
 
     if ($errorType === Error::BAD_REQUEST) {
-      $mpReinstallErrorMessage = __('The plugin has encountered an unexpected error. Please reload the page. If that does not help, re-install the MailPoet Plugin. See: https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp', 'mailpoet');
-      $errorMessages[Error::REINSTALL_PLUGIN] = $mpReinstallErrorMessage; // not all places on the frontend accept html for an error message. we want this to be backwards compatible
+      $mpReinstallErrorMessage = __('The plugin has encountered an unexpected error. Please reload the page. If that does not help, re-install the MailPoet Plugin. See: [link] https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp [/link] for more information', 'mailpoet');
+      $mpReinstallErrorMessage = Helpers::replaceLinkTags(
+        $mpReinstallErrorMessage,
+        'https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp',
+        ['target' => '_blank']
+      );
+      $errorMessages[Error::REINSTALL_PLUGIN] = $mpReinstallErrorMessage;
     }
 
     $errorResponse = new ErrorResponse(

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -274,7 +274,7 @@ class API {
     ];
 
     if ($errorType === Error::BAD_REQUEST) {
-      $mpReinstallErrorMessage = __('The plugin has encountered an unexpected error. Please reload the page. If that does not help, re-install the MailPoet Plugin. See: [link] https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp [/link] for more information', 'mailpoet');
+      $mpReinstallErrorMessage = __('The plugin has encountered an unexpected error. Please reload the page. If that does not help, [link]re-install the MailPoet Plugin.[/link]', 'mailpoet');
       $mpReinstallErrorMessage = Helpers::replaceLinkTags(
         $mpReinstallErrorMessage,
         'https://kb.mailpoet.com/article/258-re-installing-updating-the-plugin-via-ftp',

--- a/mailpoet/lib/API/JSON/Error.php
+++ b/mailpoet/lib/API/JSON/Error.php
@@ -8,6 +8,7 @@ final class Error {
   const UNAUTHORIZED = 'unauthorized';
   const FORBIDDEN = 'forbidden';
   const NOT_FOUND = 'not_found';
+  const REINSTALL_PLUGIN = 'reinstall_plugin';
 
   private function __construct() {
 

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -366,7 +366,7 @@ class APITest extends \MailPoetTest {
     $this->assertInstanceOf(LogEntity::class, $log);
     verify($log->getMessage())->stringContainsString('Some Error');
     verify($log->getName())->equals(LoggerFactory::TOPIC_API);
-    verify($response->errors)->equals([['error' => 'bad_request', 'message' => 'Some Error']]);
+    verify($response->errors)->arrayContains(['error' => 'bad_request', 'message' => 'Some Error']);
     $this->diContainer->get(SettingsController::class)->set('logging', 'errors');
   }
 


### PR DESCRIPTION

## Description

Invalid API endpoint exception improvement

## Code review notes

_N/A_

## QA notes

Please check Jan's [note](https://github.com/mailpoet/mailpoet/pull/5592#issuecomment-2133383764) below
You can rename or delete one of the [JSON API endpoints](https://github.com/mailpoet/mailpoet/tree/605664228ee1bd337ac5024eec4526778a5ed7fa/mailpoet/lib/API/JSON/v1)

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6022](https://mailpoet.atlassian.net/browse/MAILPOET-6022)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6022]: https://mailpoet.atlassian.net/browse/MAILPOET-6022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ