### PR TITLE
Fix schedule date in calendar on the send page [MAILPOET-6197]

### DIFF
--- a/mailpoet/assets/js/src/date.ts
+++ b/mailpoet/assets/js/src/date.ts
@@ -69,9 +69,7 @@ export const MailPoetDate: {
     }
     return momentDate.format(this.convertFormat(this.options.format));
   },
-  toDate: function toDate(date: MomentInput, opts?: DateOptions): Date {
-    const options = opts || {};
-    this.init(options);
+  toDate: function toDate(date: MomentInput): Date {
     return Moment.utc(date).toDate();
   },
   short: function short(date: MomentInput): string {

--- a/mailpoet/assets/js/src/newsletters/send/date-text.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-text.tsx
@@ -1,10 +1,10 @@
 import { Component, SyntheticEvent } from 'react';
+import Moment from 'moment';
 import { __, _x } from '@wordpress/i18n';
 import { registerLocale } from 'react-datepicker';
 import locale from 'date-fns/locale/en-US';
 import { Datepicker } from 'common/datepicker/datepicker';
 import { MailPoet } from 'mailpoet';
-import { DateOptions } from 'date';
 
 /**
  * This function is a copy of the buildLocalizeFn function from date-fns (date-fns/locale/_lib/buildLocalizeFn)
@@ -134,10 +134,10 @@ class DateText extends Component<DateTextProps> {
   onChange = (value: Date, event) => {
     const changeEvent: DateTextEvent = event;
     // Swap display format to storage format
-    const storageDate = this.getStorageDate(value);
+    const formattedDate = this.getAsStringInFormat(value);
 
     changeEvent.target.name = this.getFieldName();
-    changeEvent.target.value = storageDate;
+    changeEvent.target.value = formattedDate;
     this.props.onChange(changeEvent);
   };
 
@@ -155,19 +155,10 @@ class DateText extends Component<DateTextProps> {
       .replace(/\]/g, '');
   };
 
-  getDate = (date: string) => {
-    const formatting = {
-      parseFormat: this.props.storageFormat,
-    } as DateOptions;
-    return MailPoet.Date.toDate(date, formatting);
-  };
+  getDate = (date: string) => Moment(date).toDate();
 
-  getStorageDate = (date: Date) => {
-    const formatting = {
-      format: this.props.storageFormat,
-    };
-    return MailPoet.Date.format(date, formatting);
-  };
+  getAsStringInFormat = (date: Date) =>
+    Moment(date).format(MailPoet.Date.convertFormat(this.props.storageFormat));
 
   render() {
     return (


### PR DESCRIPTION
## Description

This PR fixes an issue in scheduling the calendar on the send page. In timezones that are far from UTC we display incorrect date.

## Code review notes

I tried to explain the issue in the commit message.

## QA notes

# Replication

1. Set your site timezone to Los Angels timezone (UTC-7)
3. Set your browser timezone to the same timezone ([here is how to do it in dev tools](https://www.browserstack.com/guide/change-time-zone-in-chrome-for-testing))
5. Create a newsletter and schedule it close to midnight
7. Observe the issue in the calendar and in the listing

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6197]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6197]: https://mailpoet.atlassian.net/browse/MAILPOET-6197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ