### PR TITLE
Fix occasionally failing flaky test to trash or restore newsletters

### DIFF
--- a/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
@@ -19,7 +19,8 @@ class DeleteNewsletterCest {
     $i->waitForNoticeAndClose('1 email was moved to the trash.');
     // click to select all newsletters
     $i->click('[data-automation-id="select_all"]');
-    $i->click('Move to trash');
+    $i->waitForElementVisible('[data-automation-id="action-trash"]');
+    $i->click('[data-automation-id="action-trash"]');
     $i->waitForNoticeAndClose('2 emails were moved to the trash.');
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
@@ -40,7 +41,8 @@ class DeleteNewsletterCest {
     $i->waitForText('1 email has been restored from the Trash.');
     // click to select all newsletters
     $i->click('[data-automation-id="select_all"]');
-    $i->click('Restore');
+    $i->waitForElementVisible('[data-automation-id="action-restore"]');
+    $i->click('[data-automation-id="action-restore"]');
     $i->waitForText('2 emails have been restored from the Trash.', 20);
     $i->changeGroupInListingFilter('all');
     $i->waitForText($newsletterName);
@@ -106,7 +108,8 @@ class DeleteNewsletterCest {
     $i->waitForText('All items on this page are selected.');
     $i->click('Select all items on all pages');
     $i->waitForText('All 22 items are selected.');
-    $i->click('Move to trash');
+    $i->waitForElementVisible('[data-automation-id="action-trash"]');
+    $i->click('[data-automation-id="action-trash"]');
     $i->waitForText('22 emails were moved to the trash.');
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
@@ -17,11 +17,13 @@ class DeleteNewsletterCest {
     $i->waitForText($newsletterName);
     $i->clickItemRowActionByItemName($newsletterName, 'Move to trash');
     $i->waitForNoticeAndClose('1 email was moved to the trash.');
+    $i->waitForListingItemsToLoad();
     // click to select all newsletters
     $i->click('[data-automation-id="select_all"]');
-    $i->waitForElementVisible('[data-automation-id="action-trash"]');
+    $i->waitForText('Move to trash');
+    $i->waitForElementClickable('[data-automation-id="action-trash"]');
     $i->click('[data-automation-id="action-trash"]');
-    $i->waitForNoticeAndClose('2 emails were moved to the trash.');
+    $i->waitForNoticeAndClose('2 emails were moved to the trash.', 20);
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
   }
@@ -39,9 +41,11 @@ class DeleteNewsletterCest {
     $i->waitForText($newsletterName);
     $i->clickItemRowActionByItemName($newsletterName, 'Restore');
     $i->waitForText('1 email has been restored from the Trash.');
+    $i->waitForListingItemsToLoad();
     // click to select all newsletters
     $i->click('[data-automation-id="select_all"]');
-    $i->waitForElementVisible('[data-automation-id="action-restore"]');
+    $i->waitForText('Restore');
+    $i->waitForElementClickable('[data-automation-id="action-restore"]');
     $i->click('[data-automation-id="action-restore"]');
     $i->waitForText('2 emails have been restored from the Trash.', 20);
     $i->changeGroupInListingFilter('all');

--- a/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
+++ b/mailpoet/tests/acceptance/Settings/WooCommerceSettingsTabCest.php
@@ -52,9 +52,9 @@ class WooCommerceSettingsTabCest {
     $i->waitForText('Settings saved');
     $i->addProductToCart($this->product);
     $i->goToBlockCheckout();
-    $i->see('I want to opt-in with the custom message.');
+    $i->waitForText('I want to opt-in with the custom message.');
     $i->goToShortcodeCheckout();
-    $i->see('I want to opt-in with the custom message.');
+    $i->waitForText('I want to opt-in with the custom message.');
   }
 
   public function checkWooCommerceAdditionalLists(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Fixing flaky acceptance test when moving newsletters to the trash, or restoring them, sometimes skip action clicking `Move to trash`.
Additionally, a small update on `WooCommerceSettingsTabCest.php` to use `waitForText` instead `see` to fix flakiness against WC 9.3 beta

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6202]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6202]: https://mailpoet.atlassian.net/browse/MAILPOET-6202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ