### PR TITLE
Update React Tooltip from v4 to v5 [MAILPOET-5482]

### DIFF
--- a/mailpoet/assets/css/src/components/_tooltips.scss
+++ b/mailpoet/assets/css/src/components/_tooltips.scss
@@ -2,9 +2,11 @@
   background-color: #fafbfe;
   border-color: #e5e9f8;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
   box-shadow: 0 2px 4px 0 rgba(229, 233, 248, 0.4),
     0 5px 30px 0 $color-tertiary-light;
-  color: $gray-90;
+  color: #1d2327;
   max-width: 400px;
   padding: $grid-gap-half;
   z-index: 9990; // Allow tooltip to display over #adminmenuwrap (lefthand menu) core style

--- a/mailpoet/assets/css/src/components/_tooltips.scss
+++ b/mailpoet/assets/css/src/components/_tooltips.scss
@@ -1,7 +1,10 @@
 .mailpoet-tooltip {
+  background-color: #fafbfe;
+  border-color: #e5e9f8;
   border-radius: 4px;
   box-shadow: 0 2px 4px 0 rgba(229, 233, 248, 0.4),
     0 5px 30px 0 $color-tertiary-light;
+  color: $gray-90;
   max-width: 400px;
   padding: $grid-gap-half;
   z-index: 9990; // Allow tooltip to display over #adminmenuwrap (lefthand menu) core style

--- a/mailpoet/assets/js/src/common/button/button.tsx
+++ b/mailpoet/assets/js/src/common/button/button.tsx
@@ -63,7 +63,7 @@ export function Button({
       })}
       data-automation-id={automationId}
       data-tip={dataTip}
-      data-for={dataFor}
+      data-tooltip-id={dataFor}
     >
       {iconStart}
       {children && <span>{children}</span>}

--- a/mailpoet/assets/js/src/common/form/input/input.tsx
+++ b/mailpoet/assets/js/src/common/form/input/input.tsx
@@ -40,7 +40,7 @@ export function Input({
             <span
               className="mailpoet-form-tooltip-icon"
               data-tip
-              data-for={attributes.name}
+              data-tooltip-id={attributes.name}
             />
           </span>
           <Tooltip place="right" id={attributes.name}>

--- a/mailpoet/assets/js/src/common/form/input/input.tsx
+++ b/mailpoet/assets/js/src/common/form/input/input.tsx
@@ -43,7 +43,7 @@ export function Input({
               data-for={attributes.name}
             />
           </span>
-          <Tooltip place="right" multiline id={attributes.name}>
+          <Tooltip place="right" id={attributes.name}>
             {tooltip}
           </Tooltip>
         </>

--- a/mailpoet/assets/js/src/common/form/textarea/textarea.tsx
+++ b/mailpoet/assets/js/src/common/form/textarea/textarea.tsx
@@ -40,7 +40,7 @@ export function Textarea({
               data-for={attributes.name}
             />
           </span>
-          <Tooltip place="right" multiline id={attributes.name}>
+          <Tooltip place="right" id={attributes.name}>
             {tooltip}
           </Tooltip>
         </>

--- a/mailpoet/assets/js/src/common/form/textarea/textarea.tsx
+++ b/mailpoet/assets/js/src/common/form/textarea/textarea.tsx
@@ -37,7 +37,7 @@ export function Textarea({
             <span
               className="mailpoet-form-tooltip-icon"
               data-tip
-              data-for={attributes.name}
+              data-tooltip-id={attributes.name}
             />
           </span>
           <Tooltip place="right" id={attributes.name}>

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats.tsx
@@ -59,7 +59,7 @@ export function NewsletterStats({
     const revenuesTooltipId = `revenues-${newsletterId || '0'}`;
     revenueStats = (
       <div>
-        <Tag data-tip data-for={revenuesTooltipId}>
+        <Tag data-tip data-tooltip-id={revenuesTooltipId}>
           {revenues}
         </Tag>
         <Tooltip place="top" id={revenuesTooltipId}>

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats.tsx
@@ -62,7 +62,7 @@ export function NewsletterStats({
         <Tag data-tip data-for={revenuesTooltipId}>
           {revenues}
         </Tag>
-        <Tooltip place="top" multiline id={revenuesTooltipId}>
+        <Tooltip place="top" id={revenuesTooltipId}>
           <div className="mailpoet-listing-stats-tooltip-content">
             {__(
               'Revenues by customers who clicked on this email in the last 2 weeks.',

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/badge.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/badge.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Place } from 'react-tooltip';
+import { PlacesType } from 'react-tooltip';
 import { Tag } from '../../tag';
 import { Tooltip } from '../../tooltip/tooltip';
 
@@ -7,7 +7,7 @@ type BadgeProps = {
   name: string;
   tooltip?: string | ReactNode;
   tooltipId?: string;
-  tooltipPlace?: Place;
+  tooltipPlace?: PlacesType;
   type?: 'average' | 'good' | 'excellent' | 'critical' | 'unknown';
   isInverted?: boolean;
 };

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/badge.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/badge.tsx
@@ -28,7 +28,6 @@ function Badge({
       {tooltip && (
         <Tooltip
           place={tooltipPlace || 'top'}
-          multiline
           id={tooltipId || tooltip.toString()}
         >
           {tooltip}

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/badge.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/badge.tsx
@@ -22,7 +22,12 @@ function Badge({
 }: BadgeProps) {
   return (
     <span>
-      <Tag isInverted={isInverted} variant={type} data-tip data-for={tooltipId}>
+      <Tag
+        isInverted={isInverted}
+        variant={type}
+        data-tip
+        data-tooltip-id={tooltipId}
+      >
         {name}
       </Tag>
       {tooltip && (

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
@@ -1,12 +1,12 @@
 import { __, _x } from '@wordpress/i18n';
-import { Place } from 'react-tooltip';
+import { PlacesType } from 'react-tooltip';
 import { Badge } from './badge';
 
 type StatsBadgeProps = {
   stat: string;
   rate: number;
   tooltipId?: string;
-  tooltipPlace?: Place;
+  tooltipPlace?: PlacesType;
   isInverted?: boolean;
 };
 

--- a/mailpoet/assets/js/src/common/listings/newsletter-status.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-status.tsx
@@ -106,7 +106,7 @@ function NewsletterStatus({
         : __('Tomorrow', 'mailpoet');
       label = (
         <>
-          <span data-tip data-for={randomId}>
+          <span data-tip data-tooltip-id={randomId}>
             {dateWord}
           </span>
           <Tooltip place="right" id={randomId}>

--- a/mailpoet/assets/js/src/common/tag/tags.tsx
+++ b/mailpoet/assets/js/src/common/tag/tags.tsx
@@ -73,7 +73,7 @@ function Tags({ children, tags, dimension, variant, isInverted }: TagProps) {
           const tooltipId = `tag-tooltip-${randomId}`;
           const tagWithTooltip = React.cloneElement(tag, {
             'data-tip': true,
-            'data-for': tooltipId,
+            'data-tooltip-id': tooltipId,
           });
 
           return (
@@ -96,7 +96,7 @@ function Tags({ children, tags, dimension, variant, isInverted }: TagProps) {
                 {item.tooltip}
               </Tooltip>
             )}
-            <a data-tip="" data-for={tooltipId} href={item.target}>
+            <a data-tip="" data-tooltip-id={tooltipId} href={item.target}>
               {tag}
             </a>
           </div>

--- a/mailpoet/assets/js/src/common/tooltip/_stories/tooltip.tsx
+++ b/mailpoet/assets/js/src/common/tooltip/_stories/tooltip.tsx
@@ -10,14 +10,14 @@ export function Tooltips() {
     <>
       <Heading level={1}>Placements</Heading>
       <div style={{ display: 'flex', justifyContent: 'space-around' }}>
-        <p data-tip data-for="bottom">
+        <p data-tip data-tooltip-id="bottom">
           Bottom Tooltip
         </p>
         <Tooltip id="bottom" place="bottom">
           <span>The tooltip content</span>
         </Tooltip>
 
-        <p data-tip data-for="top">
+        <p data-tip data-tooltip-id="top">
           Top Tooltip
         </p>
         <Tooltip id="top" place="top">

--- a/mailpoet/assets/js/src/common/tooltip/tooltip.tsx
+++ b/mailpoet/assets/js/src/common/tooltip/tooltip.tsx
@@ -1,11 +1,10 @@
 import classnames from 'classnames';
 import { Tooltip as ReactTooltip, ITooltip } from 'react-tooltip';
 
-export function Tooltip({ border, className, children, ...props }: ITooltip) {
+export function Tooltip({ className, children, ...props }: ITooltip) {
   return (
     <ReactTooltip
       className={classnames('mailpoet-tooltip', className)}
-      border={border === undefined ? true : border}
       {...props}
     >
       {children}

--- a/mailpoet/assets/js/src/common/tooltip/tooltip.tsx
+++ b/mailpoet/assets/js/src/common/tooltip/tooltip.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import ReactTooltip, { TooltipProps } from 'react-tooltip';
+import { Tooltip as ReactTooltip, ITooltip } from 'react-tooltip';
 
 export function Tooltip({
   effect,
@@ -10,7 +10,7 @@ export function Tooltip({
   className,
   children,
   ...props
-}: TooltipProps) {
+}: ITooltip) {
   return (
     <ReactTooltip
       effect={effect || 'solid'}

--- a/mailpoet/assets/js/src/common/tooltip/tooltip.tsx
+++ b/mailpoet/assets/js/src/common/tooltip/tooltip.tsx
@@ -1,22 +1,9 @@
 import classnames from 'classnames';
 import { Tooltip as ReactTooltip, ITooltip } from 'react-tooltip';
 
-export function Tooltip({
-  effect,
-  textColor,
-  backgroundColor,
-  border,
-  borderColor,
-  className,
-  children,
-  ...props
-}: ITooltip) {
+export function Tooltip({ border, className, children, ...props }: ITooltip) {
   return (
     <ReactTooltip
-      effect={effect || 'solid'}
-      textColor={textColor || '#1d2327'}
-      backgroundColor={backgroundColor || '#fafbfe'}
-      borderColor={borderColor || '#e5e9f8'}
       className={classnames('mailpoet-tooltip', className)}
       border={border === undefined ? true : border}
       {...props}

--- a/mailpoet/assets/js/src/help-tooltip.jsx
+++ b/mailpoet/assets/js/src/help-tooltip.jsx
@@ -9,6 +9,9 @@ function Tooltip(props) {
   if (!props.tooltipId && typeof props.tooltip === 'string') {
     tooltipId = props.tooltip;
   }
+  if (!tooltipId) {
+    tooltipId = (Math.random() + 1).toString(36).substring(7);
+  }
 
   if (typeof props.tooltip === 'string') {
     tooltip = (

--- a/mailpoet/assets/js/src/help-tooltip.jsx
+++ b/mailpoet/assets/js/src/help-tooltip.jsx
@@ -31,14 +31,13 @@ function Tooltip(props) {
           cursor: 'pointer',
         }}
         className="tooltip dashicons dashicons-editor-help"
-        data-event="click"
         data-tip
-        data-for={tooltipId}
+        data-tooltip-id={tooltipId}
       />
       <ReactTooltip
         globalEventOff="click"
+        openOnClick
         className="mailpoet-tooltip-message"
-        multiline
         id={tooltipId}
         place={props.place}
       >

--- a/mailpoet/assets/js/src/help-tooltip.jsx
+++ b/mailpoet/assets/js/src/help-tooltip.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import ReactTooltip from 'react-tooltip';
+import { Tooltip as ReactTooltip } from 'react-tooltip';
 import ReactHtmlParser from 'react-html-parser';
 
 function Tooltip(props) {
@@ -40,7 +40,6 @@ function Tooltip(props) {
         className="mailpoet-tooltip-message"
         multiline
         id={tooltipId}
-        efect="solid"
         place={props.place}
       >
         {tooltip}

--- a/mailpoet/assets/js/src/newsletters/send/filter-segment.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/filter-segment.tsx
@@ -148,7 +148,7 @@ export function FilterSegment({
           icon={help}
         />
       </span>
-      <Tooltip place="right" multiline id="filter-segment-tooltip">
+      <Tooltip place="right" id="filter-segment-tooltip">
         <div>
           {__(
             `Subscribers selected in 'Send to' will only receive an email if they also belong to this segment.`,

--- a/mailpoet/assets/js/src/newsletters/send/filter-segment.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/filter-segment.tsx
@@ -143,7 +143,7 @@ export function FilterSegment({
         {__('Filter by segment', 'mailpoet')}
         <Icon
           data-tip
-          data-for="filter-segment-tooltip"
+          data-tooltip-id="filter-segment-tooltip"
           className="filter-segment-tooltip"
           icon={help}
         />

--- a/mailpoet/assets/js/src/newsletters/send/recipient-count.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/recipient-count.tsx
@@ -82,7 +82,7 @@ export function RecipientCount(props: RecipientCountProps) {
       )}
       {!isLoading && (
         <>
-          <Tooltip place="right" multiline id="estimated-count-tooltip">
+          <Tooltip place="right" id="estimated-count-tooltip">
             {__('This count may change at the time of sending.', 'mailpoet')}
           </Tooltip>
           <span

--- a/mailpoet/assets/js/src/newsletters/send/recipient-count.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/recipient-count.tsx
@@ -87,7 +87,7 @@ export function RecipientCount(props: RecipientCountProps) {
           </Tooltip>
           <span
             data-tip
-            data-for="estimated-count-tooltip"
+            data-tooltip-id="estimated-count-tooltip"
             className="estimated-recipient-count"
           >
             {recipientCount.toLocaleString()}

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -98,7 +98,7 @@
     "react-router-dom": "^5.3.0",
     "react-select": "^5.8.0",
     "react-string-replace": "^1.0.0",
-    "react-tooltip": "^4.2.21",
+    "react-tooltip": "^5.27.0",
     "reakit": "^1.3.11",
     "satismeter-loader": "^1.1.0",
     "select2": "^4.1.0-rc.0",

--- a/mailpoet/tests/javascript-newsletter-editor/mocha-test-helper.js
+++ b/mailpoet/tests/javascript-newsletter-editor/mocha-test-helper.js
@@ -34,6 +34,10 @@ global.window.wp = global.window.wp || {
     getLocaleData: () => {},
   },
 };
+global.MutationObserver = global.window.MutationObserver;
+global.CustomEvent = global.window.CustomEvent;
+global.HTMLElement = global.window.HTMLElement;
+global.getComputedStyle = global.window.getComputedStyle;
 
 testHelpers.loadScript(
   'tests/javascript-newsletter-editor/testBundles/vendor.js',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       react-tooltip:
-        specifier: ^4.2.21
-        version: 4.2.21(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^5.27.0
+        version: 5.27.0(react-dom@18.3.1)(react@18.3.1)
       reakit:
         specifier: ^1.3.11
         version: 1.3.11(react-dom@18.3.1)(react@18.3.1)
@@ -18908,17 +18908,16 @@ packages:
       react: 18.3.1
       tslib: 2.6.3
 
-  /react-tooltip@4.2.21(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==}
-    engines: {npm: '>=6.13'}
+  /react-tooltip@5.27.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-JXROcdfCEbCqkAkh8LyTSP3guQ0dG53iY2E2o4fw3D8clKzziMpE6QG6CclDaHELEKTzpMSeAOsdtg0ahoQosw==}
     peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
     dependencies:
-      prop-types: 15.8.1
+      '@floating-ui/dom': 1.6.5
+      classnames: 2.5.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      uuid: 7.0.3
     dev: false
 
   /react-transition-group@4.4.5(react-dom@18.3.1)(react@18.3.1):


### PR DESCRIPTION
## Description

Upgrade the react tooltip. Those little bubbles that render small help for the users: https://d.pr/i/PcMM7J

## Code review notes

[Guide](https://react-tooltip.com/docs/upgrade-guide/changelog-v4-v5) – many properties were removed and we had to use CSS instead as suggested in the upgrade guide.

## QA notes

The tooltips are used all around the plugin. I think I went through all of the instances and tested them. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5482]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5482]: https://mailpoet.atlassian.net/browse/MAILPOET-5482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ