### PR TITLE
Revert "Keep text in square brackets in post notifications" [MAILPOET-6170]

### DIFF
--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -132,7 +132,7 @@ class PostContentManager {
     );
 
     // remove other shortcodes
-    $content = $this->wp->stripShortcodes($content);
+    $content = preg_replace('/\[[^\[\]]*\]/', '', $content);
 
     return $content;
   }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -498,10 +498,6 @@ class Functions {
     status_header($code, $description);
   }
 
-  public function stripShortcodes($value) {
-    return strip_shortcodes($value);
-  }
-
   public function stripslashesDeep($value) {
     return stripslashes_deep($value);
   }

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentManagerTest.php
@@ -157,41 +157,23 @@ class PostContentManagerTest extends \MailPoetTest {
   }
 
   public function testItStripsShortcodesWhenGettingPostContent() {
-    // registered shortcodes are stripped in excerpt
+    // shortcodes are stripped in excerpt
     $post = (object)[
-      'post_excerpt' => 'Test [embed]some text in excerpt[/embed]text',
+      'post_excerpt' => '[shortcode]some text in excerpt[/shortcode]',
     ];
-    verify($this->postContent->getContent($post, 'excerpt'))->equals('Test text');
+    verify($this->postContent->getContent($post, 'excerpt'))->equals('some text in excerpt');
 
-    // registered shortcodes are stripped in post content when excerpt doesn't exist
+    // shortcodes are stripped in post content when excerpt doesn't exist
     $post = (object)[
-      'post_content' => 'Test [embed]some text in content[/embed]text',
+      'post_content' => '[shortcode]some text in content[/shortcode]',
     ];
-    verify($this->postContent->getContent($post, 'excerpt'))->equals('Test text');
+    verify($this->postContent->getContent($post, 'excerpt'))->equals('some text in content');
 
-    // registered shortcodes are stripped in post content
+    // shortcodes are stripped in post content
     $post = (object)[
-      'post_content' => 'Test [embed]some text in content[/embed]text',
+      'post_content' => '[shortcode]some text in content[/shortcode]',
     ];
-    verify($this->postContent->getContent($post, ''))->equals('Test text');
-
-    // unregistered shortcodes are kept in excerpt
-    $post = (object)[
-      'post_excerpt' => 'Test [shortcode]some text in excerpt[/shortcode]text',
-    ];
-    verify($this->postContent->getContent($post, 'excerpt'))->equals($post->post_excerpt); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-
-    // unregistered shortcodes are kept in post content when excerpt doesn't exist
-    $post = (object)[
-      'post_content' => 'Test [shortcode]some text in content[/shortcode]text',
-    ];
-    verify($this->postContent->getContent($post, 'excerpt'))->equals($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-
-    // unregistered shortcodes are kept in post content
-    $post = (object)[
-      'post_content' => 'Test [shortcode]some text in content[/shortcode]text',
-    ];
-    verify($this->postContent->getContent($post, ''))->equals($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify($this->postContent->getContent($post, ''))->equals('some text in content');
   }
 
   public function testItRemovesImageCaptionsFromClassicEditorPosts() {


### PR DESCRIPTION
## Description

This reverts commit 14be775e7474d04d26d7791791a96e2e6e9a4c8d.

## Code review notes

_N/A_

## QA notes

Test that all shortcode-like text is stripped from post contents in post notifications.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6170]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6170]: https://mailpoet.atlassian.net/browse/MAILPOET-6170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ