### PR TITLE
Fix deprecation warning from mb_convert_encoding

### DIFF
--- a/mailpoet/tasks/fix-php82-deprecations.php
+++ b/mailpoet/tasks/fix-php82-deprecations.php
@@ -21,7 +21,7 @@ $replacements = [
   [
     'file' => __DIR__ . '/../vendor-prefixed/soundasleep/html2text/src/Html2Text.php',
     'find' => [
-      '$html = mb_convert_encoding($html, "HTML-ENTITIES", "UTF-8");',
+      '$html = \mb_convert_encoding($html, "HTML-ENTITIES", "UTF-8");',
     ],
     'replace' => [
       '// HTML-ENTITIES mbstring encoder is deprecated since PHP 8.2,' . PHP_EOL .


### PR DESCRIPTION
## Description

This PR fixes a deprecation warning: `mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead`

## Code review notes

I found that the fix for PHP deprecation warnings was not applied because the code we are looking for was not matched.
I was also looking for a version that introduced that, but I was not able to find a [tag in the plugin repo](https://plugins.trac.wordpress.org/browser/mailpoet/#tags/) that would contain the fixed code. So, this deprecation was probably there for a long time.

## QA notes

To replicate the issue:
1) Install plugin on site with PHP8.2+ and make sure PHP is set to log deprecation warnings. 
2) Open an email preview and observe in the error log that a deprecation warning is logged.

Please verify also that the text version of emails looks as expected. There should be no difference between the fixed and the previous version.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6258]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6258]: https://mailpoet.atlassian.net/browse/MAILPOET-6258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-mbstrig-warning)

_The latest successful build from `fix-mbstrig-warning` will be used. If none is available, the link won't work._