### PR TITLE
Fix test flakiness based on time of the day [MAILPOET-6172]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send/time-select.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/time-select.jsx
@@ -14,7 +14,7 @@ class TimeSelect extends Component {
       validation = {},
     } = this.props;
     const options = Object.keys(timeOfDayItems).map((val) => (
-      <option key={`option-${timeOfDayItems[value]}`} value={val}>
+      <option key={`option-${timeOfDayItems[val]}`} value={val}>
         {timeOfDayItems[val]}
       </option>
     ));

--- a/mailpoet/prefixer/fix-doctrine.php
+++ b/mailpoet/prefixer/fix-doctrine.php
@@ -66,7 +66,7 @@ exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/Keywords
 exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/OraclePlatform.php');
 exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/PostgreSQL94Platform.php');
 exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/PostgreSQL100Platform.php');
-exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/PostgreSqlPlatform.php');
+exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/PostgreSQLPlatform.php');
 exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/SqlitePlatform.php');
 exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/SQLServer2012Platform.php');
 exec('rm ' . __DIR__ . '/../vendor-prefixed/doctrine/dbal/src/Platforms/SQLServerPlatform.php');

--- a/mailpoet/tasks/code_sniffer/composer.json
+++ b/mailpoet/tasks/code_sniffer/composer.json
@@ -33,7 +33,8 @@
       "sed -i.bak -e \"s/trim( PHPCSHelper::get_config_data( 'text_domain' ) )/PHPCSHelper::get_config_data( 'text_domain' )/\" vendor/wp-coding-standards/wpcs/WordPress/Sniffs/WP/I18nSniff.php; rm -rf  vendor/wp-coding-standards/wpcs/WordPress/Sniffs/WP/I18nSniff.php.bak",
       "sed -i.bak -e \"s/trim( PHPCSHelper::get_config_data( 'prefixes' ) )/PHPCSHelper::get_config_data( 'prefixes' )/\" vendor/wp-coding-standards/wpcs/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php; rm -rf  vendor/wp-coding-standards/wpcs/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php.bak",
       "sed -i.bak -e \"s/trim( PHPCSHelper::get_config_data( 'minimum_supported_wp_version' ) )/PHPCSHelper::get_config_data( 'minimum_supported_wp_version' )/\" vendor/wp-coding-standards/wpcs/WordPress/Sniff.php; rm -rf  vendor/wp-coding-standards/wpcs/WordPress/Sniff.php.bak",
-      "echo '\\033[0;31m We need to remove the trim in the coding standards until v3 of the WordPress coding standards are available.'"
+      "echo '\\033[0;31m We need to remove the trim in the coding standards until v3 of the WordPress coding standards are available.'",
+      "echo '\\033[0m '"
     ]
   }
 }

--- a/mailpoet/tests/acceptance/Newsletters/ReceiveScheduledEmailCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ReceiveScheduledEmailCest.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Test\Acceptance;
 
 use Codeception\Util\Locator;
-use Facebook\WebDriver\Exception\TimeoutException;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -23,9 +22,6 @@ class ReceiveScheduledEmailCest {
   public function receiveScheduledEmail(\AcceptanceTester $i) {
     $i->wantTo('Receive a scheduled standard newsletter as a subscriber');
     $this->settings->withCronTriggerMethod('Action Scheduler');
-    /** @var string $value - for PHPStan because strval() doesn't accept a value of mixed */
-    $value = $i->executeJS('return window.mailpoet_current_date_time');
-    $currentDateTime = new \DateTime(strval($value));
 
     $newsletterTitle = 'Scheduled Test Newsletter';
     $standardTemplate = '[data-automation-id="select_template_0"]';
@@ -53,23 +49,15 @@ class ReceiveScheduledEmailCest {
     $i->waitForElement($sendFormElement);
     $i->selectOptionInSelect2($segmentName);
 
-    $i->wantTo('Schedule newsletter in the past');
+    $i->wantTo('Schedule newsletter at midnight on the 1st of next month');
     $i->click('[data-automation-id="email-schedule-checkbox"]');
     $i->waitForElement('form select[name=time]');
-    $i->selectOption('form select[name=time]', $currentDateTime->modify("+1 hour")->format('g:00 a'));
-
-    $i->wantTo('Pick today‘s date');
+    $i->selectOption('form select[name=time]', '12:00 am');
     $i->waitForElement('form input[name=date]');
     $i->click('form input[name=date]');
-    // The calendar preselects tomorrow's date, making today's date not clickable on the last day of a month.
-    // In case it is not clickable try switching to previous month
-    try {
-      $i->waitForElementClickable(['class' => 'react-datepicker__day--today'], 1);
-    } catch (TimeoutException $e) {
-      $i->click(['class' => 'react-datepicker__navigation--previous']);
-      $i->waitForElementClickable(['class' => 'react-datepicker__day--today']);
-    }
-    $i->click(['class' => "react-datepicker__day--today"]);
+    $i->waitForElement('.react-datepicker');
+    $i->click(['class' => 'react-datepicker__navigation--next']);
+    $i->click(['class' => 'react-datepicker__day--001']);
     $i->click('Schedule');
     $i->waitForText('The newsletter has been scheduled.');
 
@@ -81,7 +69,7 @@ class ReceiveScheduledEmailCest {
     if ($newsletter instanceof NewsletterEntity) {
       $scheduledTask = $scheduledTasksRepository->findOneByNewsletter($newsletter);
       if ($scheduledTask instanceof ScheduledTaskEntity) {
-        $scheduledTask->setScheduledAt($currentDateTime->modify("-2 hour"));
+        $scheduledTask->setScheduledAt((new \DateTime)->modify("-1 day"));
         $scheduledTasksRepository->persist($scheduledTask);
         $scheduledTasksRepository->flush();
       }


### PR DESCRIPTION
## Description

Fix tests that fail when run between 23:00 and midnight (in the timezone of the server they are run on).

## Code review notes

_N/A_

## QA notes

QA can be skipped, as these are fixes in automated tests.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6172]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6172]: https://mailpoet.atlassian.net/browse/MAILPOET-6172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ