### PR TITLE
Fix twig generate cache error [MAILPOET-6173]

### DIFF
--- a/mailpoet/prefixer/fix-twig.php
+++ b/mailpoet/prefixer/fix-twig.php
@@ -322,13 +322,26 @@ $replacements = [
   ],
 ];
 
+function replaceInFile($file, $find, $replace) {
+  $data = file_get_contents($file);
+  $data = str_replace($find, $replace, $data);
+  file_put_contents($file, $data);
+}
+
 foreach ($replacements as $singleFile) {
-  $data = file_get_contents($singleFile['file']);
-  $data = str_replace($singleFile['find'], $singleFile['replace'], $data);
-  file_put_contents($singleFile['file'], $data);
+  replaceInFile($singleFile['file'], $singleFile['find'], $singleFile['replace']);
 }
 
 // Remove unwanted class aliases in lib/Twig
 exec("rm -rf ../vendor-prefixed/twig/twig/lib/Twig");
 exec("rm ../vendor-prefixed/twig/twig/README.rst");
 exec("rm -rf ../vendor-prefixed/twig/twig/src/Test");
+
+// Restore prefixed attributes in Twig PHP files
+$it = new RecursiveDirectoryIterator('../vendor-prefixed/twig/twig/src/', RecursiveDirectoryIterator::SKIP_DOTS);
+foreach (new RecursiveIteratorIterator($it) as $file) {
+  if (substr($file, -3) !== 'php') {
+    continue;
+  }
+  replaceInFile($file, '#[\Twig\Attribute\YieldReady]', '#[YieldReady]');
+}


### PR DESCRIPTION
## Description

The error was caused by php-scoper prefixing the `#[YieldReady]` attribute in files because it matched a class of the same name. The generate cache command worked for me despite this error.

## Code review notes

_N/A_

## QA notes

No QA needed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6173]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6173]: https://mailpoet.atlassian.net/browse/MAILPOET-6173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ