### PR TITLE
Fix WPCOM debug bar styles exclusion [MAILPOET-6066]

### DIFF
--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -20,7 +20,7 @@ class ConflictResolver {
       'wpt-tx-updater-network',
       // WP.com
       '^/_static',
-      'atomic-plugins/debug-bar/css',
+      'mu-host-plugins/debug-bar/css',
       'woocommerce-payments/',
       'automatewoo/',
       'full-site-editing',


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

1. Install the plugin on an Atomic (WPCOM) website.
2. Make sure debug bar content is not visible in the footer of MailPoet pages.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6066]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6066]: https://mailpoet.atlassian.net/browse/MAILPOET-6066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ