### PR TITLE
Minimize the risk of race conditions for "once per subscriber" automations [MAILPOET-6177]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHook.php
@@ -5,23 +5,20 @@ namespace MailPoet\Automation\Integrations\MailPoet\Hooks;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
-use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
 
 class CreateAutomationRunHook {
-
-
-  /** @var WordPress */
-  private $wp;
-
-  private $automationRunStorage;
+  private AutomationRunStorage $automationRunStorage;
+  private WPFunctions $wp;
 
   public function __construct(
-    WordPress $wp,
-    AutomationRunStorage $automationRunStorage
+    AutomationRunStorage $automationRunStorage,
+    WPFunctions $wp
   ) {
-    $this->wp = $wp;
     $this->automationRunStorage = $automationRunStorage;
+    $this->wp = $wp;
   }
 
   public function init(): void {
@@ -39,11 +36,29 @@ class CreateAutomationRunHook {
       return true;
     }
 
-    $subscriberSubject = $args->getAutomationRun()->getSubjects(SubscriberSubject::KEY);
+    $subscriberSubject = array_values($args->getAutomationRun()->getSubjects(SubscriberSubject::KEY))[0] ?? null;
     if (!$subscriberSubject) {
       return true;
     }
 
-    return $this->automationRunStorage->getCountByAutomationAndSubject($automation, current($subscriberSubject)) === 0;
+    // Use locking mechanism to minimize the risk of race conditions.
+    // WP transients don't provide atomic operations, so we can't guarantee
+    // race-condition safety with a 100% certainty, but we can significantly
+    // minimize the risk by generating and re-checking a unique lock value.
+    $key = sprintf('mailpoet:run-once-per-subscriber:[%s][%s]', $automation->getId(), $subscriberSubject->getHash());
+
+    // 1. If lock already exists, do not create automation run.
+    $value = $this->wp->getTransient($key);
+    if ($value) {
+      return false;
+    }
+
+    // 2. If lock does not exist, create it with a unique value.
+    $value = Security::generateRandomString(16);
+    $this->wp->setTransient($key, $value, MINUTE_IN_SECONDS);
+
+    // 3. If no automation run exist, ensure that the lock wasn't updated by another process.
+    $count = $this->automationRunStorage->getCountByAutomationAndSubject($automation, $subscriberSubject);
+    return $count === 0 && $this->wp->getTransient($key) === $value;
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHookTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Hooks/CreateAutomationRunHookTest.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Hooks;
+
+use Codeception\Stub\Expected;
+use DateTimeImmutable;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Data\SubjectEntry;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Integrations\MailPoet\Hooks\CreateAutomationRunHook;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Test\DataFactories;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetTest;
+
+class CreateAutomationRunHookTest extends MailPoetTest {
+  private const TEST_SUBSCRIBER_ID = 123;
+
+  public function testWithoutPreviousRuns(): void {
+    $service = $this->diContainer->get(CreateAutomationRunHook::class);
+
+    // with run once args
+    $args = $this->getStepRunArgs(true);
+    $this->assertFalse($service->createAutomationRun(false, $args));
+    $this->assertTrue($service->createAutomationRun(true, $args));
+
+    // without run once args
+    $args = $this->getStepRunArgs(false);
+    $this->assertFalse($service->createAutomationRun(false, $args));
+    $this->assertTrue($service->createAutomationRun(true, $args));
+  }
+
+  public function testWithPreviousRuns(): void {
+    $service = $this->diContainer->get(CreateAutomationRunHook::class);
+
+    // with run once args
+    $args = $this->getStepRunArgs(true);
+    $this->createAutomationRun($args->getAutomation());
+    $this->assertFalse($service->createAutomationRun(false, $args));
+    $this->assertFalse($service->createAutomationRun(true, $args));
+
+    // without run once args
+    $args = $this->getStepRunArgs(false);
+    $this->createAutomationRun($args->getAutomation());
+    $this->assertFalse($service->createAutomationRun(false, $args));
+    $this->assertTrue($service->createAutomationRun(true, $args));
+  }
+
+  public function testItAcquiresLock(): void {
+    $service = $this->diContainer->get(CreateAutomationRunHook::class);
+
+    $args = $this->getStepRunArgs(true);
+    $this->assertFalse($service->createAutomationRun(false, $args));
+    $this->assertTrue($service->createAutomationRun(true, $args));
+
+    // next run should be blocked by the lock
+    $this->assertFalse($service->createAutomationRun(true, $args));
+
+    // check lock
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $subject = array_values($args->getAutomationRun()->getSubjects(SubscriberSubject::KEY))[0];
+    $key = sprintf('mailpoet:run-once-per-subscriber:[%s][%s]', $args->getAutomation()->getId(), $subject->getHash());
+    $lock = $wp->getTransient($key);
+    $timeout = new DateTimeImmutable('@' . $wp->getOption("_transient_timeout_$key"));
+
+    $this->assertIsString($lock);
+    $this->assertNotEmpty($lock);
+    $this->assertGreaterThan(new DateTimeImmutable('+10 seconds'), $timeout);
+    $this->assertLessThan(new DateTimeImmutable('+2 minutes'), $timeout);
+  }
+
+  public function testItVerifiesLock(): void {
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $args = $this->getStepRunArgs(true);
+    $subject = array_values($args->getAutomationRun()->getSubjects(SubscriberSubject::KEY))[0];
+    $key = sprintf('mailpoet:run-once-per-subscriber:[%s][%s]', $args->getAutomation()->getId(), $subject->getHash());
+
+    $service = $this->getServiceWithOverrides(CreateAutomationRunHook::class, [
+      'automationRunStorage' => $this->make(AutomationRunStorage::class, [
+        'getCountByAutomationAndSubject' => Expected::once(function () use ($wp, $key): int {
+          // simulate that another process caused a locking race condition
+          $wp->setTransient($key, 'lock-value-from-another-process', MINUTE_IN_SECONDS);
+          return 0;
+        }),
+      ]),
+    ]);
+
+    // run will be blocked by the lock due to a lock value mismatch
+    $this->assertFalse($service->createAutomationRun(true, $args));
+  }
+
+  private function getStepRunArgs(bool $runOncePerSubscriber): StepRunArgs {
+    $automation = (new DataFactories\Automation())
+      ->withMeta('mailpoet:run-once-per-subscriber', $runOncePerSubscriber)
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->create();
+
+    $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => self::TEST_SUBSCRIBER_ID]);
+    $automationRun = new AutomationRun($automation->getId(), 1, '', [$subject]);
+
+    $trigger = array_values($automation->getTriggers())[0];
+    $subscriberEntry = new SubjectEntry($this->diContainer->get(SubscriberSubject::class), $subject);
+    return new StepRunArgs($automation, $automationRun, $trigger, [$subscriberEntry], 1);
+  }
+
+  private function createAutomationRun(Automation $automation): AutomationRun {
+    return (new DataFactories\AutomationRun())
+      ->withAutomation($automation)
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => self::TEST_SUBSCRIBER_ID]))
+      ->create();
+  }
+}


### PR DESCRIPTION
## Description

This minimizes the risk of race conditions for "once per subscriber" automations to almost zero. While it's technically not possible to avoid them with 100% certainty using WP transients that don't support atomic operations, the implemented method should avoid them effectively in all realistic use cases.

## Code review notes

Transients are used not only to acquire a lock for a given run ID & subscriber subject combination, but also to check against a unique value to avoid additional race conditions within the transients themselves. Code comments and tests explain more.

## QA notes

Testing the race conditions is hard; a quick test that "run once per subscriber" in automations works well is enough.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6177]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6177]: https://mailpoet.atlassian.net/browse/MAILPOET-6177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ