### PR TITLE
Ensure not loaded Mixpanel is not blocking UI [MAILPOET-6116]

### DIFF
--- a/mailpoet/assets/js/src/analytics-event.js
+++ b/mailpoet/assets/js/src/analytics-event.js
@@ -27,7 +27,7 @@ function track(name, data = [], options = {}, callback = null) {
   const optionsData = options === CacheEventOptionSaveInStorage ? {} : options;
 
   if (typeof window.mixpanel.track !== 'function') {
-    window.mixpanel.init(window.mixpanelTrackingId);
+    window.mixpanel.init(window.mixpanelTrackingId, window.mixpanelInitConfig);
   }
 
   if (typeof window.mailpoet_version !== 'undefined') {
@@ -38,7 +38,14 @@ function track(name, data = [], options = {}, callback = null) {
     trackedData['MailPoet Premium version'] = window.mailpoet_premium_version;
   }
 
-  window.mixpanel.track(name, trackedData, optionsData, callback);
+  // Fallback when Mixpanel is not loaded (e.g., blocked by AdBlock)
+  if (!window.mixpanelIsLoaded) {
+    if (callback) {
+      callback();
+    }
+  } else {
+    window.mixpanel.track(name, trackedData, optionsData, callback);
+  }
 }
 
 function exportMixpanel() {

--- a/mailpoet/views/analytics.html
+++ b/mailpoet/views/analytics.html
@@ -4,8 +4,12 @@
   for(h=0;h<k.length;h++)e(d,k[h]);a._i.push([b,c,f])};a.__SV=1.2;b=e.createElement("script");b.type="text/javascript";b.async=!0;b.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";c=e.getElementsByTagName("script")[0];c.parentNode.insertBefore(b,c)}})(document,window.mixpanel||[]);
 
 window.mixpanelTrackingId = "8cce373b255e5a76fb22d57b85db0c92";
+window.mixpanelIsLoaded = false;
+window.mixpanelInitConfig = { 'loaded': function() {
+  window.mixpanelIsLoaded = true;
+}}
 
-mixpanel.init(window.mixpanelTrackingId);
+mixpanel.init(window.mixpanelTrackingId, window.mixpanelInitConfig);
 
 mixpanel.register({'Platform': 'Plugin'});
 


### PR DESCRIPTION
## Description

We initialize [basic Mixpanel object](https://github.com/mailpoet/mailpoet/blob/638fb7e56a2d5928dffc9cd1a61c6badf4cec480/mailpoet/views/analytics.html) within the plugin, and only load the full Mixpanel script from their CDN. However, some of UI components depends on calling a callback within the track function, which breaks, when the Mixpanel library is not loaded due to AdBlockers. This causes the track event to never call the callback and the original action is not performed (e.g., a redirect). 

## Code review notes

I tried to refactor `analytics-events.js` to TypeScript, but got stuck for almost two hours so rather decided to keep it `.js` in favor of shipping the fix. 

## QA notes

I think QA can be skipped. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6116]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6116]: https://mailpoet.atlassian.net/browse/MAILPOET-6116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ