### PR TITLE
Unify how an automation email type is detected [MAILPOET-6114]

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/components/content.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/content.js
@@ -4,6 +4,7 @@ import _ from 'underscore';
 import { MailPoet } from 'mailpoet';
 import { __ } from '@wordpress/i18n';
 import { NewsletterType } from '../../common/newsletter';
+import { automationTypes } from '../../newsletters/listings/utils';
 
 var Module = {};
 
@@ -26,9 +27,7 @@ Module.NewsletterModel = SuperModel.extend({
     return this.get('type') === 'wc_transactional';
   },
   isAutomationEmail: function isAutomationEmail() {
-    return ['automation', 'automation_transactional'].includes(
-      this.get('type'),
-    );
+    return automationTypes.includes(this.get('type'));
   },
   isConfirmationEmailTemplate: function isConfirmationEmailTemplate() {
     return this.get('type') === 'confirmation_email';

--- a/mailpoet/assets/js/src/newsletter-editor/initializer.jsx
+++ b/mailpoet/assets/js/src/newsletter-editor/initializer.jsx
@@ -3,7 +3,10 @@ import { MailPoet } from 'mailpoet';
 import { __ } from '@wordpress/i18n';
 import { createRoot } from 'react-dom/client';
 import { ListingHeadingSteps } from 'newsletters/listings/heading-steps';
-import { newsletterTypesWithActivation } from 'newsletters/listings/utils';
+import {
+  automationTypes,
+  newsletterTypesWithActivation,
+} from 'newsletters/listings/utils';
 import { fetchAutomaticEmailShortcodes } from 'newsletters/automatic-emails/fetch-editor-shortcodes.jsx';
 import { ErrorBoundary } from 'common';
 import { initTutorial } from './tutorial';
@@ -13,11 +16,7 @@ const renderHeading = (newsletterType, newsletterOptions) => {
     const stepsHeadingContainer = document.getElementById(
       'mailpoet_editor_steps_heading',
     );
-    const step = ['automation', 'automation_transactional'].includes(
-      newsletterType,
-    )
-      ? 2
-      : 3;
+    const step = automationTypes.includes(newsletterType) ? 2 : 3;
 
     let buttons = null;
     let onLogoClick = () => {

--- a/mailpoet/assets/js/src/newsletters/listings/heading-steps.tsx
+++ b/mailpoet/assets/js/src/newsletters/listings/heading-steps.tsx
@@ -6,6 +6,7 @@ import { HideScreenOptions } from '../../common/hide-screen-options/hide-screen-
 import { MailPoetLogoResponsive } from '../../common/top-bar/mailpoet-logo-responsive';
 import { Steps } from '../../common/steps/steps';
 import { displayTutorial } from '../../newsletter-editor/tutorial';
+import { automationTypes } from './utils';
 
 export const mapPathToSteps = (
   location: Location,
@@ -13,12 +14,12 @@ export const mapPathToSteps = (
 ): number | null => {
   const stepsMap = [
     ['/new/.+', 1],
-    ['/template/.+', emailType === 'automation' ? 1 : 2],
+    ['/template/.+', automationTypes.includes(emailType) ? 1 : 2],
     ['/send/.+', 4],
   ];
 
   if (location.search.match(/page=mailpoet-newsletter-editor/g)) {
-    return emailType === 'automation' ? 2 : 3;
+    return automationTypes.includes(emailType) ? 2 : 3;
   }
 
   let stepNumber = null;
@@ -101,7 +102,7 @@ const stepsListingHeading = (
     getEmailSendTitle(emailType),
   ];
   // Automation email has only 2 steps
-  if (emailType === 'automation') {
+  if (automationTypes.includes(emailType)) {
     stepTitles = [__('Template', 'mailpoet'), __('Design', 'mailpoet')];
   }
 
@@ -119,8 +120,7 @@ const stepsListingHeading = (
         {' '}
       </h1>
       <div className="mailpoet-flex-grow" />
-      {!['automation', 'automation_transactional'].includes(emailType) &&
-        step === 3 && <TutorialIcon />}
+      {!automationTypes.includes(emailType) && step === 3 && <TutorialIcon />}
     </div>
   );
 };

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -99,6 +99,8 @@ export const newsletterTypesWithActivation = [
   're_engagement',
 ];
 
+export const automationTypes = ['automation', 'automation_transactional'];
+
 export const confirmEdit = (newsletter) => {
   const editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
 

--- a/mailpoet/assets/js/src/newsletters/templates.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates.jsx
@@ -12,6 +12,7 @@ import { MailPoet } from 'mailpoet';
 import { TemplateBox } from 'newsletters/templates/template-box.jsx';
 import { ImportTemplate } from 'newsletters/templates/import-template.jsx';
 import { ErrorBoundary } from '../common';
+import { automationTypes } from './listings/utils';
 
 const getEditorUrl = (id) => {
   const context = new URLSearchParams(window.location.search).get('context');
@@ -318,7 +319,7 @@ class NewsletterTemplates extends Component {
 
     let buttons = null;
     let onClick;
-    if (this.state.emailType === 'automation') {
+    if (automationTypes.includes(this.state.emailType)) {
       const automationId = this.state.emailOptions?.automationId;
       const goToUrl = automationId
         ? `admin.php?page=mailpoet-automation-editor&id=${automationId}`


### PR DESCRIPTION
## Description

This fixes an issue when an automation transactional email shows the wrong steps in the email editor.

**Before**
<img width="1623" alt="Screenshot 2024-06-19 at 13 59 20" src="https://github.com/mailpoet/mailpoet/assets/470616/c7c5caca-14fd-436e-9bd2-5767a000a6e8">

**After**
<img width="1626" alt="Screenshot 2024-06-19 at 14 03 09" src="https://github.com/mailpoet/mailpoet/assets/470616/cdcb54d8-65e3-4aa5-aea9-99d43319060e">

## Code review notes

While there are changes in JS/JSX files, I decided not to refactor them to TypeScript, as that would increase the scope of this ticket quite substantially (as it touches fairly long files), while this fix is a pretty straightforward one. That said, if you think we should refactor them to TS, I can do that. 

## QA notes

I think QA could be skipped for this one, but if you think otherwise, then please test that the email editor headers correctly show 4 steps in the `Emails` menu item but only 2 steps in the `Automations` menu item - both for transactional and marketing emails. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6114]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫  I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫  I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6114]: https://mailpoet.atlassian.net/browse/MAILPOET-6114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ