### PR TITLE
Rename docker-compose to docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,19 +445,19 @@ jobs:
       - run:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
-          command: i='0';while ! docker-compose -f ../tests_env/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
+          command: i='0';while ! docker compose -f ../tests_env/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - run:
           name: Create docker containers for test
           # We experienced some failures when creating containers so we do it explicitly with one retry
           command: |
             cd ../tests_env/docker
-            docker-compose create || docker-compose create
+            docker compose create || docker compose create
       - run:
           # Some tools we use may need different version based on PHP version used in docker
           name: Ensure correct versions of tools
           command: |
             cd ../tests_env/docker
-            docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_acceptance
+            docker compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_acceptance
       - when:
           condition: ${WOOCOMMERCE_VERSION}
           steps:
@@ -465,7 +465,7 @@ jobs:
                 name: Download WooCommerce Core
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -473,7 +473,7 @@ jobs:
                 name: Download WooCommerce Subscriptions
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_memberships_version >>
           steps:
@@ -481,7 +481,7 @@ jobs:
                 name: Download WooCommerce Memberships
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -489,7 +489,7 @@ jobs:
                 name: Download AutomateWoo
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - run:
           name: Group acceptance tests
           command: |
@@ -518,7 +518,7 @@ jobs:
               --xml
               -g circleci_split_group
             )
-            docker-compose run -e SKIP_DEPS=1 \
+            docker compose run -e SKIP_DEPS=1 \
             -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
             -e CIRCLE_JOB=${CIRCLE_JOB} \
             -e MULTISITE=<< parameters.multisite >> \
@@ -577,13 +577,13 @@ jobs:
       - run:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
-          command: i='0';while ! docker-compose -f tests/performance/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
+          command: i='0';while ! docker compose -f tests/performance/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - run:
           name: Create docker containers for test
           # We experienced some failures when creating containers so we do it explicitly with one retry
           command: |
             cd tests/performance
-            docker-compose create || docker-compose create
+            docker compose create || docker compose create
       - run:
           name: Run performance tests
           command: |
@@ -741,19 +741,19 @@ jobs:
       - run:
           name: 'Pull test docker images'
           # Pull docker images with 3 retries
-          command: i='0';while ! docker-compose -f ../tests_env/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
+          command: i='0';while ! docker compose -f ../tests_env/docker/docker-compose.yml pull && ((i < 3)); do sleep 3 && i=$[$i+1]; done
       - run:
           name: Create docker containers for test
           # We experienced some failures when creating containers so we do it explicitly with one retry
           command: |
             cd ../tests_env/docker
-            docker-compose create || docker-compose create
+            docker compose create || docker compose create
       - run:
           # Some tools we use may need different version based on PHP version used in docker
           name: Ensure correct versions of tools
           command: |
             cd ../tests_env/docker
-            docker-compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_integration
+            docker compose run --rm -w /project -e COMPOSER_DEV_MODE=1 --entrypoint "php tools/install.php" codeception_integration
       - when:
           condition: ${WOOCOMMERCE_VERSION}
           steps:
@@ -761,7 +761,7 @@ jobs:
                 name: Download WooCommerce Core
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -769,7 +769,7 @@ jobs:
                 name: Download WooCommerce Subscriptions
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - when:
           condition: << parameters.woo_memberships_version >>
           steps:
@@ -777,7 +777,7 @@ jobs:
                 name: Download WooCommerce Memberships
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -785,7 +785,7 @@ jobs:
                 name: Download AutomateWoo
                 command: |
                   cd ../tests_env/docker
-                  docker-compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - run:
           name: 'PHP Integration tests'
           command: |
@@ -804,7 +804,7 @@ jobs:
             if [[ -n '<< parameters.skip_group >>' ]]; then
               args+=(--skip-group << parameters.skip_group >>)
             fi
-            docker-compose run -e SKIP_DEPS=1 \
+            docker compose run -e SKIP_DEPS=1 \
               -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
               -e CIRCLE_JOB=${CIRCLE_JOB} \
               -e SKIP_PLUGINS=<< parameters.skip_plugins >> \

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Then create a Docker Compose override file with NFS settings and restart contain
 ```shell
 cp docker-compose.override.macos-sample.yml docker-compose.override.yml
 
-docker-compose down -v --remove-orphans
-docker-compose up -d
+docker compose down -v --remove-orphans
+docker compose up -d
 ```
 
 **NOTE:** If you are on MacOS Catalina or newer, make sure to put the repository
@@ -163,10 +163,10 @@ To switch the environment to a different PHP version:
        dockerfile: dev/{PHP_VERSION}/Dockerfile
    ```
 
-3. Run `docker-compose build wordpress`.
+3. Run `docker compose build wordpress`.
 4. Start the stack with `./do start`.
 
-To switch back to the default PHP version remove what was added in 2) and, run `docker-compose build wordpress` for application container and `docker-compose build test_wordpress` for tests container,
+To switch back to the default PHP version remove what was added in 2) and, run `docker compose build wordpress` for application container and `docker compose build test_wordpress` for tests container,
 and start the stack using `./do start`.
 
 ### Disabling the Tracy panel

--- a/dev/initial-setup.sh
+++ b/dev/initial-setup.sh
@@ -21,7 +21,7 @@ mkdir -p wordpress/wp-content/plugins/mailpoet-premium
 mkdir -p dev/data/mailhog
 
 for plugin in "mailpoet" "mailpoet-premium"; do
-  docker-compose run --rm wordpress /bin/sh -c "
+  docker compose run --rm wordpress /bin/sh -c "
     [ -d /var/www/html/wp-content/plugins/$plugin ] &&
     cd /var/www/html/wp-content/plugins/$plugin &&
     ./do install &&
@@ -29,7 +29,7 @@ for plugin in "mailpoet" "mailpoet-premium"; do
   "
 done
 
-docker-compose run --rm wordpress /bin/sh -c "
+docker compose run --rm wordpress /bin/sh -c "
   cd /var/www/templates &&
   mkdir assets classes exported
 "

--- a/dev/mac-nfs-setup.sh
+++ b/dev/mac-nfs-setup.sh
@@ -29,6 +29,6 @@ cat <<EOT
 NFS volume sharing is set up. Recreate your containers and volumes using:
     cp docker-compose.override.macos-sample.yml docker-compose.override.yml
 
-    docker-compose down -v --remove-orphans
-    docker-compose up -d
+    docker compose down -v --remove-orphans
+    docker compose up -d
 EOT

--- a/do
+++ b/do
@@ -3,8 +3,8 @@
 function syntax {
   cat << EOF
   ./do setup                           Setup the dev environment.
-  ./do start                           Start the docker containers (docker-compose up -d).
-  ./do stop                            Stop the docker containers (docker-compose stop).
+  ./do start                           Start the docker containers (docker compose up -d).
+  ./do stop                            Stop the docker containers (docker compose stop).
   ./do ssh [--test]                    Run an interactive bash shell inside the plugin directory.
   ./do run [--test] <command>          Run a custom bash command in the wordpress container.
   ./do acceptance [--premium]          Run acceptance tests.
@@ -21,7 +21,7 @@ EOF
 function ssh_and_run {
   params=("$@")
   params=("${params[@]:1}")
-  docker-compose exec $1 bash -c "${params[@]}"
+  docker compose exec $1 bash -c "${params[@]}"
 }
 
 if [ "$1" = "" -o "$1" = "--help" ]; then
@@ -31,10 +31,10 @@ elif [ "$1" = "setup" ]; then
   ./dev/initial-setup.sh
 
 elif [ "$1" = "start" ]; then
-  docker-compose up -d
+  docker compose up -d
 
 elif [ "$1" = "stop" ]; then
-  docker-compose stop
+  docker compose stop
 
 elif [ "$1" = "run" ]; then
   params=("$@")
@@ -54,9 +54,9 @@ elif [ "$1" = "ssh" ]; then
   fi
 
   if [ "$2" = "--test" ] || [ "$3" = "--test" ]; then
-    docker-compose exec --workdir $dir test_wordpress bash
+    docker compose exec --workdir $dir test_wordpress bash
   else
-    docker-compose exec --workdir $dir wordpress bash
+    docker compose exec --workdir $dir wordpress bash
   fi
 
 elif [ "$1" = "acceptance" ]; then
@@ -65,7 +65,7 @@ elif [ "$1" = "acceptance" ]; then
   else
     cd mailpoet
   fi
-  COMPOSE_HTTP_TIMEOUT=200 docker-compose run codeception_acceptance -e KEEP_DEPS=1 --steps --debug -vvv
+  COMPOSE_HTTP_TIMEOUT=200 docker compose run codeception_acceptance -e KEEP_DEPS=1 --steps --debug -vvv
   cd ..
 
 elif [ "$1" = "build" ]; then

--- a/docker-compose.override.macos-sample.yml
+++ b/docker-compose.override.macos-sample.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # for M1 Macs
   db:

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -473,14 +473,14 @@ class RoboFile extends \Robo\Tasks {
 
     // import data & run WordPress setup
     $this->say('Importing data and running a WordPress setup...');
-    $this->taskExec('COMPOSE_HTTP_TIMEOUT=200 docker-compose run --rm -it setup')
+    $this->taskExec('COMPOSE_HTTP_TIMEOUT=200 docker compose run --rm -it setup')
       ->dir(__DIR__ . '/tests/performance')
       ->run();
     $this->say('Data imported, WordPress set up.');
   }
 
   public function testPerformanceClean() {
-    $this->taskExec('COMPOSE_HTTP_TIMEOUT=200 docker-compose down --remove-orphans -v')
+    $this->taskExec('COMPOSE_HTTP_TIMEOUT=200 docker compose down --remove-orphans -v')
       ->dir(__DIR__ . '/tests/performance')
       ->run();
   }
@@ -494,7 +494,7 @@ class RoboFile extends \Robo\Tasks {
    */
   public function deleteDocker() {
     return $this->taskExec(
-      'docker-compose down -v --remove-orphans --rmi all'
+      'docker compose down -v --remove-orphans --rmi all'
     )->dir(__DIR__ . '/../tests_env/docker')->run();
   }
 
@@ -504,7 +504,7 @@ class RoboFile extends \Robo\Tasks {
   public function resetTestDocker() {
     return $this
       ->taskExec(
-        'docker-compose down -v --remove-orphans'
+        'docker compose down -v --remove-orphans'
       )->dir(__DIR__ . '/../tests_env/docker')
       ->addCode([$this, 'cleanupCachedFiles'])
       ->run();
@@ -1609,7 +1609,7 @@ class RoboFile extends \Robo\Tasks {
     $testType = $opts['test_type'] ?? 'acceptance';
     $this->doctrineGenerateCache();
     return $this->taskExec(
-      'COMPOSE_HTTP_TIMEOUT=200 docker-compose run ' .
+      'COMPOSE_HTTP_TIMEOUT=200 docker compose run ' .
       (isset($opts['wordpress-version']) && $opts['wordpress-version'] ? '-e WORDPRESS_VERSION=' . $opts['wordpress-version'] . ' ' : '') .
       (isset($opts['skip-deps']) && $opts['skip-deps'] ? '-e SKIP_DEPS=1 ' : '') .
       (isset($opts['disable-hpos']) && $opts['disable-hpos'] ? '-e DISABLE_HPOS=1 ' : '') .

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   setup:
     image: wordpress:cli-2.7-php8.2

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -57,7 +57,7 @@ wp core version
 
 # Load Composer dependencies
 # Set SKIP_DEPS environment flag to not download them. E.g. you have downloaded them yourself
-# Example: docker-compose run -e SKIP_DEPS=1 codeception ...
+# Example: docker compose run -e SKIP_DEPS=1 codeception ...
 if [[ -z "${SKIP_DEPS}" ]]; then
   cd /project
   ./tools/vendor/composer.phar install

--- a/tests_env/docker/docker-compose.override.macos-sample.yml
+++ b/tests_env/docker/docker-compose.override.macos-sample.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # for M1 Macs
   mysql:


### PR DESCRIPTION
## Description

The command docker-compose has been deprecated for some time and now, in the latest version removed from Docker. We need to start using docker compose instead

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6233]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6233]: https://mailpoet.atlassian.net/browse/MAILPOET-6233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ