### PR TITLE
Update acceptance Create an account label

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -588,7 +588,7 @@ class AcceptanceTester extends \Codeception\Actor {
     if (version_compare($wooCommerceVersion, '8.3.0', '>=')) {
       $isCheckboxVisible = $i->executeJS('return document.getElementsByClassName("wc-block-checkout__create-account")');
       if ($isCheckboxVisible) {
-        $i->click(Locator::contains('label', 'Create an account?'));
+        $i->click(Locator::contains('label', 'Create an account'));
       }
     } else {
       $isCheckboxVisible = $i->executeJS('return document.getElementById("createaccount")');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -195,7 +195,7 @@ class WooCheckoutBlocksCest {
       $i->click(Locator::contains('label', $settings->get('woocommerce.optin_on_checkout.message')));
     }
     if ($doRegister) {
-      $i->click(Locator::contains('label', 'Create an account?'));
+      $i->click(Locator::contains('label', 'Create an account'));
     }
     $this->placeOrder($i);
     $i->logOut();


### PR DESCRIPTION
## Description

The label has changed in the new WC version 9.2.
If we update the test to look for `Create an Account` only, it will work with all WooCommerce versions where this label changed from `Create an Account?` to `Create an account with $test_site_name`. Thanks to Codeception for this unified possibility.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6180]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6180]: https://mailpoet.atlassian.net/browse/MAILPOET-6180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ