### PR TITLE
Email editor - fix blank screen in template mode [MAILPOET-6065]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/editor.tsx
@@ -75,7 +75,7 @@ export function InnerEditor({
     [settings, onNavigateToEntityRecord, onNavigateToPreviousEntityRecord],
   );
 
-  if (!post) {
+  if (!post || (currentPost.postType !== 'wp_template' && !template)) {
     return null;
   }
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/editor.tsx
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 
 import {
   ErrorBoundary,
+  PostLockedModal,
   // @ts-expect-error No types for this exist yet.
   privateApis as editorPrivateApis,
 } from '@wordpress/editor';
@@ -79,8 +80,6 @@ export function InnerEditor({
     return null;
   }
 
-  // Todo: <PostLockedModal /> removed due to errors when heartbeat API triggered.
-
   return (
     <SlotFillProvider>
       <ExperimentalEditorProvider
@@ -91,9 +90,10 @@ export function InnerEditor({
         __unstableTemplate={template}
         {...props}
       >
-        {/* @ts-expect-error Tada */}
+        {/* @ts-expect-error ErrorBoundary type is incorrect there is no onError */}
         <ErrorBoundary>
           <Layout />
+          <PostLockedModal />
         </ErrorBoundary>
       </ExperimentalEditorProvider>
     </SlotFillProvider>

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -140,6 +140,7 @@ export function Layout() {
                   styles={[...settings.styles, ...emailCss]}
                   autoFocus
                   className="has-global-padding"
+                  renderAppender={false} // With false the appender is rendered in the template mode
                 />
               </div>
             </BlockSelectionClearer>

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -50,7 +50,6 @@ export function Layout() {
     focusMode,
     styles,
     isEditingTemplate,
-    currentTemplate,
   } = useSelect(
     (select) => ({
       isFullscreenActive: select(storeName).isFeatureActive('fullscreenMode'),
@@ -67,8 +66,6 @@ export function Layout() {
       isEditingTemplate:
         // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() === 'wp_template',
-      // @ts-expect-error No types for this exist yet.
-      currentTemplate: select(editorStore).getCurrentTemplateId(),
     }),
     [],
   );
@@ -102,7 +99,7 @@ export function Layout() {
   };
 
   // Do not render editor if email is not loaded yet.
-  if (!isEmailLoaded || currentTemplate === null) {
+  if (!isEmailLoaded) {
     return null;
   }
 

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -44,7 +44,6 @@ export function Layout() {
     previewDeviceType,
     isInserterSidebarOpened,
     isListviewSidebarOpened,
-    isEmailLoaded,
     canUserEditMedia,
     hasFixedToolbar,
     focusMode,
@@ -58,7 +57,6 @@ export function Layout() {
       isListviewSidebarOpened: select(storeName).isListviewSidebarOpened(),
       initialSettings: select(storeName).getInitialEditorSettings(),
       previewDeviceType: select(storeName).getPreviewState().deviceType,
-      isEmailLoaded: select(storeName).isEmailLoaded(),
       canUserEditMedia: select(coreStore).canUser('create', 'media'),
       hasFixedToolbar: select(storeName).isFeatureActive('fixedToolbar'),
       focusMode: select(storeName).isFeatureActive('focusMode'),
@@ -97,11 +95,6 @@ export function Layout() {
     hasFixedToolbar,
     focusMode,
   };
-
-  // Do not render editor if email is not loaded yet.
-  if (!isEmailLoaded) {
-    return null;
-  }
 
   return (
     <>

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-preview-templates.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-preview-templates.ts
@@ -49,7 +49,11 @@ export function usePreviewTemplates() {
     return [[]];
   }
 
-  const contentPatternBlocks = patterns[0].blocks as BlockInstance[];
+  // Pick first pattern that comes from mailpoet
+  const contentPatternBlocks = patterns.find((pattern) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    pattern?.name?.startsWith('mailpoet'),
+  )?.blocks as BlockInstance[];
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return [


### PR DESCRIPTION
## Description

This PR fixes the issue with the strange WSOD happening in the editor's template mode. Plus a few tiny fixes.

## Code review notes

I found that it was related to the fact that we hide the editor when the template is not loaded. The problem with that is that in template mode, the main document is a template, and there is no template associated with it. So then, when something caused the rerendering of the Layout component, it turned blank. Such a re-render could be caused, for example, by the inserter popup, which is rendered out of the frame. I assume the issue is also related to the problem with PostLockedModal, which we deactivated. 

#### Replication

1. Open the email editor and switch to template mode
2. Insert columns block
3. Click the appender (+) in column block in the editor and observe issue

## QA notes

I think it doesn't require QA and can be tested and merged by devs.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6065]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6065]: https://mailpoet.atlassian.net/browse/MAILPOET-6065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ