### PR TITLE
Fix Atomatewoo opt-in Sync

### DIFF
--- a/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
+++ b/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
@@ -87,10 +87,10 @@ class AutomateWooHooks {
       return;
     }
 
-    if ($subscriber->getStatus() === SubscriberEntity::STATUS_UNSUBSCRIBED) {
-      $this->optOutSubscriber($subscriber);
-    } else if ($this->isWooCommerceSubscribed($subscriber)) {
+    if ($this->isWooCommerceSubscribed($subscriber)) {
       $this->optInSubscriber($subscriber);
+    } else {
+      $this->optOutSubscriber($subscriber);
     }
   }
 

--- a/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
+++ b/mailpoet/lib/WooCommerce/Integrations/AutomateWooHooks.php
@@ -103,7 +103,7 @@ class AutomateWooHooks {
     }
   }
 
-  public function isWooCommerceSubscribed(SubscriberEntity $subscriber) {
+  private function isWooCommerceSubscribed(SubscriberEntity $subscriber) {
     return $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED
       && $this->subscribersRepository->getWooCommerceSegmentSubscriber($subscriber->getEmail());
   }

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -180,6 +180,8 @@ namespace AutomateWoo {
     class Customer {
       public function opt_out() {
       }
+      public function opt_in() {
+      }
     }
   }
   if (!class_exists(\AutomateWoo\Customer_Factory::class)) {

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -70,7 +70,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
     $automateWooHooksPartialMock->syncSubscriber((int)$unsubscribedSubscriber->getId());
   }
 
-  public function testDoesNotOptOutSubscribedSubscriber() {
+  public function testOptsInSubscribedSubscriber() {
     $subscribedSubscriber = $this->subscriberFactory
       ->withEmail('subscribedUser@mailpoet.com')
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -75,6 +75,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
       ->withEmail('subscribedUser@mailpoet.com')
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
     $this->subscribersRepository->method('findOneById')->willReturn($subscribedSubscriber);
+    $this->subscribersRepository->method('getWooCommerceSegmentSubscriber')->willReturn($subscribedSubscriber);
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
       ->setConstructorArgs([$this->subscribersRepository, $this->wp])
@@ -83,6 +84,24 @@ class AutomateWooHooksTest extends \MailPoetTest {
 
     $automateWooHooksPartialMock->expects($this->never())->method('optOutSubscriber');
     $automateWooHooksPartialMock->expects($this->once())->method('optInSubscriber');
+
+    $automateWooHooksPartialMock->syncSubscriber((int)$subscribedSubscriber->getId());
+  }
+
+  public function testNotOptsInSubscribedSubscriber() {
+    $subscribedSubscriber = $this->subscriberFactory
+      ->withEmail('subscribedUser@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
+    $this->subscribersRepository->method('findOneById')->willReturn($subscribedSubscriber);
+    $this->subscribersRepository->method('getWooCommerceSegmentSubscriber')->willReturn(null);
+
+    $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
+      ->setConstructorArgs([$this->subscribersRepository, $this->wp])
+      ->onlyMethods(['optOutSubscriber', 'optInSubscriber'])
+      ->getMock();
+
+    $automateWooHooksPartialMock->expects($this->never())->method('optOutSubscriber');
+    $automateWooHooksPartialMock->expects($this->never())->method('optInSubscriber');
 
     $automateWooHooksPartialMock->syncSubscriber((int)$subscribedSubscriber->getId());
   }

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -61,12 +61,13 @@ class AutomateWooHooksTest extends \MailPoetTest {
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
     ->setConstructorArgs([$this->subscribersRepository, $this->wp])
-    ->onlyMethods(['optOutSubscriber'])
+    ->onlyMethods(['optOutSubscriber', 'optInSubscriber'])
     ->getMock();
 
     $automateWooHooksPartialMock->expects($this->once())->method('optOutSubscriber');
+    $automateWooHooksPartialMock->expects($this->never())->method('optInSubscriber');
 
-    $automateWooHooksPartialMock->maybeOptOutSubscriber((int)$unsubscribedSubscriber->getId());
+    $automateWooHooksPartialMock->syncSubscriber((int)$unsubscribedSubscriber->getId());
   }
 
   public function testDoesNotOptOutSubscribedSubscriber() {
@@ -77,10 +78,12 @@ class AutomateWooHooksTest extends \MailPoetTest {
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)
       ->setConstructorArgs([$this->subscribersRepository, $this->wp])
-      ->onlyMethods(['optOutSubscriber'])
+      ->onlyMethods(['optOutSubscriber', 'optInSubscriber'])
       ->getMock();
-    $automateWooHooksPartialMock->expects($this->never())->method('optOutSubscriber');
 
-    $automateWooHooksPartialMock->maybeOptOutSubscriber((int)$subscribedSubscriber->getId());
+    $automateWooHooksPartialMock->expects($this->never())->method('optOutSubscriber');
+    $automateWooHooksPartialMock->expects($this->once())->method('optInSubscriber');
+
+    $automateWooHooksPartialMock->syncSubscriber((int)$subscribedSubscriber->getId());
   }
 }

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -88,7 +88,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
     $automateWooHooksPartialMock->syncSubscriber((int)$subscribedSubscriber->getId());
   }
 
-  public function testNotOptsInSubscribedSubscriber() {
+  public function testOptsOutSubscribedSubscriberWithoutWooCommerceList() {
     $subscribedSubscriber = $this->subscriberFactory
       ->withEmail('subscribedUser@mailpoet.com')
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)->create();
@@ -100,7 +100,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
       ->onlyMethods(['optOutSubscriber', 'optInSubscriber'])
       ->getMock();
 
-    $automateWooHooksPartialMock->expects($this->never())->method('optOutSubscriber');
+    $automateWooHooksPartialMock->expects($this->once())->method('optOutSubscriber');
     $automateWooHooksPartialMock->expects($this->never())->method('optInSubscriber');
 
     $automateWooHooksPartialMock->syncSubscriber((int)$subscribedSubscriber->getId());

--- a/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
+++ b/mailpoet/tests/integration/WooCommerce/Integration/AutomateWooHooksTest.php
@@ -41,7 +41,7 @@ class AutomateWooHooksTest extends \MailPoetTest {
         }
         return false;
       },
-      'addAction' => Expected::exactly(1),
+      'addAction' => Expected::exactly(2),
     ]);
 
     $automateWooHooksPartialMock = $this->getMockBuilder(AutomateWooHooks::class)


### PR DESCRIPTION
## Description

This PR fixes/implements the Opt-in sync between MailPoet and AW

Currently, the Checkout implements already a compatibility between the two plugins. Also, we do full sync when the user is Unsubscribed.

However, when it subscribes via newsletter it doesn't get Opted In under AutomateWoo

## Code review notes

How to test this PR:

1. Checkout this PR
2. Install AutomateWoo Plugin
3. Create a Mail Poet signup form somewhere.
4. Sign up a user and accept the invitation
5. Go to AutomateWoo-Opt-in
6. See if the user is Opted-in
7. GO to communication preferences. Receive marketing promotions is checked.
8. Make this user Opted-out in AutomateWoo
9. Check in Mailpoet user is set as Unsubscribed.
10. Repeat step 4
11. Unsubscribe the user using Mailpoet
12. Go to AutomateWoo-Opt-in and see the user is not in Opt-in list

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
