### PR TITLE
Change form error messages font-size from px to rem [MAILPOET-6203]

### DIFF
--- a/mailpoet/assets/css/src/components/_parsley.scss
+++ b/mailpoet/assets/css/src/components/_parsley.scss
@@ -16,7 +16,7 @@ textarea.parsley-error {
 
 .parsley-errors-list {
   color: #900;
-  font-size: 13px;
+  font-size: 0.8rem;
   line-height: 1em;
   list-style-type: none;
   margin: 8px 0 3px;


### PR DESCRIPTION
## Description

`0.8rem` is roughly the same as `13px` in WordPress admin (which is set to `16px`). On frontend, it will depend on theme's setting, so it might differ in practice, but to keep it somewhat consistent, the error message is smaller than default website font-size.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6203]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6203]: https://mailpoet.atlassian.net/browse/MAILPOET-6203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:form-error-message-font)

_The latest successful build from `form-error-message-font` will be used. If none is available, the link won't work._