### PR TITLE
Fix abandoned cart task from product discovery on homepage [MAILPOET-5847][MAILPOET-5848]

### DIFF
--- a/mailpoet/assets/js/src/automation/templates/index.tsx
+++ b/mailpoet/assets/js/src/automation/templates/index.tsx
@@ -35,7 +35,11 @@ const tabs = [
 ];
 
 function Templates(): JSX.Element {
-  if (window.location.search.includes('loadedvia=woo_multichannel_dashboard')) {
+  const pageParams = new URLSearchParams(window.location.search);
+  const loadedviaParam = pageParams.get('loadedvia');
+  const initialTabParam = pageParams.get('initialTab');
+
+  if (loadedviaParam === 'woo_multichannel_dashboard') {
     window.MailPoet.trackEvent(
       'MailPoet - WooCommerce Multichannel Marketing dashboard > Automation template selection page',
       {
@@ -59,7 +63,7 @@ function Templates(): JSX.Element {
         <FromScratchButton />
       </PageHeader>
 
-      <TabPanel tabs={tabs}>
+      <TabPanel tabs={tabs} initialTabName={initialTabParam}>
         {(tab) => (
           <TemplatesGrid
             templates={automationTemplates.filter(

--- a/mailpoet/assets/js/src/homepage/components/product-discovery.tsx
+++ b/mailpoet/assets/js/src/homepage/components/product-discovery.tsx
@@ -62,7 +62,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
         slug="set up abandoned cart email"
         title={MailPoet.I18n.t('setUpAbandonedCartEmail')}
         description={MailPoet.I18n.t('setUpAbandonedCartEmailDesc')}
-        link="admin.php?page=mailpoet-newsletters#/new/woocommerce/woocommerce_abandoned_shopping_cart/conditions"
+        link="admin.php?page=mailpoet-automation-templates"
         imgSrc={`${MailPoet.cdnUrl}homepage/woo-cart-email-illustration.png`}
         isDone={tasksStatus.setUpAbandonedCartEmail}
         doneMessage={MailPoet.I18n.t('setUpAbandonedCartEmailDone')}

--- a/mailpoet/assets/js/src/homepage/components/product-discovery.tsx
+++ b/mailpoet/assets/js/src/homepage/components/product-discovery.tsx
@@ -26,7 +26,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
       slug="set up welcome campaign"
       title={MailPoet.I18n.t('setUpWelcomeCampaign')}
       description={MailPoet.I18n.t('setUpWelcomeCampaignDesc')}
-      link="admin.php?page=mailpoet-automation-templates"
+      link="admin.php?page=mailpoet-automation-templates&initialTab=welcome"
       imgSrc={`${MailPoet.cdnUrl}homepage/welcome-email-illustration.png`}
       isDone={tasksStatus.setUpWelcomeCampaign}
       doneMessage={MailPoet.I18n.t('setUpWelcomeCampaignDone')}
@@ -62,7 +62,7 @@ export function ProductDiscovery({ onHide }: Props): JSX.Element {
         slug="set up abandoned cart email"
         title={MailPoet.I18n.t('setUpAbandonedCartEmail')}
         description={MailPoet.I18n.t('setUpAbandonedCartEmailDesc')}
-        link="admin.php?page=mailpoet-automation-templates"
+        link="admin.php?page=mailpoet-automation-templates&initialTab=abandoned-cart"
         imgSrc={`${MailPoet.cdnUrl}homepage/woo-cart-email-illustration.png`}
         isDone={tasksStatus.setUpAbandonedCartEmail}
         doneMessage={MailPoet.I18n.t('setUpAbandonedCartEmailDone')}

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -16,6 +16,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\Connection;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
@@ -76,12 +77,12 @@ class NewslettersRepository extends Repository {
       ->from(NewsletterEntity::class, 'n')
       ->where('n.status = :status')
       ->andWhere('n.deletedAt IS NULL')
-      ->andWhere('n.type = :type')
+      ->andWhere('n.type IN (:types)')
       ->join('n.options', 'o', Join::WITH, 'o.value = :event')
-      ->join('o.optionField', 'f', Join::WITH, 'f.name = :nameEvent AND f.newsletterType = :type')
+      ->join('o.optionField', 'f', Join::WITH, 'f.name = :nameEvent AND f.newsletterType IN (:types)')
       ->setParameter('status', NewsletterEntity::STATUS_ACTIVE)
       ->setParameter('nameEvent', NewsletterOptionFieldEntity::NAME_EVENT)
-      ->setParameter('type', NewsletterEntity::TYPE_AUTOMATIC)
+      ->setParameter('types', [NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::TYPE_AUTOMATIC], ArrayParameterType::STRING)
       ->setParameter('event', $event)
       ->getQuery()
       ->getSingleScalarResult());

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -258,6 +258,21 @@ class Newsletter {
   }
 
   /**
+   * @return Newsletter
+   */
+  public function withAutomationTransactionalTypeWooCommerceAbandonedCart() {
+    $this->data['type'] = NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL;
+    $this->withOptions([
+      NewsletterOptionFieldEntity::NAME_GROUP => 'woocommerce',
+      NewsletterOptionFieldEntity::NAME_EVENT => 'woocommerce_abandoned_shopping_cart',
+      NewsletterOptionFieldEntity::NAME_SEND_TO => 'user',
+      NewsletterOptionFieldEntity::NAME_AFTER_TIME_NUMBER => '1',
+      NewsletterOptionFieldEntity::NAME_AFTER_TIME_TYPE => 'weeks',
+    ]);
+    return $this;
+  }
+
+  /**
    * @param array $products Array of products.
    *  $products = [
    *    [

--- a/mailpoet/tests/acceptance/Newsletters/EditorAbandonedCartBlockCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorAbandonedCartBlockCest.php
@@ -22,13 +22,15 @@ class EditorAbandonedCartBlockCest {
     // Prepare newsletter without AC block
     $newsletter = (new Newsletter())
       ->loadBodyFrom('newsletterWithText.json')
-      ->withAutomaticTypeWooCommerceAbandonedCart()
+      ->withAutomationTransactionalTypeWooCommerceAbandonedCart()
       ->withStatus(NewsletterEntity::STATUS_DRAFT)
       ->create();
 
     $i->login();
     $i->activateWooCommerce();
-    $i->amEditingNewsletter($newsletter->getId());
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-newsletter-editor&id=' . $newsletter->getId());
+    $i->waitForElement('#mailpoet_editor_content');
+    $i->waitForElementNotVisible('.velocity-animating');
 
     // Move the Abandoned Cart block to the editor
     $i->dragAndDrop('#automation_editor_block_abandoned_cart_content', '#mce_1');

--- a/mailpoet/tests/integration/Homepage/HomepageDataControllerTest.php
+++ b/mailpoet/tests/integration/Homepage/HomepageDataControllerTest.php
@@ -178,6 +178,29 @@ class HomepageDataControllerTest extends \MailPoetTest {
     verify($productDiscoveryStatus['setUpAbandonedCartEmail'])->false();
 
     $newsletter = (new Newsletter())
+      ->withAutomationTransactionalTypeWooCommerceAbandonedCart()
+      ->withStatus(NewsletterEntity::STATUS_DRAFT)
+      ->create();
+
+    // Not done when abandoned cart email is draft
+    $productDiscoveryStatus = $this->homepageDataController->getPageData()['productDiscoveryStatus'];
+    verify($productDiscoveryStatus['setUpAbandonedCartEmail'])->false();
+
+    // Done when abandoned cart email is active
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+    $this->entityManager->flush();
+    $productDiscoveryStatus = $this->homepageDataController->getPageData()['productDiscoveryStatus'];
+    verify($productDiscoveryStatus['setUpAbandonedCartEmail'])->true();
+  }
+
+  /**
+   * Some customers can have abandoned cart emails with legacy type `automatic`
+   */
+  public function testItFetchesProductDiscoveryStatusSetUpAbandonedCartEmailWithLegacyType(): void {
+    $productDiscoveryStatus = $this->homepageDataController->getPageData()['productDiscoveryStatus'];
+    verify($productDiscoveryStatus['setUpAbandonedCartEmail'])->false();
+
+    $newsletter = (new Newsletter())
       ->withAutomaticTypeWooCommerceAbandonedCart()
       ->withStatus(NewsletterEntity::STATUS_DRAFT)
       ->create();


### PR DESCRIPTION
## Description

This PR fixes two issues:
- The link for the `Set up an abandoned cart email` item on the homepage
- The condition when the item is marked as done

## Code review notes

- I was considering if the condition from the NewsletterRepository class should be changed to equal with the new type, but in the end, I decided to make it backward compatible. This means that we detect if the abandoned cart emails with old and new types.

## QA notes

There are two parts to the check:
1. Check that the link for the `Set up an abandoned cart email` item redirects to the page with automation templates
2. When the automation for an abandoned cart is created, the task should be marked as done

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5847]
[MAILPOET-5848]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5847]: https://mailpoet.atlassian.net/browse/MAILPOET-5847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-5848]: https://mailpoet.atlassian.net/browse/MAILPOET-5848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ