### PR TITLE
Add fallback support for rendering nested ALC and WC blocks in columns [MAILPOET-6212]

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/BodyRenderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/BodyRenderer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Renderer;
 
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
 
 class BodyRenderer {
   /** @var Blocks\Renderer */
@@ -19,19 +20,18 @@ class BodyRenderer {
     $this->columnsRenderer = $columnsRenderer;
   }
 
-  /**
-   * @param NewsletterEntity $newsletter
-   * @param array $content
-   * @return string
+  /*
+    - Preview parameters is needed for proper rendering of the AbandonedCart block
+    - We need to pass SendingQueueEntity as a parameter to renderBody method because it allows us rendering AbandonedCart block inside a column block
    */
-  public function renderBody(NewsletterEntity $newsletter, array $content) {
+  public function renderBody(NewsletterEntity $newsletter, array $content, bool $preview, SendingQueueEntity $sendingQueue = null): string {
     $blocks = (array_key_exists('blocks', $content))
       ? $content['blocks']
       : [];
 
     $renderedContent = [];
     foreach ($blocks as $contentBlock) {
-      $columnsData = $this->blocksRenderer->render($newsletter, $contentBlock);
+      $columnsData = $this->blocksRenderer->render($newsletter, $contentBlock, $preview, $sendingQueue);
 
       $renderedContent[] = $this->columnsRenderer->render(
         $contentBlock,

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -111,7 +111,7 @@ class Renderer {
       $renderedBody = "";
       try {
         $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingQueue);
-        $renderedBody = $this->bodyRenderer->renderBody($newsletter, $content);
+        $renderedBody = $this->bodyRenderer->renderBody($newsletter, $content, $preview, $sendingQueue);
       } catch (NewsletterProcessingException $e) {
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_COUPONS)->error(
           $e->getMessage(),


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:hotfix-nested-columns)

_The latest successful build from `hotfix-nested-columns` will be used. If none is available, the link won't work._