### PR TITLE
Add missing backward slash in the acceptance homepage test

### DIFF
--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use PHPUnit\Framework\Exception;
-
 class HomepageLandingAfterActivatingMailPoetCest {
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();

--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -31,7 +31,7 @@ class HomepageLandingAfterActivatingMailPoetCest {
     try {
       $i->waitForText('Better email — without leaving WordPress', 10);
       $i->seeInCurrentUrl('mailpoet-landingpage');
-    } catch (Exception $e) {
+    } catch (\Exception $e) {
       $i->waitForNoticeAndClose('Plugin activated.');
       $i->deactivatePlugin('mailpoet');
       $i->waitForNoticeAndClose('Selected plugins deactivated.');


### PR DESCRIPTION
## Description

This is very tiny change.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
