### PR TITLE
Fix WooCommerce sync with empty email [MAILPOET-5885]

### DIFF
--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -245,8 +245,8 @@ class WooCommerce {
     if ($collation1 === $collation2) {
       return false;
     }
-    list($charset1) = explode('_', $collation1);
-    list($charset2) = explode('_', $collation2);
+    [$charset1] = explode('_', $collation1);
+    [$charset2] = explode('_', $collation2);
 
     return $charset1 === $charset2;
   }
@@ -564,7 +564,7 @@ class WooCommerce {
 
     if ($this->woocommerceHelper->isWooCommerceCustomOrdersTableEnabled()) {
       $ordersTable = $this->woocommerceHelper->getOrdersTableName();
-      $guestCustomersSubQuery = "SELECT DISTINCT billing_email AS email FROM `{$ordersTable}` WHERE type = 'shop_order'";
+      $guestCustomersSubQuery = "SELECT DISTINCT billing_email AS email FROM `{$ordersTable}` WHERE type = 'shop_order' AND billing_email IS NOT NULL AND billing_email != ''";
     } else {
       $guestCustomersSubQuery = "SELECT DISTINCT wppm.meta_value AS email FROM {$wpdb->postmeta} wppm
         JOIN {$wpdb->posts} wpp ON wppm.post_id = wpp.ID


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5885]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5885]: https://mailpoet.atlassian.net/browse/MAILPOET-5885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ