### PR TITLE
Fix datepicker header on pages with border-box applied to all elements [MAILPOET-6140]

### DIFF
--- a/mailpoet/assets/css/src/components/_datepicker.scss
+++ b/mailpoet/assets/css/src/components/_datepicker.scss
@@ -20,6 +20,10 @@
     font-size: $font-size;
     left: -1px;
     width: $grid-column;
+
+    * {
+      box-sizing: border-box;
+    }
   }
 
   .react-datepicker-wrapper,
@@ -49,7 +53,7 @@
   .react-datepicker__current-month {
     color: $color-tertiary;
     font-size: $heading-font-size-h3;
-    height: 40px;
+    height: 40px + $grid-gap * 2;
     line-height: 40px;
     padding: $grid-gap 0;
   }
@@ -74,11 +78,11 @@
     color: $color-tertiary;
     display: inline-block;
     font-weight: bold;
-    height: 48px;
+    height: 50px;
     line-height: 48px;
     margin: 0 -1px -1px 0;
     text-align: center;
-    width: 49px;
+    width: 51px;
   }
 
   .react-datepicker__day:hover {


### PR DESCRIPTION
## Description

Some pages (e.g. Segments) set `box-sizing: border-box;` to all elements: https://github.com/mailpoet/mailpoet/blob/83c6e940730117fe7e59256b1d6ce018ad5ceeae/mailpoet/assets/css/src/mailpoet-dynamic-segments.scss#L4-L7

This caused datepicker to break because it was styled with `box-sizing: content-box;` in mind. This PR updates the datepicker to always use `border-box` on all its elements, so it won't break on different pages. 

<img width="1100" alt="Screenshot 2024-07-02 at 15 01 15" src="https://github.com/mailpoet/mailpoet/assets/470616/ec0c3efe-3a47-4aff-a5b5-3e1c5987f474">

## Code review notes

Skipping code review.

## QA notes

Skipping QA review.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6140]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6140]: https://mailpoet.atlassian.net/browse/MAILPOET-6140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ