### PR TITLE
Fix loading external images for email template thumbnails [MAILPOET-3923]

### DIFF
--- a/mailpoet/assets/js/src/common/thumbnail.ts
+++ b/mailpoet/assets/js/src/common/thumbnail.ts
@@ -3,6 +3,15 @@ import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import html2canvas from 'html2canvas';
 
+const getProxyURL = (url) => {
+  const params = new URLSearchParams({
+    mailpoet_router: '',
+    endpoint: 'template_image',
+    action: 'get_external_image',
+  });
+  return `${url}?${params.toString()}`;
+};
+
 /**
  * Generates a thumbnail from a HTML element.
  *
@@ -12,6 +21,7 @@ import html2canvas from 'html2canvas';
 export const fromDom = async (element: HTMLElement) => {
   const canvas = await html2canvas(element, {
     logging: false,
+    proxy: getProxyURL('/'),
     scale: 1, // Use a constant scale to prevent generating large images on Retina displays
   });
   return canvas.toDataURL('image/jpeg');

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -420,6 +420,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Router\Endpoints\FormPreview::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\TemplateImage::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
     // Statistics
     $container->autowire(\MailPoet\Statistics\Track\Clicks::class);
@@ -612,6 +613,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Statistics\GATracking::class)->setPublic(true);
     // Newsletter templates
     $container->autowire(\MailPoet\NewsletterTemplates\NewsletterTemplatesRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\NewsletterTemplates\TemplateImageLoader::class)->setPublic(true);
     $container->autowire(\MailPoet\NewsletterTemplates\ThumbnailSaver::class)->setPublic(true);
     $container->autowire(\MailPoet\NewsletterTemplates\BrandStyles::class)->setPublic(true);
     // Util

--- a/mailpoet/lib/NewsletterTemplates/TemplateImageLoader.php
+++ b/mailpoet/lib/NewsletterTemplates/TemplateImageLoader.php
@@ -1,0 +1,83 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\NewsletterTemplates;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class TemplateImageLoader {
+  const TIMEOUT = 30; // seconds
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  /**
+   * Acts as a proxy for html2canvas
+   */
+  public function loadExternalImage(string $url) {
+    if (!$this->isUrlAllowed($url)) {
+      // URL not allowed
+      return false;
+    }
+    $image = $this->downloadUrl($url);
+    if ($this->wp->isWpError($image)) {
+      // Failed to load the image
+      return false;
+    }
+    if (!$this->isTypeAllowed($image, $mime)) {
+      // Wrong file type
+      @unlink($image);
+      return false;
+    }
+    header('Content-Type: ' . $mime);
+    readfile($image);
+    @unlink($image);
+    return true;
+  }
+
+  protected function downloadUrl($url) {
+    require_once ABSPATH . '/wp-admin/includes/file.php';
+    return download_url($url, self::TIMEOUT);
+  }
+
+  private function isUrlAllowed($url) {
+    $urlParts = parse_url($url);
+    $allowedExtensions = ['gif', 'png', 'jpg', 'jpeg'];
+    if (
+      !isset($urlParts['path'])
+      || !preg_match('/(' . join('|', $allowedExtensions) . ')$/', $urlParts['path'])
+    ) {
+      return false;
+    }
+    /** @var string[] */
+    $allowedUrls = (array)$this->wp->applyFilters('mailpoet_template_image_allowed_urls', [
+      'https://ps.w.org/mailpoet/assets/newsletter-templates/',
+    ]);
+    foreach ($allowedUrls as $allowedUrl) {
+      $allowedUrlParts = parse_url($allowedUrl);
+      if (
+        isset($urlParts['host'], $allowedUrlParts['host'], $allowedUrlParts['path'])
+        && $urlParts['host'] === $allowedUrlParts['host']
+        && strpos($urlParts['path'], $allowedUrlParts['path']) === 0
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private function isTypeAllowed($image, &$mime = null) {
+    $allowedMimeTypes = [
+      'image/gif',
+      'image/jpeg',
+      'image/png',
+    ];
+    $mime = $this->wp->wpGetImageMime($image);
+    return $mime && in_array($mime, $allowedMimeTypes);
+  }
+}

--- a/mailpoet/lib/Router/Endpoints/TemplateImage.php
+++ b/mailpoet/lib/Router/Endpoints/TemplateImage.php
@@ -1,0 +1,38 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\Router\Endpoints;
+
+use MailPoet\Config\AccessControl;
+use MailPoet\NewsletterTemplates\TemplateImageLoader;
+
+class TemplateImage {
+  const ENDPOINT = 'template_image';
+  const ACTION_GET_EXTERNAL_IMAGE = 'getExternalImage';
+
+  /** @var TemplateImageLoader */
+  private $templateImageLoader;
+
+  public $allowedActions = [self::ACTION_GET_EXTERNAL_IMAGE];
+  public $permissions = [
+    'global' => AccessControl::PERMISSION_MANAGE_EMAILS,
+  ];
+
+  public function __construct(
+    TemplateImageLoader $templateImageLoader
+  ) {
+    $this->templateImageLoader = $templateImageLoader;
+  }
+
+  public function getExternalImage($data = [], $return = false) {
+    if (empty($_GET['url'])) {
+      return false;
+    }
+    $result = $this->templateImageLoader->loadExternalImage(
+      sanitize_text_field(wp_unslash($_GET['url']))
+    );
+    if ($return) {
+      return $result;
+    }
+    exit;
+  }
+}

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -567,6 +567,10 @@ class Functions {
     return wp_get_current_user();
   }
 
+  public function wpGetImageMime($file) {
+    return wp_get_image_mime($file);
+  }
+
   public function wpGetPostTerms($postId, $taxonomy = 'post_tag', array $args = []) {
     return wp_get_post_terms($postId, $taxonomy, $args);
   }

--- a/mailpoet/tests/integration/Router/Endpoints/TemplateImageTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/TemplateImageTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Router\Endpoints;
+
+use Codeception\Stub;
+use Codeception\Stub\Expected;
+use MailPoet\NewsletterTemplates\TemplateImageLoader;
+use MailPoet\Router\Endpoints\TemplateImage;
+use MailPoet\WP\Functions as WPFunctions;
+
+class TemplateImageTest extends \MailPoetTest {
+  public function testItDisplaysExternalImage() {
+    // Make a copy of the test image because it's going to be unlinked
+    $tempFile = (string)tempnam(dirname(__DIR__) . '/../../../tests/_output/', 'testimg');
+    copy(dirname(__DIR__) . '/../../../tests/_data/test-image.jpg', $tempFile);
+
+    $loader = Stub::make(TemplateImageLoader::class, [
+      'wp' => new WPFunctions,
+      'downloadUrl' => Expected::once($tempFile),
+    ], $this);
+    $templateImage = new TemplateImage($loader);
+
+    $url = 'https://ps.w.org/mailpoet/assets/newsletter-templates/yoga_studio/yoga-1.png';
+    [$output, $result] = $this->captureOutputAndReturnValue($templateImage, $url);
+
+    verify($result)->equals(true);
+    verify($output)->stringContainsString('JFIF'); // JPEG file header
+    verify(file_exists($tempFile))->equals(false); // Image is unlinked after display
+  }
+
+  public function testItDoesNotLoadIfUrlNotAllowed() {
+    $loader = Stub::make(TemplateImageLoader::class, [
+      'wp' => new WPFunctions,
+      'downloadUrl' => Expected::never(),
+    ], $this);
+    $templateImage = new TemplateImage($loader);
+
+    $url = 'https://example.com/some/image.jpg';
+    [$output, $result] = $this->captureOutputAndReturnValue($templateImage, $url);
+
+    verify($result)->false();
+    verify($output)->empty();
+  }
+
+  public function testItDoesNotDisplayWrongFileType() {
+    $tempFile = (string)tempnam(dirname(__DIR__) . '/../../../tests/_output/', 'testimg');
+    copy(dirname(__DIR__) . '/../../../tests/_data/newsletterWithALC.json', $tempFile);
+
+    $loader = Stub::make(TemplateImageLoader::class, [
+      'wp' => new WPFunctions,
+      'downloadUrl' => Expected::once($tempFile),
+    ], $this);
+    $templateImage = new TemplateImage($loader);
+
+    $url = 'https://ps.w.org/mailpoet/assets/newsletter-templates/yoga_studio/yoga-1.png';
+    [$output, $result] = $this->captureOutputAndReturnValue($templateImage, $url);
+
+    verify($result)->false();
+    verify($output)->empty();
+    verify(file_exists($tempFile))->equals(false);
+  }
+
+  private function captureOutputAndReturnValue(TemplateImage $templateImage, string $url): array {
+    $_GET['url'] = $url;
+    ob_start();
+    $result = $templateImage->getExternalImage([], true);
+    $output = ob_get_clean();
+    return [$output, $result];
+  }
+}


### PR DESCRIPTION
## Description

The proxy for html2canvas is added here to work around CORS when loading external images for email template thumbnails. It's access is restricted by authentication, it only works for MailPoet stock templates by default, image types are also restricted.

## Code review notes

Please let me know if you see any security issues with this approach. Or if there's a better way altogether.

## QA notes

Follow the reproduction steps from the Jira ticket.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-3923]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-3923]: https://mailpoet.atlassian.net/browse/MAILPOET-3923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ