### PR TITLE
Don't show empty WooCommerce list on send page when Woo is not active [MAILPOET-5224]

### DIFF
--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -7,10 +7,12 @@ use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
 use MailPoet\Config\Menu;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\NewsletterTemplates\NewsletterTemplatesRepository;
 use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Segments\WooCommerce;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -46,6 +48,8 @@ class Newsletters {
 
   private UserFlagsController $userFlagsController;
 
+  private WooCommerce $wooCommerceSegment;
+
   private CapabilitiesManager $capabilitiesManager;
 
   public function __construct(
@@ -61,6 +65,7 @@ class Newsletters {
     Bridge $bridge,
     AuthorizedSenderDomainController $senderDomainController,
     UserFlagsController $userFlagsController,
+    WooCommerce $wooCommerceSegment,
     CapabilitiesManager $capabilitiesManager
   ) {
     $this->pageRenderer = $pageRenderer;
@@ -75,6 +80,7 @@ class Newsletters {
     $this->bridge = $bridge;
     $this->senderDomainController = $senderDomainController;
     $this->userFlagsController = $userFlagsController;
+    $this->wooCommerceSegment = $wooCommerceSegment;
     $this->capabilitiesManager = $capabilitiesManager;
   }
 
@@ -84,7 +90,8 @@ class Newsletters {
     $data = [];
 
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('newsletters');
-    $segments = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts();
+    $includedSegmentTypes = $this->wooCommerceSegment->shouldShowWooCommerceSegment() ? [] : SegmentEntity::NON_WOO_RELATED_TYPES;
+    $segments = $this->segmentsListRepository->getListWithSubscribedSubscribersCounts($includedSegmentTypes);
     $data['segments'] = $segments;
     $data['settings'] = $this->settings->getAll();
     $data['current_wp_user'] = $this->wp->wpGetCurrentUser()->to_array();

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -22,38 +22,27 @@ use MailPoet\WP\DateTime;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Newsletters {
-  /** @var PageRenderer */
-  private $pageRenderer;
+  private PageRenderer $pageRenderer;
 
-  /** @var PageLimit */
-  private $listingPageLimit;
+  private PageLimit $listingPageLimit;
 
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
 
-  /** @var SettingsController */
-  private $settings;
+  private SettingsController $settings;
 
-  /** @var NewsletterTemplatesRepository */
-  private $newsletterTemplatesRepository;
+  private NewsletterTemplatesRepository $newsletterTemplatesRepository;
 
-  /** @var AutomaticEmails */
-  private $automaticEmails;
+  private AutomaticEmails $automaticEmails;
 
-  /** @var WPPostListLoader */
-  private $wpPostListLoader;
+  private WPPostListLoader $wpPostListLoader;
 
-  /** @var SegmentsSimpleListRepository */
-  private $segmentsListRepository;
+  private SegmentsSimpleListRepository $segmentsListRepository;
 
-  /** @var NewslettersRepository */
-  private $newslettersRepository;
+  private NewslettersRepository $newslettersRepository;
 
-  /** @var Bridge */
-  private $bridge;
+  private Bridge $bridge;
 
-  /** @var AuthorizedSenderDomainController */
-  private $senderDomainController;
+  private AuthorizedSenderDomainController $senderDomainController;
 
   private UserFlagsController $userFlagsController;
 

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -27,6 +27,13 @@ class SegmentEntity {
   const TYPE_DYNAMIC = 'dynamic';
   const TYPE_WITHOUT_LIST = 'without-list';
 
+  const NON_WOO_RELATED_TYPES = [
+    self::TYPE_WP_USERS,
+    self::TYPE_DEFAULT,
+    self::TYPE_DYNAMIC,
+    self::TYPE_WITHOUT_LIST,
+  ];
+
   const SEGMENT_ENABLED = 'active';
   const SEGMENT_DISABLED = 'disabled';
 


### PR DESCRIPTION
## Description

This PR fixes the issue of displaying the WooCommerce list on the Newsletter send page even though Woo is inactive.
I found that there is already logic for displaying/hiding the WooCommerce list in the list listing, so I reused the same logic.

The Woo list is shown if WooCommerce is active OR if there are some WooCommerce customers. This also covers cases when a Woo plugin was active Woo list was populated and then the Woo plugin was deactivated. In case the Woo was active and was deactivated the Woo list is empty it should be hidden.

## Code review notes

_N/A_

## QA notes

Please verify that the WooCommerce list is displayed according to the logic described above. The behavior on the List page and Newsletter sending page should be the same.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5224]

## After-merge notes

_N/A_

## Tasks

- [] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [] I added sufficient test coverage
- [] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5224]: https://mailpoet.atlassian.net/browse/MAILPOET-5224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ