### PR TITLE
Improve Sending Queue Worker [MAILPOET-5881]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -291,11 +291,7 @@ class SendingQueue {
         $this->scheduledTaskSubscribersRepository->deleteByScheduledTaskAndSubscriberIds($task, $subscribersToRemove);
         $this->sendingQueuesRepository->updateCounts($queue);
 
-        if (!$queue->getCountToProcess()) {
-          $this->newsletterTask->markNewsletterAsSent($newsletter);
-          continue;
-        }
-        // if there aren't any subscribers to process in batch (e.g. all unsubscribed or were deleted) continue with next batch
+        // if there aren't any subscribers to process in the batch (e.g. all unsubscribed or were deleted), continue with the next batch
         if (count($foundSubscribersIds) === 0) {
           continue;
         }
@@ -350,6 +346,9 @@ class SendingQueue {
         return;
       }
     }
+    // At this point all batches were processed or there are no batches to process
+    // Also none of the checks above paused or invalidated the task
+    $this->endSending($task, $newsletter);
   }
 
   public function getBatchSize(): int {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -349,6 +349,7 @@ class SendingQueue {
           'Can\'t send corrupt newsletter',
           ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
         );
+        return;
       }
     }
   }


### PR DESCRIPTION
## Description

This PR adds a couple of fixes and improvements for issues we identified during debugging sending issues after we released the Doctrine refactor.

## Code review notes

I followed the ideas from the ticket. Just a few notes:

1) I kept one call of the method for ending the sending also inside the batch processing loop because we have the execution limits check there, and in case the check throws an error, we would need to wait for another cron run to pick the task again. So it is more like an optimization.

2) I wanted to cover all the states in the method for handling the end of sending, but I was not sure what to do for the unexpected states (`PAUSED`, `INVALID`, `SCHEDULED`). These can, IMO, happen only because of some parallel run, or maybe the user clicking pause at the very exact moment. Paused and invalid tasks shouldn't block sending as these are not picked again. The schedule should be picked up again and hopefully processed. An alternative option I was thinking about was checking if there are unprocessed subscribers and, if not, marking a task as completed. Any thoughts/suggestions about this?

## QA notes

Please test sending thoroughly. 
Try sending different types of emails simultaneously to small and large lists.
Test also cases like welcome email and switching the related subscriber to unsubscribed before the email is trigerred.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5881]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5881]: https://mailpoet.atlassian.net/browse/MAILPOET-5881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ