### PR TITLE
Improve form validation [MAILPOET-6182]

### DIFF
--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -435,6 +435,24 @@ jQuery(($) => {
     // setup form validation
     $('form.mailpoet_form').each((_, element) => {
       const form = $(element);
+
+      form
+        .parsley()
+        .on('form:validate', (formInstance: { validationResult: boolean }) => {
+          const reCaptcha = form.find('.mailpoet_recaptcha');
+          const isReCatpchaVisible =
+            reCaptcha.length &&
+            reCaptcha.first().attr('data-size') !== 'invisible';
+          if (isReCatpchaVisible) {
+            if (window.grecaptcha.getResponse() === '') {
+              // eslint-disable-next-line no-param-reassign
+              formInstance.validationResult = false;
+              form.find('.mailpoet_error_recaptcha').addClass('filled');
+            } else {
+              form.find('.mailpoet_error_recaptcha').removeClass('filled');
+            }
+          }
+        });
       // Detect form is placed in tight container
       form.parsley().on('form:validated', () => {
         // clear messages

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -75,7 +75,7 @@ class BlockRendererHelper {
     if (in_array($block['type'], ['radio', 'checkbox'])) {
       $rules['group'] = 'custom_field_' . $blockId;
       $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
-      $rules['required-message'] = __('Please select at least one option.', 'mailpoet');
+      $rules['required-message'] = __('This field is required.', 'mailpoet');
     }
 
     if ($block['type'] === 'date') {

--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -27,7 +27,9 @@ class BlockRendererHelper {
   }
 
   public function getInputValidation(array $block, array $extraRules = [], ?int $formId = null): string {
-    $rules = [];
+    $rules = [
+      'errors-container' => '.' . $this->getErrorsContainerClass($block, $formId),
+    ];
     $blockId = $this->wp->escAttr($block['id']);
 
     if ($blockId === 'email') {
@@ -52,13 +54,11 @@ class BlockRendererHelper {
       $rules['required'] = true;
       $rules['mincheck'] = 1;
       $rules['group'] = $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId . '_' . $formId;
       $rules['required-message'] = __('Please select a list.', 'mailpoet');
     }
 
     if (!empty($block['params']['required'])) {
       $rules['required'] = true;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId . '_' . $formId;
       $rules['required-message'] = __('This field is required.', 'mailpoet');
     }
 
@@ -74,13 +74,11 @@ class BlockRendererHelper {
 
     if (in_array($block['type'], ['radio', 'checkbox'])) {
       $rules['group'] = 'custom_field_' . $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
       $rules['required-message'] = __('This field is required.', 'mailpoet');
     }
 
     if ($block['type'] === 'date') {
       $rules['group'] = 'custom_field_' . $blockId;
-      $rules['errors-container'] = '.mailpoet_error_' . $blockId . ($formId ? '_' . $formId : '');
     }
 
     $validation = [];
@@ -265,6 +263,22 @@ class BlockRendererHelper {
     return preg_replace_callback('/' . $this->wp->getShortcodeRegex() . '/s', function ($matches) {
       return str_replace(['[', ']'], ['&#91;', '&#93;'], $matches[0]);
     }, $value);
+  }
+
+  public function renderErrorsContainer(array $block = [], ?int $formId = null): string {
+    $errorContainerClass = $this->getErrorsContainerClass($block, $formId);
+    return '<span class="' . $errorContainerClass . '"></span>';
+  }
+
+  private function getErrorsContainerClass(array $block = [], ?int $formId = null): string {
+    $validationId = $block['validation_id'] ?? null;
+    if (!$validationId) {
+      $validationId = $this->wp->escAttr($block['id']);
+      if ($formId) {
+        $validationId .= '_' . $formId;
+      }
+    }
+    return 'mailpoet_error_' . $validationId;
   }
 
   private function translateValidationErrorMessage(string $validate): string {

--- a/mailpoet/lib/Form/Block/Checkbox.php
+++ b/mailpoet/lib/Form/Block/Checkbox.php
@@ -74,7 +74,7 @@ class Checkbox {
 
     $html .= '</fieldset>';
 
-    $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . ($formId ? '_' . $formId : '') . '"></span>';
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     return $this->wrapper->render($block, $html);
   }

--- a/mailpoet/lib/Form/Block/Date.php
+++ b/mailpoet/lib/Form/Block/Date.php
@@ -92,7 +92,7 @@ class Date {
       }
     }
 
-    $html .= '<span class="mailpoet_error_' . $this->wp->escAttr($block['id']) . ($formId ? '_' . $formId : '') . '"></span>';
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     return $html;
   }

--- a/mailpoet/lib/Form/Block/Radio.php
+++ b/mailpoet/lib/Form/Block/Radio.php
@@ -76,7 +76,7 @@ class Radio {
 
     $html .= '</fieldset>';
 
-    $html .= '<span class="mailpoet_error_' . $block['id'] . ($formId ? '_' . $formId : '') . '"></span>';
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     return $this->wrapper->render($block, $html);
   }

--- a/mailpoet/lib/Form/Block/Segment.php
+++ b/mailpoet/lib/Form/Block/Segment.php
@@ -69,7 +69,7 @@ class Segment {
       $html .= '</label>';
     }
 
-    $html .= '<span class="mailpoet_error_' . $block['id'] . ($formId ? '_' . $formId : '') . '"></span>';
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     // End fieldset around checkboxes
     $html .= '</fieldset>';

--- a/mailpoet/lib/Form/Block/Select.php
+++ b/mailpoet/lib/Form/Block/Select.php
@@ -32,7 +32,7 @@ class Select {
     $this->blockStylesRenderer = $blockStylesRenderer;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $html = '';
 
     $fieldName = 'data[' . $this->rendererHelper->getFieldName($block) . ']';
@@ -93,6 +93,8 @@ class Select {
       $html .= '</option>';
     }
     $html .= '</select>';
+
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     return $this->wrapper->render($block, $html);
   }

--- a/mailpoet/lib/Form/Block/Text.php
+++ b/mailpoet/lib/Form/Block/Text.php
@@ -31,7 +31,7 @@ class Text {
     $this->wp = $wp;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $type = 'text';
     $automationId = ' ';
     $id = '';
@@ -85,6 +85,8 @@ class Text {
     $html .= $this->rendererHelper->getInputModifiers($block);
 
     $html .= '/>';
+
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     return $this->wrapper->render($block, $html);
   }

--- a/mailpoet/lib/Form/Block/Textarea.php
+++ b/mailpoet/lib/Form/Block/Textarea.php
@@ -31,7 +31,7 @@ class Textarea {
     $this->wp = $wp;
   }
 
-  public function render(array $block, array $formSettings): string {
+  public function render(array $block, array $formSettings, ?int $formId = null): string {
     $html = '';
     $name = $this->rendererHelper->getFieldName($block);
     $styles = $this->inputStylesRenderer->renderForTextInput($block['styles'] ?? [], $formSettings);
@@ -56,6 +56,8 @@ class Textarea {
     }
 
     $html .= '>' . $this->rendererHelper->escapeShortCodes($this->rendererHelper->getFieldValue($block)) . '</textarea>';
+
+    $html .= $this->rendererHelper->renderErrorsContainer($block, $formId);
 
     return $this->wrapper->render($block, $html);
   }

--- a/mailpoet/lib/Form/BlocksRenderer.php
+++ b/mailpoet/lib/Form/BlocksRenderer.php
@@ -18,6 +18,7 @@ use MailPoet\Form\Block\Select;
 use MailPoet\Form\Block\Submit;
 use MailPoet\Form\Block\Text;
 use MailPoet\Form\Block\Textarea;
+use MailPoet\Util\Security;
 
 class BlocksRenderer {
   /** @var Checkbox */
@@ -104,6 +105,9 @@ class BlocksRenderer {
     if ($formId) {
       $formSettings['id'] = $formId;
     }
+    // This is used to properly show validation message when
+    // the same form is rendered on a page multiple times
+    $block['validation_id'] = Security::generateRandomString();
     switch ($block['type']) {
       case FormEntity::HTML_BLOCK_TYPE:
         $html .= $this->html->render($block, $formSettings);
@@ -142,15 +146,15 @@ class BlocksRenderer {
         break;
 
       case FormEntity::SELECT_BLOCK_TYPE:
-        $html .= $this->select->render($block, $formSettings);
+        $html .= $this->select->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::TEXT_BLOCK_TYPE:
-        $html .= $this->text->render($block, $formSettings);
+        $html .= $this->text->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::TEXTAREA_BLOCK_TYPE:
-        $html .= $this->textarea->render($block, $formSettings);
+        $html .= $this->textarea->render($block, $formSettings, $formId);
         break;
 
       case FormEntity::SUBMIT_BLOCK_TYPE:

--- a/mailpoet/lib/Form/Renderer.php
+++ b/mailpoet/lib/Form/Renderer.php
@@ -114,6 +114,9 @@ class Renderer {
       </noscript>
       <input class="mailpoet_recaptcha_field" type="hidden" name="recaptchaWidgetId">
     </div>';
+    if ($size !== 'invisible') {
+      $html .= '<div class="parsley-errors-list parsley-required mailpoet_error_recaptcha">' . __('This field is required.', 'mailpoet') . '</div>';
+    }
 
     return $html;
   }

--- a/mailpoet/tests/DataFactories/CustomField.php
+++ b/mailpoet/tests/DataFactories/CustomField.php
@@ -45,6 +45,11 @@ class CustomField {
     return $this;
   }
 
+  public function withParams(array $params): CustomField {
+    $this->data['params'] = array_merge($this->data['params'], $params);
+    return $this;
+  }
+
   public function create(): CustomFieldEntity {
     $customField = $this->repository->createOrUpdate($this->data);
     foreach ($this->data['subscribers'] as $subscriberData) {

--- a/mailpoet/tests/DataFactories/Form.php
+++ b/mailpoet/tests/DataFactories/Form.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\DataFactories;
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Form\FormMessageController;
@@ -82,6 +83,23 @@ class Form {
       'styles' => [
         'full_width' => '0',
       ],
+    ]);
+  }
+
+  /**
+   * @return $this
+   */
+  public function withCustomField(CustomFieldEntity $customField) {
+    return $this->addFormBlock([
+      'type' => $customField->getType(),
+      'params' => [
+        'label' => $customField->getName(),
+        'class_name' => '',
+        'required' => $customField->getParams()['required'] ?? '0',
+        'values' => $customField->getParams()['values'] ?? [],
+      ],
+      'id' => $customField->getId(),
+      'name' => $customField->getName(),
     ]);
   }
 

--- a/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorCreateCustomFieldCest.php
@@ -219,7 +219,7 @@ class EditorCreateCustomFieldCest {
     $i->waitForText('Option 2');
     $i->waitForText('Option 3');
     $i->click('.mailpoet_submit');
-    $i->waitForText('Please select at least one option.');
+    $i->waitForText('This field is required.');
     $i->click('(//input[@class="mailpoet_radio"])[1]'); // Select the first radio button
     $i->click('.mailpoet_submit');
     $i->waitForText('Check your inbox or spam folder to confirm your subscription.');
@@ -263,7 +263,7 @@ class EditorCreateCustomFieldCest {
     $i->waitForText($customFieldName . ' updated *');
     $i->waitForText('New option');
     $i->click('.mailpoet_submit');
-    $i->waitForText('Please select at least one option.');
+    $i->waitForText('This field is required.');
     $i->click('.mailpoet_checkbox'); // Select the checkbox
     $i->click('.mailpoet_submit');
     $i->waitForText('Check your inbox or spam folder to confirm your subscription.');

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -29,11 +29,11 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     $form = $this->formRenderer->renderForm($this->subscriber);
     verify($form)->stringMatchesRegExp('/<form class="mailpoet-manage-subscription" method="post" action="[a-z0-9:\/\._]+wp-admin\/admin-post.php" novalidate>/');
     verify($form)->stringContainsString('<input type="hidden" name="data[email]" value="subscriber@test.com" />');
-    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="given-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
-    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="family-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
-    verify($form)->stringMatchesRegExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="' . $this->segment->getId() . '" checked="checked"  \/> Test segment/');
-    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  \/>/');
-    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  \/>/');
+    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="given-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="First name" value="Fname" data-automation-id="form_first_name" data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
+    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="family-name" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Last name" value="Lname" data-automation-id="form_last_name" data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}" data-parsley-names=\'\[&quot;Please specify a valid name.&quot;,&quot;Addresses in names are not permitted, please add your name instead\.&quot;\]\'\/>/');
+    verify($form)->stringMatchesRegExp('/<input type="checkbox" class="mailpoet_checkbox" name="data\[[a-zA-Z0-9=_]+\]\[\]" value="' . $this->segment->getId() . '" checked="checked" data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}" \/> Test segment/');
+    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 1" value="some value"  data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}"\/>/');
+    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="custom field 2" value="another value"  data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}"\/>/');
 
     verify($form)->stringContainsString('Need to change your email address? Unsubscribe using the form below, then simply sign up again.');
   }
@@ -52,7 +52,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
         return $fields;
     });
     $form = $this->formRenderer->renderForm($this->subscriber);
-    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Additional info" value=""  \/>/');
+    verify($form)->stringMatchesRegExp('/<input type="text" autocomplete="on" class="mailpoet_text" name="data\[[a-zA-Z0-9=_]+\]" title="Additional info" value=""  data-parsley-errors-container=".mailpoet_error_[a-zA-Z0-9]{5}"\/>/');
   }
 
   private function getSegment(): SegmentEntity {

--- a/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -102,57 +102,61 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
   public function testItShouldRenderInputValidations() {
     $block = $this->block;
     $validation = $this->rendererHelper->getInputValidation($block);
-    verify($validation)->equals('');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1"');
 
     $block['params']['required'] = '1';
     $validation = $this->rendererHelper->getInputValidation($block, [], 2);
-    verify($validation)->equals('data-parsley-required="true" data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required-message="This field is required."');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required="true" data-parsley-required-message="This field is required."');
 
     $block['params']['required'] = '0';
     $block['id'] = 'email';
     $validation = $this->rendererHelper->getInputValidation($block);
-    verify($validation)->equals('data-parsley-required="true" data-parsley-minlength="6" data-parsley-maxlength="150" data-parsley-type-message="This value should be a valid email."');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_email" data-parsley-required="true" data-parsley-minlength="6" data-parsley-maxlength="150" data-parsley-type-message="This value should be a valid email."');
 
     $block = $this->block;
     $block['params']['validate'] = 'phone';
     $validation = $this->rendererHelper->getInputValidation($block);
-    verify($validation)->equals('data-parsley-pattern="^[\d\+\-\.\(\)\/\s]*$" data-parsley-error-message="Please specify a valid phone number."');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1" data-parsley-pattern="^[\d\+\-\.\(\)\/\s]*$" data-parsley-error-message="Please specify a valid phone number."');
 
     $block = $this->block;
     $block['type'] = 'radio';
     $validation = $this->rendererHelper->getInputValidation($block);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1" data-parsley-required-message="This field is required."');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1" data-parsley-group="custom_field_1" data-parsley-required-message="This field is required."');
 
     $block = $this->block;
     $block['type'] = 'date';
     $validation = $this->rendererHelper->getInputValidation($block);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1"');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1" data-parsley-group="custom_field_1"');
 
     $block = $this->block;
     $validation = $this->rendererHelper->getInputValidation($block, ['custom']);
-    verify($validation)->equals('data-parsley-0="custom"');
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1" data-parsley-0="custom"');
   }
 
-  public function testItShouldRenderInputValidationsWithFormId(): void {
+  public function testItShouldRenderInputValidationsWithValidationId(): void {
     $block = $this->block;
     $block['type'] = 'radio';
-    $validation = $this->rendererHelper->getInputValidation($block, [], 1);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_1" data-parsley-required-message="This field is required."');
+    $block['validation_id'] = '1';
+    $validation = $this->rendererHelper->getInputValidation($block);
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_1" data-parsley-group="custom_field_1" data-parsley-required-message="This field is required."');
 
     $block = $this->block;
     $block['type'] = 'checkbox';
-    $validation = $this->rendererHelper->getInputValidation($block, [], 2);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required-message="This field is required."');
+    $block['validation_id'] = '2';
+    $validation = $this->rendererHelper->getInputValidation($block);
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_2" data-parsley-group="custom_field_1" data-parsley-required-message="This field is required."');
 
     $block = $this->block;
     $block['type'] = 'date';
-    $validation = $this->rendererHelper->getInputValidation($block, [], 3);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_3"');
+    $block['validation_id'] = '3';
+    $validation = $this->rendererHelper->getInputValidation($block);
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_3" data-parsley-group="custom_field_1"');
 
     $block = $this->block;
     $block['id'] = 'segments';
-    $validation = $this->rendererHelper->getInputValidation($block, [], 4);
-    verify($validation)->equals('data-parsley-required="true" data-parsley-group="segments" data-parsley-errors-container=".mailpoet_error_segments_4" data-parsley-required-message="Please select a list."');
+    $block['validation_id'] = '4';
+    $validation = $this->rendererHelper->getInputValidation($block, [], 1);
+    verify($validation)->equals('data-parsley-errors-container=".mailpoet_error_4" data-parsley-required="true" data-parsley-group="segments" data-parsley-required-message="Please select a list."');
   }
 
   public function testItShouldObfuscateFieldNameIfNeeded() {

--- a/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
+++ b/mailpoet/tests/unit/Form/Block/BlockRendererHelperTest.php
@@ -121,7 +121,7 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
     $block = $this->block;
     $block['type'] = 'radio';
     $validation = $this->rendererHelper->getInputValidation($block);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1" data-parsley-required-message="Please select at least one option."');
+    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1" data-parsley-required-message="This field is required."');
 
     $block = $this->block;
     $block['type'] = 'date';
@@ -137,12 +137,12 @@ class BlockRendererHelperTest extends \MailPoetUnitTest {
     $block = $this->block;
     $block['type'] = 'radio';
     $validation = $this->rendererHelper->getInputValidation($block, [], 1);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_1" data-parsley-required-message="Please select at least one option."');
+    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_1" data-parsley-required-message="This field is required."');
 
     $block = $this->block;
     $block['type'] = 'checkbox';
     $validation = $this->rendererHelper->getInputValidation($block, [], 2);
-    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required-message="Please select at least one option."');
+    verify($validation)->equals('data-parsley-group="custom_field_1" data-parsley-errors-container=".mailpoet_error_1_2" data-parsley-required-message="This field is required."');
 
     $block = $this->block;
     $block['type'] = 'date';

--- a/mailpoet/tests/unit/Form/Block/CheckboxTest.php
+++ b/mailpoet/tests/unit/Form/Block/CheckboxTest.php
@@ -72,13 +72,14 @@ class CheckboxTest extends \MailPoetUnitTest {
     verify($checked->value)->equals('checked');
   }
 
-  public function testItShouldRenderErrorContainerWithFormId() {
+  public function testItShouldRenderErrorContainer() {
     $this->rendererHelperMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
-    $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldValue')->willReturn('1');
+    $this->rendererHelperMock->expects($this->once())->method('renderErrorsContainer')->willReturn('<span class="mailpoet_error_1_213"></span>');
 
-    $html = $this->checkbox->render($this->block, [], 213);
+
+    $html = $this->checkbox->render($this->block, []);
 
     $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_1_213']");
     verify($errorContainer)->notEmpty();

--- a/mailpoet/tests/unit/Form/Block/DateTest.php
+++ b/mailpoet/tests/unit/Form/Block/DateTest.php
@@ -130,12 +130,12 @@ class DateTest extends \MailPoetUnitTest {
     verify($selectedYear->textContent)->equals('2009');
   }
 
-  public function testItShouldRenderErrorContainerWithFormId() {
+  public function testItShouldRenderErrorContainer() {
     $this->baseMock->expects($this->once())->method('renderLabel')->willReturn('<label></label>');
     $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
-    $this->baseMock->expects($this->any())->method('getInputValidation')->willReturn(' validation="1" ');
+    $this->baseMock->expects($this->once())->method('renderErrorsContainer')->willReturn('<span class="mailpoet_error_1_44"></span>');
 
-    $html = $this->date->render($this->block, [], 44);
+    $html = $this->date->render($this->block, []);
 
     $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_1_44']");
     verify($errorContainer)->notEmpty();

--- a/mailpoet/tests/unit/Form/Block/RadioTest.php
+++ b/mailpoet/tests/unit/Form/Block/RadioTest.php
@@ -80,13 +80,13 @@ class RadioTest extends \MailPoetUnitTest {
     verify($this->htmlParser->getAttribute($radio2Input, 'checked')->value)->equals('checked');
   }
 
-  public function testItShouldRenderErrorContainerWithFormId() {
+  public function testItShouldRenderErrorContainer() {
     $this->baseMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
     $this->baseMock->expects($this->once())->method('getFieldName')->willReturn('Field name');
-    $this->baseMock->expects($this->once())->method('getInputValidation')->willReturn(' validation="1" ');
     $this->baseMock->expects($this->once())->method('getFieldValue')->willReturn('Radio 2');
+    $this->baseMock->expects($this->once())->method('renderErrorsContainer')->willReturn('<span class="mailpoet_error_1_31"></span>');
 
-    $html = $this->radio->render($this->block, [], 31);
+    $html = $this->radio->render($this->block, []);
 
     $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_1_31']");
     verify($errorContainer)->notEmpty();

--- a/mailpoet/tests/unit/Form/Block/SegmentTest.php
+++ b/mailpoet/tests/unit/Form/Block/SegmentTest.php
@@ -88,16 +88,16 @@ class SegmentTest extends \MailPoetUnitTest {
     verify($this->htmlParser->getAttribute($checkbox1Input, 'checked')->value)->equals('checked');
   }
 
-  public function testItShouldRenderErrorContainerWithFormId(): void {
+  public function testItShouldRenderErrorContainer(): void {
     $this->rendererHelperMock->expects($this->once())->method('renderLegend')->willReturn('<legend></legend>');
-    $this->rendererHelperMock->expects($this->once())->method('getInputValidation')->willReturn('validation="1"');
     $this->rendererHelperMock->expects($this->once())->method('getFieldName')->willReturn('Segments');
     $this->segmentsRepositoryMock->expects($this->once())->method('findBy')->willReturn([
       $this->createSegmentMock(1, 'List 1'),
       $this->createSegmentMock(2, 'List 2'),
     ]);
+    $this->rendererHelperMock->expects($this->once())->method('renderErrorsContainer')->willReturn('<span class="mailpoet_error_segment_1"></span>');
 
-    $html = $this->segment->render($this->block, [], 1);
+    $html = $this->segment->render($this->block, []);
 
     $errorContainer = $this->htmlParser->getElementByXpath($html, "//span[@class='mailpoet_error_segment_1']");
     verify($errorContainer)->notEmpty();


### PR DESCRIPTION
## Description

1. Change the error message for checkbox and radio blocks from `Please select at least one option`  to `This field is required.`
    - The existing error is misleading when there is only a single checkbox to select (e.g., to agree to Terms and conditions) or for radio buttons because, in radio, you can select only one option, not multiple.
2. Add the required message (`This field is required.`) to the reCAPTCHA v2 Checkbox.
3. Fix errors message position on custom fields when rendering the same form on the page multiple times.

**Screenshot for the wrong behavior in point 3.**
![Screenshot 2024-08-06 at 16 49 58](https://github.com/user-attachments/assets/ee216610-eb92-4b10-a585-30d88b5a882a)

## Code review notes

There is a new randomly generated `validation_id`, so even the same block, when rendered multiple times, has a different ID for the error container. When for some reason it's not set, it will fall back to the previous implementation of using `{$blockId}_{$formId}`.

## QA notes

There are a couple of things to test:

1. Add two forms on the page (easiest is via a shortcode - just add two) that include some custom fields (checkbox, radio, or dates) and submit the invalid form to see, that error messages are shown in the submitted form and not in the other one.
2. When `reCAPTCHA v2 Checkbox` is enabled, check that the form can't be submitted and you see a required error below reCAPTCHA.
3. When any other CAPTCHA is active, check that the form can be submitted when valid. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6182](https://mailpoet.atlassian.net/browse/MAILPOET-6182) STOMAIL-7314

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6182]: https://mailpoet.atlassian.net/browse/MAILPOET-6182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ