### PR TITLE
Fix data inconsistencies loading [MAILPOET-6219]

### DIFF
--- a/mailpoet/assets/js/src/help/data-inconsistencies.tsx
+++ b/mailpoet/assets/js/src/help/data-inconsistencies.tsx
@@ -1,6 +1,6 @@
 import { MailPoet } from 'mailpoet';
 import { Button } from '@wordpress/components';
-import { useState, useCallback, useMemo } from '@wordpress/element';
+import { useState, useCallback, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { KeyValueTable } from 'common/key-value-table';
 
@@ -8,13 +8,27 @@ type DataInconsistencies = {
   [key: string]: number;
 };
 
-type Props = {
-  dataInconsistencies: DataInconsistencies;
-};
-
-export function DataInconsistencies({ dataInconsistencies }: Props) {
-  const [data, setData] = useState(dataInconsistencies);
+export function DataInconsistencies() {
+  const [data, setData] = useState({ total: 0 } as DataInconsistencies);
   const [cleaningKey, setCleaningKey] = useState('');
+
+  useEffect(() => {
+    MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'help',
+      action: 'getInconsistentDataStatus',
+    })
+      .done((response) => {
+        setData((response.data as DataInconsistencies) || null);
+      })
+      .catch((e) => {
+        MailPoet.Notice.show({
+          type: 'error',
+          message: e.errors.map((error) => error.message).join(' '),
+          scroll: true,
+        });
+      });
+  }, []);
 
   const labelsMap = useMemo(
     () => ({

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -98,7 +98,6 @@ function renderMSSSection(data) {
 export function SystemStatus() {
   const systemStatusData = window.systemStatusData;
   const actionSchedulerData = window.actionSchedulerData;
-  const dataInconsistencies = window.dataInconsistencies;
 
   return (
     <>
@@ -116,7 +115,7 @@ export function SystemStatus() {
       {actionSchedulerData ? (
         <QueueStatus statusData={systemStatusData.queueStatus} />
       ) : null}
-      <DataInconsistencies dataInconsistencies={dataInconsistencies} />
+      <DataInconsistencies />
     </>
   );
 }

--- a/mailpoet/lib/API/JSON/v1/Help.php
+++ b/mailpoet/lib/API/JSON/v1/Help.php
@@ -63,6 +63,10 @@ class Help extends APIEndpoint {
     }
   }
 
+  public function getInconsistentDataStatus(): Response {
+    return $this->successResponse($this->dataInconsistencyController->getInconsistentDataStatus());
+  }
+
   public function fixInconsistentData($data): Response {
     try {
       $this->dataInconsistencyController->fixInconsistentData($data['inconsistency'] ?? '');

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -15,7 +15,6 @@ use MailPoet\Newsletter\Url as NewsletterURL;
 use MailPoet\Router\Endpoints\CronDaemon;
 use MailPoet\Services\Bridge;
 use MailPoet\SystemReport\SystemReportCollector;
-use MailPoet\Util\DataInconsistency\DataInconsistencyController;
 use MailPoet\WP\DateTime;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -26,7 +25,6 @@ class Help {
   private Bridge $bridge;
   private ScheduledTasksRepository $scheduledTasksRepository;
   private SendingQueuesRepository $sendingQueuesRepository;
-  private DataInconsistencyController $dataInconsistencyController;
   private NewsletterURL $newsletterUrl;
 
   public function __construct(
@@ -36,7 +34,6 @@ class Help {
     Bridge $bridge,
     ScheduledTasksRepository $scheduledTasksRepository,
     SendingQueuesRepository $sendingQueuesRepository,
-    DataInconsistencyController $dataInconsistencyController,
     NewsletterURL $newsletterUrl
   ) {
     $this->pageRenderer = $pageRenderer;
@@ -45,7 +42,6 @@ class Help {
     $this->bridge = $bridge;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
-    $this->dataInconsistencyController = $dataInconsistencyController;
     $this->newsletterUrl = $newsletterUrl;
   }
 
@@ -90,7 +86,6 @@ class Help {
         'systemInfoData' => $systemInfoData,
         'systemStatusData' => $systemStatusData,
         'actionSchedulerData' => $this->getActionSchedulerData(),
-        'dataInconsistencies' => $this->dataInconsistencyController->getInconsistentDataStatus(),
       ]
     );
   }

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
@@ -36,26 +36,15 @@ class DataInconsistencyRepository {
   }
 
   public function getOrphanedScheduledTasksSubscribersCount(): int {
-    $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+    $connection = $this->entityManager->getConnection();
     $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+
+    $this->createOrphanedScheduledTaskSubscribersTemporaryTables();
     /** @var string $count */
-    $count = $this->entityManager->getConnection()->executeQuery("
-      SELECT COUNT(*)
-        FROM $stsTable sts
-        WHERE sts.task_id IN (
-          -- SELECT ... FROM (subquery) forces the subquery to materialize first.
-          -- We're using this twice here to get the reduced data set before JOIN.
-          SELECT oprhaned_task_ids.task_id FROM
-          (
-            SELECT task_ids.task_id
-            FROM (
-              SELECT DISTINCT task_id FROM $stsTable
-            ) AS task_ids
-            LEFT JOIN $stTable st ON st.id = task_ids.task_id
-            WHERE st.id IS NULL
-          ) AS oprhaned_task_ids
-        );
+    $count = $connection->executeQuery("
+      SELECT COUNT(*) FROM $stsTable sts WHERE sts.task_id IN (SELECT task_id FROM orphaned_task_ids)
     ")->fetchOne();
+    $this->dropOrphanedScheduledTaskSubscribersTemporaryTables();
     return intval($count);
   }
 
@@ -155,35 +144,28 @@ class DataInconsistencyRepository {
   }
 
   public function cleanupOrphanedScheduledTaskSubscribers(): int {
+    $connection = $this->entityManager->getConnection();
     $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
     $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
     $deletedCount = 0;
-    $missingTaskIds = $this->entityManager->getConnection()->executeQuery("
-      SELECT task_ids.task_id
-        -- SELECT ... FROM (subquery) forces the subquery to materialize first.
-        -- We're using this here to get the reduced data set before JOIN.
-        FROM (
-          SELECT DISTINCT task_id FROM $stsTable
-        ) AS task_ids
-        LEFT JOIN $stTable st ON st.id = task_ids.task_id
-      WHERE st.id IS NULL;")->fetchFirstColumn();
 
-    if (!$missingTaskIds) {
-      return 0;
-    }
-
+    $this->createOrphanedScheduledTaskSubscribersTemporaryTables();
     do {
       $deletedCount += (int)$this->entityManager->getConnection()->executeStatement(
-        "DELETE sts_top FROM $stsTable sts_top
-        JOIN (
-          SELECT sts.`task_id`, sts.`subscriber_id` FROM $stsTable sts
-          WHERE sts.`task_id` IN (:taskIds)
-          LIMIT :limit
-        ) as to_delete ON sts_top.`task_id` = to_delete.`task_id` AND sts_top.`subscriber_id` = to_delete.`subscriber_id`",
-        ['taskIds' => $missingTaskIds, 'limit' => self::DELETE_ROWS_LIMIT],
-        ['taskIds' => ArrayParameterType::INTEGER, 'limit' => ParameterType::INTEGER]
+        "
+          DELETE sts_top FROM $stsTable sts_top
+          JOIN (
+            SELECT task_id, subscriber_id
+            FROM $stsTable
+            WHERE task_id IN (SELECT task_id FROM orphaned_task_ids)
+            LIMIT :limit
+          ) AS to_delete ON sts_top.task_id = to_delete.task_id AND sts_top.subscriber_id = to_delete.subscriber_id
+        ",
+        ['limit' => self::DELETE_ROWS_LIMIT],
+        ['limit' => ParameterType::INTEGER]
       );
     } while ($this->getOrphanedScheduledTasksSubscribersCount() > 0);
+    $this->dropOrphanedScheduledTaskSubscribersTemporaryTables();
     return $deletedCount;
   }
 
@@ -242,5 +224,28 @@ class DataInconsistencyRepository {
       ->andWhere('st.type = :type')
       ->setParameter('type', SendingQueue::TASK_TYPE)
       ->getQuery();
+  }
+
+  private function createOrphanedScheduledTaskSubscribersTemporaryTables(): void {
+    $connection = $this->entityManager->getConnection();
+    $stTable = $this->entityManager->getClassMetadata(ScheduledTaskEntity::class)->getTableName();
+    $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+
+    // 1. Get the DISTINCT task IDs so that the subsequent JOIN is more efficient.
+    $connection->executeStatement("
+      CREATE TEMPORARY TABLE IF NOT EXISTS task_ids
+      SELECT DISTINCT task_id FROM $stsTable
+    ");
+
+    // 2. Get the orphaned task IDs.
+    $connection->executeStatement("
+      CREATE TEMPORARY TABLE IF NOT EXISTS orphaned_task_ids
+      SELECT task_id FROM task_ids LEFT JOIN $stTable st ON st.id = task_ids.task_id WHERE st.id IS NULL
+    ");
+  }
+
+  private function dropOrphanedScheduledTaskSubscribersTemporaryTables(): void {
+    $this->entityManager->getConnection()->executeStatement("DROP TEMPORARY TABLE IF EXISTS task_ids");
+    $this->entityManager->getConnection()->executeStatement("DROP TEMPORARY TABLE IF EXISTS orphaned_task_ids");
   }
 }

--- a/mailpoet/tests/integration/AdminPages/HelpTest.php
+++ b/mailpoet/tests/integration/AdminPages/HelpTest.php
@@ -16,7 +16,6 @@ use MailPoet\Services\Bridge;
 use MailPoet\SystemReport\SystemReportCollector;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
-use MailPoet\Util\DataInconsistency\DataInconsistencyController;
 use MailPoetVendor\Carbon\Carbon;
 
 class HelpTest extends \MailPoetTest {
@@ -44,7 +43,6 @@ class HelpTest extends \MailPoetTest {
       $this->diContainer->get(Bridge::class),
       $this->diContainer->get(ScheduledTasksRepository::class),
       $this->sendingQueuesRepository,
-      $this->diContainer->get(DataInconsistencyController::class),
       $this->diContainer->get(Url::class)
     );
   }

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -8,7 +8,6 @@
     var systemInfoData = <%= json_encode(systemInfoData) %>;
     var systemStatusData = <%= json_encode(systemStatusData) %>;
     var actionSchedulerData = <%= json_encode(actionSchedulerData) %>;
-    var dataInconsistencies = <%= json_encode(dataInconsistencies) %>;
   </script>
 
   <div id="help_container"></div>


### PR DESCRIPTION
## Description
This PR fixes the issue preventing loading of the MailPoet > Help page for senders with long sending history (e.g. mailpoet.com).

#### Changes
- optimized check for orphaned scheduled tasks subscribers 
- data inconsistencies are now fetched via API so that fetching doesn't block page load

## Code review notes
Query improved using @JanJakes ideas https://github.com/mailpoet/mailpoet/pull/5828#discussion_r1753470931

## QA notes

Please follow the testing instructions from [the original PR](https://github.com/mailpoet/mailpoet/pull/5769), but check only `Orphaned task subscribers`.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6219]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6219]: https://mailpoet.atlassian.net/browse/MAILPOET-6219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-data-inconsistencies)

_The latest successful build from `fix-data-inconsistencies` will be used. If none is available, the link won't work._