### PR TITLE
Reduce the number of queries on plugin update and activation [MAILPOET-6218]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Setup.php
+++ b/mailpoet/lib/API/JSON/v1/Setup.php
@@ -5,6 +5,7 @@ namespace MailPoet\API\JSON\v1;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\Config\AccessControl;
 use MailPoet\Config\Activator;
+use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Setup extends APIEndpoint {
@@ -18,17 +19,23 @@ class Setup extends APIEndpoint {
   /** @var Activator */
   private $activator;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function __construct(
     WPFunctions $wp,
-    Activator $activator
+    Activator $activator,
+    SettingsController $settings
   ) {
     $this->wp = $wp;
     $this->activator = $activator;
+    $this->settings = $settings;
   }
 
   public function reset() {
     try {
       $this->activator->deactivate();
+      $this->settings->resetCache();
       $this->activator->activate();
       $this->wp->doAction('mailpoet_setup_reset');
       return $this->successResponse();

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -216,11 +216,11 @@ class Populator {
   }
 
   private function createDefaultSettings() {
-    $settingsDbVersion = $this->settings->fetch('db_version');
+    $settingsDbVersion = $this->settings->get('db_version');
     $currentUser = $this->wp->wpGetCurrentUser();
 
     // set cron trigger option to default method
-    if (!$this->settings->fetch(CronTrigger::SETTING_NAME)) {
+    if (!$this->settings->get(CronTrigger::SETTING_NAME)) {
       $this->settings->set(CronTrigger::SETTING_NAME, [
         'method' => CronTrigger::DEFAULT_METHOD,
       ]);
@@ -237,7 +237,7 @@ class Populator {
       'name' => $senderName,
       'address' => $senderAddress ?: '',
     ];
-    $savedSender = $this->settings->fetch('sender', []);
+    $savedSender = $this->settings->get('sender', []);
 
     /**
      * Set default from name & address
@@ -249,20 +249,20 @@ class Populator {
     }
 
     // enable signup confirmation by default
-    if (!$this->settings->fetch('signup_confirmation')) {
+    if (!$this->settings->get('signup_confirmation')) {
       $this->settings->set('signup_confirmation', [
         'enabled' => true,
       ]);
     }
 
     // set installation date
-    if (!$this->settings->fetch('installed_at')) {
+    if (!$this->settings->get('installed_at')) {
       $this->settings->set('installed_at', date("Y-m-d H:i:s"));
     }
 
     // set captcha settings
-    $captcha = $this->settings->fetch('captcha');
-    $reCaptcha = $this->settings->fetch('re_captcha');
+    $captcha = $this->settings->get('captcha');
+    $reCaptcha = $this->settings->get('re_captcha');
     if (empty($captcha)) {
       $captchaType = CaptchaConstants::TYPE_DISABLED;
       if (!empty($reCaptcha['enabled'])) {
@@ -277,9 +277,9 @@ class Populator {
       ]);
     }
 
-    $subscriberEmailNotification = $this->settings->fetch(NewSubscriberNotificationMailer::SETTINGS_KEY);
+    $subscriberEmailNotification = $this->settings->get(NewSubscriberNotificationMailer::SETTINGS_KEY);
     if (empty($subscriberEmailNotification)) {
-      $sender = $this->settings->fetch('sender', []);
+      $sender = $this->settings->get('sender', []);
       $this->settings->set('subscriber_email_notification', [
         'enabled' => true,
         'automated' => true,
@@ -287,16 +287,16 @@ class Populator {
       ]);
     }
 
-    $statsNotifications = $this->settings->fetch(Worker::SETTINGS_KEY);
+    $statsNotifications = $this->settings->get(Worker::SETTINGS_KEY);
     if (empty($statsNotifications)) {
-      $sender = $this->settings->fetch('sender', []);
+      $sender = $this->settings->get('sender', []);
       $this->settings->set(Worker::SETTINGS_KEY, [
         'enabled' => true,
         'address' => isset($sender['address']) ? $sender['address'] : null,
       ]);
     }
 
-    $woocommerceOptinOnCheckout = $this->settings->fetch('woocommerce.optin_on_checkout');
+    $woocommerceOptinOnCheckout = $this->settings->get('woocommerce.optin_on_checkout');
     $legacyLabelText = _x('Yes, I would like to be added to your mailing list', "default email opt-in message displayed on checkout page for ecommerce websites", 'mailpoet');
     $currentLabelText = _x('I would like to receive exclusive emails with discounts and product information', "default email opt-in message displayed on checkout page for ecommerce websites", 'mailpoet');
     if (empty($woocommerceOptinOnCheckout)) {
@@ -313,7 +313,7 @@ class Populator {
   }
 
   private function createDefaultUsersFlags() {
-    $lastAnnouncementSeen = $this->settings->fetch('last_announcement_seen');
+    $lastAnnouncementSeen = $this->settings->get('last_announcement_seen');
     if (!empty($lastAnnouncementSeen)) {
       foreach ($lastAnnouncementSeen as $userId => $value) {
         $this->createOrUpdateUserFlag($userId, 'last_announcement_seen', $value);

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -71,8 +71,18 @@ class SegmentsRepository extends Repository {
   }
 
   public function getWPUsersSegment(): SegmentEntity {
-    $segment = $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
+    $cached = current(
+      array_filter(
+        $this->getAllFromIdentityMap(),
+        fn(SegmentEntity $segment) => $segment->getType() === SegmentEntity::TYPE_WP_USERS
+      )
+    );
 
+    if ($cached) {
+      return $cached;
+    }
+
+    $segment = $this->findOneBy(['type' => SegmentEntity::TYPE_WP_USERS]);
     if (!$segment) {
       // create the wp users segment
       $segment = new SegmentEntity(
@@ -80,15 +90,24 @@ class SegmentsRepository extends Repository {
         SegmentEntity::TYPE_WP_USERS,
         __('This list contains all of your WordPress users.', 'mailpoet')
       );
-
       $this->entityManager->persist($segment);
       $this->entityManager->flush();
     }
-
     return $segment;
   }
 
   public function getWooCommerceSegment(): SegmentEntity {
+    $cached = current(
+      array_filter(
+        $this->getAllFromIdentityMap(),
+        fn(SegmentEntity $segment) => $segment->getType() === SegmentEntity::TYPE_WC_USERS
+      )
+    );
+
+    if ($cached) {
+      return $cached;
+    }
+
     $segment = $this->findOneBy(['type' => SegmentEntity::TYPE_WC_USERS]);
     if (!$segment) {
       // create the WooCommerce customers segment

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -34,7 +34,7 @@ class SetupTest extends \MailPoetTest {
     $captchaRenderer = $this->diContainer->get(CaptchaRenderer::class);
     $migrator = $this->diContainer->get(Migrator::class);
     $cronActionScheduler = $this->diContainer->get(ActionScheduler::class);
-    $router = new Setup($wpStub, new Activator($this->connection, $settings, $populator, $wpStub, $migrator, $cronActionScheduler));
+    $router = new Setup($wpStub, new Activator($this->connection, $settings, $populator, $wpStub, $migrator, $cronActionScheduler), $settings);
     $response = $router->reset();
     verify($response->status)->equals(APIResponse::STATUS_OK);
 

--- a/mailpoet/tests/integration/Config/PopulatorTest.php
+++ b/mailpoet/tests/integration/Config/PopulatorTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Config;
+
+use MailPoet\Config\Populator;
+use MailPoet\Entities\NewsletterTemplateEntity;
+use MailPoetTest;
+use MailPoetVendor\Doctrine\ORM\Query;
+
+class PopulatorTest extends MailPoetTest {
+  private const TEMPLATE_COUNT = 76;
+
+  public function testItInsertsTemplates(): void {
+    $populator = $this->diContainer->get(Populator::class);
+
+    // no templates
+    $templates = $this->getAllTemplates();
+    $this->assertSame(0, count($templates));
+
+    // insert all templates
+    $populator->up();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT, count($templates));
+
+    // delete some templates
+    $this->entityManager->createQueryBuilder()
+      ->delete(NewsletterTemplateEntity::class, 't')
+      ->where('t.id IN (:ids)')
+      ->setParameter('ids', array_map(fn($template) => $template->getId(), array_slice($templates, 0, 10)))
+      ->getQuery()
+      ->execute();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT - 10, count($templates));
+
+    // insert new templates
+    $populator->up();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT, count($templates));
+  }
+
+  public function testItUpdatesTemplates(): void {
+    $populator = $this->diContainer->get(Populator::class);
+
+    // insert all templates
+    $populator->up();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT, count($templates));
+
+    // update some templates in the database
+    $templates[0]->setBody(['blocks' => ['test']]);
+    $templates[1]->setCategories('["test-cat-1,test-cat-2,test-cat-3"]');
+    $templates[2]->setThumbnail('test-thumbnail.jpg');
+    $templates[3]->setName('Test template'); // this will cause a new template to be created
+    $this->entityManager->flush();
+
+    // update templates
+    $populator->up();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT + 1, count($templates));
+    $this->assertNotEquals(['blocks' => ['test']], $templates[0]->getBody());
+    $this->assertNotEquals('["test-cat-1,test-cat-2,test-cat-3"]', $templates[1]->getCategories());
+    $this->assertNotEquals('test-thumbnail.jpg', $templates[2]->getThumbnail());
+    $this->assertSame('Test template', $templates[3]->getName());
+    $this->assertNotEmpty(array_filter($templates, fn($template) => $template->getName() === 'Test template'));
+  }
+
+  public function testItRemovesDuplicates(): void {
+    $populator = $this->diContainer->get(Populator::class);
+
+    // insert all templates
+    $populator->up();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT, count($templates));
+
+    // create some duplicates
+    $this->entityManager->persist(clone $templates[0]);
+    $this->entityManager->persist(clone $templates[1]);
+    $this->entityManager->persist(clone $templates[2]);
+    $this->entityManager->flush();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT + 3, count($templates));
+
+    // remove duplicates
+    $populator->up();
+    $templates = $this->getAllTemplates();
+    $this->assertSame(self::TEMPLATE_COUNT, count($templates));
+  }
+
+  private function getAllTemplates(): array {
+    return (array)$this->entityManager->createQueryBuilder()
+      ->select('t')
+      ->from(NewsletterTemplateEntity::class, 't')
+      ->orderBy('t.id')
+      ->getQuery()
+      ->setHint(Query::HINT_REFRESH, true)
+      ->getResult();
+  }
+}


### PR DESCRIPTION
## Description

These changes reduce the number of queries executed on plugin activation and update by about 300.

See also: [Eliminating 300 database queries on MailPoet plugin activation and update](https://mailpoetdev.wordpress.com/2024/09/04/eliminating-300-database-queries-on-mailpoet-plugin-activation-and-update/)

## Code review notes

I added some tests, I think QA can be skipped.

## QA notes

I added some tests, I think QA can be skipped.

## Linked tickets

[MAILPOET-6218]

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:activation-queries)

_The latest successful build from `activation-queries` will be used. If none is available, the link won't work._

[MAILPOET-6218]: https://mailpoet.atlassian.net/browse/MAILPOET-6218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ