### PR TITLE
Fix flaky acceptance segment test

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -154,7 +154,9 @@ class AcceptanceTester extends \Codeception\Actor {
   public function clickWooTableActionByItemName($itemName, $actionLinkText) {
     $i = $this;
     $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//a[text()="' . $actionLinkText . '"]'];
+    $i->waitForElementVisible($xpath);
     $i->waitForElementClickable($xpath);
+    $i->moveMouseOver($xpath);
     $i->click($xpath);
   }
 

--- a/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
@@ -93,8 +93,8 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->seeNoJSErrors();
 
     $i->click('Save');
-    $i->waitForNoticeAndClose('Segment successfully updated!');
     $i->waitForListingItemsToLoad();
+    $i->waitForNoticeAndClose('Segment successfully updated!');
     $i->waitForText($segmentTitle);
 
     $i->wantTo('Check there is one subscriber on the segment');


### PR DESCRIPTION
## Description

There is light flakiness when attempting to click View Subscribers and possibly because of a race condition. The test didnt fail on clicking the View Subscribers but the action didnt succeed. I guess there is some background race conditions when it attempts to click, so slowing it down a bit and focusing before clicking might solve the flakiness.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6141]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6141]: https://mailpoet.atlassian.net/browse/MAILPOET-6141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ