### PR TITLE
Fix "Return value must be of type int, null returned" in Action Scheduler wrappers [MAILPOET-6179]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
@@ -8,11 +8,13 @@ class ActionScheduler {
   private const GROUP_ID = 'mailpoet-automation';
 
   public function enqueue(string $hook, array $args = []): int {
-    return as_enqueue_async_action($hook, $args, self::GROUP_ID);
+    $result = as_enqueue_async_action($hook, $args, self::GROUP_ID);
+    return is_int($result) ? $result : 0;
   }
 
   public function schedule(int $timestamp, string $hook, array $args = []): int {
-    return as_schedule_single_action($timestamp, $hook, $args, self::GROUP_ID);
+    $result = as_schedule_single_action($timestamp, $hook, $args, self::GROUP_ID);
+    return is_int($result) ? $result : 0;
   }
 
   public function hasScheduledAction(string $hook, array $args = []): bool {

--- a/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
+++ b/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
@@ -17,11 +17,13 @@ class ActionScheduler {
   }
 
   public function scheduleRecurringAction(int $timestamp, int $interval_in_seconds, string $hook, array $args = [], bool $unique = true): int {
-    return as_schedule_recurring_action($timestamp, $interval_in_seconds, $hook, $args, self::GROUP_ID, $unique);
+    $result = as_schedule_recurring_action($timestamp, $interval_in_seconds, $hook, $args, self::GROUP_ID, $unique);
+    return is_int($result) ? $result : 0;
   }
 
   public function scheduleImmediateSingleAction(string $hook, array $args = [], bool $unique = true): int {
-    return as_schedule_single_action($this->wp->currentTime('timestamp', true), $hook, $args, self::GROUP_ID, $unique);
+    $result = as_schedule_single_action($this->wp->currentTime('timestamp', true), $hook, $args, self::GROUP_ID, $unique);
+    return is_int($result) ? $result : 0;
   }
 
   public function unscheduleAction(string $hook, array $args = []): ?int {


### PR DESCRIPTION
## Description

Fix "Return value must be of type int, null returned" in Action Scheduler wrappers.

We've run into such errors in Grafana logs.

## Code review notes

I think we can skip QA.

## QA notes

I think we can skip QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6179]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6179]: https://mailpoet.atlassian.net/browse/MAILPOET-6179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ