### PR TITLE
Add Update Subscrber method to MP API [MAILPOET-6168]

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -27,6 +27,7 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 
 - [Add List (addList)](api_methods/AddList.md)
 - [Add Subscriber (addSubscriber)](api_methods/AddSubscriber.md)
+- [Update Subscriber (updateSubscriber)](api_methods/UpdateSubscriber.md)
 - [Add Subscriber Field (addSubscriberField)](api_methods/AddSubscriberField.md)
 - [Delete List (deleteList)](api_methods/DeleteList.md)
 - [Get Lists (getLists)](api_methods/GetLists.md)

--- a/doc/api_methods/UpdateSubscriber.md
+++ b/doc/api_methods/UpdateSubscriber.md
@@ -1,0 +1,31 @@
+[back to list](../Readme.md)
+
+# Update Subscriber
+
+## `array updateSubscriber($subscriberIdOrEmail, array $subscriber): array`
+
+This method allows a subscriber to be updated.
+The argument `$subscriber` is similar to [Add Subscriber](AddSubscriber.md) method, but the subscriber is updated instead of created.
+
+It returns the updated subscriber. See [Get Subscriber](GetSubscriber.md) for a subscriber data structure.
+
+## Arguments
+
+| Argument             | Type          | Description                               |
+| -------------------- | ------------- | ----------------------------------------- |
+| $subscriberIdOrEmail | string or int | An id or email of an existing subscriber. |
+| $subscriber          | array         | Subscriber data that will be updated      |
+
+## Error handling
+
+All expected errors from the API are exceptions of class `\MailPoet\API\MP\v1\APIException`.
+Code of the exception is populated to distinguish between different errors.
+
+An exception of base class `\Exception` can be thrown when something unexpected happens.
+
+Codes description:
+
+| Code | Description                                        |
+| ---- | -------------------------------------------------- |
+| 4    | Updating a subscriber that does not exist.         |
+| 13   | The subscriber couldn’t be updated in the database |

--- a/doc/api_methods/UpdateSubscriber.md
+++ b/doc/api_methods/UpdateSubscriber.md
@@ -9,6 +9,8 @@ The argument `$subscriber` is similar to [Add Subscriber](AddSubscriber.md) meth
 
 It returns the updated subscriber. See [Get Subscriber](GetSubscriber.md) for a subscriber data structure.
 
+If the subscriber is a WordPress user, the method does not allow updating `email`, `first_name` and `last_name`. It needs to be updated in the `wp_users` and MailPoet will synchronise the new values.
+
 ## Arguments
 
 | Argument             | Type          | Description                               |

--- a/mailpoet/lib/API/MP/v1/API.php
+++ b/mailpoet/lib/API/MP/v1/API.php
@@ -80,6 +80,10 @@ class API {
     return $this->subscribers->addSubscriber($subscriber, $listIds, $options);
   }
 
+  public function updateSubscriber($subscriberIdOrEmail, array $subscriber): array {
+    return $this->subscribers->updateSubscriber($subscriberIdOrEmail, $subscriber);
+  }
+
   public function addList(array $list) {
     return $this->segments->addList($list);
   }

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -177,6 +177,12 @@ class Subscribers {
     // filter out all incoming data that we don't want to change, like status ...
     $defaultFields = array_intersect_key($defaultFields, array_flip(['email', 'first_name', 'last_name', 'subscribed_ip']));
 
+    if ($subscriber->getWpUserId() !== null) {
+      unset($defaultFields['email']);
+      unset($defaultFields['first_name']);
+      unset($defaultFields['last_name']);
+    };
+
     if (empty($defaultFields['subscribed_ip'])) {
       $defaultFields['subscribed_ip'] = Helpers::getIP();
     }
@@ -201,7 +207,7 @@ class Subscribers {
         APIException::FAILED_TO_SAVE_SUBSCRIBER
       );
     }
-    
+
     return $this->subscribersResponseBuilder->build($subscriberEntity);
   }
 

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -810,6 +810,16 @@ class SubscribersTest extends \MailPoetTest {
     $this->assertEquals('new value', $result['cf_' . $customField->getId()]);
   }
 
+  public function testUpdateSubscriberFailsForNonExisting() {
+    $this->expectException(APIException::class);
+    $this->expectExceptionMessage('This subscriber does not exist.');
+    
+    $this->getApi()->updateSubscriber('non existing', [
+      'email' => 'newemail@example.com',
+      'first_name' => 'New Name',
+    ]);
+  }
+
   public function testItGetsSubscriber() {
     $subscriber = $this->subscriberFactory->create();
     $segment = $this->getSegment();

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -810,10 +810,24 @@ class SubscribersTest extends \MailPoetTest {
     $this->assertEquals('new value', $result['cf_' . $customField->getId()]);
   }
 
+  public function testUpdateSubscriberWordPressUser() {
+    $subscriber = $this->subscriberFactory->create();
+    $subscriber->setWpUserId(4);
+    $this->entityManager->flush();
+
+    $result = $this->getApi()->updateSubscriber($subscriber->getId(), [
+      'email' => 'newemail@example.com',
+      'first_name' => 'New Name',
+    ]);
+
+    $this->assertEquals($subscriber->getEmail(), $result['email']);
+    $this->assertEquals($subscriber->getFirstName(), $result['first_name']);
+  }
+
   public function testUpdateSubscriberFailsForNonExisting() {
     $this->expectException(APIException::class);
     $this->expectExceptionMessage('This subscriber does not exist.');
-    
+
     $this->getApi()->updateSubscriber('non existing', [
       'email' => 'newemail@example.com',
       'first_name' => 'New Name',


### PR DESCRIPTION
## Description

Some of the [3rd party plugins](https://github.com/verygoodplugins/wp-fusion-lite/issues/36) need to update subscriber values. To help them remove the old models and prevent the websites that are using both plugins from working, we need to support the new API method for updating subscribers. 

## Code review notes

_N/A_

## QA notes

I don't think QA is needed here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6168]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6168]: https://mailpoet.atlassian.net/browse/MAILPOET-6168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ