### PR TITLE
Logs improvement [MAILPOET-5670]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -1,7 +1,17 @@
-.mailpoet-logs-full-message {
+.mailpoet-logs-message {
   font-size: 12px;
-  height: 120px;
-  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mailpoet-logs-message-full {
+  white-space: normal;
+}
+
+.mailpoet-logs-min-width {
+  white-space: nowrap;
+  width: 1px;
 }
 
 .mailpoet-logs {

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { MailPoet } from 'mailpoet';
 import { curry } from 'lodash';
 import { parseISO } from 'date-fns';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 import { Datepicker } from '../common/datepicker/datepicker';
 import { Button, ErrorBoundary, Input } from '../common';
@@ -133,7 +133,7 @@ function List({
       <div className="mailpoet-listing-header">
         <div className="mailpoet-listing-search">
           <label htmlFor="search_input" className="screen-reader-text">
-            {MailPoet.I18n.t('searchLabel')}
+            {__('Search', 'mailpoet')}
           </label>
           <Input
             dimension="small"
@@ -143,11 +143,14 @@ function List({
             name="s"
             onChange={(event): void => setSearch(event.target.value)}
             value={search}
-            placeholder={MailPoet.I18n.t('searchLabel')}
+            placeholder={__('Search', 'mailpoet')}
           />
         </div>
         <div className="mailpoet-listing-filters">
-          {`${MailPoet.I18n.t('from')}:`}
+          {
+            // translators: Date from when filtering
+            `${__('From', 'mailpoet')}:`
+          }
           <ErrorBoundary>
             <Datepicker
               dateFormat="MMMM d, yyyy"
@@ -156,7 +159,10 @@ function List({
               selected={from ? parseISO(from) : undefined}
               dimension="small"
             />
-            {`${MailPoet.I18n.t('to')}:`}
+            {
+              // translators: Date to when filtering
+              `${__('To', 'mailpoet')}:`
+            }
             <Datepicker
               dateFormat="MMMM d, yyyy"
               onChange={dateChanged(setTo)}
@@ -168,7 +174,10 @@ function List({
         </div>
         <div className="mailpoet-logs-limit">
           <label htmlFor="offset_input" className="screen-reader-text">
-            {MailPoet.I18n.t('offsetLabel')}
+            {
+              // translators: Offset of search results when filtering
+              __('Offset', 'mailpoet')
+            }
           </label>
           <Input
             dimension="small"
@@ -177,12 +186,12 @@ function List({
             type="number"
             onChange={(event): void => setOffset(event.target.value)}
             value={offset}
-            placeholder={MailPoet.I18n.t('offsetLabel')}
+            placeholder={__('Offset', 'mailpoet')}
           />
         </div>
         <div className="mailpoet-logs-limit">
           <label htmlFor="limit_input" className="screen-reader-text">
-            {MailPoet.I18n.t('limitLabel')}
+            {__('Limit', 'mailpoet')}
           </label>
           <Input
             dimension="small"
@@ -191,21 +200,24 @@ function List({
             type="number"
             onChange={(event): void => setLimit(event.target.value)}
             value={limit}
-            placeholder={MailPoet.I18n.t('limitLabel')}
+            placeholder={__('Limit', 'mailpoet')}
           />
         </div>
         <Button dimension="small" onClick={filterClick}>
-          {MailPoet.I18n.t('filter')}
+          {
+            // translators: Button to filter logs
+            _x('Filter', 'verb', 'mailpoet')
+          }
         </Button>
       </div>
 
       <table className="mailpoet-listing-table widefat striped" role="grid">
         <thead>
           <tr>
-            <th>{MailPoet.I18n.t('tableHeaderName')}</th>
-            <th>{MailPoet.I18n.t('tableHeaderMessage')}</th>
+            <th>{__('Name', 'mailpoet')}</th>
+            <th>{__('Message', 'mailpoet')}</th>
             <th>{__('Action', 'mailpoet')}</th>
-            <th>{MailPoet.I18n.t('tableHeaderCreatedOn')}</th>
+            <th>{__('Created On', 'mailpoet')}</th>
           </tr>
         </thead>
         <tbody>

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { MailPoet } from 'mailpoet';
 import { curry } from 'lodash';
 import { parseISO } from 'date-fns';
+import { __ } from '@wordpress/i18n';
 
 import { Datepicker } from '../common/datepicker/datepicker';
 import { Button, ErrorBoundary, Input } from '../common';
@@ -16,52 +17,45 @@ type LogData = {
 
 export type Logs = LogData[];
 
-function isCtrl(event: {
-  ctrlKey?: boolean;
-  metaKey?: boolean;
-  altKey?: boolean;
-}): boolean {
-  return (event.ctrlKey || event.metaKey) && !event.altKey; // shiftKey allowed
-}
-
-type MessageProps = {
-  message: string;
-  editing: boolean;
-};
-
-function Message({ message, editing }: MessageProps): JSX.Element {
-  if (!editing) {
-    return <>{`${message.substr(0, 150)}…`}</>;
-  }
-  return (
-    <textarea value={message} className="mailpoet-logs-full-message" readOnly />
-  );
-}
-
 type LogProps = {
   log: LogData;
 };
 
 function Log({ log }: LogProps): JSX.Element {
-  const [editing, setEditing] = useState(false);
+  const [showFullMessage, setShowFullMessage] = useState(false);
 
-  function messageClick(event: {
-    ctrlKey?: boolean;
-    metaKey?: boolean;
-    altKey?: boolean;
-  }): void {
-    if (!isCtrl(event)) return;
-    if (editing) return;
-    setEditing(true);
-  }
+  const toggleFullMessage = () => {
+    setShowFullMessage(!showFullMessage);
+  };
 
   return (
     <tr key={`log-row-${log.id}`}>
-      <td role="gridcell">{log.name}</td>
-      <td onClick={messageClick} role="gridcell">
-        <Message message={log.message} editing={editing} />
+      <td role="gridcell" className="mailpoet-logs-min-width">
+        {log.name}
       </td>
-      <td role="gridcell">{MailPoet.Date.full(log.created_at)}</td>
+      <td role="gridcell">
+        <div
+          className={`mailpoet-logs-message ${
+            showFullMessage ? 'mailpoet-logs-message-full' : ''
+          }`}
+        >
+          {log.message}
+        </div>
+      </td>
+      <td role="gridcell" className="mailpoet-logs-min-width">
+        <Button
+          dimension="small"
+          variant="secondary"
+          onClick={toggleFullMessage}
+        >
+          {showFullMessage
+            ? __('Show less', 'mailpoet')
+            : __('Show more', 'mailpoet')}
+        </Button>
+      </td>
+      <td className="mailpoet-logs-min-width" role="gridcell">
+        {MailPoet.Date.full(log.created_at)}
+      </td>
     </tr>
   );
 }
@@ -210,6 +204,7 @@ function List({
           <tr>
             <th>{MailPoet.I18n.t('tableHeaderName')}</th>
             <th>{MailPoet.I18n.t('tableHeaderMessage')}</th>
+            <th>{__('Action', 'mailpoet')}</th>
             <th>{MailPoet.I18n.t('tableHeaderCreatedOn')}</th>
           </tr>
         </thead>

--- a/mailpoet/assets/js/src/logs/logs.tsx
+++ b/mailpoet/assets/js/src/logs/logs.tsx
@@ -5,6 +5,7 @@ import { FilterType, List, Logs } from './list';
 
 interface LogsWindow extends Window {
   mailpoet_logs: Logs;
+  mailpoet_logs_default_from: string;
 }
 
 declare let window: LogsWindow;
@@ -19,7 +20,9 @@ if (container) {
     <ErrorBoundary>
       <List
         logs={window.mailpoet_logs}
-        originalFrom={url.searchParams.get('from')}
+        originalFrom={
+          url.searchParams.get('from') || window.mailpoet_logs_default_from
+        }
         originalTo={url.searchParams.get('to')}
         originalSearch={url.searchParams.get('search')}
         originalOffset={url.searchParams.get('offset')}

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -28,6 +28,7 @@ class Logs {
     $offset = isset($_GET['offset']) ? sanitize_text_field(wp_unslash($_GET['offset'])) : null;
     $limit = isset($_GET['limit']) ? sanitize_text_field(wp_unslash($_GET['limit'])) : null;
     $dateFrom = (new Carbon())->subDays(7);
+    $defaultFrom = $dateFrom->format('Y-m-d');
     if (isset($from)) {
       $dateFrom = new Carbon($from);
     }
@@ -38,6 +39,7 @@ class Logs {
     $logs = $this->logRepository->getLogs($dateFrom, $dateTo, $search, $offset, $limit);
     $data = [
       'logs' => [],
+      'logs_default_from' => $defaultFrom,
     ];
     foreach ($logs as $log) {
       $data['logs'][] = [

--- a/mailpoet/views/logs.html
+++ b/mailpoet/views/logs.html
@@ -16,15 +16,6 @@
 
 <%= localize({
   'pageTitle': __('Logs'),
-  'tableHeaderName': __('Name'),
-  'tableHeaderMessage': __('Message'),
-  'tableHeaderCreatedOn': __('Created On'),
-  'searchLabel': __('Search'),
-  'offsetLabel': __('Offset'),
-  'limitLabel': __('Limit'),
-  'from': _x('From', 'date from'),
-  'to': _x('To', 'date to'),
-  'filter': __('Filter'),
 }) %>
 
 <% endblock %>

--- a/mailpoet/views/logs.html
+++ b/mailpoet/views/logs.html
@@ -10,6 +10,7 @@
   <script type="text/javascript">
     <% autoescape 'js' %>
       var mailpoet_logs = <%= json_encode(logs) %>;
+      var mailpoet_logs_default_from = '<%= logs_default_from %>';
     <% endautoescape %>
   </script>
 </div>


### PR DESCRIPTION
## Description

1. Add a toggle button for the full message (it was `cmd+click` before without noting it anywhere, which was difficult to discover - p1723042856448899-slack-C0602LR6D55).
2. When truncated, dynamically adjust it to take the full width instead of fixed 150 chars. 
3. Show the default `from` value (7 days ago) when not explicitly set. 

<img width="1201" alt="Screenshot 2024-08-09 at 22 19 57" src="https://github.com/user-attachments/assets/264375b6-5adc-4a72-bb98-1be56902b7c4">

## Code review notes

_N/A_

## QA notes

Probably can be skipped. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5670]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5670]: https://mailpoet.atlassian.net/browse/MAILPOET-5670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ