### PR TITLE
Fix GitHub action updating used WordPress and plugins [MAILPOET-6097]

### DIFF
--- a/.github/workflows/check-wordpress-versions.yml
+++ b/.github/workflows/check-wordpress-versions.yml
@@ -23,76 +23,80 @@ jobs:
         run: php .github/workflows/scripts/check_wordpress_versions.php
 
       - name: Check for WordPress changes
-        id: git_diff_wp
+        id: check_wp_changes
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=wordpress-changes::true"
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "WORDPRESS_CHANGES=true" >> $GITHUB_ENV
+          fi
 
       - name: Commit WordPress changes
-        if: steps.git_diff_wp.outputs.wordpress-changes == 'true'
+        if: env.WORDPRESS_CHANGES == 'true'
         run: |
           git add .
           git commit -m 'Update used WordPress images in Circle CI'
-          git push origin HEAD:refs/heads/circle-ci-wordpress-image
 
       # Updating used WooCommerce plugin
       - name: Check WooCommerce Versions
         run: php .github/workflows/scripts/check_woocommerce_versions.php
 
       - name: Check for WooCommerce changes
-        id: git_diff_wc
+        id: check_wc_changes
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=woocommerce-changes::true"
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "WOOCOMMERCE_CHANGES=true" >> $GITHUB_ENV
+          fi
 
       - name: Commit WooCommerce changes
-        if: steps.git_diff_wc.outputs.woocommerce-changes == 'true'
+        if: env.WOOCOMMERCE_CHANGES == 'true'
         run: |
           git add .
           git commit -m 'Update used WooCommerce plugin in Circle CI'
-          git push origin HEAD:refs/heads/circle-ci-wordpress-image
 
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: php .github/workflows/scripts/check_automate_woo_versions.php
 
       - name: Check for Automate Woo changes
-        id: git_diff_aw
+        id: check_aw_changes
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=automate-woo-changes::true"
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "AUTOMATE_WOO_CHANGES=true" >> $GITHUB_ENV
+          fi
 
       - name: Commit Automate Woo changes
-        if: steps.git_diff_aw.outputs.automate-woo-changes == 'true'
+        if: env.AUTOMATE_WOO_CHANGES == 'true'
         run: |
           git add .
           git commit -m 'Update used Automate Woo plugin in Circle CI'
-          git push origin HEAD:refs/heads/circle-ci-wordpress-image
 
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
 
       - name: Check for WooCommerce Subscriptions changes
-        id: git_diff_ws
+        id: check_ws_changes
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=subscriptions-changes::true"
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "SUBSCRIPTIONS_CHANGES=true" >> $GITHUB_ENV
+          fi
 
-      - name: Commit changes WooCommerce Subscriptions changes
-        if: steps.git_diff_ws.outputs.subscriptions-changes == 'true'
+      - name: Commit WooCommerce Subscriptions changes
+        if: env.SUBSCRIPTIONS_CHANGES == 'true'
         run: |
           git add .
           git commit -m 'Update used WooCommerce Subscriptions plugin in Circle CI'
-          git push origin HEAD:refs/heads/circle-ci-wordpress-image
 
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
@@ -101,15 +105,23 @@ jobs:
         run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
 
       - name: Check for WooCommerce Memberships changes
-        id: git_diff_wm
+        id: check_wm_changes
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git diff --exit-code || echo "::set-output name=memberships-changes::true"
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "MEMBERSHIPS_CHANGES=true" >> $GITHUB_ENV
+          fi
 
       - name: Commit WooCommerce Memberships changes
-        if: steps.git_diff_wm.outputs.memberships-changes == 'true'
+        if: env.MEMBERSHIPS_CHANGES == 'true'
         run: |
           git add .
           git commit -m 'Update used WooCommerce Memberships plugin in Circle CI'
+
+      # Push all changes at the end if any changes were detected
+      - name: Push changes
+        if: env.CHANGES_DETECTED == 'true'
+        run: |
           git push origin HEAD:refs/heads/circle-ci-wordpress-image

--- a/.github/workflows/check-wordpress-versions.yml
+++ b/.github/workflows/check-wordpress-versions.yml
@@ -57,7 +57,7 @@ jobs:
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
         env:
-          GH_TOKEN: ${{ secrets.WP_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: php .github/workflows/scripts/check_automate_woo_versions.php
 
       - name: Check for Automate Woo changes
@@ -77,7 +77,7 @@ jobs:
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
         env:
-          GH_TOKEN: ${{ secrets.WP_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
 
       - name: Check for WooCommerce Subscriptions changes
@@ -97,7 +97,7 @@ jobs:
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
         env:
-          GH_TOKEN: ${{ secrets.WP_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
 
       - name: Check for WooCommerce Memberships changes

--- a/.github/workflows/scripts/check_automate_woo_versions.php
+++ b/.github/workflows/scripts/check_automate_woo_versions.php
@@ -34,7 +34,16 @@ $stableVersions = filterStableVersions($allVersions);
 echo "Latest Automate Woo version: $latestVersion\n";
 echo "Previous Automate Woo version: $previousVersion\n";
 
-echo "Replacing the latest version in the config file...\n";
-replaceLatestVersion($latestVersion);
-echo "Replacing the previous version in the config file...\n";
-replacePreviousVersion($previousVersion);
+if ($latestVersion) {
+  echo "Replacing the latest version in the config file...\n";
+  replaceLatestVersion($latestVersion);
+} else {
+  echo "No latest version found.\n";
+}
+
+if ($previousVersion) {
+  echo "Replacing the previous version in the config file...\n";
+  replacePreviousVersion($previousVersion);
+} else {
+  echo "No previous version found.\n";
+}

--- a/.github/workflows/scripts/check_woocommerce_memberships_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_memberships_versions.php
@@ -34,7 +34,16 @@ $stableVersions = filterStableVersions($allVersions);
 echo "Latest WooCommerce Memberships version: $latestVersion\n";
 echo "Previous  WooCommerce Memberships version: $previousVersion\n";
 
-echo "Replacing the latest version in the config file...\n";
-replaceLatestVersion($latestVersion);
-echo "Replacing the previous version in the config file...\n";
-replacePreviousVersion($previousVersion);
+if ($latestVersion) {
+  echo "Replacing the latest version in the config file...\n";
+  replaceLatestVersion($latestVersion);
+} else {
+  echo "No latest version found.\n";
+}
+
+if ($previousVersion) {
+  echo "Replacing the previous version in the config file...\n";
+  replacePreviousVersion($previousVersion);
+} else {
+  echo "No previous version found.\n";
+}

--- a/.github/workflows/scripts/check_woocommerce_subscriptions_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_subscriptions_versions.php
@@ -34,7 +34,16 @@ $stableVersions = filterStableVersions($allVersions);
 echo "Latest WooCommerce Subscriptions version: $latestVersion\n";
 echo "Previous WooCommerce Subscriptions version: $previousVersion\n";
 
-echo "Replacing the latest version in the config file...\n";
-replaceLatestVersion($latestVersion);
-echo "Replacing the previous version in the config file...\n";
-replacePreviousVersion($previousVersion);
+if ($latestVersion) {
+  echo "Replacing the latest version in the config file...\n";
+  replaceLatestVersion($latestVersion);
+} else {
+  echo "No latest version found.\n";
+}
+
+if ($previousVersion) {
+  echo "Replacing the previous version in the config file...\n";
+  replacePreviousVersion($previousVersion);
+} else {
+  echo "No previous version found.\n";
+}


### PR DESCRIPTION
## Description

This PR fixes the GH action, which should update the used WP and plugins. It also add an improvement when we push changes once at the end.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6097]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6097]: https://mailpoet.atlassian.net/browse/MAILPOET-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ