### PR TITLE
Fix pnpm lockfile error on `./do setup` run [MAILPOET-6201]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     volumes:
       - './wordpress:/var/www/html'
       - './tsconfig.base.json:/var/www/html/wp-content/plugins/tsconfig.base.json:ro'
+      - './.npmrc:/var/www/html/wp-content/plugins/.npmrc'
       - './package.json:/var/www/html/wp-content/plugins/package.json'
       - './pnpm-lock.yaml:/var/www/html/wp-content/plugins/pnpm-lock.yaml'
       - './pnpm-workspace.yaml:/var/www/html/wp-content/plugins/pnpm-workspace.yaml'


### PR DESCRIPTION
## Description

Setting up the dev environment with `./do setup`  command, as per the [guide here](https://github.com/mailpoet/mailpoet/blob/trunk/README.md), fails with this error:

```
./do setup
...
[ExecStack] Executing cd .. && pnpm install --frozen-lockfile --prefer-offline
[ExecStack] Running cd .. && pnpm install --frozen-lockfile --prefer-offline
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn't match the value found in the lockfile
...
```

More details on the problem and the solution are in the linked Jira issue.

> [!NOTE]
> I've tested `./do setup` command after the change, and it has fixed the error.

## Code review notes

_N/A_

## QA notes

QA is not needed for this PR.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6201]

## After-merge notes

_N/A_


[MAILPOET-6201]: https://mailpoet.atlassian.net/browse/MAILPOET-6201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ