### PR TITLE
Add default value for only-tests parameter [MAILPOET-6178]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -187,7 +187,7 @@ class RoboFile extends \Robo\Tasks {
     $this->_exec('./node_modules/webpack/bin/webpack.js --watch');
   }
 
-  public function compileAll($opts = ['env' => null, 'skip-tests' => false]) {
+  public function compileAll($opts = ['env' => null, 'skip-tests' => false, 'only-tests' => false]) {
     $collection = $this->collectionBuilder();
     $collection->addCode(function() use ($opts) {
       return call_user_func([$this, 'compileJs'], $opts);


### PR DESCRIPTION
## Description

The default value in the `compile:all` commands was missing, which caused an error. This is a follow-up pull request.

## Code review notes

_N/A_

## QA notes

We can skip QA here.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5770

## Linked tickets

[MAILPOET-6178]

## After-merge notes

_N/A_

## Tasks

- [ ] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] 🚫 I added sufficient test coverage
- [ ] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6178]: https://mailpoet.atlassian.net/browse/MAILPOET-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ