### PR TITLE
Using official WordPress images and introducing new GitHub action [MAILPOET-6097]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
           command: |
             ./do download:woo-commerce-zip latest
             ./do download:woo-commerce-subscriptions-zip 5.7.0
-            ./do download:woo-commerce-memberships-zip 1.25.2
+            ./do download:woo-commerce-memberships-zip 1.26.5
             ./do download:automate-woo-zip 6.0.10
       - run:
           name: Dump tests ENV variables for acceptance tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1068,7 +1068,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: wp-6.4_php8.0_20231114.1
+          wordpress_image_version: 6.4-php8.0
           requires:
             - build_premium
       - integration_tests:

--- a/.github/workflows/check-wordpress-versions.yml
+++ b/.github/workflows/check-wordpress-versions.yml
@@ -1,0 +1,35 @@
+name: Check WordPress Docker Versions
+
+on:
+  workflow_dispatch: # Allows manual triggering
+    branches:
+      - circle-ci-wordpress-image
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3' # Specify the PHP version you want to use
+
+      - name: Check WordPress Docker Versions
+        run: php .github/workflows/scripts/check_wordpress_versions.php
+
+      - name: Check for changes
+        id: git_diff
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git diff --exit-code || echo "::set-output name=changes::true"
+
+      - name: Commit changes
+        if: steps.git_diff.outputs.changes == 'true'
+        run: |
+          git add config.yml
+          git commit -m 'Update used WordPress images in Circle CI'
+          git push origin HEAD:refs/heads/circle-ci-wordpress-image

--- a/.github/workflows/check-wordpress-versions.yml
+++ b/.github/workflows/check-wordpress-versions.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch: # Allows manual triggering
     branches:
       - circle-ci-wordpress-image
+
 jobs:
   check-versions:
     runs-on: ubuntu-latest
@@ -21,17 +22,17 @@ jobs:
       - name: Check WordPress Docker Versions
         run: php .github/workflows/scripts/check_wordpress_versions.php
 
-      - name: Check for changes
-        id: git_diff
+      - name: Check for WordPress changes
+        id: git_diff_wp
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=changes::true"
+          git diff --exit-code || echo "::set-output name=wordpress-changes::true"
 
-      - name: Commit changes
-        if: steps.git_diff.outputs.changes == 'true'
+      - name: Commit WordPress changes
+        if: steps.git_diff_wp.outputs.wordpress-changes == 'true'
         run: |
-          git add config.yml
+          git add .
           git commit -m 'Update used WordPress images in Circle CI'
           git push origin HEAD:refs/heads/circle-ci-wordpress-image
 
@@ -39,16 +40,76 @@ jobs:
       - name: Check WooCommerce Versions
         run: php .github/workflows/scripts/check_woocommerce_versions.php
 
-      - name: Check for changes
-        id: git_diff
+      - name: Check for WooCommerce changes
+        id: git_diff_wc
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=changes::true"
+          git diff --exit-code || echo "::set-output name=woocommerce-changes::true"
 
-      - name: Commit changes
-        if: steps.git_diff.outputs.changes == 'true'
+      - name: Commit WooCommerce changes
+        if: steps.git_diff_wc.outputs.woocommerce-changes == 'true'
         run: |
-          git add config.yml
+          git add .
           git commit -m 'Update used WooCommerce plugin in Circle CI'
+          git push origin HEAD:refs/heads/circle-ci-wordpress-image
+
+      # Updating used Automate Woo plugin
+      - name: Check Automate Woo Versions
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: php .github/workflows/scripts/check_automate_woo_versions.php
+
+      - name: Check for Automate Woo changes
+        id: git_diff_aw
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git diff --exit-code || echo "::set-output name=automate-woo-changes::true"
+
+      - name: Commit Automate Woo changes
+        if: steps.git_diff_aw.outputs.automate-woo-changes == 'true'
+        run: |
+          git add .
+          git commit -m 'Update used Automate Woo plugin in Circle CI'
+          git push origin HEAD:refs/heads/circle-ci-wordpress-image
+
+      # Updating used WooCommerce Subscriptions plugin
+      - name: Check WooCommerce Subscriptions Versions
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
+
+      - name: Check for WooCommerce Subscriptions changes
+        id: git_diff_ws
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git diff --exit-code || echo "::set-output name=subscriptions-changes::true"
+
+      - name: Commit changes WooCommerce Subscriptions changes
+        if: steps.git_diff_ws.outputs.subscriptions-changes == 'true'
+        run: |
+          git add .
+          git commit -m 'Update used WooCommerce Subscriptions plugin in Circle CI'
+          git push origin HEAD:refs/heads/circle-ci-wordpress-image
+
+      # Updating used WooCommerce Memberships plugin
+      - name: Check WooCommerce Memberships Versions
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
+
+      - name: Check for WooCommerce Memberships changes
+        id: git_diff_wm
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git diff --exit-code || echo "::set-output name=memberships-changes::true"
+
+      - name: Commit WooCommerce Memberships changes
+        if: steps.git_diff_wm.outputs.memberships-changes == 'true'
+        run: |
+          git add .
+          git commit -m 'Update used WooCommerce Memberships plugin in Circle CI'
           git push origin HEAD:refs/heads/circle-ci-wordpress-image

--- a/.github/workflows/check-wordpress-versions.yml
+++ b/.github/workflows/check-wordpress-versions.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           php-version: '8.3' # Specify the PHP version you want to use
 
+      # Updating used WordPress
       - name: Check WordPress Docker Versions
         run: php .github/workflows/scripts/check_wordpress_versions.php
 
@@ -32,4 +33,22 @@ jobs:
         run: |
           git add config.yml
           git commit -m 'Update used WordPress images in Circle CI'
+          git push origin HEAD:refs/heads/circle-ci-wordpress-image
+
+      # Updating used WooCommerce plugin
+      - name: Check WooCommerce Versions
+        run: php .github/workflows/scripts/check_woocommerce_versions.php
+
+      - name: Check for changes
+        id: git_diff
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git diff --exit-code || echo "::set-output name=changes::true"
+
+      - name: Commit changes
+        if: steps.git_diff.outputs.changes == 'true'
+        run: |
+          git add config.yml
+          git commit -m 'Update used WooCommerce plugin in Circle CI'
           git push origin HEAD:refs/heads/circle-ci-wordpress-image

--- a/.github/workflows/check-wordpress-versions.yml
+++ b/.github/workflows/check-wordpress-versions.yml
@@ -57,7 +57,7 @@ jobs:
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.WP_GITHUB_TOKEN }}
         run: php .github/workflows/scripts/check_automate_woo_versions.php
 
       - name: Check for Automate Woo changes
@@ -77,7 +77,7 @@ jobs:
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.WP_GITHUB_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
 
       - name: Check for WooCommerce Subscriptions changes
@@ -97,7 +97,7 @@ jobs:
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.WP_GITHUB_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
 
       - name: Check for WooCommerce Memberships changes

--- a/.github/workflows/scripts/check_automate_woo_versions.php
+++ b/.github/workflows/scripts/check_automate_woo_versions.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__ . '/helpers.php';
+
+// Read the GitHub token from environment variable
+$token = getenv('GH_TOKEN');
+if (!$token) {
+  die("GitHub token not found. Make sure it's set in the environment variable 'GH_TOKEN'.");
+}
+
+
+function replaceLatestVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(.\/do download:automate-woo-zip )\d+\.\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+function replacePreviousVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(automate_woo_version: )\d+\.\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+$repository = 'woocommerce/automatewoo';
+
+$allVersions = fetchGitHubTags($repository, $token);
+$stableVersions = filterStableVersions($allVersions);
+[$latestVersion, $previousVersion] = getLatestAndPreviousMinorMajorVersions($stableVersions);
+
+echo "Latest Automate Woo version: $latestVersion\n";
+echo "Previous Automate Woo version: $previousVersion\n";
+
+echo "Replacing the latest version in the config file...\n";
+replaceLatestVersion($latestVersion);
+echo "Replacing the previous version in the config file...\n";
+replacePreviousVersion($previousVersion);

--- a/.github/workflows/scripts/check_memberships_versions.php
+++ b/.github/workflows/scripts/check_memberships_versions.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__ . '/helpers.php';
+
+// Read the GitHub token from environment variable
+$token = getenv('GH_TOKEN');
+if (!$token) {
+  die("GitHub token not found. Make sure it's set in the environment variable 'GH_TOKEN'.");
+}
+
+
+function replaceLatestVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(.\/do download:woo-commerce-memberships-zip )\d+\.\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+function replacePreviousVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(woo_memberships_version: )\d+\.\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+$repository = 'woocommerce/woocommerce-memberships';
+
+$allVersions = fetchGitHubTags($repository, $token);
+$stableVersions = filterStableVersions($allVersions);
+[$latestVersion, $previousVersion] = getLatestAndPreviousMinorMajorVersions($stableVersions);
+
+echo "Latest WooCommerce Memberships version: $latestVersion\n";
+echo "Previous  WooCommerce Memberships version: $previousVersion\n";
+
+echo "Replacing the latest version in the config file...\n";
+replaceLatestVersion($latestVersion);
+echo "Replacing the previous version in the config file...\n";
+replacePreviousVersion($previousVersion);

--- a/.github/workflows/scripts/check_woocommerce_subscriptions_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_subscriptions_versions.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__ . '/helpers.php';
+
+// Read the GitHub token from environment variable
+$token = getenv('GH_TOKEN');
+if (!$token) {
+  die("GitHub token not found. Make sure it's set in the environment variable 'GH_TOKEN'.");
+}
+
+
+function replaceLatestVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(.\/do download:woo-commerce-subscriptions-zip )\d+\.\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+function replacePreviousVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(woo_subscriptions_version: )\d+\.\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+$repository = 'woocommerce/woocommerce-subscriptions';
+
+$allVersions = fetchGitHubTags($repository, $token);
+$stableVersions = filterStableVersions($allVersions);
+[$latestVersion, $previousVersion] = getLatestAndPreviousMinorMajorVersions($stableVersions);
+
+echo "Latest WooCommerce Subscriptions version: $latestVersion\n";
+echo "Previous WooCommerce Subscriptions version: $previousVersion\n";
+
+echo "Replacing the latest version in the config file...\n";
+replaceLatestVersion($latestVersion);
+echo "Replacing the previous version in the config file...\n";
+replacePreviousVersion($previousVersion);

--- a/.github/workflows/scripts/check_woocommerce_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_versions.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/helpers.php';
+
 function getWooCommerceVersions() {
   $url = "https://api.wordpress.org/plugins/info/1.0/woocommerce.json";
   $response = file_get_contents($url);
@@ -12,52 +14,6 @@ function getWooCommerceVersions() {
   return array_keys($data['versions']);
 }
 
-function filterStableVersions($versions) {
-  return array_filter($versions, function($version) {
-    // Only include stable versions (exclude versions with -rc, -beta, -alpha, etc.)
-    return !preg_match('/-(rc|beta|alpha|dev|nightly|pl)/i', $version);
-  });
-}
-
-function getLatestAndPreviousMinorMajorVersions($versions) {
-  usort($versions, 'version_compare');
-  $currentVersion = end($versions);
-
-  $previousVersion = null;
-  foreach (array_reverse($versions) as $version) {
-    if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
-      $previousVersion = $version;
-      break;
-    }
-  }
-
-  return [$currentVersion, $previousVersion];
-}
-
-function getMinorMajorVersion($version) {
-  $parts = explode('.', $version);
-  return $parts[0] . '.' . $parts[1];
-}
-
-function replaceVersionInFile($filePath, $pattern, $replacement): void {
-  $content = file_get_contents($filePath);
-
-  if ($content === false) {
-    die("Failed to read the file at $filePath.");
-  }
-
-  $updatedContent = preg_replace($pattern, $replacement, $content);
-
-  if ($updatedContent === null || $updatedContent === $content) {
-    echo "Nothing to update in $filePath\n";
-    return;
-  }
-
-  if (file_put_contents($filePath, $updatedContent) === false) {
-    die("Failed to write the updated file at $filePath.");
-  }
-}
-
 function replacePreviousVersion($previousVersion) {
   replaceVersionInFile(
     __DIR__ . './../../../.circleci/config.yml',
@@ -68,7 +24,7 @@ function replacePreviousVersion($previousVersion) {
 
 $allVersions = getWooCommerceVersions();
 $stableVersions = filterStableVersions($allVersions);
-list($latestVersion, $previousVersion) = getLatestAndPreviousMinorMajorVersions($stableVersions);
+[$latestVersion, $previousVersion] = getLatestAndPreviousMinorMajorVersions($stableVersions);
 
 
 echo "Latest WooCommerce version: $latestVersion\n";

--- a/.github/workflows/scripts/check_woocommerce_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_versions.php
@@ -1,0 +1,78 @@
+<?php
+
+function getWooCommerceVersions() {
+  $url = "https://api.wordpress.org/plugins/info/1.0/woocommerce.json";
+  $response = file_get_contents($url);
+  $data = json_decode($response, true);
+
+  if (!isset($data['versions'])) {
+    die("Failed to fetch WooCommerce versions.");
+  }
+
+  return array_keys($data['versions']);
+}
+
+function filterStableVersions($versions) {
+  return array_filter($versions, function($version) {
+    // Only include stable versions (exclude versions with -rc, -beta, -alpha, etc.)
+    return !preg_match('/-(rc|beta|alpha|dev|nightly|pl)/i', $version);
+  });
+}
+
+function getLatestAndPreviousMinorMajorVersions($versions) {
+  usort($versions, 'version_compare');
+  $currentVersion = end($versions);
+
+  $previousVersion = null;
+  foreach (array_reverse($versions) as $version) {
+    if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
+      $previousVersion = $version;
+      break;
+    }
+  }
+
+  return [$currentVersion, $previousVersion];
+}
+
+function getMinorMajorVersion($version) {
+  $parts = explode('.', $version);
+  return $parts[0] . '.' . $parts[1];
+}
+
+function replaceVersionInFile($filePath, $pattern, $replacement): void {
+  $content = file_get_contents($filePath);
+
+  if ($content === false) {
+    die("Failed to read the file at $filePath.");
+  }
+
+  $updatedContent = preg_replace($pattern, $replacement, $content);
+
+  if ($updatedContent === null || $updatedContent === $content) {
+    echo "Nothing to update in $filePath\n";
+    return;
+  }
+
+  if (file_put_contents($filePath, $updatedContent) === false) {
+    die("Failed to write the updated file at $filePath.");
+  }
+}
+
+function replacePreviousVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(woo_core_version: )\d+\.\d+\.?\d*/',
+    '${1}' . $previousVersion
+  );
+}
+
+$allVersions = getWooCommerceVersions();
+$stableVersions = filterStableVersions($allVersions);
+list($latestVersion, $previousVersion) = getLatestAndPreviousMinorMajorVersions($stableVersions);
+
+
+echo "Latest WooCommerce version: $latestVersion\n";
+echo "Previous  WooCommerce version: $previousVersion\n";
+
+echo "Replacing the previous version in the config file...\n";
+replacePreviousVersion($previousVersion);

--- a/.github/workflows/scripts/check_wordpress_versions.php
+++ b/.github/workflows/scripts/check_wordpress_versions.php
@@ -1,0 +1,105 @@
+<?php
+
+function fetchData($url): array {
+  $response = file_get_contents($url);
+  return json_decode($response, true);
+}
+
+function getWordpressVersions($page = 1, $pageSize = 100): array {
+  $url = "https://registry.hub.docker.com/v2/repositories/library/wordpress/tags?page_size={$pageSize}&page={$page}";
+  $data = fetchData($url);
+  return array_column($data['results'], 'name');
+}
+
+function filterVersions($versions): array {
+  return array_filter($versions, fn($version) => preg_match('/^\d+\.\d+\.\d+-php\d+\.\d+$/', $version));
+}
+
+function sortVersions(&$versions) {
+  usort($versions, function($a, $b) {
+    [$wpA, $phpA] = explode('-php', $a);
+    [$wpB, $phpB] = explode('-php', $b);
+
+    $wpCompare = version_compare($wpB, $wpA);
+    return $wpCompare !== 0 ? $wpCompare : version_compare($phpB, $phpA);
+  });
+}
+
+function getLatestAndPreviousVersions($sortedVersions) {
+  $uniqueVersions = [];
+  foreach ($sortedVersions as $version) {
+    [$wpVersion] = explode('-php', $version);
+    $majorMinorVersion = preg_replace('/\.\d+$/', '', $wpVersion);
+    $uniqueVersions[$majorMinorVersion][] = $version;
+  }
+
+  krsort($uniqueVersions);
+  $latestVersionGroup = reset($uniqueVersions);
+  $previousVersionGroup = next($uniqueVersions);
+
+  if ($previousVersionGroup === false) {
+    return [$latestVersionGroup[0], null];
+  }
+
+  return [reset($latestVersionGroup), end($previousVersionGroup)];
+}
+
+function replaceVersionInFile($filePath, $pattern, $replacement) {
+  $content = file_get_contents($filePath);
+
+  if ($content === false) {
+    die("Failed to read the file at $filePath.");
+  }
+
+  $updatedContent = preg_replace($pattern, $replacement, $content);
+
+  if ($updatedContent === null || $updatedContent === $content) {
+    echo "Nothing to update in $filePath\n";
+    return;
+  }
+
+  if (file_put_contents($filePath, $updatedContent) === false) {
+    die("Failed to write the updated file at $filePath.");
+  }
+}
+
+function replaceLatestVersion($latestVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../mailpoet/tests/docker/docker-compose.yml',
+    '/(wordpress:\${WORDPRESS_IMAGE_VERSION:-\s*)\d+\.\d+\.?\d*-php\d+\.\d+(})/',
+    '${1}' . $latestVersion . '${2}'
+  );
+}
+
+function replacePreviousVersion($previousVersion) {
+  replaceVersionInFile(
+    __DIR__ . './../../../.circleci/config.yml',
+    '/(wordpress_image_version: )\d+\.\d+\.?\d*-php\d+\.\d+/',
+    '${1}' . $previousVersion
+  );
+}
+
+$allVersions = [];
+$page = 1;
+$maxPages = 4;
+$latestVersion = null;
+$previousVersion = null;
+
+echo "Fetching WordPress versions...\n";
+
+while (($latestVersion === null || $previousVersion === null) && $page <= $maxPages) {
+  $versions = getWordpressVersions($page);
+  $allVersions = array_merge($allVersions, $versions);
+  $allVersions = filterVersions($allVersions);
+  sortVersions($allVersions);
+  [$latestVersion, $previousVersion] = getLatestAndPreviousVersions($allVersions);
+  $page++;
+}
+
+echo "Latest version: $latestVersion\n";
+echo "Previous version: $previousVersion\n";
+
+echo "Replacing the latest version in the docker file...\n";
+replaceLatestVersion($latestVersion);
+echo "Replacing the previous version in the config file...\n";
+replacePreviousVersion($previousVersion);

--- a/.github/workflows/scripts/check_wordpress_versions.php
+++ b/.github/workflows/scripts/check_wordpress_versions.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/helpers.php';
+
 function fetchData($url): array {
   $response = file_get_contents($url);
   return json_decode($response, true);
@@ -42,25 +44,6 @@ function getLatestAndPreviousVersions($sortedVersions) {
   }
 
   return [reset($latestVersionGroup), end($previousVersionGroup)];
-}
-
-function replaceVersionInFile($filePath, $pattern, $replacement) {
-  $content = file_get_contents($filePath);
-
-  if ($content === false) {
-    die("Failed to read the file at $filePath.");
-  }
-
-  $updatedContent = preg_replace($pattern, $replacement, $content);
-
-  if ($updatedContent === null || $updatedContent === $content) {
-    echo "Nothing to update in $filePath\n";
-    return;
-  }
-
-  if (file_put_contents($filePath, $updatedContent) === false) {
-    die("Failed to write the updated file at $filePath.");
-  }
 }
 
 function replaceLatestVersion($latestVersion) {

--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -45,3 +45,27 @@ function getMinorMajorVersion($version) {
   $parts = explode('.', $version);
   return $parts[0] . '.' . $parts[1];
 }
+
+function fetchGitHubTags($repo, $token) {
+  $url = "https://api.github.com/repos/$repo/tags";
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0');  // GitHub API requires a user agent
+  curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    "Authorization: token $token"
+  ]);
+  $response = curl_exec($ch);
+  curl_close($ch);
+
+  if ($response === false) {
+    die("Failed to fetch tags from GitHub.");
+  }
+
+  $data = json_decode($response, true);
+
+  if (isset($data['message']) && $data['message'] == 'Not Found') {
+    die("Repository not found or access denied.");
+  }
+
+  return array_column($data, 'name');
+}

--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -1,0 +1,47 @@
+<?php
+
+function replaceVersionInFile($filePath, $pattern, $replacement) {
+  $content = file_get_contents($filePath);
+
+  if ($content === false) {
+    die("Failed to read the file at $filePath.");
+  }
+
+  $updatedContent = preg_replace($pattern, $replacement, $content);
+
+  if ($updatedContent === null || $updatedContent === $content) {
+    echo "Nothing to update in $filePath\n";
+    return;
+  }
+
+  if (file_put_contents($filePath, $updatedContent) === false) {
+    die("Failed to write the updated file at $filePath.");
+  }
+}
+
+function filterStableVersions($versions) {
+  return array_filter($versions, function($version) {
+    // Only include stable versions (exclude versions with -rc, -beta, -alpha, etc.)
+    return preg_match('/^\d+\.\d+\.\d+$/', $version);
+  });
+}
+
+function getLatestAndPreviousMinorMajorVersions($versions) {
+  usort($versions, 'version_compare');
+  $currentVersion = end($versions);
+
+  $previousVersion = null;
+  foreach (array_reverse($versions) as $version) {
+    if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
+      $previousVersion = $version;
+      break;
+    }
+  }
+
+  return [$currentVersion, $previousVersion];
+}
+
+function getMinorMajorVersion($version) {
+  $parts = explode('.', $version);
+  return $parts[0] . '.' . $parts[1];
+}

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: mailpoet/wordpress:${WORDPRESS_IMAGE_VERSION:-wp-6.5_php8.1_20240405.1}
+    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.5.4-php8.2}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:
@@ -80,6 +80,7 @@ services:
         condition: service_healthy
     volumes:
       - wp-core:/var/www/html
+      - ./install-extensions.sh:/usr/local/bin/install-extensions.sh
       - ../..:/var/www/html/wp-content/plugins/mailpoet
       - ../../../mailpoet-premium:/project/mailpoet-premium
     tmpfs:
@@ -93,6 +94,8 @@ services:
       WORDPRESS_TABLE_PREFIX: mp_
       MAILPOET_TRACY_PRODUCTION_MODE: 1
       MAILPOET_TRACY_LOG_DIR: /var/www/html/wp-content/plugins/mailpoet/tests/_output/exceptions
+    entrypoint: ['sh', '/usr/local/bin/install-extensions.sh']
+    command: ['docker-entrypoint.sh', 'apache2-foreground']
     networks:
       default:
         aliases:

--- a/mailpoet/tests/docker/install-extensions.sh
+++ b/mailpoet/tests/docker/install-extensions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Install PHP extensions required by MailPoet
+docker-php-ext-install pdo_mysql
+
+# Execute the original command
+exec "$@"


### PR DESCRIPTION
## Description

The goal of this PR is to start using official WordPress docker images in our integration and acceptance tests. This step allows us to create automated updating docker images, which is possible via a new GitHub action. I want to test it manually in the first phase, so I need to merge those changes to the trunk branch.

## Code review notes

- I want to add more comments and polish the scripts in the next pull request when I am sure that the scripts work as I expect.
- In the first phase the action should only commit changes to the specific branch if there are some
- The next pull request will add creating a pull request

## QA notes

We can skip QA here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6097]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6097]: https://mailpoet.atlassian.net/browse/MAILPOET-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ