### PR TITLE
Merge human and machine opens by default [MAILPOET-6164]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -146,6 +146,9 @@ interface Window {
     level: 'full' | 'partial' | 'basic';
     cookieTrackingEnabled: boolean;
     emailTrackingEnabled: boolean;
+    opens: 'merged' | 'separated';
+    opensMerged: boolean;
+    opensSeparated: boolean;
   }>;
   mailpoet_display_detailed_stats: boolean;
   mailpoet_premium_plugin_installed: boolean;

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-general-stats.tsx
@@ -255,7 +255,7 @@ function NewsletterGeneralStats({ newsletter, isWoocommerceActive }: Props) {
         <div>{clicked}</div>
         <div className="mailpoet-statistics-with-left-separator">
           {opened}
-          {machineOpened}
+          {MailPoet.trackingConfig.opensSeparated && machineOpened}
         </div>
         {isWoocommerceActive && (
           <div className="mailpoet-statistics-with-left-separator">

--- a/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
@@ -2,6 +2,7 @@ import { SaveButton } from 'settings/components';
 import { TaskScheduler } from './task-scheduler';
 import { Roles } from './roles';
 import { EngagementTracking } from './engagement-tracking';
+import { HumanAndMachineOpens } from './human-and-machine-opens';
 import { Transactional } from './transactional';
 import { InactiveSubscribers } from './inactive-subscribers';
 import { ShareData } from './share-data';
@@ -19,6 +20,7 @@ export function Advanced() {
       <TaskScheduler />
       <Roles />
       <EngagementTracking />
+      <HumanAndMachineOpens />
       <Transactional />
       <RecalculateSubscriberScore />
       <InactiveSubscribers />

--- a/mailpoet/assets/js/src/settings/pages/advanced/human-and-machine-opens.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/human-and-machine-opens.tsx
@@ -1,8 +1,8 @@
 import { ReactElement } from 'react';
-import { t } from 'common/functions';
 import { Radio } from 'common/form/radio/radio';
 import { useSetting } from 'settings/store/hooks';
 import { Label, Inputs } from 'settings/components';
+import { __ } from '@wordpress/i18n';
 
 export function HumanAndMachineOpens(): ReactElement {
   const [opens, setOpensMode] = useSetting('tracking', 'opens');
@@ -10,8 +10,11 @@ export function HumanAndMachineOpens(): ReactElement {
   return (
     <>
       <Label
-        title={t('humanAndMachineOpensTitle')}
-        description={t('humanAndMachineOpensDescription')}
+        title={__('Human and machine opens', 'mailpoet')}
+        description={__(
+          'Choose how human and machine opens should be displayed.',
+          'mailpoet',
+        )}
         htmlFor="opens_mode"
       />
       <Inputs>
@@ -24,7 +27,10 @@ export function HumanAndMachineOpens(): ReactElement {
             automationId="opens-merged-radio"
           />
           <label htmlFor="opens-merged">
-            {t('humanAndMachineOpensMerged')}
+            {__(
+              'Merged – both are counted as total opens. Similar to other email marketing tools.',
+              'mailpoet',
+            )}
           </label>
         </div>
         <div className="mailpoet-settings-inputs-row">
@@ -36,7 +42,10 @@ export function HumanAndMachineOpens(): ReactElement {
             automationId="opens-separated-radio"
           />
           <label htmlFor="opens-separated">
-            {t('humanAndMachineOpensSeparated')}
+            {__(
+              'Separated – only human opens are counted as total opens. More accurate, but the numbers tend to be lower.',
+              'mailpoet',
+            )}
           </label>
         </div>
       </Inputs>

--- a/mailpoet/assets/js/src/settings/pages/advanced/human-and-machine-opens.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/human-and-machine-opens.tsx
@@ -1,0 +1,45 @@
+import { ReactElement } from 'react';
+import { t } from 'common/functions';
+import { Radio } from 'common/form/radio/radio';
+import { useSetting } from 'settings/store/hooks';
+import { Label, Inputs } from 'settings/components';
+
+export function HumanAndMachineOpens(): ReactElement {
+  const [opens, setOpensMode] = useSetting('tracking', 'opens');
+
+  return (
+    <>
+      <Label
+        title={t('humanAndMachineOpensTitle')}
+        description={t('humanAndMachineOpensDescription')}
+        htmlFor="opens_mode"
+      />
+      <Inputs>
+        <div className="mailpoet-settings-inputs-row">
+          <Radio
+            id="opens-merged"
+            value="merged"
+            checked={opens === 'merged'}
+            onCheck={setOpensMode}
+            automationId="opens-merged-radio"
+          />
+          <label htmlFor="opens-merged">
+            {t('humanAndMachineOpensMerged')}
+          </label>
+        </div>
+        <div className="mailpoet-settings-inputs-row">
+          <Radio
+            id="opens-separated"
+            value="separated"
+            checked={opens === 'separated'}
+            onCheck={setOpensMode}
+            automationId="opens-separated-radio"
+          />
+          <label htmlFor="opens-separated">
+            {t('humanAndMachineOpensSeparated')}
+          </label>
+        </div>
+      </Inputs>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -115,7 +115,10 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
         'Action Scheduler',
       ),
     }),
-    tracking: asObject({ level: asEnum(['full', 'partial', 'basic'], 'full') }),
+    tracking: asObject({
+      level: asEnum(['full', 'partial', 'basic'], 'full'),
+      opens: asEnum(['merged', 'separated'], 'merged'),
+    }),
     send_transactional_emails: disabledRadio,
     deactivate_subscriber_after_inactive_days: asEnum(
       ['', '90', '180', '365', '540'],

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -49,6 +49,7 @@ export type Settings = {
   };
   tracking: {
     level: 'full' | 'basic' | 'partial';
+    opens: 'merged' | 'separated';
   };
   '3rd_party_libs': {
     enabled: '' | '1';

--- a/mailpoet/assets/js/src/subscribers/stats/summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/summary.tsx
@@ -59,46 +59,49 @@ export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
                 },
               )}
             </tr>
-            <tr>
-              <td>
-                <Tag>{MailPoet.I18n.t('statsMachineOpened')}</Tag>
-                <Tooltip
-                  tooltip={ReactStringReplace(
-                    MailPoet.I18n.t('statsMachineOpenedTooltip'),
-                    /\[link](.*?)\[\/link]/,
-                    (match) => (
-                      <span
-                        style={{ pointerEvents: 'all' }}
-                        key="machine-opened-info"
-                      >
-                        <a
-                          href="https://kb.mailpoet.com/article/368-what-are-machine-opens"
-                          key="kb-link"
-                          target="_blank"
-                          rel="noopener noreferrer"
+            {MailPoet.trackingConfig.opensSeparated && (
+              <tr>
+                <td>
+                  <Tag>{MailPoet.I18n.t('statsMachineOpened')}</Tag>
+                  <Tooltip
+                    tooltip={ReactStringReplace(
+                      MailPoet.I18n.t('statsMachineOpenedTooltip'),
+                      /\[link](.*?)\[\/link]/,
+                      (match) => (
+                        <span
+                          style={{ pointerEvents: 'all' }}
+                          key="machine-opened-info"
                         >
-                          {match}
-                        </a>
-                      </span>
-                    ),
-                  )}
-                />
-              </td>
-              {stats.periodic_stats.map(
-                (periodicStats: PeriodicStats): JSX.Element => {
-                  const displayPercentage = periodicStats.total_sent > 0;
-                  let cell = periodicStats.machine_open.toLocaleString();
-                  if (displayPercentage) {
-                    const percentage = Math.round(
-                      (periodicStats.machine_open / periodicStats.total_sent) *
-                        100,
-                    );
-                    cell += ` (${percentage}%)`;
-                  }
-                  return <td key={periodicStats.timeframe}>{cell}</td>;
-                },
-              )}
-            </tr>
+                          <a
+                            href="https://kb.mailpoet.com/article/368-what-are-machine-opens"
+                            key="kb-link"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {match}
+                          </a>
+                        </span>
+                      ),
+                    )}
+                  />
+                </td>
+                {stats.periodic_stats.map(
+                  (periodicStats: PeriodicStats): JSX.Element => {
+                    const displayPercentage = periodicStats.total_sent > 0;
+                    let cell = periodicStats.machine_open.toLocaleString();
+                    if (displayPercentage) {
+                      const percentage = Math.round(
+                        (periodicStats.machine_open /
+                          periodicStats.total_sent) *
+                          100,
+                      );
+                      cell += ` (${percentage}%)`;
+                    }
+                    return <td key={periodicStats.timeframe}>{cell}</td>;
+                  },
+                )}
+              </tr>
+            )}
             <tr>
               <td>
                 <Tag isInverted>{MailPoet.I18n.t('statsClicked')}</Tag>

--- a/mailpoet/assets/js/src/wizard/woocommerce-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/woocommerce-controller.tsx
@@ -64,6 +64,7 @@ function WooCommerceController({
       MailPoet.trackingConfig.level === 'basic' ? 'basic' : 'partial';
     const trackingData: Settings['tracking'] = {
       level: allowed ? 'full' : trackingLevelForDisabledCookies,
+      opens: 'merged',
     };
     const subscribeOldCustomersData: Settings['mailpoet_subscribe_old_woocommerce_customers'] =
       {
@@ -77,6 +78,8 @@ function WooCommerceController({
       // cookies allowed
       'tracking.level': trackingData.level,
       'woocommerce.accept_cookie_revenue_tracking.set': '1',
+      // human and machine opens
+      'tracking.opens': trackingData.opens,
     };
     await updateSettings(settings);
     setTracking(trackingData);

--- a/mailpoet/lib/Settings/TrackingConfig.php
+++ b/mailpoet/lib/Settings/TrackingConfig.php
@@ -43,6 +43,9 @@ class TrackingConfig {
       'level' => $this->settings->get('tracking.level', self::LEVEL_FULL),
       'emailTrackingEnabled' => $this->isEmailTrackingEnabled(),
       'cookieTrackingEnabled' => $this->isCookieTrackingEnabled(),
+      'opens' => $this->settings->get('tracking.opens', self::OPENS_MERGED),
+      'opensMerged' => $this->areOpensMerged(),
+      'opensSeparated' => $this->areOpensSeparated(),
     ];
   }
 }

--- a/mailpoet/lib/Settings/TrackingConfig.php
+++ b/mailpoet/lib/Settings/TrackingConfig.php
@@ -7,6 +7,9 @@ class TrackingConfig {
   const LEVEL_PARTIAL = 'partial';
   const LEVEL_BASIC = 'basic';
 
+  const OPENS_MERGED = 'merged';
+  const OPENS_SEPARATED = 'separated';
+
   /** @var SettingsController */
   private $settings;
 
@@ -24,6 +27,15 @@ class TrackingConfig {
   public function isCookieTrackingEnabled(string $level = null): bool {
     $level = $level ?? $this->settings->get('tracking.level', self::LEVEL_FULL);
     return $level === self::LEVEL_FULL;
+  }
+
+  public function areOpensMerged(string $opens = null): bool {
+    $opens = $opens ?? $this->settings->get('tracking.opens', self::OPENS_MERGED);
+    return $opens !== self::OPENS_SEPARATED;
+  }
+
+  public function areOpensSeparated(string $opens = null): bool {
+    return !$this->areOpensMerged($opens);
   }
 
   public function getConfig(): array {

--- a/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
+++ b/mailpoet/lib/Subscribers/Statistics/SubscriberStatisticsRepository.php
@@ -10,6 +10,7 @@ use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\UserAgentEntity;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Settings\TrackingConfig;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -23,12 +24,17 @@ class SubscriberStatisticsRepository extends Repository {
   /** @var WCHelper */
   private $wcHelper;
 
+  /** @var TrackingConfig */
+  private $trackingConfig;
+
   public function __construct(
     EntityManager $entityManager,
-    WCHelper $wcHelper
+    WCHelper $wcHelper,
+    TrackingConfig $trackingConfig
   ) {
     parent::__construct($entityManager);
     $this->wcHelper = $wcHelper;
+    $this->trackingConfig = $trackingConfig;
   }
 
   protected function getEntityClassName() {
@@ -64,9 +70,13 @@ class SubscriberStatisticsRepository extends Repository {
   }
 
   public function getStatisticsOpenCount(SubscriberEntity $subscriber, ?Carbon $startTime = null): int {
-    return (int)$this->getStatisticsOpenCountQuery($subscriber, $startTime)
-      ->andWhere('(stats.userAgentType = :userAgentType)')
-      ->setParameter('userAgentType', UserAgentEntity::USER_AGENT_TYPE_HUMAN)
+    $queryBuilder = $this->getStatisticsOpenCountQuery($subscriber, $startTime);
+    if ($this->trackingConfig->areOpensSeparated()) {
+      $queryBuilder
+        ->andWhere('(stats.userAgentType = :userAgentType)')
+        ->setParameter('userAgentType', UserAgentEntity::USER_AGENT_TYPE_HUMAN);
+    }
+    return (int)$queryBuilder
       ->getQuery()
       ->getSingleScalarResult();
   }

--- a/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
+++ b/mailpoet/tests/acceptance/WelcomeWizard/WelcomeWizardCest.php
@@ -77,7 +77,7 @@ class WelcomeWizardCest {
     Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
     Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
     Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
-    Assert::assertSame(['level' => 'full'], $this->findSetting('tracking')->getValue());
+    Assert::assertSame(['level' => 'full', 'opens' => 'merged'], $this->findSetting('tracking')->getValue());
     Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 
@@ -118,7 +118,7 @@ class WelcomeWizardCest {
     Assert::assertSame($senderAddress, $this->findSetting('sender')->getValue()['address']);
     Assert::assertSame(['enabled' => '1'], $this->findSetting('3rd_party_libs')->getValue());
     Assert::assertSame(['enabled' => '1'], $this->findSetting('analytics')->getValue());
-    Assert::assertSame(['level' => 'full'], $this->findSetting('tracking')->getValue());
+    Assert::assertSame(['level' => 'full', 'opens' => 'merged'], $this->findSetting('tracking')->getValue());
     Assert::assertSame($mailPoetSendingKey, $this->findSetting('mta')->getValue()['mailpoet_api_key']);
   }
 

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -30,6 +30,7 @@ use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
@@ -94,7 +95,8 @@ class NewslettersTest extends \MailPoetTest {
           $this->diContainer->get(NewslettersRepository::class),
           new NewsletterStatisticsRepository(
             $this->diContainer->get(EntityManager::class),
-            $this->makeEmpty(WCHelper::class)
+            $this->makeEmpty(WCHelper::class),
+            $this->diContainer->get(TrackingConfig::class)
           ),
           $this->diContainer->get(Url::class),
           $this->diContainer->get(SendingQueuesRepository::class),

--- a/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Statistics/NewsletterStatisticsRepositoryTest.php
@@ -8,10 +8,13 @@ use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsWooCommercePurchasesRepository;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\NewsletterLink;
 use MailPoet\Test\DataFactories\StatisticsClicks;
+use MailPoet\Test\DataFactories\StatisticsOpens;
 use MailPoet\Test\DataFactories\Subscriber;
 
 /**
@@ -32,6 +35,9 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
   /** @var \MailPoet\Entities\SubscriberEntity */
   private $subscriber;
 
+  /** @var \MailPoet\Entities\SubscriberEntity */
+  private $subscriber2;
+
   /** @var StatisticsClickEntity */
   private $click1;
 
@@ -44,11 +50,28 @@ class NewsletterStatisticsRepositoryTest extends \MailPoetTest {
     $this->newsletter = (new Newsletter())->withSendingQueue()->create();
     $this->assertInstanceOf(NewsletterEntity::class, $this->newsletter);
     $this->subscriber = (new Subscriber())->create();
+    $this->subscriber2 = (new Subscriber())->create();
 
     $link = (new NewsletterLink($this->newsletter))->create();
     $this->click1 = (new StatisticsClicks($link, $this->subscriber))->create();
     $link = (new NewsletterLink($this->newsletter))->create();
     $this->click2 = (new StatisticsClicks($link, $this->subscriber))->create();
+  }
+
+  public function testItGetsMergedOpens() {
+    $open = (new StatisticsOpens($this->newsletter, $this->subscriber))->create();
+    $open2 = (new StatisticsOpens($this->newsletter, $this->subscriber2))->withMachineUserAgentType()->create();
+    SettingsController::getInstance()->set('tracking.opens', TrackingConfig::OPENS_MERGED);
+    $count = $this->testee->getStatisticsOpenCount($this->newsletter);
+    verify($count)->equals(2);
+  }
+
+  public function testItGetsSeparatedOpens() {
+    $open = (new StatisticsOpens($this->newsletter, $this->subscriber))->create();
+    $open2 = (new StatisticsOpens($this->newsletter, $this->subscriber2))->withMachineUserAgentType()->create();
+    SettingsController::getInstance()->set('tracking.opens', TrackingConfig::OPENS_SEPARATED);
+    $count = $this->testee->getStatisticsOpenCount($this->newsletter);
+    verify($count)->equals(1);
   }
 
   public function testItGetsOnlyStatisticsWithTheCorrectStatus() {

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -233,9 +233,4 @@
   'engagementTrackingFull': __('Full – additionally use browser cookies to improve the site and email engagement tracking and abandoned cart email accuracy.'),
   'engagementTrackingPartial': __('Partial – additionally track email engagement (opens, clicks). Disable cookie-based tracking.'),
   'engagementTrackingBasic': __('Basic – only use data your site already has about your subscribers. Disable email engagement and cookie-based tracking, and re-engagement emails.'),
-
-  'humanAndMachineOpensTitle': __('Human and machine opens'),
-  'humanAndMachineOpensDescription': __('Choose how human and machine opens should be displayed.'),
-  'humanAndMachineOpensMerged': __('Merged – both are counted as total opens. Similar to other email marketing tools.'),
-  'humanAndMachineOpensSeparated': __('Separated – only human opens are counted as total opens. More accurate, but the numbers tend to be lower.'),
 }) %>

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -233,4 +233,9 @@
   'engagementTrackingFull': __('Full – additionally use browser cookies to improve the site and email engagement tracking and abandoned cart email accuracy.'),
   'engagementTrackingPartial': __('Partial – additionally track email engagement (opens, clicks). Disable cookie-based tracking.'),
   'engagementTrackingBasic': __('Basic – only use data your site already has about your subscribers. Disable email engagement and cookie-based tracking, and re-engagement emails.'),
+
+  'humanAndMachineOpensTitle': __('Human and machine opens'),
+  'humanAndMachineOpensDescription': __('Choose how human and machine opens should be displayed.'),
+  'humanAndMachineOpensMerged': __('Merged – both are counted as total opens. Similar to other email marketing tools.'),
+  'humanAndMachineOpensSeparated': __('Separated – only human opens are counted as total opens. More accurate, but the numbers tend to be lower.'),
 }) %>


### PR DESCRIPTION
## Description

I have changed only what's displayed in total stats throughout the plugin (newsletters, subscribers, automations, stats notifications). Other things involving human and machine opens such as segment filters and subscriber tags were not changed. If set to merged, machine opens are hidden from summaries on the newsletter and subscriber stats pages.

## Code review notes

_N/A_

## QA notes

The best way to test would be to install the build on a site which has some real human and machine opens gathered and see if everything looks tight under both settings (Settings > Advanced > Human and machine opens > Merged / Separated).
It would be good to also ensure that both upgrades and clean installs have this setting set to merged by default - I have checked this already, but it's better to double-check.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6164]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6164]: https://mailpoet.atlassian.net/browse/MAILPOET-6164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ