### PR TITLE
Add commands deleting and verifying release zip [MAILPOET-5678]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1315,6 +1315,12 @@ class RoboFile extends \Robo\Tasks {
     $this->say(sprintf('Release ZIP file size: %.2F MB', filesize($path) / pow(1024, 2)));
   }
 
+  public function releaseDeleteDownloadedZip() {
+    $this->say('Delete downloaded ZIP: ' . self::ZIP_BUILD_PATH);
+    $this->taskExec('rm -f ' . self::ZIP_BUILD_PATH)->run();
+    $this->say('ZIP file was deleted');
+  }
+
   public function releasePublishGithub($version = null) {
     $jiraController = $this->createJiraController();
     $version = $jiraController->getVersion($version);

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1308,6 +1308,29 @@ class RoboFile extends \Robo\Tasks {
     $this->say("IMPORTANT NOTES \n" . ($outputs[2] ?: 'none'));
   }
 
+  public function releaseVerifyDownloadedZip($version) {
+    $this->say('Verifying ZIP file');
+    $zip = new ZipArchive();
+
+    $versionFound = false;
+    if ($zip->open(self::ZIP_BUILD_PATH) === true) {
+      $fileContent = $zip->getFromName('mailpoet/readme.txt');
+      if ($fileContent !== false) {
+        $versionFound = strpos($fileContent, 'Stable tag: ' . $version);
+      }
+      $zip->close();
+    } else {
+      $this->yell('ZIP file could not be opened!', 40, 'red');
+      exit(1);
+    }
+
+    if (!$versionFound) {
+      $this->yell('ZIP file does not contain required version: "' . $version . '" in readme.txt! ', 40, 'red');
+      exit(1);
+    }
+    $this->say('ZIP file contains required version: "' . $version . '" in readme.txt.');
+  }
+
   public function releaseDownloadZip() {
     $circleciController = $this->createCircleCiController();
     $path = $circleciController->downloadLatestBuild(self::ZIP_BUILD_PATH);

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1126,6 +1126,9 @@ class RoboFile extends \Robo\Tasks {
       ->addCode(function () {
         return $this->releaseDownloadZip();
       })
+      ->addCode(function () use ($version) {
+        return $this->releaseVerifyDownloadedZip();
+      })
       ->addCode(function () {
         return $this->translationsGetPotFileFromBuild();
       })
@@ -1149,6 +1152,9 @@ class RoboFile extends \Robo\Tasks {
       })
       ->addCode(function () {
         return $this->releaseMergePullRequest(\MailPoetTasks\Release\GitHubController::RELEASE_SOURCE_BRANCH);
+      })
+      ->addCode(function () {
+        return $this->releaseDeleteDownloadedZip();
       })
       ->run();
   }

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1127,7 +1127,7 @@ class RoboFile extends \Robo\Tasks {
         return $this->releaseDownloadZip();
       })
       ->addCode(function () use ($version) {
-        return $this->releaseVerifyDownloadedZip();
+        return $this->releaseVerifyDownloadedZip($version);
       })
       ->addCode(function () {
         return $this->translationsGetPotFileFromBuild();


### PR DESCRIPTION
## Description

This PR adds two new release commands:
- The first deletes the downloaded release zip file
- The second verifies that the zip file contains the required version

Both new commands were added to the release publish command.

## Code review notes

_N/A_

## QA notes

We can skip QA, but I would like to ask the reviewer to test new commands.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/900

## Linked tickets

[MAILPOET-5678]

## After-merge notes

_N/A_

## Tasks

- [ ] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5678]: https://mailpoet.atlassian.net/browse/MAILPOET-5678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ