### PR TITLE
Fix broken HPOS tests

### DIFF
--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -98,6 +98,7 @@ class DefaultsExtension extends Extension {
     delete_transient('_wc_activation_redirect');
 
     // mark all WC cron actions complete
+    update_option('wc_pending_batch_processes', []);
     $tableName = !empty($wpdb->actionscheduler_actions) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $sql = "UPDATE {$tableName} SET status = 'complete'";
     $wpdb->query($sql);


### PR DESCRIPTION
## Description

We complete the actions in the database. However, we don't delete the batch processes. Woo thinks those crashed. It tries to log an error but doesn't have sufficient rights for that.

This pull request deletes `wc_pending_batch_processes`, which will prevent the batch process controller from retrying those.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
