### PR TITLE
Fix MailPoet marked as incompatible with Woo HPOS [MAILPOET-6082]

### DIFF
--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -261,6 +261,11 @@ class Initializer {
       'action',
     ], 10, 2);
 
+    $this->wpFunctions->addAction('plugins_loaded', [
+      $this,
+      'pluginsLoaded',
+    ], 0);
+
     $this->wpFunctions->addAction('init', [
       $this,
       'preInitialize',
@@ -330,11 +335,14 @@ class Initializer {
     }
   }
 
+  public function pluginsLoaded() {
+    $this->hooks->init();
+  }
+
   public function preInitialize() {
     try {
       $this->renderer = $this->rendererFactory->getRenderer();
       $this->setupWidget();
-      $this->hooks->init();
       $this->setupWoocommerceTransactionalEmails();
       $this->assetsLoader->loadStyles();
     } catch (\Exception $e) {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

This changes how the plugin is initialised, so there may be issues when activating or starting the plugin. This fixes issues on Multisite, but even for single sites the code is updated.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6082]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6082]: https://mailpoet.atlassian.net/browse/MAILPOET-6082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ