### PR TITLE
Fix live preview when changing button font size in form editor [MAILPOET-5655]

### DIFF
--- a/mailpoet/assets/js/src/form-editor/blocks/submit/edit.tsx
+++ b/mailpoet/assets/js/src/form-editor/blocks/submit/edit.tsx
@@ -46,6 +46,11 @@ function SubmitEdit({ attributes, setAttributes }: Props): JSX.Element {
     </InspectorControls>
   );
 
+  const fontSize =
+    typeof attributes.styles.fontSize === 'number'
+      ? `${attributes.styles.fontSize}px`
+      : attributes.styles.fontSize;
+
   const styles: CSSProperties = !attributes.styles.inheritFromTheme
     ? {
         fontWeight: attributes.styles.bold ? 'bold' : 'inherit',
@@ -59,9 +64,7 @@ function SubmitEdit({ attributes, setAttributes }: Props): JSX.Element {
             : '1px',
         borderColor: attributes.styles.borderColor || 'transparent',
         borderStyle: 'solid',
-        fontSize: attributes.styles.fontSize
-          ? `${attributes.styles.fontSize}px`
-          : 'inherit',
+        fontSize: fontSize || 'inherit',
         color: attributes.styles.fontColor || 'inherit',
       }
     : {};


### PR DESCRIPTION
## Description

This PR fixes live preview when changing the button's font size. 

## Code review notes

The issue was that [FontSizePicker](https://developer.wordpress.org/block-editor/reference-guides/components/font-size-picker/) can return a [number or string](https://developer.wordpress.org/block-editor/reference-guides/components/font-size-picker/#onchange-value-number-string-undefined-selecteditem-fontsize-void) when changing value. However, we were expecting a number and automatically suffixed `px`, which made the value invalid (`20pxpx`). 

<img width="266" alt="Screenshot 2024-06-07 at 15 50 28" src="https://github.com/mailpoet/mailpoet/assets/470616/5d0f7761-8257-4d5f-aa45-19a9311d269e">

The fix checks the type of the value, and if it's already a string, it won't suffix it because the component could be set to `em` or `rem` instead of `px`.

## QA notes

In the form editor change the font size of the button. Try also using different units (`em` or `rem`). In all cases, you should see the font size changing also on the button. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5655]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5655]: https://mailpoet.atlassian.net/browse/MAILPOET-5655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ