### PR TITLE
Replace ts-ignore comments with ts-expect-error in the email editor code [MAILPOET-6044]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/blocks/powered-by-mailpoet/block.tsx
+++ b/mailpoet/assets/js/src/email-editor/blocks/powered-by-mailpoet/block.tsx
@@ -89,8 +89,7 @@ function Edit({
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-expect-error TS2322 Different types
 registerBlockType(metadata, {
   icon: {
     src: <Icon icon={MailPoetIcon} />,

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -61,7 +61,6 @@ export function Layout() {
       focusMode: select(storeName).isFeatureActive('focusMode'),
       styles: select(storeName).getStyles(),
       isEditingTemplate:
-        // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() === 'wp_template',
     }),
     [],

--- a/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/block-editor/layout.tsx
@@ -6,8 +6,7 @@ import {
 
 import {
   UnsavedChangesWarning,
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error No types for this exist yet.
   privateApis as editorPrivateApis,
   store as editorStore,
 } from '@wordpress/editor';

--- a/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/send-button.tsx
@@ -25,7 +25,6 @@ export function SendButton() {
       hasEmptyContent: select(storeName).hasEmptyContent(),
       isEmailSent: select(storeName).isEmailSent(),
       isEditingTemplate:
-        // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() === 'wp_template',
     }),
     [],

--- a/mailpoet/assets/js/src/email-editor/engine/components/inserter-sidebar/inserter-sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/inserter-sidebar/inserter-sidebar.tsx
@@ -12,7 +12,6 @@ export function InserterSidebar() {
       postContentId: blocks.find((block) => block.name === 'core/post-content')
         ?.clientId,
       isEditingEmailContent:
-        // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() !== 'wp_template',
     };
   });

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
@@ -18,7 +18,6 @@ export function Header() {
       selectedBlockId: select(blockEditorStore).getSelectedBlockClientId(),
       activeTab: select(storeName).getSettingsSidebarActiveTab(),
       isEditingTemplate:
-        // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() === 'wp_template',
     }),
     [],

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/header.tsx
@@ -18,8 +18,7 @@ export function Header() {
       selectedBlockId: select(blockEditorStore).getSelectedBlockClientId(),
       activeTab: select(storeName).getSettingsSidebarActiveTab(),
       isEditingTemplate:
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() === 'wp_template',
     }),
     [],

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/sidebar.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/sidebar.tsx
@@ -25,7 +25,6 @@ export function Sidebar(props: Props): JSX.Element {
     (select) => ({
       activeTab: select(storeName).getSettingsSidebarActiveTab(),
       isEditingTemplate:
-        // @ts-expect-error No types for this exist yet.
         select(editorStore).getCurrentPostType() === 'wp_template',
     }),
     [],

--- a/mailpoet/assets/js/src/email-editor/engine/components/sidebar/templates-panel.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/sidebar/templates-panel.tsx
@@ -70,20 +70,12 @@ export function TemplatesPanel() {
   async function revertAndSaveTemplate() {
     try {
       await revertTemplate(template);
-      await saveEditedEntityRecord(
-        'postType',
-        // @ts-expect-error Todo template type is not defined
-        template.type as string,
-        // @ts-expect-error Todo template type is not defined
-        template.id as string,
-        {},
-      );
+      await saveEditedEntityRecord('postType', template.type, template.id, {});
       void createSuccessNotice(
         sprintf(
           /* translators: The template/part's name. */
           __('"%s" reset.', 'mailpoet'),
-          // @ts-expect-error template type is not defined
-          decodeEntities(template.title as string),
+          decodeEntities(template.title),
         ),
         {
           type: 'snackbar',
@@ -116,12 +108,10 @@ export function TemplatesPanel() {
           variant="primary"
           onClick={() => {
             onNavigateToEntityRecord({
-              // @ts-expect-error template type is not defined
               postId: template.id,
               postType: 'wp_template',
             });
           }}
-          // @ts-expect-error template type is not defined
           disabled={!template.id}
         >
           {__('Edit template', 'mailpoet')}

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/async.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/async.ts
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState, flushSync } from '@wordpress/element';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-expect-error TS7016 Could not find a declaration file for module '@wordpress/priority-queue'
 import { createQueue } from '@wordpress/priority-queue';
 
 const blockPreviewQueue = createQueue();

--- a/mailpoet/assets/js/src/email-editor/engine/components/template-select/select-modal.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/template-select/select-modal.tsx
@@ -9,18 +9,17 @@ import {
 } from '@wordpress/components';
 import { Async } from './async';
 import { usePreviewTemplates } from '../../hooks';
-import { storeName } from '../../store/constants';
+import { storeName, TemplatePreview } from '../../store';
 
 const BLANK_TEMPLATE = 'email-general';
 
 export function SelectTemplateModal({ onSelectCallback }) {
   const [templates] = usePreviewTemplates();
 
-  const handleTemplateSelection = (template) => {
+  const handleTemplateSelection = (template: TemplatePreview) => {
     void dispatch(editorStore).resetEditorBlocks(template.patternParsed);
     void dispatch(storeName).setTemplateToPost(
       template.slug,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       template.template.mailpoet_email_theme ?? {},
     );
     onSelectCallback();
@@ -29,7 +28,7 @@ export function SelectTemplateModal({ onSelectCallback }) {
   const handleCloseWithoutSelection = () => {
     const blankTemplate = templates.find(
       (template) => template.slug === BLANK_TEMPLATE,
-    );
+    ) as unknown as TemplatePreview;
     if (!blankTemplate) return; // Prevent close if blank template is still not loaded
     handleTemplateSelection(blankTemplate);
   };
@@ -80,14 +79,12 @@ export function SelectTemplateModal({ onSelectCallback }) {
                       viewportWidth={900}
                       minHeight={300}
                       additionalStyles={[
-                        // @ts-expect-error No types for template
                         { css: template.template.email_theme_css },
                       ]}
                     />
 
                     <HStack className="block-editor-patterns__pattern-details">
                       <div className="block-editor-block-patterns-list__item-title">
-                        {/* @ts-expect-error No type for template */}
                         {template.template.title.rendered}
                       </div>
                     </HStack>

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-theme.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-theme.ts
@@ -13,21 +13,13 @@ export function useEmailTheme() {
     // Edit email post mode
     if (currentPostType === 'mailpoet_email') {
       const template = select(storeName).getEditedPostTemplate();
-      // @ts-expect-error Todo types for template with email_theme
       templateThemeData = template?.mailpoet_email_theme || {};
-      // @ts-expect-error Todo types for template with email_theme
       tId = template?.id;
-      // @ts-expect-error Todo types for template
       tContent = template?.content;
     } else {
-      // @ts-expect-error Todo types for template with email_theme
+      // @ts-expect-error TS2322: Type 'string' has no properties in common with type 'EmailTheme'.
       templateThemeData =
-        // @ts-expect-error Property 'getCurrentPostAttribute' has no types
-        select(editorStore).getCurrentPostAttribute('mailpoet_email_theme') ||
-        {};
-      // @ts-expect-error Todo types for template with email_theme
-      templateThemeData =
-        // @ts-expect-error Property 'getCurrentPostAttribute' has no types
+        // @ts-expect-error Expected 0 arguments, but got 1.
         select(editorStore).getCurrentPostAttribute('mailpoet_email_theme') ||
         {};
     }

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-theme.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-email-theme.ts
@@ -6,7 +6,6 @@ import { EmailTheme, storeName } from '../store';
 
 export function useEmailTheme() {
   const { templateTheme, templateId } = useSelect((select) => {
-    // @ts-expect-error Property 'getCurrentPostType' has no types
     const currentPostType = select(editorStore).getCurrentPostType();
     let templateThemeData: EmailTheme = {};
     let tId = null;
@@ -21,11 +20,12 @@ export function useEmailTheme() {
       // @ts-expect-error Todo types for template
       tContent = template?.content;
     } else {
-      // Edit email template mode
+      // @ts-expect-error Todo types for template with email_theme
       templateThemeData =
         // @ts-expect-error Property 'getCurrentPostAttribute' has no types
         select(editorStore).getCurrentPostAttribute('mailpoet_email_theme') ||
         {};
+      // @ts-expect-error Todo types for template with email_theme
       templateThemeData =
         // @ts-expect-error Property 'getCurrentPostAttribute' has no types
         select(editorStore).getCurrentPostAttribute('mailpoet_email_theme') ||

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-preview-templates.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-preview-templates.ts
@@ -1,7 +1,7 @@
 import { BlockInstance, parse } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { storeName } from '../store/constants';
+import { storeName, EmailTemplatePreview, TemplatePreview } from '../store';
 
 /**
  * We need to merge pattern blocks and template blocks for BlockPreview component.
@@ -30,7 +30,7 @@ function setPostContentInnerBlocks(
   });
 }
 
-export function usePreviewTemplates() {
+export function usePreviewTemplates(): TemplatePreview[][] {
   const { templates, patterns } = useSelect((select) => {
     const contentBlockId =
       // @ts-expect-error getBlocksByName is not defined in types
@@ -55,11 +55,8 @@ export function usePreviewTemplates() {
     pattern?.name?.startsWith('mailpoet'),
   )?.blocks as BlockInstance[];
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return [
-    templates.map((template) => {
-      // @ts-expect-error Missing property type
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    templates.map((template: EmailTemplatePreview): TemplatePreview => {
       let parsedTemplate = parse(template.content?.raw);
       parsedTemplate = setPostContentInnerBlocks(
         parsedTemplate,
@@ -67,7 +64,6 @@ export function usePreviewTemplates() {
       );
 
       return {
-        // @ts-expect-error Missing property type
         slug: template.slug,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         contentParsed: parsedTemplate,

--- a/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/actions.ts
@@ -108,8 +108,7 @@ export function* updateEmailMailPoetProperty(name: string, value: string) {
     'mailpoet_email',
     postId,
   );
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
   const mailpoetData = editedPost?.mailpoet_data || {};
   yield dispatch(coreDataStore).editEntityRecord(
     'postType',

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -55,8 +55,7 @@ export const isEmpty = createRegistrySelector((select) => (): boolean => {
   );
   if (!post) return true;
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error Missing property in type
   const { content, mailpoet_data: mailpoetData, title } = post;
   return (
     !content.raw &&
@@ -77,8 +76,7 @@ export const hasEmptyContent = createRegistrySelector(
     );
     if (!post) return true;
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error Missing property in type
     const { content } = post;
     return !content.raw;
   },
@@ -94,8 +92,7 @@ export const isEmailSent = createRegistrySelector((select) => (): boolean => {
   );
   if (!post) return false;
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error Missing property in type
   const status = post.status;
   return status === 'sent';
 });
@@ -140,15 +137,13 @@ export const getEditedEmailContent = createRegistrySelector(
  */
 export const getEditedPostTemplate = createRegistrySelector((select) => () => {
   const currentTemplate =
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error Property 'getEditedPostAttribute' does not exist on type '{}'
     select(editorStore).getEditedPostAttribute('template');
 
   if (currentTemplate) {
     const templateWithSameSlug = select(coreDataStore)
       .getEntityRecords('postType', 'wp_template', { per_page: -1 })
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error Missing property in type
       ?.find((template) => template.slug === currentTemplate);
 
     if (!templateWithSameSlug) {
@@ -165,8 +160,7 @@ export const getEditedPostTemplate = createRegistrySelector((select) => () => {
     );
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error Property 'getDefaultTemplateId' does not exist
   const defaultTemplateId = select(coreDataStore).getDefaultTemplateId({
     slug: 'email-general',
   });
@@ -181,13 +175,11 @@ export const getEditedPostTemplate = createRegistrySelector((select) => () => {
 
 export const getCurrentTemplate = createRegistrySelector((select) => () => {
   const isEditingTemplate =
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error Property 'getCurrentPostType' does not exist on type '{}'
     select(editorStore).getCurrentPostType() === 'wp_template';
 
   if (isEditingTemplate) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error Property 'getCurrentPostId' does not exist on type '{}'
     const templateId = select(editorStore).getCurrentPostId();
 
     return select(coreDataStore).getEditedEntityRecord(

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -175,11 +175,9 @@ export const getEditedPostTemplate = createRegistrySelector((select) => () => {
 
 export const getCurrentTemplate = createRegistrySelector((select) => () => {
   const isEditingTemplate =
-    // @ts-expect-error Property 'getCurrentPostType' does not exist on type '{}'
     select(editorStore).getCurrentPostType() === 'wp_template';
 
   if (isEditingTemplate) {
-    // @ts-expect-error Property 'getCurrentPostId' does not exist on type '{}'
     const templateId = select(editorStore).getCurrentPostId();
 
     return select(coreDataStore).getEditedEntityRecord(

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -198,6 +198,16 @@ export type MailPoetEmailData = {
   preview_url: string;
 };
 
+export type EmailTemplate = {
+  id: string;
+  content: string;
+  email_theme_css: string;
+  mailpoet_email_theme?: EmailTheme;
+  theme: string;
+  title: string;
+  type: string;
+};
+
 export type Feature =
   | 'fullscreenMode'
   | 'showIconLabels'

--- a/mailpoet/assets/js/src/email-editor/engine/store/types.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/types.ts
@@ -1,4 +1,5 @@
 import { EditorSettings, EditorColor } from '@wordpress/block-editor';
+import { BlockInstance } from '@wordpress/blocks';
 
 export enum SendingPreviewStatus {
   SUCCESS = 'success',
@@ -200,12 +201,31 @@ export type MailPoetEmailData = {
 
 export type EmailTemplate = {
   id: string;
+  slug: string;
   content: string;
   email_theme_css: string;
   mailpoet_email_theme?: EmailTheme;
   theme: string;
   title: string;
   type: string;
+};
+
+export type EmailTemplatePreview = Omit<EmailTemplate, 'content' | 'title'> & {
+  content: {
+    block_version: number;
+    raw: string;
+  };
+  title: {
+    raw: string;
+    rendered: string;
+  };
+};
+
+export type TemplatePreview = {
+  slug: string;
+  contentParsed: BlockInstance[];
+  patternParsed: BlockInstance[];
+  template: EmailTemplatePreview;
 };
 
 export type Feature =

--- a/mailpoet/assets/js/src/types/wordpress-modules.ts
+++ b/mailpoet/assets/js/src/types/wordpress-modules.ts
@@ -15,6 +15,22 @@ declare module '@wordpress/block-editor' {
   }>;
 }
 
+declare module '@wordpress/editor' {
+  import * as editorActions from '@wordpress/editor/store/actions';
+  import * as editorSelectors from '@wordpress/editor/store/selectors';
+  import { StoreDescriptor as GenericStoreDescriptor } from '@wordpress/data/build-types/types';
+
+  export * from '@wordpress/editor/index';
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - disable redeclaration error because it's a module declaration
+  export const store: { name: 'core/editor' } & GenericStoreDescriptor<{
+    reducer: () => unknown;
+    actions: typeof editorActions;
+    selectors: typeof editorSelectors;
+  }>;
+}
+
 // there are no @types/wordpress__interface yet
 declare module '@wordpress/interface' {
   import { StoreDescriptor } from '@wordpress/data/build-types/types';


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6044]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6044]: https://mailpoet.atlassian.net/browse/MAILPOET-6044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ