### PR TITLE
Fix CustomHtml block class  [MAILPOET-6287]

### DIFF
--- a/mailpoet/lib/Form/Block/BlockRendererHelper.php
+++ b/mailpoet/lib/Form/Block/BlockRendererHelper.php
@@ -216,10 +216,11 @@ class BlockRendererHelper {
 
   // return field name depending on block data
   public function getFieldName(array $block = []): string {
-    if ((int)$block['id'] > 0) {
-      return 'cf_' . $block['id'];
+    $blockId = $this->wp->escAttr($block['id']);
+    if ((int)$blockId > 0) {
+      return 'cf_' . $blockId;
     } elseif (isset($block['params']['obfuscate']) && !$block['params']['obfuscate']) {
-      return $block['id'];
+      return $blockId;
     } else {
       return $this->fieldNameObfuscator->obfuscate($block['id']);//obfuscate field name for spambots
     }

--- a/mailpoet/lib/Form/Block/Html.php
+++ b/mailpoet/lib/Form/Block/Html.php
@@ -31,7 +31,7 @@ class Html {
     }
 
     $classes = isset($block['params']['class_name']) ? " " . $block['params']['class_name'] : '';
-    $html .= '<div class="mailpoet_paragraph' . $classes . '" ' . $this->rendererHelper->renderFontStyle($formSettings) . '>';
+    $html .= '<div class="mailpoet_paragraph' . $this->wp->escAttr($classes) . '" ' . $this->rendererHelper->renderFontStyle($formSettings) . '>';
     $html .= $this->wp->wpKsesPost($text);
     $html .= '</div>';
 

--- a/mailpoet/tests/integration/Form/Block/SanitisationHtmlTest.php
+++ b/mailpoet/tests/integration/Form/Block/SanitisationHtmlTest.php
@@ -36,4 +36,12 @@ class SanitisationHtmlTest extends \MailPoetTest {
     $html = $this->html->render($block, []);
     verify($html)->equals("<div class=\"mailpoet_paragraph\" ><p class=\"my-p\">Hello</p><img src=\"x\"></div>");
   }
+
+  public function testItSanitisesClassName(): void {
+    $block = $this->block;
+    $block['params']['class_name'] = 'my_clas"s1 class2';
+    $block['params']['text'] = 'line1';
+    $html = $this->html->render($block, []);
+    verify($html)->equals("<div class=\"mailpoet_paragraph my_clas&quot;s1 class2\" >line1</div>");
+  }
 }

--- a/mailpoet/tests/unit/Form/Block/HtmlTest.php
+++ b/mailpoet/tests/unit/Form/Block/HtmlTest.php
@@ -26,6 +26,7 @@ class HtmlTest extends \MailPoetUnitTest {
     parent::_before();
     $wpMock = $this->createMock(WPFunctions::class);
     $wpMock->method('wpKsesPost')->willReturnArgument(0);
+    $wpMock->method('escAttr')->willReturnArgument(0);
     $this->html = new Html(
       $this->createMock(BlockRendererHelper::class),
       $wpMock


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6287]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6287]: https://mailpoet.atlassian.net/browse/MAILPOET-6287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:custom-html-fix)

_The latest successful build from `custom-html-fix` will be used. If none is available, the link won't work._