### PR TITLE
Fix fatal error when trying to create a new segment with option subscribed date - MAILPOET-6133

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx
@@ -51,6 +51,7 @@ const convertDateToString = (
 };
 
 const parseDate = (value: string): Date | undefined => {
+  if (!value) return undefined;
   const date = parseISO(value);
   if (!isValid(date)) return undefined;
   return date;


### PR DESCRIPTION

## Description

Fix fatal error when trying to create a new segment with option **subscribed date.**

This error was caused by the `parseISO` function used in the [parseDate method](https://github.com/mailpoet/mailpoet/blob/af53c8be7d77e0103008c6b7c66fcb1c527200b2/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx#L53-L58)

The `parseISO` function now throws an error for `undefined` or `null` values.

This PR skips the `parseISO` function if the provided value does not exist, e.g., if it is undefined, null, etc.

## Code review notes

_N/A_

## QA notes

Replication

* Ensure you have the Premium plugin installed

* Visit `/wp-admin/admin.php?page=mailpoet-segments#/new-segment`

* Select the option subscribed date

* There should be no error

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6133](https://mailpoet.atlassian.net/browse/MAILPOET-6133)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6133]: https://mailpoet.atlassian.net/browse/MAILPOET-6133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ