### PR TITLE
Ensure protocol in link inputs in legacy email editor [MAILPOET-4905]

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/blocks/base.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/base.js
@@ -5,6 +5,7 @@
  * BlockToolsView, BlockSettingsView and BlockWidgetView are optional.
  */
 import { App } from 'newsletter-editor/app';
+import { prependHTTPS } from '@wordpress/url';
 import Marionette from 'backbone.marionette';
 import SuperModel from 'backbone.supermodel';
 import _ from 'underscore';
@@ -307,6 +308,15 @@ Module.BlockSettingsView = Marionette.View.extend({
   },
   changeField: function changeField(field, event) {
     this.model.set(field, jQuery(event.target).val());
+  },
+  /*
+   * Prepends https:// if the value doesn't start as a shortcode '[' or there is already a protocol in place.
+   */
+  changeUrlField: function changeUrlField(field, event) {
+    const value = jQuery(event.target).val().trim();
+    const fixedValue = value.startsWith('[') ? value : prependHTTPS(value);
+    jQuery(event.target).val(fixedValue);
+    this.model.set(field, fixedValue);
   },
   changePixelField: function changePixelField(field, event) {
     this.changeFieldWithSuffix(field, event, 'px');

--- a/mailpoet/assets/js/src/newsletter-editor/blocks/button.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/button.js
@@ -81,7 +81,10 @@ Module.ButtonBlockSettingsView = base.BlockSettingsView.extend({
   events: function () {
     return {
       'input .mailpoet_field_button_text': _.partial(this.changeField, 'text'),
-      'input .mailpoet_field_button_url': _.partial(this.changeField, 'url'),
+      'change .mailpoet_field_button_url': _.partial(
+        this.changeUrlField,
+        'url',
+      ),
       'change .mailpoet_field_button_alignment': _.partial(
         this.changeField,
         'styles.block.textAlign',

--- a/mailpoet/assets/js/src/newsletter-editor/blocks/image.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/image.js
@@ -132,7 +132,10 @@ Module.ImageBlockSettingsView = base.BlockSettingsView.extend({
   },
   events: function () {
     return {
-      'input .mailpoet_field_image_link': _.partial(this.changeField, 'link'),
+      'change .mailpoet_field_image_link': _.partial(
+        this.changeUrlField,
+        'link',
+      ),
       'input .mailpoet_field_image_alt_text': _.partial(
         this.changeField,
         'alt',

--- a/mailpoet/assets/js/src/newsletter-editor/blocks/social.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/social.js
@@ -206,7 +206,7 @@ SocialBlockSettingsIconView = Marionette.View.extend({
         this.changeField,
         'image',
       ),
-      'input .mailpoet_social_icon_field_link': this.changeLink,
+      'change .mailpoet_social_icon_field_link': this.changeLink,
       'input .mailpoet_social_icon_field_text': _.partial(
         this.changeField,
         'text',
@@ -253,9 +253,7 @@ SocialBlockSettingsIconView = Marionette.View.extend({
     }
     return undefined;
   },
-  changeField: function (field, event) {
-    this.model.set(field, jQuery(event.target).val());
-  },
+  changeField: base.BlockSettingsView.prototype.changeUrlField,
 });
 
 SocialBlockSettingsIconCollectionView = Marionette.CollectionView.extend({

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/button.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/button.spec.js
@@ -413,9 +413,31 @@ describe('Button', function () {
       it('updates the model when link is changed', function () {
         var newValue = 'http://google.com/?q=123456';
 
-        view.$('.mailpoet_field_button_url').val(newValue).trigger('input');
+        view.$('.mailpoet_field_button_url').val(newValue).trigger('change');
 
         expect(model.get('url')).to.equal(newValue);
+      });
+
+      it('adds https protocol to url when needed', function () {
+        let newValue = 'example.com';
+        view.$('.mailpoet_field_button_url').val(newValue).trigger('change');
+        expect(model.get('url')).to.equal('https://example.com');
+
+        newValue = 'https://example2.com';
+        view.$('.mailpoet_field_button_url').val(newValue).trigger('change');
+        expect(model.get('url')).to.equal('https://example2.com');
+
+        newValue = 'http://example3.com';
+        view.$('.mailpoet_field_button_url').val(newValue).trigger('change');
+        expect(model.get('url')).to.equal('http://example3.com');
+
+        newValue = 'mailto:test@example.com';
+        view.$('.mailpoet_field_button_url').val(newValue).trigger('change');
+        expect(model.get('url')).to.equal('mailto:test@example.com');
+
+        newValue = '[shortcode]';
+        view.$('.mailpoet_field_button_url').val(newValue).trigger('change');
+        expect(model.get('url')).to.equal('[shortcode]');
       });
 
       it('updates the model when font color changes', function () {

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/image.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/image.spec.js
@@ -248,7 +248,7 @@ describe('Image', function () {
 
     describe('once rendered', function () {
       it('updates the model when link changes', function () {
-        view.$('.mailpoet_field_image_link').val(newLink).trigger('input');
+        view.$('.mailpoet_field_image_link').val(newLink).trigger('change');
         expect(model.get('link')).to.equal(newLink);
       });
 


### PR DESCRIPTION
## Description

This PR addresses the issue of allowing links without protocol in link inputs for button, image, and social button blocks. 
Instead of adding a warning, I decided to auto-fix the link and add protocol if needed after a user leaves the input. That way, they get immediate feedback that the protocol was added.

I chose to add `https://` automatically because over [85% of websites](https://w3techs.com/technologies/details/ce-httpsdefault). If a protocol is present, it is not replaced. That allows users to use `http://` or `mailto:`. Additionally I also allowed adding shortcodes as values.


https://github.com/mailpoet/mailpoet/assets/1082140/f1db0884-7650-45b3-b4e7-19ac42af61e9


## Code review notes

I found that [wordpress/url has a handy function prependHttps](https://www.npmjs.com/package/@wordpress/url) so I used it.

## QA notes

Please see the ticket for a detailed description of the issue.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4905], closes #4630

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4905]: https://mailpoet.atlassian.net/browse/MAILPOET-4905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ