### PR TITLE
Don't strip shortcode-like text in post notifications content [MAILPOET-5197]

### DIFF
--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -132,7 +132,7 @@ class PostContentManager {
     );
 
     // remove other shortcodes
-    $content = preg_replace('/\[[^\[\]]*\]/', '', $content);
+    $content = $this->wp->stripShortcodes($content);
 
     return $content;
   }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -498,6 +498,10 @@ class Functions {
     status_header($code, $description);
   }
 
+  public function stripShortcodes($value) {
+    return strip_shortcodes($value);
+  }
+
   public function stripslashesDeep($value) {
     return stripslashes_deep($value);
   }

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
@@ -157,23 +157,41 @@ class PostContentManagerTest extends \MailPoetTest {
   }
 
   public function testItStripsShortcodesWhenGettingPostContent() {
-    // shortcodes are stripped in excerpt
+    // registered shortcodes are stripped in excerpt
     $post = (object)[
-      'post_excerpt' => '[shortcode]some text in excerpt[/shortcode]',
+      'post_excerpt' => 'Test [embed]some text in excerpt[/embed]text',
     ];
-    verify($this->postContent->getContent($post, 'excerpt'))->equals('some text in excerpt');
+    verify($this->postContent->getContent($post, 'excerpt'))->equals('Test text');
 
-    // shortcodes are stripped in post content when excerpt doesn't exist
+    // registered shortcodes are stripped in post content when excerpt doesn't exist
     $post = (object)[
-      'post_content' => '[shortcode]some text in content[/shortcode]',
+      'post_content' => 'Test [embed]some text in content[/embed]text',
     ];
-    verify($this->postContent->getContent($post, 'excerpt'))->equals('some text in content');
+    verify($this->postContent->getContent($post, 'excerpt'))->equals('Test text');
 
-    // shortcodes are stripped in post content
+    // registered shortcodes are stripped in post content
     $post = (object)[
-      'post_content' => '[shortcode]some text in content[/shortcode]',
+      'post_content' => 'Test [embed]some text in content[/embed]text',
     ];
-    verify($this->postContent->getContent($post, ''))->equals('some text in content');
+    verify($this->postContent->getContent($post, ''))->equals('Test text');
+
+    // unregistered shortcodes are kept in excerpt
+    $post = (object)[
+      'post_excerpt' => 'Test [shortcode]some text in excerpt[/shortcode]text',
+    ];
+    verify($this->postContent->getContent($post, 'excerpt'))->equals($post->post_excerpt); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    // unregistered shortcodes are kept in post content when excerpt doesn't exist
+    $post = (object)[
+      'post_content' => 'Test [shortcode]some text in content[/shortcode]text',
+    ];
+    verify($this->postContent->getContent($post, 'excerpt'))->equals($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    // unregistered shortcodes are kept in post content
+    $post = (object)[
+      'post_content' => 'Test [shortcode]some text in content[/shortcode]text',
+    ];
+    verify($this->postContent->getContent($post, ''))->equals($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function testItRemovesImageCaptionsFromClassicEditorPosts() {


### PR DESCRIPTION
## Description

Here we have a tradeoff between allowing shortcode-like text and not allowing actual shortcodes to slip into the email content. I have used the `strip_shortcodes()` WP function to strip registered shortcodes from the content, but some shortcodes may not be registered in WP (although this is officially [discouraged](https://codex.wordpress.org/Shortcode_API#Unregistered_Names)), they are processed by plugins on their own terms and they might end up in the email. Should someone need to strip these non-typical codes, they will have to do it by themselves with a filter such as [mailpoet_rendering_post_process](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Newsletter/Renderer/Renderer.php#L228-L231) or `strip_shortcodes_tagnames`.

## Code review notes

_N/A_

## QA notes

Check that [text] in square brackets isn't stripped from post contents, but actual shortcodes still are ([mailpoet_form], [gallery] etc.).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5197]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5197]: https://mailpoet.atlassian.net/browse/MAILPOET-5197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ