### PR TITLE
Adding nighly jobs using WooCommerce/WordPress beta versions in test [MAILPOET-6096]

### DIFF
--- a/.circleci/check_woocommerce_beta.sh
+++ b/.circleci/check_woocommerce_beta.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Fetch the versions of WooCommerce from the WordPress API
+VERSIONS=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | keys_unsorted | .[]' | grep -v 'trunk')
+LATEST_VERSION=""
+
+# Find the latest version
+for version in $VERSIONS; do
+  LATEST_VERSION=$version
+done
+
+# Check if the latest version is a beta version
+if [[ $LATEST_VERSION != *'beta'* ]]; then
+  echo "No WooCommerce beta version found."
+  echo "LATEST_BETA="
+else
+  echo "Latest WooCommerce beta version: $LATEST_VERSION"
+  echo "LATEST_BETA=$LATEST_VERSION"
+fi

--- a/.circleci/check_woocommerce_beta.sh
+++ b/.circleci/check_woocommerce_beta.sh
@@ -9,11 +9,11 @@ for version in $VERSIONS; do
   LATEST_VERSION=$version
 done
 
-# Check if the latest version is a beta version
-if [[ $LATEST_VERSION != *'beta'* ]]; then
-  echo "No WooCommerce beta version found."
+# Check if the latest version is a beta/RC version
+if [[ $LATEST_VERSION != *'beta'* || $LATEST_VERSION != *'rc'* ]]; then
+  echo "No WooCommerce beta/RC version found."
   echo "LATEST_BETA="
 else
-  echo "Latest WooCommerce beta version: $LATEST_VERSION"
+  echo "Latest WooCommerce beta/RC version: $LATEST_VERSION"
   echo "LATEST_BETA=$LATEST_VERSION"
 fi

--- a/.circleci/check_wordpress_beta.sh
+++ b/.circleci/check_wordpress_beta.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Fetch the WordPress releases RSS feed
+RSS_FEED=$(curl -s https://wordpress.org/news/category/releases/feed/)
+
+# Extract the latest version from the feed and convert it to lowercase
+LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed -E 's/<\/?title>//g' | head -n 1 | tr [:upper:] [:lower:])
+
+# Check if a beta version is found
+if [[ "{$LAST_VERSION,,}" != *'beta'* ]]; then
+  echo "No beta version found."
+  echo "LATEST_BETA="
+else
+  # Extract titles containing beta versions from the feed
+  VERSION_LINE=$(echo "$RSS_FEED" | grep -o '<code>wp core update [^<]*</code>' | sed -E 's/<\/?code>//g' | head -n 1 | grep 'beta')
+  LATEST_BETA=$(echo "$VERSION_LINE" | sed -E 's/.*--version=([0-9\.]+-beta[0-9]+).*/\1/')
+
+  echo "Latest beta version: $LATEST_BETA"
+  echo "LATEST_BETA=$LATEST_BETA"
+fi

--- a/.circleci/check_wordpress_beta.sh
+++ b/.circleci/check_wordpress_beta.sh
@@ -6,15 +6,15 @@ RSS_FEED=$(curl -s https://wordpress.org/news/category/releases/feed/)
 # Extract the latest version from the feed and convert it to lowercase
 LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed -E 's/<\/?title>//g' | head -n 1 | tr [:upper:] [:lower:])
 
-# Check if a beta version is found
-if [[ $LAST_VERSION != *'beta'* ]]; then
-  echo "No beta version found."
+# Check if a beta or RC version is found
+if [[ $LAST_VERSION != *'beta'* || $LAST_VERSION != *'rc'* ]]; then
+  echo "No WordPress beta/RC version found."
   echo "LATEST_BETA="
 else
   # Extract titles containing beta versions from the feed
   VERSION_LINE=$(echo "$RSS_FEED" | grep -o '<code>wp core update [^<]*</code>' | sed -E 's/<\/?code>//g' | head -n 1 | grep 'beta')
   LATEST_BETA=$(echo "$VERSION_LINE" | sed -E 's/.*--version=([0-9\.]+-beta[0-9]+).*/\1/')
 
-  echo "Latest beta version: $LATEST_BETA"
+  echo "Latest WordPress beta/RC version: $LATEST_BETA"
   echo "LATEST_BETA=$LATEST_BETA"
 fi

--- a/.circleci/check_wordpress_beta.sh
+++ b/.circleci/check_wordpress_beta.sh
@@ -7,7 +7,7 @@ RSS_FEED=$(curl -s https://wordpress.org/news/category/releases/feed/)
 LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed -E 's/<\/?title>//g' | head -n 1 | tr [:upper:] [:lower:])
 
 # Check if a beta version is found
-if [[ "{$LAST_VERSION,,}" != *'beta'* ]]; then
+if [[ $LAST_VERSION != *'beta'* ]]; then
   echo "No beta version found."
   echo "LATEST_BETA="
 else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,6 +404,21 @@ jobs:
           name: 'Set up virtual host'
           command: echo 127.0.0.1 mailpoet.loc | sudo tee -a /etc/hosts
       - run:
+          name: Check for Latest WordPress Beta Version
+          command: |
+            if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
+              LATEST_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_BETA" ]; then
+                echo "No latest beta version found. Ending job early."
+                circleci-agent step halt
+              else
+                echo "export LATEST_BETA=$LATEST_BETA" >> $BASH_ENV
+                echo "Using WordPress Beta Version: $LATEST_BETA"
+              fi
+            else
+              echo "Not using WordPress Beta Version"
+            fi
+      - run:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
           command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
@@ -419,21 +434,6 @@ jobs:
           command: |
             cd tests/docker
             docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_acceptance
-      - run:
-          name: Check for Latest WordPress Beta Version
-          command: |
-            if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
-              LATEST_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
-              if [ -z "$LATEST_BETA" ]; then
-                echo "No latest beta version found. Ending job early."
-                circleci-agent step halt
-              else
-                echo "export LATEST_BETA=$LATEST_BETA" >> $BASH_ENV
-                echo "Using WordPress Beta Version: $LATEST_BETA"
-              fi
-            else
-              echo "Not using WordPress Beta Version"
-            fi
       - when:
           condition: << parameters.woo_core_version >>
           steps:
@@ -666,6 +666,9 @@ jobs:
       automate_woo_version:
         type: string
         default: ''
+      use_wordpress_beta:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -673,6 +676,21 @@ jobs:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
           command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
+      - run:
+          name: Check for Latest WordPress Beta Version
+          command: |
+            if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
+              LATEST_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_BETA" ]; then
+                echo "No latest beta version found. Ending job early."
+                circleci-agent step halt
+              else
+                echo "export LATEST_BETA=$LATEST_BETA" >> $BASH_ENV
+                echo "Using WordPress Beta Version: $LATEST_BETA"
+              fi
+            else
+              echo "Not using WordPress Beta Version"
+            fi
       - run:
           name: Create docker containers for test
           # We experienced some failures when creating containers so we do it explicitly with one retry
@@ -755,6 +773,7 @@ jobs:
               -e ENABLE_HPOS=<< parameters.enable_hpos >> \
               -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
               -e DISABLE_HPOS=<< parameters.disable_hpos >> \
+              -e LATEST_BETA=${LATEST_BETA} \
               codeception_integration "${args[@]}"
       - store_test_results:
           path: tests/_output
@@ -1062,6 +1081,14 @@ workflows:
           name: acceptance_with_premium_latest
           requires:
             - build_premium
+      - integration_tests:
+          <<: *slack-fail-post-step
+          name: integration_tests_wordpress_beta
+          use_wordpress_beta: true
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
+          requires:
+            - build
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_tests_wordpress_beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,6 +392,9 @@ jobs:
       use_wordpress_beta:
         type: boolean
         default: false
+      use_woocommerce_beta:
+        type: boolean
+        default: false
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE: << parameters.mysql_image >>
@@ -407,16 +410,32 @@ jobs:
           name: Check for Latest WordPress Beta Version
           command: |
             if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
-              LATEST_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
-              if [ -z "$LATEST_BETA" ]; then
+              LATEST_WP_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_WP_BETA" ]; then
                 echo "No latest beta version found. Ending job early."
                 circleci-agent step halt
               else
-                echo "export LATEST_BETA=$LATEST_BETA" >> $BASH_ENV
-                echo "Using WordPress Beta Version: $LATEST_BETA"
+                echo "export LATEST_WP_BETA=$LATEST_WP_BETA" >> $BASH_ENV
+                echo "Using WordPress Beta Version: $LATEST_WP_BETA"
               fi
             else
               echo "Not using WordPress Beta Version"
+            fi
+      - run:
+          name: Check for Latest WooCommerce Beta Version
+          command: |
+            if [ "<< parameters.use_woocommerce_beta >>" == "true" ]; then
+              LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_WC_BETA" ]; then
+                echo "No WooCommerce Beta version found. Ending job early."
+                circleci-agent step halt
+              else
+                echo "export WOOCOMMERCE_VERSION=$LATEST_WC_BETA" >> $BASH_ENV
+                echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
+              fi
+            else
+              echo "export WOOCOMMERCE_VERSION=<< parameters.woo_core_version >>" >> $BASH_ENV
+              echo "Not using WooCommerce Beta Version"
             fi
       - run:
           name: 'Pull test docker images'
@@ -435,13 +454,13 @@ jobs:
             cd tests/docker
             docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_acceptance
       - when:
-          condition: << parameters.woo_core_version >>
+          condition: ${WOOCOMMERCE_VERSION}
           steps:
             - run:
                 name: Download WooCommerce Core
                 command: |
                   cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -502,7 +521,7 @@ jobs:
             -e ENABLE_HPOS=<< parameters.enable_hpos >> \
             -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
             -e DISABLE_HPOS=<< parameters.disable_hpos >> \
-            -e LATEST_BETA=${LATEST_BETA} \
+            -e LATEST_BETA=${LATEST_WP_BETA} \
             codeception_acceptance "${args[@]}"
       - run:
           name: Check exceptions
@@ -669,6 +688,9 @@ jobs:
       use_wordpress_beta:
         type: boolean
         default: false
+      use_woocommerce_beta:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -680,16 +702,32 @@ jobs:
           name: Check for Latest WordPress Beta Version
           command: |
             if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
-              LATEST_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
-              if [ -z "$LATEST_BETA" ]; then
+              LATEST_WP_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_WP_BETA" ]; then
                 echo "No latest beta version found. Ending job early."
                 circleci-agent step halt
               else
-                echo "export LATEST_BETA=$LATEST_BETA" >> $BASH_ENV
-                echo "Using WordPress Beta Version: $LATEST_BETA"
+                echo "export LATEST_WP_BETA=$LATEST_WP_BETA" >> $BASH_ENV
+                echo "Using WordPress Beta Version: $LATEST_WP_BETA"
               fi
             else
               echo "Not using WordPress Beta Version"
+            fi
+      - run:
+          name: Check for Latest WooCommerce Beta Version
+          command: |
+            if [ "<< parameters.use_woocommerce_beta >>" == "true" ]; then
+              LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_WC_BETA" ]; then
+                echo "No WooCommerce Beta version found. Ending job early."
+                circleci-agent step halt
+              else
+                echo "export WOOCOMMERCE_VERSION=$LATEST_WC_BETA" >> $BASH_ENV
+                echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
+              fi
+            else
+              echo "export WOOCOMMERCE_VERSION=<< parameters.woo_core_version >>" >> $BASH_ENV
+              echo "Not using WooCommerce Beta Version"
             fi
       - run:
           name: Create docker containers for test
@@ -704,13 +742,13 @@ jobs:
             cd tests/docker
             docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_integration
       - when:
-          condition: << parameters.woo_core_version >>
+          condition: ${WOOCOMMERCE_VERSION}
           steps:
             - run:
                 name: Download WooCommerce Core
                 command: |
                   cd tests/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip << parameters.woo_core_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -773,7 +811,7 @@ jobs:
               -e ENABLE_HPOS=<< parameters.enable_hpos >> \
               -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
               -e DISABLE_HPOS=<< parameters.disable_hpos >> \
-              -e LATEST_BETA=${LATEST_BETA} \
+              -e LATEST_BETA=${LATEST_WP_BETA} \
               codeception_integration "${args[@]}"
       - store_test_results:
           path: tests/_output
@@ -1089,11 +1127,26 @@ workflows:
           mysql_command: --default-authentication-plugin=mysql_native_password
           requires:
             - build
+      - integration_tests:
+          <<: *slack-fail-post-step
+          name: integration_tests_woocommerce_beta
+          use_woocommerce_beta: true
+          mysql_image: mysql:8.3
+          mysql_command: --default-authentication-plugin=mysql_native_password
+          requires:
+            - build
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_tests_wordpress_beta
           enable_hpos: 1
           use_wordpress_beta: true
+          requires:
+            - build
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_woocommerce_beta
+          enable_hpos: 1
+          use_woocommerce_beta: true
           requires:
             - build
       - unit_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.2.0
+  jq: circleci/jq@3.0.0
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
@@ -388,6 +389,9 @@ jobs:
       disable_hpos:
         type: integer
         default: 0
+      use_wordpress_beta:
+        type: boolean
+        default: false
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE: << parameters.mysql_image >>
@@ -415,6 +419,21 @@ jobs:
           command: |
             cd tests/docker
             docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_acceptance
+      - run:
+          name: Check for Latest WordPress Beta Version
+          command: |
+            if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
+              LATEST_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              if [ -z "$LATEST_BETA" ]; then
+                echo "No latest beta version found. Ending job early."
+                circleci-agent step halt
+              else
+                echo "export LATEST_BETA=$LATEST_BETA" >> $BASH_ENV
+                echo "Using WordPress Beta Version: $LATEST_BETA"
+              fi
+            else
+              echo "Not using WordPress Beta Version"
+            fi
       - when:
           condition: << parameters.woo_core_version >>
           steps:
@@ -483,6 +502,7 @@ jobs:
             -e ENABLE_HPOS=<< parameters.enable_hpos >> \
             -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
             -e DISABLE_HPOS=<< parameters.disable_hpos >> \
+            -e LATEST_BETA=${LATEST_BETA} \
             codeception_acceptance "${args[@]}"
       - run:
           name: Check exceptions
@@ -1042,6 +1062,13 @@ workflows:
           name: acceptance_with_premium_latest
           requires:
             - build_premium
+      - acceptance_tests:
+          <<: *slack-fail-post-step
+          name: acceptance_tests_wordpress_beta
+          enable_hpos: 1
+          use_wordpress_beta: true
+          requires:
+            - build
       - unit_tests:
           <<: *slack-fail-post-step
           name: unit_with_premium_latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,10 +695,6 @@ jobs:
       - attach_workspace:
           at: /home/circleci
       - run:
-          name: 'Pull test docker images'
-          # Pull docker images with 3 retries
-          command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
-      - run:
           name: Check for Latest WordPress Beta Version
           command: |
             if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
@@ -729,6 +725,10 @@ jobs:
               echo "export WOOCOMMERCE_VERSION=<< parameters.woo_core_version >>" >> $BASH_ENV
               echo "Not using WooCommerce Beta Version"
             fi
+      - run:
+          name: 'Pull test docker images'
+          # Pull docker images with 3 retries
+          command: i='0';while ! docker-compose -f tests/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - run:
           name: Create docker containers for test
           # We experienced some failures when creating containers so we do it explicitly with one retry

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -350,7 +350,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->_exec($command);
   }
 
-  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'disable-hpos' => false, 'enable-hpos-sync' => false, 'enable-hpos' => false, 'stop-on-fail' => false]) {
+  public function testIntegration(array $opts = ['file' => null, 'group' => null, 'skip-group' => null, 'xml' => false, 'multisite' => false, 'debug' => false, 'skip-deps' => false, 'skip-plugins' => false, 'disable-hpos' => false, 'enable-hpos-sync' => false, 'enable-hpos' => false, 'stop-on-fail' => false, 'beta-version' => null]) {
     return $this->runTestsInContainer(array_merge($opts, ['test_type' => 'integration']));
   }
 

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -407,7 +407,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->testIntegration($opts);
   }
 
-  public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'group' => null, 'timeout' => null, 'disable-hpos' => false, 'enable-hpos-sync' => false, 'enable-hpos' => false]) {
+  public function testAcceptance($opts = ['file' => null, 'skip-deps' => false, 'group' => null, 'timeout' => null, 'disable-hpos' => false, 'enable-hpos-sync' => false, 'enable-hpos' => false, 'beta-version' => null]) {
     return $this->runTestsInContainer($opts);
   }
 
@@ -1636,6 +1636,7 @@ class RoboFile extends \Robo\Tasks {
     $this->doctrineGenerateCache();
     return $this->taskExec(
       'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
+      (isset($opts['beta-version']) && $opts['beta-version'] ? '-e LATEST_BETA=' . $opts['beta-version'] . ' ' : '') .
       (isset($opts['skip-deps']) && $opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
       (isset($opts['disable-hpos']) && $opts['disable-hpos'] ? '-e DISABLE_HPOS=1 ' : '') .
       (isset($opts['enable-hpos-sync']) && $opts['enable-hpos-sync'] ? '-e ENABLE_HPOS_SYNC=1 ' : '') .

--- a/mailpoet/tests/docker/codeception/docker-entrypoint.sh
+++ b/mailpoet/tests/docker/codeception/docker-entrypoint.sh
@@ -47,6 +47,10 @@ else
   wp site create --slug=$WP_TEST_MULTISITE_SLUG
 fi
 
+if [[ $LATEST_BETA != "" ]]; then
+  echo "Installing WordPress beta version: $LATEST_BETA"
+  wp core update --version=$LATEST_BETA
+fi
 echo "WORDPRESS VERSION:"
 wp core version
 


### PR DESCRIPTION
## Description

This PR adds automated testing RC/Beta versions of WordPress and WooCommerce. The job ends earlier when the latest version does not match the requirements.

## Code review notes

- We considered using a similar approach to creating PR and GH Action, but we don't want to create pull requests and branches. So, the approach with conditional jobs should be better for our requirements.
- Now it's available WooCommerce 9.1.0 beta, and it was used in [this CircleCI job automatically](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/18307/workflows/734df0a2-d605-4d00-8299-b2285c6d2713/jobs/311461).
- The Job doesn't run if the latest version is not beta or RC.


## QA notes

We don't need QA here.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/884

## Linked tickets

[MAILPOET-6096]

## After-merge notes

_N/A_

## Tasks

- [ ] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6096]: https://mailpoet.atlassian.net/browse/MAILPOET-6096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ