### PR TITLE
Fix flaky acceptance tests in Automation and Segments

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -161,6 +161,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function clickWooTableMoreButtonByItemName($itemName) {
     $i = $this;
     $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//div[contains(@class, "mailpoet-listing-more-button")]'];
+    $i->waitForElementClickable($xpath);
     $i->click($xpath);
   }
 

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -30,25 +30,27 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->click('Start with a template');
     $i->see('Start with a template', 'h1');
     $i->click($automationTitle);
+    $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
     $i->click('Start building');
 
     $i->waitForText('Draft');
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
     $i->click('Delay');
-    $i->fillField(['name' => 'delay-number'], '5');
+    $i->waitForText('Minutes');
+    $i->fillField('[placeholder="Number"]', '5');
 
     $i->wantTo('Leave the page without saving.');
     $i->reloadPage();
     $i->cancelPopup();
 
     $i->wantTo('Leave the page after saving.');
+    $automationId = $i->grabFromCurrentUrl('~(\d+)$~');
     $i->click('Save');
     $i->waitForText('saved');
     $i->amOnMailpoetPage('Automation');
     $i->waitForText('Automations');
-    $i->waitForText($automationTitle, 10, '.mailpoet-listing-card');
-    $i->click($automationTitle, '.mailpoet-listing-card');
+    $i->amOnPage('wp-admin/admin.php?page=mailpoet-automation-editor&id=' . $automationId);
     $i->waitForText('Draft');
     $i->waitForText('Move to Trash');
     $i->waitForText('Someone subscribes');

--- a/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
@@ -67,7 +67,6 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->waitForNoticeAndClose('Segment successfully added!');
 
     $i->wantTo('Edit the segment');
-    $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
     $i->waitForElementVisible('[data-automation-id="segment-number-of-opens"]');
@@ -103,7 +102,6 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->waitForText('stats_test5@example.com');
 
     $i->wantTo('Edit the segment again');
-    $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
     $i->waitForElementVisible('[data-automation-id="segment-email"]');
@@ -119,7 +117,6 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->waitForNoticeAndClose('Segment successfully updated!');
 
     $i->wantTo('Check subscribers of the segment');
-    $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'View subscribers');
     $i->seeInCurrentUrl('mailpoet-subscribers#');

--- a/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
@@ -102,6 +102,7 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->waitForText('stats_test5@example.com');
 
     $i->wantTo('Edit the segment again');
+    $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
     $i->waitForElementVisible('[data-automation-id="segment-email"]');


### PR DESCRIPTION
## Description

Fixed two flaky acceptance tests according to CircleCI insights.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6076]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6076]: https://mailpoet.atlassian.net/browse/MAILPOET-6076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ