### PR TITLE
Fix calculating stats in automation analytics flow [MAILPOET-6230]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/flow-ending.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/flow-ending.tsx
@@ -3,14 +3,23 @@ import { FlowSeparator } from './flow-separator';
 import { Step as StepData } from './types';
 
 type Props = {
-  stepData: StepData;
+  previousStepData: StepData;
   index: number;
+  nextStepData?: StepData;
 };
 
-export function FlowEnding({ stepData, index }: Props): JSX.Element {
+export function FlowEnding({
+  previousStepData,
+  index,
+  nextStepData,
+}: Props): JSX.Element {
   return (
     <div className="mailpoet-automation-editor-step-wrapper">
-      <FlowSeparator stepData={stepData} index={index} />
+      <FlowSeparator
+        previousStepData={previousStepData}
+        nextStepData={nextStepData}
+        index={index}
+      />
       <Icon
         className="mailpoet-automation-editor-automation-end"
         icon={check}

--- a/mailpoet/assets/js/src/automation/editor/components/automation/flow-separator.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/flow-separator.tsx
@@ -6,8 +6,9 @@ import { Step as StepData } from './types';
 import { RenderStepSeparatorType } from '../../../types/filters';
 
 type Props = {
-  stepData: StepData;
+  previousStepData: StepData;
   index: number;
+  nextStepData?: StepData;
 };
 
 export function FlowSeparator(props: Props): JSX.Element {
@@ -35,5 +36,9 @@ export function FlowSeparator(props: Props): JSX.Element {
       ),
     [context],
   );
-  return renderSeparator(props.stepData, props.index);
+  return renderSeparator(
+    props.previousStepData,
+    props.index,
+    props.nextStepData,
+  );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/automation/flow.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/flow.tsx
@@ -40,13 +40,24 @@ export function Flow({ stepData, row }: Props): JSX.Element {
 
           return nextStepData ? (
             <div key={id}>
-              {row > 0 && <FlowSeparator stepData={stepData} index={i} />}
+              {row > 0 && (
+                <FlowSeparator
+                  previousStepData={stepData}
+                  index={i}
+                  nextStepData={nextStepData}
+                />
+              )}
               <FlowStep stepData={nextStepData} index={i} />
               <Flow stepData={nextStepData} row={row + 1} />
             </div>
           ) : (
-            // eslint-disable-next-line react/no-array-index-key
-            <FlowEnding key={i} stepData={stepData} index={i} />
+            <FlowEnding
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              previousStepData={stepData}
+              index={i}
+              nextStepData={nextStepData}
+            />
           );
         })}
       </div>

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/hooks/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/hooks/index.tsx
@@ -50,6 +50,7 @@ export function initHooks() {
       return function StatisticSeparatorWrapper(
         previousStepData: StepData,
         index: number,
+        nextStepData: StepData,
       ) {
         return (
           <>
@@ -62,7 +63,11 @@ export function initHooks() {
                 }
               />
             )}
-            <StatisticSeparator previousStep={previousStepData} index={index} />
+            <StatisticSeparator
+              previousStep={previousStepData}
+              nextStep={nextStepData}
+              index={index}
+            />
           </>
         );
       };

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
@@ -8,11 +8,13 @@ import { Step } from '../../../../../../editor/components/automation/types';
 type Props = {
   previousStep: Step;
   index: number;
+  nextStep?: Step;
 };
 
 export function StatisticSeparator({
   previousStep,
   index,
+  nextStep,
 }: Props): JSX.Element | null {
   const { section, stepType } = useSelect(
     (s) => ({

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
@@ -54,15 +54,25 @@ export function StatisticSeparator({
     );
   }
 
-  const completed = data.step_data?.completed;
-  const value = completed !== undefined ? completed[previousStep.id] ?? 0 : 0;
+  const completed = data.step_data?.completed || {};
+  const failed = data.step_data?.failed || {};
+  const waiting = data.step_data?.waiting || {};
+  let totalEntered = 0;
+  if (nextStep) {
+    totalEntered =
+      (completed[nextStep.id] ?? 0) +
+      (failed[nextStep.id] ?? 0) +
+      (waiting[nextStep.id] ?? 0);
+  } else {
+    totalEntered = completed[previousStep.id] ?? 0;
+  }
   const percent =
     data.step_data.total > 0
-      ? Math.round((value / data.step_data.total) * 100)
+      ? Math.round((totalEntered / data.step_data.total) * 100)
       : 0;
   const formattedValue = Intl.NumberFormat(locale.toString(), {
     notation: 'compact',
-  }).format(value);
+  }).format(totalEntered);
   const formattedPercent = Intl.NumberFormat(locale.toString(), {
     style: 'percent',
   }).format(percent / 100);

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
@@ -52,8 +52,8 @@ export function StatisticSeparator({
     );
   }
 
-  const flow = data.step_data?.flow;
-  const value = flow !== undefined ? flow[previousStep.id] ?? 0 : 0;
+  const completed = data.step_data?.completed;
+  const value = completed !== undefined ? completed[previousStep.id] ?? 0 : 0;
   const percent =
     data.step_data.total > 0
       ? Math.round((value / data.step_data.total) * 100)

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
@@ -57,12 +57,19 @@ export function StatisticSeparator({
   const completed = data.step_data?.completed || {};
   const failed = data.step_data?.failed || {};
   const waiting = data.step_data?.waiting || {};
+  const calculateTotals = (id) =>
+    (completed[id] ?? 0) + (failed[id] ?? 0) + (waiting[id] ?? 0);
   let totalEntered = 0;
   if (nextStep) {
-    totalEntered =
-      (completed[nextStep.id] ?? 0) +
-      (failed[nextStep.id] ?? 0) +
-      (waiting[nextStep.id] ?? 0);
+    totalEntered = calculateTotals(nextStep.id);
+  } else if (previousStep.next_steps.length === 2) {
+    // When there is no next step and the previous step has 2+ next steps we are
+    // in an empty if/else branch. To calculate the total we need to subtract
+    // totalEntered of the sibling step from totalEntered of previousStep
+    const siblingStep = previousStep.next_steps.find((step) => step.id);
+    const totalEnteredSibling = calculateTotals(siblingStep.id);
+    const totalEnteredPrevious = completed[previousStep.id] ?? 0;
+    totalEntered = totalEnteredPrevious - totalEnteredSibling;
   } else {
     totalEntered = completed[previousStep.id] ?? 0;
   }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -167,7 +167,7 @@ export type StepFlowData = {
   total: number;
   waiting: Record<string, number> | undefined;
   failed: Record<string, number> | undefined;
-  flow: Record<string, number> | undefined;
+  completed: Record<string, number> | undefined;
 };
 
 export type AutomationFlowSectionData = SectionData & {

--- a/mailpoet/assets/js/src/automation/types/filters.ts
+++ b/mailpoet/assets/js/src/automation/types/filters.ts
@@ -37,8 +37,9 @@ export type RenderStepFooterType = JSX.Element | null;
 
 // mailpoet.automation.render_step_separator
 export type RenderStepSeparatorType = (
-  step: Step,
+  previousStep: Step,
   index: number,
+  nextStep?: Step,
 ) => JSX.Element;
 
 // mailpoet.automation.editor.create_store

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/StepStatisticController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/StepStatisticController.php
@@ -64,7 +64,7 @@ class StepStatisticController {
     return $data;
   }
 
-  public function getFlowStatistics(Automation $automation, Query $query): array {
+  public function getCompletedStatistics(Automation $automation, Query $query): array {
     $statistics = $this->automationRunLogStorage->getAutomationRunStatisticsForAutomationInTimeFrame(
       $automation->getId(),
       AutomationRunLog::STATUS_COMPLETE,

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/AutomationFlowEndpoint.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/AutomationFlowEndpoint.php
@@ -68,7 +68,7 @@ class AutomationFlowEndpoint extends Endpoint {
     $waitingData = $this->stepStatisticController->getWaitingStatistics($automation, $query);
     $failedData = $this->stepStatisticController->getFailedStatistics($automation, $query);
     try {
-      $flowData = $this->stepStatisticController->getFlowStatistics($automation, $query);
+      $completedData = $this->stepStatisticController->getCompletedStatistics($automation, $query);
     } catch (\Throwable $e) {
       return new Response([$e->getMessage()], 500);
     }
@@ -81,8 +81,8 @@ class AutomationFlowEndpoint extends Endpoint {
     if ($failedData) {
       $stepData['failed'] = $failedData;
     }
-    if ($flowData) {
-      $stepData['flow'] = $flowData;
+    if ($completedData) {
+      $stepData['completed'] = $completedData;
     }
 
     $data = [

--- a/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
+++ b/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
@@ -6,6 +6,9 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\StatisticsClickEntity;
@@ -176,13 +179,13 @@ class AnalyticsCest {
     $firstEmailStep = null;
     $secondEmailStep = null;
     foreach ($automationSteps as $step) {
-      if ($step->getKey() === 'core:delay') {
+      if ($step->getKey() === DelayAction::KEY) {
         $delayStep = $step->getId();
       }
-      if ($step->getKey() === 'mailpoet:send-email' && $step->getArgs()['email_id'] === $this->newsletter1->getId()) {
+      if ($step->getKey() === SendEmailAction::KEY && $step->getArgs()['email_id'] === $this->newsletter1->getId()) {
         $firstEmailStep = $step->getId();
       }
-      if ($step->getKey() === 'mailpoet:send-email' && $step->getArgs()['email_id'] === $this->newsletter2->getId()) {
+      if ($step->getKey() === SendEmailAction::KEY && $step->getArgs()['email_id'] === $this->newsletter2->getId()) {
         $secondEmailStep = $step->getId();
       }
     }
@@ -223,7 +226,7 @@ class AnalyticsCest {
       ->withAutomation($this->automation)
       ->withStatus($nextStep ? $status : AutomationRun::STATUS_COMPLETE)
       ->withNextStep($nextStep)
-      ->withSubject(new Subject('mailpoet:subscriber', ['subscriber_id' => $subscriber->getId()]))
+      ->withSubject(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]))
       ->create();
 
     $runStepSequence = $this->getRunStepSequence($nextStep);


### PR DESCRIPTION
## Description

Fix automation flow analytics when the if/else branch is included. 


**Before:**
![Annotation on 2024-09-19 at 22-01-47](https://github.com/user-attachments/assets/dbb88f9f-169d-4c87-8fb4-69cf1559588d)

**After:**
![Screenshot 2024-09-19 at 22 26 08](https://github.com/user-attachments/assets/bd57b662-6ee4-4bc2-aea7-7adba5957622)

## Code review notes

Stats are rendered in the step separator, which accepts the previous step. This was causing issues because both branches of the if/else step would receive the if/else step to calculate stats from—this results in both showing the same number (I don't know how this could ever work before). 

This PR changes this so the separator also receives the next step, which is primarily used to calculate stats. The previous step is only used if the next step is unavailable (end of automation or a branch). 

There is also a special case with an empty if/else branch, in which we need to calculate the stats by looking at the sibling. 

## QA notes

Please test that the numbers in the automation analytics flow are correctly calculated when if/else steps are used. Also, focus on empty branches and processing users (those who have yet to complete the automation). 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6230]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6230]: https://mailpoet.atlassian.net/browse/MAILPOET-6230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:if-else-stats)

_The latest successful build from `if-else-stats` will be used. If none is available, the link won't work._