### PR TITLE
Don't generate SCSS source maps in release build [MAILPOET-6247]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -220,7 +220,7 @@ class RoboFile extends \Robo\Tasks {
 
     $compilationResult = $this->taskExecStack()
       ->exec('pnpm run stylelint-check -- "assets/css/src/**/*.scss"')
-      ->exec('pnpm run scss')
+      ->exec('pnpm run scss' . ($opts['env'] === 'production' ? ' --no-source-map' : ''))
       ->exec('pnpm run autoprefixer')
       ->run();
 


### PR DESCRIPTION
## Description

Skip generating source map when the environment is set to `production`. This saves ~100KB in release .zip file, or ~500KB when unzipped.

- [ZIP file before](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/19097/workflows/7aef8e14-8213-4767-9894-40803c9f5a98/jobs/325048/artifacts)
- [ZIP file after](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/19099/workflows/85ad2086-dc24-4daa-99dd-97bb4c267e0f/jobs/325088/artifacts)

## Code review notes

_N/A_

## QA notes

QA can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6247]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6247]: https://mailpoet.atlassian.net/browse/MAILPOET-6247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:no-source-map)

_The latest successful build from `no-source-map` will be used. If none is available, the link won't work._