### PR TITLE
Fix typo. 'would' -> 'will' [MAILPOET-6156]

### DIFF
--- a/mailpoet/assets/js/src/common/manage-sender-domain/manage-sender-domain.tsx
+++ b/mailpoet/assets/js/src/common/manage-sender-domain/manage-sender-domain.tsx
@@ -143,7 +143,7 @@ function ManageSenderDomain({
               )}
             </strong>{' '}
             {__(
-              'MailPoet would verify your DNS records to ensure it matches. Do note that it may take up to 24 hours for DNS changes to propagate after you make the change.',
+              'MailPoet will verify your DNS records to ensure it matches. Do note that it may take up to 24 hours for DNS changes to propagate after you make the change.',
               'mailpoet',
             )}
           </div>


### PR DESCRIPTION
## Description
[MAILPOET-6156]

## Code review notes
Skipping

## QA notes
Skipping

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-6156]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6156]: https://mailpoet.atlassian.net/browse/MAILPOET-6156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-6156]: https://mailpoet.atlassian.net/browse/MAILPOET-6156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ