### PR TITLE
Add WordPress-VIP-Go ruleset to CodeSniffer [MAILPOET-6225]

### DIFF
--- a/mailpoet/tasks/code_sniffer/MailPoet/shared-ruleset.xml
+++ b/mailpoet/tasks/code_sniffer/MailPoet/shared-ruleset.xml
@@ -195,6 +195,49 @@
   <rule ref="WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet"><severity>0</severity></rule>
   <rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited"><severity>0</severity></rule>
 
+  <!-- WordPress VIP Go -->
+  <rule ref="WordPress-VIP-Go">
+    <exclude-pattern>./tasks/*</exclude-pattern>
+    <exclude-pattern>./tests/*</exclude-pattern>
+    <exclude-pattern>./tools/*</exclude-pattern>
+    <exclude-pattern>./prefixer/*</exclude-pattern>
+    <exclude-pattern>./RoboFile.php</exclude-pattern>
+  </rule>
+
+  <!--
+    Disabled WordPress VIP Go rules.
+    These rules are disabled because our current codebase does not comply with them.
+    We can gradually enable them and make this list shorter and shorter.
+  -->
+  <rule ref="WordPress.DB.DirectDatabaseQuery.DirectQuery"><severity>0</severity></rule>
+  <rule ref="WordPress.DB.DirectDatabaseQuery.NoCaching"><severity>0</severity></rule>
+  <rule ref="WordPress.DB.DirectDatabaseQuery.SchemaChange"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Files.IncludingNonPHPFile.IncludingNonPHPFile"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writable"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_symlink"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.session_session_start"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Functions.StripTags.StripTagsTwoParameters"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsRemoteFile"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Security.ProperEscapingFunction.hrefSrcEscUrl"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Security.ProperEscapingFunction.notAttrEscAttr"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Security.Underscorejs.OutputNotation"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users"><severity>0</severity></rule>
+  <rule ref="WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders"><severity>0</severity></rule>
+
   <!-- Files -->
   <rule ref="Generic.Files.ByteOrderMark"/> <!-- Disallow usage of BOMs -->
   <rule ref="Generic.Files.LineEndings"> <!-- Use Unix newlines -->

--- a/mailpoet/tasks/code_sniffer/composer.json
+++ b/mailpoet/tasks/code_sniffer/composer.json
@@ -1,6 +1,7 @@
 {
   "minimum-stability": "dev",
   "require-dev": {
+    "automattic/vipwpcs": "^3.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
     "php-parallel-lint/php-console-highlighter": "0.5",
     "php-parallel-lint/php-parallel-lint": "^1.3",

--- a/mailpoet/tasks/code_sniffer/composer.lock
+++ b/mailpoet/tasks/code_sniffer/composer.lock
@@ -4,9 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "579386986e5333268ca1ed637d0f0769",
+    "content-hash": "f48e143b38e827c505ddb09d40b6b892",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "automattic/vipwpcs",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.11",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
+                "squizlabs/php_codesniffer": "^3.9.2",
+                "wp-coding-standards/wpcs": "^3.1.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2024-05-10T20:31:09+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",
@@ -521,6 +575,65 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
             "time": "2024-05-31T08:52:43+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "a15f05d76447879110d6bf888236f47eff834c07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/a15f05d76447879110d6bf888236f47eff834c07",
+                "reference": "a15f05d76447879110d6bf888236f47eff834c07",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2024-09-09T20:10:36+00:00"
         },
         {
             "name": "slevomat/coding-standard",


### PR DESCRIPTION
## Description

Add WordPress-VIP-Go ruleset to CodeSniffer. For now, we are ignoring rules we don't currently comply with.

## Code review notes

QA can be skipped.

## QA notes

QA can be skipped.

## Linked PRs

This is similar to what was done in https://github.com/mailpoet/mailpoet/pull/5801.

## Linked tickets

 [MAILPOET-6225]

[MAILPOET-6225]: https://mailpoet.atlassian.net/browse/MAILPOET-6225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:vip-sniffs)

_The latest successful build from `vip-sniffs` will be used. If none is available, the link won't work._