### PR TITLE
Fix false MSS connection error notice [MAILPOET-6189]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -57,6 +57,7 @@ class Services extends APIEndpoint {
 
   public $permissions = [
     'global' => AccessControl::PERMISSION_MANAGE_SETTINGS,
+    'methods' => ['pingBridge' => AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN],
   ];
 
   public function __construct(


### PR DESCRIPTION
## Description

We call the Services::pingBridge endpoint on the admin pages. The restricted access was causing editor users to get false error notices. 

Allowing the pingBridge endpoint for all users with access to the plugin admin fixes the issue.

![Markup 2024-08-14 at 16 46 08](https://github.com/user-attachments/assets/4b06b148-be42-47d7-bdc8-a0fa2b0bfa2c)


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6189]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6189]: https://mailpoet.atlassian.net/browse/MAILPOET-6189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ