### PR TITLE
Add a limit to timeout in throttling function

### DIFF
--- a/mailpoet/lib/Subscription/Throttling.php
+++ b/mailpoet/lib/Subscription/Throttling.php
@@ -35,6 +35,8 @@ class Throttling {
         $subscriptionCount = $this->subscriberIPsRepository->getCountByIPAndCreatedAtAfterTimeInSeconds($subscriberIp, $subscriptionLimitWindow);
         if ($subscriptionCount > 0) {
           $timeout = $subscriptionLimitBase * pow(2, $subscriptionCount - 1);
+          // Cap timeout and avoid float numbers
+          $timeout = min($timeout, $subscriptionLimitWindow);
           $existingUser = $this->subscriberIPsRepository->findOneByIPAndCreatedAtAfterTimeInSeconds($subscriberIp, $timeout);
           if (!empty($existingUser)) {
             return $timeout;

--- a/mailpoet/tests/integration/Subscription/ThrottlingTest.php
+++ b/mailpoet/tests/integration/Subscription/ThrottlingTest.php
@@ -31,6 +31,16 @@ class ThrottlingTest extends \MailPoetTest {
     verify($this->throttling->throttle())->equals(MINUTE_IN_SECONDS * pow(2, 10));
   }
 
+  public function testItDoesNotThrowErrorForBigNumbersAndCapsTimeout() {
+    $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+    verify($this->throttling->throttle())->equals(false);
+    verify($this->throttling->throttle())->equals(60);
+    for ($i = 1; $i <= 64; $i++) {
+      $this->createSubscriberIP('127.0.0.1', Carbon::now()->subMinutes($i));
+    }
+    verify($this->throttling->throttle())->equals(DAY_IN_SECONDS);
+  }
+
   public function testItDoesNotThrottleIfDisabledByAHook() {
     $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
     $wp = new WPFunctions;


### PR DESCRIPTION
## Description

A customer reported the following error:
```
MailPoet\Subscribers\SubscriberIPsRepository::findOneByIPAndCreatedAtAfterTimeInSeconds(): Argument #2 ($seconds) must be of type int, float given, called in /home/site/public_html/wp-content/plugins/mailpoet/Subscription/Throttling.php on line 41
```
This can happen in the [throttling function](https://github.com/mailpoet/mailpoet/blob/db370dc96295a023457313106d6cace85b298f16/mailpoet/lib/Subscription/Throttling.php#L37) if `pow` returns a float (eg: `$subscriptionsCount` > 63).

To avoid that we can limit the value of the timeout to `$subscriptionLimitWindow`

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6103]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6103]: https://mailpoet.atlassian.net/browse/MAILPOET-6103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ