### PR TITLE
Trigger abandoned cart for non subscribed subscribers [MAILPOET-6115]

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
@@ -168,7 +168,7 @@ class AbandonedCart {
 
   private function scheduleAbandonedCartEmail(array $cartProductIds = []) {
     $subscriber = $this->getSubscriber();
-    if (!$subscriber || $subscriber->getStatus() !== SubscriberEntity::STATUS_SUBSCRIBED) {
+    if (!$subscriber) {
       return;
     }
 

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -363,7 +363,7 @@ class Scheduler {
   public function verifySubscriber(SubscriberEntity $subscriber, ScheduledTaskEntity $task): bool {
     $queue = $task->getSendingQueue();
     $newsletter = $queue ? $queue->getNewsletter() : null;
-    if ($newsletter && $newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
+    if ($newsletter && $newsletter->isTransactional()) {
       return $subscriber->getStatus() !== SubscriberEntity::STATUS_BOUNCED;
     }
     if ($subscriber->getStatus() === SubscriberEntity::STATUS_UNCONFIRMED) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -187,11 +187,6 @@ class SendingQueue {
       return;
     }
 
-    $isTransactional = in_array($newsletter->getType(), [
-      NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
-      NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL,
-    ]);
-
     // configure mailer
     $this->mailerTask->configureMailer($newsletter);
     // get newsletter segments
@@ -272,7 +267,7 @@ class SendingQueue {
           ->setParameter('subscriberIds', $subscribersToProcessIds)
           ->andWhere('s.deletedAt IS NULL');
 
-        if ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) {
+        if ($newsletter->isTransactional()) {
           $queryBuilder->andWhere('s.status != :bouncedStatus')
             ->setParameter('bouncedStatus', SubscriberEntity::STATUS_BOUNCED);
         } else {
@@ -323,7 +318,7 @@ class SendingQueue {
           $foundSubscribers,
           $timer
         );
-        if (!$isTransactional) {
+        if (!$newsletter->isTransactional()) {
           $this->entityManager->wrapInTransaction(function() use ($foundSubscribersIds) {
             $now = Carbon::createFromTimestamp((int)current_time('timestamp'));
             $this->subscribersRepository->bulkUpdateLastSendingAt($foundSubscribersIds, $now);

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -608,4 +608,11 @@ class NewsletterEntity {
     $campaignName = $this->getCampaignName();
     return $campaignName ?: $this->getSubject();
   }
+
+  public function isTransactional(): bool {
+    return in_array($this->getType(), [
+      NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+      NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL,
+    ]);
+  }
 }

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Entities;
 
 use DateTimeInterface;
+use MailPoet\AutomaticEmails\WooCommerce\Events\AbandonedCart;
 use MailPoet\Doctrine\EntityTraits\AutoincrementedIdTrait;
 use MailPoet\Doctrine\EntityTraits\CreatedAtTrait;
 use MailPoet\Doctrine\EntityTraits\DeletedAtTrait;
@@ -610,6 +611,15 @@ class NewsletterEntity {
   }
 
   public function isTransactional(): bool {
+
+    // Legacy Abandoned Cart emails are transactional
+    if (
+      $this->getType() === NewsletterEntity::TYPE_AUTOMATIC
+      && $this->getOptionValue(NewsletterOptionFieldEntity::NAME_EVENT) === AbandonedCart::SLUG
+    ) {
+      return true;
+    }
+
     return in_array($this->getType(), [
       NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
       NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL,

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -164,7 +164,7 @@ class AbandonedCartTest extends \MailPoetTest {
 
   public function testItSchedulesAbandonedCartAlsoForNonSubscribedSubscribers() {
     $this->createNewsletter();
-    $this->createSubscriberAsCurrentUser('unconfirmed');
+    $this->createSubscriberAsCurrentUser(SubscriberEntity::STATUS_UNCONFIRMED);
     $this->wooCommerceCartMock->method('is_empty')->willReturn(false);
 
     $abandonedCartEmail = $this->createAbandonedCartEmail();
@@ -359,14 +359,14 @@ class AbandonedCartTest extends \MailPoetTest {
     return $scheduledTask;
   }
 
-  private function createSubscriber(string $status = 'subscribed'): SubscriberEntity {
+  private function createSubscriber(string $status = SubscriberEntity::STATUS_SUBSCRIBED): SubscriberEntity {
     return (new SubscriberFactory())
       ->withWpUserId(123)
       ->withStatus($status)
       ->create();
   }
 
-  private function createSubscriberAsCurrentUser(string $status = 'subscribed'): SubscriberEntity {
+  private function createSubscriberAsCurrentUser(string $status = SubscriberEntity::STATUS_SUBSCRIBED): SubscriberEntity {
     $subscriber = $this->createSubscriber($status);
     $this->wp->method('wpGetCurrentUser')->willReturn(
       $this->makeEmpty(WP_User::class, [

--- a/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
+++ b/mailpoet/tests/integration/Entities/NewsletterEntityTest.php
@@ -220,6 +220,16 @@ class NewsletterEntityTest extends \MailPoetTest {
     verify($notificationHistoryNewsletter->getFilterSegmentId())->equals(2);
   }
 
+  public function testIsTransactional(): void {
+    $newsletter = $this->createNewsletter();
+    $this->assertFalse($newsletter->isTransactional());
+
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL);
+    $this->assertTrue($newsletter->isTransactional());
+    $newsletter->setType(NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL);
+    $this->assertTrue($newsletter->isTransactional());
+  }
+
   private function createNewsletter(string $type = NewsletterEntity::TYPE_STANDARD): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType($type);


### PR DESCRIPTION
## Description

In Automations, we treat abandoned carts as transactional. Therefore we must start the abandoned cart process without checking the subscriber status.

This change does not apply to legacy abandoned cart emails because we check in the SendingQueue the status of the subscriber [here](https://github.com/mailpoet/mailpoet/blob/aea6eb3dbbfc88d891c86f52cad11bd05f2677be/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php#L275-L281) (and maybe in other places, would need to check). I think that is an okay trade off, but let me know if you think we should apply this change also to legacy abandoned cart emails.

## Code review notes

_N/A_

## QA notes

Check if the abandoned cart automation works with subscribers who do not have the status "subscribed". Please check also legacy abandoned cart emails. I did so by downloading an old plugin (e.g. [4.41.0](https://github.com/mailpoet/mailpoet/releases/tag/4.41.0)) to set the legacy abandoned cart email up and then updating to this version.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6115]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6115]: https://mailpoet.atlassian.net/browse/MAILPOET-6115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ