### PR TITLE
Differentiate between changing URL and iconType in social block [MAILPOET-6106]

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/blocks/social.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/social.js
@@ -203,7 +203,7 @@ SocialBlockSettingsIconView = Marionette.View.extend({
         'iconType',
       ),
       'input .mailpoet_social_icon_field_image': _.partial(
-        this.changeField,
+        this.changeUrlField,
         'image',
       ),
       'change .mailpoet_social_icon_field_link': this.changeLink,
@@ -249,11 +249,12 @@ SocialBlockSettingsIconView = Marionette.View.extend({
     if (this.model.get('iconType') === 'email') {
       this.model.set('link', 'mailto:' + jQuery(event.target).val());
     } else {
-      return this.changeField('link', event);
+      return this.changeUrlField('link', event);
     }
     return undefined;
   },
-  changeField: base.BlockSettingsView.prototype.changeUrlField,
+  changeField: base.BlockSettingsView.prototype.changeField,
+  changeUrlField: base.BlockSettingsView.prototype.changeUrlField,
 });
 
 SocialBlockSettingsIconCollectionView = Marionette.CollectionView.extend({


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Please see the commit message description.

## QA notes

Steps to test:
1. Create an email containing the social media icons block
  a. Test existing icons modification
  b. Test adding new icons

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6106]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6106]: https://mailpoet.atlassian.net/browse/MAILPOET-6106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ