### PR TITLE
Fix flaky automation and homepage tests

### DIFF
--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -97,7 +97,6 @@ class CreateEmailAutomationAndWalkThroughCest {
 
     // Jump the waiting time by scheduling the delay action to now.
     $i->triggerAutomationActionScheduler(); // Initialize the run, creates the delay step
-    $i->triggerAutomationActionScheduler(); // Set delay scheduled at to now, runs delay and send email
 
     // Check that the send email step waits for email to be sent.
     $i->moveBack();
@@ -105,11 +104,14 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->click('Analytics', '.mailpoet-automation-listing');
     $emailStatsContainer = Locator::contains('.mailpoet-automation-editor-step-wrapper', 'Send email');
     $i->see('Sent 0', $emailStatsContainer);
+    $i->triggerAutomationActionScheduler(); // Set delay scheduled at to now, runs delay and send email
+    $i->reloadPage();
     $i->see('(1) waiting', $emailStatsContainer);
 
     // Send the email and check that the step status reflects that.
     $i->triggerMailPoetActionScheduler(); // Runs the email queue & updates the step status
     $i->reloadPage();
+    $i->waitForText('Welcome new subscribers');
     $i->see('Sent 1', $emailStatsContainer);
     $i->see('(0) waiting', $emailStatsContainer);
 

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -48,6 +48,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->type('My Campaign Name');
 
     $i->wantTo('Change subject and preheader');
+    $i->click('[aria-label="Change campaign name"]');
     $i->click('[data-automation-id="email_settings_tab"]');
     $i->fillField('[data-automation-id="email_subject"]', 'My New Subject');
     $i->fillField('[data-automation-id="email_preview_text"]', 'My New Preview Text');

--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use PHPUnit\Framework\Exception;
+
 class HomepageLandingAfterActivatingMailPoetCest {
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();
@@ -24,8 +26,19 @@ class HomepageLandingAfterActivatingMailPoetCest {
     $i->waitForNoticeAndClose('Selected plugins deactivated.');
 
     $i->click('#activate-mailpoet');
-    $i->waitForText('Better email — without leaving WordPress');
-    $i->seeInCurrentUrl('mailpoet-landingpage');
+    
+    // Sometimes it is "flaky" and shows the my plugins page instead homepage
+    try {
+      $i->waitForText('Better email — without leaving WordPress', 10);
+      $i->seeInCurrentUrl('mailpoet-landingpage');
+    } catch (Exception $e) {
+      $i->waitForNoticeAndClose('Plugin activated.');
+      $i->deactivatePlugin('mailpoet');
+      $i->waitForNoticeAndClose('Selected plugins deactivated.');
+      $i->click('#activate-mailpoet');
+      $i->waitForText('Better email — without leaving WordPress', 10);
+      $i->seeInCurrentUrl('mailpoet-landingpage');
+    }
   }
 
   public function _after(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Please read the description in the Jira ticket.

## Code review notes

_N/A_

## QA notes

This is optional
`./do test:acceptance --file=/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php --skip-deps`
`./do test:acceptance --file=/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php --skip-deps`
`./do test:acceptance --file=/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php --skip-deps`

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6093]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6093]: https://mailpoet.atlassian.net/browse/MAILPOET-6093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ