### PR TITLE
Fix automation action selector popup on small devices [MAILPOET-5184]

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_automation.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_automation.scss
@@ -9,6 +9,11 @@
 
 .mailpoet-automation-editor-automation-wrapper {
   padding: 0 20px 50px;
+
+  // Fix for action selector popup on small devices
+  .components-popover__content {
+    min-width: 280px;
+  }
 }
 
 .mailpoet-automation-editor-automation-flow {

--- a/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
@@ -37,6 +37,7 @@ export function InserterPopover(): JSX.Element | null {
   return (
     <>
       <Popover
+        placement="bottom"
         ref={popoverRef}
         anchorRect={inserterPopover.anchor.getBoundingClientRect()}
         onClose={() => {

--- a/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
@@ -39,7 +39,7 @@ export function InserterPopover(): JSX.Element | null {
       <Popover
         placement="bottom"
         ref={popoverRef}
-        anchorRect={inserterPopover.anchor.getBoundingClientRect()}
+        anchor={inserterPopover.anchor}
         onClose={() => {
           if (!showModal) {
             void setInserterPopover(undefined);


### PR DESCRIPTION
## Description

Add a `min-width` for automation action selector popup, otherwise it will be too narrow due to `width: min-content` property. 

## Code review notes

_N/A_

## QA notes

QA can be skipped. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5184]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5184]: https://mailpoet.atlassian.net/browse/MAILPOET-5184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ