### PR TITLE
Fix flaky acceptance tests addSendingKey and Automation

### DIFF
--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -32,13 +32,15 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->click('Start with a template');
     $i->see('Start with a template', 'h1');
     $i->click('Welcome new subscribers');
+    $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
     $i->click('Start building');
 
     $i->waitForText('Draft');
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
     $i->click('Delay');
-    $i->fillField(['name' => 'delay-number'], '5');
+    $i->waitForText('Minutes');
+    $i->fillField('[placeholder="Number"]', '5');
 
     $i->click('Send email');
     $i->fillField('"From" name', 'From');

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -23,7 +23,7 @@ class AddSendingKeyCest {
     $i->click('Verify');
 
     // validate key, activate MSS, install & activate Premium plugin
-    $i->waitForText('Your key is valid');
+    $i->waitForText('Your key is valid', 20);
     $i->waitForText('MailPoet Sending Service is active');
     $i->waitForText('It’s time to set your default FROM address!');
     $i->waitForText('Set one of your authorized email addresses as the default FROM email for your MailPoet emails.');
@@ -39,7 +39,7 @@ class AddSendingKeyCest {
     $i->waitForText('Sending all of your emails has been paused because your email address wp@example.com hasn’t been authorized yet.');
 
     $i->click('Verify');
-    $i->waitForText('It’s time to set your default FROM address!');
+    $i->waitForText('It’s time to set your default FROM address!', 20);
     $i->waitForText('Set one of your authorized email addresses as the default FROM email for your MailPoet emails.');
 
     $i->fillField(['id' => 'mailpoet-set-from-address-modal-input'], 'invalid@email.com');
@@ -96,11 +96,11 @@ class AddSendingKeyCest {
     $i->dontSee('A test email was sent to');
 
     // test modal for authorized FROM address
-    $i->waitForText('It’s time to set your default FROM address!');
+    $i->waitForText('It’s time to set your default FROM address!', 20);
     $i->waitForText('Set one of your authorized email addresses as the default FROM email for your MailPoet emails.');
     $i->fillField(['id' => 'mailpoet-set-from-address-modal-input'], 'blackhole@mailpoet.com');
     $i->click('Save', '.set-from-address-modal');
-    $i->waitForText('A test email was sent to blackhole@mailpoet.com', 15);
+    $i->waitForText('A test email was sent to blackhole@mailpoet.com', 20);
   }
 
   public function resumeSendingWhenKeyApproved(\AcceptanceTester $i, Scenario $scenario) {
@@ -129,7 +129,7 @@ class AddSendingKeyCest {
     $i->click('[data-automation-id="activation_settings_tab"]');
     $i->waitForText('Your key is valid');
     $i->click('Verify');
-    $i->waitForText('MailPoet Sending Service is active');
+    $i->waitForText('MailPoet Sending Service is active', 20);
 
     // ensure status is running
     $i->amOnMailpoetPage('Help#/systemStatus');


### PR DESCRIPTION
## Description

Fixed flakiness in three tests.
The reason why MSS tests were flaky is because it seems it requires now more than 10s to activate MSS or license key, this was not present before. The acceptance tests are not performance tests so extending waiting time is allowed, but something to think about why it takes not a few seconds more.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6083]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6083]: https://mailpoet.atlassian.net/browse/MAILPOET-6083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ