### PR TITLE
README, SUPPORT, CONTRIBUTING updates [MAILPOET-6136]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,12 +45,6 @@ There is a `./do` command that helps with the development process. See README.md
 - Use good commit messages as explained here https://chris.beams.io/posts/git-commit
 - Wait for review from another developer.
 
-## Issues creation
-
-- Issues are managed on Jira.
-- Discuss issues on public Slack chats, discuss code in pull requests.
-- Open a small Jira issue only when it has been discussed.
-
 ## Feature flags
 
 We use feature flags to control the visibility of new features. This allows us to work on new features in smaller chunks before they are released to all customers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,51 @@
 # Contributing
 
-There is a `./do` command that helps with the development process. See README.md for more details.
+There is a `./do` command that helps with the development process. See [README](README.md) for more details.
 
 ## PHP Code
 
 - Two spaces indentation.
-- Space between keyword (if, for, switch...) and left bracket
-- CamelCase for classes.
-- camelCase for methods.
-- snake_case for variables and class properties.
+- Space between keyword and left bracket (`if ()`, `for ()`, `switch ()`...).
+- `CamelCase` for classes.
+- `camelCase` for methods.
+- `snake_case` for variables and class properties.
 - Composition over Inheritance.
 - Comments are a code smell. If you need to use a comment - see if same idea can be achieved by more clearly expressing code.
-- Require other classes with 'use' at the beginning of the class file.
-- Do not specify 'public' if method is public, it's implicit.
+- Require other classes with `use` at the beginning of the class file.
 - Always use guard clauses.
-- Ensure compatibility with PHP 7.1 and newer versions.
+- Ensure compatibility with PHP 7.4 and newer versions.
 - Cover your code in tests.
 
 ## SCSS Code
 
-- camelCase for file name
-- Components files are prefixed with underscore, to indicate, that they aren't compiled separately.
+- `kebab-case` for file names.
+- Components files are prefixed with underscore, to indicate, that they aren't compiled separately (`_new-component.scss`).
 
 ## JS Code
 
 - Javascript code should follow the [Airbnb style guide](https://github.com/airbnb/javascript).
 - Prefer named export before default export in JS and TS files
+- Default to TypeScript for new files.
 
 ## Disabling linting rules
 
-- we want to avoid using `eslint-disable`
-- if we have to use it we need to use a comment explaining why do we need it:
+- We want to avoid using `eslint-disable`
+- If we have to use it we need to use a comment explaining why do we need it:
   `/* eslint-disable no-new -- this class has a side-effect in the constructor and it's a library's. */`
-- for PHP we do the same with the exception `// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps` which for now doesn’t require an explanation
+- For PHP we do the same with the exception `// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps` which for now doesn’t require an explanation
 
 ## Git flow
 
 - Do not commit to trunk.
 - Open a short-living feature branch.
-- Open a pull request.
-- Add Jira issue reference in the title of the Pull Request.
-- Work on the pull request.
+- Use good commit messages as explained here https://chris.beams.io/posts/git-commit. Include Jira ticket in the commit message.
 - Use the `./do qa` command to check your code style before pushing.
-- Use good commit messages as explained here https://chris.beams.io/posts/git-commit
+- Create a pull request when finished. Include Jira ticket in the title of the pull request.
 - Wait for review from another developer.
 
 ## Feature flags
 
 We use feature flags to control the visibility of new features. This allows us to work on new features in smaller chunks before they are released to all customers.
 
-- Feature flags can be enabled on the experimental page: wp-admin/admin.php?page=mailpoet-experimental
-- New feature flags can be added in the class `FeaturesController`
+- Feature flags can be enabled on the experimental page: `/admin.php?page=mailpoet-experimental`.
+- New feature flags can be added in the class `FeaturesController`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,6 @@ There is a `./do` command that helps with the development process. See README.md
 - Discuss issues on public Slack chats, discuss code in pull requests.
 - Open a small Jira issue only when it has been discussed.
 
-## Migration from IdiORM to Doctrine
-
-MailPoet used to use [IdiORM](https://github.com/j4mie/idiorm) as its object-relational mapper (ORM), but the project was abandoned a while ago, so we started a migration to [Doctrine](https://www.doctrine-project.org/). This is a significant effort that has been going on for quite some time. Although you will still see parts of the code that use IdioORM, we ask that all new code be added using Doctrine instead.
-
-All IdioORM models live in [mailpoet/lib/Models](https://github.com/mailpoet/mailpoet/tree/trunk/mailpoet/lib/Models), should be considered deprecated and shouldn't be used by new code. We are moving everything to Doctrine entities and some auxiliary code when needed. You can find Doctrine entities in [mailpoet/lib/Entities](https://github.com/mailpoet/mailpoet/tree/trunk/mailpoet/lib/Entities).
-
 ## Feature flags
 
 We use feature flags to control the visibility of new features. This allows us to work on new features in smaller chunks before they are released to all customers.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MailPoet
+## MailPoet
 
 The **MailPoet** plugin monorepo.
 
@@ -7,16 +7,16 @@ If you have **any questions or need help or support**, please see the [Support](
 To use our Docker-based development environment (recommended), continue with the steps below.
 If you'd like to use the plugin code directly, see details in [the plugin's readme](mailpoet/README.md).
 
-## 🔌 Initial setup
+## Initial setup
 
 1. Run `./do setup` to pull everything and install necessary dependencies.
 2. Add secrets to `.env` files in `mailpoet` and `mailpoet-premium` directories. Go to the Secret Store and look for "MailPoet: plugin .env"
 3. Run `./do start` to start the stack.
 4. Go to http://localhost:8888 to see the dashboard of the dev environment.
 
-## ✅ Additional dependencies
+### Additional dependencies
 
-Even though it possible to run everything using Docker, in the development workflow,
+Even though it's possible to run everything using Docker, in the development workflow,
 it may be faster and more convenient to run some tasks outside the container. Therefore,
 the following tools are recommended:
 
@@ -24,7 +24,9 @@ the following tools are recommended:
 2. **Node.js**, as specified by `.nvmrc`. For automatic management use [nvm](https://github.com/nvm-sh/nvm), [FNM](https://github.com/Schniz/fnm), or [Volta](https://github.com/volta-cli/volta).
 3. **pnpm**, as specified in `package.json`. For automatic setup enable [Corepack](https://nodejs.org/docs/latest-v17.x/api/corepack.html) using `corepack enable`.
 
-## 🔍 PHPStorm setup for XDebug
+## Xdebug
+
+### PhpStorm setup
 
 In `Languages & Preferences > PHP > Servers` set path mappings:
 
@@ -41,7 +43,7 @@ To use XDebug inside the **cron**, you need to pass a URL argument `&XDEBUG_TRIG
 [in the cron request](https://github.com/mailpoet/mailpoet/blob/bf7bd6d2d9090ed6ec7b8b575bb7d6b08e663a52/lib/Cron/CronHelper.php#L155-L166).
 Alternatively, you can add `XDEBUG_TRIGGER: yes` to the `wordpress` service in `docker-compose.yml` and restart it (which will run XDebug also for all other requests).
 
-## Xdebug develop mode
+### Xdebug develop mode
 
 [Xdebug develop mode](https://xdebug.org/docs/develop) is disabled by default because it causes performance issues due to conflicts with the DI container.
 
@@ -52,7 +54,7 @@ environment:
     XDEBUG_MODE: debug, develop
 ```
 
-## Xdebug for integration tests
+### Xdebug for integration tests
 
 - In Languages & Preferences > PHP > Servers create a new sever named `MailPoetTest`, set the host to `localhost` and port to `80` and set following path mappings:
 
@@ -67,7 +69,9 @@ mailpoet/vendor/bin/wp -> /usr/local/bin/wp
 - Add `XDEBUG_TRIGGER: 1` environment to `mailpoet/tests/docker/docker-compose.yml` -> codeception service to start triggering Xdebug
 - Make PHPStorm listen to connections by clicking on the phone icon
 
-## 💾 NFS volume sharing for Mac
+## Local development
+
+### NFS volume sharing for Mac
 
 NFS volumes can bring more stability and performance on Docker for Mac. To setup NFS volume sharing run:
 
@@ -87,7 +91,7 @@ docker-compose up -d
 **NOTE:** If you are on MacOS Catalina or newer, make sure to put the repository
 outside your `Documents` folder, otherwise you may run into [file permission issues](https://objekt.click/2019/11/docker-the-problem-with-macos-catalina/).
 
-# 🐶 Husky
+### Husky hooks
 
 We use [Husky](https://github.com/typicode/husky) to run automated checks in pre-commit hooks.
 
@@ -102,7 +106,9 @@ export NVM_DIR="$HOME/.nvm"
 
 Without it, you may experience errors in some Git clients.
 
-## 🕹 Commands
+## Docker
+
+### Commands
 
 The `./do` script define aliases for most of the commands you will need while working on plugins:
 
@@ -124,7 +130,7 @@ Options:
 
 You can access this help in your command line running `./do` without parameters.
 
-## 🚥 Testing with different PHP versions
+### Available PHP versions
 
 To switch the environment to a different PHP version:
 
@@ -144,7 +150,7 @@ To switch the environment to a different PHP version:
 To switch back to the default PHP version remove what was added in 2) and, run `docker-compose build wordpress` for application container and `docker-compose build test_wordpress` for tests container,
 and start the stack using `./do start`.
 
-## Disabling the Tracy panel
+### Disabling the Tracy panel
 
 To disable the Tracy panel, add the following to `docker-compose.override.yml`:
 
@@ -179,6 +185,9 @@ cd ../mailpoet-premium # switch to premium plugin directory
 ./do test:unit --file=tests/unit/Config/EnvTest.php
 ```
 
-## ✅ TODO
+## TODO
 
-- install woo commerce, members and other useful plugins by default
+- [ ] Install WooCommerce
+- [ ] Install Members
+- [ ] Install other useful plugins by default
+- [ ] Run individual acceptance test in premium plugin

--- a/README.md
+++ b/README.md
@@ -204,9 +204,15 @@ cd ../mailpoet-premium # switch to premium plugin directory
 ./do test:unit --file=tests/unit/Config/EnvTest.php
 ```
 
+#### Acceptance test in the premium plugin
+
+```shell
+cd ./mailpoet-premium # switch to premium plugin directory on your local machine
+./do test:acceptance --skip-deps --file tests/acceptance/PremiumCheckCest.php
+```
+
 ## TODO
 
 - [ ] Install WooCommerce
 - [ ] Install Members
 - [ ] Install other useful plugins by default
-- [ ] Run individual acceptance test in premium plugin

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+### Table of Contents
+
+1. [MailPoet](#mailpoet)
+2. [Initial setup](#initial-setup)
+   1. [Additional dependencies](#additional-dependencies)
+3. [Xdebug](#xdebug)
+   1. [PhpStorm setup](#phpstorm-setup)
+   2. [Xdebug develop mode](#xdebug-develop-mode)
+   3. [Xdebug for integration tests](#xdebug-for-integration-tests)
+4. [Local development](#local-development)
+   1. [NFS volume sharing for Mac](#nfs-volume-sharing-for-mac)
+   2. [Husky hooks](#husky-hooks)
+5. [Docker](#docker)
+   1. [Commands](#commands)
+   2. [Available PHP versions](#available-php-versions)
+   3. [Disabling the Tracy panel](#disabling-the-tracy-panel)
+   4. [Running individual tests](#running-individual-tests)
+6. [TODO](#todo)
+
 ## MailPoet
 
 The **MailPoet** plugin monorepo.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,30 @@ services:
       MAILPOET_DISABLE_TRACY_PANEL: 1
 ```
 
+### Running individual tests
+
+It's recommended to run tests in Docker. Free plugin tests can be run using --test flag (`./do --test`). However, to run a premium test, you need to ssh into test container (`./do ssh --test`) and run tests there.
+
+#### Integration test in the free plugin
+
+```shell
+./do --test test:integration --skip-deps --file=tests/integration/WP/EmojiTest.php
+```
+
+#### Acceptance test in the free plugin
+
+```shell
+./do --test test:acceptance --skip-deps --file=tests/acceptance/Misc/MailpoetMenuCest.php
+```
+
+#### Unit/integration test in the premium plugin
+
+```shell
+./do ssh --test # to enter the container
+cd ../mailpoet-premium # switch to premium plugin directory
+./do test:unit --file=tests/unit/Config/EnvTest.php
+```
+
 ## ✅ TODO
 
 - install woo commerce, members and other useful plugins by default

--- a/README.md
+++ b/README.md
@@ -124,10 +124,6 @@ Options:
 
 You can access this help in your command line running `./do` without parameters.
 
-## ✉️ Adding new templates to the plugin
-
-[Read the article.](https://mailpoet.atlassian.net/wiki/spaces/MAILPOET/pages/629374977/Adding+new+templates+to+the+plugin)
-
 ## 🚥 Testing with different PHP versions
 
 To switch the environment to a different PHP version:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,5 @@
-# Getting Support
+# Support
 
-Welcome to MailPoet!
-This isn't the right place to get support for using MailPoet,
-but the following resources are available below,
-thanks for understanding.
+Please visit our [Support](https://www.mailpoet.com/support/) page. We have a team of Happiness Engineers ready to help you.
 
-When you need help, please visit our [Support](https://www.mailpoet.com/support) page.
-We have a team of Happiness Engineers ready to help you.
-
-Free users can also ask questions in the [WordPress.org support forum](https://wordpress.org/support/plugin/mailpoet).
-
-For feature Requests use our [tracker](https://feedback.mailpoet.com).
+For feature requests, please use our [tracker](https://feedback.mailpoet.com).

--- a/mailpoet/README.md
+++ b/mailpoet/README.md
@@ -143,6 +143,20 @@ Dependencies handled by PHP-Scoper are configured in extra configuration files `
 
 We use functions `__()`, `_n()`, `_x()`, and `_nx()` with domain `mailpoet` to translate strings.
 
+#### Comments for translators
+
+When the translation string can be ambiguous, add [a translators comment](https://codex.wordpress.org/I18n_for_WordPress_Developers#Descriptions) for clarification. Don't use `_x()` or `_xn()` for clarification.
+
+```php
+// translators:
+$customErrorMessage = sprintf(
+  // translators: %1$s is the link, %2$s is the error message.
+  __('Please see %1$s for more information. %2$s.', 'mailpoet'),
+  'https://kb.mailpoet.com',
+  $errorMessage
+);
+```
+
 **in PHP code**
 
 ```php

--- a/mailpoet/README.md
+++ b/mailpoet/README.md
@@ -1,26 +1,14 @@
-# MailPoet
+## MailPoet
 
-The **MailPoet** plugin.
-
-If you have **any questions or need help or support**, please see the [Support](../SUPPORT.md) document.
-
-To use the official Docker-based development environment, see details
-in [the readme file](../README.md) in the root of this repository. If
-you'd like to use the plugin code directly, you can follow the instructions
-below.
-
-## Contents
-
-- [Setup](#setup)
-- [Frameworks and libraries](#frameworks-and-libraries)
-- [Workflow Commands](#workflow-commands)
-- [Coding and Testing](#coding-and-testing)
+- For help with product, visit [SUPPORT](../SUPPORT.md).
+- To use the Docker-based development environment, see [monorepo README](../README.md).
+- To use plugin code directly, follow instructions below.
 
 ## Setup
 
 ### Requirements
 
-- PHP >= 7.3 (only for the development environment, to run the plugin PHP >= 7.2 is required)
+- PHP >= 7.4
 - NodeJS
 - WordPress
 
@@ -48,9 +36,8 @@ cp .env.sample .env
 ./do compile:all
 ```
 
-## Frameworks and libraries
+### Frameworks and libraries
 
-- [Paris ORM](https://github.com/j4mie/paris).
 - [Symfony/dependency-injection](https://github.com/symfony/dependency-injection) ([docs for 3.4](https://symfony.com/doc/3.4/components/dependency_injection.html)).
 - [PHP-Scoper](https://github.com/humbug/php-scoper) for moving dependencies into MP namespace
 - [Twig](https://twig.symfony.com/) and [Handlebars](https://handlebarsjs.com/) are used for templates rendering.
@@ -141,7 +128,7 @@ Dependencies handled by PHP-Scoper are configured in extra configuration files `
 
 ### i18n
 
-We use functions `__()`, `_n()`, `_x()`, and `_nx()` with domain `mailpoet` to translate strings.
+We use functions `__()`, `_n()`, `_x()`, and `_nx()` with domain `mailpoet` to translate strings. Please follow [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers).
 
 #### Comments for translators
 
@@ -157,7 +144,7 @@ $customErrorMessage = sprintf(
 );
 ```
 
-**in PHP code**
+#### In PHP code
 
 ```php
 __('text to translate', 'mailpoet');
@@ -166,7 +153,7 @@ _x('text to translate', 'context', 'mailpoet');
 _xn('single text', 'plural text', $number, 'context', 'mailpoet');
 ```
 
-**in JavaScript/TypeScript code**
+#### In JavaScript/TypeScript code
 
 ```ts
 import { __, _n, _x, _xn } from '@wordpress/i18n';

--- a/mailpoet/README.md
+++ b/mailpoet/README.md
@@ -1,3 +1,17 @@
+### Table of Contents
+
+1. [MailPoet](#mailpoet)
+2. [Setup](#setup)
+   1. [Requirements](#requirements)
+   2. [Installation](#installation)
+   3. [Frameworks and libraries](#frameworks-and-libraries)
+3. [Workflow Commands](#workflow-commands)
+4. [Coding and Testing](#coding-and-testing)
+   1. [DI](#di)
+   2. [PHP-Scoper](#php-scoper)
+   3. [i18n](#i18n)
+   4. [Acceptance testing](#acceptance-testing)
+
 ## MailPoet
 
 - For help with product, visit [SUPPORT](../SUPPORT.md).


### PR DESCRIPTION
## Description

- Simplified SUPPORT.md.
- Updated outdated information in CONTRIBUTING.md.
- In monorepo README:
  - Added section on running individual tests.
  - General cleanup + table of contents.
- In free plugin README:
  - Added section for translators comments
  - General cleanup + table of contents.

## Code review notes

_N/A_

## QA notes

QA can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6136]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6136]: https://mailpoet.atlassian.net/browse/MAILPOET-6136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ