### PR TITLE
Improve check versions job [MAILPOET-6171]

### DIFF
--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -155,6 +155,13 @@ jobs:
           git commit -m $'Update used WooCommerce Memberships plugin in Circle CI\n\n - latest version: ${{ env.WOOCOMMERCE_MEMBERSHIPS_LATEST_VERSION }}\n - previous version: ${{ env.WOOCOMMERCE_MEMBERSHIPS_PREVIOUS_VERSION }}'
 
       # Push all changes at the end if any changes were detected
+      #
+      # For local testing with act tool add following:
+      # env:
+      #   GH_PAT: ${{ secrets.GH_TOKEN }}
+      # run: |
+      #   git remote set-url origin https://${GH_PAT}@github.com/mailpoet/mailpoet
+      #   git push -f origin HEAD:refs/heads/update-plugins-and-wordpress-test
       - name: Push changes
         if: env.CHANGES_DETECTED == 'true'
         run: |

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Push changes
         if: env.CHANGES_DETECTED == 'true'
         run: |
-          git push origin HEAD:refs/heads/update-plugins-and-wordpress
+          git push -f origin HEAD:refs/heads/update-plugins-and-wordpress
 
       # Create a pull request if there are changes
       - name: Create Pull Request

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -167,5 +167,9 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           branch: update-plugins-and-wordpress
-          title: 'Update used WordPress Docker image and used plugin versions in Circle CI jobs'
+          title: Update WordPress and plugins in CI jobs
           base: trunk
+          labels: automated
+          body: |
+            1. If all checks passed, you can merge this PR.
+            2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -176,7 +176,7 @@ jobs:
           branch: update-plugins-and-wordpress
           title: Update WordPress and plugins in CI jobs
           base: trunk
-          labels: automated
+          labels: automated, check-versions
           body: |
             1. If all checks passed, you can merge this PR.
             2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.


### PR DESCRIPTION
## Description

This PR improves action that creates PRs for updating WP Images and plugin versions in tests.

### Changes

1. Simpler PR title
2. Added description with instructions for Porter
3. Add labels to the PR
4. Prevent failures if PR exists, but update it instead

## Code review notes

For updating existing PR, I chose to use force push. Alternatively, we could pull the existing branch and run all updates on to of the branch. Force push was a much simpler change. 

Here is a PR I created when testing the change with act  https://github.com/mailpoet/mailpoet/pull/5761
Note I added the label `check-versions` after the test so it is not present in the PR and I added some texts to mark the PR as testing.

## QA notes

Can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6171]

## After-merge notes

Ping @costasovo to update previous PRs created by the action and add labels `automated` and `check-versions`. Or update them yourself. [Search for Update used WordPress Docker](https://github.com/mailpoet/mailpoet/pulls?q=is%3Apr+Update+used+WordPress+Docker+image++).

## Tasks

- [ ] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6171]: https://mailpoet.atlassian.net/browse/MAILPOET-6171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ