### PR TITLE
Prevent a warning if caption is not present [MAILPOET-6261]

### DIFF
--- a/mailpoet/lib/Form/Block/Image.php
+++ b/mailpoet/lib/Form/Block/Image.php
@@ -63,7 +63,7 @@ class Image {
     if ($params['href']) {
       $img = $this->wrapToLink($params, $img);
     }
-    $caption = $params['caption'] ? "<figcaption>{$this->htmlSanitizer->sanitize($params['caption'])}</figcaption>" : '';
+    $caption = isset($params['caption']) && $params['caption'] ? "<figcaption>{$this->htmlSanitizer->sanitize($params['caption'])}</figcaption>" : '';
     $figure = '<figure class="' . $this->wp->escAttr(implode(' ', $figureClasses)) . '">' . $img . $caption . '</figure>';
     // Main wrapper
     $divClasses = ['mailpoet_form_image'];


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6261]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6261]: https://mailpoet.atlassian.net/browse/MAILPOET-6261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:caption-warning)

_The latest successful build from `caption-warning` will be used. If none is available, the link won't work._