### PR TITLE
Revert interactjs 1.10 to 1.2 [MAILPOET-6211]

### DIFF
--- a/mailpoet/assets/css/src/generic/_helpers.scss
+++ b/mailpoet/assets/css/src/generic/_helpers.scss
@@ -110,10 +110,3 @@ span.mailpoet-gap-half {
   height: 6px;
   width: 8px;
 }
-
-.mailpoet-is-dragging {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/container-drop-zone-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/container-drop-zone-behavior.js
@@ -67,8 +67,8 @@ BehaviorsLookup.ContainerDropZoneBehavior = Marionette.Behavior.extend({
         //     display position visualization there,
         //     remove other visualizations from this container
         var dropPosition = that.getDropPosition(
-          event.dragEvent.pageX,
-          event.dragEvent.pageY,
+          event.dragmove.pageX,
+          event.dragmove.pageY,
           view.$el,
           view.model.get('orientation'),
           view.model.get('blocks').length,

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/container-drop-zone-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/container-drop-zone-behavior.js
@@ -10,7 +10,7 @@ import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 import jQuery from 'jquery';
 import { BehaviorsLookup } from 'newsletter-editor/behaviors/behaviors-lookup';
-import interact from 'interactjs';
+import interact from 'interact';
 
 BehaviorsLookup.ContainerDropZoneBehavior = Marionette.Behavior.extend({
   defaults: {

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
@@ -40,11 +40,13 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
     // Give instances more control over whether Draggable should be applied
     if (!this.options.testAttachToInstance(this.view.model, this.view)) return;
 
-    interactable = interact(this.$el.get(0))
+    interactable = interact(this.$el.get(0), {
+      ignoreFrom: this.options.ignoreSelector,
+    })
       .draggable({
-        ignoreFrom: this.options.ignoreSelector,
         // allow dragging of multiple elements at the same time
         max: Infinity,
+
         // Scroll when dragging near edges of a window
         autoScroll: true,
 

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
@@ -58,10 +58,6 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
           var clone;
           var $clone;
 
-          if (event.target.__clone) {
-            return;
-          }
-
           // Prevent text selection while dragging
           document.body.classList.add('mailpoet-is-dragging');
 
@@ -118,8 +114,7 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
           target.setAttribute('data-y', y);
         },
         onend: function onend(event) {
-          var endEvent = event;
-          var target = endEvent.target.__clone;
+          var target = event.target.__clone;
 
           // Allow text selection when not dragging
           document.body.classList.remove('mailpoet-is-dragging');
@@ -134,7 +129,6 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
 
           if (that.options.cloneOriginal === true) {
             jQuery(target).remove();
-            endEvent.target.__clone = undefined;
 
             if (that.options.hideOriginal === true) {
               that.view.$el.removeClass('mailpoet_hidden');

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
@@ -44,7 +44,7 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
       ignoreFrom: this.options.ignoreSelector,
     })
       .draggable({
-        // allow dragging of multiple elements at the same time
+        // allow dragging of multple elements at the same time
         max: Infinity,
 
         // Scroll when dragging near edges of a window
@@ -65,6 +65,7 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
             }
             // Or use a clone
             clone = tempClone || event.target.cloneNode(true);
+            jQuery(event.target);
             $clone = jQuery(clone);
 
             $clone.addClass('mailpoet_droppable_active');
@@ -81,7 +82,7 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
             $clone.css('top', event.pageY - centerYOffset);
             $clone.css('left', event.pageX - centerXOffset);
 
-            event.target.__clone = clone;
+            event.interaction.element = clone;
 
             if (that.options.hideOriginal === true) {
               that.view.$el.addClass('mailpoet_hidden');
@@ -92,15 +93,10 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
         },
         // call this function on every dragmove event
         onmove: function onmove(event) {
-          var target = event.target.__clone;
-          var x;
-          var y;
-          if (!target) {
-            return;
-          }
+          var target = event.target;
           // keep the dragged position in the data-x/data-y attributes
-          x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
-          y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+          var x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+          var y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
 
           // translate the element
           target.style.transform = 'translate(' + x + 'px, ' + y + 'px)';
@@ -111,14 +107,14 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
           target.setAttribute('data-y', y);
         },
         onend: function onend(event) {
-          var target = event.target.__clone;
-          if (!target) {
-            return;
-          }
+          var target = event.target;
           target.style.transform = '';
           target.style.webkitTransform = target.style.transform;
           target.removeAttribute('data-x');
           target.removeAttribute('data-y');
+          jQuery(event.interaction.element).addClass(
+            'mailpoet_droppable_active',
+          );
 
           if (that.options.cloneOriginal === true) {
             jQuery(target).remove();

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
@@ -58,9 +58,6 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
           var clone;
           var $clone;
 
-          // Prevent text selection while dragging
-          document.body.classList.add('mailpoet-is-dragging');
-
           if (that.options.cloneOriginal === true) {
             // Use substitution instead of a clone
             if (_.isFunction(that.options.onDragSubstituteBy)) {
@@ -115,10 +112,6 @@ BL.DraggableBehavior = Marionette.Behavior.extend({
         },
         onend: function onend(event) {
           var target = event.target.__clone;
-
-          // Allow text selection when not dragging
-          document.body.classList.remove('mailpoet-is-dragging');
-
           if (!target) {
             return;
           }

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/draggable-behavior.js
@@ -8,7 +8,7 @@ import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 import jQuery from 'jquery';
 import { BehaviorsLookup } from 'newsletter-editor/behaviors/behaviors-lookup';
-import interact from 'interactjs';
+import interact from 'interact';
 import { App } from 'newsletter-editor/app';
 
 var BL = BehaviorsLookup;

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/resizable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/resizable-behavior.js
@@ -61,9 +61,6 @@ BL.ResizableBehavior = Marionette.Behavior.extend({
       .on('resizestart', function resizestart() {
         that.view.model.trigger('startResizing');
         document.activeElement.blur();
-
-        // Prevent text selection while resizing
-        document.body.classList.add('mailpoet-is-dragging');
       })
       .on('resizemove', function resizemove(event) {
         var onResize = that.options.onResize.bind(that);
@@ -72,9 +69,6 @@ BL.ResizableBehavior = Marionette.Behavior.extend({
       .on('resizeend', function resizeend(event) {
         that.view.model.trigger('stopResizing', event);
         that.$el.removeClass('mailpoet_resize_active');
-
-        // Allow text selection when not resizing
-        document.body.classList.remove('mailpoet-is-dragging');
       });
   },
 });

--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/resizable-behavior.js
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/resizable-behavior.js
@@ -5,7 +5,7 @@
  */
 import Marionette from 'backbone.marionette';
 import { BehaviorsLookup } from 'newsletter-editor/behaviors/behaviors-lookup';
-import interact from 'interactjs';
+import interact from 'interact';
 
 var BL = BehaviorsLookup;
 

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -77,7 +77,7 @@
     "handlebars": "^4.7.8",
     "history": "^4.10.1",
     "html2canvas": "^1.4.1",
-    "interactjs": "^1.10.27",
+    "interact.js": "1.2.8",
     "jquery": "^3.7.1",
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 overrides:
   react: 18.3.1
   react-dom: 18.3.1
@@ -215,9 +211,9 @@ importers:
       html2canvas:
         specifier: ^1.4.1
         version: 1.4.1
-      interactjs:
-        specifier: ^1.10.27
-        version: 1.10.27
+      interact.js:
+        specifier: 1.2.8
+        version: 1.2.8
       jquery:
         specifier: ^3.7.1
         version: 3.7.1
@@ -515,7 +511,7 @@ importers:
         version: 5.92.0(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
-        version: 5.1.4(webpack@5.92.0)
+        version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-manifest-plugin:
         specifier: ^5.0.0
         version: 5.0.0(webpack@5.92.0)
@@ -605,8 +601,8 @@ packages:
   /@ariakit/react-core@0.3.14(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@ariakit/core': 0.3.11
       '@floating-ui/dom': 1.6.5
@@ -617,8 +613,8 @@ packages:
   /@ariakit/react@0.3.14(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@ariakit/react-core': 0.3.14(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
@@ -644,8 +640,8 @@ packages:
     resolution: {integrity: sha512-xvIfbLcX869Cx4ccDUC5hb9MqTvZDNC5ho2yI0g1aveUfVGn7FqPxNiHwCEfW2fi5f85T63CZ727Q+ECawDoKQ==}
     peerDependencies:
       '@wordpress/data': ^6.1.5
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.2
+      react-dom: ^17.0.2
     dependencies:
       '@automattic/calypso-url': 1.0.0
       '@automattic/data-stores': 3.0.1(@types/react@18.3.3)(@wordpress/data@10.0.0)(react-dom@18.3.1)(react@18.3.1)
@@ -674,7 +670,7 @@ packages:
     resolution: {integrity: sha512-+ZcN8x+gNf4I7nGAjbZy6ubpMPiPleOQIVPbMwkHb32v/zoJ+fL4CGa9YcgiCCjJjaEEKcPZfl5Qbuo7ddGdpA==}
     peerDependencies:
       '@wordpress/data': ^6
-      react: 18.3.1
+      react: ^17.0.2
     dependencies:
       '@automattic/domain-utils': 1.0.0-alpha.0
       '@automattic/format-currency': 1.0.1
@@ -715,7 +711,7 @@ packages:
   /@automattic/happychat-connection@1.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-l97adFiyKptK+ZmJNgg174njpxepbDTZBaSggZdMbJIVLQv04dt6cxNzcq4Or70NAUx7XfOYtbPS0GfskSMbMg==}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.2
     dependencies:
       '@automattic/calypso-config': 1.2.0
       '@automattic/i18n-utils': 1.0.1
@@ -749,8 +745,8 @@ packages:
   /@automattic/interpolate-components@1.2.1(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-YNQtJsrs9KQ3lkBdtLyDheVRijoBA3y/PuHdgJ0eB4AX9JyjkDX7jd79Inh79+01CGNLbMQGrEJby2zvbJr17A==}
     peerDependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
+      '@types/react': '>=16.14.23'
+      react: '>=16.2.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -769,8 +765,8 @@ packages:
     resolution: {integrity: sha512-qC15YGZZW5VUhvl47y9C+aN0q0QIejP9g9pFZ9M3PRRgaZcXx00+ZrL1Ngg0+V9eS5io5OZcji3D8OU6i48t/w==}
     peerDependencies:
       '@wordpress/data': ^6.1.5
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.2
+      react-dom: ^17.0.2
       reakit-utils: ^0.15.1
       redux: ^4.1.2
     dependencies:
@@ -807,7 +803,7 @@ packages:
   /@automattic/viewport-react@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-+6+l4jj14GXeoc5Jpic5E5eVvNL88Ezz8cMLmKAw0fpPDsz4gJv7o0hgShu0hjGjKTtBeUkBGfFWMCdRjZaVcA==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.0.0
     dependencies:
       '@automattic/viewport': 1.1.0
       '@wordpress/compose': 3.25.3(react@18.3.1)
@@ -2461,7 +2457,7 @@ packages:
     resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
     peerDependencies:
       '@types/react': '*'
-      react: 18.3.1
+      react: '>=16.8.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2496,7 +2492,7 @@ packages:
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
       '@types/react': '*'
-      react: 18.3.1
+      react: '>=16.8.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2519,7 +2515,7 @@ packages:
   /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.3.1):
     resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
     peerDependencies:
-      react: 18.3.1
+      react: '>=16.8.0'
     dependencies:
       react: 18.3.1
 
@@ -2603,8 +2599,8 @@ packages:
   /@floating-ui/react-dom@0.6.3(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-hC+pS5D6AgS2wWjbmSQ6UR6Kpy+drvWGJIri6e1EDGADTPsCaa4KzCgmCczHrQeInx9tqs81EyDmbKJYY2swKg==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 0.4.5
       react: 18.3.1
@@ -2617,8 +2613,8 @@ packages:
   /@floating-ui/react-dom@2.1.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 1.6.5
       react: 18.3.1
@@ -2627,8 +2623,8 @@ packages:
   /@floating-ui/react@0.26.17(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-ESD+jYWwqwVzaIgIhExrArdsCL1rOAzryG/Sjlu8yaD3Mtqi3uVyhbE2V7jD58Mo52qbzKz2eUY/Xgh5I86FCQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/react-dom': 2.1.0(react-dom@18.3.1)(react@18.3.1)
       '@floating-ui/utils': 0.2.2
@@ -2671,10 +2667,6 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     deprecated: Use @eslint/object-schema instead
     dev: true
-
-  /@interactjs/types@1.10.27:
-    resolution: {integrity: sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==}
-    dev: false
 
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -2961,7 +2953,7 @@ packages:
   /@marvelapp/react-ab-test@3.1.0(react@18.3.1):
     resolution: {integrity: sha512-MDWBoCY7N0z3447Ril86H8nTPk95IALNbMt4YRrEChlTLM12PpzuhkahhLbaBHJ08Ex6KetwlpSYd6OREBlbHw==}
     peerDependencies:
-      react: 18.3.1
+      react: '>=16.8.0 <18.0.0'
     dependencies:
       fbemitter: 3.0.0
       fbjs: 3.0.4
@@ -3113,7 +3105,7 @@ packages:
     engines: {node: '>=16.3.0'}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>= 4.7.4'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3138,7 +3130,7 @@ packages:
   /@radix-ui/react-compose-refs@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       react: 18.3.1
@@ -3146,7 +3138,7 @@ packages:
   /@radix-ui/react-context@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       react: 18.3.1
@@ -3154,8 +3146,8 @@ packages:
   /@radix-ui/react-dialog@1.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/primitive': 1.0.0
@@ -3180,8 +3172,8 @@ packages:
   /@radix-ui/react-dismissable-layer@1.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/primitive': 1.0.0
@@ -3195,7 +3187,7 @@ packages:
   /@radix-ui/react-focus-guards@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       react: 18.3.1
@@ -3203,8 +3195,8 @@ packages:
   /@radix-ui/react-focus-scope@1.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
@@ -3216,7 +3208,7 @@ packages:
   /@radix-ui/react-id@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.3.1)
@@ -3225,8 +3217,8 @@ packages:
   /@radix-ui/react-portal@1.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1)(react@18.3.1)
@@ -3236,8 +3228,8 @@ packages:
   /@radix-ui/react-presence@1.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
@@ -3248,8 +3240,8 @@ packages:
   /@radix-ui/react-primitive@1.0.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-slot': 1.0.0(react@18.3.1)
@@ -3259,7 +3251,7 @@ packages:
   /@radix-ui/react-slot@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
@@ -3268,7 +3260,7 @@ packages:
   /@radix-ui/react-use-callback-ref@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       react: 18.3.1
@@ -3276,7 +3268,7 @@ packages:
   /@radix-ui/react-use-controllable-state@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
@@ -3285,7 +3277,7 @@ packages:
   /@radix-ui/react-use-escape-keydown@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
@@ -3294,7 +3286,7 @@ packages:
   /@radix-ui/react-use-layout-effect@1.0.0(react@18.3.1):
     resolution: {integrity: sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.24.7
       react: 18.3.1
@@ -3302,7 +3294,7 @@ packages:
   /@react-spring/animated@9.7.1(react@18.3.1):
     resolution: {integrity: sha512-EX5KAD9y7sD43TnLeTNG1MgUVpuRO1YaSJRPawHNRgUWYfILge3s85anny4S4eTJGpdp5OoFV2kx9fsfeo0qsw==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@react-spring/shared': 9.7.1(react@18.3.1)
       '@react-spring/types': 9.7.1
@@ -3311,7 +3303,7 @@ packages:
   /@react-spring/core@9.7.1(react@18.3.1):
     resolution: {integrity: sha512-8K9/FaRn5VvMa24mbwYxwkALnAAyMRdmQXrARZLcBW2vxLJ6uw9Cy3d06Z8M12kEqF2bDlccaCSDsn2bSz+Q4A==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@react-spring/animated': 9.7.1(react@18.3.1)
       '@react-spring/rafz': 9.7.1
@@ -3325,7 +3317,7 @@ packages:
   /@react-spring/shared@9.7.1(react@18.3.1):
     resolution: {integrity: sha512-R2kZ+VOO6IBeIAYTIA3C1XZ0ZVg/dDP5FKtWaY8k5akMer9iqf5H9BU0jyt3Qtxn0qQY7whQdf6MTcWtKeaawg==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@react-spring/rafz': 9.7.1
       '@react-spring/types': 9.7.1
@@ -3337,8 +3329,8 @@ packages:
   /@react-spring/web@9.7.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-6uUE5MyKqdrJnIJqlDN/AXf3i8PjOQzUuT26nkpsYxUGOk7c+vZVPcfrExLSoKzTb9kF0i66DcqzO5fXz/Z1AA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@react-spring/animated': 9.7.1(react@18.3.1)
       '@react-spring/core': 9.7.1(react@18.3.1)
@@ -4447,8 +4439,8 @@ packages:
       '@babel/runtime': '>=7.11.0'
       '@codemirror/view': '>=6.0.0'
       codemirror: '>=6.0.0'
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
     dependencies:
       '@babel/runtime': 7.24.7
       '@codemirror/commands': 6.6.0
@@ -4466,7 +4458,7 @@ packages:
   /@use-gesture/react@10.3.1(react@18.3.1):
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
-      react: 18.3.1
+      react: '>= 16.8.0'
     dependencies:
       '@use-gesture/core': 10.3.1
       react: 18.3.1
@@ -4585,7 +4577,7 @@ packages:
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.92.0)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
     dev: true
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.92.0):
@@ -4596,7 +4588,7 @@ packages:
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.92.0)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
     dev: true
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.2)(webpack@5.92.0):
@@ -4615,31 +4607,16 @@ packages:
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.92.0)
     dev: true
 
-  /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.92.0):
-    resolution: {integrity: sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      webpack: 5.x.x
-      webpack-cli: 5.x.x
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      webpack-dev-server:
-        optional: true
-    dependencies:
-      webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.92.0)
-    dev: true
-
   /@woocommerce/components@12.3.0(patch_hash=rc6hnjhca2pqrlb5fea6tr4fze)(@babel/runtime@7.24.7)(@types/react-dom@18.3.0)(@types/react@18.3.3)(@wordpress/data@10.0.0)(lodash@4.17.21)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-1opGsZBI6SppDLw/9uu+f3STqcmj5uE94WlZsnj6ChuU5IrI9Bv0tgyb4DYUSdOoNgUjTH1TZUlV9r3xXQDnLg==}
     engines: {node: ^20.11.1, pnpm: ^8.12.1}
     peerDependencies:
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
+      '@types/react': ^17.0.71
+      '@types/react-dom': ^17.0.25
       '@wordpress/data': wp-6.0
       lodash: ^4.17.0
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.2
+      react-dom: ^17.0.2
     dependencies:
       '@automattic/calypso-color-schemes': 2.1.1
       '@automattic/interpolate-components': 1.2.1(@types/react@18.3.3)(react@18.3.1)
@@ -4753,8 +4730,8 @@ packages:
     peerDependencies:
       '@wordpress/core-data': ^4.1.0
       moment: ^2.18.1
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.0
+      react-dom: ^17.0.0
     dependencies:
       '@woocommerce/date': 4.2.0(lodash@4.17.21)
       '@woocommerce/navigation': 8.1.0(@types/react@18.3.3)(lodash@4.17.21)(react-dom@18.3.1)(react@18.3.1)
@@ -4968,8 +4945,8 @@ packages:
     resolution: {integrity: sha512-wkBP37hB6Fb1AaUIjry6S3LlFrjnVq3Seg8ktZPLozDv2cyODs/ym8+wjv8TR/aiuSWdk0dZZywYMNc+vHEfEg==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
@@ -5029,8 +5006,8 @@ packages:
     resolution: {integrity: sha512-n699mUzd+ngF/Mu92vZ+tPmQh9gJJJv7XtIfJvSc9PslxQf3KY1AX9iiqzApK+IuIZrmG1VjlKDjVOfmvcw5hA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
@@ -5090,8 +5067,8 @@ packages:
     resolution: {integrity: sha512-v/BILeZvae1jgu/nQU30WB0QJRTcLSLrOXJxXJwAAL91XzBOTAkOgpb45BQlmQp9U2EzN78HtQjnU5yt3KLoww==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -5166,7 +5143,7 @@ packages:
     resolution: {integrity: sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/autop': 3.58.0
@@ -5200,7 +5177,7 @@ packages:
     resolution: {integrity: sha512-BwjMca4aGuttu3C0nLLpt6MBg6IBCogA6ulGTyg+0YdKnwac52k+2wfersqAem8AFgG0hTDwrIpLsWLxpF9dtg==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/autop': 3.58.0
@@ -5236,7 +5213,7 @@ packages:
     resolution: {integrity: sha512-+gBgpNbWCX23w90LewSoNAdFHJjK0le6ounrfgNC+0w6g/Mu8RQpU/8XCBeZealelVaIO6lkTDf3dk4t64JqHw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/autop': 4.0.0
@@ -5281,8 +5258,8 @@ packages:
     resolution: {integrity: sha512-HqTrYfQw/5cdT2hPgmuKW6gugnt1Pqtg9zjRHUa+D4ME7mjR4dYQoHRgnFM+hm8OOuEZRVBsa1kYO3t3041Jew==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/components': 27.6.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -5306,8 +5283,8 @@ packages:
     resolution: {integrity: sha512-4++ob0qXKFmJP38UWizXjWJAegyq2CnxYcq7A7pUF73MVAN+zF+WuEic8LdHQ0foGu3nvfkJrbuXUWRc9Hgg9A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/components': 28.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -5331,8 +5308,8 @@ packages:
     resolution: {integrity: sha512-6FsLq1WS924fjZjRGSuen3Tzaa4mEWRtCTHM2JS5eE5+rnuhddiHNNgvw26IZCwhQYQwIvIKq9m9in0F0fSOzg==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^17.0.0
+      react-dom: ^17.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@emotion/cache': 11.11.0
@@ -5385,8 +5362,8 @@ packages:
     resolution: {integrity: sha512-f+fXENkgrPs5GLo2yu9fEAdVX0KriEatRcjDUyw0+DbNbJR62sCdDtGdhJRW4jPUUoUowxaGO0y4+jvQWxnbyg==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@18.3.1)(react@18.3.1)
       '@babel/runtime': 7.24.7
@@ -5446,8 +5423,8 @@ packages:
     resolution: {integrity: sha512-55VEwJmiA9QSg2bnRtHIRxkjbV9wYLfzaCfWgksd018kkLtwXpZcKeQQvevmKTdL9PeIeLC1lDO4H+cdExcOXw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@18.3.1)(react@18.3.1)
       '@babel/runtime': 7.24.7
@@ -5528,7 +5505,7 @@ packages:
     resolution: {integrity: sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@types/mousetrap': 1.6.15
@@ -5548,7 +5525,7 @@ packages:
     resolution: {integrity: sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@types/mousetrap': 1.6.15
@@ -5569,7 +5546,7 @@ packages:
     resolution: {integrity: sha512-TXVGa2M96y/pRRVzh8iDMuktoseTEcQGOqBZQ9Pr1kk+mAPYCEUnGpactoZQxDlznQiM5vaD79aEQu04s1AHXA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@types/mousetrap': 1.6.15
@@ -5591,8 +5568,8 @@ packages:
     resolution: {integrity: sha512-7W5C40uCnw1yN9wldpZOLwwyB93hbQ18ebk190htMZmgqkQ9FYbQue1+pU9hgXEnruxotOYpwdzl2/ySqGnXmA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/block-editor': 13.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -5620,7 +5597,7 @@ packages:
     resolution: {integrity: sha512-Nf7fhCyZOSl3156jGy0M2vHwQVT7Kp/NxMnDpdvCWIvJ7EzjoycSzbxpdjoG5UAQTNWiItdvRopzKJ/e9sA1Vg==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/api-fetch': 6.55.0
@@ -5646,8 +5623,8 @@ packages:
     resolution: {integrity: sha512-VnESF55nkAkKHQVwj0Oo8AU6w/yWjg/RQb+wKqJRnDuHEKHDAF5PI+9lYmcAsbXdnAc2yyf3lwBGk4w8m4uxlA==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/api-fetch': 6.55.0
@@ -5684,8 +5661,8 @@ packages:
     resolution: {integrity: sha512-ON/XJoUe4FenOkYX2Szu+V7M6CGmuR2sctUI9lfAyHOPT9j0pKdeBi+h0hN24pAiFDwWi4T4DVBmzAx3JEhJPw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/api-fetch': 7.0.0
@@ -5734,7 +5711,7 @@ packages:
     resolution: {integrity: sha512-R34QPymjmUUzNwUTP1v4KAQi92SxRlF2o0EFgVwtoTHdTzhumPJJFWA4vcm8qphimaRVVSkfI99Scz/exF5EHA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/api-fetch': 7.0.0
@@ -5747,7 +5724,7 @@ packages:
     resolution: {integrity: sha512-TCRlzYIVrQqAkjgVevJYzkga2zt+lHI6m3rnBzCH2QUvv/p/L388pMCNWUByhjhXNnsHRdY1/FeqYQmG+LwQ0g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/compose': 7.0.0(react@18.3.1)
@@ -5771,7 +5748,7 @@ packages:
     resolution: {integrity: sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/compose': 5.20.0(react@18.3.1)
@@ -5793,7 +5770,7 @@ packages:
     resolution: {integrity: sha512-+bQ5dTkJkHeOng3mXXzLBZkudUlOifJql1U99sWGbtLarU/yjfF0ldi/a6uR1cVvDJkGizDYHf9vv/nA39Oaqw==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/compose': 6.35.0(react@18.3.1)
@@ -5817,7 +5794,7 @@ packages:
     resolution: {integrity: sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/compose': 6.35.0(react@18.3.1)
@@ -5840,7 +5817,7 @@ packages:
     resolution: {integrity: sha512-8ueWXSjDuKp67fbPkIibX4a3Q2rBtT+iNT0Tk6hLLHvkK9RNF6GWddoGF2TUDhZAn6PFkrqEtovclfVqohKZOA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@18.3.1)(react@18.3.1)
       '@babel/runtime': 7.24.7
@@ -5974,8 +5951,8 @@ packages:
     resolution: {integrity: sha512-5PWFajzp/apcB7xmc1D1+ZlIuRSkvHFY/yNUUkuV+us7oQ2IzSg9qijtgqb3dK9jNIwJsLkqpmuGX4WGd7My/w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6024,8 +6001,8 @@ packages:
     resolution: {integrity: sha512-JiA0RcfVr+/VrZdI96cFeXbm8FuyDHvV4m44vk2t9reHza+6mJx7qyAKFUVZcOm6VpvAlGjyLfQwYKI60d6TYA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@react-spring/web': 9.7.1(react-dom@18.3.1)(react@18.3.1)
@@ -6090,8 +6067,8 @@ packages:
     resolution: {integrity: sha512-jTkoq5qldLZzECPd46oXWw3mGlShtrhXgGeQZiMWPqS9G2fmlD0r2o2z/5HG9wwvXzgiMbUCAUMfBhtBtDdaHA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6225,7 +6202,7 @@ packages:
       '@babel/core': '>=7'
       eslint: '>=8'
       prettier: '>=3'
-      typescript: ^5.0.2
+      typescript: '>=4'
     peerDependenciesMeta:
       prettier:
         optional: true
@@ -6241,7 +6218,7 @@ packages:
       cosmiconfig: 7.1.0
       eslint: 8.36.0
       eslint-config-prettier: 8.8.0(eslint@8.36.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0)(eslint-import-resolver-webpack@0.13.2)(eslint@8.36.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.36.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.36.0)
@@ -6265,8 +6242,8 @@ packages:
     resolution: {integrity: sha512-aGlHce+94ieOLUnTRRlJSXz437T+1MjEst2ns6nP4whIrXQyaU+/ZI9TUf+qtjXDbNWrK/pMtujXnsuBGXkeQA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6402,8 +6379,8 @@ packages:
     resolution: {integrity: sha512-7nx+3cJfGzpR/0+i2I8nVLH+OtkNEVGP9eG7oVli+IrCisOzIqK2d5R6+c7mmD8m16ypul+PKnhTRF3QGmt+4Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6475,7 +6452,7 @@ packages:
     resolution: {integrity: sha512-DR+fWhHt67GQT6PlrfMBpSmEYNCep+XvMYA55cnxoQ80LIFN5N5bkr4VeYdbrSatuOSRACm+6cfoQSIMQbdmjw==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/data': 9.28.0(react@18.3.1)
@@ -6488,7 +6465,7 @@ packages:
     resolution: {integrity: sha512-6UkiiMjIVsif9O93KuJJt6IoGbMZx9/YvFd6hp+9yU1qqRqlev9k9kSqCEVGuBf4Xsy7JfgfvAiUOgpyAacThg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/data': 10.0.0(react@18.3.1)
@@ -6535,7 +6512,7 @@ packages:
     resolution: {integrity: sha512-Lu98xQdtZHgC3d32IFalZbOiIu8aRFWlEQXXfRutD7EhXXp6FIXvnvc054700/Dk1mg9P/bWd0zm/cigkXgfkA==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 3.58.0
@@ -6547,7 +6524,7 @@ packages:
     resolution: {integrity: sha512-ezLuWHoLIO/9dV9YZnxosW9N1F9o6nyupXyM0Lu9tdcB9Wb1SFRRStG/BOjOin82TZVdUab6L5BPlvHl9/b7KQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6568,8 +6545,8 @@ packages:
     resolution: {integrity: sha512-wqZ90fjGiL99d/mmnKTLebM08USAAcdUjL400Xnjb8y2/cLbhN8aeh2yX6ZKqKZ2AAFNExtXh0XH3+qonYgYEA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6600,8 +6577,8 @@ packages:
     resolution: {integrity: sha512-X/dMJbbW/Rl3epjS482iAP0mj9V1kW+QnyNjGBYkBoQxn+DG3v2Ok6A31lrzxiebl1yACVvwxSKR85xHNFcZ6A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/components': 28.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -6634,8 +6611,8 @@ packages:
     resolution: {integrity: sha512-OFzSEiI8Kk5YJtyPFnAauRHXtjuTJHkWapvcagpMoTP0WvwBwGfr5AeIIgV2ONtA3edrfMGgmrJUK7pd61K/1Q==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 3.58.0
@@ -6660,8 +6637,8 @@ packages:
     resolution: {integrity: sha512-4GR2SquImQnVCSMZoepqpWHu6hzICISU78dU9G5dYrP0vV+ynQf0SRvTjLPVBA/fbi/YtXsvIflUkbKsQ9Hieg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6788,8 +6765,8 @@ packages:
     resolution: {integrity: sha512-KCJYENZ3KNaUlwZOogWNy2hDntfgSKj7drCh5gHOhg5MhSCkg+WJI7OTaf4CGJtIVQgAojRUeg/K++KFLOKRQQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/block-editor': 13.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -6817,7 +6794,7 @@ packages:
     resolution: {integrity: sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 3.58.0
@@ -6837,7 +6814,7 @@ packages:
     resolution: {integrity: sha512-h6/XftSqo9UQZebuNZyLfOVu+ButBLITW/BILsKeJhSpmM19VNdz8UhVGLp+xQPE+/GPCIMJrhhqipISDfc2Ig==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 3.58.0
@@ -6855,7 +6832,7 @@ packages:
     resolution: {integrity: sha512-OV1OTUkK7oHzJpsNUGwpZAHcXtubohFGY5TRiKobFHAhDuhML0tXWLKEwwsbBZj7v2t6YTWakD+WC6449IZn7w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/a11y': 4.0.0
@@ -6874,7 +6851,7 @@ packages:
     resolution: {integrity: sha512-oeBHirB9RyrPsMM4s2AM4jnmGoP3RelK6eIDfjNC+6izRDrEsFg5T7hT6p59xAUlh396pSZjVFuztQR0LwMuWQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/element': 6.0.0
@@ -6890,8 +6867,8 @@ packages:
     hasBin: true
     peerDependencies:
       '@playwright/test': ^1.43.0
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/core': 7.24.7
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
@@ -6986,8 +6963,8 @@ packages:
     resolution: {integrity: sha512-7HZocZcTbqtKBXJOvaaVxbOlfH049pBu2OGMyVXB5ew5/Y+tTLfqZEpLR+pxveES+Rb/2QLqJU0NnRESS7CWXA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/api-fetch': 7.0.0
@@ -7141,7 +7118,7 @@ packages:
     resolution: {integrity: sha512-ffG7pSUCB5NGeJSvUZRWo/cIm3mRZMfI7sdiObbbRjWMuROmo+iGjmswHfJ7wNnOHHuRUDUMaPBZfS+tosh2ig==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/compose': 7.0.0(react@18.3.1)
@@ -7162,8 +7139,8 @@ packages:
     resolution: {integrity: sha512-OBvDhEJ/+dxKj+vgvSMQxHoc+ASY/ZuiLmr4XdlaVnHBzHfpmnVSIDWVvlCcTftWxMx80WCK5Cfy/4cb7KUYiw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/api-fetch': 7.0.0
@@ -7302,7 +7279,7 @@ packages:
     resolution: {integrity: sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==}
     deprecated: This package has been renamed to 'prop-types-tools'
     peerDependencies:
-      react: 18.3.1
+      react: ^0.14 || ^15.0.0 || ^16.0.0-alpha
     dependencies:
       array.prototype.find: 2.2.1
       function.prototype.name: 1.1.6
@@ -7326,6 +7303,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.16.0
     dev: true
@@ -8584,8 +8564,8 @@ packages:
   /cmdk@0.2.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-U6//9lQ6JvT47+6OF6Gi8BvkxYQ8SCRRSKIJkthIMsFsLZRG0cKvTtuTaefyIKMQb8rvvXy0wGdpTNq/jPtm+g==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@radix-ui/react-dialog': 1.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
@@ -8876,7 +8856,7 @@ packages:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>=4.9.5'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -8892,7 +8872,7 @@ packages:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>=4.9.5'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9748,7 +9728,7 @@ packages:
   /downshift@6.1.12(react@18.3.1):
     resolution: {integrity: sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==}
     peerDependencies:
-      react: 18.3.1
+      react: '>=16.12.0'
     dependencies:
       '@babel/runtime': 7.24.7
       compute-scroll-into-view: 1.0.20
@@ -10170,35 +10150,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint@8.36.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
-      debug: 3.2.7
-      eslint: 8.36.0
-      eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-plugin-check-file@2.8.0:
     resolution: {integrity: sha512-FvvafMTam2WJYH9uj+FuMxQ1y+7jY3Z6P9T4j2214cH0FBxNzTcmeCiGTj1Lxp3mI6kbbgsXvmgewvf+llKYyw==}
     engines: {node: '>=18'}
@@ -10228,39 +10179,6 @@ packages:
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.56.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-webpack@0.13.2)(eslint@8.36.0)
-      has: 1.0.3
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.7
-      resolve: 1.22.8
-      semver: 6.3.1
-      tsconfig-paths: 3.14.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.21.0)(eslint@8.36.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
-      array-includes: 3.1.7
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.36.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint@8.36.0)
       has: 1.0.3
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11003,7 +10921,7 @@ packages:
     resolution: {integrity: sha512-uOfQdg/iQ8iokQ64qcbu8iZb114rOmaKLQFu7hU14/eJaKgsP91cQ7ts7v2iiDld6TzDe84Meksha8/MkWiCyw==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>3.6.0'
       vue-template-compiler: '*'
       webpack: ^5.11.0
     peerDependenciesMeta:
@@ -11047,8 +10965,8 @@ packages:
     resolution: {integrity: sha512-/gr3PLZUVFCc86a9MqCUboVrALscrdluzTb3yew+2/qKBU8CX6nzs918/SRBRCqaPbx0TZP10CB6yFgK2C5cYQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -11064,8 +10982,8 @@ packages:
   /framer-motion@6.5.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8 || ^17.0.0 || ^18.0.0'
+      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
     dependencies:
       '@motionone/dom': 10.12.0
       framesync: 6.0.1
@@ -11447,7 +11365,7 @@ packages:
   /gridicons@3.4.2(react@18.3.1):
     resolution: {integrity: sha512-KC2BzPDh3F0vJzYa7KYBWJOO9gTHoKoFiHNazZEU9Gq2jIJ2zObOA67wlZjZkPHPCjZiLQrko3AYFLrMrHXKrA==}
     peerDependencies:
-      react: 18.3.1
+      react: 15 - 18
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
@@ -11809,7 +11727,7 @@ packages:
   /i18n-calypso@6.0.1(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-+/mWjFd0IR7VWqTV4iVOiu2wyKLtkoiioABPISVVTy3ybe1EnW8JmTnWnpQh3t6Fq3rHhstO6lMzpi/b6Idk4A==}
     peerDependencies:
-      react: 18.3.1
+      react: ^17.0.2
     dependencies:
       '@automattic/interpolate-components': 1.2.1(@types/react@18.3.3)(react@18.3.1)
       '@babel/runtime': 7.24.7
@@ -11970,10 +11888,9 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
-  /interactjs@1.10.27:
-    resolution: {integrity: sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==}
-    dependencies:
-      '@interactjs/types': 1.10.27
+  /interact.js@1.2.8:
+    resolution: {integrity: sha512-VXUfuD1xCq97yYfp0qi5D+dkEBKsvSkOaoIQuWualzrHh5oVF6IbEc8jZRpfnooQShFJNPBdoDhN6SBKAdEJ6Q==}
+    deprecated: This package has been renamed to 'interactjs' (without the dot)
     dev: false
 
   /internal-slot@1.0.7:
@@ -15332,7 +15249,7 @@ packages:
     resolution: {integrity: sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==}
     engines: {node: '>=16.3.0'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>= 4.7.4'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -15417,8 +15334,8 @@ packages:
   /re-resizable@6.9.11(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-a3hiLWck/NkmyLvGWUuvkAmN1VhwAz4yOhS6FdMTaxCUVN9joIWkT11wsO68coG/iEYuwn+p/7qAmfQzRhiPLQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.13.1 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15426,8 +15343,8 @@ packages:
   /react-autosize-textarea@7.1.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0
+      react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
     dependencies:
       autosize: 4.0.4
       line-height: 0.3.1
@@ -15438,8 +15355,8 @@ packages:
   /react-beautiful-dnd@13.1.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.5 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       css-box-model: 1.2.1
@@ -15457,8 +15374,8 @@ packages:
   /react-colorful@5.6.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15466,8 +15383,8 @@ packages:
   /react-datepicker@6.9.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-QTxuzeem7BUfVFWv+g5WuvzT0c5BPo+XTCNbMTZKSZQLU+cMMwSUHwspaxuIcDlwNcOH0tiJ+bh1fJ2yxOGYWA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.9.0 || ^17 || ^18
+      react-dom: ^16.9.0 || ^17 || ^18
     dependencies:
       '@floating-ui/react': 0.26.17(react-dom@18.3.1)(react@18.3.1)
       clsx: 2.1.1
@@ -15483,8 +15400,8 @@ packages:
     peerDependencies:
       '@babel/runtime': ^7.0.0
       moment: ^2.18.1
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^0.14 || ^15.5.4 || ^16.1.1
+      react-dom: ^0.14 || ^15.5.4 || ^16.1.1
     dependencies:
       '@babel/runtime': 7.24.7
       airbnb-prop-types: 2.16.0(react@18.3.1)
@@ -15510,7 +15427,7 @@ packages:
   /react-dom@18.3.1(react@18.3.1):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: 18.3.1
+      react: ^18.3.1
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
@@ -15519,8 +15436,8 @@ packages:
   /react-easy-crop@5.0.7(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-6d5IUt09M3HwdDGwrcjPVgfrOfYWAOku8sCTn/xU7b1vkEg+lExMLwW8UbR39L8ybQi0hJZTU57yprF9h5Q5Ig==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
     dependencies:
       normalize-wheel: 1.0.1
       react: 18.3.1
@@ -15533,7 +15450,7 @@ packages:
   /react-html-parser@2.0.2(react@18.3.1):
     resolution: {integrity: sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==}
     peerDependencies:
-      react: 18.3.1
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0
     dependencies:
       htmlparser2: 3.10.1
       react: 18.3.1
@@ -15556,8 +15473,8 @@ packages:
     resolution: {integrity: sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==}
     engines: {node: '>=8'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
+      react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
     dependencies:
       exenv: 1.2.2
       prop-types: 15.8.1
@@ -15578,8 +15495,8 @@ packages:
   /react-onclickoutside@6.13.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-LdrrxK/Yh9zbBQdFbMTXPp3dTSN9B+9YJQucdDu3JNKRrbdU+H+/TVONJoWtOwy4II8Sqf1y/DTI6w/vGPYW0w==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^15.5.x || ^16.x || ^17.x || ^18.x
+      react-dom: ^15.5.x || ^16.x || ^17.x || ^18.x
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15588,8 +15505,8 @@ packages:
   /react-outside-click-handler@1.3.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^0.14 || >=15
+      react-dom: ^0.14 || >=15
     dependencies:
       airbnb-prop-types: 2.16.0(react@18.3.1)
       consolidated-events: 2.0.2
@@ -15604,8 +15521,8 @@ packages:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
       '@popperjs/core': 2.11.8
       react: 18.3.1
@@ -15616,8 +15533,8 @@ packages:
   /react-portal@4.2.2(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-vS18idTmevQxyQpnde0Td6ZcUlv+pD8GTyR42n3CHUQq9OHi1C4jDE4ZWEbEsrbrLRhSECYiao58cvocwMtP7Q==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+      react-dom: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
@@ -15627,7 +15544,7 @@ packages:
   /react-query@3.39.3(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -15646,7 +15563,7 @@ packages:
   /react-redux@7.2.9(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.3 || ^17 || ^18
       react-dom: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -15674,8 +15591,8 @@ packages:
     resolution: {integrity: sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -15689,8 +15606,8 @@ packages:
     resolution: {integrity: sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -15706,7 +15623,7 @@ packages:
   /react-resize-aware@3.1.2(react@18.3.1):
     resolution: {integrity: sha512-sBtMIEy/9oI+Xf2o7IdWdkTokpZSPo9TWn60gqWKPG3BXg44Rg3FCIMiIjmgvRUF4eQptw6pqYTUhYwkeVSxXA==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || 17.x || 18.x
     dependencies:
       react: 18.3.1
     dev: false
@@ -15715,8 +15632,8 @@ packages:
     resolution: {integrity: sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.8'
+      react-dom: '>=16.8'
     dependencies:
       '@remix-run/router': 1.17.0
       react: 18.3.1
@@ -15728,7 +15645,7 @@ packages:
     resolution: {integrity: sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: 18.3.1
+      react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.17.0
       react: 18.3.1
@@ -15737,8 +15654,8 @@ packages:
   /react-select@5.8.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
       '@emotion/cache': 11.11.0
@@ -15765,8 +15682,8 @@ packages:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -15780,8 +15697,8 @@ packages:
   /react-tooltip@5.27.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-JXROcdfCEbCqkAkh8LyTSP3guQ0dG53iY2E2o4fw3D8clKzziMpE6QG6CclDaHELEKTzpMSeAOsdtg0ahoQosw==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
     dependencies:
       '@floating-ui/dom': 1.6.5
       classnames: 2.5.1
@@ -15792,8 +15709,8 @@ packages:
   /react-transition-group@4.4.5(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
     dependencies:
       '@babel/runtime': 7.24.7
       dom-helpers: 5.2.1
@@ -15806,8 +15723,8 @@ packages:
   /react-with-direction@1.4.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^0.14 || ^15 || ^16
+      react-dom: ^0.14 || ^15 || ^16
     dependencies:
       airbnb-prop-types: 2.16.0(react@18.3.1)
       brcast: 2.0.2
@@ -15837,7 +15754,7 @@ packages:
     resolution: {integrity: sha512-tZCTY27KriRNhwHIbg1NkSdTTOSfXDg6Z7s+Q37mtz0Ym7Sc7IOr3PzVt4qJhJMW6Nkvfi3g34FuhtiGAJCBQA==}
     peerDependencies:
       '@babel/runtime': ^7.0.0
-      react: 18.3.1
+      react: '>=0.14'
     dependencies:
       '@babel/runtime': 7.24.7
       airbnb-prop-types: 2.16.0(react@18.3.1)
@@ -15911,8 +15828,8 @@ packages:
   /reakit-system@0.15.2(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15922,8 +15839,8 @@ packages:
   /reakit-utils@0.15.2(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15932,7 +15849,7 @@ packages:
   /reakit-warning@0.6.2(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0
     dependencies:
       react: 18.3.1
       reakit-utils: 0.15.2(react-dom@18.3.1)(react@18.3.1)
@@ -15943,8 +15860,8 @@ packages:
   /reakit@1.3.11(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@popperjs/core': 2.11.8
       body-scroll-lock: 3.1.5
@@ -17597,7 +17514,7 @@ packages:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>=4.2.0'
     dependencies:
       typescript: 5.0.2
     dev: true
@@ -17606,7 +17523,7 @@ packages:
     resolution: {integrity: sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '*'
       webpack: ^5.0.0
     dependencies:
       chalk: 4.1.2
@@ -17638,7 +17555,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: ^5.0.2
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
       typescript: 5.0.2
@@ -17917,8 +17834,8 @@ packages:
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -17930,7 +17847,7 @@ packages:
   /use-debounce@3.4.3(react@18.3.1):
     resolution: {integrity: sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA==}
     peerDependencies:
-      react: 18.3.1
+      react: '>=16.8.0'
     dependencies:
       react: 18.3.1
     dev: false
@@ -17939,7 +17856,7 @@ packages:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -17951,8 +17868,8 @@ packages:
   /use-lilius@2.0.5(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==}
     peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
+      react: '*'
+      react-dom: '*'
     dependencies:
       date-fns: 3.6.0
       react: 18.3.1
@@ -17961,7 +17878,7 @@ packages:
   /use-memo-one@1.1.3(react@18.3.1):
     resolution: {integrity: sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.3.1
 
@@ -17969,8 +17886,8 @@ packages:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -17983,7 +17900,7 @@ packages:
   /use-subscription@1.5.1(react@18.3.1):
     resolution: {integrity: sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0
     dependencies:
       object-assign: 4.1.1
       react: 18.3.1
@@ -17992,7 +17909,7 @@ packages:
   /use-sync-external-store@1.2.2(react@18.3.1):
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
-      react: 18.3.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.3.1
 
@@ -18210,39 +18127,6 @@ packages:
       webpack-merge: 5.9.0
     dev: true
 
-  /webpack-cli@5.1.4(webpack@5.92.0):
-    resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
-    engines: {node: '>=14.15.0'}
-    hasBin: true
-    peerDependencies:
-      '@webpack-cli/generators': '*'
-      webpack: 5.x.x
-      webpack-bundle-analyzer: '*'
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      '@webpack-cli/generators':
-        optional: true
-      webpack-bundle-analyzer:
-        optional: true
-      webpack-dev-server:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.92.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.92.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.92.0)
-      colorette: 2.0.20
-      commander: 10.0.1
-      cross-spawn: 7.0.3
-      envinfo: 7.10.0
-      fastest-levenshtein: 1.0.16
-      import-local: 3.1.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack: 5.92.0(webpack-cli@5.1.4)
-      webpack-merge: 5.9.0
-    dev: true
-
   /webpack-dev-middleware@5.3.4(webpack@5.92.0):
     resolution: {integrity: sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==}
     engines: {node: '>= 12.13.0'}
@@ -18374,7 +18258,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(webpack@5.92.0)
       watchpack: 2.4.1
-      webpack-cli: 5.1.4(webpack@5.92.0)
+      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -18857,3 +18741,7 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Description

Reverting `interact.js` udpate https://github.com/mailpoet/mailpoet/pull/5716 as it causes issues in newsletter editor. 

## Code review notes

_N/A_

## QA notes

I've tested that the issue is no longer replicable with this change, so maybe QA can be skipped if we want to release sooner, and it can be tested in the release branch. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6211](https://mailpoet.atlassian.net/browse/MAILPOET-6211)

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:interactjs-revert)

_The latest successful build from `interactjs-revert` will be used. If none is available, the link won't work._

[MAILPOET-6211]: https://mailpoet.atlassian.net/browse/MAILPOET-6211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ