### PR TITLE
Fix re-engagement setup layout [MAILPOET-6266]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_newsletter-types.scss
+++ b/mailpoet/assets/css/src/components-plugin/_newsletter-types.scss
@@ -90,12 +90,21 @@
   width: max-content;
 }
 
+.mailpoet-re-engagement-scheduling {
+  display: grid;
+  grid-template-columns: 5fr 2fr 3fr;
+
+  .mailpoet-form-input {
+    width: auto;
+  }
+}
+
 .mailpoet-re-engagement-scheduling-note {
   color: $color-input-error;
 }
 
-.mailpoet-re-engagement-scheduling .mailpoet-form-input-small {
-  width: 150px;
+.mailpoet-re-engagement-scheduling-period {
+  white-space: normal;
 }
 
 [data-type='re_engagement'] .mailpoet-newsletter-type-image {

--- a/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
@@ -49,8 +49,8 @@ export function Scheduling({
           required
         />
         <Select value={afterTimeType} onChange={onChange(updateAfterTimeType)}>
-          <option value="weeks">weeks</option>
-          <option value="months">months</option>
+          <option value="weeks">{__('weeks', 'mailpoet')}</option>
+          <option value="months">{__('months', 'mailpoet')}</option>
         </Select>
       </Grid.CenteredRow>
       <div className="mailpoet-gap" />

--- a/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
@@ -38,7 +38,9 @@ export function Scheduling({
         {__('When to send this re-engagement email?', 'mailpoet')}
       </Heading>
       <Grid.CenteredRow className="mailpoet-re-engagement-scheduling">
-        <p>{__('After no activity for', 'mailpoet')}</p>
+        <div className="mailpoet-re-engagement-scheduling-period">
+          {__('After no activity for', 'mailpoet')}
+        </div>
         <Input
           type="number"
           placeholder={__('count', 'mailpoet')}
@@ -51,6 +53,7 @@ export function Scheduling({
           <option value="months">months</option>
         </Select>
       </Grid.CenteredRow>
+      <div className="mailpoet-gap" />
       {!!inactiveSubscribersPeriod && inactivePeriod <= daysSelected && (
         <p className="mailpoet-re-engagement-scheduling-note">
           {ReactStringReplace(

--- a/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
@@ -45,6 +45,7 @@ export function Scheduling({
           type="number"
           placeholder={__('count', 'mailpoet')}
           value={afterTimeNumber}
+          min={1}
           onChange={onChange(updateAfterTimeNumber)}
           required
         />


### PR DESCRIPTION
## Description

Make the re-engagement setup stick to a single line without line breaks.

<img width="382" alt="Screenshot 2024-10-07 at 09 28 02" src="https://github.com/user-attachments/assets/9c1dc0c0-3366-4e9e-988c-177f5000fe80">

## Code review notes

_N/A_

## QA notes

Please, check if the layout is not broken in different languages (especially those long ones like German, or Dutch)

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6266]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6266]: https://mailpoet.atlassian.net/browse/MAILPOET-6266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:re-engagement-layout)

_The latest successful build from `re-engagement-layout` will be used. If none is available, the link won't work._