### PR TITLE
Update k6 to 0.51 and improve existing segmentation tests and implement new helper

### DIFF
--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -31,9 +31,7 @@ export async function automationTriggerWorkflow() {
 
   try {
     const subscriberEmail =
-      'blackhole+automation' +
-      Math.floor(Math.random() * 9999 + 1) +
-      '@mailpoet.com';
+      'blackhole+automation' + Date.now() + '@mailpoet.com';
 
     // Log in to WP Admin
     await login(page);

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -25,15 +25,14 @@ import {
   login,
   selectInReact,
   focusAndClick,
-  waitForSelectorToBeClickable
+  waitForSelectorToBeClickable,
 } from '../utils/helpers.js';
 
 export async function segmentsCreateCustom() {
   const page = browser.newPage();
 
   try {
-    const complexSegmentName =
-      'Complex Segment ' + Math.floor(Math.random() * 9999 + 1);
+    const complexSegmentName = 'Complex Segment ' + Date.now();
 
     // Log in to WP Admin
     await login(page);

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -21,7 +21,12 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInReact, focusAndClick } from '../utils/helpers.js';
+import {
+  login,
+  selectInReact,
+  focusAndClick,
+  waitForSelectorToBeClickable
+} from '../utils/helpers.js';
 
 export async function segmentsCreateCustom() {
   const page = browser.newPage();
@@ -121,18 +126,17 @@ export async function segmentsCreateCustom() {
     });
 
     // Save the segment
-    const calculatedMessage =
-      "//div[@class='mailpoet-form-field'].//span[starts-with(text(),'This segment has')]";
-    await calculatedMessage.waitFor();
-    await focusAndClick(page, 'div.mailpoet-form-actions > button');
-    await page.waitForSelector('[data-automation-id="filters_all"]', {
+    await waitForSelectorToBeClickable(page, 'button[type="submit"]');
+    await focusAndClick(page, 'button[type="submit"]');
+    await page.waitForSelector('[data-automation-id="new-segment"]', {
       state: 'visible',
     });
-    const segmentUpdatedMessage =
-      "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
+    await page.waitForLoadState('networkidle');
+    const segmentAddedMessage =
+      "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully added!')]";
     describe(segmentsPageTitle, () => {
-      describe('segments-create-custom: should be able to see Segment Updated message', () => {
-        expect(page.locator(segmentUpdatedMessage)).to.exist;
+      describe('segments-create-custom: should be able to see Segment Added message', () => {
+        expect(page.locator(segmentAddedMessage)).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -125,8 +125,11 @@ export async function segmentsCreateCustom() {
     });
 
     // Save the segment
-    await waitForSelectorToBeClickable(page, 'button[type="submit"]');
-    await focusAndClick(page, 'button[type="submit"]');
+    await waitForSelectorToBeClickable(
+      page,
+      'div.mailpoet-form-actions > button',
+    );
+    await focusAndClick(page, 'div.mailpoet-form-actions > button');
     await page.waitForSelector('[data-automation-id="new-segment"]', {
       state: 'visible',
     });

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -23,7 +23,7 @@ import {
 import {
   login,
   focusAndClick,
-  waitForSelectorToBeClickable
+  waitForSelectorToBeClickable,
 } from '../utils/helpers.js';
 
 export async function segmentsSelectTemplate() {

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -56,8 +56,11 @@ export async function segmentsSelectTemplate() {
     ]);
 
     // Save the segment
-    await waitForSelectorToBeClickable(page, 'button[type="submit"]');
-    await focusAndClick(page, 'button[type="submit"]');
+    await waitForSelectorToBeClickable(
+      page,
+      'div.mailpoet-form-actions > button',
+    );
+    await focusAndClick(page, 'div.mailpoet-form-actions > button');
 
     await page.waitForLoadState('networkidle');
     await page.screenshot({

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -20,7 +20,11 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, focusAndClick } from '../utils/helpers.js';
+import {
+  login,
+  focusAndClick,
+  waitForSelectorToBeClickable
+} from '../utils/helpers.js';
 
 export async function segmentsSelectTemplate() {
   const page = browser.newPage();
@@ -52,6 +56,7 @@ export async function segmentsSelectTemplate() {
     ]);
 
     // Save the segment
+    await waitForSelectorToBeClickable(page, 'button[type="submit"]');
     await focusAndClick(page, 'button[type="submit"]');
 
     await page.waitForLoadState('networkidle');
@@ -61,11 +66,11 @@ export async function segmentsSelectTemplate() {
     });
 
     await page.waitForSelector('[data-automation-id="select_all"]');
-    const locator =
+    const segmentUpdatedMessage =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
     describe(segmentsPageTitle, () => {
-      describe('segments-select-template: should be able to see Segment saved message', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('segments-select-template: should be able to see Segment Updated message', () => {
+        expect(page.locator(segmentUpdatedMessage)).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -30,10 +30,7 @@ export async function subscribersAdding() {
   const page = browser.newPage();
 
   try {
-    let subscriberEmail =
-      'blackhole+automation' +
-      Math.floor(Math.random() * 9999 + 1) +
-      '@mailpoet.com';
+    let subscriberEmail = 'blackhole+automation' + Date.now() + '@mailpoet.com';
 
     // Log in to WP Admin
     await login(page);

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -68,6 +68,11 @@ export async function waitForSelectorToBeVisible(page, element) {
   await page.locator(element).waitFor({ state: 'visible' });
 }
 
+// Wait for selector to be available
+export async function waitForSelectorToBeClickable(page, element) {
+  await page.locator(element).waitFor({ trial: true });
+}
+
 // Add an item to the automation workflow
 export async function addActionTriggerItemToWorkflow(page, actionName) {
   await page.locator('.components-search-control__input').type(actionName);

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.50.0';
+$version = 'v0.51.0';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Updated k6 to latest version and improved segments tests. Small update to other tests using Math instead Date.now().

## Code review notes

Feel free not to test this locally, as I tested it many times, and it worked. You can optionally check CI tests, and if they pass, we are good.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6071]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6071]: https://mailpoet.atlassian.net/browse/MAILPOET-6071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ