### PR TITLE
Add scheduling to the GitHub action updating used versions [MAILPOET-6097]

### DIFF
--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -1,6 +1,8 @@
 name: Check new versions of plugins and WordPress
 
 on:
+  schedule:
+    - cron: '0 6 * * 1' # At 06:00 on Monday
   workflow_dispatch: # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
## Description

Because we have a new GitHub action creating a pull request if there are new versions of used plugins or a new WordPress Docker image, we want to automate this process, and this should be possible by configuring cron in this job.

## Code review notes

The history of runs for the new action can be found [here](https://github.com/mailpoet/mailpoet/actions/workflows/update-wordpress-and-plugins.yml). I tried to run the action while creating this PR to verify that the new PR is not created if there is nothing to update.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6097]

## After-merge notes

_N/A_

## Tasks

- [ ] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6097]: https://mailpoet.atlassian.net/browse/MAILPOET-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ