### PR TITLE
Fix List-Unsubscribe URL for non-MSS methods when tracking enabled

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -416,7 +416,7 @@ class SendingQueue {
           [
             'unsubscribe_url' => $unsubscribeUrls[0],
             'meta' => $metas[0],
-            'one_click_unsubscribe' => $oneClickUnsubscribeUrls,
+            'one_click_unsubscribe' => $oneClickUnsubscribeUrls[0],
           ]
         );
         $preparedNewsletters = [];

--- a/mailpoet/lib/Mailer/MailerFactory.php
+++ b/mailpoet/lib/Mailer/MailerFactory.php
@@ -60,7 +60,8 @@ class MailerFactory {
           $replyTo,
           $returnPath,
           new AmazonSESMapper(),
-          $this->wp
+          $this->wp,
+          ContainerWrapper::getInstance()->get(Url::class)
         );
         break;
       case Mailer::METHOD_MAILPOET:
@@ -79,7 +80,8 @@ class MailerFactory {
           $mailerConfig['api_key'],
           $sender,
           $replyTo,
-          new SendGridMapper()
+          new SendGridMapper(),
+          ContainerWrapper::getInstance()->get(Url::class)
         );
         break;
       case Mailer::METHOD_PHPMAIL:
@@ -87,7 +89,8 @@ class MailerFactory {
           $sender,
           $replyTo,
           $returnPath,
-          new PHPMailMapper()
+          new PHPMailMapper(),
+          ContainerWrapper::getInstance()->get(Url::class)
         );
         break;
       case Mailer::METHOD_SMTP:
@@ -100,6 +103,7 @@ class MailerFactory {
           $replyTo,
           $returnPath,
           new SMTPMapper(),
+          ContainerWrapper::getInstance()->get(Url::class),
           $mailerConfig['login'],
           $mailerConfig['password']
         );

--- a/mailpoet/lib/Mailer/Methods/AmazonSES.php
+++ b/mailpoet/lib/Mailer/Methods/AmazonSES.php
@@ -5,6 +5,7 @@ namespace MailPoet\Mailer\Methods;
 use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\AmazonSESMapper;
+use MailPoet\Util\Url;
 use MailPoet\WP\Functions as WPFunctions;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -74,7 +75,8 @@ class AmazonSES extends PHPMailerMethod {
     $replyTo,
     $returnPath,
     AmazonSESMapper $errorMapper,
-    WPFunctions $wp
+    WPFunctions $wp,
+    Url $urlUtils
   ) {
     $this->awsAccessKey = $accessKey;
     $this->awsSecretKey = $secretKey;
@@ -95,6 +97,7 @@ class AmazonSES extends PHPMailerMethod {
     $this->dateWithoutTime = gmdate('Ymd');
     $this->errorMapper = $errorMapper;
     $this->wp = $wp;
+    $this->urlUtils = $urlUtils;
     $this->blacklist = new BlacklistCheck();
     $this->mailer = $this->buildMailer();
   }

--- a/mailpoet/lib/Mailer/Methods/SMTP.php
+++ b/mailpoet/lib/Mailer/Methods/SMTP.php
@@ -4,6 +4,7 @@ namespace MailPoet\Mailer\Methods;
 
 use MailPoet\Mailer\Methods\ErrorMappers\SMTPMapper;
 use MailPoet\RuntimeException;
+use MailPoet\Util\Url;
 use MailPoet\WP\Functions as WPFunctions;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -36,6 +37,7 @@ class SMTP extends PHPMailerMethod {
     $replyTo,
     $returnPath,
     SMTPMapper $errorMapper,
+    Url $urlUtils,
     $login = null,
     $password = null
   ) {
@@ -46,7 +48,7 @@ class SMTP extends PHPMailerMethod {
     $this->login = $login;
     $this->password = $password;
     $this->encryption = $encryption;
-    parent::__construct($sender, $replyTo, $returnPath, $errorMapper);
+    parent::__construct($sender, $replyTo, $returnPath, $errorMapper, $urlUtils);
   }
 
   public function buildMailer(): PHPMailer {

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -7,6 +7,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\AmazonSES;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\AmazonSESMapper;
+use MailPoet\Util\Url;
 use MailPoet\WP\Functions as WPFunctions;
 
 class AmazonSESTest extends \MailPoetTest {
@@ -53,7 +54,8 @@ class AmazonSESTest extends \MailPoetTest {
       $this->replyTo,
       $this->returnPath,
       new AmazonSESMapper(),
-      new WPFunctions()
+      new WPFunctions(),
+      $this->diContainer->get(Url::class)
     );
     $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [
@@ -91,7 +93,8 @@ class AmazonSESTest extends \MailPoetTest {
         $this->replyTo,
         $this->returnPath,
         new AmazonSESMapper(),
-        new WPFunctions()
+        new WPFunctions(),
+        $this->diContainer->get(Url::class)
       );
       $this->fail('Unsupported region exception was not thrown');
     } catch (\Exception $e) {
@@ -275,7 +278,8 @@ class AmazonSESTest extends \MailPoetTest {
       $this->replyTo,
       $this->returnPath,
       new AmazonSESMapper(),
-      $mockedWp
+      $mockedWp,
+      $this->diContainer->get(Url::class)
     );
     $result = $mailer->send(
       $this->newsletter,

--- a/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -7,6 +7,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\PHPMailMapper;
 use MailPoet\Mailer\Methods\PHPMail;
+use MailPoet\Util\Url;
 use PHPMailer\PHPMailer\PHPMailer;
 
 class PHPMailTest extends \MailPoetTest {
@@ -36,7 +37,8 @@ class PHPMailTest extends \MailPoetTest {
       $this->sender,
       $this->replyTo,
       $this->returnPath,
-      new PHPMailMapper()
+      new PHPMailMapper(),
+      $this->diContainer->get(Url::class)
     );
     $this->subscriber = 'Recipient <blackhole@mailpoet.com>';
     $this->newsletter = [

--- a/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
@@ -7,6 +7,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\SMTPMapper;
 use MailPoet\Mailer\Methods\SMTP;
+use MailPoet\Util\Url;
 use MailPoet\WP\Functions as WPFunctions;
 
 //phpcs:disable Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
@@ -59,6 +60,7 @@ class SMTPTest extends \MailPoetTest {
       $this->replyTo,
       $this->returnPath,
       new SMTPMapper(),
+      $this->diContainer->get(Url::class),
       $this->settings['login'],
       $this->settings['password']
     );

--- a/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
@@ -7,6 +7,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\Methods\Common\BlacklistCheck;
 use MailPoet\Mailer\Methods\ErrorMappers\SendGridMapper;
 use MailPoet\Mailer\Methods\SendGrid;
+use MailPoet\Util\Url;
 
 class SendGridTest extends \MailPoetTest {
   public $extraParams;
@@ -40,7 +41,8 @@ class SendGridTest extends \MailPoetTest {
       $this->settings['api_key'],
       $this->sender,
       $this->replyTo,
-      new SendGridMapper()
+      new SendGridMapper(),
+      $this->diContainer->get(Url::class)
     );
     $this->subscriber = 'Recipient <mailpoet@sink.sendgrid.net>';
     $this->newsletter = [


### PR DESCRIPTION
## Description

When using a non-MSS method, the `List-Unsubscribe` header URL points to a tracking link when tracking is enabled. This is invalid — 1-click unsubscribe cannot be followed by a redirect.

While for the MailPoet sending method, the List-Unsubscribe header can differ from the in-email unsubscribe link, for other methods, they are the same. This PR fixes it by using the same logic for all methods, as for the MailPoet method.

## QA notes

With a build from trunk, try to reproduce this first:

1. The testing site must use HTTPS. 
2. Use a non-MSS sending method (Your web host, SMTP, AWS, or SendGrid).
3. Turn on engagement tracking in MailPoet settings (Settings > Advanced >Engagement analytics tracking to Partial or Full).
4. Send a newsletter and check its `List-Unsubscribe` header.

With the build from `trunk`, the `List-Unsubscribe` header will point to the `track` endpoint. With the build from this branch, it should point to the `subscription` endpoint (action `unsubscribe`) directly.

## Linked tickets

[MAILPOET-6242]

[MAILPOET-6242]: https://mailpoet.atlassian.net/browse/MAILPOET-6242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-unsubscribe-url)

_The latest successful build from `fix-unsubscribe-url` will be used. If none is available, the link won't work._