### PR TITLE
Hide screen reader text in email [MAILPOET-6098]

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Template.html
+++ b/mailpoet/lib/Newsletter/Renderer/Template.html
@@ -65,6 +65,27 @@
             overflow: hidden;
         }
 
+        /* Hide text meant for screen readers. Styles copied from WordPress' common.css file */
+        /* In addition, there are color, font-size, line-height, and mso-hide properties for clients where it doesn't work */
+        .screen-reader-text {
+            border: 0;
+            clip: rect(1px, 1px, 1px, 1px);
+            -webkit-clip-path: inset(50%);
+            clip-path: inset(50%);
+            height: 1px;
+            margin: -1px;
+            overflow: hidden;
+            padding: 0;
+            position: absolute;
+            width: 1px;
+            word-wrap: normal !important;
+
+            color: transparent;
+            font-size: 0;
+            line-height: 0;
+            mso-hide: all;
+        }
+
         @media screen and (max-width: 480px) {
             .mailpoet_button {width:100% !important;}
         }

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -723,6 +723,18 @@ class RendererTest extends \MailPoetTest {
     $this->assertEquals($expectedLanguage, $html->attr('lang'));
   }
 
+  public function testItRendersScreenReaderText() {
+    $body = json_decode(
+      (string)file_get_contents(dirname(__FILE__) . '/RendererTestData.json'),
+      true
+    );
+    $this->assertIsArray($body);
+    $this->newsletter->setBody($body);
+    $template = $this->renderer->render($this->newsletter);
+    $DOM = $this->dOMParser->parseStr($template['html']);
+    verify((string)$DOM)->stringContainsString('<span class="screen-reader-text" style="border:0;clip:rect(1px,1px,1px,1px);-webkit-clip-path:inset(50%);clip-path:inset(50%);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;word-wrap:normal;color:transparent;font-size:0;line-height:0;mso-hide:all">');
+  }
+
   private function currentGlobalLocale() {
     global $locale;
     return $locale;

--- a/mailpoet/tests/integration/Newsletter/RendererTestData.json
+++ b/mailpoet/tests/integration/Newsletter/RendererTestData.json
@@ -1040,6 +1040,10 @@
                 }
               },
               {
+                "type": "text",
+                "text": "<p>Text containing <span class=\"screen-reader-text\">screen reader only text</span></p>"
+              },
+              {
                 "type": "social",
                 "iconSet": "default",
                 "icons": [


### PR DESCRIPTION
## Description

WooCommerce recently added [accessibility markup to sale prices](https://github.com/woocommerce/woocommerce/commit/72f75edf58781da02280f3792015cf57aa00639f), which is a text not visible for regular visitors, but only for screen readers. However, our email renderer wasn't hiding this content and so it was visible in email preview and also in actual email. 

**Before**
<img width="453" alt="Screenshot 2024-06-04 at 17 01 23" src="https://github.com/mailpoet/mailpoet/assets/470616/fe8b4d8e-3d62-4a39-98ce-8a0bf2dda64b">

**After**
<img width="487" alt="Screenshot 2024-06-04 at 17 01 01" src="https://github.com/mailpoet/mailpoet/assets/470616/b29c6a0b-c9a0-40a9-b220-5d5c669480b8">

## Code review notes

Originally I only copied the same styles from WordPress core, but they [didn't work in Outlook](https://litmus.com/folders/unsorted_emails/emails/14182282/checklist). I added a couple more properties, which [seemed to work](https://litmus.com/folders/unsorted_emails/emails/14182665/checklist) now. 

I also tested the VoiceOver in macOS (select the text > right click > Speech > Start speaking) to be sure, the screen reader still reads the content of the email in MailHog. 

## QA notes

1. Create a product with a sale price.
2. Add the product to the email editor.
3. Preview the email (you don't have to send it). 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6098]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6098]: https://mailpoet.atlassian.net/browse/MAILPOET-6098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ