### PR TITLE
Fix not opened stats on subscriber stats page [MAILPOET-6220]

### DIFF
--- a/mailpoet/assets/js/src/subscribers/stats/summary.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/summary.tsx
@@ -124,9 +124,10 @@ export function Summary({ stats, subscriber }: PropTypes): JSX.Element {
               <td>{MailPoet.I18n.t('statsNotClicked')}</td>
               {stats.periodic_stats.map(
                 (periodicStats: PeriodicStats): JSX.Element => {
-                  const notOpen =
-                    periodicStats.total_sent -
-                    (periodicStats.open + periodicStats.machine_open);
+                  const openedCount = MailPoet.trackingConfig.opensSeparated
+                    ? periodicStats.open + periodicStats.machine_open
+                    : periodicStats.open;
+                  const notOpen = periodicStats.total_sent - openedCount;
                   const displayPercentage = periodicStats.total_sent > 0;
                   let cell = notOpen.toLocaleString();
                   if (displayPercentage) {


### PR DESCRIPTION
## Description

This PR fixes an issue that **not opened** stats are not computed properly when Settings > Advanced > Human and machine opens setting is set to `Merged`.

![MailPoet - Subscribers ‹ CharterFolk — WordPress 2024-09-10 17-00-48](https://github.com/user-attachments/assets/60269428-670c-4def-88dc-4b4e21e14a1c)


## Code review notes

When the setting is set to `merged` opens, it already contains the sum of human and machine open. So when we compute not opened on client we need to check whether to include also machine opens in to the computation.

## QA notes

#### Replication

1. Send a couple of newsletters to a single subscriber
3. Create a couple of machine opens. You can create normal opens, then go to Adminer and `wp_mailpoet_statistics_opens` and set `user_agent_type` to `1` for a couple of rows for the subscriber.
5. Open subscriber stats and observe the issue that the sum of opened + not opened is not equal to the total sent emails in periodic stats.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6220]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6220]: https://mailpoet.atlassian.net/browse/MAILPOET-6220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-not-opened-stats)

_The latest successful build from `fix-not-opened-stats` will be used. If none is available, the link won't work._