### PR TITLE
Add new acceptance tests for timezone change scenario

### DIFF
--- a/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/ScheduleNewsletterCest.php
@@ -33,6 +33,10 @@ class ScheduleNewsletterCest {
     $i->waitForText('The newsletter has been scheduled.');
     $i->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
     $i->waitForText('6:00 am');
+    $i->cli(['option', 'update', 'timezone_string', 'Etc/GMT+10']);
+    $i->reloadPage();
+    $i->waitForElement('[data-automation-id="newsletters_listing_tabs"]');
+    $i->waitForText('8:00 pm');
   }
 
   public function scheduleStandardNewsletterButtonCaption(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Newsletters/StatsPageCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/StatsPageCest.php
@@ -9,9 +9,12 @@ class StatsPageCest {
     $i->wantTo('Open stats page of a sent newsletter');
 
     $newsletterTitle = 'Stats Page Test';
+    $date = (new \DateTimeImmutable('2024-01-01 06:00:00'));
     (new Newsletter())->withSubject($newsletterTitle)
       ->withSentStatus()
-      ->withSendingQueue()
+      ->withSendingQueue(
+        ['created_at' => $date,
+        ])
       ->create();
 
     $i->login();
@@ -19,6 +22,11 @@ class StatsPageCest {
     $i->waitForText($newsletterTitle);
     $i->clickItemRowActionByItemName($newsletterTitle, 'Statistics');
     $i->waitForText($newsletterTitle);
+    $i->waitForText('6:00 am');
+    $i->cli(['option', 'update', 'timezone_string', 'Etc/GMT+10']);
+    $i->reloadPage();
+    $i->waitForText($newsletterTitle);
+    $i->waitForText('8:00 pm');
 
     if (!$i->checkPluginIsActive('mailpoet-premium/mailpoet-premium.php')) {
       // the premium plugin is not active

--- a/mailpoet/tests/acceptance/Newsletters/StatsPageCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/StatsPageCest.php
@@ -12,9 +12,7 @@ class StatsPageCest {
     $date = (new \DateTimeImmutable('2024-01-01 06:00:00'));
     (new Newsletter())->withSubject($newsletterTitle)
       ->withSentStatus()
-      ->withSendingQueue(
-        ['created_at' => $date,
-        ])
+      ->withSendingQueue(['created_at' => $date])
       ->create();
 
     $i->login();

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -74,18 +74,18 @@ class ManageSubscribersCest {
     $i->seeNoJSErrors();
 
     $i->wantTo('see subscribed date changed upon switching timezone');
-    $subscriberFirstName = 'John ';
+    $subscriberFirstName = 'John';
     $subscriberLastName = 'TimezoneCheck';
     $subscriberEmail = 'timezonecheck@fakemail.fake';
     $this->generateSingleSubscriber($subscriberEmail, $subscriberFirstName, $subscriberLastName, $this->segment);
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForElementVisible('[data-automation-id="filters_subscribed"]');
     $i->click('[data-automation-id="filters_subscribed"]');
-    $i->waitForText($subscriberFirstName . $subscriberLastName);
+    $i->waitForText($subscriberFirstName . ' ' . $subscriberLastName);
     $i->waitForText('6:00 am');
     $i->cli(['option', 'update', 'timezone_string', 'Etc/GMT+10']);
     $i->reloadPage();
-    $i->waitForText($subscriberFirstName . $subscriberLastName);
+    $i->waitForText($subscriberFirstName . ' ' . $subscriberLastName);
     $i->waitForText('8:00 pm');
   }
 


### PR DESCRIPTION
## Description

This is to cover the recent issue in production when changing timezone for the scheduled newsletter resulted in hotfix release.

I added tests to cover scheduled newsletter, subscribed subscriber and newsletter stats page.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6221]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6221]: https://mailpoet.atlassian.net/browse/MAILPOET-6221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:acceptance/new/timezone-tests)

_The latest successful build from `acceptance/new/timezone-tests` will be used. If none is available, the link won't work._