### PR TITLE
Fix forms privacy policy links [MAILPOET-4504]

### DIFF
--- a/mailpoet/lib/Form/Templates/FormTemplate.php
+++ b/mailpoet/lib/Form/Templates/FormTemplate.php
@@ -148,20 +148,18 @@ EOL;
     return $this->cdnAssetUrl->generateCdnUrl("form-templates/{$this->assetsDirectory}/$filename");
   }
 
-  protected function replaceLinkTags($source, $link, $attributes = [], $linkTag = false): string {
-    return Helpers::replaceLinkTags($source, $link, $attributes, $linkTag);
+  protected function replaceLinkTags($source, $link, $attributes = []): string {
+    return Helpers::replaceLinkTags($source, $link, $attributes);
   }
 
   protected function replacePrivacyLinkTags($source, $link = '#'): string {
     $privacyPolicyUrl = $this->wp->getPrivacyPolicyUrl();
     $attributes = [];
-    $linkTag = false;
 
     if (!empty($privacyPolicyUrl)) {
       $link = $this->wp->escUrl($privacyPolicyUrl);
       $attributes = ['target' => '_blank'];
-      $linkTag = 'link';
     }
-    return $this->replaceLinkTags($source, $link, $attributes, $linkTag);
+    return $this->replaceLinkTags($source, $link, $attributes);
   }
 }


### PR DESCRIPTION
## Description

The replacement of link tags was failing if a privacy policy page wasn't set up. In this case incorrect arguments were passed to the `Helpers::replaceLinkTags()` method.

~~Existing saved forms need to be fixed too, I've made a migration for that. There is no easy way to tell a privacy policy link from another link (it can be translated, modified etc.), but looking at form templates I see that only privacy policy links had `[link]` tags that could have remained unprocessed, so we can replace all of them. If a form body is malformed, there will be a PHP warning about unserialization, but the migration should still be completed.~~

## Code review notes

_N/A_

## QA notes

Follow the reproduction steps from the Jira ticket. Check with the privacy page set up or not in WP Admin > Settings > Privacy.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4504]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4504]: https://mailpoet.atlassian.net/browse/MAILPOET-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ