### PR TITLE
Newsletter stats badge info is not translated [MAILPOET-6262]

### DIFF
--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
@@ -10,59 +10,7 @@ type StatsBadgeProps = {
   isInverted?: boolean;
 };
 
-const stats = {
-  opened: {
-    badgeRanges: [30, 10, 0],
-    badgeTypes: ['excellent', 'good', 'critical'],
-    tooltipText: {
-      // translators: Excellent open rate
-      excellent: __('above 30%', 'mailpoet'),
-      // translators: Good open rate
-      good: __('between 10 and 30%', 'mailpoet'),
-      // translators: Critical open rate
-      critical: __('under 10%', 'mailpoet'),
-    },
-  },
-  clicked: {
-    badgeRanges: [3, 1, 0],
-    badgeTypes: ['excellent', 'good', 'critical'],
-    tooltipText: {
-      // translators: Excellent click rate
-      excellent: __('above 3%', 'mailpoet'),
-      // translators: Good click rate
-      good: __('between 1 and 3%', 'mailpoet'),
-      // translators: Critical click rate
-      critical: __('under 1%', 'mailpoet'),
-    },
-  },
-  bounced: {
-    badgeRanges: [1.5, 0.5, 0],
-    badgeTypes: ['critical', 'good', 'excellent'],
-    tooltipText: {
-      // translators: Excellent bounce rate
-      excellent: __('below 0.5%', 'mailpoet'),
-      // translators: Good bounce rate
-      good: __('between 0.5% and 1.5%', 'mailpoet'),
-      // translators: Critical bounce rate
-      critical: __('above 1.5%', 'mailpoet'),
-    },
-  },
-  unsubscribed: {
-    badgeRanges: [0.7, 0.3, 0],
-    badgeTypes: ['critical', 'good', 'excellent'],
-    tooltipText: {
-      // translators: Excellent unsubscribe rate
-      excellent: __('Below 0.3%', 'mailpoet'),
-      // translators: Good unsubscribe rate
-      good: __('between 0.3% and 0.7%', 'mailpoet'),
-      // translators: Critical unsubscribe rate
-      critical: __('above 0.7%', 'mailpoet'),
-    },
-  },
-};
-
-export const getBadgeType = (statName, rate) => {
-  const stat = stats[statName] || null;
+export const getBadgeType = (stat, rate) => {
   if (!stat) {
     return null;
   }
@@ -96,8 +44,58 @@ function StatsBadge(props: StatsBadgeProps) {
       tooltipTitle: __('Something to improve.', 'mailpoet'),
     },
   };
+  const stats = {
+    opened: {
+      badgeRanges: [30, 10, 0],
+      badgeTypes: ['excellent', 'good', 'critical'],
+      tooltipText: {
+        // translators: Excellent open rate
+        excellent: __('above 30%', 'mailpoet'),
+        // translators: Good open rate
+        good: __('between 10 and 30%', 'mailpoet'),
+        // translators: Critical open rate
+        critical: __('under 10%', 'mailpoet'),
+      },
+    },
+    clicked: {
+      badgeRanges: [3, 1, 0],
+      badgeTypes: ['excellent', 'good', 'critical'],
+      tooltipText: {
+        // translators: Excellent click rate
+        excellent: __('above 3%', 'mailpoet'),
+        // translators: Good click rate
+        good: __('between 1 and 3%', 'mailpoet'),
+        // translators: Critical click rate
+        critical: __('under 1%', 'mailpoet'),
+      },
+    },
+    bounced: {
+      badgeRanges: [1.5, 0.5, 0],
+      badgeTypes: ['critical', 'good', 'excellent'],
+      tooltipText: {
+        // translators: Excellent bounce rate
+        excellent: __('below 0.5%', 'mailpoet'),
+        // translators: Good bounce rate
+        good: __('between 0.5% and 1.5%', 'mailpoet'),
+        // translators: Critical bounce rate
+        critical: __('above 1.5%', 'mailpoet'),
+      },
+    },
+    unsubscribed: {
+      badgeRanges: [0.7, 0.3, 0],
+      badgeTypes: ['critical', 'good', 'excellent'],
+      tooltipText: {
+        // translators: Excellent unsubscribe rate
+        excellent: __('Below 0.3%', 'mailpoet'),
+        // translators: Good unsubscribe rate
+        good: __('between 0.3% and 0.7%', 'mailpoet'),
+        // translators: Critical unsubscribe rate
+        critical: __('above 0.7%', 'mailpoet'),
+      },
+    },
+  };
 
-  const badgeType = getBadgeType(props.stat, props.rate);
+  const badgeType = getBadgeType(stats[props.stat], props.rate);
   const badge = badges[badgeType] || null;
   if (!badge) {
     return null;

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
@@ -1,4 +1,4 @@
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { PlacesType } from 'react-tooltip';
 import { Badge } from './badge';
 
@@ -15,36 +15,48 @@ const stats = {
     badgeRanges: [30, 10, 0],
     badgeTypes: ['excellent', 'good', 'critical'],
     tooltipText: {
-      excellent: _x('above 30%', 'Excellent open rate', 'mailpoet'),
-      good: _x('between 10 and 30%', 'Good open rate', 'mailpoet'),
-      critical: _x('under 10%', 'Critical open rate', 'mailpoet'),
+      // translators: Excellent open rate
+      excellent: __('above 30%', 'mailpoet'),
+      // translators: Good open rate
+      good: __('between 10 and 30%', 'mailpoet'),
+      // translators: Critical open rate
+      critical: __('under 10%', 'mailpoet'),
     },
   },
   clicked: {
     badgeRanges: [3, 1, 0],
     badgeTypes: ['excellent', 'good', 'critical'],
     tooltipText: {
-      excellent: _x('above 3%', 'Excellent click rate', 'mailpoet'),
-      good: _x('between 1 and 3%', 'Good click rate', 'mailpoet'),
-      critical: _x('under 1%', 'Critical click rate', 'mailpoet'),
+      // translators: Excellent click rate
+      excellent: __('above 3%', 'mailpoet'),
+      // translators: Good click rate
+      good: __('between 1 and 3%', 'mailpoet'),
+      // translators: Critical click rate
+      critical: __('under 1%', 'mailpoet'),
     },
   },
   bounced: {
     badgeRanges: [1.5, 0.5, 0],
     badgeTypes: ['critical', 'good', 'excellent'],
     tooltipText: {
-      excellent: _x('below 0.5%', 'Excellent bounce rate', 'mailpoet'),
-      good: _x('between 0.5% and 1.5%', 'Good bounce rate', 'mailpoet'),
-      critical: _x('above 1.5%', 'Critical bounce rate', 'mailpoet'),
+      // translators: Excellent bounce rate
+      excellent: __('below 0.5%', 'mailpoet'),
+      // translators: Good bounce rate
+      good: __('between 0.5% and 1.5%', 'mailpoet'),
+      // translators: Critical bounce rate
+      critical: __('above 1.5%', 'mailpoet'),
     },
   },
   unsubscribed: {
     badgeRanges: [0.7, 0.3, 0],
     badgeTypes: ['critical', 'good', 'excellent'],
     tooltipText: {
-      excellent: _x('Below 0.3%', 'Excellent unsubscribe rate', 'mailpoet'),
-      good: _x('between 0.3% and 0.7%', 'Good unsubscribe rate', 'mailpoet'),
-      critical: _x('above 0.7%', 'Critical unsubscribe rate', 'mailpoet'),
+      // translators: Excellent unsubscribe rate
+      excellent: __('Below 0.3%', 'mailpoet'),
+      // translators: Good unsubscribe rate
+      good: __('between 0.3% and 0.7%', 'mailpoet'),
+      // translators: Critical unsubscribe rate
+      critical: __('above 0.7%', 'mailpoet'),
     },
   },
 };


### PR DESCRIPTION
## Description

Fix for translations not being applied on newsletter stats badge descriptions.

## Code review notes

I've changed translation functions, which means, that existing translations won't be applied, as they no longer provide context (and as such are taken as different strings). It's possible to test it locally if you replace the new `__()` with the old `_x()` using the same context (but them must stay inside the React component). 

## QA notes

I think the QA review can be skipped, as they won't be able to verify it's working because strings are changed. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6262]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6262]: https://mailpoet.atlassian.net/browse/MAILPOET-6262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:translation-fix)

_The latest successful build from `translation-fix` will be used. If none is available, the link won't work._