### PR TITLE
Fix test data not always being 3 months ago at the end of the month

### DIFF
--- a/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
+++ b/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
@@ -126,7 +126,7 @@ class AnalyticsCest {
     $i->see('2clicked', '.woocommerce-table__summary');
 
     $i->wantTo("Compare historical data");
-    $date = (new \DateTimeImmutable())->modify('-3 months');
+    $date = (new \DateTimeImmutable('first day of this month'))->modify('+15 days')->modify('-3 months'); // 3 months ago, mid-month
     $this->alterCreateDateForClick($click1, $date);
     $this->alterCreateDateForOpen($open2, $date);
 
@@ -230,7 +230,7 @@ class AnalyticsCest {
 
   private function createNewsletter($newsletterTitle) {
 
-    $date = (new \DateTimeImmutable())->modify('-3 months');
+    $date = (new \DateTimeImmutable('first day of this month'))->modify('+15 days')->modify('-3 months'); // 3 months ago, mid-month
     return (new Newsletter())
       ->withSubject($newsletterTitle)
       ->loadBodyFrom('newsletterWithText.json')


### PR DESCRIPTION
## Description

For instance, when it's May 31, then "new \DateTimeImmutable()->modify('-3 months')" is March 1, while we would expect the date to be in February.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
