### PR TITLE
Fix Archive page shortcode tooltip not working due to missing "name" attribute [MAILPOET-6122]

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
@@ -98,6 +98,7 @@ export function Shortcode({ name, title, description }: Props) {
                 'Include newsletters sent no more than this many days ago. This overrides start and end dates.',
                 'mailpoet',
               )}
+              name="in_the_last_days"
               placeholder={__('In the last days', 'mailpoet')}
               onChange={(event) => {
                 const inputValue = event.target.value.trim();


### PR DESCRIPTION
## Description

I'm not sure why it worked before because the `<Input>` tooltip [uses the `name` attribute](https://github.com/mailpoet/mailpoet/blob/39849a61f10108ea4b60607939b4fb2bd03e13a9/mailpoet/assets/js/src/common/form/input/input.tsx#L43-L46) to pair it with the `<Tooltip>` component. Adding `name` to the `<Input>` helps, and the tooltip is showing again.

<img width="1025" alt="Screenshot 2024-06-25 at 10 55 58" src="https://github.com/mailpoet/mailpoet/assets/470616/1eb02f4a-146b-426b-a764-234b406bdf61">

## Code review notes

Skipping code review.

## QA notes

Skipping QA review.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6122]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6122]: https://mailpoet.atlassian.net/browse/MAILPOET-6122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ