### PR TITLE
Update WooCommerce action when setting cart item to zero [MAILPOET-6069]

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/AbandonedCart.php
@@ -120,9 +120,9 @@ class AbandonedCart {
       10
     );
 
-    // item quantity set to zero (it removes the item but does not fire remove event)
+    // item quantity set to zero
     $this->wp->addAction(
-      'woocommerce_before_cart_item_quantity_zero',
+      'woocommerce_remove_cart_item',
       [$this, 'handleCartChange'],
       10
     );

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -138,7 +138,7 @@ class AbandonedCartTest extends \MailPoetTest {
     verify($registeredActions)->arrayContains('woocommerce_add_to_cart');
     verify($registeredActions)->arrayContains('woocommerce_cart_item_removed');
     verify($registeredActions)->arrayContains('woocommerce_after_cart_item_quantity_update');
-    verify($registeredActions)->arrayContains('woocommerce_before_cart_item_quantity_zero');
+    verify($registeredActions)->arrayContains('woocommerce_remove_cart_item');
     verify($registeredActions)->arrayContains('woocommerce_cart_emptied');
     verify($registeredActions)->arrayContains('woocommerce_cart_item_restored');
     verify($registeredActions)->arrayContains('woocommerce_load_cart_from_session');


### PR DESCRIPTION
## Description

Replace the [deprecated](https://github.com/woocommerce/woocommerce/blob/e19110c56458798e5cf3311d1ab512502254fa8b/plugins/woocommerce/includes/class-wc-cart.php#L1355) `woocommerce_before_cart_item_quantity_zero` action with `woocommerce_remove_cart_item.` 

## Code review notes

_N/A_

## QA notes

I think QA can be skipped. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6069]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6069]: https://mailpoet.atlassian.net/browse/MAILPOET-6069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:woo-remove-item-action)

_The latest successful build from `woo-remove-item-action` will be used. If none is available, the link won't work._