### PR TITLE
Email Editor: Fix various rendering issues [MAILPOET-6017]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/Preprocessors/SpacingPreprocessor.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/ContentRenderer/Preprocessors/SpacingPreprocessor.php
@@ -8,7 +8,7 @@ namespace MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors;
  */
 class SpacingPreprocessor implements Preprocessor {
   public function preprocess(array $parsedBlocks, array $layout, array $styles): array {
-    $parsedBlocks = $this->addBlockGaps($parsedBlocks, $styles['spacing']['blockGap'] ?? '');
+    $parsedBlocks = $this->addBlockGaps($parsedBlocks, $styles['spacing']['blockGap'] ?? '', null);
     $parsedBlocks = $this->addBlockPadding(
       $parsedBlocks,
       $styles['spacing']['padding']['left'] ?? '',
@@ -18,12 +18,16 @@ class SpacingPreprocessor implements Preprocessor {
     return $parsedBlocks;
   }
 
-  private function addBlockGaps(array $parsedBlocks, string $gap = ''): array {
+  private function addBlockGaps(array $parsedBlocks, string $gap = '', $parentBlock = null): array {
     foreach ($parsedBlocks as $key => $block) {
-      if ($key !== 0 && $gap) {
+      $parentBlockName = $parentBlock['blockName'] ?? '';
+
+      // Do not add a gap to the first child, or if the parent block is a buttons block (where buttons are side by side).
+      if ($key !== 0 && $gap && $parentBlockName !== 'core/buttons') {
         $block['email_attrs']['margin-top'] = $gap;
       }
-      $block['innerBlocks'] = $this->addBlockGaps($block['innerBlocks'] ?? [], $gap);
+
+      $block['innerBlocks'] = $this->addBlockGaps($block['innerBlocks'] ?? [], $gap, $block);
       $parsedBlocks[$key] = $block;
     }
 

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -60,6 +60,7 @@ class Renderer {
             'padding-top' => $emailStyles['spacing']['padding']['top'] ?? '0px',
             'padding-bottom' => $emailStyles['spacing']['padding']['bottom'] ?? '0px',
             'font-family' => $emailStyles['typography']['fontFamily'] ?? 'inherit',
+            'line-height' => $emailStyles['typography']['lineHeight'] ?? '1.5',
           ],
       'body, .email_layout_wrapper'
     );

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.css
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/template-canvas.css
@@ -3,7 +3,6 @@
 /* StyleLint is disabled because some rules contain properties that linter marks as unknown (e.g. mso- prefix), but they are valid for email rendering */
 /* stylelint-disable property-no-unknown */
 body {
-  line-height: 1.4; /* Recommended line-height that is also used in the email editor */
   margin: 0;
   padding: 0;
   -webkit-text-size-adjust: 100%; /* From MJMJ - Automatic test adjustment on mobile max to 100% */

--- a/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
+++ b/mailpoet/lib/EmailEditor/Engine/flex-email-layout.css
@@ -32,7 +32,8 @@
 .wp-block-columns:not(.is-not-stacked-on-mobile)
   > .wp-block-column
   > .wp-block {
-  margin: var(--wp--style--block-gap, 16px) 0;
+  margin-bottom: var(--wp--style--block-gap, 16px);
+  margin-top: var(--wp--style--block-gap, 16px);
 }
 
 .wp-block-columns:not(.is-not-stacked-on-mobile)

--- a/mailpoet/lib/EmailEditor/Engine/theme.json
+++ b/mailpoet/lib/EmailEditor/Engine/theme.json
@@ -19,7 +19,7 @@
     },
     "spacing": {
       "units": ["px"],
-      "blockGap": true,
+      "blockGap": false,
       "padding": true,
       "margin": true,
       "spacingSizes": [


### PR DESCRIPTION
## Description

Fixes some reported rendering issues:

1. Fixes image positioning in the editor (center alignment)
2. Fixes button alignment
3. Adds styles for line-height
4. Removes block gap settings at block level. This is not properly supported.

## Code review notes

I've removed Block Spacing from block level because it was not functional. It seems to be a conflict with how global styles are generated. I will create a follow up ticket to address this.

Testing:

1. Edit an email with the new editor. If there is no image, insert one.
2. Change the image slignment to "center" and resize it so it doesn't fit the full width. It should display centered, not left aligned.
3. Insert a buttons block with 3 buttons inside
4. Preview the email. The buttons should align vertically.
5. Compare line height in the preview to the editor for a paragraph. They should match.

## QA notes

Since this addresses a few minor visual bugs this shouldn't require additional QA beyond code review.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6017](https://mailpoet.atlassian.net/browse/MAILPOET-6017)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6017]: https://mailpoet.atlassian.net/browse/MAILPOET-6017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ