### PR TITLE
Update selector in reengagement k6 test

### DIFF
--- a/mailpoet/tests/performance/tests/newsletter-reengagement.js
+++ b/mailpoet/tests/performance/tests/newsletter-reengagement.js
@@ -51,7 +51,7 @@ export async function newsletterReEngagement() {
     });
 
     // Click to add a new re-engagement email and set frequency
-    await waitAndType(page, 'input[type="text"]', '99');
+    await waitAndType(page, '.mailpoet-form-input > input', '99');
     await page.locator('.mailpoet-button.mailpoet-full-width').click();
     await page.waitForSelector('.mailpoet_loading');
     await page.waitForSelector(


### PR DESCRIPTION
## Description

Just a tiny update of the selector in k6 performance test.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/fix-reengagement-test)

_The latest successful build from `performance/fix-reengagement-test` will be used. If none is available, the link won't work._