### PR TITLE
Fix SendEmailAction's check to support multiple emails per subscriber [MAILPOET-6155]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -157,10 +157,11 @@ class SendEmailAction implements Action {
   public function run(StepRunArgs $args, StepRunController $controller): void {
     $newsletter = $this->getEmailForStep($args->getStep());
     $subscriber = $this->getSubscriber($args);
+    $runId = $args->getAutomationRun()->getId();
 
     // sync sending status with the automation step
     if (!$args->isFirstRun()) {
-      $this->checkSendingStatus($newsletter, $subscriber);
+      $this->checkSendingStatus($newsletter, $subscriber, $runId);
       return;
     }
 
@@ -210,8 +211,8 @@ class SendEmailAction implements Action {
     $this->automationController->enqueueProgress($runId, $stepId);
   }
 
-  private function checkSendingStatus(NewsletterEntity $newsletter, SubscriberEntity $subscriber): void {
-    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($newsletter, $subscriber);
+  private function checkSendingStatus(NewsletterEntity $newsletter, SubscriberEntity $subscriber, int $runId): void {
+    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($newsletter, $subscriber, $runId);
     if (!$scheduledTaskSubscriber) {
       throw InvalidStateException::create()->withMessage('Email failed to schedule.');
     }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -6,6 +6,7 @@ use MailPoet\AutomaticEmails\WooCommerce\Events\AbandonedCart;
 use MailPoet\Automation\Engine\Control\AutomationController;
 use MailPoet\Automation\Engine\Control\StepRunController;
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\StepValidationArgs;
@@ -157,11 +158,11 @@ class SendEmailAction implements Action {
   public function run(StepRunArgs $args, StepRunController $controller): void {
     $newsletter = $this->getEmailForStep($args->getStep());
     $subscriber = $this->getSubscriber($args);
-    $runId = $args->getAutomationRun()->getId();
+    $run = $args->getAutomationRun();
 
     // sync sending status with the automation step
     if (!$args->isFirstRun()) {
-      $this->checkSendingStatus($newsletter, $subscriber, $runId);
+      $this->checkSendingStatus($newsletter, $subscriber, $run);
       return;
     }
 
@@ -211,8 +212,8 @@ class SendEmailAction implements Action {
     $this->automationController->enqueueProgress($runId, $stepId);
   }
 
-  private function checkSendingStatus(NewsletterEntity $newsletter, SubscriberEntity $subscriber, int $runId): void {
-    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($newsletter, $subscriber, $runId);
+  private function checkSendingStatus(NewsletterEntity $newsletter, SubscriberEntity $subscriber, AutomationRun $run): void {
+    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($newsletter, $subscriber, $run);
     if (!$scheduledTaskSubscriber) {
       throw InvalidStateException::create()->withMessage('Email failed to schedule.');
     }

--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -76,8 +76,11 @@ class AutomationEmailScheduler {
       ->andWhere('st.createdAt >= :runCreatedAt')
       ->setParameter('newsletter', $email)
       ->setParameter('subscriber', $subscriber)
-      // Subtract one second to prevent rounding issue as $run->getCreatedAt() may contain milliseconds
-      ->setParameter('runCreatedAt', $run->getCreatedAt()->modify('-1 second'))
+      // Automation Run is fetched via WPDB and it ignores the gmt_offset. This query is processed via Doctrine.
+      // Doctrine uses PDO connection and uses offset. So the run's created_at is expected to be provided with the offset.
+      // By removing one day we make sure the offset is not a problem. It makes no harm as this is only performance optimization.
+      // After we switch to WPDB we could remove this modification and use the exact created_at.
+      ->setParameter('runCreatedAt', $run->getCreatedAt()->modify('-1 day'))
       ->getQuery()
       ->getResult();
     $result = null;

--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -76,7 +76,8 @@ class AutomationEmailScheduler {
       ->andWhere('st.createdAt >= :runCreatedAt')
       ->setParameter('newsletter', $email)
       ->setParameter('subscriber', $subscriber)
-      ->setParameter('runCreatedAt', $run->getCreatedAt())
+      // Subtract one second to prevent rounding issue as $run->getCreatedAt() may contain milliseconds
+      ->setParameter('runCreatedAt', $run->getCreatedAt()->modify('-1 second'))
       ->getQuery()
       ->getResult();
     $result = null;

--- a/mailpoet/tests/DataFactories/AutomationRun.php
+++ b/mailpoet/tests/DataFactories/AutomationRun.php
@@ -3,19 +3,20 @@
 namespace MailPoet\Test\DataFactories;
 
 use DateTimeImmutable;
-use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Automation as AutomationEntity;
 use MailPoet\Automation\Engine\Data\AutomationRun as Entity;
 use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\InvalidStateException;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 
 class AutomationRun {
   /** @var ?Entity */
   private $automationRun = null;
 
-  /** @var Automation  */
-  private $automation;
+  /** @var AutomationEntity | null  */
+  private $automation = null;
 
   /** @var array Subject[] */
   private $subjects = [];
@@ -41,7 +42,7 @@ class AutomationRun {
     $this->storage = ContainerWrapper::getInstance(WP_DEBUG)->get(AutomationRunStorage::class);
   }
 
-  public function withAutomation(Automation $automation): self {
+  public function withAutomation(AutomationEntity $automation): self {
     $this->automation = $automation;
     return $this;
   }
@@ -84,10 +85,11 @@ class AutomationRun {
 
   public function create(): Entity {
     $now = new DateTimeImmutable();
+    $automation = $this->automation ?? (new AutomationFactory())->create();
     $automationRun = Entity::fromArray([
       'id' => 0,
-      'automation_id' => $this->automation->getId(),
-      'version_id' => $this->automation->getVersionId(),
+      'automation_id' => $automation->getId(),
+      'version_id' => $automation->getVersionId(),
       'trigger_key' => $this->triggerKey,
       'status' => $this->status,
       'created_at' => ($this->createdAt ?? $now)->format(DateTimeImmutable::W3C),

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -174,6 +174,7 @@ class SendEmailActionTest extends \MailPoetTest {
 
     // create scheduled task & subscriber
     $scheduledTask = (new ScheduledTask())->create('sending', ScheduledTaskEntity::STATUS_SCHEDULED);
+    $scheduledTask->setMeta(['automation' => ['run_id' => $run->getId(), 'step_id' => $step->getId(), 'run_number' => 1]]);
     (new SendingQueue())->create($scheduledTask, $email);
     $scheduledTaskSubscriber = (new ScheduledTaskSubscriber())->createFailed($scheduledTask, $subscriber, 'Test error');
 

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomationEmailSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomationEmailSchedulerTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Scheduler;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\Subscriber;
+
+class AutomationEmailSchedulerTest extends \MailPoetTest {
+
+  /** @var AutomationEmailScheduler */
+  private $automationEmailScheduler;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  public function _before() {
+    parent::_before();
+    $this->automationEmailScheduler = $this->diContainer->get(AutomationEmailScheduler::class);
+    $this->newsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)->create();
+    $this->subscriber = (new Subscriber())->create();
+  }
+
+  public function testGetScheduledTaskSubscriberReturnsNullWhenNonExists() {
+    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($this->newsletter, $this->subscriber, 1);
+    verify($scheduledTaskSubscriber)->null();
+  }
+
+  public function testGetScheduledTaskSubscriberReturnsNullForUnknownRunId() {
+    $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, []);
+    $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta(1));
+
+    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($this->newsletter, $this->subscriber, 2);
+    verify($scheduledTaskSubscriber)->null();
+  }
+
+  public function testGetScheduledTaskSubscriberReturnsProperEntityForRun() {
+    $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, []);
+    $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta(1));
+    $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta(2));
+    $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta(3));
+
+    $scheduledTaskSubscriber = $this->automationEmailScheduler->getScheduledTaskSubscriber($this->newsletter, $this->subscriber, 1);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $scheduledTaskSubscriber);
+    $task = $scheduledTaskSubscriber->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $meta = $task->getMeta();
+    verify($meta['automation']['run_id'] ?? null)->equals(1);
+  }
+
+  private function getMeta(int $runId) {
+    return ['automation' => ['run_id' => $runId]];
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Scheduler/AutomationEmailSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/AutomationEmailSchedulerTest.php
@@ -43,8 +43,8 @@ class AutomationEmailSchedulerTest extends \MailPoetTest {
     verify($scheduledTaskSubscriber)->null();
   }
 
-  public function testGetScheduledTaskSubscriberOnlyFetchesScheduledTasksCreatedAfterRun() {
-    $run1 = (new AutomationRun())->withCreatedAt(new \DateTimeImmutable('now + 1 hour'))->create();
+  public function testGetScheduledTaskSubscriberOnlyIgnoresScheduledTasksCreatedLongTimeBeforeRun() {
+    $run1 = (new AutomationRun())->withCreatedAt(new \DateTimeImmutable('now + 2 days'))->create();
     $run2 = (new AutomationRun())->withCreatedAt(new \DateTimeImmutable('now - 1 hour'))->create();
     $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta($run1->getId()));
     $this->automationEmailScheduler->createSendingTask($this->newsletter, $this->subscriber, $this->getMeta($run2->getId()));


### PR DESCRIPTION
## Description

It is possible that one email (e.g., purchase in category) is sent multiple times to the same subscriber. Due to an issue in a query that checks the status of sending, some sent email actions were marked as failed even though the email was successfully sent.

This PR fixes the query that was causing the issue.

## Code review notes

AutomationEmailScheduler::getScheduledTaskSubscriber was selecting the task based on subscriber and newsletter. In the case of multiple emails sent to one subscriber, the method failed to pick ScheduledTaskSubsrciberEntity because the query was fetching multiple results, but getOneOrNullResult expects only one result.

This commit fixes it by adding additional filtering by $runId to get the ScheduledTaskSubsriberEntity associated with the correct run.

I did the filtering in PHP because an alternative would be using LIKE %% in the query. The meta column is text. 

## QA notes

#### Steps to replication:

1. Create an automation for example Purchased in a category
3. Make sure that option Run this automation only once per subscriber is disabled (It should be by default)
5. Purchase a product from the category with the same subscriber at least twice
7. Make order as complete
9. Observe the issue on the automation analytics → tab Subscribers

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6155]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6155]: https://mailpoet.atlassian.net/browse/MAILPOET-6155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ