### PR TITLE
Use post_type parameter to filter email-related templates [MAILPOET-6279]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -196,10 +196,18 @@ export const getCurrentTemplate = createRegistrySelector((select) => () => {
  */
 export const getEmailTemplates = createRegistrySelector(
   (select) => () =>
-    select(coreDataStore).getEntityRecords('postType', 'wp_template', {
-      per_page: -1,
-      post_type: 'mailpoet_email',
-    }),
+    select(coreDataStore)
+      .getEntityRecords('postType', 'wp_template', {
+        per_page: -1,
+        post_type: 'mailpoet_email',
+      })
+      // We still need to filter the templates because, in some cases, the API also returns custom templates
+      // ignoring the post_type filter in the query
+      ?.filter(
+        (template) =>
+          // @ts-expect-error Missing property in type
+          template.theme === 'mailpoet/mailpoet',
+      ),
 );
 
 export function getEmailPostId(state: State): number {

--- a/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/store/selectors.ts
@@ -196,15 +196,10 @@ export const getCurrentTemplate = createRegistrySelector((select) => () => {
  */
 export const getEmailTemplates = createRegistrySelector(
   (select) => () =>
-    select(coreDataStore)
-      .getEntityRecords('postType', 'wp_template', {
-        per_page: -1,
-      })
-      ?.filter(
-        (template) =>
-          // @ts-expect-error Missing property in type
-          template.theme === 'mailpoet/mailpoet',
-      ),
+    select(coreDataStore).getEntityRecords('postType', 'wp_template', {
+      per_page: -1,
+      post_type: 'mailpoet_email',
+    }),
 );
 
 export function getEmailPostId(state: State): number {


### PR DESCRIPTION
## Description

This PR improves the fetching of templates for the email editor by moving the filtering of the templates from the client to the REST API.

## Code review notes

Please verify that the template selector offers the correct templates.

## QA notes

We can skip QA.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6279]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6279]: https://mailpoet.atlassian.net/browse/MAILPOET-6279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/templates-fetch-by-post-type)

_The latest successful build from `email-editor/templates-fetch-by-post-type` will be used. If none is available, the link won't work._