### PR TITLE
Make error messages in automations more human-friendly [MAILPOET-6174]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
@@ -38,7 +38,7 @@ const sections: Record<string, Section> = {
       },
     },
     customQuery: {
-      order: 'asc',
+      order: 'desc',
       order_by: 'updated_at',
       limit: 25,
       page: 1,

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -295,7 +295,11 @@ class SendEmailAction implements Action {
     ]);
 
     if (!$subscriberSegment) {
-      throw InvalidStateException::create()->withMessage(sprintf("Subscriber ID '%s' is not subscribed to segment ID '%s'.", $subscriberId, $segmentId));
+      $segment = $this->segmentsRepository->findOneById($segmentId);
+      if (!$segment) { // This state should not happen because it is checked in the validation.
+        throw InvalidStateException::create()->withMessage("Cannot send the email because the list was not found.");
+      }
+      throw InvalidStateException::create()->withMessage(sprintf("Cannot send the email because the subscriber is not subscribed to the '%s' list.", $segment->getName()));
     }
 
     $subscriber = $subscriberSegment->getSubscriber();

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -174,11 +174,11 @@ class SendEmailAction implements Action {
       // run #1: schedule email sending
       $subscriberStatus = $subscriber->getStatus();
       if ($newsletter->getType() !== NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL && $subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED) {
-        throw InvalidStateException::create()->withMessage(sprintf("Cannot schedule a newsletter for subscriber ID '%s' because their status is '%s'.", $subscriber->getId(), $subscriberStatus));
+        throw InvalidStateException::create()->withMessage(sprintf("Cannot send the email because the subscriber's status is '%s'.", $subscriberStatus));
       }
 
       if ($subscriberStatus === SubscriberEntity::STATUS_BOUNCED) {
-        throw InvalidStateException::create()->withMessage(sprintf("Cannot schedule an email for subscriber ID '%s' because their status is '%s'.", $subscriber->getId(), $subscriberStatus));
+        throw InvalidStateException::create()->withMessage(sprintf("Cannot send the email because the subscriber's status is '%s'.", $subscriberStatus));
       }
 
       $meta = $this->getNewsletterMeta($args);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -25,6 +25,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Newsletter\Scheduler\AutomationEmailScheduler;
+use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -62,29 +63,23 @@ class SendEmailAction implements Action {
     'woocommerce-subscriptions:trial-started',
   ];
 
-  /** @var AutomationController */
-  private $automationController;
+  private AutomationController $automationController;
 
-  /** @var SettingsController */
-  private $settings;
+  private SettingsController $settings;
 
-  /** @var NewslettersRepository */
-  private $newslettersRepository;
+  private NewslettersRepository $newslettersRepository;
 
-  /** @var SubscriberSegmentRepository */
-  private $subscriberSegmentRepository;
+  private SubscriberSegmentRepository $subscriberSegmentRepository;
 
-  /** @var SubscribersRepository  */
-  private $subscribersRepository;
+  private SubscribersRepository $subscribersRepository;
 
-  /** @var AutomationEmailScheduler */
-  private $automationEmailScheduler;
+  private SegmentsRepository $segmentsRepository;
 
-  /** @var NewsletterOptionsRepository */
-  private $newsletterOptionsRepository;
+  private AutomationEmailScheduler $automationEmailScheduler;
 
-  /** @var NewsletterOptionFieldsRepository */
-  private $newsletterOptionFieldsRepository;
+  private NewsletterOptionsRepository $newsletterOptionsRepository;
+
+  private NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository;
 
   public function __construct(
     AutomationController $automationController,
@@ -92,6 +87,7 @@ class SendEmailAction implements Action {
     NewslettersRepository $newslettersRepository,
     SubscriberSegmentRepository $subscriberSegmentRepository,
     SubscribersRepository $subscribersRepository,
+    SegmentsRepository $segmentsRepository,
     AutomationEmailScheduler $automationEmailScheduler,
     NewsletterOptionsRepository $newsletterOptionsRepository,
     NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository
@@ -101,6 +97,7 @@ class SendEmailAction implements Action {
     $this->newslettersRepository = $newslettersRepository;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
     $this->subscribersRepository = $subscribersRepository;
+    $this->segmentsRepository = $segmentsRepository;
     $this->automationEmailScheduler = $automationEmailScheduler;
     $this->newsletterOptionsRepository = $newsletterOptionsRepository;
     $this->newsletterOptionFieldsRepository = $newsletterOptionFieldsRepository;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -149,17 +149,20 @@ class SendEmailAction implements Action {
     try {
       $this->getEmailForStep($args->getStep());
     } catch (InvalidStateException $exception) {
+      $exception = ValidationException::create()
+        ->withMessage(__('Cannot send the email because it was not found. Please, go to the automation editor and update the email contents.', 'mailpoet'));
+
       $emailId = $args->getStep()->getArgs()['email_id'] ?? '';
       if (empty($emailId)) {
-        throw ValidationException::create()
-          ->withError('email_id', __("Automation email not found.", 'mailpoet'));
-      }
-      throw ValidationException::create()
-        ->withError(
+        $exception->withError('email_id', __("Automation email not found.", 'mailpoet'));
+      } else {
+        $exception->withError(
           'email_id',
           // translators: %s is the ID of email.
           sprintf(__("Automation email with ID '%s' not found.", 'mailpoet'), $emailId)
         );
+      }
+      throw $exception;
     }
   }
 


### PR DESCRIPTION
## Description

This PR improves error messages, which can be displayed in Automation Analytics.

## Code review notes

- I noticed some error messages are not translatable, so I changed it.
- I haven't changed the error message `Could not create sending task.` according to instruction `1.c` because I couldn't replicate it. When I changed the email type, the problem was detected in the method `SendEmailAction::getEmailForStep()`.  I also tried to modify the email content to an invalid, which was detected during the validation.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6174]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6174]: https://mailpoet.atlassian.net/browse/MAILPOET-6174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ