### PR TITLE
Don't show "authorize now" message when email field is empty [MAILPOET-6111]

### DIFF
--- a/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
+++ b/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
@@ -56,7 +56,7 @@ function SenderEmailAddressWarning({
     MailPoet.freeMailDomains.indexOf(emailAddressDomain) > -1;
 
   if (mssActive) {
-    if (!isEmailAuthorized) {
+    if (!isEmailAuthorized && emailAddress) {
       displayElements.push(
         <div key="authorizeMyEmail">
           <p className="sender_email_address_warning">


### PR DESCRIPTION
## Description

`Not an authorized sender email address. Authorize it now.` message is shown even when no email is entered, which throws JS errors because the authorize email modal expects _some_ email.

### Before:
<img width="769" alt="Screenshot 2024-06-17 at 13 56 46" src="https://github.com/mailpoet/mailpoet/assets/470616/da7f886b-e41c-4602-82f7-4238f326a43d">

### After:
<img width="704" alt="Screenshot 2024-06-17 at 13 57 17" src="https://github.com/mailpoet/mailpoet/assets/470616/48a81996-4be4-427f-9eeb-9cae605d6bbc">

<img width="767" alt="Screenshot 2024-06-17 at 13 57 06" src="https://github.com/mailpoet/mailpoet/assets/470616/67c876e6-402a-45cd-9cc6-6facc9784154">

## Code review notes

_N/A_

## QA notes

I think QA can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6111]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫  I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫  I added sufficient test coverage
- [x] 🚫  I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6111]: https://mailpoet.atlassian.net/browse/MAILPOET-6111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ