### PR TITLE
Reword sending paused message for Creator plans [MAILPOET-6026]

### DIFF
--- a/mailpoet/assets/js/src/automation/automation.tsx
+++ b/mailpoet/assets/js/src/automation/automation.tsx
@@ -5,6 +5,7 @@ import { TopBarWithBeamer } from 'common/top-bar/top-bar';
 import { SlotFillProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { registerTranslations } from 'common';
+import { MssAccessNotices } from 'notices/mss-access-notices';
 import { initializeApi } from './api';
 import { legacyAutomationCount } from './config';
 import { createStore, storeName } from './listing/store';
@@ -72,6 +73,7 @@ function Automations(): JSX.Element {
     <>
       <TopBarWithBeamer />
       <Notices />
+      <MssAccessNotices />
       <Content />
     </>
   );

--- a/mailpoet/assets/js/src/forms/forms.jsx
+++ b/mailpoet/assets/js/src/forms/forms.jsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Route } from 'react-router-dom';
 import { GlobalContext, useGlobalContextValue } from 'context';
+import { MssAccessNotices } from 'notices/mss-access-notices';
 import { Notices } from 'notices/notices.jsx';
 import { registerTranslations, withBoundary } from 'common';
 import { FormList } from './list.jsx';
@@ -10,6 +11,7 @@ function App() {
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <HashRouter>
         <Notices />
+        <MssAccessNotices />
         <Route path="*" render={withBoundary(FormList)} />
       </HashRouter>
     </GlobalContext.Provider>

--- a/mailpoet/assets/js/src/help/help.jsx
+++ b/mailpoet/assets/js/src/help/help.jsx
@@ -5,6 +5,7 @@ import { SystemInfo } from 'help/system-info.tsx';
 import { SystemStatus } from 'help/system-status.jsx';
 import { YourPrivacy } from 'help/your-privacy.jsx';
 import { GlobalContext, useGlobalContextValue } from 'context';
+import { MssAccessNotices } from 'notices/mss-access-notices';
 import { Notices } from 'notices/notices.jsx';
 import { RoutedTabs } from '../common/tabs/routed-tabs';
 import { registerTranslations, Tab } from '../common';
@@ -15,6 +16,7 @@ function App() {
     <GlobalContext.Provider value={useGlobalContextValue(window)}>
       <TopBar />
       <Notices />
+      <MssAccessNotices />
       <RoutedTabs activeKey="knowledgeBase">
         <Tab
           key="knowledgeBase"

--- a/mailpoet/assets/js/src/notices/invalid-mss-key-notice.tsx
+++ b/mailpoet/assets/js/src/notices/invalid-mss-key-notice.tsx
@@ -4,11 +4,67 @@ import ReactStringReplace from 'react-string-replace';
 
 type Props = {
   mssKeyInvalid: boolean;
+  pluginPartialKey: string;
+  premiumKeyValid: boolean;
   subscribersCount: number;
 };
 
-function InvalidMssKeyNotice({ mssKeyInvalid, subscribersCount }: Props) {
+function InvalidMssKeyNotice({
+  mssKeyInvalid,
+  pluginPartialKey,
+  premiumKeyValid,
+  subscribersCount,
+}: Props) {
   if (!mssKeyInvalid) return null;
+  if (premiumKeyValid) {
+    const upgradeLink = `${MailPoet.MailPoetComUrlFactory.getUpgradeUrl(
+      pluginPartialKey,
+      { s: subscribersCount, capabilities: { sendingService: true } },
+    )}&utm_source=plugin&utm_medium=premium&utm_campaign=upgrade&ref=creator-sending-paused-message`;
+    return (
+      <Notice type="error" timeout={false} closable={false} renderInPlace>
+        <h3>{MailPoet.I18n.t('allSendingPausedHeader')}</h3>
+        <p>
+          {ReactStringReplace(
+            MailPoet.I18n.t('allSendingPausedPremiumValidBody'),
+            /\[link\](.*?)\[\/link\]/g,
+            (match, index) => {
+              // first link tag
+              if (index === 1) {
+                return (
+                  <a
+                    href={upgradeLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    key="purchase-plan"
+                  >
+                    {match}
+                  </a>
+                );
+              }
+              // second link tag
+              return (
+                <a href="?page=mailpoet-settings#premium" key="check-sending">
+                  {match}
+                </a>
+              );
+            },
+          )}
+        </p>
+        <p>
+          <a
+            href={upgradeLink}
+            className="button button-primary"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {MailPoet.I18n.t('allSendingPausedPremiumValidLink')}
+          </a>
+        </p>
+      </Notice>
+    );
+  }
+  // Premium key invalid
   return (
     <Notice type="error" timeout={false} closable={false} renderInPlace>
       <h3>{MailPoet.I18n.t('allSendingPausedHeader')}</h3>

--- a/mailpoet/assets/js/src/notices/mss-access-notices.tsx
+++ b/mailpoet/assets/js/src/notices/mss-access-notices.tsx
@@ -43,6 +43,8 @@ export function MssAccessNotices() {
         !MailPoet.emailVolumeLimitReached && (
           <InvalidMssKeyNotice
             mssKeyInvalid={MailPoet.hasInvalidMssApiKey}
+            pluginPartialKey={MailPoet.pluginPartialKey}
+            premiumKeyValid={MailPoet.hasValidPremiumKey}
             subscribersCount={MailPoet.subscribersCount}
           />
         )}

--- a/mailpoet/assets/js/src/settings/settings.tsx
+++ b/mailpoet/assets/js/src/settings/settings.tsx
@@ -1,3 +1,4 @@
+import { MssAccessNotices } from 'notices/mss-access-notices';
 import { Notices } from 'notices/notices.jsx';
 import { Loading } from 'common/loading';
 import { t } from 'common/functions';
@@ -23,6 +24,7 @@ export function Settings() {
       <TopBar />
       {isSaving && <Loading />}
       <Notices />
+      <MssAccessNotices />
       <UnsavedChangesNotice storeName="mailpoet-settings" />
       <RoutedTabs activeKey="basics">
         <Tab

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -155,7 +155,9 @@
 
   'allSendingPausedHeader': __('All sending is currently paused!'),
   'allSendingPausedBody': __('Your [link]API key[/link] to send with MailPoet is invalid.'),
+  'allSendingPausedPremiumValidBody': __('You are not allowed to use the MailPoet sending service with your current API key. Kindly upgrate to a [link]MailPoet sending plan[/link] or switch your [link]sending method[/link].'),
   'allSendingPausedLink': __('Purchase a key'),
+  'allSendingPausedPremiumValidLink': __('Upgrade the plan'),
 
   'transactionalEmailNoticeTitle': __('Good news! MailPoet can now send your website’s emails too'),
   'transactionalEmailNoticeBody': __('All of your WordPress and WooCommerce emails are sent with your hosting company, unless you have an SMTP plugin. Would you like such emails to be delivered with MailPoet’s active sending method for better deliverability?'),


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

Testing instructions:
1. Verify a Creator API key on your test site. If you had another plan before it, you may need to clear the `mta.mailpoet_api_key_state` setting manually if it retains the `valid` state.
2. Select MSS as sending method.
3. Observe the message, check links.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6026]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6026]: https://mailpoet.atlassian.net/browse/MAILPOET-6026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ