### PR TITLE
Move tests compilation to the Newsletter test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,7 @@ jobs:
           name: 'JS Newsletter Editor Tests'
           command: |
             mkdir test-results/mocha
+            ./do compile:js --env production --only-tests
             ./do t:newsletter-editor test-results/mocha/newsletter_editor_junit.xml
       - run:
           name: 'JS Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
             ./tools/vendor/composer.phar validate --no-check-all --no-check-publish --working-dir=prefixer
             touch .env
             ./do install
-            ./do compile:all --env production
+            ./do compile:all --env production --skip-tests
             ./do doctrine:generate-cache
             vendor/bin/codecept build
             ./do twig:generate-cache

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -198,15 +198,17 @@ class RoboFile extends \Robo\Tasks {
     return $collection->run();
   }
 
-  public function compileJs($opts = ['env' => null, 'skip-tests' => false]) {
+  public function compileJs($opts = ['env' => null, 'skip-tests' => false, 'only-tests' => false]) {
     if (!is_dir('assets/dist/js')) {
       mkdir('assets/dist/js', 0777, true);
     }
-    $this->_exec('rm -rf ' . __DIR__ . '/assets/dist/js/*');
+    if (!$opts['only-tests']) {
+      $this->_exec('rm -rf ' . __DIR__ . '/assets/dist/js/*');
+    }
     $env = ($opts['env']) ?
       sprintf('./node_modules/.bin/cross-env NODE_ENV="%s"', $opts['env']) :
       null;
-    return $this->_exec($env . ' ./node_modules/webpack/bin/webpack.js --env BUILD_TESTS=' . ($opts['skip-tests'] ? 'skip' : 'build'));
+    return $this->_exec($env . ' ./node_modules/webpack/bin/webpack.js --env BUILD_TESTS=' . ($opts['skip-tests'] ? 'skip' : 'build') . '--env BUILD_ONLY_TESTS=' . ($opts['only-tests'] ? 'true' : 'false'));
   }
 
   public function compileCss($opts = ['env' => null]) {

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -265,6 +265,7 @@ const publicConfig = {
 // Newsletter Editor Tests Config
 const testConfig = {
   name: 'test',
+  mode: PRODUCTION_ENV ? 'production' : 'development', // Add mode directly to testConfig
   entry: {
     vendor: 'webpack-vendor-index.jsx',
     testNewsletterEditor: [
@@ -529,6 +530,12 @@ module.exports = (env) => {
   if (env && env.BUILD_TESTS === 'build') {
     configs.push(testConfig);
   }
+
+  // If only the test build is requested
+  if (env && env.BUILD_ONLY_TESTS === 'true') {
+    return [testConfig];
+  }
+
   return configs.map((conf) => {
     const config = Object.assign({}, conf);
     if (


### PR DESCRIPTION
## Description

This PR adds a new parameter to the compile:js command, which allows the compilation of tests only.

## Code review notes

I tried to test it by running the job multiple times. You can see it on Circle CI: https://app.circleci.com/pipelines/github/mailpoet/mailpoet?branch=failing-build

## QA notes

We can skip QA here. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6178]

## After-merge notes

_N/A_

## Tasks

- [ ]  🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6178]: https://mailpoet.atlassian.net/browse/MAILPOET-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ