### PR TITLE
Fix inactive notifications clog sending queue [MAILPOET-6259]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -11,6 +11,7 @@ use MailPoet\Cron\CronHelper;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\InvalidStateException;
 use MailPoet\Listing;
@@ -211,6 +212,17 @@ class Newsletters extends APIEndpoint {
 
     $this->newslettersRepository->prefetchOptions([$newsletter]);
     $newsletter->setStatus($status);
+
+    // if there are paused tasks unpause them
+    if ($newsletter->getStatus() === NewsletterEntity::STATUS_ACTIVE) {
+      $queues = $newsletter->getQueues();
+      foreach ($queues as $queue) {
+        $task = $queue->getTask();
+        if ($task && $task->getStatus() === ScheduledTaskEntity::STATUS_PAUSED) {
+          $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+        }
+      }
+    }
 
     // if there are past due notifications, reschedule them for the next send date
     if ($newsletter->getType() === NewsletterEntity::TYPE_NOTIFICATION && $status === NewsletterEntity::STATUS_ACTIVE) {

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -123,6 +123,8 @@ class Scheduler {
         if (!$newsletter instanceof NewsletterEntity || $newsletter->getDeletedAt() !== null) {
           $this->deleteByTask($task);
         } elseif ($newsletter->getStatus() !== NewsletterEntity::STATUS_ACTIVE && $newsletter->getStatus() !== NewsletterEntity::STATUS_SCHEDULED) {
+          $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+          $this->scheduledTasksRepository->flush();
           continue;
         } elseif ($newsletter->getType() === NewsletterEntity::TYPE_WELCOME) {
           $this->processWelcomeNewsletter($newsletter, $task);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -175,6 +175,8 @@ class SendingQueue {
     $queue = $task->getSendingQueue();
     $newsletter = $this->newsletterTask->getNewsletterFromQueue($task);
     if (!$queue || !$newsletter) {
+      $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+      $this->scheduledTasksRepository->flush();
       return;
     }
 
@@ -184,6 +186,8 @@ class SendingQueue {
     // During pre-processing we may find that the newsletter can't be sent and we delete it including all associated entities
     // E.g. post notification history newsletter when there are no posts to send
     if (!$newsletter) {
+      $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+      $this->scheduledTasksRepository->flush();
       return;
     }
 

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -597,12 +597,17 @@ class SchedulerTest extends \MailPoetTest {
 
   public function testItDoesNotProcessScheduledJobsWhenNewsletterIsNotActive() {
     $newsletter = $this->_createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_DRAFT);
-    $this->createTaskWithQueue($newsletter);
+    $task = $this->createTaskWithQueue($newsletter);
     $scheduler = $this->getSchedulerMock([
       'processScheduledStandardNewsletter' => Expected::never(),
     ]);
-    // scheduled job is not processed
+    
     $scheduler->process();
+
+    $refetchedTask = $this->scheduledTasksRepository->findOneById($task->getId());
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $refetchedTask);
+    verify($refetchedTask->getId())->equals($task->getId());
+    verify($refetchedTask->getStatus())->equals(ScheduledTaskEntity::STATUS_PAUSED);
   }
 
   public function testItProcessesScheduledJobsWhenNewsletterIsActive() {


### PR DESCRIPTION
## Description

From Support: a user has 80+ post notifications. In the database a lot of very old scheduled tasks that would not go out. The associated newsletters where not active. In the scheduler we pick up 5 sending tasks to start sending. If no queue or newsletter is found we delete the task. Otherwise we start to process the newsletter, except for when the newsletter is not active, then we continue; and the sending task will just return into the queue until the status of the newsletter changes and gets actually processed.

## Code review notes

Please let me know if you think this is the right approach. It was described in the ticket, but I am not sure if that is correct. 

## QA notes

Sending was changed. If there is a paused email with a scheduled task the task is now paused as well. If the email is unpaused the task is scheduled and should be sent.  

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6259]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6259]: https://mailpoet.atlassian.net/browse/MAILPOET-6259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-inactive-notifications)

_The latest successful build from `fix-inactive-notifications` will be used. If none is available, the link won't work._