### PR TITLE
Retry download WooCommerce packages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   dashboard:
     container_name: mp-dashboard

--- a/mailpoet/tests/docker/docker-compose.yml
+++ b/mailpoet/tests/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   codeception_acceptance:
     image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}


### PR DESCRIPTION
## Description

Sometimes, we experience failures while downloading the WooCommerce zip files from GitHub. See an example: [https://d.pr/i/p9kX3U](https://d.pr/i/p9kX3U). This pull request implements retry; when the download fails, we try again.  

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
