### PR TITLE
Make <Toggle> and <YesNo> components focusable [MAILPOET-4546]

### DIFF
--- a/mailpoet/assets/css/src/generic/_forms-checkbox.scss
+++ b/mailpoet/assets/css/src/generic/_forms-checkbox.scss
@@ -21,7 +21,7 @@
 
     &:focus {
       ~ .mailpoet-form-checkbox-control {
-        border: 2px solid $color-input-border;
+        border-color: $color-input-border-focus;
       }
     }
   }

--- a/mailpoet/assets/css/src/generic/_forms-radio.scss
+++ b/mailpoet/assets/css/src/generic/_forms-radio.scss
@@ -21,7 +21,7 @@
 
     &:focus {
       ~ .mailpoet-form-radio-control {
-        border: 2px solid $color-input-border;
+        border-color: $color-input-border-focus;
       }
     }
   }

--- a/mailpoet/assets/css/src/generic/_forms-toggle.scss
+++ b/mailpoet/assets/css/src/generic/_forms-toggle.scss
@@ -12,6 +12,12 @@
     opacity: 0;
     position: absolute;
     width: 1px;
+
+    &:focus {
+      ~ .mailpoet-form-toggle-control {
+        border-color: $color-input-border-focus;
+      }
+    }
   }
 }
 

--- a/mailpoet/assets/css/src/generic/_forms-toggle.scss
+++ b/mailpoet/assets/css/src/generic/_forms-toggle.scss
@@ -9,8 +9,8 @@
 
   input {
     height: 1px;
+    opacity: 0;
     position: absolute;
-    visibility: hidden;
     width: 1px;
   }
 }

--- a/mailpoet/assets/css/src/generic/_forms-yesno.scss
+++ b/mailpoet/assets/css/src/generic/_forms-yesno.scss
@@ -25,6 +25,13 @@
     opacity: 0;
     position: absolute;
     width: 1px;
+
+    &:focus {
+      ~ .mailpoet-form-yesno-control {
+        box-shadow: 0 0 0 1px $color-input-border-focus;
+        z-index: 1;
+      }
+    }
   }
 }
 

--- a/mailpoet/assets/css/src/generic/_forms-yesno.scss
+++ b/mailpoet/assets/css/src/generic/_forms-yesno.scss
@@ -22,8 +22,8 @@
 
   input {
     height: 1px;
+    opacity: 0;
     position: absolute;
-    visibility: hidden;
     width: 1px;
   }
 }

--- a/mailpoet/assets/css/src/settings/_colors.scss
+++ b/mailpoet/assets/css/src/settings/_colors.scss
@@ -31,6 +31,7 @@ $color-tertiary-hover: darken($color-tertiary, 10%);
 $color-tertiary-light: #dcdcde;
 $color-grey-0: #f6f7f7;
 $color-tertiary-light-hover: darken($color-tertiary-light, 10%);
+$color-tertiary-light-focus: #777;
 $color-tertiary-light-background: rgba($color-tertiary-light, 0.3);
 $color-destructive: #b52727;
 $color-destructive-hover: #a02222;
@@ -46,6 +47,7 @@ $color-text-dark: #2c3338;
 // Form colors
 $color-input-background: #fdfdff;
 $color-input-border: $color-tertiary-light-hover;
+$color-input-border-focus: $color-tertiary-light-focus;
 $color-input-error: #f00;
 $color-input-success: #7ed321;
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4546]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4546]: https://mailpoet.atlassian.net/browse/MAILPOET-4546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:toggle-yesno-focus)

_The latest successful build from `toggle-yesno-focus` will be used. If none is available, the link won't work._