### PR TITLE
Fix transaction test for MyISAM [MAILPOET-6195]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1072,7 +1072,7 @@ workflows:
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           requires:
             - build
@@ -1111,7 +1111,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI # We use image with PHP 6.4 and install required WordPress version via CLI
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5
@@ -1174,7 +1174,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           requires:
             - build_premium
@@ -1186,7 +1186,7 @@ workflows:
           woo_memberships_version: 1.25.2
           automate_woo_version: 5.8.5
           codeception_image_version: 7.4-cli_20220605.0
-          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 6.4 and install required WordPress version via CLI
+          wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.5.5
           mysql_command: --max_allowed_packet=100M --default-storage-engine=MYISAM
           mysql_image: mysql:5.5


### PR DESCRIPTION
## Description

This PR fixes the failing test in a nightly job that uses the MyISAM engine in the DB.

## Code review notes

I found I could also fix the test by enforcing the InnoDB engine in the create table query, but I decided to detect MyISAM and use a different assert. I think this way, we cover more cases.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6195]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6195]: https://mailpoet.atlassian.net/browse/MAILPOET-6195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ