### PR TITLE
[MAILPOET-4326] Adapt form-placement hints to available theme features

### DIFF
--- a/mailpoet/assets/js/src/form-editor/components/form-settings/form-placement-options/settings-panels/other-settings.tsx
+++ b/mailpoet/assets/js/src/form-editor/components/form-settings/form-placement-options/settings-panels/other-settings.tsx
@@ -26,16 +26,7 @@ function OtherSettings(): JSX.Element {
     [],
   );
   const { changeFormSettings } = useDispatch(storeName);
-
-  const addFormWidgetHint = ReactStringReplace(
-    MailPoet.I18n.t('addFormWidgetHint'),
-    /\[link](.*?)\[\/link]/g,
-    (match) => (
-      <a key="addFormWidgetHintLink" href="site-editor.php" target="_blank">
-        {match}
-      </a>
-    ),
-  );
+  const themeSupport = useSelect(storeName).getThemeSupport();
 
   const addFormShortcodeHint = ReactStringReplace(
     MailPoet.I18n.t('addFormShortcodeHint'),
@@ -89,13 +80,35 @@ function OtherSettings(): JSX.Element {
     );
   };
 
+  const getFormWidgetHint = ({ hasWidgets, hasFSE }) => {
+    if (!hasWidgets && !hasFSE) return null;
+
+    let conf: { href: string; i18nKey: string };
+    if (hasWidgets === true) {
+      conf = { href: 'widgets.php', i18nKey: 'addFormWidgetHint' };
+    } else if (hasFSE === true) {
+      conf = { href: 'site-editor.php', i18nKey: 'addFormFSEHint' };
+    }
+
+    const nodes = ReactStringReplace(
+      MailPoet.I18n.t(conf.i18nKey),
+      /\[link](.*?)\[\/link]/g,
+      (match) => (
+        <a key="addFormWidgetHintLink" href={conf.href} target="_blank">
+          {match}
+        </a>
+      ),
+    );
+    return <p>{nodes}</p>;
+  };
+
   if (!isFormSaved) {
     return <p>{MailPoet.I18n.t('saveFormFirst')}</p>;
   }
 
   return (
     <>
-      <p>{addFormWidgetHint}</p>
+      {getFormWidgetHint(themeSupport)}
       <p>{addFormShortcodeHint}</p>
       <p>{addFormPhpIframeHint}</p>
       {getCopyTextArea({})}

--- a/mailpoet/assets/js/src/form-editor/components/form-settings/form-placement-options/settings-panels/other-settings.tsx
+++ b/mailpoet/assets/js/src/form-editor/components/form-settings/form-placement-options/settings-panels/other-settings.tsx
@@ -94,7 +94,12 @@ function OtherSettings(): JSX.Element {
       MailPoet.I18n.t(conf.i18nKey),
       /\[link](.*?)\[\/link]/g,
       (match) => (
-        <a key="addFormWidgetHintLink" href={conf.href} target="_blank">
+        <a
+          key="addFormWidgetHintLink"
+          href={conf.href}
+          target="_blank"
+          rel="noreferrer"
+        >
           {match}
         </a>
       ),

--- a/mailpoet/assets/js/src/form-editor/components/form-settings/form-placement-options/settings-panels/other-settings.tsx
+++ b/mailpoet/assets/js/src/form-editor/components/form-settings/form-placement-options/settings-panels/other-settings.tsx
@@ -31,7 +31,7 @@ function OtherSettings(): JSX.Element {
     MailPoet.I18n.t('addFormWidgetHint'),
     /\[link](.*?)\[\/link]/g,
     (match) => (
-      <a key="addFormWidgetHintLink" href="widgets.php" target="_blank">
+      <a key="addFormWidgetHintLink" href="site-editor.php" target="_blank">
         {match}
       </a>
     ),

--- a/mailpoet/assets/js/src/form-editor/store/selectors.ts
+++ b/mailpoet/assets/js/src/form-editor/store/selectors.ts
@@ -227,4 +227,7 @@ export const selectors = {
   isUserAdministrator(state: State) {
     return state.user.isAdministrator;
   },
+  getThemeSupport(state: State) {
+    return state.theme;
+  },
 } as const;

--- a/mailpoet/assets/js/src/form-editor/store/state-types.ts
+++ b/mailpoet/assets/js/src/form-editor/store/state-types.ts
@@ -51,6 +51,8 @@ export interface FormEditorWindow extends Window {
   mailpoet_tutorial_seen: '0' | '1';
   mailpoet_tutorial_url: string;
   mailpoet_is_administrator: boolean;
+  mailpoet_theme_support_widgets: boolean;
+  mailpoet_theme_support_fse: boolean;
 }
 
 declare let window: FormEditorWindow;
@@ -111,5 +113,9 @@ export type State = {
   tutorialUrl: string;
   user: {
     isAdministrator: boolean;
+  };
+  theme: {
+    hasWidgets: boolean;
+    hasFSE: boolean;
   };
 };

--- a/mailpoet/assets/js/src/form-editor/store/store.ts
+++ b/mailpoet/assets/js/src/form-editor/store/store.ts
@@ -113,6 +113,10 @@ export const initStore = () => {
     user: {
       isAdministrator: window.mailpoet_is_administrator,
     },
+    theme: {
+      hasWidgets: window.mailpoet_theme_support_widgets,
+      hasFSE: window.mailpoet_theme_support_fse,
+    },
   } as const;
 
   const config = {

--- a/mailpoet/lib/AdminPages/Pages/FormEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/FormEditor.php
@@ -273,6 +273,8 @@ class FormEditor {
       'product_categories' => $this->wpPostListLoader->getWooCommerceCategories(),
       'product_tags' => $this->wpPostListLoader->getWooCommerceTags(),
       'is_administrator' => $this->wp->currentUserCan('administrator'),
+      'theme_support_widgets' => $this->wp->wpGetThemeSupport('widgets'),
+      'theme_support_fse' => $this->wp->wpGetTheme()->is_block_theme(),
     ];
     $this->wp->wpEnqueueMedia();
     $this->assetsController->setupFormEditorDependencies();

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -586,6 +586,10 @@ class Functions {
     return wp_get_theme($stylesheet, $themeRoot);
   }
 
+  public function wpGetThemeSupport($feature = null, $args = null) {
+    return get_theme_support($feature, $args);
+  }
+
   public function wpInsertPost(array $postarr, $wpError = false) {
     return wp_insert_post($postarr, $wpError);
   }

--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -103,7 +103,7 @@
   'formPlacementOtherLabel': _x('Shortcode & other', 'Label in the form placement section (Other form placements)'),
   'animationHeader': __('Show animation on display'),
   'animationNone': _x('No Animation', 'Value in a selectbox with a list of animations'),
-  'addFormWidgetHint': __('You can add this form to a [link]widget area of your theme[/link] (new tab).'),
+  'addFormWidgetHint': __('You can add this form to your site using the [link]site editor[/link] (new tab).'),
   'addFormShortcodeHint': __('Or in any page or post as a block, or with this shortcode if you prefer [shortcode].'),
   'addFormPhpIframeHint': __('Use [link]PHP[/link] or [link]iFrame[/link].'),
   'settingsListLabel': __('This form adds the subscribers to these lists'),

--- a/mailpoet/views/form/editor.html
+++ b/mailpoet/views/form/editor.html
@@ -31,6 +31,8 @@
   var mailpoet_tutorial_url = '<%= cdn_url('form-editor/tutorial.mp4') %>';
   var mailpoet_is_administrator = <%= is_administrator ? 'true' : 'false' %>;
   var mailpoet_form_edit_url = "<%= admin_url('admin.php?page=mailpoet-form-editor&id=') %>";
+  var mailpoet_theme_support_widgets = <%= theme_support_widgets ? 'true' : 'false' %>;
+  var mailpoet_theme_support_fse = <%= theme_support_fse ? 'true' : 'false' %>;
   <% endautoescape %>
 </script>
 
@@ -103,9 +105,10 @@
   'formPlacementOtherLabel': _x('Shortcode & other', 'Label in the form placement section (Other form placements)'),
   'animationHeader': __('Show animation on display'),
   'animationNone': _x('No Animation', 'Value in a selectbox with a list of animations'),
-  'addFormWidgetHint': __('You can add this form to your site using the [link]site editor[/link] (new tab).'),
-  'addFormShortcodeHint': __('Or in any page or post as a block, or with this shortcode if you prefer [shortcode].'),
-  'addFormPhpIframeHint': __('Use [link]PHP[/link] or [link]iFrame[/link].'),
+  'addFormWidgetHint': __('You can add this form to a [link]widget area of your theme[/link] (new tab).'),
+  'addFormFSEHint': __('You can add this form to your site using the [link]site editor[/link] (new tab).'),
+  'addFormShortcodeHint': __('You can also use a block on any page or post, or this shortcode if you prefer [shortcode].'),
+  'addFormPhpIframeHint': __('When needed, use [link]PHP[/link] or an [link]iFrame[/link] HTML element.'),
   'settingsListLabel': __('This form adds the subscribers to these lists'),
   'settingsAfterSubmit': __('After submit…'),
   'settingsShowMessage': __('Show message'),


### PR DESCRIPTION
## Description

To quote the original issue for our form editor:

> When I have a FSE theme installed and I edit a form, there is a link to the widgets.php area, which is broken, because the wp-admin/widgets.php is not supported by FSE themes

This PR changes that behavior, so that for a theme with FSE, we will link to site-editor.php instead. Theme with widgets-support still retain the previous behavior. If the active theme doesn't support widgets nor FSE, then the hint is not displayed at all (there are other hints about using short-codes, PHP, or iframes — this is unchanged).

## Code review notes

I had to add new `window` globals in the form-editor's HTML to pass-on information about the current theme's feature to the front-end TypeScript code. Is there a better way?

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4326](https://mailpoet.atlassian.net/browse/MAILPOET-4326)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4326]: https://mailpoet.atlassian.net/browse/MAILPOET-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-4326-widget)

_The latest successful build from `MAILPOET-4326-widget` will be used. If none is available, the link won't work._