### PR TITLE
Fix send email step time-out happening too early

### DIFF
--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -248,7 +248,7 @@ class SendEmailAction implements Action {
     }
 
     $wasSent = $scheduledTaskSubscriber->getProcessed() === ScheduledTaskSubscriberEntity::STATUS_PROCESSED;
-    $isLastRun = $args->getRunNumber() >= count(self::POLL_INTERVALS);
+    $isLastRun = $args->getRunNumber() >= 1 + count(self::POLL_INTERVALS);
 
     // email was never sent
     if (!$wasSent && $isLastRun) {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -207,8 +207,8 @@ class SendEmailActionTest extends \MailPoetTest {
     $this->assertSame('mailpoet/automation/step', $actions[0]->get_hook());
     $this->assertSame([['automation_run_id' => $run->getId(), 'step_id' => 'step-id', 'run_number' => 3]], $actions[0]->get_args());
 
-    // email was never sent (7th run is the last check after ~1 month)
-    $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 7);
+    // email was never sent (8th run is the last check after ~1 month)
+    $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 8);
     $this->assertThrowsExceptionWithMessage(
       'Email sending process timed out.',
       function() use ($args, $controller) {


### PR DESCRIPTION
## Description

In automation, these are the checks whether an email was sent in the Send email step:

```
~5 minutes
~15 minutes
~1 hour
~5 hours
~1 day
~5 days
~1 month
```

We seem to end time out the runs after 5 days, not 1 month.

This was an off-by-one error — the first step run is the email scheduling run.

## Code review notes

I think that QA can be skipped here. Not sure, if we can add a reasonable test, I didn't get to trying that (timewise).

## QA notes

QA can be skipped.

## Linked tickets

[MAILPOET-6246]

[MAILPOET-6246]: https://mailpoet.atlassian.net/browse/MAILPOET-6246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-send-email-timeout)

_The latest successful build from `fix-send-email-timeout` will be used. If none is available, the link won't work._