### PR TITLE
Fix destructuring assignment [MAILPOET-6138]

### DIFF
--- a/mailpoet/assets/js/src/form/fields/radio.jsx
+++ b/mailpoet/assets/js/src/form/fields/radio.jsx
@@ -10,7 +10,7 @@ class FormFieldRadio extends Component {
   }
 
   onValueChange = (value, e) => {
-    const { onValueChange = () => {} } = this.props.onValueChange;
+    const { onValueChange = () => {} } = this.props;
     onValueChange(e);
   };
 

--- a/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
@@ -39,7 +39,7 @@ class SenderField extends Component {
   }
 
   onChange(event) {
-    const { onValueChange = () => {} } = this.props.onValueChange;
+    const { onValueChange = () => {} } = this.props;
     const emailAddress = event.target.value.toLowerCase();
     this.setState({
       emailAddress,


### PR DESCRIPTION
## Description

There was a bug introduced in a351437 that caused `onValueChange` to not be called when the radio button or sender email changes.  

## Code review notes

_N/A_

## QA notes

How to replicate the bug (before this PR):

**Radio button**
1. Create a Radio button custom field.
2. Edit any subscriber in the admin.
3. Clicking on the radio button does nothing.

**Sender email**
_Note: I tested it locally in Mailhog, not using MSS._ 

1. On the send page (the last page when sending any email), note the default sender email (`mailpoet@mailpoet.com` in my case).
2. Change the sender email address.
3. Send the email.
4. When you receive an email, observe that it was send from the default email and not the changed one.

<img width="387" alt="Screenshot 2024-07-02 at 09 01 45" src="https://github.com/mailpoet/mailpoet/assets/470616/39640c2a-6d6c-4169-b507-690d87bf074f">

<img width="342" alt="Screenshot 2024-07-02 at 09 02 08" src="https://github.com/mailpoet/mailpoet/assets/470616/c8b3d23c-ed93-44e3-9fd4-be3f82ebd375">

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6138]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6138]: https://mailpoet.atlassian.net/browse/MAILPOET-6138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ