### PR TITLE
Display a notice when some MailPoet tables don't use the InnoDB engine [MAILPOET-6184]

### DIFF
--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -71,7 +71,7 @@ class DatabaseEngineNotice {
       fn($row) => $row['Name'],
       array_filter(
         $data,
-        fn($row) => is_string($row['Engine']) && (strtolower($row['Engine']) !== 'innodb')
+        fn($row) => isset($row['Engine']) && is_string($row['Engine']) && (strtolower($row['Engine']) !== 'innodb')
       )
     );
   }

--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class DatabaseEngineNotice {
+  const OPTION_NAME = 'database-engine-notice';
+  const DISMISS_NOTICE_TIMEOUT_SECONDS = 15_552_000; // 6 months
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function init($shouldDisplay): ?Notice {
+    if (!$shouldDisplay || $this->wp->getTransient(self::OPTION_NAME)) {
+      return null;
+    }
+
+    return $this->display();
+  }
+
+  private function display(): ?Notice {
+    return null;
+  }
+
+  public function disable() {
+    $this->wp->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
+  }
+}

--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -31,12 +31,16 @@ class DatabaseEngineNotice {
       return null;
     }
 
-    $tablesWithIncorrectEngine = $this->checkTableEngines();
-    if ($tablesWithIncorrectEngine === []) {
-      return null;
-    }
+    try {
+      $tablesWithIncorrectEngine = $this->checkTableEngines();
+      if ($tablesWithIncorrectEngine === []) {
+        return null;
+      }
 
-    return $this->display($tablesWithIncorrectEngine);
+      return $this->display($tablesWithIncorrectEngine);
+    } catch (\Exception $e) {
+        return null;
+    }
   }
 
   /**

--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -2,32 +2,75 @@
 
 namespace MailPoet\Util\Notices;
 
+use MailPoet\Config\Env;
+use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class DatabaseEngineNotice {
   const OPTION_NAME = 'database-engine-notice';
   const DISMISS_NOTICE_TIMEOUT_SECONDS = 15_552_000; // 6 months
 
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
+
+  private EntityManager $entityManager;
 
   public function __construct(
-    WPFunctions $wp
+    WPFunctions $wp,
+    EntityManager $entityManager
   ) {
     $this->wp = $wp;
+    $this->entityManager = $entityManager;
   }
 
+  //TODO: check only once a day
+  //TODO: display better list of table names (“wp_mailpoet_settings”, “wp_mailpoet_feature_flags”, and 7 more)
   public function init($shouldDisplay): ?Notice {
     if (!$shouldDisplay || $this->wp->getTransient(self::OPTION_NAME)) {
       return null;
     }
 
-    return $this->display();
+    $tablesWithIncorrectEngine = $this->checkTableEngines();
+    if ($tablesWithIncorrectEngine === []) {
+      return null;
+    }
+
+    return $this->display($tablesWithIncorrectEngine);
   }
 
-  private function display(): ?Notice {
-    return null;
+  /**
+   * Returns a list of table names that are not using the InnoDB engine.
+   */
+  private function checkTableEngines(): array {
+    $data = $this->entityManager->getConnection()->executeQuery(
+      'SHOW TABLE STATUS WHERE Name LIKE :prefix',
+      [
+        'prefix' => Env::$dbPrefix . '_%',
+      ]
+    )->fetchAllAssociative();
+
+    return array_map(
+      fn($row) => $row['Name'],
+      array_filter(
+        $data,
+        fn($row) => strtolower($row['Engine']) !== 'innodb'
+      )
+    );
+  }
+
+  private function display(array $tablesWithIncorrectEngine): ?Notice {
+    // translators: %s is the list of the table names
+    $errorString = __('Some of the MailPoet plugin’s tables are not using the InnoDB engine (“%s”). This may cause performance and compatibility issues. Please ensure all MailPoet tables are converted to use the InnoDB engine. For more information, check out [link]this guide[/link].', 'mailpoet');
+    $tables = implode(", ", $tablesWithIncorrectEngine);
+    $errorString = sprintf($errorString, $tables);
+    $error = Helpers::replaceLinkTags($errorString, 'https://kb.mailpoet.com/article/200-solving-database-connection-issues#database-configuration', [
+      'target' => '_blank',
+    ]);
+
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+
+    return Notice::displayWarning($error, $extraClasses, self::OPTION_NAME);
   }
 
   public function disable() {

--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -11,6 +11,7 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
 class DatabaseEngineNotice {
   const OPTION_NAME = 'database-engine-notice';
   const DISMISS_NOTICE_TIMEOUT_SECONDS = 15_552_000; // 6 months
+  const MAX_TABLES_TO_DISPLAY = 2;
 
   private WPFunctions $wp;
 
@@ -25,7 +26,6 @@ class DatabaseEngineNotice {
   }
 
   //TODO: check only once a day
-  //TODO: display better list of table names (“wp_mailpoet_settings”, “wp_mailpoet_feature_flags”, and 7 more)
   public function init($shouldDisplay): ?Notice {
     if (!$shouldDisplay || $this->wp->getTransient(self::OPTION_NAME)) {
       return null;
@@ -61,8 +61,8 @@ class DatabaseEngineNotice {
 
   private function display(array $tablesWithIncorrectEngine): ?Notice {
     // translators: %s is the list of the table names
-    $errorString = __('Some of the MailPoet plugin’s tables are not using the InnoDB engine (“%s”). This may cause performance and compatibility issues. Please ensure all MailPoet tables are converted to use the InnoDB engine. For more information, check out [link]this guide[/link].', 'mailpoet');
-    $tables = implode(", ", $tablesWithIncorrectEngine);
+    $errorString = __('Some of the MailPoet plugin’s tables are not using the InnoDB engine (%s). This may cause performance and compatibility issues. Please ensure all MailPoet tables are converted to use the InnoDB engine. For more information, check out [link]this guide[/link].', 'mailpoet');
+    $tables = $this->formatTableNames($tablesWithIncorrectEngine);
     $errorString = sprintf($errorString, $tables);
     $error = Helpers::replaceLinkTags($errorString, 'https://kb.mailpoet.com/article/200-solving-database-connection-issues#database-configuration', [
       'target' => '_blank',
@@ -71,6 +71,23 @@ class DatabaseEngineNotice {
     $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
 
     return Notice::displayWarning($error, $extraClasses, self::OPTION_NAME);
+  }
+
+  private function formatTableNames(array $tablesWithIncorrectEngine): string {
+    sort($tablesWithIncorrectEngine);
+
+    $tables = array_map(
+      fn($table) => "“${table}”",
+      array_slice($tablesWithIncorrectEngine, 0, self::MAX_TABLES_TO_DISPLAY)
+    );
+
+    $remainingTablesCount = count($tablesWithIncorrectEngine) - count($tables);
+    if ($remainingTablesCount > 0) {
+      // translators: %d is the number of remaining tables, the whole string will be: "table1, table2 and 3 more"
+      $tables[] = sprintf(__('and %d more', 'mailpoet'), $remainingTablesCount);
+    }
+
+    return implode(', ', $tables);
   }
 
   public function disable() {

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -10,6 +10,7 @@ use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class PermanentNotices {
 
@@ -66,9 +67,10 @@ class PermanentNotices {
 
   /** @var DatabaseEngineNotice */
   private $databaseEngineNotice;
-
+  
   public function __construct(
     WPFunctions $wp,
+    EntityManager $entityManager,
     TrackingConfig $trackingConfig,
     SubscribersRepository $subscribersRepository,
     SettingsController $settings,
@@ -93,7 +95,7 @@ class PermanentNotices {
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
     $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);
-    $this->databaseEngineNotice = new DatabaseEngineNotice($wp);
+    $this->databaseEngineNotice = new DatabaseEngineNotice($wp, $entityManager);
     $this->senderDomainAuthenticationNotices = $senderDomainAuthenticationNotices;
   }
 

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -64,6 +64,9 @@ class PermanentNotices {
   /** @var SenderDomainAuthenticationNotices */
   private $senderDomainAuthenticationNotices;
 
+  /** @var DatabaseEngineNotice */
+  private $databaseEngineNotice;
+
   public function __construct(
     WPFunctions $wp,
     TrackingConfig $trackingConfig,
@@ -90,6 +93,7 @@ class PermanentNotices {
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
     $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);
+    $this->databaseEngineNotice = new DatabaseEngineNotice($wp);
     $this->senderDomainAuthenticationNotices = $senderDomainAuthenticationNotices;
   }
 
@@ -150,6 +154,9 @@ class PermanentNotices {
     $this->premiumFeaturesAvailableNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
+    $this->databaseEngineNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
     $excludeDomainAuthenticationNotices = [
       'mailpoet-settings',
       'mailpoet-newsletter-editor',
@@ -192,6 +199,9 @@ class PermanentNotices {
         break;
       case (WooCommerceVersionWarning::OPTION_NAME):
         $this->woocommerceVersionWarning->disable();
+        break;
+      case (DatabaseEngineNotice::OPTION_NAME):
+        $this->databaseEngineNotice->disable();
         break;
       case (PremiumFeaturesAvailableNotice::OPTION_NAME):
         $this->premiumFeaturesAvailableNotice->disable();

--- a/mailpoet/tests/integration/Util/Notices/DatabaseEngineNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/DatabaseEngineNoticeTest.php
@@ -2,17 +2,43 @@
 
 namespace MailPoet\Util\Notices;
 
+use MailPoet\Entities\SegmentEntity;
 use MailPoet\WP\Functions as WPFunctions;
 
 class DatabaseEngineNoticeTest extends \MailPoetTest {
   /** @var DatabaseEngineNotice */
   private $notice;
 
+  private $tableName;
+
   public function _before() {
     parent::_before();
+    $this->tableName = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
     $this->notice = new DatabaseEngineNotice(
-      new WPFunctions()
+      new WPFunctions(),
+      $this->entityManager
     );
+  }
+
+  public function _after() {
+    $this->entityManager->getConnection()->executeStatement("
+      ALTER TABLE {$this->tableName}
+      ENGINE = INNODB;
+    ");
+    parent::_after();
+  }
+
+  public function testItDisplaysNoticeWhenMyISAMDetected() {
+    $this->entityManager->getConnection()->executeStatement("
+      ALTER TABLE {$this->tableName}
+      ENGINE = MyISAM;
+    ");
+    $result = $this->notice->init(true);
+    verify($result)->notEmpty();
+    $message = $result->getMessage();
+    verify($message)->stringContainsString('Some of the MailPoet plugin’s tables are not using the InnoDB engine');
+    verify($message)->stringContainsString('https://kb.mailpoet.com/article/200-solving-database-connection-issues#database-configuration');
+    verify($message)->stringContainsString($this->tableName);
   }
 
   public function testItDoesntDisplayWhenDisabled() {

--- a/mailpoet/tests/integration/Util/Notices/DatabaseEngineNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/DatabaseEngineNoticeTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class DatabaseEngineNoticeTest extends \MailPoetTest {
+  /** @var DatabaseEngineNotice */
+  private $notice;
+
+  public function _before() {
+    parent::_before();
+    $this->notice = new DatabaseEngineNotice(
+      new WPFunctions()
+    );
+  }
+
+  public function testItDoesntDisplayWhenDisabled() {
+    $this->notice->disable();
+    $result = $this->notice->init(true);
+    verify($result)->null();
+  }
+}


### PR DESCRIPTION
## Description

Some users have been running into performance issues that turned out to be caused by MyISAM table engine. We can detect if this is happening and display a notice to the user.

## Code review notes

_N/A_

## QA notes

You can change the table engines using a plugin: https://wordpress.org/plugins/wp-phpmyadmin-extension/ and then test if you see the notice

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6184]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6184]: https://mailpoet.atlassian.net/browse/MAILPOET-6184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ