### PR TITLE
Fix CustomHtml block [MAILPOET-6287]

### DIFF
--- a/mailpoet/lib/Form/Block/Html.php
+++ b/mailpoet/lib/Form/Block/Html.php
@@ -2,14 +2,20 @@
 
 namespace MailPoet\Form\Block;
 
+use MailPoet\WP\Functions as WPFunctions;
+
 class Html {
   /** @var BlockRendererHelper */
   private $rendererHelper;
 
+  private WPFunctions $wp;
+
   public function __construct(
-    BlockRendererHelper $rendererHelper
+    BlockRendererHelper $rendererHelper,
+    WPFunctions $wp
   ) {
     $this->rendererHelper = $rendererHelper;
+    $this->wp = $wp;
   }
 
   public function render(array $block, array $formSettings): string {
@@ -26,7 +32,7 @@ class Html {
 
     $classes = isset($block['params']['class_name']) ? " " . $block['params']['class_name'] : '';
     $html .= '<div class="mailpoet_paragraph' . $classes . '" ' . $this->rendererHelper->renderFontStyle($formSettings) . '>';
-    $html .= $text;
+    $html .= $this->wp->wpKsesPost($text);
     $html .= '</div>';
 
     return $html;

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -812,6 +812,10 @@ class Functions {
     return wp_kses($string, $allowedHtml, $allowedProtocols);
   }
 
+  public function wpKsesPost(string $string): string {
+    return wp_kses_post($string);
+  }
+
   public function deprecatedHook(string $hook_name, string $version, string $replacement, string $message) {
     _deprecated_hook(
       esc_html($hook_name),

--- a/mailpoet/tests/integration/Form/Block/SanitisationHtmlTest.php
+++ b/mailpoet/tests/integration/Form/Block/SanitisationHtmlTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Form\Block;
+
+use MailPoet\Form\Block\BlockRendererHelper;
+use MailPoet\Form\Block\Html;
+use MailPoet\WP\Functions as WPFunctions;
+
+class SanitisationHtmlTest extends \MailPoetTest {
+  private Html $html;
+
+  private $block = [
+    'type' => 'html',
+    'name' => 'Html',
+    'id' => 'html',
+    'unique' => '1',
+    'static' => '0',
+    'params' => [
+      'nl2br' => '1',
+      'text' => "line1\nline2",
+    ],
+    'position' => '1',
+  ];
+
+  public function _before() {
+    parent::_before();
+    $this->html = new Html(
+      $this->diContainer->get(BlockRendererHelper::class),
+      $this->diContainer->get(WPFunctions::class)
+    );
+  }
+
+  public function testItSanitisesHtml(): void {
+    $block = $this->block;
+    $block['params']['text'] = '<p class="my-p">Hello</p><img src=x onerror=alert(1)>';
+    $html = $this->html->render($block, []);
+    verify($html)->equals("<div class=\"mailpoet_paragraph\" ><p class=\"my-p\">Hello</p><img src=\"x\"></div>");
+  }
+}

--- a/mailpoet/tests/unit/Form/Block/HtmlTest.php
+++ b/mailpoet/tests/unit/Form/Block/HtmlTest.php
@@ -4,10 +4,10 @@ namespace MailPoet\Test\Form\Block;
 
 use MailPoet\Form\Block\BlockRendererHelper;
 use MailPoet\Form\Block\Html;
+use MailPoet\WP\Functions as WPFunctions;
 
 class HtmlTest extends \MailPoetUnitTest {
-  /** @var Html */
-  private $html;
+  private Html $html;
 
   private $block = [
     'type' => 'html',
@@ -24,7 +24,12 @@ class HtmlTest extends \MailPoetUnitTest {
 
   public function _before() {
     parent::_before();
-    $this->html = new Html($this->createMock(BlockRendererHelper::class));
+    $wpMock = $this->createMock(WPFunctions::class);
+    $wpMock->method('wpKsesPost')->willReturnArgument(0);
+    $this->html = new Html(
+      $this->createMock(BlockRendererHelper::class),
+      $wpMock
+    );
   }
 
   public function testItShouldRenderCustomHtml() {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6287]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6287]: https://mailpoet.atlassian.net/browse/MAILPOET-6287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:custom-html-fix)

_The latest successful build from `custom-html-fix` will be used. If none is available, the link won't work._