### PR TITLE
Trigger "tag added" automation when tag is added via form [MAILPOET-6128]

### DIFF
--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -283,6 +283,7 @@ class SubscriberSubscribeController {
         $subscriber->getSubscriberTags()->add($subscriberTag);
         $this->subscriberTagRepository->persist($subscriberTag);
         $this->subscriberTagRepository->flush();
+        $this->wp->doAction('mailpoet_subscriber_tag_added', $subscriberTag);
       }
     }
   }


### PR DESCRIPTION
## Description

Call the `mailpoet_subscriber_tag_added` action when a tag is added to a subscriber after they subscribe through a form. This action will then trigger an automation. 

## Code review notes

_N/A_

## QA notes

1. Create a Form that adds a Tag to the subscriber (e.g., `automation-trigger-test`)
2. Create an automation with a “Tag added to subscriber” trigger and set it to trigger on that tag.
3. Sign up via the form and confirm subscription — see the subscriber has the tag added, and the automation was triggered. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6128]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6128]: https://mailpoet.atlassian.net/browse/MAILPOET-6128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ