### PR TITLE
Disallow activating emails without a list in newsletter listings [MAILPOET-5352]

### DIFF
--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -38,6 +38,7 @@ class NewsletterValidator {
       return null;
     }
     try {
+      $this->validateSegments($newsletterEntity);
       $this->validateBody($newsletterEntity);
       $this->validateUnsubscribeRequirements($newsletterEntity);
       $this->validateReEngagementRequirements($newsletterEntity);
@@ -58,6 +59,22 @@ class NewsletterValidator {
 
     if (!$hasUnsubscribeLink && !$hasUnsubscribeUrl) {
       throw new ValidationException(__('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.', 'mailpoet'));
+    }
+  }
+
+  private function validateSegments(NewsletterEntity $newsletterEntity): void {
+    if (
+      $newsletterEntity->getType() !== NewsletterEntity::TYPE_NOTIFICATION
+      && $newsletterEntity->getType() !== NewsletterEntity::TYPE_RE_ENGAGEMENT
+    ) {
+      return;
+    }
+
+    $emptySegmentsErrorMessage = __('You need to select a list to send to.', 'mailpoet');
+    $segmentIds = $newsletterEntity->getSegmentIds();
+
+    if (empty($segmentIds)) {
+      throw new ValidationException($emptySegmentsErrorMessage);
     }
   }
 

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -357,6 +357,12 @@ class Newsletter {
     return $this;
   }
 
+  public function withDefaultSegments() {
+    $defaultSegment = (new Segment())->withType(SegmentEntity::TYPE_DEFAULT)->create();
+    $this->segments[$defaultSegment->getId()] = $defaultSegment;
+    return $this;
+  }
+
   /**
    * @param SegmentEntity[] $segments
    * @return Newsletter

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -311,6 +311,9 @@ class NewslettersTest extends \MailPoetTest {
       );
     (new SendingQueueFactory())->create($scheduledTask3, $this->postNotification);
 
+    $segment1 = $this->segmentRepository->createOrUpdate('Segment 1');
+    $this->createNewsletterSegment($this->postNotification, $segment1);
+
     $this->entityManager->clear();
     $this->endpoint->setStatus(
       [
@@ -334,6 +337,10 @@ class NewslettersTest extends \MailPoetTest {
     $schedule = '* * * * *';
     (new NewsletterOption())->create($this->postNotification, NewsletterOptionFieldEntity::NAME_SCHEDULE, $schedule);
 
+    $segment1 = $this->segmentRepository->createOrUpdate('Segment 1');
+    $this->createNewsletterSegment($this->postNotification, $segment1);
+
+    $this->entityManager->clear();
     $this->endpoint->setStatus(
       [
         'id' => $this->postNotification->getId(),

--- a/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterValidatorTest.php
@@ -31,6 +31,18 @@ class NewsletterValidatorTest extends \MailPoetTest {
     verify($validationError)->equals('All emails must include an "Unsubscribe" link. Add a footer widget to your email to continue.');
   }
 
+  public function testItRequiresSegments() {
+    $newsletter = (new Newsletter())->withPostNotificationsType()->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    verify($validationError)->equals('You need to select a list to send to.');
+    $newsletter = (new Newsletter())->withReengagementType()->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    verify($validationError)->equals('You need to select a list to send to.');
+    $newsletter = (new Newsletter())->create();
+    $validationError = $this->newsletterValidator->validate($newsletter);
+    verify($validationError)->equals(null);
+  }
+
   public function testItRequiresBodyContent() {
     $newsletter = (new Newsletter())->withBody('')->create();
     $validationError = $this->newsletterValidator->validate($newsletter);
@@ -55,13 +67,13 @@ class NewsletterValidatorTest extends \MailPoetTest {
   }
 
   public function testItRequiresReengagementShortcodes() {
-    $newsletter = (new Newsletter())->withReengagementType()->withDefaultBody()->create();
+    $newsletter = (new Newsletter())->withReengagementType()->withDefaultSegments()->withDefaultBody()->create();
     $validationError = $this->newsletterValidator->validate($newsletter);
     verify($validationError)->equals('A re-engagement email must include a link with [link:subscription_re_engage_url] shortcode.');
   }
 
   public function testReengagementNewsletterIsValidWithRequiredShortcode() {
-    $newsletter = (new Newsletter())->withReengagementType()->withBody([
+    $newsletter = (new Newsletter())->withReengagementType()->withDefaultSegments()->withBody([
       'content' => [
         'blocks' => [
           [
@@ -76,7 +88,7 @@ class NewsletterValidatorTest extends \MailPoetTest {
   }
 
   public function testItRequiresTrackingForReengagementEmails() {
-    $newsletter = (new Newsletter())->withReengagementType()->withBody([
+    $newsletter = (new Newsletter())->withReengagementType()->withDefaultSegments()->withBody([
       'content' => [
         'blocks' => [
           [
@@ -94,13 +106,13 @@ class NewsletterValidatorTest extends \MailPoetTest {
   }
 
   public function testAlcEmailFailsValidationWithoutAlcBlock() {
-    $newsletter = (new Newsletter())->withDefaultBody()->withPostNotificationsType()->create();
+    $newsletter = (new Newsletter())->withDefaultBody()->withPostNotificationsType()->withDefaultSegments()->create();
     $validationError = $this->newsletterValidator->validate($newsletter);
     verify($validationError)->equals('Please add an “Automatic Latest Content” widget to the email from the right sidebar.');
   }
 
   public function testAlcEmailPassesWithAlcBlock() {
-    $newsletter = (new Newsletter())->loadBodyFrom('newsletterWithALC.json')->withPostNotificationsType()->create();
+    $newsletter = (new Newsletter())->loadBodyFrom('newsletterWithALC.json')->withPostNotificationsType()->withDefaultSegments()->create();
     $validationError = $this->newsletterValidator->validate($newsletter);
     verify($validationError)->null();
   }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Spec #2 from the Jira ticket became obsolete since welcome emails were moved to the Automations page, therefore it wasn't implemented.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5352]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5352]: https://mailpoet.atlassian.net/browse/MAILPOET-5352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ