### PR TITLE
Improve WP-Cron notice by checking whether the cron is running [MAILPOET-6224]

### DIFF
--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -4,6 +4,7 @@ namespace MailPoet\Util\Notices;
 
 use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
+use MailPoet\Cron\CronHelper;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
@@ -73,6 +74,7 @@ class PermanentNotices {
   
   public function __construct(
     WPFunctions $wp,
+    CronHelper $cronHelper,
     EntityManager $entityManager,
     TrackingConfig $trackingConfig,
     SubscribersRepository $subscribersRepository,
@@ -94,7 +96,7 @@ class PermanentNotices {
     $this->changedTrackingNotice = new ChangedTrackingNotice($wp);
     $this->deprecatedFilterNotice = new DeprecatedFilterNotice($wp);
     $this->disabledMailFunctionNotice = new DisabledMailFunctionNotice($wp, $settings, $subscribersFeature, $mailerFactory);
-    $this->disabledWPCronNotice = new DisabledWPCronNotice($wp, $settings);
+    $this->disabledWPCronNotice = new DisabledWPCronNotice($wp, $cronHelper, $settings);
     $this->pendingApprovalNotice = new PendingApprovalNotice($settings);
     $this->woocommerceVersionWarning = new WooCommerceVersionWarning($wp);
     $this->premiumFeaturesAvailableNotice = new PremiumFeaturesAvailableNotice($subscribersFeature, $serviceChecker, $wp);


### PR DESCRIPTION
## Description

Some hosts set `DISABLE_WP_CRON` to `true`, but execute the cron in a different way. This is also the case of WordPress VIP.

In addition to checking the value of the constant, we will now also make sure that the cron is not running indeed (= last cron run was more than an hour ago).

## Code review notes

QA can be skipped.

## QA notes

QA can be skipped.

## Linked PRs

The original implementation was done in https://github.com/mailpoet/mailpoet/pull/5614.

## Linked tickets

[MAILPOET-6224]

[MAILPOET-6224]: https://mailpoet.atlassian.net/browse/MAILPOET-6224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wp-cron-notice)

_The latest successful build from `wp-cron-notice` will be used. If none is available, the link won't work._