### PR TITLE
Fix Help > System Status > Last run started displays `unknown`

### DIFF
--- a/mailpoet/assets/js/src/help/cron-status.jsx
+++ b/mailpoet/assets/js/src/help/cron-status.jsx
@@ -45,7 +45,7 @@ function CronStatus(props) {
           },
           {
             key: MailPoet.I18n.t('lastRunStarted'),
-            value: status.run_accessed_at
+            value: status.run_started_at
               ? MailPoet.Date.full(status.run_started_at * 1000)
               : MailPoet.I18n.t('unknown'),
           },


### PR DESCRIPTION
## Description

Fix Help > System Status > Last run started displays `unknown`.

## Code review notes

QA can be skipped.

## QA notes

QA can be skipped.

## Linked tickets

[MAILPOET-6222]

[MAILPOET-6222]: https://mailpoet.atlassian.net/browse/MAILPOET-6222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-help-last-run-started)

_The latest successful build from `fix-help-last-run-started` will be used. If none is available, the link won't work._