### PR TITLE
Fix extraction of RC WordPress versions [MAILPOET-6096]

### DIFF
--- a/.circleci/check_wordpress_beta.sh
+++ b/.circleci/check_wordpress_beta.sh
@@ -7,14 +7,22 @@ RSS_FEED=$(curl -s https://wordpress.org/news/category/releases/feed/)
 LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed -E 's/<\/?title>//g' | head -n 1 | tr [:upper:] [:lower:])
 
 # Check if a beta or RC version is found
-if [[ $LAST_VERSION != *'beta'* && $LAST_VERSION != *'rc'* ]]; then
-  echo "No WordPress beta/RC version found."
-  echo "LATEST_BETA="
-else
+if [[ $LAST_VERSION == *'beta'* ]]; then
   # Extract titles containing beta versions from the feed
   VERSION_LINE=$(echo "$RSS_FEED" | grep -o '<code>wp core update [^<]*</code>' | sed -E 's/<\/?code>//g' | head -n 1 | grep 'beta')
   LATEST_BETA=$(echo "$VERSION_LINE" | sed -E 's/.*--version=([0-9\.]+-beta[0-9]+).*/\1/')
 
-  echo "Latest WordPress beta/RC version: $LATEST_BETA"
+  echo "Latest WordPress beta version: $LATEST_BETA"
   echo "LATEST_BETA=$LATEST_BETA"
+
+elif [[ $LAST_VERSION == *'release candidate'* ]]; then
+  # Extract titles containing RC versions from the feed
+  VERSION_LINE=$(echo "$RSS_FEED" | grep -o '<code>wp core update [^<]*</code>' | sed -E 's/<\/?code>//g' | head -n 1 | grep 'RC')
+  LATEST_BETA=$(echo "$VERSION_LINE" | sed -E 's/.*--version=([0-9\.]+-RC[0-9]+).*/\1/')
+
+  echo "Latest WordPress RC version: $LATEST_BETA"
+  echo "LATEST_BETA=$LATEST_BETA"
+else
+  echo "No WordPress beta/RC version found."
+  echo "LATEST_BETA="
 fi


### PR DESCRIPTION
## Description

I noticed that using RC versions doesn't work properly, so I prepared a fix because we always extracted versions using the beta pattern, but RC versions have a different one. I decided to split the code into two conditions. 

## Code review notes

_N/A_

## QA notes

We don't need QA here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6096]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6096]: https://mailpoet.atlassian.net/browse/MAILPOET-6096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ