### PR TITLE
Use WP-native `nocache_headers()` when bypassing cache

### DIFF
--- a/mailpoet/lib/Cron/DaemonHttpRunner.php
+++ b/mailpoet/lib/Cron/DaemonHttpRunner.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron;
 
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Headers;
 use MailPoet\WP\Functions as WPFunctions;
 use Tracy\Debugger;
 
@@ -50,7 +51,7 @@ class DaemonHttpRunner {
     if (class_exists(Debugger::class) && $userAgent === 'MailPoet Cron') {
       Debugger::$showBar = false;
     }
-    $this->addCacheHeaders();
+    Headers::setNoCacheHeaders();
     $this->terminateRequest(self::PING_SUCCESS_RESPONSE);
   }
 
@@ -59,7 +60,7 @@ class DaemonHttpRunner {
     if (strpos((string)@ini_get('disable_functions'), 'set_time_limit') === false) {
       set_time_limit(0);
     }
-    $this->addCacheHeaders();
+    Headers::setNoCacheHeaders();
     if (!$requestData) {
       $error = __('Invalid or missing request data.', 'mailpoet');
     } else {
@@ -146,17 +147,5 @@ class DaemonHttpRunner {
     return !$settingsDaemonData ||
        $settingsDaemonData['token'] !== $this->token ||
        (isset($settingsDaemonData['status']) && $settingsDaemonData['status'] !== CronHelper::DAEMON_STATUS_ACTIVE);
-  }
-
-  private function addCacheHeaders() {
-    if (headers_sent()) {
-      return;
-    }
-    // Common Cache Control header. Should be respected by cache proxies and CDNs.
-    header('Cache-Control: no-cache');
-    // Mark as blacklisted for SG Optimizer for sites hosted on SiteGround.
-    header('X-Cache-Enabled: False');
-    // Set caching header for LiteSpeed server.
-    header('X-LiteSpeed-Cache-Control: no-cache');
   }
 }

--- a/mailpoet/lib/Cron/DaemonHttpRunner.php
+++ b/mailpoet/lib/Cron/DaemonHttpRunner.php
@@ -4,7 +4,6 @@ namespace MailPoet\Cron;
 
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\Settings\SettingsController;
-use MailPoet\Util\Headers;
 use MailPoet\WP\Functions as WPFunctions;
 use Tracy\Debugger;
 
@@ -51,7 +50,6 @@ class DaemonHttpRunner {
     if (class_exists(Debugger::class) && $userAgent === 'MailPoet Cron') {
       Debugger::$showBar = false;
     }
-    Headers::setNoCacheHeaders();
     $this->terminateRequest(self::PING_SUCCESS_RESPONSE);
   }
 
@@ -60,7 +58,6 @@ class DaemonHttpRunner {
     if (strpos((string)@ini_get('disable_functions'), 'set_time_limit') === false) {
       set_time_limit(0);
     }
-    Headers::setNoCacheHeaders();
     if (!$requestData) {
       $error = __('Invalid or missing request data.', 'mailpoet');
     } else {

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -5,7 +5,6 @@ namespace MailPoet\Router\Endpoints;
 use MailPoet\Config\AccessControl;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Subscription as UserSubscription;
-use MailPoet\Util\Headers;
 use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -86,7 +85,6 @@ class Subscription {
   }
 
   public function captchaRefresh($data): void {
-    Headers::setNoCacheHeaders();
     $captchaSessionId = $data['captcha_session_id'] ?? null;
     if (!$captchaSessionId) {
       return;

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -5,6 +5,7 @@ namespace MailPoet\Router\Endpoints;
 use MailPoet\Config\AccessControl;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Subscription as UserSubscription;
+use MailPoet\Util\Headers;
 use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -85,7 +86,7 @@ class Subscription {
   }
 
   public function captchaRefresh($data): void {
-    $this->captchaRenderer->setNoCacheHeaders();
+    Headers::setNoCacheHeaders();
     $captchaSessionId = $data['captcha_session_id'] ?? null;
     if (!$captchaSessionId) {
       return;

--- a/mailpoet/lib/Router/Router.php
+++ b/mailpoet/lib/Router/Router.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Router;
 
 use MailPoet\Config\AccessControl;
+use MailPoet\Util\Headers;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Psr\Container\ContainerInterface;
@@ -42,6 +43,11 @@ class Router {
 
   public function init() {
     if (!$this->apiRequest) return;
+
+    // The public MailPoet router is using GET requests,
+    // but we don't expect any caching of the responses.
+    Headers::setNoCacheHeaders();
+
     $endpointClass = __NAMESPACE__ . "\\Endpoints\\" . ucfirst($this->endpoint);
 
     if (!$this->endpoint || !class_exists($endpointClass)) {

--- a/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
+++ b/mailpoet/lib/Subscription/Captcha/CaptchaRenderer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Subscription\Captcha;
 
 use MailPoet\Config\Env;
+use MailPoet\Util\Headers;
 use MailPoetVendor\Gregwar\Captcha\CaptchaBuilder;
 
 class CaptchaRenderer {
@@ -34,7 +35,7 @@ class CaptchaRenderer {
       $files[] = $file;
     }
 
-    $this->setNoCacheHeaders();
+    Headers::setNoCacheHeaders();
     header('Content-Type: audio/mpeg');
     foreach ($files as $file) {
       readfile($file);
@@ -63,19 +64,13 @@ class CaptchaRenderer {
       ->setMaxBehindLines(0)
       ->build($width, $height, $font);
 
-    $this->setNoCacheHeaders();
+    Headers::setNoCacheHeaders();
     header('Content-Type: image/jpeg');
     $builder->output();
   }
 
   public function refreshPhrase(string $sessionId): string {
     return $this->phrase->createPhrase($sessionId);
-  }
-
-  public function setNoCacheHeaders(): void {
-    header('Cache-Control: no-cache, no-store, must-revalidate'); // HTTP 1.1+
-    header('Pragma: no-cache'); // HTTP 1.0
-    header('Expires: 0'); // proxies
   }
 
   private function getPhrase(string $sessionId): string {

--- a/mailpoet/lib/Util/Headers.php
+++ b/mailpoet/lib/Util/Headers.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+class Headers {
+  public static function setNoCacheHeaders(): void {
+    $wp = WPFunctions::get();
+    if ($wp->headersSent()) {
+      return;
+    }
+
+    // Set default no-cache headers:
+    header('Cache-Control: no-cache, no-store, must-revalidate'); // HTTP 1.1+
+    header('Pragma: no-cache'); // HTTP 1.0
+    header('Expires: 0'); // proxies
+    header('X-Cache-Enabled: False'); // SG Optimizer on SiteGround
+    header('X-LiteSpeed-Cache-Control: no-cache'); // LiteSpeed server
+
+    // Use WP-native nocache_headers(). This can override the defaults above.
+    $wp->nocacheHeaders();
+  }
+}

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -987,4 +987,12 @@ class Functions {
   public function wpIsMaintenanceMode(): bool {
     return wp_is_maintenance_mode();
   }
+
+  public function headersSent(): bool {
+    return headers_sent();
+  }
+
+  public function nocacheHeaders(): void {
+    nocache_headers();
+  }
 }


### PR DESCRIPTION
## Description

Currently, we set some no-cache headers manually in a few places in the plugin. In WordPress, there is the `nocache_headers()` function for that. We should use it, and it should [ensure our compatibility with WordPress VIP](https://docs.wpvip.com/caching/page-cache/#h-cache-bypass-or-prevention).

## Code review notes

I decided to apply the no-cache headers on the whole public `mailpoet_router`. We seem to use it as an API, or for user-specific actions, but since it uses GET requests, they could get accidentally cached.

These actions are:
- Open and click tracking.
- Cron daemon (run and ping).
- Subscription management including CAPTCHA.
- View-in-browser.
- Form previews.
- Proxy for external template images when creating a thumbnail.

I believe none of these should allow caching.

QA can be skipped.

## QA notes

QA can be skipped.

## Linked tickets

[MAILPOET-6226]

[MAILPOET-6226]: https://mailpoet.atlassian.net/browse/MAILPOET-6226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:no-cache-headers)

_The latest successful build from `no-cache-headers` will be used. If none is available, the link won't work._