### PR TITLE
Show "Bridge is not accessible" notice globally [MAILPOET-6030]

### DIFF
--- a/mailpoet/assets/js/src/notices/bridge-ping-error-notice.tsx
+++ b/mailpoet/assets/js/src/notices/bridge-ping-error-notice.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react';
+import { extractPageNameFromUrl } from 'common/functions';
+import { Notice } from 'notices/notice';
+import { MailPoet } from 'mailpoet';
+import ReactStringReplace from 'react-string-replace';
+
+const LOCAL_STORAGE_KEY = 'mailpoet_mss_ping_last_success_at';
+const CACHE_TIME = 60 * 60 * 1000; // 1 hour
+
+const cacheSuccessfulResult = () => {
+  window.localStorage.setItem(LOCAL_STORAGE_KEY, Date.now().toString());
+};
+
+const isSuccessfulResultCached = () => {
+  const lastSuccessAt = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+  return (
+    lastSuccessAt && Date.now() - parseInt(lastSuccessAt, 10) <= CACHE_TIME
+  );
+};
+
+function BridgePingErrorNotice() {
+  const [bridgeError, setBridgeError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Show only when sending method is MailPoet
+    if (MailPoet.mtaMethod !== 'MailPoet') return;
+    // Do not show on the MailPoet Help page, it has its own MSS status indication
+    if (extractPageNameFromUrl() === 'help') return;
+
+    // Don't make a request if we have a recently cached successful result
+    if (isSuccessfulResultCached()) return;
+
+    void MailPoet.Ajax.post({
+      api_version: MailPoet.apiVersion,
+      endpoint: 'Services',
+      action: 'pingBridge',
+    })
+      .done(() => {
+        cacheSuccessfulResult();
+        // Do not display the notice if there are no errors
+        setBridgeError(null);
+      })
+      .fail((errorResponse) => {
+        const errObject = errorResponse?.errors?.[0];
+        if (errObject.error && errObject.message) {
+          // Display MSS error if server responded with error message
+          setBridgeError(errObject.message);
+        } else {
+          // Do not display the notice if there is no server response
+          setBridgeError(null);
+        }
+      });
+  }, []);
+
+  if (!bridgeError) return null;
+  return (
+    <Notice type="error" timeout={false} closable={false} renderInPlace>
+      <h3>{MailPoet.I18n.t('bridgePingErrorHeader')}</h3>
+      <p>
+        {ReactStringReplace(
+          `${MailPoet.I18n.t('systemStatusMSSConnectionCanNotConnect')}`,
+          /\[link\](.*?)\[\/link\]/g,
+          (match) => (
+            <a
+              href="https://kb.mailpoet.com/article/319-known-errors-when-validating-a-mailpoet-key"
+              target="_blank"
+              rel="noopener noreferrer"
+              key="bridge-ping-error-kb-link"
+            >
+              {match}
+            </a>
+          ),
+        )}
+      </p>
+      {bridgeError ? (
+        <p>
+          <i>{bridgeError}</i>
+        </p>
+      ) : null}
+    </Notice>
+  );
+}
+
+BridgePingErrorNotice.displayName = 'BridgePingErrorNotice';
+export { BridgePingErrorNotice };

--- a/mailpoet/assets/js/src/notices/bridge-ping-error-notice.tsx
+++ b/mailpoet/assets/js/src/notices/bridge-ping-error-notice.tsx
@@ -1,56 +1,19 @@
-import { useState, useEffect } from 'react';
 import { extractPageNameFromUrl } from 'common/functions';
 import { Notice } from 'notices/notice';
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
-
-const LOCAL_STORAGE_KEY = 'mailpoet_mss_ping_last_success_at';
-const CACHE_TIME = 60 * 60 * 1000; // 1 hour
-
-const cacheSuccessfulResult = () => {
-  window.localStorage.setItem(LOCAL_STORAGE_KEY, Date.now().toString());
-};
-
-const isSuccessfulResultCached = () => {
-  const lastSuccessAt = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-  return (
-    lastSuccessAt && Date.now() - parseInt(lastSuccessAt, 10) <= CACHE_TIME
-  );
-};
+import { useServiceCheck } from './hooks/use-service-check';
 
 function BridgePingErrorNotice() {
-  const [bridgeError, setBridgeError] = useState<string | null>(null);
-
-  useEffect(() => {
-    // Show only when sending method is MailPoet
-    if (MailPoet.mtaMethod !== 'MailPoet') return;
-    // Do not show on the MailPoet Help page, it has its own MSS status indication
-    if (extractPageNameFromUrl() === 'help') return;
-
-    // Don't make a request if we have a recently cached successful result
-    if (isSuccessfulResultCached()) return;
-
-    void MailPoet.Ajax.post({
-      api_version: MailPoet.apiVersion,
-      endpoint: 'Services',
-      action: 'pingBridge',
-    })
-      .done(() => {
-        cacheSuccessfulResult();
-        // Do not display the notice if there are no errors
-        setBridgeError(null);
-      })
-      .fail((errorResponse) => {
-        const errObject = errorResponse?.errors?.[0];
-        if (errObject.error && errObject.message) {
-          // Display MSS error if server responded with error message
-          setBridgeError(errObject.message);
-        } else {
-          // Do not display the notice if there is no server response
-          setBridgeError(null);
-        }
-      });
-  }, []);
+  const bridgeError = useServiceCheck(
+    'Services',
+    'pingBridge',
+    () =>
+      // Show only when sending method is MailPoet
+      MailPoet.mtaMethod === 'MailPoet' &&
+      // Do not show on the MailPoet Help page, it has its own MSS status indication
+      extractPageNameFromUrl() !== 'help',
+  );
 
   if (!bridgeError) return null;
   return (

--- a/mailpoet/assets/js/src/notices/cron-ping-error-notice.tsx
+++ b/mailpoet/assets/js/src/notices/cron-ping-error-notice.tsx
@@ -1,56 +1,19 @@
-import { useState, useEffect } from 'react';
 import { extractPageNameFromUrl } from 'common/functions';
 import { Notice } from 'notices/notice';
 import { MailPoet } from 'mailpoet';
 import ReactStringReplace from 'react-string-replace';
-
-const LOCAL_STORAGE_KEY = 'mailpoet_cron_ping_last_success_at';
-const CACHE_TIME = 60 * 60 * 1000; // 1 hour
-
-const cacheSuccessfulResult = () => {
-  window.localStorage.setItem(LOCAL_STORAGE_KEY, Date.now().toString());
-};
-
-const isSuccessfulResultCached = () => {
-  const lastSuccessAt = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-  return (
-    lastSuccessAt && Date.now() - parseInt(lastSuccessAt, 10) <= CACHE_TIME
-  );
-};
+import { useServiceCheck } from './hooks/use-service-check';
 
 function CronPingErrorNotice() {
-  const [cronError, setCronError] = useState<string | null>(null);
-
-  useEffect(() => {
-    // Show only when cron trigger method is WordPress
-    if (MailPoet.cronTriggerMethod !== 'WordPress') return;
-    // Do not show on the MailPoet Help page, it has its own cron status indication
-    if (extractPageNameFromUrl() === 'help') return;
-
-    // Don't make a request if we have a recently cached successful result
-    if (isSuccessfulResultCached()) return;
-
-    void MailPoet.Ajax.post({
-      api_version: MailPoet.apiVersion,
-      endpoint: 'sendingQueue',
-      action: 'pingCron',
-    })
-      .done(() => {
-        cacheSuccessfulResult();
-        // Do not display the notice if there are no errors
-        setCronError(null);
-      })
-      .fail((errorResponse) => {
-        const errObject = errorResponse?.errors?.[0];
-        if (errObject.error && errObject.message) {
-          // Display cron error if server responded with error message
-          setCronError(errObject.message);
-        } else {
-          // Do not display the notice if there is no server response
-          setCronError(null);
-        }
-      });
-  }, []);
+  const cronError = useServiceCheck(
+    'sendingQueue',
+    'pingCron',
+    () =>
+      // Show only when sending method is MailPoet
+      MailPoet.cronTriggerMethod === 'WordPress' &&
+      // Do not show on the MailPoet Help page, it has its own MSS status indication
+      extractPageNameFromUrl() !== 'help',
+  );
 
   if (!cronError) return null;
   return (

--- a/mailpoet/assets/js/src/notices/global-notices.tsx
+++ b/mailpoet/assets/js/src/notices/global-notices.tsx
@@ -1,7 +1,13 @@
+import { BridgePingErrorNotice } from './bridge-ping-error-notice';
 import { CronPingErrorNotice } from './cron-ping-error-notice';
 
 function GlobalNotices() {
-  return <CronPingErrorNotice />;
+  return (
+    <>
+      <BridgePingErrorNotice />
+      <CronPingErrorNotice />
+    </>
+  );
 }
 
 GlobalNotices.displayName = 'GlobalNotices';

--- a/mailpoet/assets/js/src/notices/hooks/use-service-check.tsx
+++ b/mailpoet/assets/js/src/notices/hooks/use-service-check.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { MailPoet } from 'mailpoet';
+
+const CACHE_TIME = 60 * 60 * 1000; // 1 hour
+
+const cacheSuccessfulResult = (storageKey: string) => {
+  window.localStorage.setItem(storageKey, Date.now().toString());
+};
+
+const isSuccessfulResultCached = (storageKey: string) => {
+  const lastSuccessAt = window.localStorage.getItem(storageKey);
+  return (
+    lastSuccessAt && Date.now() - parseInt(lastSuccessAt, 10) <= CACHE_TIME
+  );
+};
+
+export const useServiceCheck = (
+  endpoint: string,
+  action: string,
+  preconditionsCallback: () => boolean,
+) => {
+  const [serviceError, setServiceError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (preconditionsCallback && !preconditionsCallback()) return;
+
+    // Don't make a request if we have a recently cached successful result
+    const storageKey =
+      `mailpoet_${endpoint}_${action}_last_success_at`.toLowerCase();
+    if (isSuccessfulResultCached(storageKey)) return;
+
+    void MailPoet.Ajax.post({
+      api_version: MailPoet.apiVersion,
+      endpoint,
+      action,
+    })
+      .done(() => {
+        cacheSuccessfulResult(storageKey);
+        // Do not display the notice if there are no errors
+        setServiceError(null);
+      })
+      .fail((errorResponse) => {
+        const errObject = errorResponse?.errors?.[0];
+        if (errObject.error && errObject.message) {
+          // Display error notice if server responded with error message
+          setServiceError(errObject.message);
+        } else {
+          // Do not display the notice if there is no server response
+          setServiceError(null);
+        }
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return serviceError;
+};

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -290,6 +290,23 @@ class Services extends APIEndpoint {
     ]);
   }
 
+  public function pingBridge() {
+    try {
+      $bridgePingResponse = $this->bridge->pingBridge();
+    } catch (\Exception $e) {
+      return $this->errorResponse([
+        APIError::UNKNOWN => $e->getMessage(),
+      ]);
+    }
+    if (!$this->bridge->validateBridgePingResponse($bridgePingResponse)) {
+      $code = $bridgePingResponse ?: Bridge::CHECK_ERROR_UNKNOWN;
+      return $this->errorResponse([
+        APIError::UNKNOWN => $this->getErrorDescriptionByCode($code),
+      ]);
+    }
+    return $this->successResponse();
+  }
+
   public function refreshMSSKeyStatus() {
     $key = $this->settings->get('mta.mailpoet_api_key');
     return $this->checkMSSKey(['key' => $key]);

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -83,7 +83,7 @@ class Help {
       ],
       'mss' => [
         'enabled' => $this->bridge->isMailpoetSendingServiceEnabled(),
-        'isReachable' => $this->bridge->pingBridge(),
+        'isReachable' => $this->bridge->validateBridgePingResponse($this->bridge->pingBridge()),
       ],
       'cronStatus' => $this->cronHelper->getDaemon(),
       'queueStatus' => $mailerLog,

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -98,14 +98,18 @@ class Bridge {
     return !empty($key);
   }
 
-  public static function pingBridge() {
+  public function pingBridge() {
     $params = [
       'blocking' => true,
       'timeout' => 10,
     ];
     $wp = new WPFunctions();
     $result = $wp->wpRemoteGet(self::BRIDGE_URL, $params);
-    return $wp->wpRemoteRetrieveResponseCode($result) === 200;
+    return $wp->wpRemoteRetrieveResponseCode($result);
+  }
+
+  public function validateBridgePingResponse($responseCode) {
+    return $responseCode === 200;
   }
 
   /**

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -232,7 +232,8 @@ class BridgeTest extends \MailPoetTest {
 
   public function testItPingsBridge() {
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
-    verify(Bridge::pingBridge())->true();
+    $result = $this->bridge->pingBridge();
+    verify($this->bridge->validateBridgePingResponse($result))->true();
   }
 
   public function testItAllowsChangingRequestTimeout() {

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -24,7 +24,6 @@
     'systemStatusMSSTitle': __('Connection to the MailPoet Sending Service'),
     'systemStatusMSSConnectionUnsuccessfulInfo': __('Please contact our technical support for assistance.'),
     'systemStatusMSSConnectionCanConnect': __('Your installation can connect to our sending service.'),
-    'systemStatusMSSConnectionCanNotConnect': __('Currently, your installation can not reach the sending service. If you want to use our service please consult our [link]knowledge base article[/link] for troubleshooting tips.'),
     'knowledgeBaseIntro': __('Click on one of these categories below to find more information:'),
     'knowledgeBaseButton': __('Visit our Knowledge Base for more articles'),
     'systemInfoIntro': __('The information below is useful when you need to get in touch with our support. Just copy all the text below and paste it into a message to us.'),

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -166,6 +166,9 @@
   'systemStatusCronConnectionUnsuccessfulInfo': __('Please consult our [link]knowledge base article[/link] for troubleshooting tips.'),
   'systemStatusIntroCron': __('For the plugin to work, it must be able to establish connection with the task scheduler.'),
 
+  'bridgePingErrorHeader': __('There is an issue with the connection to the MailPoet Sending Service'),
+  'systemStatusMSSConnectionCanNotConnect': __('Currently, your installation can not reach the sending service. If you want to use our service please consult our [link]knowledge base article[/link] for troubleshooting tips.'),
+
   'transactionalEmailNoticeTitle': __('Good news! MailPoet can now send your website’s emails too'),
   'transactionalEmailNoticeBody': __('All of your WordPress and WooCommerce emails are sent with your hosting company, unless you have an SMTP plugin. Would you like such emails to be delivered with MailPoet’s active sending method for better deliverability?'),
   'transactionalEmailNoticeBodyReadMore': _x('Read more.', 'This is a link that leads to more information about transactional emails'),


### PR DESCRIPTION
## Description

The PR is very similar to https://github.com/mailpoet/mailpoet/pull/5631, but with a different endpoint and text.

## Code review notes

_N/A_

## QA notes

Testing instructions:
1. Break MSS connection, e.g. by replacing `self::BRIDGE_URL` with `'https://some-non-existent-domain-for-testing-mailpoet.com'` [here](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Services/Bridge.php#L107).
2. Select MailPoet Sending Service as the sending method in "Settings > Send with...".
3. Clear the `mailpoet_services_pingbridge_last_success_at` key in your browser's localStorage.
4. Observe the error message about MSS connection on all menu pages.
5. Please also retest the https://github.com/mailpoet/mailpoet/pull/5631 PR, it was refactored in this one.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5631

## Linked tickets

[MAILPOET-6030]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6030]: https://mailpoet.atlassian.net/browse/MAILPOET-6030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ