### PR TITLE
Fix abandoned cart email automation sending [MAILPOET-6260]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/AbandonedCart/AbandonedCartHandler.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/AbandonedCart/AbandonedCartHandler.php
@@ -100,11 +100,11 @@ class AbandonedCartHandler {
     }
 
     $wait = $trigger->getArgs()['wait'] * 60;
-    $scheduledAt = Carbon::createFromTimestamp((int)$this->wp->currentTime('timestamp') + $wait);
+    $scheduledAt = Carbon::now()->millisecond(0)->addSeconds($wait);
     $task = new ScheduledTaskEntity();
     $task->setType(AbandonedCartWorker::TASK_TYPE);
 
-    $lastActivity = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'));
+    $lastActivity = Carbon::now()->millisecond(0);
     $task->setCreatedAt($lastActivity);
     $task->setPriority(ScheduledTaskEntity::PRIORITY_MEDIUM);
     $task->setMeta([

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/AbandonedCart/AbandonedCartTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/AbandonedCart/AbandonedCartTrigger.php
@@ -109,7 +109,7 @@ class AbandonedCartTrigger implements Trigger {
     $abandonedCartPayload = $args->getSinglePayloadByClass(AbandonedCartPayload::class);
     $lastActivityAt = $abandonedCartPayload->getLastActivityAt();
 
-    $compareDate = Carbon::createFromTimestamp($this->wp->currentTime('timestamp'))->subMinutes($args->getStep()->getArgs()['wait']);
+    $compareDate = Carbon::now()->millisecond(0)->subMinutes($args->getStep()->getArgs()['wait']);
     if ($lastActivityAt > $compareDate) {
       return false;
     }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -320,7 +320,7 @@ class SendingQueue {
         );
         if (!$newsletter->isTransactional()) {
           $this->entityManager->wrapInTransaction(function() use ($foundSubscribersIds) {
-            $now = Carbon::createFromTimestamp((int)current_time('timestamp'));
+            $now = Carbon::now()->millisecond(0);
             $this->subscribersRepository->bulkUpdateLastSendingAt($foundSubscribersIds, $now);
             // We're nullifying this value so these subscribers' engagement score will be recalculated the next time the cron runs
             $this->subscribersRepository->bulkUpdateEngagementScoreUpdatedAt($foundSubscribersIds, null);
@@ -577,9 +577,9 @@ class SendingQueue {
     $bounceTasks = $this->scheduledTasksRepository->findFutureScheduledByType(Bounce::TASK_TYPE);
     if (count($bounceTasks)) {
       $bounceTask = reset($bounceTasks);
-      if (Carbon::createFromTimestamp((int)current_time('timestamp'))->addHours(42)->lessThan($bounceTask->getScheduledAt())) {
+      if (Carbon::now()->millisecond(0)->addHours(42)->lessThan($bounceTask->getScheduledAt())) {
         $randomOffset = rand(-6 * 60 * 60, 6 * 60 * 60);
-        $bounceTask->setScheduledAt(Carbon::createFromTimestamp((int)current_time('timestamp'))->addSeconds((36 * 60 * 60) + $randomOffset));
+        $bounceTask->setScheduledAt(Carbon::now()->millisecond(0)->addSeconds((36 * 60 * 60) + $randomOffset));
         $this->scheduledTasksRepository->persist($bounceTask);
         $this->scheduledTasksRepository->flush();
       }

--- a/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
+++ b/mailpoet/lib/Statistics/StatisticsNewslettersRepository.php
@@ -30,7 +30,7 @@ class StatisticsNewslettersRepository extends Repository {
           continue;
         }
 
-        $sentAt = Carbon::createFromTimestamp((int)current_time('timestamp'));
+        $sentAt = Carbon::now()->millisecond(0);
         $entity = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber, $sentAt);
 
         $this->entityManager->persist($entity);


### PR DESCRIPTION
## Description

This PR fixes that abandoned cart emails created as automation are not being sent.

## Code review notes

We need to use GMT time when we save timestamps to the DB.
The scheduled task for the abandoned cart was using the site's time, and it could cause a delay of the trigger in UTC+ zones or run it too early and cause email not to be sent in UTC- zones.

I'm using `Carbon::now()->millisecond(0)` because WP sets PHP time to UTC and `millisecond(0)` resets milliseconds to 0. This is because we store with seconds precision in DB, and it is better to have the same value set from PHP as the one that is later loaded from the DB.

This was caused by migration to WPDB. I missed these occurrences when I was fixing the timezone issues. When I was replacing times during the migration to WPDB I was relying on usage of the WPFunctions wrapper. The Automations codebase uses its own wrapper class so I missed that. 

There are a few more fixes in the second commit. They are not critical. They just affects times in logs.

## QA notes

Test that the Abandoned Cart Automation works.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6260]

## After-merge notes

_N/A_

## Tasks

- [x] ⛔ I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] ⛔ I added sufficient test coverage - we had good coverage in integration, but to catch this we would need an acceptance test, which will be more complex because we need to deal with 30 minutes waiting time
- [x] ⛔ I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6260]: https://mailpoet.atlassian.net/browse/MAILPOET-6260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-abandoned-cart-attempt1)

_The latest successful build from `fix-abandoned-cart-attempt1` will be used. If none is available, the link won't work._