### PR TITLE
Fix deprecation notice about ${var} in strings [MAILPOET-6207]

### DIFF
--- a/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
+++ b/mailpoet/lib/Util/Notices/DatabaseEngineNotice.php
@@ -94,7 +94,7 @@ class DatabaseEngineNotice {
     sort($tablesWithIncorrectEngine);
 
     $tables = array_map(
-      fn($table) => "“${table}”",
+      fn($table) => "“{$table}”",
       array_slice($tablesWithIncorrectEngine, 0, self::MAX_TABLES_TO_DISPLAY)
     );
 


### PR DESCRIPTION
## Description

Fixes: `Using ${var} in strings is deprecated, use {$var} instead`

## Code review notes

QA can be skipped.

## QA notes

QA can be skipped.

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5785

## Linked tickets

[MAILPOET-6207]

[MAILPOET-6207]: https://mailpoet.atlassian.net/browse/MAILPOET-6207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ