### PR TITLE
Fix post-notification history subject search - MAILPOET-6072

### DIFF
--- a/mailpoet/lib/Form/Listing/FormListingRepository.php
+++ b/mailpoet/lib/Form/Listing/FormListingRepository.php
@@ -60,7 +60,7 @@ class FormListingRepository extends ListingRepository {
     $queryBuilder->addOrderBy("f.$sortBy", $sortOrder);
   }
 
-  protected function applySearch(QueryBuilder $queryBuilder, string $search) {
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
     // the parent class requires this method, but forms listing doesn't currently support this feature.
   }
 

--- a/mailpoet/lib/Listing/ListingRepository.php
+++ b/mailpoet/lib/Listing/ListingRepository.php
@@ -87,7 +87,7 @@ abstract class ListingRepository {
 
   abstract protected function applyGroup(QueryBuilder $queryBuilder, string $group);
 
-  abstract protected function applySearch(QueryBuilder $queryBuilder, string $search);
+  abstract protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters);
 
   abstract protected function applyFilters(QueryBuilder $queryBuilder, array $filters);
 

--- a/mailpoet/lib/Listing/ListingRepository.php
+++ b/mailpoet/lib/Listing/ListingRepository.php
@@ -69,8 +69,10 @@ abstract class ListingRepository {
     }
 
     $search = $definition->getSearch();
+    $parameters = $definition->getParameters();
+
     if ($search && strlen(trim($search)) > 0) {
-      $this->applySearch($queryBuilder, $search);
+      $this->applySearch($queryBuilder, $search, $parameters ?: []);
     }
 
     $filters = $definition->getFilters();
@@ -78,7 +80,6 @@ abstract class ListingRepository {
       $this->applyFilters($queryBuilder, $filters);
     }
 
-    $parameters = $definition->getParameters();
     if ($parameters) {
       $this->applyParameters($queryBuilder, $parameters);
     }

--- a/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
+++ b/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
@@ -211,8 +211,8 @@ class NewsletterListingRepository extends ListingRepository {
 
     if ($type && $type === NewsletterEntity::TYPE_NOTIFICATION_HISTORY) {
       $queryBuilder
-        ->join('n.queues', 'sq')
-        ->andWhere('sq.newsletterRenderedSubject LIKE :search')
+        ->leftJoin('n.queues', 'sq')
+        ->andWhere('sq.newsletterRenderedSubject LIKE :search or n.subject LIKE :search')
         ->setParameter('search', "%$search%");
     } else {
       $queryBuilder

--- a/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
+++ b/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
@@ -204,11 +204,21 @@ class NewsletterListingRepository extends ListingRepository {
       ->setParameter('status', $group);
   }
 
-  protected function applySearch(QueryBuilder $queryBuilder, string $search) {
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
     $search = Helpers::escapeSearch($search);
-    $queryBuilder
-      ->andWhere('n.subject LIKE :search')
-      ->setParameter('search', "%$search%");
+
+    $type = $parameters['type'] ?? null;
+
+    if ($type && $type === NewsletterEntity::TYPE_NOTIFICATION_HISTORY) {
+      $queryBuilder
+        ->join('n.queues', 'sq')
+        ->andWhere('sq.newsletterRenderedSubject LIKE :search')
+        ->setParameter('search', "%$search%");
+    } else {
+      $queryBuilder
+        ->andWhere('n.subject LIKE :search')
+        ->setParameter('search', "%$search%");
+    }
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersListingRepository.php
@@ -103,7 +103,7 @@ class ScheduledTaskSubscribersListingRepository extends ListingRepository {
     $queryBuilder->addOrderBy($sortBy, $sortOrder);
   }
 
-  protected function applySearch(QueryBuilder $queryBuilder, string $search) {
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
     $search = Helpers::escapeSearch($search);
     $queryBuilder
       ->andWhere('s.email LIKE :search or s.firstName LIKE :search or s.lastName LIKE :search')

--- a/mailpoet/lib/Segments/SegmentListingRepository.php
+++ b/mailpoet/lib/Segments/SegmentListingRepository.php
@@ -39,7 +39,7 @@ class SegmentListingRepository extends ListingRepository {
     }
   }
 
-  protected function applySearch(QueryBuilder $queryBuilder, string $search) {
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
     $search = Helpers::escapeSearch($search);
     $queryBuilder
       ->andWhere('s.name LIKE :search or s.description LIKE :search')

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -145,7 +145,7 @@ class SubscriberListingRepository extends ListingRepository {
       ->setParameter('status', $group);
   }
 
-  protected function applySearch(QueryBuilder $queryBuilder, string $search) {
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters = []) {
     $search = Helpers::escapeSearch($search);
     $queryBuilder
       ->andWhere('s.email LIKE :search or s.firstName LIKE :search or s.lastName LIKE :search')

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -876,7 +876,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['action-scheduler', 'run', '--force']);
   }
 
-  public function triggerNewsletterScheduledTask($newsletterId) {
+  public function rescheduleNewsletterToBeSentImmediately($newsletterId) {
     $i = $this;
 
     // scheduler will create a task and schedule run in the next minute.

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -876,6 +876,19 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['action-scheduler', 'run', '--force']);
   }
 
+  public function triggerNewsletterScheduledTask($newsletterId) {
+    $i = $this;
+
+    // scheduler will create a task and schedule run in the next minute.
+    // setting to a date and time in the past to force sending
+    $sql = "UPDATE mp_mailpoet_scheduled_tasks t "
+      . " JOIN mp_mailpoet_sending_queues q ON t.id = q.task_id "
+      . " SET t.scheduled_at= SUBTIME(now(), '01:00:00'), t.updated_at= SUBTIME(now(), '01:00:00'), t.created_at= SUBTIME(now(), '01:00:00'), q.created_at= SUBTIME(now(), '01:00:00') "
+      . " WHERE q.newsletter_id= $newsletterId;";
+
+    $i->importSql([$sql]);
+  }
+
   public function isWooCustomOrdersTableEnabled(): bool {
     return (bool)getenv('ENABLE_COT');
   }

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -876,19 +876,6 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['action-scheduler', 'run', '--force']);
   }
 
-  public function rescheduleNewsletterToBeSentImmediately($newsletterId) {
-    $i = $this;
-
-    // scheduler will create a task and schedule run in the next minute.
-    // setting to a date and time in the past to force sending
-    $sql = "UPDATE mp_mailpoet_scheduled_tasks t "
-      . " JOIN mp_mailpoet_sending_queues q ON t.id = q.task_id "
-      . " SET t.scheduled_at= SUBTIME(now(), '01:00:00'), t.updated_at= SUBTIME(now(), '01:00:00'), t.created_at= SUBTIME(now(), '01:00:00'), q.created_at= SUBTIME(now(), '01:00:00') "
-      . " WHERE q.newsletter_id= $newsletterId;";
-
-    $i->importSql([$sql]);
-  }
-
   public function isWooCustomOrdersTableEnabled(): bool {
     return (bool)getenv('ENABLE_COT');
   }

--- a/mailpoet/tests/acceptance/Newsletters/SearchForNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SearchForNotificationCest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Acceptance;
 
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
+use MailPoet\Test\DataFactories\Subscriber;
 
 class SearchForNotificationCest {
   public function searchForStandardNotification(\AcceptanceTester $i) {
@@ -46,5 +47,52 @@ class SearchForNotificationCest {
     $i->click('[data-automation-id="filters_not_active"]');
     $i->searchFor($newsletterTitle);
     $i->waitForText('No emails found.', 15, '[data-automation-id="newsletters_listing_tabs"]');
+  }
+
+  public function searchForStandardNotificationHistoryItem(\AcceptanceTester $i) {
+    $i->wantTo('Successfully search for an active notification history item');
+
+    $newsletterTitle = 'New Post Alert [newsletter:post_title]';
+    $segmentName = 'New post alert list';
+    $postTitle = 'Hello how do you do';
+
+    // step 1 - Prepare newsletter data
+    $segmentFactory = new Segment();
+    $segment = $segmentFactory->withName($segmentName)->create();
+
+    $subscriberFactory = new Subscriber();
+    $subscriberFactory->withSegments([$segment])->create();
+
+    $newsletterFactory = new Newsletter();
+    $newsletter = $newsletterFactory->withSubject($newsletterTitle)
+      ->withPostNotificationsType()
+      ->withSegments([$segment])
+      ->withActiveStatus()
+      ->withImmediateSendingSettings()
+      ->create();
+
+
+    $postNotificationHistory = (new Newsletter())
+      ->withSubject($postTitle)
+      ->withPostNotificationHistoryType()
+      ->withParent($newsletter)
+      ->create();
+
+    // step 2 - Search post-notification
+    $i->login();
+
+
+    $i->amOnMailpoetPage('Emails');
+    $i->click('Post Notifications', '[data-automation-id="newsletters_listing_tabs"]');
+    $i->waitForListingItemsToLoad();
+    $i->searchFor($newsletterTitle);
+    $i->waitForText($newsletterTitle, 15, '[data-automation-id="newsletters_listing_tabs"]'); // confirm post-notification as created
+
+    // step 3 - Search post-notification history item
+    $selector = sprintf('[data-automation-id="history-%d"]', $newsletter->getId());
+    $i->click($selector);
+     $i->waitForElement(sprintf('[data-automation-id="listing_item_%d"]', $postNotificationHistory->getId()));
+    $i->searchFor($postTitle); // search by rendered post title
+    $i->waitForText($postTitle, 15, '[data-automation-id="newsletters_listing_tabs"]');
   }
 }

--- a/mailpoet/tests/acceptance/Newsletters/SearchForNotificationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/SearchForNotificationCest.php
@@ -89,10 +89,8 @@ class SearchForNotificationCest {
     // create a  WP post
     $i->cli(['post', 'create', "--post_title='$dynamicPostTitle'", '--post_content="Lorem Ipsum"', '--post_status=publish']);
 
-    $i->triggerNewsletterScheduledTask($newsletter->getId());
+    $i->rescheduleNewsletterToBeSentImmediately($newsletter->getId());
     $i->triggerMailPoetActionScheduler();
-
-    $i->wait(1);
 
     // step 2 - Search post-notification
     $i->login();


### PR DESCRIPTION
## Description

Fix post-notification history subject search. 

When searching for post-notification history items, we only check for the item in the Newsletter subject table column. Post notification titles may contain MailPoet shortcodes like [newsletter:post_title], which correspond to the Post title when the Newsletter is sent. Due to the limitation of only checking for the newsletter subject (which would be saved in the Database as "Post notification title [whatever shortcode]"), we were unable to fetch some post notification history items.

This PR fixes the issue by ensuring we also check for the Rendered Newsletter subject when searching for a post-notification history item.

## Code review notes

_N/A_

## QA notes

* Create a post notification email for testing, and make sure the subject line contains dynamic content, for example → “New Post Alert! [newsletter:post_title]”

* Create a few WordPress posts and ensure the post notification emails are sent so there is a history

* Under MailPoet > Emails, click the Post Notification tab

* Click “View History” next to this Post Notification email that has dynamic content in the subject line

* use the search box in the top left to search for a specific subject, i.e. the dynamic content filled into the subject/name of the post

* Check and confirm the items exist

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/876

## Linked tickets

[MAILPOET-6072](https://mailpoet.atlassian.net/browse/MAILPOET-6072)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6072]: https://mailpoet.atlassian.net/browse/MAILPOET-6072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ