### PR TITLE
Fix rendering buttons in Outlook 2023 [MAILPOET-5732]

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
@@ -8,7 +8,7 @@ use MailPoet\Newsletter\Renderer\StylesHelper;
 class Button {
   public function render($element, $columnBaseWidth) {
     $element['styles']['block']['width'] = $this->calculateWidth($element, $columnBaseWidth);
-    $styles = 'display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;' . StylesHelper::getBlockStyles($element, $exclude = ['textAlign']);
+    $styles = 'display:block;text-decoration:none;text-align:center;' . StylesHelper::getBlockStyles($element, $exclude = ['textAlign']);
     $styles = EHelper::escapeHtmlStyleAttr($styles);
     $template = '
       <tr>
@@ -35,7 +35,29 @@ class Button {
                   </v:roundrect>
                   <![endif]-->
                   <!--[if !mso]><!-- -->
-                  <a class="mailpoet_button" href="' . EHelper::escapeHtmlLinkAttr($element['url']) . '" style="' . $styles . '"> ' . EHelper::escapeHtmlText($element['text']) . '</a>
+                  <table
+                    border="0"
+                    cellspacing="0"
+                    cellpadding="0"
+                    role="presentation"
+                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:' . EHelper::escapeHtmlStyleAttr($element['styles']['block']['width']) . '"
+                    width="' . EHelper::escapeHtmlStyleAttr($element['styles']['block']['width']) . '"
+                  >
+                    <tr>
+                      <td class="mailpoet_table_button"
+                        valign="middle"
+                        role="presentation"
+                        style="mso-table-lspace: 0;mso-table-rspace: 0;' . $styles . '"
+                      >
+                        <a class="mailpoet_button" style="
+                          text-decoration: none;
+                          display: block;
+                          line-height: ' . EHelper::escapeHtmlStyleAttr($element['styles']['block']['lineHeight']) . ';
+                          color: ' . EHelper::escapeHtmlStyleAttr($element['styles']['block']['fontColor']) . ';
+                        " href="' . EHelper::escapeHtmlLinkAttr($element['url']) . '" target="_blank">' . EHelper::escapeHtmlText($element['text']) . '</a>
+                      </td>
+                    </tr>
+                  </table>
                   <!--<![endif]-->
                 </td>
               </tr>
@@ -46,7 +68,7 @@ class Button {
     return $template;
   }
 
-  public function calculateWidth($element, $columnBaseWidth) {
+  public function calculateWidth($element, $columnBaseWidth): string {
     $columnWidth = $columnBaseWidth - (StylesHelper::$paddingWidth * 2);
     $borderWidth = (int)$element['styles']['block']['borderWidth'];
     $buttonWidth = (int)$element['styles']['block']['width'];

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
@@ -7,7 +7,7 @@ use MailPoet\Newsletter\Renderer\StylesHelper;
 
 class Button {
   public function render($element, $columnBaseWidth) {
-    $originalWidth = $element['styles']['block']['width'];
+    $originalWidth = $this->getOriginalWidth($element, $columnBaseWidth);
     $element['styles']['block']['width'] = $this->calculateWidth($element, $columnBaseWidth);
     $styles = 'display:block;text-decoration:none;text-align:center;' . StylesHelper::getBlockStyles($element, $exclude = ['textAlign']);
     $styles = EHelper::escapeHtmlStyleAttr($styles);
@@ -67,6 +67,16 @@ class Button {
         </td>
       </tr>';
     return $template;
+  }
+
+  public function getOriginalWidth($element, $columnBaseWidth): string {
+    $columnWidth = $columnBaseWidth - (StylesHelper::$paddingWidth * 2);
+    $originalWidth = (int)$element['styles']['block']['width'];
+    $originalWidth = ($originalWidth > $columnWidth) ?
+      $columnWidth :
+      $originalWidth;
+
+    return $originalWidth . 'px';
   }
 
   public function calculateWidth($element, $columnBaseWidth): string {

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Button.php
@@ -7,6 +7,7 @@ use MailPoet\Newsletter\Renderer\StylesHelper;
 
 class Button {
   public function render($element, $columnBaseWidth) {
+    $originalWidth = $element['styles']['block']['width'];
     $element['styles']['block']['width'] = $this->calculateWidth($element, $columnBaseWidth);
     $styles = 'display:block;text-decoration:none;text-align:center;' . StylesHelper::getBlockStyles($element, $exclude = ['textAlign']);
     $styles = EHelper::escapeHtmlStyleAttr($styles);
@@ -40,8 +41,8 @@ class Button {
                     cellspacing="0"
                     cellpadding="0"
                     role="presentation"
-                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:' . EHelper::escapeHtmlStyleAttr($element['styles']['block']['width']) . '"
-                    width="' . EHelper::escapeHtmlStyleAttr($element['styles']['block']['width']) . '"
+                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:' . EHelper::escapeHtmlStyleAttr($originalWidth) . '"
+                    width="' . EHelper::escapeHtmlStyleAttr($originalWidth) . '"
                   >
                     <tr>
                       <td class="mailpoet_table_button"

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -502,7 +502,7 @@ class RendererTest extends \MailPoetTest {
     $DOM = $this->dOMParser->parseStr((new Button)->render($template, self::COLUMN_BASE_WIDTH));
     // element should be properly nested with arcsize/styles/fillcolor set
     verify(
-      $DOM('tr > td > div > table > tr > td > a.mailpoet_button', 0)->html()
+      $DOM('tr > td > div > table > tr > td > table > tr > td > a.mailpoet_button', 0)->html()
     )->notEmpty();
     verify(
       preg_match(
@@ -541,7 +541,7 @@ class RendererTest extends \MailPoetTest {
     $template = $newsletter['content']['blocks'][0]['blocks'][0]['blocks'][5];
     $template['styles']['block']['fontFamily'] = 'Lucida';
     $DOM = $this->dOMParser->parseStr((new Button)->render($template, self::COLUMN_BASE_WIDTH));
-    $style = $DOM('a.mailpoet_button', 0)->attr('style');
+    $style = $DOM('td.mailpoet_table_button', 0)->attr('style');
     verify($style)->stringContainsString('font-family: \'Lucida Sans Unicode\', \'Lucida Grande\', sans-serif');
   }
 
@@ -672,7 +672,7 @@ class RendererTest extends \MailPoetTest {
     verify(preg_match('/link%20with%20space.jpg/s', $template['html']))->equals(0);
 
     // non mso condition for button is rendered correctly
-    verify(preg_match('/<\!--\[if \!mso\]><\!-- -->\s+<a class=\"mailpoet\_button\".+<\/a>\s+<\!--<\!\[endif\]-->/s', $template['html']))->equals(1);
+    verify(preg_match('/<\!--\[if \!mso\]><\!-- -->\s*<table.*<td class=\"mailpoet\_table\_button\".+<\/td>.*<\/table>\s*<\!--<\!\[endif\]-->/s', $template['html']))->equals(1);
   }
 
   // Test case for MAILPOET-3660

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -318,7 +318,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $confirmationNewsletter = $confirmationEmailCustomizer->getNewsletter();
     verify($confirmationNewsletter->getId())->equals($newsletter->getId());
     $confirmationMailBody = $sender->getMailBodyWithCustomizer($this->subscriber, ['test_segment']);
-    verify($confirmationMailBody['body']['html'])->stringContainsString('<a class="mailpoet_button" href="https://example.com"');
+    verify($confirmationMailBody['body']['html'])->stringMatchesRegExp('/<a class="mailpoet_button" .* href="https:\/\/example\.com".*>Click here to confirm your subscription<\/a>/');
 
 
     // See MAILPOET-5253
@@ -354,7 +354,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $confirmationNewsletter = $confirmationEmailCustomizer->getNewsletter();
     verify($confirmationNewsletter->getId())->equals($newsletter->getId());
     $confirmationMailBody = $sender->getMailBodyWithCustomizer($this->subscriber, ['test_segment']);
-    verify($confirmationMailBody['body']['html'])->stringContainsString('<a class="mailpoet_button" href="https://example.com"');
+    verify($confirmationMailBody['body']['html'])->stringMatchesRegExp('/<a class="mailpoet_button" .* href="https:\/\/example\.com".*>Click here to confirm your subscription<\/a>/');
 
   }
 }

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
@@ -58,8 +58,8 @@ class ButtonTest extends \MailPoetUnitTest {
                     cellspacing="0"
                     cellpadding="0"
                     role="presentation"
-                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:156px"
-                    width="156px"
+                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:180px"
+                    width="180px"
                   >
                     <tr>
                       <td class="mailpoet_table_button"

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
@@ -53,7 +53,29 @@ class ButtonTest extends \MailPoetUnitTest {
                   </v:roundrect>
                   <![endif]-->
                   <!--[if !mso]><!-- -->
-                  <a class="mailpoet_button" href="https://example.com" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color: #252525;border-color: #363636;border-width: 2px;border-radius: 5px;border-style: solid;width: 156px;line-height: 40px;color: #ffffff;font-family: \'source sans pro\', \'helvetica neue\', helvetica, arial, sans-serif;font-size: 14px;font-weight: bold;"> Button</a>
+                  <table
+                    border="0"
+                    cellspacing="0"
+                    cellpadding="0"
+                    role="presentation"
+                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:156px"
+                    width="156px"
+                  >
+                    <tr>
+                      <td class="mailpoet_table_button"
+                        valign="middle"
+                        role="presentation"
+                        style="mso-table-lspace: 0;mso-table-rspace: 0;display:block;text-decoration:none;text-align:center;background-color: #252525;border-color: #363636;border-width: 2px;border-radius: 5px;border-style: solid;width: 156px;line-height: 40px;color: #ffffff;font-family: \'source sans pro\', \'helvetica neue\', helvetica, arial, sans-serif;font-size: 14px;font-weight: bold;"
+                      >
+                        <a class="mailpoet_button" style="
+                          text-decoration: none;
+                          display: block;
+                          line-height: 40px;
+                          color: #ffffff;
+                        " href="https://example.com" target="_blank">Button</a>
+                      </td>
+                    </tr>
+                  </table>
                   <!--<![endif]-->
                 </td>
               </tr>

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/ButtonTest.php
@@ -58,8 +58,8 @@ class ButtonTest extends \MailPoetUnitTest {
                     cellspacing="0"
                     cellpadding="0"
                     role="presentation"
-                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:180px"
-                    width="180px"
+                    style="display:inline-block;border-collapse:separate;mso-table-lspace:0;mso-table-rspace:0;width:160px"
+                    width="160px"
                   >
                     <tr>
                       <td class="mailpoet_table_button"


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

The new email editor inspired the solution, where the buttons are compatible with the new Outlook. I kept the conditional rendering because I didn't want to break the old Outlooks.

## QA notes

Test the old email editor buttons across supported email clients.
You can use Email on Acid for this purpose.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5732]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5732]: https://mailpoet.atlassian.net/browse/MAILPOET-5732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ