### PR TITLE
Remove Google+ icons from email templates [MAILPOET-6264]

### DIFF
--- a/mailpoet/lib/Config/PopulatorData/Templates/KidsClothing.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/KidsClothing.php
@@ -271,16 +271,6 @@ class KidsClothing {
                                       0 =>
                                          [
                                           'type' => 'socialIcon',
-                                          'iconType' => 'google-plus',
-                                          'link' => 'http://plus.google.com',
-                                          'image' => $this->social_icon_url . '/03-circles/Google-Plus.png',
-                                          'height' => '32px',
-                                          'width' => '32px',
-                                          'text' => 'Google Plus',
-                                        ],
-                                      1 =>
-                                         [
-                                          'type' => 'socialIcon',
                                           'iconType' => 'instagram',
                                           'link' => 'http://instagram.com',
                                           'image' => $this->social_icon_url . '/03-circles/Instagram.png',

--- a/mailpoet/lib/Config/PopulatorData/Templates/NotSoMedium.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/NotSoMedium.php
@@ -503,16 +503,6 @@ class NotSoMedium {
                                       2 =>
                                          [
                                           'type' => 'socialIcon',
-                                          'iconType' => 'google-plus',
-                                          'link' => 'http://plus.google.com',
-                                          'image' => $this->social_icon_url . '/03-circles/Google-Plus.png',
-                                          'height' => '32px',
-                                          'width' => '32px',
-                                          'text' => 'Google Plus',
-                                         ],
-                                      3 =>
-                                         [
-                                          'type' => 'socialIcon',
                                           'iconType' => 'linkedin',
                                           'link' => 'http://www.linkedin.com',
                                           'image' => $this->social_icon_url . '/03-circles/LinkedIn.png',
@@ -520,7 +510,7 @@ class NotSoMedium {
                                           'width' => '32px',
                                           'text' => 'LinkedIn',
                                          ],
-                                      4 =>
+                                      3 =>
                                          [
                                           'type' => 'socialIcon',
                                           'iconType' => 'email',

--- a/mailpoet/lib/Config/PopulatorData/Templates/TakeAHike.php
+++ b/mailpoet/lib/Config/PopulatorData/Templates/TakeAHike.php
@@ -554,15 +554,6 @@ class TakeAHike {
                       ],
                       3 => [
                         'type' => 'socialIcon',
-                        'iconType' => 'google-plus',
-                        'link' => 'http://plus.google.com',
-                        'image' => $this->social_icon_url . '/03-circles/Google-Plus.png',
-                        'height' => '32px',
-                        'width' => '32px',
-                        'text' => 'Google Plus',
-                      ],
-                      4 => [
-                        'type' => 'socialIcon',
                         'iconType' => 'youtube',
                         'link' => 'http://www.youtube.com',
                         'image' => $this->social_icon_url . '/03-circles/Youtube.png',

--- a/mailpoet/lib/Migrations/Db/Migration_20241007_170437_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20241007_170437_Db.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Migrator\DbMigration;
+
+/**
+ * In https://github.com/mailpoet/mailpoet/pull/5628 we removed Google+ social icons
+ * but they were still used in templates. This migration removes them from the templates.
+ */
+class Migration_20241007_170437_Db extends DbMigration {
+  public function run(): void {
+    global $wpdb;
+    $templatesTable = esc_sql($wpdb->prefix . 'mailpoet_newsletter_templates');
+
+    if (!$this->tableExists($templatesTable)) {
+      return;
+    }
+
+    $templatesWithGooglePlus = $this->connection->fetchAllAssociative(
+      "SELECT id, body FROM $templatesTable WHERE body LIKE '%\"iconType\":\"google-plus\"%'"
+    );
+    foreach ($templatesWithGooglePlus as $template) {
+      if (!is_string($template['body'])) {
+        continue;
+      }
+      $body = json_decode($template['body'], true);
+      $error = json_last_error();
+      if ($error || !is_array($body)) {
+        continue;
+      }
+      $content = &$body['content'];
+      $this->removeGooglePlusIcons($content);
+      $updatedBody = json_encode($body);
+      if ($updatedBody === false) {
+        continue;
+      }
+      $this->connection->update(
+        $templatesTable,
+        ['body' => $updatedBody],
+        ['id' => $template['id']]
+      );
+    }
+  }
+
+  private function removeGooglePlusIcons(&$array) {
+    if (!isset($array['blocks']) || !is_array($array['blocks'])) {
+      return;
+    }
+    foreach ($array['blocks'] as &$block) {
+      $this->removeGooglePlusIcons($block);
+      if (!isset($block['type']) || $block['type'] !== 'social') {
+        continue;
+      }
+      $filteredIcons = array_filter($block['icons'], function($icon) {
+        return $icon['iconType'] !== 'google-plus';
+      });
+      $block['icons'] = array_values($filteredIcons);
+    }
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -559,10 +559,10 @@ class RendererTest extends \MailPoetTest {
     // image source/link href/alt should be  properly set
     verify($DOM('tr > td', 0)->html())->notEmpty();
     verify($DOM('a', 0)->attr('href'))->equals('http://example.com');
-    verify($DOM('td > a:nth-of-type(10) > img')->attr('src'))->stringContainsString('custom.png');
-    verify($DOM('td > a:nth-of-type(10) > img')->attr('alt'))->equals('custom');
-    // there should be 10 icons
-    verify(count($DOM('a > img')))->equals(10);
+    verify($DOM('td > a:nth-of-type(9) > img')->attr('src'))->stringContainsString('custom.png');
+    verify($DOM('td > a:nth-of-type(9) > img')->attr('alt'))->equals('custom');
+    // there should be 9 icons
+    verify(count($DOM('a > img')))->equals(9);
   }
 
   public function testItDoesNotRenderSocialIconsWithoutImageSrc() {

--- a/mailpoet/tests/integration/Newsletter/RendererTestData.json
+++ b/mailpoet/tests/integration/Newsletter/RendererTestData.json
@@ -122,15 +122,6 @@
                   },
                   {
                     "type": "socialIcon",
-                    "iconType": "google-plus",
-                    "link": "http://plus.google.com",
-                    "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Google-Plus.png",
-                    "height": "32px",
-                    "width": "32px",
-                    "text": "Google Plus"
-                  },
-                  {
-                    "type": "socialIcon",
                     "iconType": "youtube",
                     "link": "http://www.youtube.com",
                     "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Youtube.png",
@@ -332,15 +323,6 @@
                   },
                   {
                     "type": "socialIcon",
-                    "iconType": "google-plus",
-                    "link": "http://plus.google.com",
-                    "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Google-Plus.png",
-                    "height": "32px",
-                    "width": "32px",
-                    "text": "Google Plus"
-                  },
-                  {
-                    "type": "socialIcon",
                     "iconType": "youtube",
                     "link": "http://www.youtube.com",
                     "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Youtube.png",
@@ -500,15 +482,6 @@
                     "height": "32px",
                     "width": "32px",
                     "text": "Twitter"
-                  },
-                  {
-                    "type": "socialIcon",
-                    "iconType": "google-plus",
-                    "link": "http://plus.google.com",
-                    "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Google-Plus.png",
-                    "height": "32px",
-                    "width": "32px",
-                    "text": "Google Plus"
                   },
                   {
                     "type": "socialIcon",
@@ -703,15 +676,6 @@
                   },
                   {
                     "type": "socialIcon",
-                    "iconType": "google-plus",
-                    "link": "http://plus.google.com",
-                    "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Google-Plus.png",
-                    "height": "32px",
-                    "width": "32px",
-                    "text": "Google Plus"
-                  },
-                  {
-                    "type": "socialIcon",
                     "iconType": "youtube",
                     "link": "http://www.youtube.com",
                     "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Youtube.png",
@@ -880,15 +844,6 @@
                     "height": "32px",
                     "width": "32px",
                     "text": "Twitter"
-                  },
-                  {
-                    "type": "socialIcon",
-                    "iconType": "google-plus",
-                    "link": "http://plus.google.com",
-                    "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Google-Plus.png",
-                    "height": "32px",
-                    "width": "32px",
-                    "text": "Google Plus"
                   },
                   {
                     "type": "socialIcon",
@@ -1064,15 +1019,6 @@
                     "height": "32px",
                     "width": "32px",
                     "text": "Twitter"
-                  },
-                  {
-                    "type": "socialIcon",
-                    "iconType": "google-plus",
-                    "link": "http://plus.google.com",
-                    "image": "http://test.mailpoet.net/wp-content/plugins/wysija-newsletters/assets/img/newsletter_editor/social-icons/01-social/Google-Plus.png",
-                    "height": "32px",
-                    "width": "32px",
-                    "text": "Google Plus"
                   },
                   {
                     "type": "socialIcon",


### PR DESCRIPTION
## Description

Remove Google+ icons from the templates we ship in the plugin (as files) and from templates for existing users (in the database). 

## Code review notes

_N/A_

## QA notes

Google+ icon was present in three templates: Kids Clothing, Not so Medium, Take a Hike.

Please test that Google+ icons are not present in any of these templates for:
1. New installations.
2. Existing users. To simulate this, install and activate the MailPoet plugin before this change. Then, update to this build, run the migration (should be done automatically), and no template should include the Google+ icon. This includes also any custom template that used the Google+ icon.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6264]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6264]: https://mailpoet.atlassian.net/browse/MAILPOET-6264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:google-plus-templates)

_The latest successful build from `google-plus-templates` will be used. If none is available, the link won't work._