### PR TITLE
WordPress Playground & Studio improvements [MAILPOET-6185]

### DIFF
--- a/.github/workflows/wordpress-playground-preview.yml
+++ b/.github/workflows/wordpress-playground-preview.yml
@@ -1,0 +1,27 @@
+name: Add link to WordPress Playground preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  append-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check and append description
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BRANCH_NAME="${{ github.head_ref }}"
+          DESCRIPTION="$(gh pr view $PR_NUMBER --json body -q .body)"
+          HEADING="## Preview"
+          CONTENT="$(printf "\n\n${HEADING}\n\n[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:${BRANCH_NAME})\n\n_The latest successful build from \`${BRANCH_NAME}\` will be used. If none is available, the link won't work._")"
+
+          if [[ "$DESCRIPTION" != *"$HEADING"* ]]; then
+            gh pr edit $PR_NUMBER --body "${DESCRIPTION}\n\n${CONTENT}"
+          fi

--- a/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20230825_093531_App.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Migrations\App;
 
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Entities\StatisticsWooCommercePurchaseEntity;
 use MailPoet\Migrations\Db\Migration_20230824_054259_Db;
 use MailPoet\Migrator\AppMigration;
@@ -16,6 +17,12 @@ class Migration_20230825_093531_App extends AppMigration {
 
     // If Woo is not active and the table doesn't exist, we can skip this migration
     if (!$wooCommerceHelper->isWooCommerceActive() && !$this->tableExists()) {
+      return;
+    }
+
+    // Temporarily skip the queries in WP Playground.
+    // The SQLite integration doesn't seem to support them yet.
+    if (Connection::isSQLite()) {
       return;
     }
 

--- a/mailpoet/lib/Migrations/App/Migration_20231128_120355_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20231128_120355_App.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Migrations\App;
 
+use MailPoet\Doctrine\WPDB\Connection as WPDBConnection;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -21,6 +22,12 @@ class Migration_20231128_120355_App extends AppMigration {
 
     // If Woo is not active and the table doesn't exist, we can skip this migration
     if (!$wooCommerceHelper->isWooCommerceActive()) {
+      return;
+    }
+
+    // Temporarily skip the queries in WP Playground.
+    // UPDATE with JOIN is not yet supported by the SQLite integration.
+    if (WPDBConnection::isSQLite()) {
       return;
     }
 

--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Util\Notices;
 
 use MailPoet\Config\Env;
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice;
@@ -27,7 +28,7 @@ class DatabaseEngineNotice {
   }
 
   public function init($shouldDisplay): ?Notice {
-    if (!$shouldDisplay || $this->wp->getTransient(self::OPTION_NAME)) {
+    if (!$shouldDisplay || Connection::isSQLite() || $this->wp->getTransient(self::OPTION_NAME)) {
       return null;
     }
 

--- a/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
+++ b/mailpoet/lib/Util/Notices/DisabledMailFunctionNotice.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Util\Notices;
 
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes;
+use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Settings\SettingsController;
@@ -44,7 +45,7 @@ class DisabledMailFunctionNotice {
   }
 
   public function init($shouldDisplay): ?string {
-    $shouldDisplay = $shouldDisplay && $this->shouldCheckMisconfiguredFunction() && $this->checkRequirements();
+    $shouldDisplay = $shouldDisplay && !Connection::isSQLite() && $this->shouldCheckMisconfiguredFunction() && $this->checkRequirements();
     if (!$shouldDisplay) {
       return null;
     }

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -65,6 +65,9 @@ class PermanentNotices {
   /** @var SenderDomainAuthenticationNotices */
   private $senderDomainAuthenticationNotices;
 
+  /** @var WordPressPlaygroundNotice */
+  private $wordPressPlaygroundNotice;
+
   /** @var DatabaseEngineNotice */
   private $databaseEngineNotice;
   
@@ -96,6 +99,7 @@ class PermanentNotices {
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
     $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);
     $this->databaseEngineNotice = new DatabaseEngineNotice($wp, $entityManager);
+    $this->wordPressPlaygroundNotice = new WordPressPlaygroundNotice();
     $this->senderDomainAuthenticationNotices = $senderDomainAuthenticationNotices;
   }
 
@@ -157,6 +161,9 @@ class PermanentNotices {
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->databaseEngineNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
+    $this->wordPressPlaygroundNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $excludeDomainAuthenticationNotices = [

--- a/mailpoet/lib/Util/Notices/WordPressPlaygroundNotice.php
+++ b/mailpoet/lib/Util/Notices/WordPressPlaygroundNotice.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Doctrine\WPDB\Connection;
+use MailPoet\WP\Notice;
+
+class WordPressPlaygroundNotice {
+  const OPTION_NAME = 'wordpress-playground-notice';
+
+  public function init($shouldDisplay): ?Notice {
+    if (!$shouldDisplay || !Connection::isSQLite()) {
+      return null;
+    }
+    return $this->display();
+  }
+
+  private function display(): Notice {
+    return Notice::displayWarning(
+      sprintf(
+        '<p><strong>%s</strong></p><p>%s</p>',
+        __('MailPoet Preview', 'mailpoet'),
+        __('This is a preview of the MailPoet plugin. Please note that some functionality may be limited.', 'mailpoet')
+      ),
+      null,
+      self::OPTION_NAME,
+      false
+    );
+  }
+}


### PR DESCRIPTION
## Description

Just a few more fixes for WordPress Playground & Studio, and a notice about this being a plugin preview.

<img width="1331" alt="Screenshot 2024-08-30 at 16 57 47" src="https://github.com/user-attachments/assets/75bd0e62-a2da-40fc-b5c3-b95545cf7d14">

## Code review notes

Please, just see the commit messages. QA can be skipped, I think.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5777

## Linked tickets

[MAILPOET-6185]

[MAILPOET-6185]: https://mailpoet.atlassian.net/browse/MAILPOET-6185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wp-playground-improvements)

_The latest successful build from `wp-playground-improvements` will be used. If none is available, the link won't work._