### PR TITLE
Increase top padding for block tools in the form editor [MAILPOET-5340]

### DIFF
--- a/mailpoet/assets/css/src/components-form-editor/_block-editor.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_block-editor.scss
@@ -132,7 +132,7 @@ h2 {
 
 .edit-post-visual-editor {
   background-color: $color-white;
-  padding: 10px 10px 100px;
+  padding: 50px 10px 100px;
 }
 
 // Unify padding o wp-block-columns with background with front end rendering


### PR DESCRIPTION
## Description

In this PR I increased the padding on the top of the form editor so that the block tools popup has enough space to render above the content of the first block.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5340]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5340]: https://mailpoet.atlassian.net/browse/MAILPOET-5340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ