### PR TITLE
Properly cancel automation runs when deactivating [MAILPOET-6131]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -2,8 +2,10 @@
 
 namespace MailPoet\Automation\Engine\Builder;
 
+use ActionScheduler_Store;
 use MailPoet\Automation\Engine\Control\ActionScheduler;
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
@@ -161,11 +163,13 @@ class UpdateAutomationController {
     $runIds = [];
     $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
     foreach ($runs as $run) {
+      if ($run->getStatus() === AutomationRun::STATUS_RUNNING) {
+        $this->automationRunStorage->updateStatus($run->getId(), AutomationRun::STATUS_CANCELLED);
+      }
       $runIds[$run->getId()] = $run;
     }
 
-    $actions = $this->actionScheduler->getScheduledActions(['hook' => Hooks::AUTOMATION_STEP, 'status' => \ActionScheduler_Store::STATUS_PENDING]);
-
+    $actions = $this->actionScheduler->getScheduledActions(['hook' => Hooks::AUTOMATION_STEP, 'status' => ActionScheduler_Store::STATUS_PENDING]);
     foreach ($actions as $action) {
       $args = $action->get_args();
       $automationArgs = reset($args);

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -390,7 +390,7 @@ class IntegrationTester extends \Codeception\Actor {
     verify($date1->getTimestamp())->equalsWithDelta($date2->getTimestamp(), $delta);
   }
 
-  public function createAutomation(string $name, Step ...$steps): ?Automation {
+  public function createAutomation(string $name, Step ...$steps): Automation {
     $automationStorage = ContainerWrapper::getInstance()->get(AutomationStorage::class);
 
     if (!$steps) {
@@ -416,10 +416,13 @@ class IntegrationTester extends \Codeception\Actor {
     }
     $automation = new Automation($name, $stepsWithIds, wp_get_current_user());
     $automation->setStatus(Automation::STATUS_ACTIVE);
-    return $automationStorage->getAutomation($automationStorage->createAutomation($automation));
+    $automation = $automationStorage->getAutomation($automationStorage->createAutomation($automation));
+    $this->assertInstanceOf(Automation::class, $automation);
+    /** @var Automation $automation -- PHPStan fails to exclude "null" */
+    return $automation;
   }
 
-  public function createAutomationRun(Automation $automation, $subjects = []): ?AutomationRun {
+  public function createAutomationRun(Automation $automation, $subjects = []): AutomationRun {
     $trigger = array_values($automation->getTriggers())[0] ?? null;
     $triggerKey = $trigger ? $trigger->getKey() : '';
     $automationRun = new AutomationRun(
@@ -429,7 +432,10 @@ class IntegrationTester extends \Codeception\Actor {
       $subjects
     );
     $automationRunStorage = ContainerWrapper::getInstance()->get(AutomationRunStorage::class);
-    return $automationRunStorage->getAutomationRun($automationRunStorage->createAutomationRun($automationRun));
+    $automationRun = $automationRunStorage->getAutomationRun($automationRunStorage->createAutomationRun($automationRun));
+    $this->assertInstanceOf(AutomationRun::class, $automationRun);
+    /** @var AutomationRun $automationRun -- PHPStan fails to exclude "null" */
+    return $automationRun;
   }
 
   public function getSubscriberEmailsMatchingDynamicFilter(DynamicSegmentFilterData $data, Filter $filter): array {

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Control;
+
+use ActionScheduler_Store;
+use MailPoet\Automation\Engine\Builder\UpdateAutomationController;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoetTest;
+
+class UpdateAutomationControllerTest extends MailPoetTest {
+  public function testItUnschedulesTasksWhenSwitchedToDraft(): void {
+    $automation = $this->tester->createAutomation(
+      'Test automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', [], [new NextStep('a2')]),
+      new Step('a2', Step::TYPE_ACTION, 'test:action', [], [])
+    );
+
+    $run1 = $this->tester->createAutomationRun($automation);
+    $run2 = $this->tester->createAutomationRun($automation);
+    $run3 = $this->tester->createAutomationRun($automation);
+    $run4 = $this->tester->createAutomationRun($automation);
+
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $runStorage->updateStatus($run1->getId(), AutomationRun::STATUS_RUNNING);
+    $runStorage->updateStatus($run2->getId(), AutomationRun::STATUS_COMPLETE);
+    $runStorage->updateStatus($run3->getId(), AutomationRun::STATUS_FAILED);
+    $runStorage->updateStatus($run4->getId(), AutomationRun::STATUS_CANCELLED);
+
+    $this->scheduleAction(time() + 100, ['automation_run_id' => $run1->getId(), 'step_id' => 'aaa', 'run_number' => 1]);
+    $this->scheduleAction(time() + 200, ['automation_run_id' => $run1->getId(), 'step_id' => 'bbb', 'run_number' => 1]);
+    $this->scheduleAction(time() + 300, ['automation_run_id' => $run1->getId(), 'step_id' => 'bbb', 'run_number' => 2]);
+
+    $this->assertCount(3, $this->getActions());
+    $this->assertCount(3, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
+
+    // switch to draft
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+    $controller->updateAutomation($automation->getId(), [
+      'status' => Automation::STATUS_DRAFT,
+    ]);
+
+    $automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $updatedAutomation = $automationStorage->getAutomation($automation->getId());
+
+    $this->assertInstanceOf(Automation::class, $updatedAutomation);
+    $this->assertSame(Automation::STATUS_DRAFT, $updatedAutomation->getStatus());
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $this->getAutomationRun($run1->getId())->getStatus());
+    $this->assertSame(AutomationRun::STATUS_COMPLETE, $this->getAutomationRun($run2->getId())->getStatus());
+    $this->assertSame(AutomationRun::STATUS_FAILED, $this->getAutomationRun($run3->getId())->getStatus());
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $this->getAutomationRun($run4->getId())->getStatus());
+
+    $this->assertCount(3, $this->getActions());
+    $this->assertCount(3, $this->getActions(['status' => ActionScheduler_Store::STATUS_CANCELED]));
+    $this->assertCount(0, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
+
+    // resume automation and check that no run status was changed
+    $controller->updateAutomation($automation->getId(), [
+      'status' => Automation::STATUS_ACTIVE,
+    ]);
+
+    $automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $updatedAutomation = $automationStorage->getAutomation($automation->getId());
+
+    $this->assertInstanceOf(Automation::class, $updatedAutomation);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updatedAutomation->getStatus());
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $this->getAutomationRun($run1->getId())->getStatus());
+    $this->assertSame(AutomationRun::STATUS_COMPLETE, $this->getAutomationRun($run2->getId())->getStatus());
+    $this->assertSame(AutomationRun::STATUS_FAILED, $this->getAutomationRun($run3->getId())->getStatus());
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $this->getAutomationRun($run4->getId())->getStatus());
+
+    $this->assertCount(3, $this->getActions());
+    $this->assertCount(3, $this->getActions(['status' => ActionScheduler_Store::STATUS_CANCELED]));
+    $this->assertCount(0, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
+  }
+
+  private function getAutomationRun(int $id): AutomationRun {
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $run = $runStorage->getAutomationRun($id);
+    $this->assertInstanceOf(AutomationRun::class, $run);
+    return $run;
+  }
+
+  private function scheduleAction(int $timestamp, array $args): int {
+    return as_schedule_single_action($timestamp, Hooks::AUTOMATION_STEP, [$args], 'mailpoet-automation');
+  }
+
+  private function getActions(array $args = []): array {
+    return array_values(
+      as_get_scheduled_actions(
+        array_merge(['hook' => Hooks::AUTOMATION_STEP, 'group' => 'mailpoet-automation'], $args)
+      )
+    );
+  }
+
+  public function _before(): void {
+    $this->cleanup();
+  }
+
+  public function _after(): void {
+    $this->cleanup();
+  }
+
+  private function cleanup() {
+    $this->diContainer->get(AutomationStorage::class)->truncate();
+    $this->diContainer->get(AutomationRunStorage::class)->truncate();
+
+    global $wpdb;
+    $actionsTable = $wpdb->prefix . 'actionscheduler_actions';
+    $wpdb->query('TRUNCATE ' . $actionsTable);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepHandlerTest.php
@@ -55,9 +55,7 @@ class StepHandlerTest extends \MailPoetTest {
     // run step
     $stepHandler = $this->getServiceWithOverrides(StepHandler::class, ['registry' => $registry]);
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $run = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $run);
     $stepHandler->handle(['automation_run_id' => $run->getId(), 'step_id' => 'a1', 'run_number' => 1]);
   }
 
@@ -70,9 +68,7 @@ class StepHandlerTest extends \MailPoetTest {
 
     $stepHandler = $this->getServiceWithOverrides(StepHandler::class, ['registry' => $registry]);
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $run = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $run);
 
     // create start log and modify "updated_at" to an older date
     $oldDate = new DateTimeImmutable('2000-01-01 00:00:00');
@@ -104,9 +100,7 @@ class StepHandlerTest extends \MailPoetTest {
 
     $stepHandler = $this->getServiceWithOverrides(StepHandler::class, ['registry' => $registry]);
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $run = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $run);
 
     // create start log and modify "updated_at" to an older date
     $oldDate = new DateTimeImmutable('2000-01-01 00:00:00');
@@ -144,10 +138,8 @@ class StepHandlerTest extends \MailPoetTest {
     ]);
 
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $steps = $automation->getSteps();
     $automationRun = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $automationRun);
 
     $currentStep = current($steps);
     $this->assertInstanceOf(Step::class, $currentStep);
@@ -178,7 +170,6 @@ class StepHandlerTest extends \MailPoetTest {
       $automation->setStatus($status);
       $this->automationStorage->updateAutomation($automation);
       $automationRun = $this->tester->createAutomationRun($automation);
-      $this->assertInstanceOf(AutomationRun::class, $automationRun);
       $error = null;
       try {
         $stepHandler->handle(['automation_run_id' => $automationRun->getId(), 'step_id' => $currentStep->getId()]);
@@ -204,11 +195,8 @@ class StepHandlerTest extends \MailPoetTest {
     ]);
 
     $automation = $this->createAutomation();
-    $this->assertInstanceOf(Automation::class, $automation);
     $automationRun1 = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $automationRun1);
     $automationRun2 = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $automationRun2);
     $automation->setStatus(Automation::STATUS_DEACTIVATING);
     $this->automationStorage->updateAutomation($automation);
 
@@ -233,7 +221,7 @@ class StepHandlerTest extends \MailPoetTest {
     $this->assertSame(AutomationRun::STATUS_COMPLETE, $updatedautomationRun->getStatus());
   }
 
-  private function createAutomation(): ?Automation {
+  private function createAutomation(): Automation {
     return $this->tester->createAutomation(
       'Test automation',
       new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),

--- a/mailpoet/tests/integration/Automation/Engine/Control/StepSchedulerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/StepSchedulerTest.php
@@ -7,8 +7,6 @@ use ActionScheduler_SimpleSchedule;
 use ActionScheduler_Store;
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Control\StepScheduler;
-use MailPoet\Automation\Engine\Data\Automation;
-use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
@@ -143,9 +141,7 @@ class StepSchedulerTest extends MailPoetTest {
       new Step('a1', Step::TYPE_ACTION, 'test:action', [], [new NextStep('a2')]),
       new Step('a2', Step::TYPE_ACTION, 'test:action', [], [])
     );
-    $this->assertInstanceOf(Automation::class, $automation);
     $run = $this->tester->createAutomationRun($automation);
-    $this->assertInstanceOf(AutomationRun::class, $run);
     return new StepRunArgs($automation, $run, $automation->getSteps()['a1'], [], 1);
   }
 

--- a/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Control/TriggerHandlerTest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\Automation\Engine\Control;
 
 use MailPoet\Automation\Engine\Control\TriggerHandler;
-use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\Filter;
 use MailPoet\Automation\Engine\Data\FilterGroup;
 use MailPoet\Automation\Engine\Data\Filters;
@@ -82,8 +81,6 @@ class TriggerHandlerTest extends \MailPoetTest {
         []
       )
     );
-    $this->assertInstanceOf(Automation::class, $automation1);
-    $this->assertInstanceOf(Automation::class, $automation2);
 
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation1));
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation2));
@@ -129,8 +126,6 @@ class TriggerHandlerTest extends \MailPoetTest {
         []
       )
     );
-    $this->assertInstanceOf(Automation::class, $automation1);
-    $this->assertInstanceOf(Automation::class, $automation2);
 
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation1));
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation2));
@@ -158,7 +153,6 @@ class TriggerHandlerTest extends \MailPoetTest {
         []
       )
     );
-    $this->assertInstanceOf(Automation::class, $automation1);
 
     $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation1));
 
@@ -184,7 +178,6 @@ class TriggerHandlerTest extends \MailPoetTest {
       'Will not run',
       new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], $filters)
     );
-    $this->assertInstanceOf(Automation::class, $automation);
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
     $this->testee->processTrigger($trigger, [$segmentSubject, $subscriberSubject]);
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
@@ -196,7 +189,6 @@ class TriggerHandlerTest extends \MailPoetTest {
       'Will run',
       new Step('trigger', Step::TYPE_TRIGGER, $trigger->getKey(), [], [], $filters)
     );
-    $this->assertInstanceOf(Automation::class, $automation);
     $this->assertCount(0, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
     $this->testee->processTrigger($trigger, [$segmentSubject, $subscriberSubject]);
     $this->assertCount(1, $this->automationRunStorage->getAutomationRunsForAutomation($automation));
@@ -205,9 +197,7 @@ class TriggerHandlerTest extends \MailPoetTest {
   public function testItLogs(): void {
     $trigger = $this->diContainer->get(SomeoneSubscribesTrigger::class);
     $automation1 = $this->tester->createAutomation('Test 1', new Step('trigger-1', Step::TYPE_TRIGGER, $trigger->getKey(), [], []));
-    $this->assertInstanceOf(Automation::class, $automation1);
     $automation2 = $this->tester->createAutomation('Test 2', new Step('trigger-2', Step::TYPE_TRIGGER, $trigger->getKey(), [], []));
-    $this->assertInstanceOf(Automation::class, $automation2);
 
     $segmentSubject = new Subject(SegmentSubject::KEY, ['segment_id' => $this->segments['segment_1']->getId()]);
     $this->testee->processTrigger($trigger, [$segmentSubject]);

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationTest.php
@@ -16,7 +16,6 @@ class AutomationTest extends \MailPoetTest {
 
   public function testMetaDataIsStored() {
     $automation = $this->tester->createAutomation('test');
-    $this->assertInstanceOf(Automation::class, $automation);
 
     $automation->setMeta('foo', 'bar');
     $this->assertEquals('bar', $automation->getMeta('foo'));
@@ -31,7 +30,6 @@ class AutomationTest extends \MailPoetTest {
   public function testMetaDataIsDeleted() {
 
     $automation = $this->tester->createAutomation('test');
-    $this->assertInstanceOf(Automation::class, $automation);
 
     $automation->setMeta('foo', 'bar');
     $automation->deleteMeta('foo');
@@ -49,7 +47,6 @@ class AutomationTest extends \MailPoetTest {
 
   public function testAutomationComparisonWorks() {
     $automation = $this->tester->createAutomation('test');
-    $this->assertInstanceOf(Automation::class, $automation);
 
     $automation2 = clone $automation;
     $automation2->setMeta('foo', 'bar');
@@ -63,7 +60,6 @@ class AutomationTest extends \MailPoetTest {
    */
   public function testFullValidationWorks($status, $expected) {
     $automation = $this->tester->createAutomation('test');
-    $this->assertInstanceOf(Automation::class, $automation);
     $automation->setStatus($status);
     $this->assertEquals($expected, $automation->needsFullValidation());
   }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -30,7 +30,6 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
 
     for ($i = 1; $i <= 3; $i++) {
       $automation = $this->tester->createAutomation((string)$i);
-      $this->assertInstanceOf(Automation::class, $automation);
       $this->automations[] = $automation->getId();
     }
   }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanControllerTest.php
@@ -30,7 +30,6 @@ class AutomationTimeSpanControllerTest extends \MailPoetTest {
 
   public function testItReturnsNoEmailWhenNoEmailStepExist() {
     $automation = $this->tester->createAutomation('test');
-    $this->assertInstanceOf(Automation::class, $automation);
     $this->createEmail();
     $emails = $this->testee->getEmailsFromAutomations([$automation]);
     $this->assertEmpty($emails);
@@ -67,7 +66,6 @@ class AutomationTimeSpanControllerTest extends \MailPoetTest {
       []
     );
     $automation = $this->tester->createAutomation('test', $trigger, $firstEmail, $secondEmail);
-    $this->assertInstanceOf(Automation::class, $automation);
 
     $emails = $this->testee->getEmailsFromAutomations([$automation]);
     $this->assertCount(2, $emails);
@@ -83,7 +81,6 @@ class AutomationTimeSpanControllerTest extends \MailPoetTest {
     $after = new \DateTimeImmutable('2022-01-01 00:00:00');
     $before = new \DateTimeImmutable('2022-02-02 00:00:00');
     $automation = $this->tester->createAutomation('test');
-    $this->assertInstanceOf(Automation::class, $automation);
     $emailBefore = $this->createEmail('emailBefore');
     $emailInTimeSpan = $this->createEmail('emailInTimeSpan');
     $emailInTimeSpan2 = $this->createEmail('emailInTimeSpan2');

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -160,7 +160,6 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
 
   private function createAutomation(string $name, string $status): Automation {
     $automation = $this->tester->createAutomation($name);
-    $this->assertInstanceOf(Automation::class, $automation);
     $automation->setStatus($status);
     $this->diContainer->get(AutomationStorage::class)->updateAutomation($automation);
     return $automation;
@@ -174,7 +173,6 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
   ): AutomationRun {
     $runStorage = $this->diContainer->get(AutomationRunStorage::class);
     $run = $this->tester->createAutomationRun($automation, $subjects);
-    $this->assertInstanceOf(AutomationRun::class, $run);
 
     global $wpdb;
     $wpdb->update(

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Test\Automation\Integrations\MailPoet\SubjectTransformers;
 
 use MailPoet\Automation\Engine\Control\StepHandler;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
-use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
@@ -67,7 +66,6 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
       new Step('action', Step::TYPE_ACTION, $testAction->getKey(), [], []),
     ];
     $automation = $this->tester->createAutomation('test', ...$steps);
-    $this->assertInstanceOf(Automation::class, $automation);
 
     /**
      * We need to register the hooks ourselves because the active automation has been created too late


### PR DESCRIPTION
## Description

When automation is deactivated with “Stop automation for all subscribers”, in-progress automation runs will no longer appear to be “processing” in the stats.

## Code review notes

I was considering whether we need to update anything in automation run logs, but since we don't log steps that are only scheduled at the moment, it seems that this is not necessary.

I also added tests.

## QA notes

_N/A_

## Linked PRs

This PR completes the logic implemented in https://github.com/mailpoet/mailpoet/pull/5634.

## Linked tickets

[MAILPOET-6131]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6131]: https://mailpoet.atlassian.net/browse/MAILPOET-6131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ