### PR TITLE
Release 5.1.1

### DIFF
--- a/mailpoet/CHANGELOG.md
+++ b/mailpoet/CHANGELOG.md
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 5.1.1 - 2024-09-04 =
+
+- Fixed: broken email rendering when ALC, Products, or WC content blocks are manually dragged into a column block (since 4.56.0). If you experience this issue, please readd these blocks or drag and drop the existing ones which should fix the issue.
+
 = 5.1.0 - 2024-09-02 =
 
 - Improved: form validation messages;

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.1.0
+ * Version: 5.1.1
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.1.0',
+  'version' => '5.1.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.5
 Tested up to: 6.6
-Stable tag: 5.1.0
+Stable tag: 5.1.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -230,8 +230,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.1.0 - 2024-09-02 =
-* Improved: form validation messages;
-* Fixed: using ${var} in strings is deprecated, use {$var} instead.
+= 5.1.1 - 2024-09-04 =
+* Fixed: broken email rendering when ALC, Products, or WC content blocks are manually dragged into a column block (since 4.56.0). If you experience this issue, please readd these blocks or drag and drop the existing ones which should fix the issue.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/CHANGELOG.md)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._