### PR TITLE
Email editor: Fixes for various styling issues [MAILPOET-6078][MAILPOET-6035][MAILPOET-6081]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/index.scss
@@ -1,5 +1,14 @@
 @import '~@wordpress/base-styles/colors';
 
+#mailpoet-email-editor {
+  .editor-header__toolbar {
+    flex-grow: 1;
+  }
+  .editor-header__center {
+    flex-grow: 3;
+  }
+}
+
 // Specific styles for the component EmailTypeInfo
 // Styles are based on the Block Card component from Gutenberg block editor
 .mailpoet-email-sidebar__email-type-info {

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -95,10 +95,10 @@ export function Header() {
     : __('Close', 'mailpoet');
 
   return (
-    <div className="edit-post-header">
-      <div className="edit-post-header__toolbar">
+    <div className="editor-header edit-post-header">
+      <div className="editor-header__toolbar edit-post-header__toolbar">
         <NavigableToolbar
-          className="edit-post-header-toolbar is-unstyled editor-document-tools"
+          className="editor-header__toolbar edit-post-header-toolbar is-unstyled editor-document-tools"
           aria-label={__('Email document tools', 'mailpoet')}
         >
           {/* edit-post-header-toolbar__left can be removed after we drop support of WP 6.4 */}
@@ -106,7 +106,7 @@ export function Header() {
             <ToolbarItem
               ref={inserterButton}
               as={Button}
-              className="edit-post-header-toolbar__inserter-toggle"
+              className="editor-header-toolbar__inserter-toggle edit-post-header-toolbar__inserter-toggle"
               variant="primary"
               isPressed={isInserterSidebarOpened}
               onMouseDown={preventDefault}
@@ -144,7 +144,7 @@ export function Header() {
             <ToolbarItem
               ref={listviewButton}
               as={Button}
-              className="edit-post-header-toolbar__document-overview-toggle"
+              className="editor-header-toolbar__document-overview-toggle edit-post-header-toolbar__document-overview-toggle"
               isPressed={isListviewSidebarOpened}
               onMouseDown={preventDefault}
               onClick={toggleListviewSidebar}
@@ -168,7 +168,7 @@ export function Header() {
                 <BlockToolbar hideDragHandle />
               </div>
               <Button
-                className="edit-post-header__block-tools-toggle"
+                className="editor-header__block-tools-toggle edit-post-header__block-tools-toggle"
                 icon={isBlockToolsCollapsed ? next : previous}
                 onClick={() => {
                   setIsBlockToolsCollapsed((collapsed) => !collapsed);
@@ -185,12 +185,12 @@ export function Header() {
           !isFixedToolbarActive ||
           !isBlockSelected ||
           isBlockToolsCollapsed) && (
-          <div className="edit-post-header__center">
+          <div className="editor-header__center edit-post-header__center">
             {hasDocumentNavigationHistory ? <DocumentBar /> : <CampaignName />}
           </div>
         )}
       </div>
-      <div className="edit-post-header__settings">
+      <div className="editor-header__settings edit-post-header__settings">
         <SaveButton />
         <PreviewDropdown />
         <SendButton />

--- a/mailpoet/assets/js/src/email-editor/engine/components/inserter-sidebar/inserter-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/inserter-sidebar/inserter-sidebar.tsx
@@ -18,7 +18,7 @@ export function InserterSidebar() {
   });
 
   return (
-    <div className="edit-post-editor__inserter-panel ">
+    <div className="edit-post-editor__inserter-panel">
       <div className="edit-post-editor__inserter-panel-content">
         <Library
           showMostUsedBlocks

--- a/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
+++ b/mailpoet/lib/EmailEditor/Engine/Renderer/Renderer.php
@@ -61,6 +61,7 @@ class Renderer {
             'padding-bottom' => $emailStyles['spacing']['padding']['bottom'] ?? '0px',
             'font-family' => $emailStyles['typography']['fontFamily'] ?? 'inherit',
             'line-height' => $emailStyles['typography']['lineHeight'] ?? '1.5',
+            'font-size' => $emailStyles['typography']['fontSize'] ?? 'inherit',
           ],
       'body, .email_layout_wrapper'
     );

--- a/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Group.php
+++ b/mailpoet/lib/EmailEditor/Integrations/Core/Renderer/Blocks/Group.php
@@ -30,9 +30,7 @@ class Group extends AbstractBlockRenderer {
       'backgroundColor' => '',
       'textColor' => '',
       'borderColor' => '',
-      'layout' => [
-        'justifyContent' => '',
-      ],
+      'layout' => [],
     ]);
 
     // Layout, background, borders need to be on the outer table element.
@@ -52,9 +50,9 @@ class Group extends AbstractBlockRenderer {
       'spacing' => [ 'padding' => $blockAttributes['style']['spacing']['padding'] ?? [] ],
     ])['declarations'];
 
-    if (empty($tableStyles['background-size'])) {
-      $tableStyles['background-size'] = 'cover';
-    }
+    $tableStyles['background-size'] = empty($tableStyles['background-size']) ? 'cover' : $tableStyles['background-size'];
+    $justifyContent = $blockAttributes['layout']['justifyContent'] ?? 'center';
+    $width = $parsedBlock['email_attrs']['width'] ?? '100%';
 
     return sprintf(
       '<table class="email-block-group %3$s" style="%1$s" width="100%%" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
@@ -69,8 +67,8 @@ class Group extends AbstractBlockRenderer {
       esc_attr(WP_Style_Engine::compile_css($tableStyles, '')),
       esc_attr(WP_Style_Engine::compile_css($cellStyles, '')),
       esc_attr($originalClassname),
-      esc_attr($blockAttributes['layout']['justifyContent'] ?: 'center'),
-      esc_attr($parsedBlock['email_attrs']['width'] ?: '100%'),
+      esc_attr($justifyContent),
+      esc_attr($width),
     );
   }
 }


### PR DESCRIPTION
## Description

Fixes some styling issues in the new email editor, as well as conflicts with Gutenberg 18.4.0

## Code review notes

- Activate Gutenberg version [18.4.0](https://github.com/WordPress/gutenberg/releases/tag/v18.4.0) to test against
- Check top toolbar in email editor for alignment issues
- Edit top level styles and change "text" size to XL. Font sizes should change in editor, and same changes should be present in preview.
- Check there are no PHP notices in preview mode when a group block is used

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

- [MAILPOET-6078](https://mailpoet.atlassian.net/browse/MAILPOET-6078)
- [MAILPOET-6035](https://mailpoet.atlassian.net/browse/MAILPOET-6035)
- [MAILPOET-6081](https://mailpoet.atlassian.net/browse/MAILPOET-6081)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6078]: https://mailpoet.atlassian.net/browse/MAILPOET-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-6035]: https://mailpoet.atlassian.net/browse/MAILPOET-6035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-6081]: https://mailpoet.atlassian.net/browse/MAILPOET-6081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ