### PR TITLE
Add a knowledge base link to mysql server has gone away - MAILPOET-6020

### DIFF
--- a/mailpoet/lib/Cron/CronTrigger.php
+++ b/mailpoet/lib/Cron/CronTrigger.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron;
 
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
 
 class CronTrigger {
   const METHOD_LINUX_CRON = 'Linux Cron';
@@ -51,6 +52,7 @@ class CronTrigger {
       return false;
     } catch (\Exception $e) {
       // cron exceptions should not prevent the rest of the site from loading
+      Helpers::mySqlGoneAwayExceptionHandler($e);
     }
   }
 

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron;
 
 use MailPoet\Cron\Workers\WorkersFactory;
 use MailPoet\Logging\LoggerFactory;
+use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class Daemon {
@@ -61,6 +62,8 @@ class Daemon {
           $worker->process($this->timer); // BC for workers not implementing CronWorkerInterface
         }
       } catch (\Exception $e) {
+        Helpers::mySqlGoneAwayExceptionHandler($e);
+
         $workerClassNameParts = explode('\\', get_class($worker));
         $workerName = end($workerClassNameParts);
         $errors[] = [

--- a/mailpoet/lib/Doctrine/SerializableConnection.php
+++ b/mailpoet/lib/Doctrine/SerializableConnection.php
@@ -36,6 +36,18 @@ class SerializableConnection extends Connection {
     parent::__construct($this->params, $this->driver, $this->config, $this->eventManager);
   }
 
+  public function rollBack() {
+    try {
+      return parent::rollBack();
+    } catch (Throwable $e) {
+      $mySqlGoneAwayMessage = Helpers::mySqlGoneAwayExceptionHandler($e);
+      if ($mySqlGoneAwayMessage) {
+        throw new \Exception($mySqlGoneAwayMessage, (int)$e->getCode(), $e);
+      }
+      throw $e;
+    }
+  }
+
   public function handleExceptionDuringQuery(Throwable $e, string $sql, array $params = [], array $types = []): void {
     try {
       parent::handleExceptionDuringQuery($e, $sql, $params, $types);

--- a/mailpoet/lib/Doctrine/SerializableConnection.php
+++ b/mailpoet/lib/Doctrine/SerializableConnection.php
@@ -2,10 +2,12 @@
 
 namespace MailPoet\Doctrine;
 
+use MailPoet\Util\Helpers;
 use MailPoetVendor\Doctrine\Common\EventManager;
 use MailPoetVendor\Doctrine\DBAL\Configuration;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\DBAL\Driver;
+use Throwable;
 
 class SerializableConnection extends Connection {
   private $params;
@@ -32,5 +34,17 @@ class SerializableConnection extends Connection {
 
   public function __wakeup() {
     parent::__construct($this->params, $this->driver, $this->config, $this->eventManager);
+  }
+
+  public function handleExceptionDuringQuery(Throwable $e, string $sql, array $params = [], array $types = []): void {
+    try {
+      parent::handleExceptionDuringQuery($e, $sql, $params, $types);
+    } catch (Throwable $err) {
+      $mySqlGoneAwayMessage = Helpers::mySqlGoneAwayExceptionHandler($err);
+      if ($mySqlGoneAwayMessage) {
+        throw new \Exception($mySqlGoneAwayMessage, (int)$err->getCode(), $err);
+      }
+      throw $err;
+    }
   }
 }

--- a/mailpoet/lib/Tracy/ApiPanel/api-panel.phtml
+++ b/mailpoet/lib/Tracy/ApiPanel/api-panel.phtml
@@ -29,12 +29,19 @@ use Tracy\Dumper;
       <th>Name</th>
       <th>Value</th>
     </tr>
-    <?php foreach ($this->requestData as $name => $value): ?>
-    <tr>
-      <td><?php echo $name ?></td>
-      <td><?php echo Dumper::toHtml($value) ?></td>
-    </tr>
-    <?php endforeach ?>
+    <?php if(in_array(gettype($this->requestData), ['array', 'object'])): ?>
+      <?php foreach ($this->requestData as $name => $value): ?>
+      <tr>
+        <td><?php echo $name ?></td>
+        <td><?php echo Dumper::toHtml($value) ?></td>
+      </tr>
+      <?php endforeach ?>
+    <?php else: ?>
+      <tr>
+        <td><?php echo 'no name' ?></td>
+        <td><?php echo Dumper::toHtml($this->requestData) ?></td>
+      </tr>
+    <?php endif; ?>
   </table>
 </div>
 <?php endif; ?>

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -119,4 +119,26 @@ class Helpers {
     $arrayOfItems = explode('@', trim($email));
     return strtolower(array_pop($arrayOfItems));
   }
+
+  public static function mySqlGoneAwayExceptionHandler(\Throwable $err): string {
+    $errorMessage = $err->getMessage() ? $err->getMessage() : '';
+    $mySqlGoneAwayCheck = strpos(strtolower($errorMessage), 'mysql server has gone away') !== false;
+
+    if ($mySqlGoneAwayCheck) {
+      $customErrorMessage = sprintf(
+        // translators: the %1$s is the link, the %2$s is the error message.
+        __('Please see %1$s for more information. %2$s.', 'mailpoet'),
+        'https://kb.mailpoet.com/article/307-how-to-fix-general-error-2006-mysql-server-has-gone-away',
+        $errorMessage
+      );
+      // logging to the php log
+      if (function_exists('error_log')) {
+        error_log($customErrorMessage); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+      }
+
+      return $customErrorMessage;
+    }
+
+    return '';
+  }
 }


### PR DESCRIPTION
## Description

This error can be thrown in multiple places. I  added an exception handler for MailPoet files.
We can't do anything about the error when it's thrown from within WordPress core or from other plugins or themes.

I tested the error on a non-English WP site, and it seems to work, but please reconfirm.


## Code review notes

`handleExceptionDuringQuery` is marked internal, but it's the method we need.
The alternative would be to wrap all the query methods on the `MailPoetVendor\Doctrine\DBAL\Connection` class.

## QA notes

I think the easiest way to test this PR is to trigger the error.


Get these values and save them somewhere
(If you get an error, login to the DB with root credentials)

```
SHOW VARIABLES LIKE 'net_buffer_length';
SHOW VARIABLES LIKE 'max_allowed_packet';
SHOW VARIABLES LIKE 'wait_timeout';
```

Set this value
```
SET GLOBAL wait_timeout = 1;
SET GLOBAL net_buffer_length = 1200;
SET GLOBAL max_allowed_packet = 3000;
```

Please experiment with the `max_allowed_packet` value. Examples can be 3000, 5000, etc

Visit `/wp-admin/admin.php?page=mailpoet-newsletters#/new` and try to create a new email
You should get the error
Also, check your error log file

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6020](https://mailpoet.atlassian.net/browse/MAILPOET-6020)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6020]: https://mailpoet.atlassian.net/browse/MAILPOET-6020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ