### PR TITLE
Fix rendering of special characters using [site:name] shortcode [MAILPOET-5359]

### DIFF
--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -27,7 +27,8 @@ class Site implements CategoryInterface {
   ): ?string {
     switch ($shortcodeDetails['action']) {
       case 'title':
-        return $this->wp->getBloginfo('name');
+        // Decoding special characters such as &amp; to &, etc.
+        return htmlspecialchars_decode($this->wp->getBloginfo('name'));
 
       case 'homepage_url':
         return $this->wp->getBloginfo('url');

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -414,8 +414,8 @@ class ShortcodesTest extends \MailPoetTest {
   }
 
   public function testItCanProcessSiteTitleShortcode() {
-    $optionName = 'blogname';
-    $siteName = get_option($optionName);
+    $siteName = 'Test site name with characters like ’, <, >, &';
+    update_option('blogname', $siteName);
 
     $shortcode = '[site:title]';
     $shortcodesObject = $this->shortcodesObject;


### PR DESCRIPTION
## Description

This fix is analogous to https://github.com/mailpoet/mailpoet/commit/aba54c51160b61eb53a8f640ccb1a438763aed0b.

I'm only not sure if `$this->wp->wpStripAllTags` should be used as well. The referenced commit uses it, but in the order of 1. strip all tags and 2. then decode HTML special chars, which, I believe, will have no effect (=  we strip tags that are still encoded).

I think either we should use `$this->wp->wpStripAllTags(...)` in both cases _after_ `htmlspecialchars_decode` or maybe not use it at all, at least for the site title, that is unlikely to contain HTML tags.

What do you think?

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5359], closes #4947

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5359]: https://mailpoet.atlassian.net/browse/MAILPOET-5359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ