### PR TITLE
Load missing styles in iframe mode of editor [MAILPOET-6079]

### DIFF
--- a/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Engine/EmailEditor.php
@@ -20,17 +20,20 @@ class EmailEditor {
   private Templates $templates;
   private TemplatePreview $templatePreview;
   private Patterns $patterns;
+  private SettingsController $settingsController;
 
   public function __construct(
     EmailApiController $emailApiController,
     Templates $templates,
     TemplatePreview $templatePreview,
-    Patterns $patterns
+    Patterns $patterns,
+    SettingsController $settingsController
   ) {
     $this->emailApiController = $emailApiController;
     $this->templates = $templates;
     $this->templatePreview = $templatePreview;
     $this->patterns = $patterns;
+    $this->settingsController = $settingsController;
   }
 
   public function initialize(): void {
@@ -40,7 +43,11 @@ class EmailEditor {
     $this->registerBlockPatterns();
     $this->registerEmailPostTypes();
     $this->registerEmailPostSendStatus();
-    $this->extendEmailPostApi();
+    $isEditorPage = apply_filters('mailpoet_is_email_editor_page', false);
+    if ($isEditorPage) {
+      $this->extendEmailPostApi();
+      $this->settingsController->init();
+    }
   }
 
   private function registerBlockTemplates(): void {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\Config\Menu;
 use MailPoet\Features\FeaturesController;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -35,6 +36,7 @@ class EmailEditor {
     $this->cli->initialize();
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
     $this->wp->addAction('rest_delete_mailpoet_email', [$this->emailApiController, 'trashEmail'], 10, 1);
+    $this->wp->addFilter('mailpoet_is_email_editor_page', [$this, 'isEditorPage'], 10, 1);
     $this->extendEmailPostApi();
   }
 
@@ -50,6 +52,10 @@ class EmailEditor {
       ],
     ];
     return $postTypes;
+  }
+
+  public function isEditorPage(bool $isEditorPage): bool {
+    return $isEditorPage || (isset($_GET['page']) && $_GET['page'] === Menu::EMAIL_EDITOR_V2_PAGE_SLUG);
   }
 
   public function extendEmailPostApi() {


### PR DESCRIPTION
## Description

This PR should address visual issues with the editor canvas after we switched to the iframe mode. The most affected blocks were groups and images.

## Code review notes

Please see the comment in the commit message for the details.

To replicate the issue, just insert an image or group block.

## QA notes

I think we can skip the QA if the code reviewer checks the functionality.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6079]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6079]: https://mailpoet.atlassian.net/browse/MAILPOET-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ