### PR TITLE
Use cached authorized emails when API is down

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,3 +55,4 @@ ij_php_space_after_for_semicolon = true
 ij_php_space_after_colon_in_return_type = true
 ij_php_space_before_else_keyword = true
 ij_php_for_statement_new_line_after_left_paren = true
+ij_php_class_brace_style = end_of_line

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 [ "$MP_GIT_HOOKS_ENABLE" != "true" ] && exit 0
 

--- a/mailpoet/lib/API/JSON/v1/Mailer.php
+++ b/mailpoet/lib/API/JSON/v1/Mailer.php
@@ -92,7 +92,7 @@ class Mailer extends APIEndpoint {
   }
 
   public function getAuthorizedEmailAddresses() {
-    $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses();
+    $authorizedEmails = $this->authorizedEmailsController->getAuthorizedEmailAddresses();
     return $this->successResponse($authorizedEmails);
   }
 

--- a/mailpoet/lib/API/JSON/v1/Mailer.php
+++ b/mailpoet/lib/API/JSON/v1/Mailer.php
@@ -10,16 +10,12 @@ use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
-use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 
 class Mailer extends APIEndpoint {
 
   /** @var AuthorizedEmailsController */
   private $authorizedEmailsController;
-
-  /** @var Bridge */
-  private $bridge;
 
   /** @var SettingsController */
   private $settings;
@@ -40,14 +36,12 @@ class Mailer extends APIEndpoint {
   public function __construct(
     AuthorizedEmailsController $authorizedEmailsController,
     SettingsController $settings,
-    Bridge $bridge,
     MailerFactory $mailerFactory,
     MetaInfo $mailerMetaInfo,
     AuthorizedSenderDomainController $senderDomainController
   ) {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->settings = $settings;
-    $this->bridge = $bridge;
     $this->mailerFactory = $mailerFactory;
     $this->mailerMetaInfo = $mailerMetaInfo;
     $this->senderDomainController = $senderDomainController;

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -12,6 +12,7 @@ use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\Workers\KeyCheck\PremiumKeyCheck;
 use MailPoet\Cron\Workers\KeyCheck\SendingServiceKeyCheck;
 use MailPoet\Mailer\MailerLog;
+use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Services\CongratulatoryMssEmailController;
@@ -52,6 +53,9 @@ class Services extends APIEndpoint {
   /** @var AuthorizedSenderDomainController */
   private $senderDomainController;
 
+  /** @var AuthorizedEmailsController */
+  private $authorizedEmailsController;
+
   /** @var SubscribersCountReporter */
   private $subscribersCountReporter;
 
@@ -70,7 +74,8 @@ class Services extends APIEndpoint {
     SubscribersCountReporter $subscribersCountReporter,
     CongratulatoryMssEmailController $congratulatoryMssEmailController,
     WPFunctions $wp,
-    AuthorizedSenderDomainController $senderDomainController
+    AuthorizedSenderDomainController $senderDomainController,
+    AuthorizedEmailsController $authorizedEmailsController
   ) {
     $this->bridge = $bridge;
     $this->settings = $settings;
@@ -83,6 +88,7 @@ class Services extends APIEndpoint {
     $this->congratulatoryMssEmailController = $congratulatoryMssEmailController;
     $this->wp = $wp;
     $this->senderDomainController = $senderDomainController;
+    $this->authorizedEmailsController = $authorizedEmailsController;
   }
 
   public function checkMSSKey($data = []) {
@@ -266,7 +272,7 @@ class Services extends APIEndpoint {
     $emailDomain = Helpers::extractEmailDomain($fromEmail);
 
     if (!$this->isItemInArray($emailDomain, $verifiedDomains)) {
-      $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses();
+      $authorizedEmails = $this->authorizedEmailsController->getAuthorizedEmailAddresses();
 
       if (!$authorizedEmails) {
         return $this->createBadRequest(__('No FROM email addresses are authorized.', 'mailpoet'));

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\NewsletterTemplates\NewsletterTemplatesRepository;
 use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Segments\WooCommerce;
+use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -46,6 +47,8 @@ class Newsletters {
 
   private AuthorizedSenderDomainController $senderDomainController;
 
+  private AuthorizedEmailsController $authorizedEmailsController;
+
   private UserFlagsController $userFlagsController;
 
   private WooCommerce $wooCommerceSegment;
@@ -64,6 +67,7 @@ class Newsletters {
     NewslettersRepository $newslettersRepository,
     Bridge $bridge,
     AuthorizedSenderDomainController $senderDomainController,
+    AuthorizedEmailsController $authorizedEmailsController,
     UserFlagsController $userFlagsController,
     WooCommerce $wooCommerceSegment,
     CapabilitiesManager $capabilitiesManager
@@ -79,6 +83,7 @@ class Newsletters {
     $this->newslettersRepository = $newslettersRepository;
     $this->bridge = $bridge;
     $this->senderDomainController = $senderDomainController;
+    $this->authorizedEmailsController = $authorizedEmailsController;
     $this->userFlagsController = $userFlagsController;
     $this->wooCommerceSegment = $wooCommerceSegment;
     $this->capabilitiesManager = $capabilitiesManager;
@@ -136,7 +141,7 @@ class Newsletters {
     $data['sender_restrictions'] = [];
 
     if ($this->bridge->isMailpoetSendingServiceEnabled()) {
-      $data['authorized_emails'] = $this->bridge->getAuthorizedEmailAddresses();
+      $data['authorized_emails'] = $this->authorizedEmailsController->getAuthorizedEmailAddresses();
       $data['verified_sender_domains'] = $this->senderDomainController->getFullyVerifiedSenderDomains(true);
       $data['partially_verified_sender_domains'] = $this->senderDomainController->getPartiallyVerifiedSenderDomains(true);
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -7,6 +7,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\Hosts;
@@ -41,6 +42,9 @@ class Settings {
   /** @var AuthorizedSenderDomainController */
   private $senderDomainController;
 
+  /** @var AuthorizedEmailsController */
+  private $authorizedEmailsController;
+
   /** @var AssetsController */
   private $assetsController;
 
@@ -53,7 +57,8 @@ class Settings {
     CaptchaRenderer $captchaRenderer,
     SegmentsSimpleListRepository $segmentsListRepository,
     Bridge $bridge,
-    AuthorizedSenderDomainController $senderDomainController
+    AuthorizedSenderDomainController $senderDomainController,
+    AuthorizedEmailsController $authorizedEmailsController
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
@@ -64,6 +69,7 @@ class Settings {
     $this->segmentsListRepository = $segmentsListRepository;
     $this->bridge = $bridge;
     $this->senderDomainController = $senderDomainController;
+    $this->authorizedEmailsController = $authorizedEmailsController;
   }
 
   public function render() {
@@ -100,7 +106,7 @@ class Settings {
     $data['sender_restrictions'] = [];
 
     if ($this->bridge->isMailpoetSendingServiceEnabled()) {
-      $data['authorized_emails'] = $this->bridge->getAuthorizedEmailAddresses();
+      $data['authorized_emails'] = $this->authorizedEmailsController->getAuthorizedEmailAddresses();
       $data['verified_sender_domains'] = $this->senderDomainController->getFullyVerifiedSenderDomains(true);
       $data['partially_verified_sender_domains'] = $this->senderDomainController->getPartiallyVerifiedSenderDomains(true);
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();

--- a/mailpoet/lib/Automation/Integrations/MailPoet/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/ContextFactory.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Integrations\MailPoet;
 
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Services\Bridge;
 
@@ -20,16 +21,21 @@ class ContextFactory {
   /** @var AuthorizedSenderDomainController */
   private $authorizedSenderDomainController;
 
+  /** @var AuthorizedEmailsController */
+  private $authorizedEmailsController;
+
   public function __construct(
     SegmentsRepository $segmentsRepository,
     Bridge $bridge,
     ServicesChecker $servicesChecker,
-    AuthorizedSenderDomainController $authorizedSenderDomainController
+    AuthorizedSenderDomainController $authorizedSenderDomainController,
+    AuthorizedEmailsController $authorizedEmailsController
   ) {
     $this->segmentsRepository = $segmentsRepository;
     $this->servicesChecker = $servicesChecker;
     $this->bridge = $bridge;
     $this->authorizedSenderDomainController = $authorizedSenderDomainController;
+    $this->authorizedEmailsController = $authorizedEmailsController;
   }
 
   /** @return mixed[] */
@@ -48,7 +54,7 @@ class ContextFactory {
 
   private function getSenderDomainsConfig(): array {
     $senderDomainsConfig = $this->authorizedSenderDomainController->getContextDataForAutomations();
-    $senderDomainsConfig['authorizedEmails'] = $this->bridge->getAuthorizedEmailAddresses();
+    $senderDomainsConfig['authorizedEmails'] = $this->authorizedEmailsController->getAuthorizedEmailAddresses();
     return $senderDomainsConfig;
   }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -51,7 +51,7 @@ class AuthorizedEmailsController {
   }
 
   public function setFromEmailAddress(string $address) {
-    $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses() ?: [];
+    $authorizedEmails = $this->getAuthorizedEmailAddresses() ?: [];
     $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
     $isAuthorized = $this->validateAuthorizedEmail($authorizedEmails, $address);
 
@@ -74,12 +74,17 @@ class AuthorizedEmailsController {
     $this->settings->set(self::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, null);
   }
 
-  public function getAllAuthorizedEmailAddress(): array {
-    return $this->bridge->getAuthorizedEmailAddresses(self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_ALL);
+  public function getAuthorizedEmailAddresses(string $type = 'authorized'): array {
+    $data = $this->bridge->getAuthorizedEmailAddresses();
+    if ($data && $type === self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_ALL) {
+      return $data;
+    }
+
+    return $data[$type] ?? [];
   }
 
   public function createAuthorizedEmailAddress(string $email): array {
-    $allEmails = $this->getAllAuthorizedEmailAddress();
+    $allEmails = $this->getAuthorizedEmailAddresses(self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_ALL);
 
     $authorizedEmails = isset($allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED]) ? $allEmails[self::AUTHORIZED_EMAIL_ADDRESSES_API_TYPE_AUTHORIZED] : [];
     $isAuthorized = $this->validateAuthorizedEmail($authorizedEmails, $email);
@@ -104,7 +109,7 @@ class AuthorizedEmailsController {
   }
 
   public function isEmailAddressAuthorized(string $email): bool {
-    $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses() ?: [];
+    $authorizedEmails = $this->getAuthorizedEmailAddresses() ?: [];
     return $this->validateAuthorizedEmail($authorizedEmails, $email);
   }
 
@@ -115,7 +120,7 @@ class AuthorizedEmailsController {
       return null;
     }
 
-    $authorizedEmails = $this->bridge->getAuthorizedEmailAddresses();
+    $authorizedEmails = $this->getAuthorizedEmailAddresses();
     // Keep previous check result for an invalid response from API
     if (!$authorizedEmails) {
       return null;

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -109,7 +109,7 @@ class AuthorizedEmailsController {
   }
 
   public function checkAuthorizedEmailAddresses() {
-    if (!Bridge::isMPSendingServiceEnabled()) {
+    if (!$this->bridge->isMailpoetSendingServiceEnabled()) {
       $this->settings->set(self::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, null);
       $this->updateMailerLog();
       return null;

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -133,15 +133,10 @@ class Bridge {
     return $this->initApi($key);
   }
 
-  public function getAuthorizedEmailAddresses($type = 'authorized'): array {
-    $data = $this
+  public function getAuthorizedEmailAddresses(): ?array {
+    return $this
       ->getApi($this->settings->get(self::API_KEY_SETTING_NAME))
       ->getAuthorizedEmailAddresses();
-    if ($data && $type === 'all') {
-      return $data;
-    }
-
-    return $data[$type] ?? [];
   }
 
   /**

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -24,8 +24,6 @@ class Bridge {
     self::WPCOM_BUNDLE_SUBSCRIPTION_TYPE,
   ];
 
-  const AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING_NAME = 'authorized_emails_addresses_check';
-
   const PREMIUM_KEY_SETTING_NAME = 'premium.premium_key';
   const PREMIUM_KEY_STATE_SETTING_NAME = 'premium.premium_key_state';
 

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -61,7 +61,7 @@ class Bridge {
   }
 
   /**
-   * @deprecated Use non static function isMailpoetSendingServiceEnabled instead
+   * @deprecated Use non-static function isMailpoetSendingServiceEnabled instead
    * @return bool
    */
   public static function isMPSendingServiceEnabled() {
@@ -74,6 +74,9 @@ class Bridge {
     }
   }
 
+  /**
+   * @return bool
+   */
   public function isMailpoetSendingServiceEnabled() {
     try {
       $mailerConfig = SettingsController::getInstance()->get(Mailer::MAILER_CONFIG_SETTING_NAME);
@@ -137,7 +140,8 @@ class Bridge {
     if ($data && $type === 'all') {
       return $data;
     }
-    return isset($data[$type]) ? $data[$type] : [];
+
+    return $data[$type] ?? [];
   }
 
   /**

--- a/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/MailerTest.php
@@ -10,7 +10,6 @@ use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\AuthorizedSenderDomainController;
-use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 
 class MailerTest extends \MailPoetTest {
@@ -25,8 +24,7 @@ class MailerTest extends \MailPoetTest {
     $authorizedEmailsController = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::never()]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     // resumeSending() method should clear the mailer log's status
-    $bridge = new Bridge($settings);
-    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $bridge, $this->diContainer->get(MailerFactory::class), new MetaInfo, $senderDomainController);
+    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $this->diContainer->get(MailerFactory::class), new MetaInfo, $senderDomainController);
     $response = $mailerEndpoint->resumeSending();
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $mailerLog = MailerLog::getMailerLog();
@@ -38,8 +36,7 @@ class MailerTest extends \MailPoetTest {
     $settings->set(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, ['invalid_sender_address' => 'a@b.c']);
     $authorizedEmailsController = $this->makeEmpty(AuthorizedEmailsController::class, ['checkAuthorizedEmailAddresses' => Expected::once()]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
-    $bridge = new Bridge($settings);
-    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $bridge, $this->diContainer->get(MailerFactory::class), new MetaInfo, $senderDomainController);
+    $mailerEndpoint = new Mailer($authorizedEmailsController, $settings, $this->diContainer->get(MailerFactory::class), new MetaInfo, $senderDomainController);
     $mailerEndpoint->resumeSending();
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -30,6 +30,7 @@ use MailPoet\Statistics\StatisticsOpensRepository;
 use MailPoet\Subscribers\ConfirmationEmailCustomizer;
 use MailPoet\Subscribers\SubscribersCountsController;
 use MailPoet\WooCommerce\TransactionalEmails;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -133,10 +134,11 @@ class SettingsTest extends \MailPoetTest {
   public function testItSetsAuthorizedFromAddressAndResumesSending() {
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['authorized@email.com']])]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+    $wp = $this->diContainer->get(WPFunctions::class);
     $this->endpoint = new Settings(
       $this->settings,
       $bridgeMock,
-      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController),
+      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController, $wp),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
       $this->diContainer->get(EntityManager::class),
@@ -164,10 +166,11 @@ class SettingsTest extends \MailPoetTest {
     $this->settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, ['method' => Mailer::METHOD_MAILPOET]);
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['authorized@email.com']])]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+    $wp = $this->diContainer->get(WPFunctions::class);
     $this->endpoint = new Settings(
       $this->settings,
       $bridgeMock,
-      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController),
+      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController, $wp),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
       $this->diContainer->get(EntityManager::class),
@@ -197,10 +200,11 @@ class SettingsTest extends \MailPoetTest {
   public function testItRejectsUnauthorizedFromAddress() {
     $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['authorized@email.com']])]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
+    $wp = $this->diContainer->get(WPFunctions::class);
     $this->endpoint = new Settings(
       $this->settings,
       $bridgeMock,
-      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController),
+      new AuthorizedEmailsController($this->settings, $bridgeMock, $this->diContainer->get(NewslettersRepository::class), $senderDomainController, $wp),
       $this->diContainer->get(AuthorizedSenderDomainController::class),
       $this->make(TransactionalEmails::class),
       $this->diContainer->get(EntityManager::class),

--- a/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SettingsTest.php
@@ -131,7 +131,7 @@ class SettingsTest extends \MailPoetTest {
   }
 
   public function testItSetsAuthorizedFromAddressAndResumesSending() {
-    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized@email.com'])]);
+    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['authorized@email.com']])]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $this->endpoint = new Settings(
       $this->settings,
@@ -162,7 +162,7 @@ class SettingsTest extends \MailPoetTest {
 
   public function testItSaveUnauthorizedAddressAndReturnsMeta() {
     $this->settings->set(Mailer::MAILER_CONFIG_SETTING_NAME, ['method' => Mailer::METHOD_MAILPOET]);
-    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized@email.com'])]);
+    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['authorized@email.com']])]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $this->endpoint = new Settings(
       $this->settings,
@@ -195,7 +195,7 @@ class SettingsTest extends \MailPoetTest {
   }
 
   public function testItRejectsUnauthorizedFromAddress() {
-    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized@email.com'])]);
+    $bridgeMock = $this->make(Bridge::class, ['getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['authorized@email.com']])]);
     $senderDomainController = $this->diContainer->get(AuthorizedSenderDomainController::class);
     $this->endpoint = new Settings(
       $this->settings,

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -42,7 +42,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', '2018-03-04');
     $this->settings->set('sender.address', 'invalid@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     verify($this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING))->equals(['invalid_sender_address' => 'invalid@email.com']);
   }
@@ -51,7 +51,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'invalid@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     verify($this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING))->equals(['invalid_sender_address' => 'invalid@email.com']);
   }
@@ -60,7 +60,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'auth@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     verify($this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING))->null();
   }
@@ -70,9 +70,8 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('sender.address', 'not-valid-auth@email.com');
     $this->setMailPoetSendingMethod();
 
-    $authorizedEmails = ['auth@email.com'];
     $bridgeMock = $this->make(Bridge::class, [
-      'getAuthorizedEmailAddresses' => Expected::once($authorizedEmails),
+      'getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['auth@email.com']]),
     ]);
 
     $verifiedDomains = ['email.com'];
@@ -117,7 +116,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'auth@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     $error = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
     verify($error)->null();
@@ -129,7 +128,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'auth@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     $error = MailerLog::getError();
     verify($error)->null();
@@ -142,9 +141,8 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('sender.address', 'invalid@email.com');
     $this->setMailPoetSendingMethod();
 
-    $authorizedEmails = ['auth@email.com'];
     $bridgeMock = $this->make(Bridge::class, [
-      'getAuthorizedEmailAddresses' => Expected::once($authorizedEmails),
+      'getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['auth@email.com']]),
     ]);
 
     $verifiedDomains = ['email.com'];
@@ -170,7 +168,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'auth@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     $error = MailerLog::getError();
     expect(is_array($error));
@@ -185,7 +183,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'invalid@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     $error = MailerLog::getError();
     expect(is_array($error));
@@ -205,7 +203,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'auth@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['auth@email.com']);
+    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
     $controller->checkAuthorizedEmailAddresses();
     $error = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
     verify(count($error['invalid_senders_in_newsletters']))->equals(1);
@@ -216,7 +214,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
 
   public function testItSetsFromAddressInSettings() {
     $this->settings->set('sender.address', '');
-    $controller = $this->getController(['authorized@email.com']);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $controller->setFromEmailAddress('authorized@email.com');
     verify($this->settings->get('sender.address'))->same('authorized@email.com');
   }
@@ -224,12 +222,17 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
   public function testItSetsFromAddressInSettingsWhenDomainIsVerified() {
     $this->settings->set('sender.address', '');
 
+    $bridgeMock = $this->make(Bridge::class, [
+      'getAuthorizedEmailAddresses' => Expected::once(['authorized' => []]),
+    ]);
+
     $verifiedDomains = ['email.com'];
     $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
       'getVerifiedSenderDomainsIgnoringCache' => Expected::once($verifiedDomains),
     ]);
 
     $mocks = [
+      'Bridge' => $bridgeMock,
       'AuthorizedSenderDomainController' => $senderDomainMock,
     ];
     $controller = $this->getControllerWithCustomMocks($mocks);
@@ -373,7 +376,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $this->settings->set('sender.address', '');
-    $controller = $this->getController(['authorized@email.com']);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $controller->setFromEmailAddress('authorized@email.com');
     verify($newsletter->getSenderAddress())->same('authorized@email.com');
 
@@ -392,7 +395,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $this->settings->set('sender.address', '');
-    $controller = $this->getController(['authorized@email.com']);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $controller->setFromEmailAddress('authorized@email.com');
     verify($newsletter->getSenderAddress())->same('authorized@email.com');
 
@@ -411,7 +414,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $this->settings->set('sender.address', '');
-    $controller = $this->getController(['authorized@email.com']);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $controller->setFromEmailAddress('authorized@email.com');
     verify($newsletter->getSenderAddress())->same('invalid@email.com');
 
@@ -423,7 +426,7 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
   public function testSetsFromAddressThrowsForUnauthorizedEmail() {
     $this->expectException(InvalidArgumentException::class);
     $this->expectExceptionMessage("Email address 'invalid@email.com' is not authorized");
-    $controller = $this->getController(['authorized@email.com']);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $controller->setFromEmailAddress('invalid@email.com');
   }
 
@@ -490,15 +493,13 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
   }
 
   public function testItReturnsTrueWhenAuthorizedForIsEmailAddressAuthorized() {
-    $array = ['authorized@email.com'];
-    $controller = $this->getController($array);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $result = $controller->isEmailAddressAuthorized('authorized@email.com');
     verify($result)->equals(true);
   }
 
   public function testItReturnsFalseWhenNotAuthorizedForIsEmailAddressAuthorized() {
-    $array = ['authorized@email.com'];
-    $controller = $this->getController($array);
+    $controller = $this->getController(['authorized' => ['authorized@email.com']]);
     $result = $controller->isEmailAddressAuthorized('pending@email.com');
     verify($result)->equals(false);
   }

--- a/mailpoet/tests/integration/Services/BridgeTest.php
+++ b/mailpoet/tests/integration/Services/BridgeTest.php
@@ -262,19 +262,6 @@ class BridgeTest extends \MailPoetTest {
     $wp->removeFilter('mailpoet_bridge_api_request_timeout', $filter);
   }
 
-  public function testItReturnsOnlyAuthorizedEmails() {
-    $array = [
-      'pending' => ['pending@email.com'],
-      'authorized' => ['authorized@email.com'],
-      'main' => 'main@email.com',
-    ];
-    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => $array], $this);
-    $this->bridge->api = $api;
-
-    $result = $this->bridge->getAuthorizedEmailAddresses();
-    verify($result)->same(['authorized@email.com']);
-  }
-
   public function testItReturnsAllUserEmails() {
     $array = [
       'pending' => ['pending@email.com'],
@@ -284,7 +271,7 @@ class BridgeTest extends \MailPoetTest {
     $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => $array], $this);
     $this->bridge->api = $api;
 
-    $result = $this->bridge->getAuthorizedEmailAddresses('all');
+    $result = $this->bridge->getAuthorizedEmailAddresses();
     verify($result)->same($array);
   }
 
@@ -292,20 +279,12 @@ class BridgeTest extends \MailPoetTest {
     $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => []], $this);
     $this->bridge->api = $api;
 
-    $result = $this->bridge->getAuthorizedEmailAddresses('all');
+    $result = $this->bridge->getAuthorizedEmailAddresses();
     verify($result)->same([]);
   }
 
   public function testItReturnsAnEmptyArrayIfNoEmailForAuthorizedParam() {
     $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => []], $this);
-    $this->bridge->api = $api;
-
-    $result = $this->bridge->getAuthorizedEmailAddresses();
-    verify($result)->same([]);
-  }
-
-  public function testItReturnsAnEmptyArrayIfNoNullForAuthorizedParam() {
-    $api = Stub::make(new API(null), ['getAuthorizedEmailAddresses' => null], $this);
     $this->bridge->api = $api;
 
     $result = $this->bridge->getAuthorizedEmailAddresses();

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     tmpfs:
       - /var/www/html/wp-content/uploads/mailpoet/
     ports:
-      - 8080:80
+      - 8888:80
     environment:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_USER: wordpress


### PR DESCRIPTION
## Description

If the shop API is down or broken, the sender-authorized email check will fail, and we will block sending. It seems to be the case even if the user has previously used the same authorized email address. See the linked Jira issue for more details.

I've implemented caching logic, where API data for authorized emails is cached. However, the logic will **only fall back to the cache if the service method returns `NULL`**, which may occur when:

- The shop API is down, or
- The shop API is broken (returns a non-2xx code), or
- The bridge API is down, in which case caching won't really help anyway!

## Code review notes

_N/A_

## QA notes

Here are a couple of suggestions, but feel free to expand with more scenarios:

- Verify that you can get a newly authorized email to be accepted by the plugin.
- After successful authorization, verify that you can send a newsletter.
- Then, attempt to send a newsletter while the shop is down.

The first two scenarios ensure there is no regression; only the last one verifies the changes introduced here!

> [!TIP]
> I'm not sure if this would work, but you should be able to simulate the "shop down" scenario by mocking the bridge API host in the Docker Compose file. If this introduces a blocker (e.g., preliminary step fails), it would render testing unfeasible, but it's worth trying!

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5980]

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-5980]: https://mailpoet.atlassian.net/browse/MAILPOET-5980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-shop-down-break-sending)

_The latest successful build from `fix-shop-down-break-sending` will be used. If none is available, the link won't work._