### PR TITLE
Fix MySQL platform detection

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1598,7 +1598,7 @@ class RoboFile extends \Robo\Tasks {
     }
     $annotationReaderProvider = new \MailPoet\Doctrine\Annotations\AnnotationReaderProvider();
     $configuration = (new \MailPoet\Doctrine\ConfigurationFactory($annotationReaderProvider, true))->createConfiguration();
-    $platformClass = \MailPoet\Doctrine\ConnectionFactory::PLATFORM_CLASS;
+    $platformClass = \MailPoetVendor\Doctrine\DBAL\Platforms\MySQLPlatform::class;
     return \MailPoetVendor\Doctrine\ORM\EntityManager::create([
       'driverClass' => \MailPoet\Doctrine\ConnectionFactory::DRIVER_CLASS,
       'platform' => new $platformClass,

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -509,8 +509,8 @@ class Populator {
     $tableName = $this->entityManager->getClassMetadata(NewsletterOptionFieldEntity::class)->getTableName();
     $connection = $this->entityManager->getConnection();
     $existingOptionFields = $connection->createQueryBuilder()
-      ->select('of.name, of.newsletter_type')
-      ->from($tableName, 'of')
+      ->select('f.name, f.newsletter_type')
+      ->from($tableName, 'f')
       ->executeQuery()
       ->fetchAllAssociative();
 

--- a/mailpoet/lib/Doctrine/ConnectionFactory.php
+++ b/mailpoet/lib/Doctrine/ConnectionFactory.php
@@ -13,12 +13,10 @@ use MailPoetVendor\Doctrine\DBAL\Configuration;
 use MailPoetVendor\Doctrine\DBAL\Driver;
 use MailPoetVendor\Doctrine\DBAL\Driver\Middleware;
 use MailPoetVendor\Doctrine\DBAL\DriverManager;
-use MailPoetVendor\Doctrine\DBAL\Platforms\MySQLPlatform;
 use MailPoetVendor\Doctrine\DBAL\Types\Type;
 
 class ConnectionFactory {
   const DRIVER_CLASS = WPDBDriver::class;
-  const PLATFORM_CLASS = MySQLPlatform::class;
 
   private $types = [
     BigIntType::NAME => BigIntType::class,
@@ -29,14 +27,13 @@ class ConnectionFactory {
   ];
 
   public function createConnection() {
-    $platformClass = self::PLATFORM_CLASS;
-    $connectionParams = [
-      'driverClass' => self::DRIVER_CLASS,
-      'platform' => new $platformClass,
-    ];
-
     $this->setupTypes();
-    return DriverManager::getConnection($connectionParams, $this->getConfiguration());
+    return DriverManager::getConnection(
+      [
+        'driverClass' => self::DRIVER_CLASS,
+      ],
+      $this->getConfiguration()
+    );
   }
 
   private function setupTypes() {

--- a/mailpoet/tasks/phpstan/create-entity-manager.php
+++ b/mailpoet/tasks/phpstan/create-entity-manager.php
@@ -5,6 +5,7 @@
 use MailPoet\Doctrine\Annotations\AnnotationReaderProvider;
 use MailPoet\Doctrine\ConfigurationFactory;
 use MailPoet\Doctrine\ConnectionFactory;
+use MailPoetVendor\Doctrine\DBAL\Platforms\MySQLPlatform;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 
@@ -29,8 +30,8 @@ $configuration->setMetadataDriverImpl(
     }
   }
 );
-$platformClass = ConnectionFactory::PLATFORM_CLASS;
+
 return EntityManager::create([
   'driverClass' => ConnectionFactory::DRIVER_CLASS,
-  'platform' => new $platformClass,
+  'platform' => new MySQLPlatform(),
 ], $configuration);


### PR DESCRIPTION
## Description

Extending [AbstractMySQLDriver](https://github.com/mailpoet/mailpoet/blob/9fb48d39b4a2e9b487c14e50e80f1d4ad8188ae2/mailpoet/lib/Doctrine/WPDB/Driver.php#L7) together with implementing [ServerInfoAwareConnection](https://github.com/mailpoet/mailpoet/blob/9fb48d39b4a2e9b487c14e50e80f1d4ad8188ae2/mailpoet/lib/Doctrine/WPDB/Connection.php#L18C29-L18C54) allows for autodetection of the SQL platform (MySQL vs. MariaDB) + it’s version (5.7, 8.0, etc.). This is useful for automatic keyword escaping, etc.

However, the automatic logic is overwritten by specifying an explicit driver: https://github.com/mailpoet/mailpoet/blob/9fb48d39b4a2e9b487c14e50e80f1d4ad8188ae2/mailpoet/lib/Doctrine/ConnectionFactory.php#L35 

This was exposed by latest test suites — from MySQL 8.0.1, OF is a reserved keyword.

## Code review notes

I also changed the alias 'of' (reserved keyword on MySQL >= 8.0.1) to `f` because it's easy, although it's not strictly necessary with the driver detection fix.

QA can be skipped.

## QA notes

QA can be skipped.

## Linked tickets

[MAILPOET-6232]

[MAILPOET-6232]: https://mailpoet.atlassian.net/browse/MAILPOET-6232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-mysq-platform)

_The latest successful build from `fix-mysq-platform` will be used. If none is available, the link won't work._