### PR TITLE
Make the form border consistent [MAILPOET-6193]

### DIFF
--- a/mailpoet/assets/js/src/form-editor/components/form-styling-background.jsx
+++ b/mailpoet/assets/js/src/form-editor/components/form-styling-background.jsx
@@ -28,11 +28,6 @@ function FormStylingBackground({ children }) {
     [previewSettings.formType],
   );
 
-  let borderStyle;
-  if (borderSize && borderColor) {
-    borderStyle = 'solid';
-  }
-
   let radius;
   if (borderRadius) radius = Number(borderRadius);
   let padding;
@@ -51,15 +46,18 @@ function FormStylingBackground({ children }) {
     fontFamily,
     lineHeight: 1.2,
     borderRadius: radius,
-    borderWidth: borderSize,
-    borderColor,
-    borderStyle,
     textAlign,
     padding,
     width: formWidth.unit === 'pixel' ? formWidth.value : `${formWidth.value}%`,
     margin: '0 auto',
     maxWidth: '100%',
   };
+
+  if (borderSize && borderColor) {
+    style.borderWidth = borderSize;
+    style.borderColor = borderColor;
+    style.borderStyle = 'solid';
+  }
 
   // Render virtual container for widgets and below pages/post forms with width in percent
   if (


### PR DESCRIPTION
## Description

In the renderer, we only display the border if both colour and size are set. Before this commit in the editor, we showed the border even if the colour was transparent. This makes it consistent and displays the border in the editor the same way as in the renderer.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6193]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6193]: https://mailpoet.atlassian.net/browse/MAILPOET-6193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ