### PR TITLE
Show notice when WP-cron is disabled [MAILPOET-6027]

### DIFF
--- a/mailpoet/lib/Util/Notices/DisabledWPCronNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledWPCronNotice.php
@@ -1,0 +1,62 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Cron\CronTrigger;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class DisabledWPCronNotice {
+
+  const DISMISS_NOTICE_TIMEOUT_SECONDS = YEAR_IN_SECONDS;
+  const OPTION_NAME = 'dismissed-wp-cron-disabled-notice';
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function __construct(
+    WPFunctions $wp,
+    SettingsController $settings
+  ) {
+    $this->wp = $wp;
+    $this->settings = $settings;
+  }
+
+  public function init($shouldDisplay) {
+    if (!$shouldDisplay) {
+      return null;
+    }
+    $isDismissed = $this->wp->getTransient(self::OPTION_NAME);
+    $currentMethod = $this->settings->get(CronTrigger::SETTING_CURRENT_METHOD);
+    $isWPCronMethodActive = $currentMethod === CronTrigger::METHOD_ACTION_SCHEDULER;
+    if (!$isDismissed && $isWPCronMethodActive && $this->isWPCronDisabled()) {
+      return $this->display();
+    }
+  }
+
+  public function isWPCronDisabled() {
+    return defined('DISABLE_WP_CRON') && DISABLE_WP_CRON;
+  }
+
+  public function display() {
+    $errorString = __('WordPress built-in cron is disabled with the DISABLE_WP_CRON constant on your website, this prevents MailPoet sending from working. Please enable WordPress built-in cron or choose a different cron method in MailPoet Settings.', 'mailpoet');
+
+    $buttonString = __('[link]Go to Settings[/link]', 'mailpoet');
+    $error = $errorString . '<br><br>' . Helpers::replaceLinkTags($buttonString, 'admin.php?page=mailpoet-settings#advanced', [
+      'class' => 'button-primary',
+    ]);
+
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+
+    return Notice::displayError($error, $extraClasses, self::OPTION_NAME, true, false);
+  }
+
+  public function disable() {
+    $this->wp->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+  }
+}

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -49,6 +49,9 @@ class PermanentNotices {
   /** @var DisabledMailFunctionNotice */
   private $disabledMailFunctionNotice;
 
+  /** @var DisabledWPCronNotice */
+  private $disabledWPCronNotice;
+
   /** @var PendingApprovalNotice */
   private $pendingApprovalNotice;
 
@@ -83,6 +86,7 @@ class PermanentNotices {
     $this->changedTrackingNotice = new ChangedTrackingNotice($wp);
     $this->deprecatedFilterNotice = new DeprecatedFilterNotice($wp);
     $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature, $mailerFactory);
+    $this->disabledWPCronNotice = new DisabledWPCronNotice($wp, $settings);
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
     $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);
@@ -134,6 +138,9 @@ class PermanentNotices {
     $this->disabledMailFunctionNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
+    $this->disabledWPCronNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
     $this->pendingApprovalNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
@@ -176,6 +183,9 @@ class PermanentNotices {
         break;
       case (ChangedTrackingNotice::OPTION_NAME):
         $this->changedTrackingNotice->disable();
+        break;
+      case (DisabledWPCronNotice::OPTION_NAME):
+        $this->disabledWPCronNotice->disable();
         break;
       case (DeprecatedFilterNotice::OPTION_NAME):
         $this->deprecatedFilterNotice->disable();

--- a/mailpoet/tests/integration/Util/Notices/DisabledWPCronNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/DisabledWPCronNoticeTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use Codeception\Util\Stub;
+use MailPoet\Cron\CronTrigger;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+
+class DisabledWPCronNoticeTest extends \MailPoetTest {
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  private $originalCronMethodSetting;
+
+  public function _before() {
+    parent::_before();
+
+    $this->settings = SettingsController::getInstance();
+    $this->originalCronMethodSetting = $this->settings->get(CronTrigger::SETTING_CURRENT_METHOD);
+    $this->settings->set(CronTrigger::SETTING_CURRENT_METHOD, CronTrigger::METHOD_ACTION_SCHEDULER);
+
+    $this->wp = new WPFunctions;
+    delete_transient(DisabledWPCronNotice::OPTION_NAME);
+  }
+
+  public function _after() {
+    parent::_after();
+    $this->settings->set(CronTrigger::SETTING_CURRENT_METHOD, $this->originalCronMethodSetting);
+    delete_transient(DisabledWPCronNotice::OPTION_NAME);
+  }
+
+  public function testItPrintsWarningWhenWPCronIsDisabled() {
+    $disabledWPCronNotice = Stub::construct(
+      DisabledWPCronNotice::class,
+      [$this->wp, $this->settings],
+      ['isWPCronDisabled' => true]
+    );
+    $notice = $disabledWPCronNotice->init(true);
+    verify($notice->getMessage())->stringContainsString('WordPress built-in cron is disabled');
+    verify($notice->getMessage())->stringContainsString('admin.php?page=mailpoet-settings#advanced');
+  }
+
+  public function testItPrintsNoWarningWhenWPCronIsNotDisabled() {
+    $disabledWPCronNotice = Stub::construct(
+      DisabledWPCronNotice::class,
+      [$this->wp, $this->settings],
+      ['isWPCronDisabled' => false]
+    );
+    $notice = $disabledWPCronNotice->init(true);
+    verify($notice)->null();
+  }
+
+  public function testItPrintsNoWarningWhenCronMethodIsNotActionScheduler() {
+    $this->settings->set(CronTrigger::SETTING_CURRENT_METHOD, CronTrigger::METHOD_WORDPRESS);
+    $disabledWPCronNotice = Stub::construct(
+      DisabledWPCronNotice::class,
+      [$this->wp, $this->settings],
+      ['isWPCronDisabled' => true]
+    );
+    $notice = $disabledWPCronNotice->init(true);
+    verify($notice)->null();
+  }
+
+  public function testItPrintsNoWarningWhenDisabled() {
+    $disabledWPCronNotice = Stub::construct(
+      DisabledWPCronNotice::class,
+      [$this->wp, $this->settings],
+      ['isWPCronDisabled' => true]
+    );
+    $warning = $disabledWPCronNotice->init(false);
+    verify($warning)->null();
+  }
+
+  public function testItPrintsNoWarningWhenDismissed() {
+    $disabledWPCronNotice = Stub::construct(
+      DisabledWPCronNotice::class,
+      [$this->wp, $this->settings],
+      ['isWPCronDisabled' => true]
+    );
+    $disabledWPCronNotice->disable();
+    $warning = $disabledWPCronNotice->init(true);
+    verify($warning)->null();
+  }
+}


### PR DESCRIPTION
## Description

The notice is shown only when the "WordPress built-in cron" option for Newsletter task scheduler is selected in Settings > Advanced.

## Code review notes

_N/A_

## QA notes

Testing instructions:
1. Select the "WordPress built-in cron option" for Newsletter task scheduler in Settings > Advanced.
2. Disable WP cron by setting the `DISABLE_WP_CRON` constant to `true`, e.g. in theme functions.php.
3. Observe the error message. It can be dismissed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6027]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6027]: https://mailpoet.atlassian.net/browse/MAILPOET-6027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ