### PR TITLE
Add form placement options to readme.txt [MAILPOET-6152]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -33,6 +33,7 @@ Trusted by 700,000 WordPress websites since 2011.
 * Send automated welcome emails
 * Behavior and interest-based subscriber segmentation options
 * Pre-built and customizable email and subscription form templates
+* Multiple subscription form placements: below pages, fixed bar, popup, slide-in, shortcode, on exit intent
 * WooCommerce emails: abandoned cart, first purchase, specific product, product category
 * Customize WooCommerce transactional emails
 * Reliable email delivery with MailPoet Sending Service (available for free – plan required)


### PR DESCRIPTION
## Description

We want to mention form placement options in the description so people looking for those keywords (such as `popup`, or `exit intent`) can find MailPoet in [WordPress.org plugins search](https://wordpress.org/plugins/search/exit+intent/) .

## Code review notes

Code review can be skipped.

## QA notes

QA can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6152]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6152]: https://mailpoet.atlassian.net/browse/MAILPOET-6152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ