### PR TITLE
Update readme.txt tags [MAILPOET-6107]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,6 +1,6 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
-Tags: email, email marketing, post notification, woocommerce emails, email automation, newsletter, newsletter builder, newsletter subscribers
+Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.4
 Tested up to: 6.5
 Stable tag: 4.51.2


### PR DESCRIPTION
## Description

WordPress.org only allows 5 tags in readme.txt, all others are ignored. This PR removes 3 tags, so we have control over what 5 tags are used in the plugin repo. 

pcD9cT-8ju-p2

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6107]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-6107]: https://mailpoet.atlassian.net/browse/MAILPOET-6107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ