### PR TITLE
Add reset template button to Woo email customizer [MAILPOET-6213]

### DIFF
--- a/mailpoet/assets/css/src/components-editor/components/_history.scss
+++ b/mailpoet/assets/css/src/components-editor/components/_history.scss
@@ -1,11 +1,16 @@
 .mailpoet_history_wrapper {
-  display: flex;
+  display: grid;
+  grid-gap: $grid-gap;
+  grid-template-columns: 26px 26px auto;
   padding: 12px 20px;
+
+  .mailpoet_reset_template {
+    justify-self: end;
+  }
 }
 
 .mailpoet_history_arrow {
   cursor: pointer;
-  margin-right: 20px;
 
   svg {
     display: inline-block;

--- a/mailpoet/assets/js/src/newsletter-editor/components/heading.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/heading.js
@@ -12,6 +12,9 @@ Module.HeadingView = Marionette.View.extend({
   getTemplate: function () {
     return window.templates.heading;
   },
+  initialize: function initialize() {
+    App.getChannel().on('historyUpdate', this.onHistoryUpdate, this);
+  },
   // eslint-disable-next-line func-names
   templateContext: function () {
     return {
@@ -37,6 +40,11 @@ Module.HeadingView = Marionette.View.extend({
   // eslint-disable-next-line func-names
   changeField: function (field, event) {
     this.model.set(field, jQuery(event.target).val());
+  },
+  onHistoryUpdate: function onHistoryUpdate() {
+    const type =
+      jQuery('#mailpoet_heading_email_type').val() || 'completed_order';
+    App.getChannel().trigger('changeWCEmailType', type);
   },
 });
 

--- a/mailpoet/assets/js/src/newsletter-editor/components/history.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/history.js
@@ -2,6 +2,7 @@ import { App } from 'newsletter-editor/app';
 import Marionette from 'backbone.marionette';
 import Mousetrap from 'mousetrap';
 import { _x, __ } from '@wordpress/i18n';
+import { cloneDeep } from 'lodash';
 
 var Module = {};
 
@@ -30,7 +31,7 @@ Module.HistoryView = Marionette.View.extend({
   },
 
   getOriginalTemplate: function getOriginalTemplate() {
-    return window.mailpoet_original_template_body;
+    return cloneDeep(window.mailpoet_original_template_body);
   },
 
   initialize: function initialize() {
@@ -127,10 +128,7 @@ Module.HistoryView = Marionette.View.extend({
     if (!confirmed) {
       return;
     }
-    App.getChannel().trigger(
-      'historyUpdate',
-      this.getOriginalTemplate(templateBody),
-    );
+    App.getChannel().trigger('historyUpdate', templateBody);
     App.getChannel().request('save');
   },
 

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -23,45 +23,19 @@ use MailPoet\WP\Functions as WPFunctions;
 class NewsletterEditor {
   private const DATE_FORMAT = 'Y-m-d H:i:s';
 
-  /** @var PageRenderer */
-  private $pageRenderer;
-
-  /** @var SettingsController */
-  private $settings;
-
-  /** @var UserFlagsController */
-  private $userFlags;
-
-  /** @var WooCommerceHelper */
-  private $woocommerceHelper;
-
-  /** @var WPFunctions */
-  private $wp;
-
-  /** @var TransactionalEmails */
-  private $wcTransactionalEmails;
-
-  /** @var ShortcodesHelper */
-  private $shortcodesHelper;
-
-  /** @var SubscribersRepository */
-  private $subscribersRepository;
-
-  /** @var TransactionalEmailHooks */
-  private $wooEmailHooks;
-
-  /** @var WPPostListLoader */
-  private $wpPostListLoader;
-
-  /** @var CustomFonts  */
-  private $customFonts;
-
-  /*** @var AssetsController */
-  private $assetsController;
-
-  /** @var BrandStyles */
-  private $brandStyles;
-
+  private PageRenderer $pageRenderer;
+  private SettingsController $settings;
+  private UserFlagsController $userFlags;
+  private WooCommerceHelper $woocommerceHelper;
+  private WPFunctions $wp;
+  private TransactionalEmails $wcTransactionalEmails;
+  private ShortcodesHelper $shortcodesHelper;
+  private SubscribersRepository $subscribersRepository;
+  private TransactionalEmailHooks $wooEmailHooks;
+  private WPPostListLoader $wpPostListLoader;
+  private CustomFonts $customFonts;
+  private AssetsController $assetsController;
+  private BrandStyles $brandStyles;
   private WooTransactionalEmailTemplate $template;
 
   public function __construct(

--- a/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
+++ b/mailpoet/lib/Util/DataInconsistency/DataInconsistencyRepository.php
@@ -37,12 +37,12 @@ class DataInconsistencyRepository {
 
   public function getOrphanedScheduledTasksSubscribersCount(): int {
     $this->createOrphanedScheduledTaskSubscribersTemporaryTables();
-    $count = $this->getOrphanedScheduledTasksSubscribersCountFromTemplateTables();
+    $count = $this->getOrphanedScheduledTasksSubscribersCountFromTemporaryTables();
     $this->dropOrphanedScheduledTaskSubscribersTemporaryTables();
     return $count;
   }
 
-  private function getOrphanedScheduledTasksSubscribersCountFromTemplateTables(): int {
+  private function getOrphanedScheduledTasksSubscribersCountFromTemporaryTables(): int {
     $connection = $this->entityManager->getConnection();
     $stsTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
     /** @var string $count */
@@ -166,7 +166,7 @@ class DataInconsistencyRepository {
         ['limit' => self::DELETE_ROWS_LIMIT],
         ['limit' => ParameterType::INTEGER]
       );
-    } while ($this->getOrphanedScheduledTasksSubscribersCountFromTemplateTables() > 0);
+    } while ($this->getOrphanedScheduledTasksSubscribersCountFromTemporaryTables() > 0);
     $this->dropOrphanedScheduledTaskSubscribersTemporaryTables();
     return $deletedCount;
   }

--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -673,6 +673,7 @@
     var currentUserEmail = '<%= current_wp_user.user_email %>';
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
     var mailpoet_products = <%= json_encode(products) %>;
+    var mailpoet_original_template_body = <%= json_encode(original_template_body) %>;
 
     var config = {
       availableStyles: {

--- a/mailpoet/views/newsletter/templates/components/history.hbs
+++ b/mailpoet/views/newsletter/templates/components/history.hbs
@@ -12,4 +12,5 @@
       <polyline points="16 15 19 18 22 15"/>
     </svg>
   </a>
+  <input type="button" id="mailpoet-history-reset-template" class="button-link mailpoet_reset_template mailpoet_hidden" value="<%= __('Reset template') | escape('html_attr') %>" />
 </div>


### PR DESCRIPTION
## Description

This PR adds possibility to reset the WooCommerce email template to the initial state.

## Code review notes
Instead of a form or API that would reset the template on the backend, I decided to use the editor application. The advantage is that the reset is done as a single edit step and can be reverted via undo arrow.

## QA notes

1) Go to Woo Transactional Email customizer
2) Make some edits
3) Click Reset template button and the template should reset to the initial state when the plugin was installed

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6213]

## After-merge notes

_N/A_

## Tasks

- [] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [] I added sufficient test coverage
- [] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6213]: https://mailpoet.atlassian.net/browse/MAILPOET-6213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:reset-woo-template)

_The latest successful build from `reset-woo-template` will be used. If none is available, the link won't work._