### PR TITLE
Prevent negative sizes of captcha image  [MAILPOET-6112]

### DIFF
--- a/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
@@ -7,6 +7,8 @@ use MailPoetVendor\Gregwar\Captcha\CaptchaBuilder;
 
 class CaptchaRenderer {
 
+  const DEFAULT_WIDTH = 220;
+  const DEFAULT_HEIGHT = 60;
 
   private $phrase;
 
@@ -58,6 +60,9 @@ class CaptchaRenderer {
       return false;
     }
 
+    $width = (isset($width) && $width > 0) ? intval($width) : self::DEFAULT_WIDTH;
+    $height = (isset($height) && $height > 0) ? intval($height) : self::DEFAULT_HEIGHT;
+
     $fontNumbers = array_merge(range(0, 3), [5]); // skip font #4
     $fontNumber = $fontNumbers[mt_rand(0, count($fontNumbers) - 1)];
 
@@ -70,7 +75,7 @@ class CaptchaRenderer {
       ->setBackgroundColor(255, 255, 255)
       ->setTextColor(1, 1, 1)
       ->setMaxBehindLines(0)
-      ->build($width ?: 220, $height ?: 60, $font);
+      ->build($width, $height, $font);
 
     if ($return) {
       return $builder->get();


### PR DESCRIPTION
## Description

This PR aims to prevent Fatal error `PHP Fatal error:  Uncaught ValueError: imagecreatetruecolor(): Argument #2 ($height) must be greater than 0` that happens if the captcha image is requested with a negative width or height.

## Code review notes

_N/A_

## QA notes

Please see the ticket [MAILPOET-6112] for info about replication.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6112]

## After-merge notes

_N/A_

## Tasks

- [x] ⛔ I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] ⛔ I added sufficient test coverage
- [x] ⛔ I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6112]: https://mailpoet.atlassian.net/browse/MAILPOET-6112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-6112]: https://mailpoet.atlassian.net/browse/MAILPOET-6112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ