### PR TITLE
Upgrade codemirror [MAILPOET-5483]

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-form-editor.scss
+++ b/mailpoet/assets/css/src/mailpoet-form-editor.scss
@@ -25,8 +25,6 @@
 @import '../../../node_modules/@wordpress/block-library/build-style/theme';
 @import '../../../node_modules/@wordpress/block-library/build-style/editor';
 @import '../../../node_modules/@wordpress/format-library/build-style/style';
-@import '../../../node_modules/codemirror/lib/codemirror';
-@import '../../../node_modules/codemirror/theme/neo';
 
 // Components
 // Actual UI components.

--- a/mailpoet/assets/js/src/form-editor/components/form-settings/codemirror-wrap.jsx
+++ b/mailpoet/assets/js/src/form-editor/components/form-settings/codemirror-wrap.jsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useRef } from 'react';
-import codemirror from 'codemirror';
-import 'codemirror/mode/css/css'; // Side effect
+import { useCallback } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
 import PropTypes from 'prop-types';
 
 function CodemirrorWrap({
@@ -10,47 +9,25 @@ function CodemirrorWrap({
     lineNumbers: true,
     tabMode: 'indent',
     matchBrackets: true,
-    theme: 'neo',
-    mode: 'css',
   },
 }) {
-  const textArea = useRef(null);
-  const editor = useRef(null);
-
   const changeEvent = useCallback(
-    (doc) => {
-      onChange(doc.getValue());
+    (currentValue) => {
+      onChange(currentValue);
     },
     [onChange],
   );
 
-  useEffect(() => {
-    editor.current = codemirror.fromTextArea(textArea.current, options);
-    editor.current.on('change', changeEvent);
-    return () => {
-      if (editor.current) {
-        editor.current.toTextArea();
-      }
-    };
-  }, [options, changeEvent]);
-
-  useEffect(() => {
-    if (editor.current.getValue() !== value) {
-      editor.current.off('change', changeEvent);
-      editor.current.setValue(value);
-      editor.current.on('change', changeEvent);
-    }
-  }, [value, changeEvent]);
-
   return (
-    <div>
-      <textarea
-        ref={textArea}
-        name="name"
-        defaultValue={value}
-        autoComplete="off"
-      />
-    </div>
+    <CodeMirror
+      value={value}
+      onChange={changeEvent}
+      basicSetup={{
+        lineNumbers: options.lineNumbers,
+        indentWithTabs: options.tabMode === 'indent',
+        bracketMatching: options.matchBrackets,
+      }}
+    />
   );
 }
 
@@ -61,8 +38,6 @@ CodemirrorWrap.propTypes = {
     lineNumbers: PropTypes.bool,
     tabMode: PropTypes.string,
     matchBrackets: PropTypes.bool,
-    theme: PropTypes.string,
-    mode: PropTypes.string,
   }),
 };
 

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -27,6 +27,7 @@
     "@mailpoet/components": "workspace:^",
     "@marvelapp/react-ab-test": "^3.1.0",
     "@types/select2": "^4.0.55",
+    "@uiw/react-codemirror": "^4.22.2",
     "@woocommerce/components": "^12.3.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -68,7 +68,7 @@
     "backbone.supermodel": "1.2.0",
     "blob-tmp": "^1.0.0",
     "classnames": "^2.5.1",
-    "codemirror": "^5.65.2",
+    "codemirror": "^6.0.1",
     "css": "^3.0.0",
     "date-fns": "^3.6.0",
     "deepmerge": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       codemirror:
-        specifier: ^5.65.2
-        version: 5.65.2
+        specifier: ^6.0.1
+        version: 6.0.1
       css:
         specifier: ^3.0.0
         version: 3.0.0
@@ -436,7 +436,7 @@ importers:
         version: 5.0.0(webpack@5.92.0)
       fork-ts-checker-webpack-plugin:
         specifier: ^7.2.1
-        version: 7.2.1(webpack@5.92.0)
+        version: 7.2.1(typescript@5.0.2)(webpack@5.92.0)
       grunt-cli:
         specifier: ^1.4.3
         version: 1.4.3
@@ -490,7 +490,7 @@ importers:
         version: 3.1.0(webpack@5.92.0)
       stylelint:
         specifier: ^16.6.1
-        version: 16.6.1
+        version: 16.6.1(typescript@5.0.2)
       stylelint-order:
         specifier: ^6.0.4
         version: 6.0.4(stylelint@16.6.1)
@@ -502,7 +502,7 @@ importers:
         version: 5.3.10(webpack@5.92.0)
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(webpack@5.92.0)
+        version: 9.5.1(typescript@5.0.2)(webpack@5.92.0)
       url:
         specifier: ^0.11.3
         version: 0.11.3
@@ -511,7 +511,7 @@ importers:
         version: 5.92.0(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
-        version: 5.1.4(webpack@5.92.0)
+        version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-manifest-plugin:
         specifier: ^5.0.0
         version: 5.0.0(webpack@5.92.0)
@@ -784,7 +784,7 @@ packages:
       '@wordpress/primitives': 3.56.0
       '@wordpress/react-i18n': 3.36.0
       classnames: 2.5.1
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.3.1)(react@18.3.1)
@@ -841,7 +841,7 @@ packages:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
       convert-source-map: 2.0.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -940,7 +940,7 @@ packages:
       '@babel/core': 7.24.7
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2256,7 +2256,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2272,6 +2272,63 @@ packages:
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
+
+  /@codemirror/autocomplete@6.16.3:
+    resolution: {integrity: sha512-Vl/tIeRVVUCRDuOG48lttBasNQu8usGgXQawBXI7WJAiUDSFOfzflmEsZFZo48mAvAaa4FZ/4/yLLxFtdJaKYA==}
+    dependencies:
+      '@codemirror/language': 6.10.2
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@codemirror/commands@6.6.0:
+    resolution: {integrity: sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==}
+    dependencies:
+      '@codemirror/language': 6.10.2
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@codemirror/language@6.10.2:
+    resolution: {integrity: sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==}
+    dependencies:
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.1
+      style-mod: 4.1.2
+    dev: false
+
+  /@codemirror/lint@6.8.1:
+    resolution: {integrity: sha512-IZ0Y7S4/bpaunwggW2jYqwLuHj0QtESf5xcROewY6+lDNwZ/NzvR4t+vpYgg9m7V8UXLPYqG+lu3DF470E5Oxg==}
+    dependencies:
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+      crelt: 1.0.6
+    dev: false
+
+  /@codemirror/search@6.5.6:
+    resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
+    dependencies:
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+      crelt: 1.0.6
+    dev: false
+
+  /@codemirror/state@6.4.1:
+    resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
+    dev: false
+
+  /@codemirror/view@6.28.3:
+    resolution: {integrity: sha512-QVqP+ko078/h9yrW+u5grX3rQhC+BkGKADRrlDaJznfPngJOv5zObiVf0+SgAWhL/Yt0nvZ+10rO3L+gU5IbFw==}
+    dependencies:
+      '@codemirror/state': 6.4.1
+      style-mod: 4.1.2
+      w3c-keyname: 2.2.8
+    dev: false
 
   /@csstools/css-parser-algorithms@2.6.3(@csstools/css-tokenizer@2.3.1):
     resolution: {integrity: sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==}
@@ -2867,6 +2924,22 @@ packages:
   /@leichtgewicht/ip-codec@2.0.5:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: true
+
+  /@lezer/common@1.2.1:
+    resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
+    dev: false
+
+  /@lezer/highlight@1.2.0:
+    resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
+    dependencies:
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@lezer/lr@1.4.1:
+    resolution: {integrity: sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==}
+    dependencies:
+      '@lezer/common': 1.2.1
+    dev: false
 
   /@marvelapp/react-ab-test@3.1.0(react@18.3.1):
     resolution: {integrity: sha512-MDWBoCY7N0z3447Ril86H8nTPk95IALNbMt4YRrEChlTLM12PpzuhkahhLbaBHJ08Ex6KetwlpSYd6OREBlbHw==}
@@ -4474,7 +4547,7 @@ packages:
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.92.0)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
     dev: true
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.92.0):
@@ -4485,7 +4558,7 @@ packages:
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.92.0)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
     dev: true
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.2)(webpack@5.92.0):
@@ -4502,21 +4575,6 @@ packages:
       webpack: 5.92.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.92.0)
-    dev: true
-
-  /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.92.0):
-    resolution: {integrity: sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      webpack: 5.x.x
-      webpack-cli: 5.x.x
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      webpack-dev-server:
-        optional: true
-    dependencies:
-      webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.92.0)
     dev: true
 
   /@woocommerce/components@12.3.0(patch_hash=rc6hnjhca2pqrlb5fea6tr4fze)(@babel/runtime@7.24.7)(@types/react-dom@18.3.0)(@types/react@18.3.3)(@wordpress/data@10.0.0)(lodash@4.17.21)(react-dom@18.3.1)(react@18.3.1):
@@ -7172,7 +7230,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8490,8 +8548,16 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemirror@5.65.2:
-    resolution: {integrity: sha512-SZM4Zq7XEC8Fhroqe3LxbEEX1zUPWH1wMr5zxiBuiUF64iYOUH/JI88v4tBag8MiBS8B8gRv8O1pPXGYXQ4ErA==}
+  /codemirror@6.0.1:
+    resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
+    dependencies:
+      '@codemirror/autocomplete': 6.16.3
+      '@codemirror/commands': 6.6.0
+      '@codemirror/language': 6.10.2
+      '@codemirror/lint': 6.8.1
+      '@codemirror/search': 6.5.6
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
     dev: false
 
   /collect-v8-coverage@1.0.2:
@@ -8772,7 +8838,7 @@ packages:
       typescript: 5.0.2
     dev: true
 
-  /cosmiconfig@9.0.0:
+  /cosmiconfig@9.0.0(typescript@5.0.2):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -8785,6 +8851,7 @@ packages:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
+      typescript: 5.0.2
     dev: true
 
   /crc32@0.2.2:
@@ -8811,6 +8878,10 @@ packages:
       - supports-color
       - ts-node
     dev: true
+
+  /crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+    dev: false
 
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -9236,17 +9307,6 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /debug@4.3.5:
-    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
   /debug@4.3.5(supports-color@9.3.1):
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
@@ -9258,7 +9318,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.3.1
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -10854,31 +10913,6 @@ packages:
       webpack: 5.92.0(webpack-cli@5.1.4)
     dev: true
 
-  /fork-ts-checker-webpack-plugin@7.2.1(webpack@5.92.0):
-    resolution: {integrity: sha512-uOfQdg/iQ8iokQ64qcbu8iZb114rOmaKLQFu7hU14/eJaKgsP91cQ7ts7v2iiDld6TzDe84Meksha8/MkWiCyw==}
-    engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
-    peerDependencies:
-      typescript: '>3.6.0'
-      vue-template-compiler: '*'
-      webpack: ^5.11.0
-    peerDependenciesMeta:
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      schema-utils: 4.0.0
-      semver: 7.6.2
-      tapable: 2.2.1
-      webpack: 5.92.0(webpack-cli@5.1.4)
-    dev: true
-
   /form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -11601,7 +11635,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11651,7 +11685,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11676,7 +11710,7 @@ packages:
       '@babel/runtime': 7.24.7
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 5.20.0(react@18.3.1)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       events: 3.3.0
       hash.js: 1.1.7
       lodash: 4.17.21
@@ -14465,7 +14499,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.7
       crc32: 0.2.2
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       seed-random: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -16463,7 +16497,7 @@ packages:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
     dependencies:
       buffer: 6.0.3
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       err-code: 3.0.1
       get-browser-rtc: 1.1.0
       queue-microtask: 1.2.3
@@ -16981,6 +17015,10 @@ packages:
       escape-string-regexp: 1.0.5
     dev: true
 
+  /style-mod@4.1.2:
+    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
+    dev: false
+
   /style-search@0.1.0:
     resolution: {integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==}
     dev: true
@@ -17031,7 +17069,7 @@ packages:
     dependencies:
       postcss: 8.4.38
       postcss-sorting: 8.0.2(postcss@8.4.38)
-      stylelint: 16.6.1
+      stylelint: 16.6.1(typescript@5.0.2)
     dev: true
 
   /stylelint-scss@4.7.0(stylelint@14.16.1):
@@ -17057,7 +17095,7 @@ packages:
       postcss-resolve-nested-selector: 0.1.1
       postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
-      stylelint: 16.6.1
+      stylelint: 16.6.1(typescript@5.0.2)
     dev: true
 
   /stylelint@14.16.1:
@@ -17107,7 +17145,7 @@ packages:
       - supports-color
     dev: true
 
-  /stylelint@16.6.1:
+  /stylelint@16.6.1(typescript@5.0.2):
     resolution: {integrity: sha512-yNgz2PqWLkhH2hw6X9AweV9YvoafbAD5ZsFdKN9BvSDVwGvPh+AUIrn7lYwy1S7IHmtFin75LLfX1m0D2tHu8Q==}
     engines: {node: '>=18.12.0'}
     hasBin: true
@@ -17119,10 +17157,10 @@ packages:
       '@dual-bundle/import-meta-resolve': 4.1.0
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.0
+      cosmiconfig: 9.0.0(typescript@5.0.2)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 9.0.0
@@ -17187,7 +17225,6 @@ packages:
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
-    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -17492,7 +17529,7 @@ packages:
       typescript: 5.0.2
     dev: true
 
-  /ts-loader@9.5.1(webpack@5.92.0):
+  /ts-loader@9.5.1(typescript@5.0.2)(webpack@5.92.0):
     resolution: {integrity: sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -17504,6 +17541,7 @@ packages:
       micromatch: 4.0.7
       semver: 7.6.2
       source-map: 0.7.4
+      typescript: 5.0.2
       webpack: 5.92.0(webpack-cli@5.1.4)
     dev: true
 
@@ -17967,6 +18005,10 @@ packages:
     resolution: {integrity: sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==}
     dev: false
 
+  /w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+    dev: false
+
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
@@ -18092,39 +18134,6 @@ packages:
       webpack: 5.92.0(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.92.0)
-      webpack-merge: 5.9.0
-    dev: true
-
-  /webpack-cli@5.1.4(webpack@5.92.0):
-    resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
-    engines: {node: '>=14.15.0'}
-    hasBin: true
-    peerDependencies:
-      '@webpack-cli/generators': '*'
-      webpack: 5.x.x
-      webpack-bundle-analyzer: '*'
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      '@webpack-cli/generators':
-        optional: true
-      webpack-bundle-analyzer:
-        optional: true
-      webpack-dev-server:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.92.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.92.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.92.0)
-      colorette: 2.0.20
-      commander: 10.0.1
-      cross-spawn: 7.0.3
-      envinfo: 7.10.0
-      fastest-levenshtein: 1.0.16
-      import-local: 3.1.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack: 5.92.0(webpack-cli@5.1.4)
       webpack-merge: 5.9.0
     dev: true
 
@@ -18259,7 +18268,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(webpack@5.92.0)
       watchpack: 2.4.1
-      webpack-cli: 5.1.4(webpack@5.92.0)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -18413,7 +18422,7 @@ packages:
     resolution: {integrity: sha512-NMp0YsBM40CuI5vWtHpjWOuf96rPfbpGkamlJpVwYvgenIh1ynRzqVnGfsnjofgz13T2qcKkdwJY0Y2X7z+W+w==}
     dependencies:
       '@babel/runtime': 7.24.7
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@9.3.1)
       progress-event: 1.0.0
       uuid: 7.0.3
       wp-error: 1.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       '@types/select2':
         specifier: ^4.0.55
         version: 4.0.55
+      '@uiw/react-codemirror':
+        specifier: ^4.22.2
+        version: 4.22.2(@babel/runtime@7.24.7)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1)
       '@woocommerce/components':
         specifier: ^12.3.0
         version: 12.3.0(patch_hash=rc6hnjhca2pqrlb5fea6tr4fze)(@babel/runtime@7.24.7)(@types/react-dom@18.3.0)(@types/react@18.3.3)(@wordpress/data@10.0.0)(lodash@4.17.21)(react-dom@18.3.1)(react@18.3.1)
@@ -2273,8 +2276,10 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codemirror/autocomplete@6.16.3:
+  /@codemirror/autocomplete@6.16.3(@codemirror/state@6.4.1):
     resolution: {integrity: sha512-Vl/tIeRVVUCRDuOG48lttBasNQu8usGgXQawBXI7WJAiUDSFOfzflmEsZFZo48mAvAaa4FZ/4/yLLxFtdJaKYA==}
+    peerDependencies:
+      '@codemirror/state': ^6.0.0
     dependencies:
       '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
@@ -2320,6 +2325,15 @@ packages:
 
   /@codemirror/state@6.4.1:
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
+    dev: false
+
+  /@codemirror/theme-one-dark@6.1.2:
+    resolution: {integrity: sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==}
+    dependencies:
+      '@codemirror/language': 6.10.2
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+      '@lezer/highlight': 1.2.0
     dev: false
 
   /@codemirror/view@6.28.3:
@@ -4421,6 +4435,37 @@ packages:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
     dev: true
+
+  /@uiw/codemirror-extensions-basic-setup@4.22.2:
+    resolution: {integrity: sha512-zcHGkldLFN3cGoI5XdOGAkeW24yaAgrDEYoyPyWHODmPiNwybQQoZGnH3qUdzZwUaXtAcLWoAeOPzfNRW2yGww==}
+    dependencies:
+      '@codemirror/autocomplete': 6.16.3(@codemirror/state@6.4.1)
+      '@codemirror/commands': 6.6.0
+      '@codemirror/language': 6.10.2
+      '@codemirror/lint': 6.8.1
+      '@codemirror/search': 6.5.6
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.28.3
+    dev: false
+
+  /@uiw/react-codemirror@4.22.2(@babel/runtime@7.24.7)(codemirror@6.0.1)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-okCSl+WJG63gRx8Fdz7v0C6RakBQnbb3pHhuzIgDB+fwhipgFodSnu2n9oOsQesJ5YQ7mSOcKMgX0JEsu4nnfQ==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@codemirror/commands': 6.6.0
+      '@codemirror/state': 6.4.1
+      '@codemirror/theme-one-dark': 6.1.2
+      '@uiw/codemirror-extensions-basic-setup': 4.22.2
+      codemirror: 6.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
 
   /@use-gesture/core@10.3.1:
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
@@ -8551,7 +8596,7 @@ packages:
   /codemirror@6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.16.3
+      '@codemirror/autocomplete': 6.16.3(@codemirror/state@6.4.1)
       '@codemirror/commands': 6.6.0
       '@codemirror/language': 6.10.2
       '@codemirror/lint': 6.8.1


### PR DESCRIPTION
## Description

Upgrade the CodeMirror dependency

## Code review notes

I used a new package react-codemirror. The library considers using the old method with [TextArea](https://codemirror.net/docs/migration/#codemirror.fromtextarea) as a hack and discourages from using it. The original Code Mirror is a vanilla library and works with DOM, so in order to retain the functionality, I had to either use a lot of DOM manipulation or a library. I think the library react-codemirror is a good choice right now; it is popular and maintained.

I removed the use of a theme to limit the number of dependencies, and the editor doesn't understand CSS. I think this is an acceptable tradeoff for our usage. 

## QA notes

The Code Mirror library is used in the form editor in the sidebar where users can edit their own CSS.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5483]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5483]: https://mailpoet.atlassian.net/browse/MAILPOET-5483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ