### PR TITLE
Fix beta version detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,7 @@ jobs:
           name: Check for Latest WordPress Beta Version
           command: |
             if [ "<< parameters.use_wordpress_beta >>" == "true" ]; then
-              LATEST_WP_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              LATEST_WP_BETA=$(../.circleci/check_wordpress_beta.sh | grep 'LATEST_BETA' | sed 's/^.*--version=\(.*\)$/\1/')
               if [ -z "$LATEST_WP_BETA" ]; then
                 echo "No latest beta version found. Ending job early."
                 circleci-agent step halt
@@ -430,7 +430,7 @@ jobs:
           name: Check for Latest WooCommerce Beta Version
           command: |
             if [ "<< parameters.use_woocommerce_beta >>" == "true" ]; then
-              LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+              LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | sed 's/^.*--version=\(.*\)$/\1/')
               if [ -z "$LATEST_WC_BETA" ]; then
                 echo "No WooCommerce Beta version found. Ending job early."
                 circleci-agent step halt


### PR DESCRIPTION
## Description

The beta version detection is broken

![Screenshot 2024-10-15 at 13 36 10](https://github.com/user-attachments/assets/d7558d29-f354-41c0-a676-9929360c2f55)

I fixed that and hopefully, this is more robust.


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-beta-version-detection)

_The latest successful build from `fix-beta-version-detection` will be used. If none is available, the link won't work._