### PR TITLE
Improve condition in acceptance tests for WP 6.6

### DIFF
--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -224,7 +224,8 @@ class WooCheckoutBlocksCest {
     $i->click('[aria-label="Block: Contact Information"]');
 
     // From WP 6.6 the button label is Save
-    if (version_compare($i->getWordPressVersion(), '6.6', '<')) {
+    $version = (string)preg_replace('/-(RC|beta)\d*/', '', $i->getWordPressVersion());
+    if (version_compare($version, '6.6', '<')) {
       $i->click('Update');
     } else {
       $i->click('Save');


### PR DESCRIPTION
## Description

Because we ran tests with release candidate versions, the condition didn't work as expected in those cases.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
