### PR TITLE
Update k6 to 0.52 and selector for automation test

### DIFF
--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -23,7 +23,7 @@ import {
 import { login, waitAndType } from '../utils/helpers.js';
 
 export async function automationAnalytics() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -111,8 +111,8 @@ export async function automationAnalytics() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/automation-create-custom.js
+++ b/mailpoet/tests/performance/tests/automation-create-custom.js
@@ -30,7 +30,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function automationCreateCustom() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
   const triggerbutton = '.mailpoet-automation-add-trigger';
 
   try {
@@ -133,8 +133,8 @@ export async function automationCreateCustom() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -28,7 +28,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function automationCreateWelcome() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -108,8 +108,8 @@ export async function automationCreateWelcome() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/automation-create-woocommerce.js
+++ b/mailpoet/tests/performance/tests/automation-create-woocommerce.js
@@ -28,7 +28,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function automationCreateWooCommerce() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -108,8 +108,8 @@ export async function automationCreateWooCommerce() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -23,7 +23,7 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function automationTrashRestore() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -92,8 +92,8 @@ export async function automationTrashRestore() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -27,7 +27,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function automationTriggerWorkflow() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     const subscriberEmail =
@@ -129,8 +129,8 @@ export async function automationTriggerWorkflow() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -24,7 +24,7 @@ import {
 import { login, selectInSelect2, waitAndClick } from '../utils/helpers.js';
 
 export async function formsAdding() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -85,8 +85,8 @@ export async function formsAdding() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/forms-subscribing.js
+++ b/mailpoet/tests/performance/tests/forms-subscribing.js
@@ -27,7 +27,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function formsSubscribing() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     let subscriberEmail = 'blackhole+testform' + Date.now() + '@mailpoet.com';
@@ -96,8 +96,8 @@ export async function formsSubscribing() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -25,7 +25,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function listsViewSubscribers() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -74,8 +74,8 @@ export async function listsViewSubscribers() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -24,7 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function newsletterListing() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -58,8 +58,8 @@ export async function newsletterListing() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-reengagement.js
+++ b/mailpoet/tests/performance/tests/newsletter-reengagement.js
@@ -25,7 +25,7 @@ import { login, selectInSelect2, waitAndType } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterReEngagement() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -117,8 +117,8 @@ export async function newsletterReEngagement() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -24,7 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function newsletterSearching() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -76,8 +76,8 @@ export async function newsletterSearching() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -25,7 +25,7 @@ import { login, selectInSelect2 } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterSending() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -104,8 +104,8 @@ export async function newsletterSending() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -24,7 +24,7 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function newsletterStatistics() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -85,8 +85,8 @@ export async function newsletterStatistics() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/newsletters-post-notification.js
+++ b/mailpoet/tests/performance/tests/newsletters-post-notification.js
@@ -25,7 +25,7 @@ import { login, selectInSelect2 } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterPostNotification() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -145,8 +145,8 @@ export async function newsletterPostNotification() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -25,7 +25,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function onboardingWizard() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -110,8 +110,8 @@ export async function onboardingWizard() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -29,7 +29,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function segmentsCreateCustom() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     const complexSegmentName = 'Complex Segment ' + Date.now();
@@ -151,8 +151,8 @@ export async function segmentsCreateCustom() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -27,7 +27,7 @@ import {
 } from '../utils/helpers.js';
 
 export async function segmentsSelectTemplate() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -86,8 +86,8 @@ export async function segmentsSelectTemplate() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -23,7 +23,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function settingsBasic() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -65,8 +65,8 @@ export async function settingsBasic() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -27,7 +27,7 @@ import {
 import { login, selectInSelect2 } from '../utils/helpers.js';
 
 export async function subscribersAdding() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     let subscriberEmail = 'blackhole+automation' + Date.now() + '@mailpoet.com';
@@ -103,8 +103,8 @@ export async function subscribersAdding() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -24,7 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function subscribersFiltering() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -96,8 +96,8 @@ export async function subscribersFiltering() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -24,7 +24,7 @@ import {
 import { login } from '../utils/helpers.js';
 
 export async function subscribersListing() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -58,8 +58,8 @@ export async function subscribersListing() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -23,7 +23,7 @@ import {
 import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
 
 export async function subscribersTrashingRestoring() {
-  const page = browser.newPage();
+  const page = await browser.newPage();
 
   try {
     // Log in to WP Admin
@@ -96,8 +96,8 @@ export async function subscribersTrashingRestoring() {
     // Thinking time and closing
     sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
-    page.close();
-    browser.context().close();
+    await page.close();
+    await browser.context().close();
   }
 }
 

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -75,7 +75,7 @@ export async function waitForSelectorToBeClickable(page, element) {
 
 // Add an item to the automation workflow
 export async function addActionTriggerItemToWorkflow(page, actionName) {
-  await page.locator('.components-search-control__input').type(actionName);
+  await page.locator('.components-input-control__input').type(actionName);
   await page.keyboard.press('Tab');
   await page.keyboard.press('Tab');
   await page.keyboard.press('Enter');

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.51.0';
+$version = 'v0.52.0';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Added `await` and updated k6 to 0.52, plus updated class selector in one test.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6134]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6134]: https://mailpoet.atlassian.net/browse/MAILPOET-6134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ