### PR TITLE
Ensure the newsletter has hash before preview [MAILPOET-6273]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -28,6 +28,7 @@ use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\Util\Security;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -327,6 +328,10 @@ class Newsletters extends APIEndpoint {
     $newsletter->setBody(
       json_decode($this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']), true)
     );
+    // ensure newsletter has hash
+    if (!$newsletter->getHash()) {
+      $newsletter->setHash(Security::generateHash());
+    }
     $this->newslettersRepository->flush();
 
     $response = $this->newslettersResponseBuilder->build($newsletter);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -28,7 +28,6 @@ use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
-use MailPoet\Util\Security;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -328,10 +327,6 @@ class Newsletters extends APIEndpoint {
     $newsletter->setBody(
       json_decode($this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']), true)
     );
-    // ensure newsletter has hash
-    if (!$newsletter->getHash()) {
-      $newsletter->setHash(Security::generateHash());
-    }
     $this->newslettersRepository->flush();
 
     $response = $this->newslettersResponseBuilder->build($newsletter);

--- a/mailpoet/lib/Migrations/App/Migration_20241015_105511_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20241015_105511_App.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\ConfirmationEmailCustomizer;
+use MailPoet\Util\Security;
+
+/**
+ * Fixes confirmation emails with missing hash.
+ * These emails were created by plugin before we fixed [MAILPOET-6273]
+ */
+class Migration_20241015_105511_App extends AppMigration {
+  public function run(): void {
+    $settings = $this->container->get(SettingsController::class);
+    $confirmationEmailTemplateId = (int)$settings->get(ConfirmationEmailCustomizer::SETTING_EMAIL_ID, null);
+    if (!$confirmationEmailTemplateId) {
+      return;
+    }
+
+    $repository = $this->container->get(NewslettersRepository::class);
+    $confirmationEmail = $repository->findOneById($confirmationEmailTemplateId);
+    if (!$confirmationEmail instanceof NewsletterEntity || $confirmationEmail->getHash()) {
+      return;
+    }
+
+    $confirmationEmail->setHash(Security::generateHash());
+    $repository->flush();
+  }
+}

--- a/mailpoet/lib/Subscribers/ConfirmationEmailCustomizer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailCustomizer.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer as NewsletterRenderer;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Security;
 
 class ConfirmationEmailCustomizer {
   const SETTING_EMAIL_ID = 'signup_confirmation.transactional_email_id';
@@ -53,6 +54,7 @@ class ConfirmationEmailCustomizer {
     $newsletter->setType(NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER);
     $newsletter->setSubject($this->settings->get('signup_confirmation.subject', 'Confirm your subscription to [site:title]'));
     $newsletter->setBody($emailTemplate);
+    $newsletter->setHash(Security::generateHash());
     $this->newslettersRepository->persist($newsletter);
     $this->newslettersRepository->flush();
     return $newsletter;


### PR DESCRIPTION
## Description

The preview of the Sign-Up Confirmation email is not working

There is no form hash being passed in the encoded URL param. The happiness team reported this. 
WP-Admin > MailPoet > Settings > Sign-up Confirmation > Open template editor > Preview
It works on some older sites but not on new ones.

## Code review notes

_N/A_

## QA notes

To replicate the issue, you need to find a newsletter with the type `confirmation_email` in the `mailpoet_newsletters` table and ensure that the `hash` column is empty. Then in MailPoet > Settings > Sign-up Confirmation > Open template editor and click Preview and observe that the preview is not displaying any content.

The issue is fixed in migration, so you need to run migrations, e.g., by activating and deactivating the plugin. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6273]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6273]: https://mailpoet.atlassian.net/browse/MAILPOET-6273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:preview-confirmation)

_The latest successful build from `preview-confirmation` will be used. If none is available, the link won't work._