### PR TITLE
Add spinner to the email editor when loading is in progress [MAILPOET-6085]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/editor.tsx
@@ -10,7 +10,7 @@ import {
   privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { useMemo } from '@wordpress/element';
-import { SlotFillProvider } from '@wordpress/components';
+import { SlotFillProvider, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { storeName } from '../../store';
 
@@ -77,7 +77,11 @@ export function InnerEditor({
   );
 
   if (!post || (currentPost.postType !== 'wp_template' && !template)) {
-    return null;
+    return (
+      <div className="spinner-container">
+        <Spinner style={{ width: '80px', height: '80px' }} />
+      </div>
+    );
   }
 
   return (

--- a/mailpoet/assets/js/src/email-editor/engine/editor.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/editor.tsx
@@ -8,6 +8,7 @@ import { InnerEditor } from './components/block-editor/editor';
 import { createStore, storeName } from './store';
 import { initHooks } from './editor-hooks';
 import { KeyboardShortcuts } from './components/keybord-shortcuts';
+import './index.scss';
 
 function Editor() {
   const { postId, settings } = useSelect(

--- a/mailpoet/assets/js/src/email-editor/engine/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/index.scss
@@ -1,0 +1,7 @@
+.spinner-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh; /* Full viewport height */
+  width: 100vw; /* Full viewport width */
+}


### PR DESCRIPTION
## Description

This PR adds a spinner to the new email editor when loading is in progress.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6085]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6085]: https://mailpoet.atlassian.net/browse/MAILPOET-6085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ