### PR TITLE
Fix deprecation warning from interact.js [MAILPOET-6151]

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
@@ -40,13 +40,11 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
     // Give instances more control over whether Draggable should be applied
     if (!this.options.testAttachToInstance(this.view.model, this.view)) return;
 
-    interactable = interact(this.$el.get(0), {
-      ignoreFrom: this.options.ignoreSelector,
-    })
+    interactable = interact(this.$el.get(0))
       .draggable({
+        ignoreFrom: this.options.ignoreSelector,
         // allow dragging of multiple elements at the same time
         max: Infinity,
-
         // Scroll when dragging near edges of a window
         autoScroll: true,
 


### PR DESCRIPTION
## Description

Also present in the production build, interact.js shows a deprecation warning in the console when in the email editor. 

> Interactable.ignoreFrom() has been deprecated. Use Interactble.draggable({ignoreFrom: newValue}).

## Code review notes

_N/A_

## QA notes

QA can be skipped (I tested that the `ignoreFrom` is honored) 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6151]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6151]: https://mailpoet.atlassian.net/browse/MAILPOET-6151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ