### PR TITLE
Replace deprecated Query with direct access to DataStore [MAILPOET-6253]

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -2,7 +2,7 @@
 
 namespace MailPoet\WooCommerce;
 
-use Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Query;
+use Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\DataStore;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\RuntimeException;
 use MailPoet\WP\Functions as WPFunctions;
@@ -148,14 +148,14 @@ class Helper {
   }
 
   public function getCustomersCount(): int {
-    if (!$this->isWooCommerceActive() || !class_exists(Query::class)) {
+    if (!$this->isWooCommerceActive() || !class_exists(DataStore::class)) {
       return 0;
     }
-    $query = new Query([
+
+    $dataStore = new DataStore();
+    $result = (array)$dataStore->get_data([
       'fields' => ['customers_count'],
     ]);
-    // Query::get_data declares it returns array but the underlying DataStore returns stdClass
-    $result = (array)$query->get_data();
     return isset($result['customers_count']) ? intval($result['customers_count']) : 0;
   }
 


### PR DESCRIPTION
## Description

`Automattic\WooCommerce\Admin\API\Reports\Customers\Stats\Query` is deprecated, and the recommendation is to access `DataStore` directly, which is what `Query` would do previously.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6253]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6253]: https://mailpoet.atlassian.net/browse/MAILPOET-6253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wc-94-deprecation-fix)

_The latest successful build from `wc-94-deprecation-fix` will be used. If none is available, the link won't work._