### PR TITLE
Update performance tests to be in line with the latest changes from k6 browser

### DIFF
--- a/mailpoet/tests/performance/README.md
+++ b/mailpoet/tests/performance/README.md
@@ -93,7 +93,7 @@ Included in the `tests` folder is a set of test scripts which includes all scena
 
 Another aspect that affects the traffic pattern of the tests is the amount of “Think Time” in between requests. In real world usage of an application users will spend some amount of time before doing some action. For some situations there will be a need to simulate this as part of the test traffic and it is common to have this as part of load tests.
 
-To do this a sleep step is included between each request ``sleep(randomIntBetween(`${think_time_min}`, `${think_time_max}`))``.
+To do this a sleep step is included between each request `` sleep(randomIntBetween(`${think_time_min}`, `${think_time_max}`)) ``.
 The amount of think time can be controlled from `config.js`.
 
 > **_Note for Protocol-level tests: It’s important to note to be very careful when adding load to a scenario. By accident a dangerous amount of load could be ran aginst the test environment that could effectively be like a denial-of-service attack on the test environment. Also important to consider any other consequences of running large load such as triggering of emails._**

--- a/mailpoet/tests/performance/README.md
+++ b/mailpoet/tests/performance/README.md
@@ -93,7 +93,7 @@ Included in the `tests` folder is a set of test scripts which includes all scena
 
 Another aspect that affects the traffic pattern of the tests is the amount of “Think Time” in between requests. In real world usage of an application users will spend some amount of time before doing some action. For some situations there will be a need to simulate this as part of the test traffic and it is common to have this as part of load tests.
 
-To do this a sleep step is included between each request `` sleep(randomIntBetween(`${think_time_min}`, `${think_time_max}`)) ``.
+To do this a sleep step is included between each request ``sleep(randomIntBetween(`${think_time_min}`, `${think_time_max}`))``.
 The amount of think time can be controlled from `config.js`.
 
 > **_Note for Protocol-level tests: It’s important to note to be very careful when adding load to a scenario. By accident a dangerous amount of load could be ran aginst the test environment that could effectively be like a denial-of-service attack on the test environment. Also important to consider any other consequences of running large load such as triggering of emails._**

--- a/mailpoet/tests/performance/config.js
+++ b/mailpoet/tests/performance/config.js
@@ -17,7 +17,7 @@ export const firstName = 'John';
 export const lastName = 'Doe';
 export const defaultListName = 'Newsletter mailing list';
 
-export const thinkTimeMin = '1';
+export const thinkTimeMin = '2';
 export const thinkTimeMax = '3';
 
 export const emailsPageTitle = 'Emails Page';

--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -74,7 +74,8 @@ export async function automationAnalytics() {
 
     describe(automationsPageTitle, () => {
       describe('automation-analytics: should be able to see Emails tab loaded', async () => {
-        expect(await page.$$('.mailpoet-automation-analytics-email-name')).to.exist;
+        expect(await page.$$('.mailpoet-automation-analytics-email-name')).to
+          .exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -57,8 +57,8 @@ export async function automationAnalytics() {
       'In this time period, the automation structure did change and therefore some numbers in the flow chart might not be accurate.';
     const locator = `//div[@class='components-notice__content'].//p[starts-with(text(),${message})]`;
     describe(automationsPageTitle, () => {
-      describe('settings-basic: should be able to see inaccurate data message', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('settings-basic: should be able to see inaccurate data message', async () => {
+        expect(await page.locator(locator)).to.exist;
       });
     });
 
@@ -73,8 +73,8 @@ export async function automationAnalytics() {
     });
 
     describe(automationsPageTitle, () => {
-      describe('automation-analytics: should be able to see Emails tab loaded', () => {
-        expect(page.$$('.mailpoet-automation-analytics-email-name')).to.exist;
+      describe('automation-analytics: should be able to see Emails tab loaded', async () => {
+        expect(await page.$$('.mailpoet-automation-analytics-email-name')).to.exist;
       });
     });
 
@@ -84,8 +84,8 @@ export async function automationAnalytics() {
     await page.waitForLoadState('networkidle');
 
     describe(automationsPageTitle, () => {
-      describe('automation-analytics: should be able to see Orders tab loaded', () => {
-        expect(page.$$('.mailpoet-analytics-filter-controls')).to.exist;
+      describe('automation-analytics: should be able to see Orders tab loaded', async () => {
+        expect(await page.$$('.mailpoet-analytics-filter-controls')).to.exist;
       });
     });
 
@@ -98,8 +98,8 @@ export async function automationAnalytics() {
     await page.waitForLoadState('networkidle');
 
     describe(automationsPageTitle, () => {
-      describe('automation-analytics: should be able to see Subscribers items loaded', () => {
-        expect(page.$$('.woocommerce-table__item')[0]).to.exist;
+      describe('automation-analytics: should be able to see Subscribers items loaded', async () => {
+        expect(await page.$$('.woocommerce-table__item')[0]).to.exist;
       });
     });
 
@@ -109,7 +109,7 @@ export async function automationAnalytics() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/automation-create-custom.js
+++ b/mailpoet/tests/performance/tests/automation-create-custom.js
@@ -65,8 +65,8 @@ export async function automationCreateCustom() {
     await page.waitForLoadState('networkidle');
 
     describe(automationsPageTitle, () => {
-      describe('automation-create-custom: should be able to see Add Trigger button', () => {
-        expect(page.locator(triggerbutton)).to.exist;
+      describe('automation-create-custom: should be able to see Add Trigger button', async () => {
+        expect(await page.locator(triggerbutton)).to.exist;
       });
     });
 
@@ -113,9 +113,9 @@ export async function automationCreateCustom() {
     await activateWorkflow(page);
 
     describe(automationsPageTitle, () => {
-      describe('automation-create-custom: should be able to see Automation added message', () => {
+      describe('automation-create-custom: should be able to see Automation added message', async () => {
         expect(
-          page.locator('.components-snackbar__content').innerText(),
+          await page.locator('.components-snackbar__content').innerText(),
         ).to.contain('Well done! Automation is now activated!');
       });
     });
@@ -126,12 +126,13 @@ export async function automationCreateCustom() {
     });
 
     // Go to Automations listing to measure performance from workflow to listing
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
     await page.locator('.is-secondary').click();
     await waitForSelectorToBeVisible(page, '.wp-heading-inline');
     await page.waitForLoadState('networkidle');
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -68,8 +68,8 @@ export async function automationCreateWelcome() {
 
     describe(automationsPageTitle, () => {
       describe('automation-create-welcome: should be able to see items in the workflow', async () => {
-        expect(await page.locator('.mailpoet-automation-editor-automation-row')).to
-          .exist;
+        expect(await page.locator('.mailpoet-automation-editor-automation-row'))
+          .to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -67,8 +67,8 @@ export async function automationCreateWelcome() {
     await page.waitForLoadState('networkidle');
 
     describe(automationsPageTitle, () => {
-      describe('automation-create-welcome: should be able to see items in the workflow', () => {
-        expect(page.locator('.mailpoet-automation-editor-automation-row')).to
+      describe('automation-create-welcome: should be able to see items in the workflow', async () => {
+        expect(await page.locator('.mailpoet-automation-editor-automation-row')).to
           .exist;
       });
     });
@@ -93,9 +93,9 @@ export async function automationCreateWelcome() {
     await activateWorkflow(page);
 
     describe(automationsPageTitle, () => {
-      describe('automation-create-welcome: should be able to see Automation added message', () => {
+      describe('automation-create-welcome: should be able to see Automation added message', async () => {
         expect(
-          page.locator('.components-snackbar__content').innerText(),
+          await page.locator('.components-snackbar__content').innerText(),
         ).to.contain('Well done! Automation is now activated!');
       });
     });
@@ -106,7 +106,7 @@ export async function automationCreateWelcome() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/automation-create-woocommerce.js
+++ b/mailpoet/tests/performance/tests/automation-create-woocommerce.js
@@ -68,8 +68,8 @@ export async function automationCreateWooCommerce() {
 
     describe(automationsPageTitle, () => {
       describe('automation-create-woocommerce: should be able to see items in the workflow', async () => {
-        expect(await page.locator('.mailpoet-automation-editor-automation-row')).to
-          .exist;
+        expect(await page.locator('.mailpoet-automation-editor-automation-row'))
+          .to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-create-woocommerce.js
+++ b/mailpoet/tests/performance/tests/automation-create-woocommerce.js
@@ -67,8 +67,8 @@ export async function automationCreateWooCommerce() {
     await page.waitForLoadState('networkidle');
 
     describe(automationsPageTitle, () => {
-      describe('automation-create-woocommerce: should be able to see items in the workflow', () => {
-        expect(page.locator('.mailpoet-automation-editor-automation-row')).to
+      describe('automation-create-woocommerce: should be able to see items in the workflow', async () => {
+        expect(await page.locator('.mailpoet-automation-editor-automation-row')).to
           .exist;
       });
     });
@@ -93,9 +93,9 @@ export async function automationCreateWooCommerce() {
     await activateWorkflow(page);
 
     describe(automationsPageTitle, () => {
-      describe('automation-create-woocommerce: should be able to see Automation added message', () => {
+      describe('automation-create-woocommerce: should be able to see Automation added message', async () => {
         expect(
-          page.locator('.components-snackbar__content').innerText(),
+          await page.locator('.components-snackbar__content').innerText(),
         ).to.contain('Well done! Automation is now activated!');
       });
     });
@@ -106,7 +106,7 @@ export async function automationCreateWooCommerce() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -20,7 +20,7 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, waitForSelectorToBeVisible } from '../utils/helpers.js';
+import { login, waitForSelectorToBeVisible, clickFirstSelector } from '../utils/helpers.js';
 
 export async function automationTrashRestore() {
   const page = await browser.newPage();
@@ -41,7 +41,7 @@ export async function automationTrashRestore() {
     });
 
     // Move to trash one of the existing automation listing
-    await page.$$('[aria-label="More"]')[0].click(); // click More
+    await clickFirstSelector(page, '[aria-label="More"]')
     await page.locator('.components-popover__content').click(); // click Trash
     await page.waitForLoadState('networkidle');
     await page.locator('div.components-flex > button.is-primary').focus();
@@ -52,8 +52,8 @@ export async function automationTrashRestore() {
     const movedToTrashNotice =
       "//div[@class='notice-success'].//p[contains(text(),'was moved to the trash')]";
     describe(automationsPageTitle, () => {
-      describe('automation-trash-restore: should be able to see moved to trash notice', () => {
-        expect(page.locator(movedToTrashNotice)).to.exist;
+      describe('automation-trash-restore: should be able to see moved to trash notice', async () => {
+        expect(await page.locator(movedToTrashNotice)).to.exist;
       });
     });
 
@@ -68,18 +68,17 @@ export async function automationTrashRestore() {
     await page.locator('.mailpoet-tab-trash').click(); // click Trash tab
     await page.waitForLoadState('networkidle');
     await waitForSelectorToBeVisible(page, '.mailpoet-tab-trash.is-active');
-    await page.$$('[aria-label="More"]')[0].click(); // click More
+    await clickFirstSelector(page, '[aria-label="More"]');
     await page.waitForLoadState('networkidle');
-    await page.$$('.components-dropdown-menu__menu-item')[0].focus();
-    await page.$$('.components-dropdown-menu__menu-item')[0].click(); // click Restore
+    await clickFirstSelector(page, '.components-dropdown-menu__menu-item'); // click Restore
     await page.waitForLoadState('networkidle');
 
     // Wait for the success notice message and confirm it
     const restoredFromTrashNotice =
       "//div[@class='notice-success'].//p[contains(text(),'was restored from the trash')]";
     describe(automationsPageTitle, () => {
-      describe('automation-trash-restore: should be able to see restored from trash notice', () => {
-        expect(page.locator(restoredFromTrashNotice)).to.exist;
+      describe('automation-trash-restore: should be able to see restored from trash notice', async () => {
+        expect(await page.locator(restoredFromTrashNotice)).to.exist;
       });
     });
 
@@ -90,7 +89,7 @@ export async function automationTrashRestore() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -20,7 +20,11 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, waitForSelectorToBeVisible, clickFirstSelector } from '../utils/helpers.js';
+import {
+  login,
+  waitForSelectorToBeVisible,
+  clickFirstSelector,
+} from '../utils/helpers.js';
 
 export async function automationTrashRestore() {
   const page = await browser.newPage();
@@ -41,7 +45,7 @@ export async function automationTrashRestore() {
     });
 
     // Move to trash one of the existing automation listing
-    await clickFirstSelector(page, '[aria-label="More"]')
+    await clickFirstSelector(page, '[aria-label="More"]');
     await page.locator('.components-popover__content').click(); // click Trash
     await page.waitForLoadState('networkidle');
     await page.locator('div.components-flex > button.is-primary').focus();

--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -59,8 +59,8 @@ export async function automationTriggerWorkflow() {
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
     describe(automationsPageTitle, () => {
-      describe('automation-trigger-workflow: should be able to see success notice for adding subscriber', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('automation-trigger-workflow: should be able to see success notice for adding subscriber', async () => {
+        expect(await page.locator(locator)).to.exist;
       });
     });
 
@@ -119,15 +119,15 @@ export async function automationTriggerWorkflow() {
     });
 
     describe(automationsPageTitle, () => {
-      describe('automation-trigger-workflow: should be able to see subscriber in the results', () => {
+      describe('automation-trigger-workflow: should be able to see subscriber in the results', async () => {
         expect(
-          page.locator('.mailpoet-analytics-orders__customer').innerText(),
+          await page.locator('.mailpoet-analytics-orders__customer').innerText(),
         ).to.contain(subscriberEmail);
       });
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -121,7 +121,9 @@ export async function automationTriggerWorkflow() {
     describe(automationsPageTitle, () => {
       describe('automation-trigger-workflow: should be able to see subscriber in the results', async () => {
         expect(
-          await page.locator('.mailpoet-analytics-orders__customer').innerText(),
+          await page
+            .locator('.mailpoet-analytics-orders__customer')
+            .innerText(),
         ).to.contain(subscriberEmail);
       });
     });

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -68,9 +68,9 @@ export async function formsAdding() {
     await page.locator('[data-automation-id="form_save_button"]').click();
     await page.waitForSelector('.components-notice');
     describe(formsPageTitle, () => {
-      describe('forms-adding: should be able to see Forms Saved message', () => {
+      describe('forms-adding: should be able to see Forms Saved message', async () => {
         expect(
-          page.locator('.components-notice__content').innerText(),
+          await page.locator('.components-notice__content').innerText(),
         ).to.contain(
           'Form saved. Cookies reset — you will see all your dismissed popup forms again.',
         );
@@ -83,7 +83,7 @@ export async function formsAdding() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/forms-subscribing.js
+++ b/mailpoet/tests/performance/tests/forms-subscribing.js
@@ -82,9 +82,9 @@ export async function formsSubscribing() {
     await page.waitForLoadState('networkidle');
     describe(formsPageTitle, () => {
       describe('forms-subscribing: should be able to search for a new subscriber', async () => {
-        expect(await page.locator('.mailpoet-listing-title').innerText()).to.contain(
-          subscriberEmail,
-        );
+        expect(
+          await page.locator('.mailpoet-listing-title').innerText(),
+        ).to.contain(subscriberEmail);
       });
     });
 

--- a/mailpoet/tests/performance/tests/forms-subscribing.js
+++ b/mailpoet/tests/performance/tests/forms-subscribing.js
@@ -57,9 +57,9 @@ export async function formsSubscribing() {
       .click();
     await waitForSelectorToBeVisible(page, '.mailpoet_validate_success');
     describe(formsPageTitle, () => {
-      describe('forms-subscribing: should be able to see successfully subscribed message', () => {
+      describe('forms-subscribing: should be able to see successfully subscribed message', async () => {
         expect(
-          page.locator('.mailpoet_validate_success').innerText(),
+          await page.locator('.mailpoet_validate_success').innerText(),
         ).to.contain('Successfully subscribed!');
       });
     });
@@ -81,8 +81,8 @@ export async function formsSubscribing() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     await page.waitForLoadState('networkidle');
     describe(formsPageTitle, () => {
-      describe('forms-subscribing: should be able to search for a new subscriber', () => {
-        expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
+      describe('forms-subscribing: should be able to search for a new subscriber', async () => {
+        expect(await page.locator('.mailpoet-listing-title').innerText()).to.contain(
           subscriberEmail,
         );
       });
@@ -94,7 +94,7 @@ export async function formsSubscribing() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -59,8 +59,8 @@ export async function listsViewSubscribers() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(listsPageTitle, () => {
-      describe('lists-view-subscribers: should be able to see Lists Filter', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('lists-view-subscribers: should be able to see Lists Filter', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -72,7 +72,7 @@ export async function listsViewSubscribers() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -60,8 +60,9 @@ export async function listsViewSubscribers() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(listsPageTitle, () => {
       describe('lists-view-subscribers: should be able to see Lists Filter', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
     await page.waitForLoadState('networkidle');

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -45,8 +45,8 @@ export async function newsletterListing() {
     await page.waitForSelector('[data-automation-id="filters_all"]');
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
-      describe('newsletter-listing: should be able to see All Filter', () => {
-        expect(page.locator('[data-automation-id="filters_all"]')).to.exist;
+      describe('newsletter-listing: should be able to see All Filter', async () => {
+        expect(await page.locator('[data-automation-id="filters_all"]')).to.exist;
       });
     });
 
@@ -56,7 +56,7 @@ export async function newsletterListing() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -46,7 +46,8 @@ export async function newsletterListing() {
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
       describe('newsletter-listing: should be able to see All Filter', async () => {
-        expect(await page.locator('[data-automation-id="filters_all"]')).to.exist;
+        expect(await page.locator('[data-automation-id="filters_all"]')).to
+          .exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-reengagement.js
+++ b/mailpoet/tests/performance/tests/newsletter-reengagement.js
@@ -21,7 +21,12 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2, waitAndType, clickFirstSelector } from '../utils/helpers.js';
+import {
+  login,
+  selectInSelect2,
+  waitAndType,
+  clickFirstSelector,
+} from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterReEngagement() {
@@ -78,7 +83,7 @@ export async function newsletterReEngagement() {
     }
 
     // Click to proceed to the next step (the last one)
-    await clickFirstSelector(page, 'input[value="Next"]')
+    await clickFirstSelector(page, 'input[value="Next"]');
     await page.waitForNavigation();
     await page.waitForSelector(
       '[data-automation-id="newsletter_send_heading"]',

--- a/mailpoet/tests/performance/tests/newsletter-reengagement.js
+++ b/mailpoet/tests/performance/tests/newsletter-reengagement.js
@@ -21,7 +21,7 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2, waitAndType } from '../utils/helpers.js';
+import { login, selectInSelect2, waitAndType, clickFirstSelector } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterReEngagement() {
@@ -78,7 +78,7 @@ export async function newsletterReEngagement() {
     }
 
     // Click to proceed to the next step (the last one)
-    await page.$$('input[value="Next"]')[0].click();
+    await clickFirstSelector(page, 'input[value="Next"]')
     await page.waitForNavigation();
     await page.waitForSelector(
       '[data-automation-id="newsletter_send_heading"]',
@@ -104,8 +104,8 @@ export async function newsletterReEngagement() {
       "//div[@class='notice-success'].//p[starts-with(text(),'Your Re-engagement Email is now activated!')]";
     await page.waitForSelector('#mailpoet_notices');
     describe(emailsPageTitle, () => {
-      describe('newsletter-re-engagement: should be able to see Re-engagement is active message', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('newsletter-re-engagement: should be able to see Re-engagement is active message', async () => {
+        expect(await page.locator(locator)).to.exist;
       });
     });
 
@@ -115,7 +115,7 @@ export async function newsletterReEngagement() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -47,8 +47,8 @@ export async function newsletterSearching() {
     await page.waitForSelector('[data-automation-id="listing_filter_segment"]');
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
-      describe('newsletter-searching: should be able to search for Newsletter 1st', () => {
-        expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
+      describe('newsletter-searching: should be able to search for Newsletter 1st', async () => {
+        expect(await page.locator('.mailpoet-listing-title').innerText()).to.contain(
           'Newsletter 1st',
         );
       });
@@ -62,8 +62,8 @@ export async function newsletterSearching() {
     await page.waitForSelector('[data-automation-id="listing_filter_segment"]');
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
-      describe('newsletter-searching: should be able to see Lists Filter', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('newsletter-searching: should be able to see Lists Filter', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -74,7 +74,7 @@ export async function newsletterSearching() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -48,9 +48,9 @@ export async function newsletterSearching() {
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
       describe('newsletter-searching: should be able to search for Newsletter 1st', async () => {
-        expect(await page.locator('.mailpoet-listing-title').innerText()).to.contain(
-          'Newsletter 1st',
-        );
+        expect(
+          await page.locator('.mailpoet-listing-title').innerText(),
+        ).to.contain('Newsletter 1st');
       });
     });
 
@@ -63,8 +63,9 @@ export async function newsletterSearching() {
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
       describe('newsletter-searching: should be able to see Lists Filter', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -21,7 +21,11 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2, clickFirstSelector } from '../utils/helpers.js';
+import {
+  login,
+  selectInSelect2,
+  clickFirstSelector,
+} from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterSending() {
@@ -65,7 +69,7 @@ export async function newsletterSending() {
     });
 
     // Click to proceed to the next step (the last one)
-    await clickFirstSelector(page, 'input[value="Next"]')
+    await clickFirstSelector(page, 'input[value="Next"]');
     await page.waitForNavigation();
     await page.waitForSelector(
       '[data-automation-id="newsletter_send_heading"]',

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -21,7 +21,7 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2 } from '../utils/helpers.js';
+import { login, selectInSelect2, clickFirstSelector } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterSending() {
@@ -65,7 +65,7 @@ export async function newsletterSending() {
     });
 
     // Click to proceed to the next step (the last one)
-    await page.$$('input[value="Next"]')[0].click();
+    await clickFirstSelector(page, 'input[value="Next"]')
     await page.waitForNavigation();
     await page.waitForSelector(
       '[data-automation-id="newsletter_send_heading"]',
@@ -90,8 +90,8 @@ export async function newsletterSending() {
       "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
     await page.waitForSelector('#mailpoet_notices');
     describe(emailsPageTitle, () => {
-      describe('newsletter-sending: should be able to see Newsletter Sent message', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('newsletter-sending: should be able to see Newsletter Sent message', async () => {
+        expect(await page.locator(locator)).to.exist;
       });
     });
 
@@ -102,7 +102,7 @@ export async function newsletterSending() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -72,8 +72,8 @@ export async function newsletterStatistics() {
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
       describe('newsletter-statistics: should be able to see Link Clicked filter', async () => {
-        expect(await page.locator('[data-automation-id="filters_all_engaged"]')).to
-          .exist;
+        expect(await page.locator('[data-automation-id="filters_all_engaged"]'))
+          .to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -57,9 +57,9 @@ export async function newsletterStatistics() {
       '[data-acceptance-id="purchased-product-Simple Product"]',
     );
     describe(emailsPageTitle, () => {
-      describe('newsletter-statistics: should be able to see the product as sold', () => {
+      describe('newsletter-statistics: should be able to see the product as sold', async () => {
         expect(
-          page.locator(
+          await page.locator(
             '[data-acceptance-id="purchased-product-Simple Product"]',
           ),
         ).to.exist;
@@ -71,8 +71,8 @@ export async function newsletterStatistics() {
     await page.waitForSelector('[data-automation-id="filters_all_engaged"]');
     await page.waitForLoadState('networkidle');
     describe(emailsPageTitle, () => {
-      describe('newsletter-statistics: should be able to see Link Clicked filter', () => {
-        expect(page.locator('[data-automation-id="filters_all_engaged"]')).to
+      describe('newsletter-statistics: should be able to see Link Clicked filter', async () => {
+        expect(await page.locator('[data-automation-id="filters_all_engaged"]')).to
           .exist;
       });
     });
@@ -83,7 +83,7 @@ export async function newsletterStatistics() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/newsletters-post-notification.js
+++ b/mailpoet/tests/performance/tests/newsletters-post-notification.js
@@ -21,7 +21,11 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2, clickFirstSelector } from '../utils/helpers.js';
+import {
+  login,
+  selectInSelect2,
+  clickFirstSelector,
+} from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterPostNotification() {
@@ -85,7 +89,7 @@ export async function newsletterPostNotification() {
     }
 
     // Click to proceed to the next step (the last one)
-    await clickFirstSelector(page, 'input[value="Next"]')
+    await clickFirstSelector(page, 'input[value="Next"]');
     await page.waitForNavigation();
     await page.waitForSelector(
       '[data-automation-id="newsletter_send_heading"]',

--- a/mailpoet/tests/performance/tests/newsletters-post-notification.js
+++ b/mailpoet/tests/performance/tests/newsletters-post-notification.js
@@ -21,7 +21,7 @@ import {
   fullPageSet,
   screenshotPath,
 } from '../config.js';
-import { login, selectInSelect2 } from '../utils/helpers.js';
+import { login, selectInSelect2, clickFirstSelector } from '../utils/helpers.js';
 /* global Promise */
 
 export async function newsletterPostNotification() {
@@ -85,7 +85,7 @@ export async function newsletterPostNotification() {
     }
 
     // Click to proceed to the next step (the last one)
-    await page.$$('input[value="Next"]')[0].click();
+    await clickFirstSelector(page, 'input[value="Next"]')
     await page.waitForNavigation();
     await page.waitForSelector(
       '[data-automation-id="newsletter_send_heading"]',
@@ -110,9 +110,9 @@ export async function newsletterPostNotification() {
       // Wait for the success page and confirm it
       await page.waitForSelector('.mailpoet-wizard-step');
       describe(emailsPageTitle, () => {
-        describe('newsletter-post-notification: should be able to see confirmation page for the first time', () => {
+        describe('newsletter-post-notification: should be able to see confirmation page for the first time', async () => {
           expect(
-            page.locator('.mailpoet-congratulate > h1').innerText(),
+            await page.locator('.mailpoet-congratulate > h1').innerText(),
           ).to.contain('You are all set up and ready to go!');
         });
       });
@@ -130,8 +130,8 @@ export async function newsletterPostNotification() {
         "//div[@class='notice-success'].//p[starts-with(text(),'Your post notification is now active!')]";
       await page.waitForSelector('#mailpoet_notices');
       describe(emailsPageTitle, () => {
-        describe('newsletter-post-notification: should be able to see Post Notification is active message', () => {
-          expect(page.locator(locator)).to.exist;
+        describe('newsletter-post-notification: should be able to see Post Notification is active message', async () => {
+          expect(await page.locator(locator)).to.exist;
         });
       });
     }
@@ -143,7 +143,7 @@ export async function newsletterPostNotification() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -64,7 +64,7 @@ export async function onboardingWizard() {
       .click();
     await page.locator('button[type="submit"]').click();
 
-    sleep(1);
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 
     await page.waitForSelector('span.mailpoet-form-yesno-yes');
     await page.locator('span.mailpoet-form-yesno-yes').click();
@@ -72,7 +72,7 @@ export async function onboardingWizard() {
 
     await page.locator('.mailpoet-wizard-step-content > p > a').click();
 
-    sleep(2);
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 
     await page.screenshot({
       path: screenshotPath + 'Onboarding_Wizard_02.png',
@@ -93,9 +93,9 @@ export async function onboardingWizard() {
 
     // Check if you see Send With tab at the end
     describe(settingsPageTitle, () => {
-      describe('onboarding-wizard: should be able to see Send With tab present', () => {
+      describe('onboarding-wizard: should be able to see Send With tab present', async () => {
         expect(
-          page
+          await page
             .locator('[data-automation-id="send_with_settings_tab"]')
             .innerText(),
         ).to.contain('Send With...');
@@ -108,7 +108,7 @@ export async function onboardingWizard() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -64,7 +64,8 @@ export async function onboardingWizard() {
       .click();
     await page.locator('button[type="submit"]').click();
 
-    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
 
     await page.waitForSelector('span.mailpoet-form-yesno-yes');
     await page.locator('span.mailpoet-form-yesno-yes').click();

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -62,9 +62,9 @@ export async function segmentsCreateCustom() {
     await selectInReact(page, '#react-select-4-input', defaultListName);
     await page.waitForSelector('.mailpoet-form-notice-message');
     describe(segmentsPageTitle, () => {
-      describe('segments-create-custom: should be able to see calculating message 1st time', () => {
+      describe('segments-create-custom: should be able to see calculating message 1st time', async () => {
         expect(
-          page.locator('.mailpoet-form-notice-message').innerText(),
+          await page.locator('.mailpoet-form-notice-message').innerText(),
         ).to.contain('Calculating segment size…');
       });
     });
@@ -84,9 +84,9 @@ export async function segmentsCreateCustom() {
     await selectInReact(page, '#react-select-5-input', 'subscribed date');
     await page.waitForSelector('.mailpoet-form-notice-message');
     describe(segmentsPageTitle, () => {
-      describe('segments-create-custom: should be able to see calculating message 2nd time', () => {
+      describe('segments-create-custom: should be able to see calculating message 2nd time', async () => {
         expect(
-          page.locator('.mailpoet-form-notice-message').innerText(),
+          await page.locator('.mailpoet-form-notice-message').innerText(),
         ).to.contain('Calculating segment size…');
       });
     });
@@ -107,9 +107,9 @@ export async function segmentsCreateCustom() {
     await page.waitForSelector('.mailpoet-form-notice-message');
     await page.waitForLoadState('networkidle');
     describe(segmentsPageTitle, () => {
-      describe('segments-create-custom: should be able to see Calculating message 3rd time', () => {
+      describe('segments-create-custom: should be able to see Calculating message 3rd time', async () => {
         expect(
-          page.locator('.mailpoet-form-notice-message').innerText(),
+          await page.locator('.mailpoet-form-notice-message').innerText(),
         ).to.contain('Calculating segment size…');
       });
     });
@@ -137,8 +137,8 @@ export async function segmentsCreateCustom() {
     const segmentAddedMessage =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully added!')]";
     describe(segmentsPageTitle, () => {
-      describe('segments-create-custom: should be able to see Segment Added message', () => {
-        expect(page.locator(segmentAddedMessage)).to.exist;
+      describe('segments-create-custom: should be able to see Segment Added message', async () => {
+        expect(await page.locator(segmentAddedMessage)).to.exist;
       });
     });
 
@@ -149,7 +149,7 @@ export async function segmentsCreateCustom() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -24,6 +24,7 @@ import {
   login,
   focusAndClick,
   waitForSelectorToBeClickable,
+  clickFirstSelector,
 } from '../utils/helpers.js';
 
 export async function segmentsSelectTemplate() {
@@ -48,12 +49,8 @@ export async function segmentsSelectTemplate() {
     });
 
     // Select any segment's template on page
-    await Promise.all([
-      page.$$('.mailpoet-templates-card')[0].click(), // this will randomly pick
-      page.waitForNavigation(),
-      page.waitForSelector('[data-automation-id="select-segment-action"]'),
-      page.waitForLoadState('networkidle'),
-    ]);
+    await clickFirstSelector(page, '.mailpoet-templates-card');
+    await page.waitForSelector('[data-automation-id="select-segment-action"]');
 
     await page.screenshot({
       path: screenshotPath + 'Segments_Select_Template_02.png',
@@ -71,8 +68,8 @@ export async function segmentsSelectTemplate() {
     const segmentUpdatedMessage =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
     describe(segmentsPageTitle, () => {
-      describe('segments-select-template: should be able to see Segment Updated message', () => {
-        expect(page.locator(segmentUpdatedMessage)).to.exist;
+      describe('segments-select-template: should be able to see Segment Updated message', async () => {
+        expect(await page.locator(segmentUpdatedMessage)).to.exist;
       });
     });
 
@@ -83,7 +80,7 @@ export async function segmentsSelectTemplate() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -52,8 +52,8 @@ export async function settingsBasic() {
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Settings saved')]";
     describe(settingsPageTitle, () => {
-      describe('settings-basic: should be able to see Settings Saved message', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('settings-basic: should be able to see Settings Saved message', async () => {
+        expect(await page.locator(locator)).to.exist;
       });
     });
 
@@ -63,7 +63,7 @@ export async function settingsBasic() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -71,8 +71,9 @@ export async function subscribersAdding() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-adding: should be able to see Lists Filter', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
     await page.waitForLoadState('networkidle');
@@ -89,9 +90,9 @@ export async function subscribersAdding() {
     await page.waitForLoadState('networkidle');
     describe(subscribersPageTitle, () => {
       describe('subscribers-adding: should be able to search for Newly Added Subscriber', async () => {
-        expect(await page.locator('.mailpoet-listing-title').innerText()).to.contain(
-          subscriberEmail,
-        );
+        expect(
+          await page.locator('.mailpoet-listing-title').innerText(),
+        ).to.contain(subscriberEmail);
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -63,15 +63,15 @@ export async function subscribersAdding() {
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
     describe(subscribersPageTitle, () => {
-      describe('subscribers-adding: should be able to see Subscriber Added message', () => {
-        expect(page.locator(locator)).to.exist;
+      describe('subscribers-adding: should be able to see Subscriber Added message', async () => {
+        expect(await page.locator(locator)).to.exist;
       });
     });
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-adding: should be able to see Lists Filter', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('subscribers-adding: should be able to see Lists Filter', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -88,8 +88,8 @@ export async function subscribersAdding() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     await page.waitForLoadState('networkidle');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-adding: should be able to search for Newly Added Subscriber', () => {
-        expect(page.locator('.mailpoet-listing-title').innerText()).to.contain(
+      describe('subscribers-adding: should be able to search for Newly Added Subscriber', async () => {
+        expect(await page.locator('.mailpoet-listing-title').innerText()).to.contain(
           subscriberEmail,
         );
       });
@@ -101,7 +101,7 @@ export async function subscribersAdding() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -45,8 +45,8 @@ export async function subscribersFiltering() {
     await page.locator('[data-automation-id="filters_subscribed"]').click();
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-filtering: should be able to see Lists Filter 1st time', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('subscribers-filtering: should be able to see Lists Filter 1st time', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -64,8 +64,8 @@ export async function subscribersFiltering() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-filtering: should be able to see Lists Filter 2nd time', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('subscribers-filtering: should be able to see Lists Filter 2nd time', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -81,8 +81,8 @@ export async function subscribersFiltering() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-filtering: should be able to see Lists Filter 3rd time', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('subscribers-filtering: should be able to see Lists Filter 3rd time', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -94,7 +94,7 @@ export async function subscribersFiltering() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -46,8 +46,9 @@ export async function subscribersFiltering() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-filtering: should be able to see Lists Filter 1st time', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
 
@@ -65,8 +66,9 @@ export async function subscribersFiltering() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-filtering: should be able to see Lists Filter 2nd time', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
 
@@ -82,8 +84,9 @@ export async function subscribersFiltering() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-filtering: should be able to see Lists Filter 3rd time', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -44,8 +44,8 @@ export async function subscribersListing() {
     // Verify filter, tag and listing are loaded and visible
     await page.waitForLoadState('networkidle');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-listing: should be able to see Tags Filter', () => {
-        expect(page.locator('[data-automation-id="listing_filter_tag"]')).to
+      describe('subscribers-listing: should be able to see Tags Filter', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_tag"]')).to
           .exist;
       });
     });
@@ -56,7 +56,7 @@ export async function subscribersListing() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -45,8 +45,8 @@ export async function subscribersListing() {
     await page.waitForLoadState('networkidle');
     describe(subscribersPageTitle, () => {
       describe('subscribers-listing: should be able to see Tags Filter', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_tag"]')).to
-          .exist;
+        expect(await page.locator('[data-automation-id="listing_filter_tag"]'))
+          .to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -44,8 +44,9 @@ export async function subscribersTrashingRestoring() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-trashing-restoring: should be able to see Lists Filter', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
-          .exist;
+        expect(
+          await page.locator('[data-automation-id="listing_filter_segment"]'),
+        ).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -43,8 +43,8 @@ export async function subscribersTrashingRestoring() {
     // Check the subscribers filter is present
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-trashing-restoring: should be able to see Lists Filter', () => {
-        expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
+      describe('subscribers-trashing-restoring: should be able to see Lists Filter', async () => {
+        expect(await page.locator('[data-automation-id="listing_filter_segment"]')).to
           .exist;
       });
     });
@@ -60,8 +60,8 @@ export async function subscribersTrashingRestoring() {
     await page.waitForSelector('.notice-success');
     await page.waitForSelector('.colspanchange');
     describe(subscribersPageTitle, () => {
-      describe('subscribers-trashing-restoring: should be able to see the message', () => {
-        expect(page.locator('.colspanchange').innerText()).to.contain(
+      describe('subscribers-trashing-restoring: should be able to see the message', async () => {
+        expect(await page.locator('.colspanchange').innerText()).to.contain(
           'No items found.',
         );
       });
@@ -75,7 +75,7 @@ export async function subscribersTrashingRestoring() {
     // Restore from trash all the trashed subscribers
     await page.locator('[data-automation-id="filters_trash"]').click();
     await page.waitForSelector('[data-automation-id="empty_trash"]');
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
     await page.locator('[data-automation-id="select_all"]').click();
     await page.waitForSelector('.mailpoet-listing-select-all');
     await page.locator('.mailpoet-listing-select-all > a').click();
@@ -94,7 +94,7 @@ export async function subscribersTrashingRestoring() {
     });
 
     // Thinking time and closing
-    sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
+    await sleep(randomIntBetween(thinkTimeMin, thinkTimeMax));
   } finally {
     await page.close();
     await browser.context().close();

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -157,3 +157,20 @@ export async function designEmailInWorkflow(page) {
   ]);
   await page.waitForLoadState('networkidle');
 }
+
+// Wait and click first selector
+export async function clickFirstSelector(page, selector) {
+  // Wait for the selector to be available
+  await page.waitForSelector(selector);
+
+  // Get all selectors
+  const selectors = await page.$$(selector);
+
+  // Ensure that the first selector exists before trying to click
+  if (selectors.length > 0) {
+    await selectors[0].focus();
+    await selectors[0].click();
+  } else {
+    throw new Error("No selector found on the page.");
+  }
+}

--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -171,6 +171,6 @@ export async function clickFirstSelector(page, selector) {
     await selectors[0].focus();
     await selectors[0].click();
   } else {
-    throw new Error("No selector found on the page.");
+    throw new Error('No selector found on the page.');
   }
 }


### PR DESCRIPTION
## Description

This is to make the tests executable at least from the local (confirmed working).

There will be follow-up PR to fix checks visibility in the output, currently says 15 ✅ but in reality it is 41 ✅ due to some issue in the latest k6 browser, will be heading to community forum for help.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6274]

## After-merge notes

_N/A_

[MAILPOET-6274]: https://mailpoet.atlassian.net/browse/MAILPOET-6274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/fix-tests)

_The latest successful build from `performance/fix-tests` will be used. If none is available, the link won't work._