### PR TITLE
Fix dual buttons in Outlook [MAILPOET-6190]

### DIFF
--- a/mailpoet/lib-3rd-party/pquery/gan_node_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_node_html.php
@@ -271,7 +271,9 @@ class DomNode implements IQuery {
 	 * @access private
 	 */
 	function __toString() {
-		return (($this->tag === '~root~') ? $this->toString(true, true, 1) : $this->tag);
+		$string = (($this->tag === '~root~') ? $this->toString(true, true, 1) : $this->tag);
+		// because tburry/pquery contains a bug and replaces the opening non mso condition incorrectly we have to replace the opening tag with correct value
+		return str_replace('<!--[if !mso]><![endif]-->', '<!--[if !mso]><!-- -->', $string);;
 	}
 
 	/**

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -222,9 +222,7 @@ class Renderer {
     foreach ($templateDom->query('img') as $image) {
       $image->src = str_replace(' ', '%20', $image->src);
     }
-    // because tburry/pquery contains a bug and replaces the opening non mso condition incorrectly we have to replace the opening tag with correct value
     $template = $templateDom->__toString();
-    $template = str_replace('<!--[if !mso]><![endif]-->', '<!--[if !mso]><!-- -->', $template);
     $template = $this->wp->applyFilters(
       self::FILTER_POST_PROCESS,
       $template

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -88,6 +88,12 @@ class RendererTest extends \MailPoetTest {
 
     // nested vertical container should be rendered
     verify(count($DOM('.nested-vertical-container')))->equals(1);
+
+    // Verify it doesn't replace <!--[if !mso]><!-- --> with <!--[if !mso]><![endif]-->
+    // This comment is needed for outlook and should not be replaced. There was an issue in pQuery that was replacing it.
+    // The email content contain button and the button contains this comment.
+    verify($template['html'])->stringContainsString('mailpoet_table_button');
+    verify($template['html'])->stringContainsString('<!--[if !mso]><!-- -->');
   }
 
   public function testItRendersOneColumn() {

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -92,6 +92,15 @@ class GATrackingTest extends \MailPoetTest {
     verify($result['html'])->stringContainsString('email=[subscriber:email]');
   }
 
+  public function testItDoesntBreakSpecialHtmlComments() {
+    $this->renderedNewsletter = [
+      'html' => '<p><!--[if !mso]><!-- -->Test</p>',
+      'text' => 'Test',
+    ];
+    $result = $this->tracking->applyGATracking($this->renderedNewsletter, $this->newsletter, $this->internalHost);
+    verify($result['html'])->stringContainsString('<!--[if !mso]><!-- -->');
+  }
+
   public function testItDoesNotOverwriteExistingParameters() {
     $link = add_query_arg(
       [


### PR DESCRIPTION
## Description

This PR fixes an issue introduced recently in https://github.com/mailpoet/mailpoet/pull/5745.
The issue doesn't happen when sending a preview email, but it is reproducible when sending it to a list. 

## Code review notes

I found that the issue was caused by a comment in button output `<!--[if !mso]><!-- -->` was being replaced with `<!--[if !mso]><![endif]-->`

This was a known issue when parsing HTML via pQuery and we had a fix for that in the Renderer class. I found that that we use pQuery in more places in processing email during sending e.g. in code that adds GA tracking parameters.

I fixed it by moving the fix directly to pQuery's toString method.


## QA notes
#### Replication

1. Create a newsletter with a button
2. Make sure GA tracking is enabled
3. Send the email via send page (note sending preview is not enough for replication)
4. Observe the issue in Outlook (you can use Litmus for checking)

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6190]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6190]: https://mailpoet.atlassian.net/browse/MAILPOET-6190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ