### PR TITLE
Prevent mss sending with creator plan - MAILPOET-6028

### DIFF
--- a/mailpoet/assets/js/src/common/premium-key/key-activation-button.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-activation-button.tsx
@@ -35,10 +35,18 @@ export function KeyActivationButton({
   const sendCongratulatoryMssEmail = useAction('sendCongratulatoryMssEmail');
   const [apiKeyState] = useSetting('mta', 'mailpoet_api_key_state', 'data');
 
+  const saveStateFromAddressModalCanBeShown = (status: boolean) => {
+    sessionStorage.setItem(
+      'mailpoet_from_address_modal_can_be_shown',
+      JSON.stringify(status),
+    );
+    void setState({ fromAddressModalCanBeShown: status });
+  };
+
   async function activationCallback() {
     await verifyMssKey(state.key);
     void sendCongratulatoryMssEmail();
-    void setState({ fromAddressModalCanBeShown: true });
+    saveStateFromAddressModalCanBeShown(true);
   }
 
   const showPendingApprovalNotice =
@@ -76,7 +84,7 @@ export function KeyActivationButton({
     await verifyPremiumKey(state.key);
     void setState({ inProgress: false });
     MailPoet.Modal.loading(false);
-    void setState({ fromAddressModalCanBeShown: true });
+    saveStateFromAddressModalCanBeShown(true);
     // pending approval refresh link should only show on refresh of the page and should get hidden after the refresh button is clicked
     setShowRefreshMessage(false);
     reloadPageAfterKeyActivation();

--- a/mailpoet/assets/js/src/common/premium-key/key-activation-button.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-activation-button.tsx
@@ -19,7 +19,8 @@ type KeyActivationButtonPropType = {
 };
 
 const reloadPageAfterKeyActivation = () => {
-  setTimeout(() => window.location.reload(), 1000); // using setTimeout to add a little delay
+  if (!window.location.href.includes('/premium')) return; // only reload on settings page
+  setTimeout(() => window.location.reload(), 100); // using setTimeout to add a little delay
 };
 
 export function KeyActivationButton({

--- a/mailpoet/assets/js/src/common/premium-key/key-activation-button.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-activation-button.tsx
@@ -18,6 +18,10 @@ type KeyActivationButtonPropType = {
   isFullWidth?: boolean;
 };
 
+const reloadPageAfterKeyActivation = () => {
+  setTimeout(() => window.location.reload(), 1000); // using setTimeout to add a little delay
+};
+
 export function KeyActivationButton({
   label,
   isFullWidth = false,
@@ -75,6 +79,7 @@ export function KeyActivationButton({
     void setState({ fromAddressModalCanBeShown: true });
     // pending approval refresh link should only show on refresh of the page and should get hidden after the refresh button is clicked
     setShowRefreshMessage(false);
+    reloadPageAfterKeyActivation();
   };
 
   return (

--- a/mailpoet/assets/js/src/settings/components/sending-method-confirmation-modal.tsx
+++ b/mailpoet/assets/js/src/settings/components/sending-method-confirmation-modal.tsx
@@ -1,0 +1,42 @@
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Button } from 'common';
+import { useState } from '@wordpress/element';
+
+function SendingMethodConfirmationModal(): JSX.Element {
+  const [confirmationModalIsOpen, setConfirmationModalOpen] = useState(true);
+
+  const closeSendingMethodConfirmationModal = () =>
+    setConfirmationModalOpen(false);
+
+  return (
+    confirmationModalIsOpen && (
+      <Modal
+        className="mailpoet-welcome-wizard-confirmation-modal"
+        title={__('Confirm sending service selection', 'mailpoet')}
+        onRequestClose={() => {}} // users aren't permitted to close
+        isDismissible={false}
+      >
+        <p>
+          {__(
+            'Your currently selected sending method is "MailPoet Sending Service". The API key you entered is not valid for sending with our sending service. You can either upgrade to a subscription which allows you sending with our service or choose a different',
+            'mailpoet',
+          )}
+        </p>
+        <div className="mailpoet-welcome-wizard-confirmation-modal-buttons">
+          <Button
+            onClick={() => {
+              closeSendingMethodConfirmationModal();
+              window.location.href =
+                'admin.php?page=mailpoet-settings#/mta/other';
+            }}
+          >
+            {__('Update service settings', 'mailpoet')}
+          </Button>
+        </div>
+      </Modal>
+    )
+  );
+}
+
+export { SendingMethodConfirmationModal };

--- a/mailpoet/assets/js/src/settings/components/sending-method-confirmation-modal.tsx
+++ b/mailpoet/assets/js/src/settings/components/sending-method-confirmation-modal.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+import { createInterpolateElement } from '@wordpress/element';
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Button } from 'common';
-import { useState } from '@wordpress/element';
 
 function SendingMethodConfirmationModal(): JSX.Element {
   const [confirmationModalIsOpen, setConfirmationModalOpen] = useState(true);
@@ -14,13 +15,27 @@ function SendingMethodConfirmationModal(): JSX.Element {
       <Modal
         className="mailpoet-welcome-wizard-confirmation-modal"
         title={__('Confirm sending service selection', 'mailpoet')}
-        onRequestClose={() => {}} // users aren't permitted to close
+        onRequestClose={() => {}} // users aren't permitted to close the modal
         isDismissible={false}
       >
         <p>
-          {__(
-            'Your currently selected sending method is "MailPoet Sending Service". The API key you entered is not valid for sending with our sending service. You can either upgrade to a subscription which allows you sending with our service or choose a different',
-            'mailpoet',
+          {createInterpolateElement(
+            __(
+              'Your currently selected sending method is "MailPoet Sending Service". The API key you entered is not valid for sending with our sending service. You can either <link>upgrade to a subscription</link> that allows you to send with our service or choose a different sending service',
+              'mailpoet',
+            ),
+            {
+              link: (
+                <a
+                  href={`https://account.mailpoet.com/?s=${window.mailpoet_subscribers_count}&utm_source=plugin&utm_medium=settings&utm_campaign=switch-to-sending-plan&ref=settings-key-activation`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {' '}
+                  &nbsp;{' '}
+                </a>
+              ),
+            },
           )}
         </p>
         <div className="mailpoet-welcome-wizard-confirmation-modal-buttons">

--- a/mailpoet/assets/js/src/settings/pages/key-activation/key-activation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/key-activation/key-activation.tsx
@@ -51,13 +51,17 @@ export function KeyActivation({ subscribersCount }: Props) {
   );
   const setSaveDone = useAction('setSaveDone');
   const setAuthorizedAddress = async (address: string) => {
+    sessionStorage.removeItem('mailpoet_from_address_modal_can_be_shown');
     await setSenderAddress(address);
     await setUnauthorizedAddresses(null);
     void setSaveDone();
   };
 
   const showFromAddressModal =
-    state.fromAddressModalCanBeShown &&
+    (state.fromAddressModalCanBeShown ||
+      JSON.parse(
+        sessionStorage.getItem('mailpoet_from_address_modal_can_be_shown'),
+      )) &&
     state.mssStatus === MssStatus.VALID_MSS_ACTIVE &&
     (!senderAddress || unauthorizedAddresses);
 
@@ -100,6 +104,9 @@ export function KeyActivation({ subscribersCount }: Props) {
           onRequestClose={() => {
             void setState({ fromAddressModalCanBeShown: false });
             void sendCongratulatoryMssEmail();
+            sessionStorage.removeItem(
+              'mailpoet_from_address_modal_can_be_shown',
+            );
           }}
           setAuthorizedAddress={setAuthorizedAddress}
         />

--- a/mailpoet/assets/js/src/settings/settings.tsx
+++ b/mailpoet/assets/js/src/settings/settings.tsx
@@ -14,6 +14,9 @@ import {
   WooCommerce,
 } from './pages';
 import { useSelector } from './store/hooks';
+import { SendingMethodConfirmationModal } from './components/sending-method-confirmation-modal';
+
+const isOnSendWithPage = window.location.href.includes('/mta');
 
 export function Settings() {
   const isSaving = useSelector('isSaving')();
@@ -72,6 +75,9 @@ export function Settings() {
           <KeyActivation subscribersCount={window.mailpoet_subscribers_count} />
         </Tab>
       </RoutedTabs>
+      {window.mailpoet_mss_active &&
+        !window.mailpoet_mss_key_valid &&
+        !isOnSendWithPage && <SendingMethodConfirmationModal />}
     </>
   );
 }

--- a/mailpoet/assets/js/src/settings/store/make-default-state.ts
+++ b/mailpoet/assets/js/src/settings/store/make-default-state.ts
@@ -13,7 +13,9 @@ declare let window: SettingsWindow;
 function getPremiumStatus(keyValid, premiumInstalled, data): PremiumStatus {
   const pluginActive = !!MailPoet.premiumVersion;
   if (!keyValid) {
-    return data.premium?.premium_key_state?.state === 'valid_underprivileged'
+    return data.premium?.premium_key_state?.state === 'valid_underprivileged' &&
+      data.mta.mailpoet_api_key_state.access_restriction !==
+        'insufficient_privileges'
       ? PremiumStatus.VALID_UNDERPRIVILEGED
       : PremiumStatus.INVALID;
   }
@@ -27,7 +29,9 @@ function getPremiumStatus(keyValid, premiumInstalled, data): PremiumStatus {
 
 export function getMssStatus(keyValid, data): MssStatus {
   if (!keyValid)
-    return data.mta.mailpoet_api_key_state.state === 'valid_underprivileged'
+    return data.mta.mailpoet_api_key_state.state === 'valid_underprivileged' &&
+      data.mta.mailpoet_api_key_state.access_restriction !==
+        'insufficient_privileges'
       ? MssStatus.VALID_UNDERPRIVILEGED
       : MssStatus.INVALID;
 

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -99,7 +99,7 @@ class Settings {
     $data['all_sender_domains'] = [];
     $data['sender_restrictions'] = [];
 
-    if ($this->bridge->isMailpoetSendingServiceEnabled() && $mpApiKeyValid) {
+    if ($this->bridge->isMailpoetSendingServiceEnabled()) {
       $data['authorized_emails'] = $this->bridge->getAuthorizedEmailAddresses();
       $data['verified_sender_domains'] = $this->senderDomainController->getFullyVerifiedSenderDomains(true);
       $data['partially_verified_sender_domains'] = $this->senderDomainController->getPartiallyVerifiedSenderDomains(true);

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -28,6 +28,7 @@ class AddSendingKeyCest {
     $i->waitForText('It’s time to set your default FROM address!');
     $i->waitForText('Set one of your authorized email addresses as the default FROM email for your MailPoet emails.');
     $i->dontSee('A test email was sent to');
+    $i->click('[data-automation-id="mailpoet-modal-close"]'); // close modal since we don't need it now
 
     // check the state after reload
     $i->reloadPage();


### PR DESCRIPTION
## Description

This PR removes the confusing messages and notices when switching from an MSS API to a Premium-only API.

## Code review notes

_N/A_

## QA notes

* Validate with an MSS API, ensure the MailPoet sending service is activated
* Switch to a Premium-only API
* Notice the new message modal

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6028](https://mailpoet.atlassian.net/browse/MAILPOET-6028)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6028]: https://mailpoet.atlassian.net/browse/MAILPOET-6028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ