### PR TITLE
Fix subscribers count tooltip overlay with recalculate button [MAILPOET-6121]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_common.scss
+++ b/mailpoet/assets/css/src/components-plugin/_common.scss
@@ -67,6 +67,8 @@ p.sender_email_address_warning:first-child {
 .mailpoet-subscribers-in-plan {
   font-size: 18px;
   margin-bottom: 20px;
+  position: relative;
+  z-index: 1;
 
   .mailpoet-subscribers-in-plan-spacer {
     display: inline-block;


### PR DESCRIPTION
## Description
The `<Button>` component has relative positioning, so anything in the DOM before the button will be rendered behind it. I changed the subscriber's count positioning to a relative with `z-index: 1`, so even though it's before the `Recalculate now` button in DOM, it will be rendered above it. 

**Before**
<img width="754" alt="Screenshot 2024-06-25 at 11 23 32" src="https://github.com/mailpoet/mailpoet/assets/470616/c19199df-cb81-4308-b431-a02c58c0dda6">

**After**
<img width="774" alt="Screenshot 2024-06-25 at 11 21 28" src="https://github.com/mailpoet/mailpoet/assets/470616/aaf71098-1b90-4302-bb16-10782698b059">

## Code review notes

Skipping code review.

## QA notes

Skipping QA review.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6121]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6121]: https://mailpoet.atlassian.net/browse/MAILPOET-6121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ