### PR TITLE
Automations sender domain notice [MAILPOET-5270]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/components/sender-domain-notice.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/components/sender-domain-notice.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { extractEmailDomain } from 'common/functions';
-import { SenderEmailAddressWarning } from '../../../../../../common/sender-email-address-warning';
-import { MailPoet } from '../../../../../../mailpoet';
-import { useSelectContext, updateSenderDomainsConfig } from '../../../context';
+import { SenderEmailAddressWarning } from '../../../../common/sender-email-address-warning';
+import { MailPoet } from '../../../../mailpoet';
+import { useSelectContext, updateSenderDomainsConfig } from '../context';
 
 type SenderDomainInlineNoticeProps = {
   email: string;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/expose.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/expose.ts
@@ -1,0 +1,2 @@
+// exports for extensibility
+export { SenderDomainNotice } from './components/sender-domain-notice';

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
@@ -4,7 +4,7 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { isEmail } from 'common/functions';
 import { ShortcodeHelpText } from './shortcode-help-text';
-import { SenderDomainNotice } from './sender-domain-notice';
+import { SenderDomainNotice } from '../../../components/sender-domain-notice';
 import { PlainBodyTitle } from '../../../../../editor/components';
 import { storeName } from '../../../../../editor/store';
 import { StepName } from '../../../../../editor/components/panel/step-name';

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
@@ -85,7 +85,17 @@ export function EmailPanel(): JSX.Element {
         className={
           senderAddressErrorMessage ? 'mailpoet-automation-field__error' : ''
         }
-        help={senderAddressErrorMessage}
+        help={
+          <>
+            {senderAddressErrorMessage}
+            {window.mailpoet_mss_active &&
+              isEmail((selectedStep.args.sender_address as string) ?? '') && (
+                <SenderDomainNotice
+                  email={(selectedStep.args.sender_address as string) ?? ''}
+                />
+              )}
+          </>
+        }
         type="email"
         label={__('"From" email address', 'mailpoet')}
         placeholder={
@@ -101,12 +111,6 @@ export function EmailPanel(): JSX.Element {
           )
         }
       />
-      {window.mailpoet_mss_active &&
-        isEmail((selectedStep.args.sender_address as string) ?? '') && (
-          <SenderDomainNotice
-            email={(selectedStep.args.sender_address as string) ?? ''}
-          />
-        )}
       <SingleLineTextareaControl
         className={
           subjectErrorMessage ? 'mailpoet-automation-field__error' : ''

--- a/mailpoet/assets/js/src/webpack-admin-expose.js
+++ b/mailpoet/assets/js/src/webpack-admin-expose.js
@@ -55,4 +55,5 @@ export * as Listing from 'listing';
 export * as DynamicSegments from 'segments/dynamic';
 export * as AutomationEditorComponents from 'automation/editor/components';
 export * as AutomationAnalyticsStore from 'automation/integrations/mailpoet/analytics/store';
+export * as AutomationIntegrationsMailPoet from 'automation/integrations/mailpoet/expose';
 export * as AutomationIntegrationsWooCommerceContext from 'automation/integrations/woocommerce/context';


### PR DESCRIPTION
## Description

Adds FROM email address validation to the notification email step.
The send email step already has this functionality.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/891

## Linked tickets

[MAILPOET-5270]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5270]: https://mailpoet.atlassian.net/browse/MAILPOET-5270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ