### PR TITLE
Use a different port for testing in order

### DIFF
--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -89,8 +89,6 @@ services:
       - ../../mailpoet-premium:/var/www/html/wp-content/plugins/mailpoet-premium
     tmpfs:
       - /var/www/html/wp-content/uploads/mailpoet/
-    ports:
-      - 8889:80
     environment:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_USER: wordpress

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     tmpfs:
       - /var/www/html/wp-content/uploads/mailpoet/
     ports:
-      - 8888:80
+      - 8889:80
     environment:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_USER: wordpress


### PR DESCRIPTION
## Description

We need to prevent a conflict with the dashboard

## Code review notes

_N/A_

## QA notes

We don't need QA for this

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:testing-port)

_The latest successful build from `testing-port` will be used. If none is available, the link won't work._