### PR TITLE
Using older WordPress with PHP 7.4 in automated tests [MAILPOET-6159]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1072,7 +1072,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           requires:
             - build
@@ -1111,7 +1111,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI # We use image with PHP 6.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
@@ -1174,7 +1174,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           requires:
             - build_premium
@@ -1186,7 +1186,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,11 +396,15 @@ jobs:
       use_woocommerce_beta:
         type: boolean
         default: false
+      wordpress_version:
+        type: string
+        default: ''
     environment:
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE: << parameters.mysql_image >>
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
       WORDPRESS_IMAGE_VERSION: << parameters.wordpress_image_version >>
+      WORDPRESS_VERSION: << parameters.wordpress_version >>
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -416,7 +420,7 @@ jobs:
                 echo "No latest beta version found. Ending job early."
                 circleci-agent step halt
               else
-                echo "export LATEST_WP_BETA=$LATEST_WP_BETA" >> $BASH_ENV
+                echo "export WORDPRESS_VERSION=$LATEST_WP_BETA" >> $BASH_ENV
                 echo "Using WordPress Beta Version: $LATEST_WP_BETA"
               fi
             else
@@ -522,7 +526,7 @@ jobs:
             -e ENABLE_HPOS=<< parameters.enable_hpos >> \
             -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
             -e DISABLE_HPOS=<< parameters.disable_hpos >> \
-            -e WORDPRESS_VERSION=${LATEST_WP_BETA} \
+            -e WORDPRESS_VERSION=${WORDPRESS_VERSION} \
             codeception_acceptance "${args[@]}"
       - run:
           name: Check exceptions
@@ -643,8 +647,13 @@ jobs:
       CODECEPTION_IMAGE_VERSION: << parameters.codeception_image_version >>
       MYSQL_COMMAND: << parameters.mysql_command >>
       MYSQL_IMAGE: << parameters.mysql_image >>
+      WORDPRESS_IMAGE_VERSION: << parameters.wordpress_image_version >>
+      WORDPRESS_VERSION: << parameters.wordpress_version >>
     parameters:
       codeception_image_version:
+        type: string
+        default: ''
+      wordpress_image_version:
         type: string
         default: ''
       group:
@@ -692,6 +701,9 @@ jobs:
       use_woocommerce_beta:
         type: boolean
         default: false
+      wordpress_version:
+        type: string
+        default: ''
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -704,7 +716,7 @@ jobs:
                 echo "No latest beta version found. Ending job early."
                 circleci-agent step halt
               else
-                echo "export LATEST_WP_BETA=$LATEST_WP_BETA" >> $BASH_ENV
+                echo "export WORDPRESS_VERSION=$LATEST_WP_BETA" >> $BASH_ENV
                 echo "Using WordPress Beta Version: $LATEST_WP_BETA"
               fi
             else
@@ -812,7 +824,7 @@ jobs:
               -e ENABLE_HPOS=<< parameters.enable_hpos >> \
               -e ENABLE_HPOS_SYNC=<< parameters.enable_hpos_sync >> \
               -e DISABLE_HPOS=<< parameters.disable_hpos >> \
-              -e WORDPRESS_VERSION=${LATEST_WP_BETA} \
+              -e WORDPRESS_VERSION=${WORDPRESS_VERSION} \
               codeception_integration "${args[@]}"
       - store_test_results:
           path: tests/_output
@@ -1060,7 +1072,8 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.5.5-php8.1
+          wordpress_image_version: 6.1.1-php7.4
+          wordpress_version: 6.5.5
           requires:
             - build
       - performance_tests:
@@ -1098,6 +1111,8 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: 6.1.1-php7.4
+          wordpress_version: 6.5.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           requires:
@@ -1159,7 +1174,8 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.5.5-php8.1
+          wordpress_image_version: 6.1.1-php7.4
+          wordpress_version: 6.5.5
           requires:
             - build_premium
       - integration_tests:
@@ -1170,6 +1186,8 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
+          wordpress_image_version: 6.1.1-php7.4
+          wordpress_version: 6.5.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           requires:

--- a/.github/workflows/scripts/check_wordpress_versions.php
+++ b/.github/workflows/scripts/check_wordpress_versions.php
@@ -77,7 +77,7 @@ function replaceLatestWordPressVersion(string $latestVersion): void {
 function replacePreviousWordPressVersion(string $previousVersion): void {
   replaceVersionInFile(
     __DIR__ . './../../../.circleci/config.yml',
-    '/(wordpress_image_version: )\d+\.\d+\.?\d*-php\d+\.\d+/',
+    '/(wordpress_version: )\d+\.\d+\.?\d*/',
     '${1}' . $previousVersion
   );
 }
@@ -113,6 +113,8 @@ if ($latestVersion) {
 
 if ($previousVersion) {
   echo "Replacing the previous version in the config file...\n";
+  // We install previous WordPress version via CLI so we need a version without PHP in the name.
+  $previousVersion = preg_replace('/-php\d+\.\d+$/', '', $previousVersion);
   replacePreviousWordPressVersion($previousVersion);
 } else {
   echo "No previous version found.\n";

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -154,7 +154,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function clickWooTableActionByItemName($itemName, $actionLinkText) {
     $i = $this;
     $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//a[text()="' . $actionLinkText . '"]'];
-    $i->waitForElementClickable($xpath); 
+    $i->waitForElementClickable($xpath);
     $i->click($xpath);
   }
 
@@ -409,6 +409,16 @@ class AcceptanceTester extends \Codeception\Actor {
     $this->_waitForText($text, $this->getDefaultTimeout($timeout), $selector);
     $this->waitForElementVisible('.notice-dismiss', 1);
     $this->click('.notice-dismiss');
+  }
+
+  public function closeNoticeIfVisible() {
+    // Dismiss notice if it is visible. This is needed especially for the tests with the lowest supported PHP version
+    // because we display a warning about the minimum required PHP version.
+    $noticeIsVisible = $this->executeJS('return document.getElementsByClassName("notice-dismiss")');
+    if ($noticeIsVisible) {
+      $this->click('.notice-dismiss');
+      $this->waitForElementNotVisible('.notice-dismiss', 3);
+    }
   }
 
   public function scrollToTop() {

--- a/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriptionPageCest.php
@@ -38,6 +38,7 @@ class SubscriptionPageCest {
     $i->login();
 
     $i->amOnMailPoetPage('Settings');
+    $i->closeNoticeIfVisible(); // Waning about used PHP can cause test failure on testing with the lowest supported PHP version
     $i->click(['css' => '[data-automation-id="subscription-manage-page-selection"]']);
     $i->selectOption('[data-automation-id="subscription-manage-page-selection"]', $pageTitle);
     $i->click('[data-automation-id="settings-submit-button"]');

--- a/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
+++ b/mailpoet/tests/acceptance/Settings/UnsubscribePageCest.php
@@ -50,6 +50,7 @@ class UnsubscribePageCest {
 
     $i->login();
     $i->amOnMailPoetPage('Settings');
+    $i->closeNoticeIfVisible(); // Waning about used PHP can cause test failure on testing with the lowest supported PHP version
     $i->scrollTo('[data-automation-id="subscription-manage-page-selection"]');
     $i->click(['css' => '[data-automation-id="unsubscribe-confirmation-page-selection"]']);
     $i->selectOption('[data-automation-id="unsubscribe-confirmation-page-selection"]', $this->pageTitleConfirmation);
@@ -57,7 +58,7 @@ class UnsubscribePageCest {
     $i->waitForNoticeAndClose('Settings saved');
 
     $i->wantTo('Click the Unsubscribe link and verify the Confirmation page');
-    
+
     // Making a shortcut in this scenario by providing required url in the conf email
     $i->click('[data-automation-id="signup_settings_tab"]');
     $i->checkOption('[data-automation-id="mailpoet_confirmation_email_customizer"]');
@@ -86,6 +87,7 @@ class UnsubscribePageCest {
 
     $i->login();
     $i->amOnMailPoetPage('Settings');
+    $i->closeNoticeIfVisible(); // Waning about used PHP can cause test failure on testing with the lowest supported PHP version
     $i->scrollTo('[data-automation-id="subscription-manage-page-selection"]');
     $i->click(['css' => '[data-automation-id="unsubscribe-success-page-selection"]']);
     $i->selectOption('[data-automation-id="unsubscribe-success-page-selection"]', $this->pageTitleSuccess);

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -50,6 +50,7 @@ fi
 if [[ $WORDPRESS_VERSION != "" ]]; then
   echo "Installing WordPress version: $WORDPRESS_VERSION"
   wp core update --version=$WORDPRESS_VERSION
+  wp core update-db
 fi
 echo "WORDPRESS VERSION:"
 wp core version


### PR DESCRIPTION
## Description

This PR starts using a different WordPress Docker image, which allows us to run our automated tests with the required PHP version.

## Code review notes

_N/A_

## QA notes

We don't need QA here because it's related only to automated tests only.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6159]

## After-merge notes

_N/A_

## Tasks

- [ ] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6159]: https://mailpoet.atlassian.net/browse/MAILPOET-6159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ