### PR TITLE
Fix form placement appearance when scrollbars are active [MAILPOET-6127]

### DIFF
--- a/mailpoet/assets/css/src/components-form-editor/_form-placement.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_form-placement.scss
@@ -1,15 +1,8 @@
 .form-placement-option-list {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-around;
-  margin: 0 -12px;
-}
-
-.form-placement-option {
-  height: $form-placement-option-height;
+  display: grid;
+  grid-gap: $grid-gap;
+  grid-template-columns: 1fr 1fr;
   text-align: center;
-  width: $form-placement-option-width;
 }
 
 .form-placement-settings {

--- a/mailpoet/assets/css/src/components-form-editor/_form-placement.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_form-placement.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-around;
-  margin: 0 -8px;
+  margin: 0 -12px;
 }
 
 .form-placement-option {

--- a/mailpoet/assets/css/src/components-form-editor/_selection-item.scss
+++ b/mailpoet/assets/css/src/components-form-editor/_selection-item.scss
@@ -7,7 +7,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  margin-bottom: 16px;
   padding: 6px;
   pointer-events: auto;
   position: relative;

--- a/mailpoet/assets/css/src/settings/_form-editor.scss
+++ b/mailpoet/assets/css/src/settings/_form-editor.scss
@@ -6,7 +6,4 @@ $selection-item-text-color: #23282d;
 $selection-item-oval-color: #dcdcdc;
 $selection-item-oval-border-color: #969ca1;
 $selection-item-active-border: 1px;
-$form-placement-option-height: 142px;
-$form-placement-option-width: 112px;
-$form-placement-option-active-border: 2px;
 $form-preview-mobile-height: 760px;

--- a/mailpoet/assets/css/src/settings/_form-editor.scss
+++ b/mailpoet/assets/css/src/settings/_form-editor.scss
@@ -7,6 +7,6 @@ $selection-item-oval-color: #dcdcdc;
 $selection-item-oval-border-color: #969ca1;
 $selection-item-active-border: 1px;
 $form-placement-option-height: 142px;
-$form-placement-option-width: 116px;
+$form-placement-option-width: 112px;
 $form-placement-option-active-border: 2px;
 $form-preview-mobile-height: 760px;


### PR DESCRIPTION
## Description

It fixes the appearance of form placement options so that they display two in a row in the form sidebar.

## Code review notes

_N/A_

## QA notes

Please see the ticket for replication details. [MAILPOET-6127]

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6127]

## After-merge notes

_N/A_

## Tasks

- [x] ⛔ I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] ⛔ I added sufficient test coverage
- [x] ⛔ I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6127]: https://mailpoet.atlassian.net/browse/MAILPOET-6127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-6127]: https://mailpoet.atlassian.net/browse/MAILPOET-6127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ