### PR TITLE
Make re-engagement period value required and number only [MAILPOET-6267]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/re-engagement/scheduling.tsx
@@ -40,10 +40,11 @@ export function Scheduling({
       <Grid.CenteredRow className="mailpoet-re-engagement-scheduling">
         <p>{__('After no activity for', 'mailpoet')}</p>
         <Input
-          type="text"
+          type="number"
           placeholder={__('count', 'mailpoet')}
           value={afterTimeNumber}
           onChange={onChange(updateAfterTimeNumber)}
+          required
         />
         <Select value={afterTimeType} onChange={onChange(updateAfterTimeType)}>
           <option value="weeks">weeks</option>


### PR DESCRIPTION
## Description

Make re-engagement period required and only allow numbers to be entered.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6267]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6267]: https://mailpoet.atlassian.net/browse/MAILPOET-6267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:re-engagement-period)

_The latest successful build from `re-engagement-period` will be used. If none is available, the link won't work._