### PR TITLE
Fix empty else branch failure [MAILPOET-6154]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/index.tsx
@@ -29,6 +29,20 @@ export function Tabs(): JSX.Element {
       className: 'mailpoet-analytics-tab-flow',
       title: __('Automation flow', 'mailpoet'),
     },
+    {
+      name: 'automation-subscribers',
+      className: classNames(
+        'mailpoet-analytics-tab-subscribers',
+        !MailPoet.capabilities.detailedAnalytics.isRestricted
+          ? 'is-unlocked'
+          : '',
+      ),
+      title: (
+        <>
+          {__('Subscribers', 'mailpoet')} <Icon icon={lockSmall} />
+        </>
+      ) as unknown as string,
+    },
   ];
   if (hasEmails) {
     tabs.push({
@@ -54,20 +68,6 @@ export function Tabs(): JSX.Element {
         ) as unknown as string,
       });
     }
-    tabs.push({
-      name: 'automation-subscribers',
-      className: classNames(
-        'mailpoet-analytics-tab-subscribers',
-        !MailPoet.capabilities.detailedAnalytics.isRestricted
-          ? 'is-unlocked'
-          : '',
-      ),
-      title: (
-        <>
-          {__('Subscribers', 'mailpoet')} <Icon icon={lockSmall} />
-        </>
-      ) as unknown as string,
-    });
   }
 
   const updateUrlSearchString = useCallback(

--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -150,6 +150,13 @@ class StepHandler {
     $step->validate($validationArgs);
     $step->run($args, $this->stepRunControllerFactory->createController($args));
 
+    // check if run is not completed by now (e.g., one of if/else branches is empty)
+    $automationRun = $this->automationRunStorage->getAutomationRun($runId);
+    if ($automationRun && $automationRun->getStatus() !== AutomationRun::STATUS_RUNNING) {
+      $logger->logSuccess();
+      return;
+    }
+
     // schedule next step if not scheduled by action
     if (!$this->stepScheduler->hasScheduledStep($args)) {
       $this->stepScheduler->scheduleNextStep($args);

--- a/mailpoet/lib/Migrations/Db/Migration_20240725_182318_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20240725_182318_Db.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20240725_182318_Db extends DbMigration {
+  public function run(): void {
+    global $wpdb;
+    $automationRunsTable = esc_sql($wpdb->prefix . 'mailpoet_automation_runs');
+    $automationRunLogsTable = esc_sql($wpdb->prefix . 'mailpoet_automation_run_logs');
+
+    if (!$this->tableExists($automationRunsTable) || !$this->tableExists($automationRunLogsTable)) {
+      return;
+    }
+
+    // update failed automation runs that should be complete, but keep updated_at column unchanged
+    $this->connection->executeStatement(
+      "UPDATE $automationRunsTable
+      SET
+        `status` = 'complete',
+        `updated_at` = `updated_at`
+      WHERE id IN (
+        SELECT `automation_run_id`
+        FROM $automationRunLogsTable
+        WHERE `status` = 'failed'
+          AND `error` LIKE '%nextStepNotScheduled%'
+          AND `step_key` = 'core:if-else'
+      )"
+    );
+
+    // update failed automation run logs that should be complete, but keep updated_at column unchanged
+    $this->connection->executeStatement(
+      "UPDATE $automationRunLogsTable
+      SET
+        `status` = 'complete',
+        `error` = NULL,
+        `updated_at` = `updated_at`
+      WHERE `status` = 'failed'
+        AND `error` LIKE '%nextStepNotScheduled%'
+        AND `step_key` = 'core:if-else'"
+    );
+  }
+}


### PR DESCRIPTION
## Description

If one of the if/else branches is empty, the automation will result in a failed state. While the `StepScheduler` correctly [completes the automation run](https://github.com/mailpoet/mailpoet/blob/dec9a02ca48e4b9209b969b81aceffb994729610/mailpoet/lib/Automation/Engine/Control/StepScheduler.php#L59), `StepHandler` [will try to schedule next step](https://github.com/mailpoet/mailpoet/blob/dec9a02ca48e4b9209b969b81aceffb994729610/mailpoet/lib/Automation/Engine/Control/StepHandler.php#L154), which will fail, because if/else action has two next steps.

This PR fixes it by checking if the automation run isn't completed between running the step, and scheduling the next one. 

In addition, while implementing I realized we don't show  the `Subscribers` tab in Analytics, even though there is no technical or product reason for it (surfaced also in p1721676078611049-slack-C0313447YBC), so this PR also adds the tab to be always visible (I used it for debugging in automations without `Send email` step).

## Code review notes

_N/A_

## QA notes

To test:
1. Create automation with if/else step, but don't add any more steps below (can be as simple as tag added trigger + if/else action). 
2. Run the automation with a subscriber.
3. On Analytics > Subscribers, observe that the subscriber status is `completed` as well as the if/else step status is completed. 

In this screenshot, the first three rows are before this PR (wrong status), the other three are after this PR (correct status). 
<img width="1545" alt="Screenshot 2024-07-23 at 17 16 19" src="https://github.com/user-attachments/assets/67529e9b-d0b3-44b0-aadd-14e470cca68a">

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6154]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-6154]: https://mailpoet.atlassian.net/browse/MAILPOET-6154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ