### PR TITLE
Refactor and relogic acceptance tests to be capable of testing blockbased and non block themes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,9 @@ jobs:
       automate_woo_version:
         type: string
         default: ''
+      blockbased_theme:
+        type: integer
+        default: 0
       enable_hpos:
         type: integer
         default: 0
@@ -476,6 +479,7 @@ jobs:
             -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
             -e CIRCLE_JOB=${CIRCLE_JOB} \
             -e MULTISITE=<< parameters.multisite >> \
+            -e BLOCKBASED_THEME=<< parameters.blockbased_theme >> \
             -e ENABLE_HPOS=<< parameters.enable_hpos >> \
             -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
             -e DISABLE_HPOS=<< parameters.disable_hpos >> \
@@ -840,6 +844,16 @@ workflows:
             - static_analysis_php8
             - qa_js
             - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_blockbased_theme
+          group: frontend
+          blockbased_theme: 1
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
       - performance_tests:
           <<: *slack-fail-post-step
           name: performance_tests
@@ -937,6 +951,7 @@ workflows:
             - integration_test_woo_hpos_sync_on
             - acceptance_tests_woo_hpos_sync_on
             - acceptance_tests_woo_hpos_off
+            - acceptance_tests_blockbased_theme
             - performance_tests
 
   nightly:
@@ -953,6 +968,19 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
+          woo_core_version: latest
+          woo_subscriptions_version: latest
+          woo_memberships_version: latest
+          automate_woo_version: latest
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
+          requires:
+            - build
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_latest_blockbased_theme
+          group: frontend
+          blockbased_theme: 1
           woo_core_version: latest
           woo_subscriptions_version: latest
           woo_memberships_version: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,95 +817,58 @@ workflows:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
-          name: acceptance_tests_base_and_woo
-          enable_hpos: 1
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_tests_woo_hpos_sync_on
-          group: woo
-          enable_hpos_sync: 1
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_tests_woo_hpos_off
-          group: woo
-          disable_hpos: 1
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_tests_blockbased_theme
+          name: acceptance_latest_blockbased_theme
           group: frontend
           blockbased_theme: 1
+          woo_core_version: latest
+          woo_subscriptions_version: latest
+          woo_memberships_version: latest
+          automate_woo_version: latest
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
           requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - performance_tests:
+            - build
+      - acceptance_tests:
           <<: *slack-fail-post-step
-          name: performance_tests
+          name: acceptance_oldest_blockbased_theme
+          group: frontend
+          blockbased_theme: 1
+          woo_core_version: 8.6.0
+          woo_subscriptions_version: 5.6.0
+          woo_memberships_version: 1.23.1
+          automate_woo_version: 5.8.5
+          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
+          mysql_image: mysql:5.5
           requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
+            - build
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_latest
+          woo_core_version: latest
+          woo_subscriptions_version: latest
+          woo_memberships_version: latest
+          automate_woo_version: latest
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
+          requires:
+            - build
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_oldest
+          woo_core_version: 8.6.0
+          woo_subscriptions_version: 5.6.0
+          woo_memberships_version: 1.23.1
+          automate_woo_version: 5.8.5
+          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
+          mysql_image: mysql:5.5
+          codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: wp-6.4_php8.0_20231114.1
+          requires:
+            - build
       - js_tests:
           <<: *slack-fail-post-step
           requires:
             - build
-      - integration_tests:
-          <<: *slack-fail-post-step
-          group: woo
-          enable_hpos_sync: 1
-          name: integration_test_woo_hpos_sync_on
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - integration_tests:
-          <<: *slack-fail-post-step
-          group: woo
-          name: integration_test_woo_hpos_on
-          enable_hpos: 1
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - integration_tests:
-          <<: *slack-fail-post-step
-          group: woo
-          disable_hpos: 1
-          name: integration_test_woo_hpos_off
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
-      - integration_tests:
-          <<: *slack-fail-post-step
-          skip_group: woo
-          skip_plugins: 1
-          name: integration_test_base
-          requires:
-            - unit_tests
-            - static_analysis_php8
-            - qa_js
-            - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
           <<: *multisite_acceptance_config
@@ -943,16 +906,11 @@ workflows:
           <<: *slack-fail-post-step
           requires:
             - build
-            - acceptance_tests_base_and_woo
             - js_tests
-            - integration_test_base
-            - integration_test_woo_hpos_on
-            - integration_test_woo_hpos_off
-            - integration_test_woo_hpos_sync_on
-            - acceptance_tests_woo_hpos_sync_on
-            - acceptance_tests_woo_hpos_off
-            - acceptance_tests_blockbased_theme
-            - performance_tests
+            - acceptance_latest_blockbased_theme
+            - acceptance_oldest_blockbased_theme
+            - acceptance_latest
+            - acceptance_oldest
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,58 +817,95 @@ workflows:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
-          name: acceptance_latest_blockbased_theme
+          name: acceptance_tests_base_and_woo
+          enable_hpos: 1
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woo_hpos_sync_on
+          group: woo
+          enable_hpos_sync: 1
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woo_hpos_off
+          group: woo
+          disable_hpos: 1
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_blockbased_theme
           group: frontend
           blockbased_theme: 1
-          woo_core_version: latest
-          woo_subscriptions_version: latest
-          woo_memberships_version: latest
-          automate_woo_version: latest
-          mysql_image: mysql:8.3
-          mysql_command: --default-authentication-plugin=mysql_native_password
           requires:
-            - build
-      - acceptance_tests:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - performance_tests:
           <<: *slack-fail-post-step
-          name: acceptance_oldest_blockbased_theme
-          group: frontend
-          blockbased_theme: 1
-          woo_core_version: 8.6.0
-          woo_subscriptions_version: 5.6.0
-          woo_memberships_version: 1.23.1
-          automate_woo_version: 5.8.5
-          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
-          mysql_image: mysql:5.5
+          name: performance_tests
           requires:
-            - build
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_latest
-          woo_core_version: latest
-          woo_subscriptions_version: latest
-          woo_memberships_version: latest
-          automate_woo_version: latest
-          mysql_image: mysql:8.3
-          mysql_command: --default-authentication-plugin=mysql_native_password
-          requires:
-            - build
-      - acceptance_tests:
-          <<: *slack-fail-post-step
-          name: acceptance_oldest
-          woo_core_version: 8.6.0
-          woo_subscriptions_version: 5.6.0
-          woo_memberships_version: 1.23.1
-          automate_woo_version: 5.8.5
-          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
-          mysql_image: mysql:5.5
-          codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-6.4_php8.0_20231114.1
-          requires:
-            - build
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
       - js_tests:
           <<: *slack-fail-post-step
           requires:
             - build
+      - integration_tests:
+          <<: *slack-fail-post-step
+          group: woo
+          enable_hpos_sync: 1
+          name: integration_test_woo_hpos_sync_on
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - integration_tests:
+          <<: *slack-fail-post-step
+          group: woo
+          name: integration_test_woo_hpos_on
+          enable_hpos: 1
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - integration_tests:
+          <<: *slack-fail-post-step
+          group: woo
+          disable_hpos: 1
+          name: integration_test_woo_hpos_off
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
+      - integration_tests:
+          <<: *slack-fail-post-step
+          skip_group: woo
+          skip_plugins: 1
+          name: integration_test_base
+          requires:
+            - unit_tests
+            - static_analysis_php8
+            - qa_js
+            - qa_php
       - acceptance_tests:
           <<: *slack-fail-post-step
           <<: *multisite_acceptance_config
@@ -906,11 +943,16 @@ workflows:
           <<: *slack-fail-post-step
           requires:
             - build
+            - acceptance_tests_base_and_woo
             - js_tests
-            - acceptance_latest_blockbased_theme
-            - acceptance_oldest_blockbased_theme
-            - acceptance_latest
-            - acceptance_oldest
+            - integration_test_base
+            - integration_test_woo_hpos_on
+            - integration_test_woo_hpos_off
+            - integration_test_woo_hpos_sync_on
+            - acceptance_tests_woo_hpos_sync_on
+            - acceptance_tests_woo_hpos_off
+            - acceptance_tests_blockbased_theme
+            - performance_tests
 
   nightly:
     triggers:

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -650,11 +650,11 @@ class AcceptanceTester extends \Codeception\Actor {
       $i->waitForText('Place Order');
       $i->waitForElementClickable(Locator::contains('button', 'Place Order'));
       $i->click(Locator::contains('button', 'Place Order'));
-      $i->waitForText('Order received');
+      $i->waitForText('Thank you. Your order has been received.');
     } else {
       $i->waitForText('Place order');
       $i->click('Place order');
-      $i->waitForText('Order received');
+      $i->waitForText('Thank you. Your order has been received.');
     }
   }
 

--- a/mailpoet/tests/acceptance/Forms/DisplayFormBellowPostCest.php
+++ b/mailpoet/tests/acceptance/Forms/DisplayFormBellowPostCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class DisplayFormBellowPostCest {
 
   /** @var Segment */

--- a/mailpoet/tests/acceptance/Forms/EditorAddDividerCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddDividerCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class EditorAddDividerCest {
   public function addDividerBlock(\AcceptanceTester $i) {
     $i->wantTo('Add divider block to the editor');

--- a/mailpoet/tests/acceptance/Forms/EditorAddListSelectionCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddListSelectionCest.php
@@ -6,6 +6,9 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class EditorAddListSelectionCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;

--- a/mailpoet/tests/acceptance/Forms/EditorAddNamesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorAddNamesCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class EditorAddNamesCest {
   public function addNamesToAForm(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorButtonStylesCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class EditorButtonStylesCest {
   public function changeSubmitButtonStyles(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class EditorCreateCustomFieldCest {
   private function prepareTheForm(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/EditorCustomClassesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCustomClassesCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class EditorCustomClassesCest {
   public function setCustomClassName(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/EditorFormPreviewCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorFormPreviewCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class EditorFormPreviewCest {
   public function previewUnsavedChangesAndRememberPreviewSettings(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/EditorPlaceFormOnSpecifiedPageCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorPlaceFormOnSpecifiedPageCest.php
@@ -6,6 +6,9 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 use PHPUnit\Framework\Assert;
 
+/**
+ * @group frontend
+ */
 class EditorPlaceFormOnSpecifiedPageCest {
   public function testFormPlacement(\AcceptanceTester $i) {
     $i->wantTo('Place form on a specific page');

--- a/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorTextInputStylesCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class EditorTextInputStylesCest {
   public function changeTextInputStyles(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class EditorUpdateNewFormCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;

--- a/mailpoet/tests/acceptance/Forms/FormWithColumnsCest.php
+++ b/mailpoet/tests/acceptance/Forms/FormWithColumnsCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class FormWithColumnsCest {
   public function createAndTestFormWithColumns(\AcceptanceTester $i) {
     $segmentFactory = new Segment();

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -7,6 +7,9 @@ use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class GutenbergFormBlockCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;

--- a/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
@@ -3,6 +3,8 @@
 namespace MailPoet\Test\Acceptance;
 
 use Codeception\Util\Locator;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Form\FormMessageController;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
@@ -24,6 +26,7 @@ class SubscribeToMultipleListsCest {
     $formName = 'Multiple Lists Form';
     $formFactory = new Form();
     $form = $formFactory->withName($formName)->withSegments([$segment1, $segment2, $segment3])->create();
+    $formId = $form->getId();
 
     $settings = new Settings();
     $settings
@@ -34,9 +37,30 @@ class SubscribeToMultipleListsCest {
 
     $formFactory->withDefaultSuccessMessage();
 
-    //Add this form to a widget
-    $i->createFormAndSubscribe();
-    //Subscribe via that form
+    $i->havePostInDatabase([
+      'post_author' => 1,
+      'post_type' => 'page',
+      'post_name' => 'form-test',
+      'post_title' => 'Form Test',
+      'post_content' => '
+        Regular form:
+          [mailpoet_form id="' . $formId . '"]
+        Iframe form:
+          <iframe class="mailpoet_form_iframe" id="mailpoet_form_iframe" tabindex="0" src="http://test.local?mailpoet_form_iframe=1" width="100%" height="100%" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+      ',
+      'post_status' => 'publish',
+    ]);
+  
+    $i->wantTo('Subscribe to the form with multiple lists attached');
+    $i->amOnPage('/form-test');
+    $i->waitForElement('[data-automation-id="form_email"]');
+    $i->fillField('[data-automation-id="form_email"]', 'subscriber@example.com');
+    $i->click('[data-automation-id="subscribe-submit-button"]');
+    $messageController = ContainerWrapper::getInstance()->get(FormMessageController::class);
+    $i->waitForText($messageController->getDefaultSuccessMessage(), 30, '.mailpoet_validate_success');
+    $i->seeNoJSErrors();
+
+    $i->wantTo('Confirm subscription to subscribed form');
     $i->amOnMailboxAppPage();
     $i->click(Locator::contains('span.subject', 'Subscribe to multiple test subject'));
     $i->switchToIframe('#preview-html');
@@ -44,5 +68,13 @@ class SubscribeToMultipleListsCest {
     $i->switchToNextTab();
     $i->see('You have subscribed');
     $i->seeNoJSErrors();
+
+    $i->wantTo('Check if the three lists are present for the subscribed user');
+    $i->amOnUrl(\AcceptanceTester::WP_URL);
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->waitForText($seg1);
+    $i->waitForText($seg2);
+    $i->waitForText($seg3);
   }
 }

--- a/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
@@ -35,7 +35,7 @@ class SubscribeToMultipleListsCest {
     $formFactory->withDefaultSuccessMessage();
 
     //Add this form to a widget
-    $i->createFormAndSubscribe($form);
+    $i->createFormAndSubscribe();
     //Subscribe via that form
     $i->amOnMailboxAppPage();
     $i->click(Locator::contains('span.subject', 'Subscribe to multiple test subject'));

--- a/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscribeToMultipleListsCest.php
@@ -8,6 +8,9 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class SubscribeToMultipleListsCest {
   public function subscribeToMultipleLists(\AcceptanceTester $i) {
     //Step one - create form with three lists

--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -6,7 +6,11 @@ use Codeception\Util\Locator;
 use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
+use MailPoet\WP\Functions as WPFunctions;
 
+/**
+ * @group frontend
+ */
 class SubscriptionFormCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;
@@ -49,21 +53,23 @@ class SubscriptionFormCest {
   }
 
   public function subscriptionFormWidget(\AcceptanceTester $i) {
-    $i->wantTo('Subscribe using form widget');
+    $currentTheme = WPFunctions::get()->wpGetTheme();
+    if ($currentTheme->get('Name') == 'Twenty Twenty-One') {
+      $i->wantTo('Subscribe using form widget');
 
-    $i->cli(['widget', 'add', 'mailpoet_form', 'sidebar-1', '2', "--form=$this->formId", '--title="Subscribe to Our Newsletter"']);
-    //login to avoid time limit for subscribing
-    $i->login();
-    $i->amOnPage('/');
-    $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
-    $i->click('.mailpoet_submit');
-    $i->waitForText('Check your inbox or spam folder to confirm your subscription.', self::CONFIRMATION_MESSAGE_TIMEOUT, '.mailpoet_validate_success');
-    $i->seeNoJSErrors();
+      $i->cli(['widget', 'add', 'mailpoet_form', 'sidebar-1', '2', "--form=$this->formId", '--title="Subscribe to Our Newsletter"']);
+      //login to avoid time limit for subscribing
+      $i->login();
+      $i->amOnPage('/');
+      $i->fillField('[data-automation-id="form_email"]', $this->subscriberEmail);
+      $i->click('.mailpoet_submit');
+      $i->waitForText('Check your inbox or spam folder to confirm your subscription.', self::CONFIRMATION_MESSAGE_TIMEOUT, '.mailpoet_validate_success');
+      $i->seeNoJSErrors();
+    } else {
+      $i->comment('Skipping test as it depends on a non-block theme.');
+    }
   }
 
-  /**
-   * @group frontend
-   */
   public function subscriptionFormShortcode(\AcceptanceTester $i) {
     $i->wantTo('Subscribe using form shortcode');
 
@@ -76,9 +82,6 @@ class SubscriptionFormCest {
     $i->seeCurrentUrlEquals('/form-test/');
   }
 
-  /**
-   * @group frontend
-   */
   public function subscriptionFormIframe(\AcceptanceTester $i) {
     $i->wantTo('Subscribe using iframe form');
 
@@ -117,9 +120,6 @@ class SubscriptionFormCest {
     $i->see('Subscribed', Locator::contains('tr', $this->subscriberEmail));
   }
 
-  /**
-   * @group frontend
-   */
   public function subscriptionAfterDisablingConfirmation(\AcceptanceTester $i) {
     $i->wantTo('Disable sign-up confirmation then subscribe and see a different message');
     $i->login();
@@ -139,9 +139,6 @@ class SubscriptionFormCest {
     $i->seeNoJSErrors();
   }
 
-  /**
-   * @group frontend
-   */
   public function subscriptionNewPageConfirmation(\AcceptanceTester $i) {
     $i->wantTo('Subscribe to a form and to see new page confirmation');
     $i->login();

--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -7,6 +7,9 @@ use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class SubscriptionFormCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;

--- a/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/SubscriptionFormCest.php
@@ -7,9 +7,6 @@ use MailPoet\Subscription\Captcha\CaptchaConstants;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 
-/**
- * @group frontend
- */
 class SubscriptionFormCest {
 
   const CONFIRMATION_MESSAGE_TIMEOUT = 20;
@@ -64,6 +61,9 @@ class SubscriptionFormCest {
     $i->seeNoJSErrors();
   }
 
+  /**
+   * @group frontend
+   */
   public function subscriptionFormShortcode(\AcceptanceTester $i) {
     $i->wantTo('Subscribe using form shortcode');
 
@@ -76,6 +76,9 @@ class SubscriptionFormCest {
     $i->seeCurrentUrlEquals('/form-test/');
   }
 
+  /**
+   * @group frontend
+   */
   public function subscriptionFormIframe(\AcceptanceTester $i) {
     $i->wantTo('Subscribe using iframe form');
 
@@ -114,6 +117,9 @@ class SubscriptionFormCest {
     $i->see('Subscribed', Locator::contains('tr', $this->subscriberEmail));
   }
 
+  /**
+   * @group frontend
+   */
   public function subscriptionAfterDisablingConfirmation(\AcceptanceTester $i) {
     $i->wantTo('Disable sign-up confirmation then subscribe and see a different message');
     $i->login();
@@ -133,6 +139,9 @@ class SubscriptionFormCest {
     $i->seeNoJSErrors();
   }
 
+  /**
+   * @group frontend
+   */
   public function subscriptionNewPageConfirmation(\AcceptanceTester $i) {
     $i->wantTo('Subscribe to a form and to see new page confirmation');
     $i->login();

--- a/mailpoet/tests/acceptance/Newsletters/EditorProductsCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorProductsCest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Assert;
 
 /**
  * @group woo
+ * @group frontend
  */
 class EditorProductsCest {
   const EDITOR_PRODUCTS_SELECTOR = '.mailpoet_products_container > .mailpoet_block > .mailpoet_container';

--- a/mailpoet/tests/acceptance/Newsletters/EditorSocialBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorSocialBlockCest.php
@@ -4,6 +4,9 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Newsletter;
 
+/**
+ * @group frontend
+ */
 class EditorSocialBlockCest {
   public function addSocialBlock(\AcceptanceTester $i) {
     $i->wantTo('add social block to newsletter');

--- a/mailpoet/tests/acceptance/Newsletters/PreviewStandardNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/PreviewStandardNewsletterCest.php
@@ -6,6 +6,9 @@ use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class PreviewStandardNewsletterCest {
 
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendCategoryPurchaseEmailCest.php
@@ -10,6 +10,7 @@ use MailPoet\Util\Security;
 
 /**
  * @group woo
+ * @group frontend
  */
 class SendCategoryPurchaseEmailCest {
   public function _before(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendFirstPurchaseEmailCest.php
@@ -9,6 +9,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
 
 /**
  * @group woo
+ * @group frontend
  */
 class SendFirstPurchaseEmailCest {
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SendProductPurchaseEmailCest.php
@@ -9,6 +9,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
 
 /**
  * @group woo
+ * @group frontend
  */
 class SendProductPurchaseEmailCest {
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class BasicsPageCest {
   public function checkSettingsPagesLoad(\AcceptanceTester $i) {
     $i->wantTo('Confirm all settings pages load correctly');

--- a/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/BasicsPageCest.php
@@ -74,13 +74,13 @@ class BasicsPageCest {
     try {
       $i->seeInField('#comment', $comment);
       $i->click('Post Comment');
-      $i->waitForText($comment, 10, '.comment-content');
+      $i->waitForText($comment, 10);
     }
     catch (\Exception $e) {
       $i->clearField('#comment');
       $i->fillField('#comment', $comment);
       $i->click('Post Comment');
-      $i->waitForText($comment, 10, '.comment-content');
+      $i->waitForText($comment, 10);
     }
     //check if user is really subscribed to a list
     $i->amOnMailpoetPage('Lists');

--- a/mailpoet/tests/acceptance/Settings/BuiltInCaptchaSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Settings/BuiltInCaptchaSubscriptionCest.php
@@ -7,6 +7,9 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\Subscriber;
 
+/**
+ * @group frontend
+ */
 class BuiltInCaptchaSubscriptionCest {
 
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
@@ -7,6 +7,9 @@
  use MailPoet\Test\DataFactories\Form;
  use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class ConfirmConfirmationPageCest {
   
     const CONFIRMATION_MESSAGE_TIMEOUT = 20;

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class CreateNewWordPressUserCest {
 
   /** @var Settings */

--- a/mailpoet/tests/acceptance/Settings/CustomUnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/CustomUnsubscribePageCest.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Test\Acceptance;
 
+/**
+ * @group frontend
+ */
 class CustomUnsubscribePageCest {
   public function createCustomUnsubscribePage(\AcceptanceTester $i) {
     $i->wantTo('Create page with MP subscriber shortcode');

--- a/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
+++ b/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
@@ -6,6 +6,9 @@ use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class EditSignUpConfirmationEmailCest {
   public function editSignUpConfContentAndVerify(\AcceptanceTester $i) {
     $i->wantTo('Edit sign up confirmation email');

--- a/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
+++ b/mailpoet/tests/acceptance/Settings/EditSignUpConfirmationEmailCest.php
@@ -29,6 +29,7 @@ class EditSignUpConfirmationEmailCest {
     $i->fillField('[data-automation-id="signup_confirmation_email_subject"]', $confirmationEmailSubject);
     $i->fillField('[data-automation-id="signup_confirmation_email_body"]', 'Confirmation email body [activation_link]link[/activation_link]');
     $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForText('Settings saved');
     // create form and subscribe
     $i->createFormAndSubscribe();
     // performing some clicks and getting back to verify the content

--- a/mailpoet/tests/acceptance/Settings/EnableAndDisableSignupConfirmationCest.php
+++ b/mailpoet/tests/acceptance/Settings/EnableAndDisableSignupConfirmationCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use AcceptanceTester;
 use MailPoet\Test\DataFactories\Settings;
 
+/**
+ * @group frontend
+ */
 class EnableAndDisableSignupConfirmationCest {
   public function disableSignupConfirmation(AcceptanceTester $i) {
     $settings = new Settings();

--- a/mailpoet/tests/acceptance/Settings/RevenueTrackingCookieCest.php
+++ b/mailpoet/tests/acceptance/Settings/RevenueTrackingCookieCest.php
@@ -8,6 +8,7 @@ use MailPoet\Test\DataFactories\Settings;
 
 /**
  * @group woo
+ * @group frontend
  */
 class RevenueTrackingCookieCest {
 

--- a/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SettingsArchivePageCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class SettingsArchivePageCest {
   public function createArchivePageNoSentNewsletters(\AcceptanceTester $i) {
     $i->wantTo('Create page with MP archive shortcode, showing no sent newsletters');

--- a/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Segment;
 
+/**
+ * @group frontend
+ */
 class SubscribeOnRegistrationPageCest {
   public function allowSubscribeOnRegistrationPage(\AcceptanceTester $i) {
     $i->wantTo('Allow users to subscribe to lists on site registration page');

--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -6,6 +6,9 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
 
+/**
+ * @group frontend
+ */
 class SubscriberCountShortcodeCest {
 
   const ACTIVE_SUBSCRIBERS_COUNT = 5;

--- a/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Subscriber;
 
+/**
+ * @group frontend
+ */
 class SubscriptionPageCest {
   public function previewDefaultSubscriptionPage(\AcceptanceTester $i) {
     $i->wantTo('Preview default MailPoet page from MP Settings page');

--- a/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
@@ -42,7 +42,7 @@ class UnsubscribePageCest {
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="unsubscribe_page_preview_link"]');
     $i->switchToNextTab();
-    $i->waitForElement(['css' => '.entry-title']);
+    $i->waitForText('You are now unsubscribed.');
   }
 
   public function createNewUnsubscribeConfirmationPage(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
@@ -5,6 +5,9 @@ namespace MailPoet\Test\Acceptance;
 use Codeception\Util\Locator;
 use MailPoet\Test\DataFactories\Subscriber;
 
+/**
+ * @group frontend
+ */
 class UnsubscribePageCest {
 
   /** @var string */

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -111,7 +111,7 @@ class ManageSubscriptionLinkCest {
     $i->click('Save');
     $i->waitForText('Subscriber was updated successfully!');
     $i->amOnUrl(\AcceptanceTester::WP_URL . '/?mailpoet_page=subscriptions&mailpoet_router&endpoint=subscription&action=unsubscribe&data=');
-    $i->waitForText("Hmmm... we don't have a record of you.");
+    $i->see("we don’t have a record of you.");
     $i->amOnMailpoetPage('Subscribers');
     $i->waitForText(\AcceptanceTester::ADMIN_EMAIL);
     $i->see('Subscribed');

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -111,7 +111,10 @@ class ManageSubscriptionLinkCest {
     $i->click('Save');
     $i->waitForText('Subscriber was updated successfully!');
     $i->amOnUrl(\AcceptanceTester::WP_URL . '/?mailpoet_page=subscriptions&mailpoet_router&endpoint=subscription&action=unsubscribe&data=');
-    $i->see("we don’t have a record of you.");
+    $i->waitForElementVisible('.mailpoet_page-template-default');
+    // we will verify only a portion of the full sentence
+    // since there is a microscopic difference between blockbased and non-block theme
+    $i->see(" have a record of you.");
     $i->amOnMailpoetPage('Subscribers');
     $i->waitForText(\AcceptanceTester::ADMIN_EMAIL);
     $i->see('Subscribed');

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -8,6 +8,9 @@ use MailPoet\Test\DataFactories\Settings;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Exception;
 
+/**
+ * @group frontend
+ */
 class ManageSubscriptionLinkCest {
 
   const ADDITIONAL_FIRST_FANCY_LIST = 'First fancy list';

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -12,6 +12,9 @@ use MailPoet\Test\DataFactories\User;
 use MailPoet\Test\DataFactories\WooCommerceProduct;
 use PHPUnit\Framework\Assert;
 
+/**
+ * @group frontend
+ */
 class SubscriberCookieCest {
   private const SUBSCRIBER_COOKIE_NAME = 'mailpoet_subscriber';
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutAutomateWooSubscriptionsCest.php
@@ -12,6 +12,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
  * AutomateWoo plugin active which has its own
  * checkout opt-in functionality
  * @group woo
+ * @group frontend
  */
 class WooCheckoutAutomateWooSubscriptionsCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -15,6 +15,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
  * This class contains tests for subscriptions
  * of registered customers done via checkout page
  * @group woo
+ * @group frontend
  */
 class WooCheckoutBlocksCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutCustomerSubscriptionsCest.php
@@ -12,6 +12,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
  * This class contains tests for subscriptions
  * of registered customers done via checkout page
  * @group woo
+ * @group frontend
  */
 class WooCheckoutCustomerSubscriptionsCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutGuestSubscriptionsCest.php
@@ -12,6 +12,7 @@ use MailPoet\Test\DataFactories\WooCommerceProduct;
  * This class contains tests for subscriptions
  * of guest customers done via checkout page
  * @group woo
+ * @group frontend
  */
 class WooCheckoutGuestSubscriptionsCest {
 

--- a/mailpoet/tests/acceptance/Subscriptions/WooMyAccountRegistrationCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooMyAccountRegistrationCest.php
@@ -9,6 +9,7 @@ use MailPoet\Test\DataFactories\Settings;
  * This class contains tests for subscriptions
  * of guest customers done via checkout page
  * @group woo
+ * @group frontend
  */
 class WooMyAccountRegistrationCest {
 

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -165,9 +165,9 @@ wp config set DISABLE_WP_CRON true --raw
 wp config set MAILPOET_USE_CDN false --raw
 
 # activate theme
-wp theme install twentytwentythree --activate
+wp theme install twentytwentyone --activate
 if [[ $MULTISITE == "1" ]]; then
-  wp theme install twentytwentyfour --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG --activate
+  wp theme install twentytwentyone --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG --activate
 fi
 if [[ $BLOCKBASED_THEME == "1" ]]; then
   wp theme install twentytwentyfour --activate

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -165,9 +165,12 @@ wp config set DISABLE_WP_CRON true --raw
 wp config set MAILPOET_USE_CDN false --raw
 
 # activate theme
-wp theme install twentytwentyone --activate
+wp theme install twentytwentythree --activate
 if [[ $MULTISITE == "1" ]]; then
-  wp theme install twentytwentyone --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG --activate
+  wp theme install twentytwentyfour --url=$HTTP_HOST/$WP_TEST_MULTISITE_SLUG --activate
+fi
+if [[ $BLOCKBASED_THEME == "1" ]]; then
+  wp theme install twentytwentyfour --activate
 fi
 
 # Remove Doctrine Annotations (they are not needed since generated metadata are packed)


### PR DESCRIPTION
## Description

In this PR, I'd like to refactor and change logic of some tests to fulfil requirement to have acceptance tests testing both blockbased and non-block themes. This can be a go for testing more themes, but for now let's stick to these two types.

We will have additional job with all those frontend tests that are actually related to different theme use. We don't want to waste time and money on testing tests that are irrelevant of the theme in use. In that favor, I added additional group `frontend` to catch only those important tests for theme testing.

## Code review notes

Check the additional CI job `acceptance_tests_blockbased_theme` that will run over 100 tests on a block-based TT4 theme.

I had to rewrite some tests because the old tests were not compatible with a block-based theme, some of the tests.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5787]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5787]: https://mailpoet.atlassian.net/browse/MAILPOET-5787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ