### PR TITLE
Update ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN

### DIFF
--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -31,7 +31,7 @@ class API {
   public const ERROR_MESSAGE_INVALID_FROM = 'The email address is not authorized';
   public const ERROR_MESSAGE_PENDING_APPROVAL = 'Key is valid, but not approved yet; you can send only to authorized email addresses at the moment';
   public const ERROR_MESSAGE_DMRAC = "Email violates Sender Domain's DMARC policy. Please set up sender authentication.";
-  public const ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN = 'Bulk email are forbidden for the sender address';
+  public const ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN = 'Please update the plugin and add/update your sender domain (refer to https://account.mailpoet.com/sender_domains)';
   // Bridge message from https://github.com/mailpoet/services-bridge/blob/master/extensions/authentication/basic_strategy.rb
   public const ERROR_MESSAGE_UNAUTHORIZED = 'No valid API key provided';
   public const ERROR_MESSAGE_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges';


### PR DESCRIPTION
## Description

Update `ERROR_MESSAGE_BULK_EMAIL_FORBIDDEN` to match the [Bridge error messages](https://github.com/mailpoet/services-bridge/blob/master/api/messages.rb) so that the error mapping works [here](https://github.com/mailpoet/mailpoet/blob/77e3bfa823d3fb54334b903721f4187d271e16fa/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php#L87).

With this change, the sending error is qualified as soft, sending is not globally paused, and the notice in the ticket screenshot is not displayed.

## Code review notes

I also [opened this PR](https://github.com/mailpoet/services-bridge/pull/186) so that the messages get updated in both places.

## QA notes

It can't be tested because the conditions are hard to create. 
For example:
- you have a very old version of the plugin (4.32.0) + a key with Sending Service access
- a From address that is authorized but not from an authorized sender domain 
- you schedule a newsletter for a list with more than 5000 recipients.
- you update the plugin to this version
- the newsletter starts sending
- the sending service sends the error

In that case, the expected behavior is:
- the newsletter is paused but global sending is not paused
- It's not possible to resume the newsletter unless the 'From address' is from an authorized sender domain

Please note that if the plugin is on a newer version, it is not possible to schedule bulk emails if the 'From' address is not from an authorized sender domain.

Note: We have automated tests that check the behavior is correct but this requires that the errors match.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6024]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6024]: https://mailpoet.atlassian.net/browse/MAILPOET-6024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ