### PR TITLE
Allow formatting tags in post titles [MAILPOET-5920]

### DIFF
--- a/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformerContentsExtractor.php
@@ -165,6 +165,11 @@ class PostTransformerContentsExtractor {
       'h1' => $commonAttributes,
       'h2' => $commonAttributes,
       'h3' => $commonAttributes,
+      'b' => [],
+      'i' => [],
+      'strong' => [],
+      'em' => [],
+      'small' => [],
     ];
 
     return [


### PR DESCRIPTION
## Description

Some customers requested that tags be preserved in the post titles when sending post notifications. To limit the breaking change, I decided not to include any attributes and only limit the preserved HTML tags to a handful. See Jira discussion for more context. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5920]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5920]: https://mailpoet.atlassian.net/browse/MAILPOET-5920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ