### PR TITLE
Add backslash character to rexExp in parseQuery function [MAILPOET-6074]

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/list/query.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/list/query.ts
@@ -15,7 +15,7 @@ export type Query = typeof defaultQuery;
 function parseQuery(path: string): Partial<Query> {
   return path
     .split('/')
-    .map((part) => part.replace(/]$/, '').split('['))
+    .map((part) => part.replace(/\]$/, '').split('['))
     .map(([key, value]) => [
       key,
       typeof defaultQuery[key] === 'number' ? parseInt(value, 10) : value,


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Adding a backslash to regExp helps to avoid failing the make-pot command when we extract JS translations.

## QA notes

I checked that translation strings from JS are extracted properly by downloading the build from CricleCI.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6074]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6074]: https://mailpoet.atlassian.net/browse/MAILPOET-6074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ