### PR TITLE
Add bool type cast to the return value - MAILPOET-6299

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WordPress/Fields/PostFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/Fields/PostFieldsFactory.php
@@ -235,7 +235,7 @@ class PostFieldsFactory {
       array_filter(
         $postTypes,
         function(\WP_Post_Type $type): bool {
-          return $type->public;
+          return (bool)$type->public;
         }
       )
     ));


### PR DESCRIPTION


## Description

Please see the ticket for more information [MAILPOET-6299](https://mailpoet.atlassian.net/browse/MAILPOET-6299)

We are making this code change to assist one of our users who has an improperly set custom post-type.

According to wp.org [docs](https://developer.wordpress.org/reference/classes/wp_post_type/), the `public` property should be a boolean.

## Code review notes

_N/A_

## QA notes

We can skip QA

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6299](https://mailpoet.atlassian.net/browse/MAILPOET-6299)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6299]: https://mailpoet.atlassian.net/browse/MAILPOET-6299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAILPOET-6299]: https://mailpoet.atlassian.net/browse/MAILPOET-6299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-error-with-wp_post_type-on-mailpoet-automations)

_The latest successful build from `fix-error-with-wp_post_type-on-mailpoet-automations` will be used. If none is available, the link won't work._