### PR TITLE
Don't allow importing to "WordPress Users" list [MAILPOET-3977]

### DIFF
--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -37,7 +37,7 @@ class ImportExportFactory {
 
   public function getSegments() {
     if ($this->action === self::IMPORT_ACTION) {
-      $segments = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts([SegmentEntity::TYPE_DEFAULT, SegmentEntity::TYPE_WP_USERS]);
+      $segments = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts([SegmentEntity::TYPE_DEFAULT]);
     } else {
       $segments = $this->segmentsListRepository->getListWithAssociatedSubscribersCounts();
       $segments = $this->segmentsListRepository->addVirtualSubscribersWithoutListSegment($segments);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Subscribers\ImportExport;
 
 use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -29,6 +30,8 @@ class ImportExportFactoryTest extends \MailPoetTest {
 
     $segment1 = $segmentFactory->withName('Unconfirmed Segment')->create();
     $segment2 = $segmentFactory->withName('Confirmed Segment')->create();
+    $segment3 = $segmentFactory->withName('WordPress Users')->withType(SegmentEntity::TYPE_WP_USERS)->create();
+    $segment4 = $segmentFactory->withName('WooCommerce Customers')->withType(SegmentEntity::TYPE_WC_USERS)->create();
 
     $subscriberFactory
       ->withFirstName('John')
@@ -44,6 +47,22 @@ class ImportExportFactoryTest extends \MailPoetTest {
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
       ->withEmail('mike@mailpoet.com')
       ->withSegments([$segment2])
+      ->create();
+
+    $subscriberFactory
+      ->withFirstName('John')
+      ->withLastName('Doe')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withEmail('john@doe.com')
+      ->withSegments([$segment3])
+      ->create();
+
+    $subscriberFactory
+      ->withFirstName('Jane')
+      ->withLastName('Doe')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withEmail('jane@doe.com')
+      ->withSegments([$segment4])
       ->create();
 
     $customFieldFactory
@@ -89,7 +108,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
 
   public function testItCanGetPublicSegmentsForExport() {
     $segments = $this->exportFactory->getSegments();
-    verify(count($segments))->equals(2);
+    verify(count($segments))->equals(4);
 
     $subscriber = $this->subscribersRepository->findOneBy(['email' => 'john@mailpoet.com']);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
@@ -99,17 +118,21 @@ class ImportExportFactoryTest extends \MailPoetTest {
 
     $this->clearSubscribersCountCache();
     $segments = $this->exportFactory->getSegments();
-    verify(count($segments))->equals(1);
+    verify(count($segments))->equals(3);
   }
 
   public function testItCanGetSegmentsForExport() {
     $segments = $this->exportFactory->getSegments();
-    verify(count($segments))->equals(2);
+    verify(count($segments))->equals(4);
 
     verify($segments[0]['name'])->equals('Confirmed Segment');
     verify($segments[0]['count'])->equals(1);
     verify($segments[1]['name'])->equals('Unconfirmed Segment');
     verify($segments[1]['count'])->equals(1);
+    verify($segments[2]['name'])->equals('WooCommerce Customers');
+    verify($segments[2]['count'])->equals(1);
+    verify($segments[3]['name'])->equals('WordPress Users');
+    verify($segments[3]['count'])->equals(1);
   }
 
   public function testItCanGetSubscriberFields() {


### PR DESCRIPTION
## Description

This PR removes the option to select the "WordPress Users" list when importing subscribers. You can't really import them anyway because the next time a WP user sync happens, it would remove everyone who isn't a WP user, which would result in data loss. 

## Code review notes

I opted for the simplest solution of just hiding the "WordPress Users" list on the import page. 

I considered keeping it there and showing a message that you can only update subscribers in that list, but it has some downsides
- on the next page, you'd still see `X subscribers added to "WordPress Users"` or `X existing subscribers were updated and added to "WordPress Users"`.
- if I'd just hide those names from these notices, they would look broken, because they expect at least one list
- the backend would still import them, only to remove them the next time a sync occurs

In the end, I think it wouldn't really solve the issue we are trying to solve. 

Regarding supporters' use case (p1637742878412000/1637725149.408100-slack-C01GH6AED0S), that they use the list to update existing subscribers' status without creating new ones: a workaround is to create a new list for this import, and then bulk remove those new subscribers. At least it's clear what's happening, without misleading notices and potentially vanished users after sync. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-3977]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-3977]: https://mailpoet.atlassian.net/browse/MAILPOET-3977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ