### PR TITLE
Add max-width for email preview templates [MAILPOET-6265]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_newsletter-templates.scss
+++ b/mailpoet/assets/css/src/components-plugin/_newsletter-templates.scss
@@ -30,6 +30,11 @@
   }
 }
 
+.mailpoet-template-preview-image {
+  max-width: 100%;
+  width: 700px;
+}
+
 .mailpoet-template-info {
   align-items: center;
   display: flex;

--- a/mailpoet/assets/js/src/newsletters/templates/template-box.jsx
+++ b/mailpoet/assets/js/src/newsletters/templates/template-box.jsx
@@ -56,7 +56,8 @@ class TemplateBox extends Component {
   onPreview() {
     MailPoet.Modal.popup({
       title: this.props.name,
-      template: '<img src="{{ thumbnail }}" />',
+      template:
+        '<img class="mailpoet-template-preview-image" src="{{ thumbnail }}" />',
       data: this.props,
     });
   }


### PR DESCRIPTION
## Description

Email template previews didn't have any width constraints, so when we added retina-ready thumbnails, instead of being sharper, they overflowed. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6265]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6265]: https://mailpoet.atlassian.net/browse/MAILPOET-6265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-preview-width)

_The latest successful build from `email-preview-width` will be used. If none is available, the link won't work._