### PR TITLE
Change time for the nightly Circle CI workflow and update used packages [MAILPOET-6095]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -957,7 +957,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: '0 22 * * 1-5'
+          cron: '0 1 * * 1-5'
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -993,8 +993,8 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_oldest
           woo_core_version: 8.8.3
-          woo_subscriptions_version: 5.6.0
-          woo_memberships_version: 1.23.1
+          woo_subscriptions_version: 5.9.1
+          woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
@@ -1033,8 +1033,8 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           woo_core_version: 8.8.3
-          woo_subscriptions_version: 5.6.0
-          woo_memberships_version: 1.24.0
+          woo_subscriptions_version: 5.9.1
+          woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
@@ -1058,5 +1058,34 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_latest
+          requires:
+            - build_premium
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_with_premium_oldest
+          woo_core_version: 8.8.3
+          woo_subscriptions_version: 5.9.1
+          woo_memberships_version: 1.25.2
+          automate_woo_version: 5.8.5
+          codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: wp-6.4_php8.0_20231114.1
+          requires:
+            - build_premium
+      - unit_tests:
+          <<: *slack-fail-post-step
+          name: unit_with_premium_oldest
+          executor: wpcli_php_mysql_oldest
+          requires:
+            - build_premium
+      - integration_tests:
+          <<: *slack-fail-post-step
+          name: integration_with_premium_oldest
+          woo_core_version: 8.8.3
+          woo_subscriptions_version: 5.9.1
+          woo_memberships_version: 1.25.2
+          automate_woo_version: 5.8.5
+          codeception_image_version: 7.4-cli_20220605.0
+          mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
+          mysql_image: mysql:5.5
           requires:
             - build_premium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1071,12 +1071,6 @@ workflows:
           wordpress_image_version: wp-6.4_php8.0_20231114.1
           requires:
             - build_premium
-      - unit_tests:
-          <<: *slack-fail-post-step
-          name: unit_with_premium_oldest
-          executor: wpcli_php_mysql_oldest
-          requires:
-            - build_premium
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest


### PR DESCRIPTION
## Description

This PR slightly updates our Circle CI jobs.
- it changes the time of the nightly job
- it updates used versions of the 3rd plugins
- it adds using the oldest PHP and MySQL in the nightly job with premium

## Code review notes

_N/A_

## QA notes

We can skip QA here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6095]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6095]: https://mailpoet.atlassian.net/browse/MAILPOET-6095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ