### PR TITLE
Prevent adding subscriber with empty email [MAILPOET-6188]

### DIFF
--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -68,6 +68,7 @@ class Registration {
       if (
         isset($_POST['mailpoet']['subscribe_on_register'])
         && (bool)$_POST['mailpoet']['subscribe_on_register'] === true
+        && !empty($result['user_email'])
       ) {
         $this->subscribeNewUser(
           $result['user_name'],

--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -87,6 +87,7 @@ class Registration {
       empty($errors->errors)
       && isset($_POST['mailpoet']['subscribe_on_register'])
       && (bool)$_POST['mailpoet']['subscribe_on_register'] === true
+      && !empty($userEmail)
     ) {
       $this->subscribeNewUser(
         $userLogin,

--- a/mailpoet/tests/integration/Subscription/RegistrationTest.php
+++ b/mailpoet/tests/integration/Subscription/RegistrationTest.php
@@ -34,4 +34,28 @@ class RegistrationTest extends \MailPoetTest {
     $this->registration->onRegister(new \WP_Error(), 'login', '');
     verify($initialCount)->equals(count($this->subscribersRepository->findAll()));
   }
+
+  public function testItAddsSubscriberOnMultisite() {
+    $_POST['mailpoet']['subscribe_on_register'] = true;
+    $result = [
+      'errors' => new \WP_Error(),
+      'user_name' => 'login',
+      'user_email' => 'tester@email.com',
+    ];
+    $this->registration->onMultiSiteRegister($result);
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'tester@email.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+  }
+
+  public function testItDoesntAddSubscriberWithEmptyOnMultisite() {
+    $_POST['mailpoet']['subscribe_on_register'] = true;
+    $result = [
+      'errors' => new \WP_Error(),
+      'user_name' => 'login',
+      'user_email' => '',
+    ];
+    $initialCount = count($this->subscribersRepository->findAll());
+    $this->registration->onMultiSiteRegister($result);
+    verify($initialCount)->equals(count($this->subscribersRepository->findAll()));
+  }
 }

--- a/mailpoet/tests/integration/Subscription/RegistrationTest.php
+++ b/mailpoet/tests/integration/Subscription/RegistrationTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscription;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+
+class RegistrationTest extends \MailPoetTest {
+  private Registration $registration;
+  private SubscribersRepository $subscribersRepository;
+
+  public function _before() {
+    $this->registration = $this->diContainer->get(Registration::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+  }
+
+  public function testItAddsSubscriber() {
+    $_POST['mailpoet']['subscribe_on_register'] = true;
+    $this->registration->onRegister(new \WP_Error(), 'login', 'tester@email.com');
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'tester@email.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+  }
+
+  public function testItDoesntAddSubscriberWhenCheckboxIsNotChecked() {
+    $_POST['mailpoet']['subscribe_on_register'] = false;
+    $this->registration->onRegister(new \WP_Error(), 'login', 'tester@email.com');
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'tester@email.com']);
+    verify($subscriber)->null();
+  }
+
+  public function testItDoesntAddSubscriberWhenEmailIsEmpty() {
+    $_POST['mailpoet']['subscribe_on_register'] = true;
+    $initialCount = count($this->subscribersRepository->findAll());
+    $this->registration->onRegister(new \WP_Error(), 'login', '');
+    verify($initialCount)->equals(count($this->subscribersRepository->findAll()));
+  }
+}


### PR DESCRIPTION
## Description

This fixes an error caught by logs. We don't allow to save a subscriber with an empty email, and it seems that in some cases, there are attempts to save such subscriber when a new user registers on a site.

## Code review notes

_N/A_

## QA notes

We can skip QA for this one.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6188]

## After-merge notes

_N/A_

## Tasks

- [x] ⛔ I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage.
- [x] ⛔ I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6188]: https://mailpoet.atlassian.net/browse/MAILPOET-6188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ