### PR TITLE
Fix error on email statistics page [MAILPOET-6296]

### DIFF
--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
@@ -10,7 +10,59 @@ type StatsBadgeProps = {
   isInverted?: boolean;
 };
 
-export const getBadgeType = (stat, rate) => {
+const stats = {
+  opened: {
+    badgeRanges: [30, 10, 0],
+    badgeTypes: ['excellent', 'good', 'critical'],
+    tooltipText: {
+      // translators: Excellent open rate
+      excellent: __('above 30%', 'mailpoet'),
+      // translators: Good open rate
+      good: __('between 10 and 30%', 'mailpoet'),
+      // translators: Critical open rate
+      critical: __('under 10%', 'mailpoet'),
+    },
+  },
+  clicked: {
+    badgeRanges: [3, 1, 0],
+    badgeTypes: ['excellent', 'good', 'critical'],
+    tooltipText: {
+      // translators: Excellent click rate
+      excellent: __('above 3%', 'mailpoet'),
+      // translators: Good click rate
+      good: __('between 1 and 3%', 'mailpoet'),
+      // translators: Critical click rate
+      critical: __('under 1%', 'mailpoet'),
+    },
+  },
+  bounced: {
+    badgeRanges: [1.5, 0.5, 0],
+    badgeTypes: ['critical', 'good', 'excellent'],
+    tooltipText: {
+      // translators: Excellent bounce rate
+      excellent: __('below 0.5%', 'mailpoet'),
+      // translators: Good bounce rate
+      good: __('between 0.5% and 1.5%', 'mailpoet'),
+      // translators: Critical bounce rate
+      critical: __('above 1.5%', 'mailpoet'),
+    },
+  },
+  unsubscribed: {
+    badgeRanges: [0.7, 0.3, 0],
+    badgeTypes: ['critical', 'good', 'excellent'],
+    tooltipText: {
+      // translators: Excellent unsubscribe rate
+      excellent: __('Below 0.3%', 'mailpoet'),
+      // translators: Good unsubscribe rate
+      good: __('between 0.3% and 0.7%', 'mailpoet'),
+      // translators: Critical unsubscribe rate
+      critical: __('above 0.7%', 'mailpoet'),
+    },
+  },
+};
+
+export const getBadgeType = (statName, rate) => {
+  const stat = stats[statName] || null;
   if (!stat) {
     return null;
   }
@@ -44,58 +96,8 @@ function StatsBadge(props: StatsBadgeProps) {
       tooltipTitle: __('Something to improve.', 'mailpoet'),
     },
   };
-  const stats = {
-    opened: {
-      badgeRanges: [30, 10, 0],
-      badgeTypes: ['excellent', 'good', 'critical'],
-      tooltipText: {
-        // translators: Excellent open rate
-        excellent: __('above 30%', 'mailpoet'),
-        // translators: Good open rate
-        good: __('between 10 and 30%', 'mailpoet'),
-        // translators: Critical open rate
-        critical: __('under 10%', 'mailpoet'),
-      },
-    },
-    clicked: {
-      badgeRanges: [3, 1, 0],
-      badgeTypes: ['excellent', 'good', 'critical'],
-      tooltipText: {
-        // translators: Excellent click rate
-        excellent: __('above 3%', 'mailpoet'),
-        // translators: Good click rate
-        good: __('between 1 and 3%', 'mailpoet'),
-        // translators: Critical click rate
-        critical: __('under 1%', 'mailpoet'),
-      },
-    },
-    bounced: {
-      badgeRanges: [1.5, 0.5, 0],
-      badgeTypes: ['critical', 'good', 'excellent'],
-      tooltipText: {
-        // translators: Excellent bounce rate
-        excellent: __('below 0.5%', 'mailpoet'),
-        // translators: Good bounce rate
-        good: __('between 0.5% and 1.5%', 'mailpoet'),
-        // translators: Critical bounce rate
-        critical: __('above 1.5%', 'mailpoet'),
-      },
-    },
-    unsubscribed: {
-      badgeRanges: [0.7, 0.3, 0],
-      badgeTypes: ['critical', 'good', 'excellent'],
-      tooltipText: {
-        // translators: Excellent unsubscribe rate
-        excellent: __('Below 0.3%', 'mailpoet'),
-        // translators: Good unsubscribe rate
-        good: __('between 0.3% and 0.7%', 'mailpoet'),
-        // translators: Critical unsubscribe rate
-        critical: __('above 0.7%', 'mailpoet'),
-      },
-    },
-  };
 
-  const badgeType = getBadgeType(stats[props.stat], props.rate);
+  const badgeType = getBadgeType(props.stat, props.rate);
   const badge = badges[badgeType] || null;
   if (!badge) {
     return null;

--- a/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
+++ b/mailpoet/assets/js/src/common/listings/newsletter-stats/stats.tsx
@@ -10,7 +10,7 @@ type StatsBadgeProps = {
   isInverted?: boolean;
 };
 
-const stats = {
+const getStats = () => ({
   opened: {
     badgeRanges: [30, 10, 0],
     badgeTypes: ['excellent', 'good', 'critical'],
@@ -59,10 +59,10 @@ const stats = {
       critical: __('above 0.7%', 'mailpoet'),
     },
   },
-};
+});
 
 export const getBadgeType = (statName, rate) => {
-  const stat = stats[statName] || null;
+  const stat = getStats()[statName] || null;
   if (!stat) {
     return null;
   }
@@ -103,7 +103,7 @@ function StatsBadge(props: StatsBadgeProps) {
     return null;
   }
 
-  const stat = stats[props.stat] || null;
+  const stat = getStats()[props.stat] || null;
   if (!stat) {
     return null;
   }


### PR DESCRIPTION
## Description

Fix the error introduced in #5866 and implement it in a different way.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6296]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6296]: https://mailpoet.atlassian.net/browse/MAILPOET-6296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:campaign-stats-fix)

_The latest successful build from `campaign-stats-fix` will be used. If none is available, the link won't work._