### PR TITLE
Email Editor: Audit escaping usage during block rendering [MAILPOET-5922]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Patterns/Library/DefaultContent.php
+++ b/mailpoet/lib/EmailEditor/Engine/Patterns/Library/DefaultContent.php
@@ -22,7 +22,7 @@ class DefaultContent extends AbstractPattern {
     <figure class="wp-block-image"><img src="' . esc_url($this->cdnAssetUrl->generateCdnUrl("newsletter/congratulation-page-illustration-transparent-LQ.20181121-1440.png")) . '" alt="Banner Image"/></figure>
     <!-- /wp:image -->
     <!-- wp:paragraph -->
-    <p>' . __('A one-column layout is great for simplified and concise content, like announcements or newsletters with brief updates. Drag blocks to add content and customize your styles from the styles panel on the top right.', 'mailpoet') . '</p>
+    <p>' . esc_html__('A one-column layout is great for simplified and concise content, like announcements or newsletters with brief updates. Drag blocks to add content and customize your styles from the styles panel on the top right.', 'mailpoet') . '</p>
     <!-- /wp:paragraph -->
     <!-- wp:paragraph {"fontSize":"small"} -->
     <p class="has-small-font-size">' . esc_html__('You received this email because you are subscribed to the [site:title]', 'mailpoet') . '</p>

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/ContentRenderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/ContentRenderer.php
@@ -96,7 +96,7 @@ class ContentRenderer {
       '*:not(.alignleft):not(.alignright):not(.alignfull)',
       \wp_style_engine_get_stylesheet_from_context('block-supports', [])
     );
-    $styles = '<style>' . (string)apply_filters('mailpoet_email_content_renderer_styles', $styles, $post) . '</style>';
+    $styles = '<style>' . wp_strip_all_tags((string)apply_filters('mailpoet_email_content_renderer_styles', $styles, $post)) . '</style>';
 
     return CssInliner::fromHtml($styles . $html)->inlineCss()->render();
   }

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -62,7 +62,8 @@ class Renderer {
       'body, .email_layout_wrapper'
     );
     $templateStyles .= file_get_contents(dirname(__FILE__) . '/' . self::TEMPLATE_STYLES_FILE);
-    $renderedTemplate = $this->inlineCSSStyles('<style>' . (string)apply_filters('mailpoet_email_renderer_styles', $templateStyles, $post) . '</style>' . $renderedTemplate);
+    $templateStyles = '<style>' . wp_strip_all_tags((string)apply_filters('mailpoet_email_renderer_styles', $templateStyles, $post)) . '</style>';
+    $renderedTemplate = $this->inlineCSSStyles($templateStyles . $renderedTemplate);
 
     return [
       'html' => $renderedTemplate,

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.php
@@ -15,7 +15,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="format-detection" content="telephone=no" />
-  <?php echo $metaRobots; ?>
+  <?php echo $metaRobots; // HTML defined by MailPoet--do not escape ?>
 </head>
 <body>
     <div class="email_layout_wrapper">
@@ -23,7 +23,7 @@
           <tbody>
             <tr>
               <td class="email_preheader" height="1">
-                <?php echo $preHeader; ?>
+                <?php echo esc_html(wp_strip_all_tags($preHeader)); ?>
               </td>
             </tr>
             <tr>

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Image.php
@@ -85,12 +85,12 @@ class Image extends AbstractBlockRenderer {
       $height = $styles['height'] ?? null;
       if ($height && $height !== 'auto' && is_numeric($settingsController->parseNumberFromStringWithPixels($height))) {
         $height = $settingsController->parseNumberFromStringWithPixels($height);
-        $html->set_attribute('height', $height);
+        $html->set_attribute('height', esc_attr($height));
       }
 
       if (isset($parsedBlock['attrs']['width'])) {
         $width = $settingsController->parseNumberFromStringWithPixels($parsedBlock['attrs']['width']);
-        $html->set_attribute('width', $width);
+        $html->set_attribute('width', esc_attr($width));
       }
       $blockContent = $html->get_updated_html();
     }
@@ -141,24 +141,24 @@ class Image extends AbstractBlockRenderer {
         border="0"
         cellpadding="0"
         cellspacing="0"
-        style="' . \WP_Style_Engine::compile_css($styles, '') . '"
+        style="' . esc_attr(\WP_Style_Engine::compile_css($styles, '')) . '"
         width="100%"
       >
         <tr>
-          <td align="' . $align . '">
+          <td align="' . esc_attr($align) . '">
             <table
               role="presentation"
               border="0"
               cellpadding="0"
               cellspacing="0"
-              style="' . \WP_Style_Engine::compile_css($wrapperStyles, '') . '"
-              width="' . $wrapperWidth . '"
+              style="' . esc_attr(\WP_Style_Engine::compile_css($wrapperStyles, '')) . '"
+              width="' . esc_attr($wrapperWidth) . '"
             >
               <tr>
                 <td>{image_content}</td>
               </tr>
               <tr>
-                <td style="' . $captionStyles . '">{caption_content}</td>
+                <td style="' . esc_attr($captionStyles) . '">{caption_content}</td>
               </tr>
             </table>
           </td>
@@ -174,10 +174,10 @@ class Image extends AbstractBlockRenderer {
   private function addStyleToElement($blockContent, array $tag, string $style): string {
     $html = new \WP_HTML_Tag_Processor($blockContent);
     if ($html->next_tag($tag)) {
-      $elementStyle = $html->get_attribute('style');
+      $elementStyle = $html->get_attribute('style') ?? '';
       $elementStyle = !empty($elementStyle) ? (rtrim($elementStyle, ';') . ';') : ''; // Adding semicolon if it's missing
       $elementStyle .= $style;
-      $html->set_attribute('style', $elementStyle);
+      $html->set_attribute('style', esc_attr($elementStyle));
       $blockContent = $html->get_updated_html();
     }
 
@@ -192,7 +192,7 @@ class Image extends AbstractBlockRenderer {
     if ($html->next_tag($tag)) {
       $elementStyle = $html->get_attribute('style') ?? '';
       $elementStyle = preg_replace('/' . $styleName . ':(.?[0-9]+px)+;?/', '', $elementStyle);
-      $html->set_attribute('style', $elementStyle);
+      $html->set_attribute('style', esc_attr($elementStyle));
       $blockContent = $html->get_updated_html();
     }
 
@@ -205,15 +205,21 @@ class Image extends AbstractBlockRenderer {
    */
   private function parseBlockContent(string $blockContent): ?array {
     // If block's image is not set, we don't need to parse the content
-    if (empty($blockContent)) return null;
+    if (empty($blockContent)) {
+      return null;
+    }
 
     $domHelper = new DomDocumentHelper($blockContent);
 
     $figureTag = $domHelper->findElement('figure');
-    if (!$figureTag) return null;
+    if (!$figureTag) {
+      return null;
+    }
 
     $imgTag = $domHelper->findElement('img');
-    if (!$imgTag) return null;
+    if (!$imgTag) {
+      return null;
+    }
 
     $imageSrc = $domHelper->getAttributeValue($imgTag, 'src');
     $imageHtml = $domHelper->getOuterHtml($imgTag);

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/ListBlock.php
@@ -22,7 +22,7 @@ class ListBlock extends AbstractBlockRenderer {
         $styles['font-size'] = $themeData['styles']['typography']['fontSize'];
       }
 
-      $html->set_attribute('style', \WP_Style_Engine::compile_css($styles, ''));
+      $html->set_attribute('style', esc_attr(\WP_Style_Engine::compile_css($styles, '')));
       $blockContent = $html->get_updated_html();
     }
 
@@ -32,15 +32,11 @@ class ListBlock extends AbstractBlockRenderer {
 
     // \WP_HTML_Tag_Processor escapes the content, so we have to replace it back
     $blockContent = str_replace('&#039;', "'", $blockContent);
-    $blockContent = str_replace('{listContent}', $blockContent, $this->getMarkup());
-    $blockContent = str_replace('{wrapperStyle}', $wrapperStyle, $blockContent);
-    return $blockContent;
-  }
 
-  private function getMarkup(): string {
-    return '
-      <div style="{wrapperStyle}">
-            {listContent}
-      </div>';
+    return sprintf(
+      '<div style="%1$s">%2$s</div>',
+      esc_attr($wrapperStyle),
+      $blockContent
+    );
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Text.php
@@ -82,7 +82,7 @@ class Text extends AbstractBlockRenderer {
       // to prevent CSS Inliner from adding a default value and overriding the value set by user, which is on the wrapper element.
       // The value provided by WP uses clamp() function which is not supported in many email clients
       $elementStyle = preg_replace('/font-size:[^;]+;?/', 'font-size: inherit;', $elementStyle);
-      $html->set_attribute('style', $elementStyle);
+      $html->set_attribute('style', esc_attr($elementStyle));
       $blockContent = $html->get_updated_html();
     }
 


### PR DESCRIPTION
## Description

This PR adds missing escaping functions during email template and block rendering. This mainly involved manually auditing the code and inserting `esc_attr`/`esc_html` where needed.

## Code review notes

Tests and CI should pass to ensure there are no obvious mistakes. Note I only audited code within the `mailpoet/lib/EmailEditor` directory.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5922](https://mailpoet.atlassian.net/browse/MAILPOET-5922)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5922]: https://mailpoet.atlassian.net/browse/MAILPOET-5922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ