### PR TITLE
Fix adding unsubscribe link to the email [MAILPOET-6254]

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-content-validation.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-content-validation.ts
@@ -3,7 +3,6 @@ import { useCallback, useMemo } from '@wordpress/element';
 import { dispatch, useSelect, subscribe } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { useDebounce } from '@wordpress/compose';
 import { storeName as emailEditorStore } from 'email-editor/engine/store';
 import { useShallowEqual } from './use-shallow-equal';
 import { useValidationNotices } from './use-validation-notices';
@@ -89,14 +88,12 @@ export const useContentValidation = (): ContentValidationData => {
     rules,
   ]);
 
-  const debouncedValidateContent = useDebounce(validateContent, 500);
-
   // Subscribe to updates so notices can be dismissed once resolved.
   subscribe(() => {
     if (!hasValidationNotice()) {
       return;
     }
-    debouncedValidateContent();
+    validateContent();
   }, emailEditorStore);
 
   return {

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-content-validation.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-content-validation.ts
@@ -15,35 +15,6 @@ export type ContentValidationData = {
 
 let contentBlockId;
 
-const rules = [
-  {
-    id: 'missing-unsubscribe-link',
-    test: (content) => !content.includes('[link:subscription_unsubscribe_url]'),
-    message: __('All emails must include an "Unsubscribe" link.', 'mailpoet'),
-    actions: [
-      {
-        label: __('Insert link', 'mailpoet'),
-        onClick: () => {
-          void dispatch(blockEditorStore).insertBlock(
-            createBlock('core/paragraph', {
-              className: 'has-small-font-size',
-              content: `<a href="[link:subscription_unsubscribe_url]">${__(
-                'Unsubscribe',
-                'mailpoet',
-              )}</a> | <a href="[link:subscription_manage_url]">${__(
-                'Manage subscription',
-                'mailpoet',
-              )}</a>`,
-            }),
-            undefined,
-            contentBlockId,
-          );
-        },
-      },
-    ],
-  },
-];
-
 export const useContentValidation = (): ContentValidationData => {
   contentBlockId = useSelect((select) => {
     // @ts-expect-error getBlocksByName is not defined in types
@@ -58,6 +29,36 @@ export const useContentValidation = (): ContentValidationData => {
 
   const content = useShallowEqual(editedContent);
   const templateContent = useShallowEqual(editedTemplateContent);
+
+  const rules = [
+    {
+      id: 'missing-unsubscribe-link',
+      test: (content) =>
+        !content.includes('[link:subscription_unsubscribe_url]'),
+      message: __('All emails must include an "Unsubscribe" link.', 'mailpoet'),
+      actions: [
+        {
+          label: __('Insert link', 'mailpoet'),
+          onClick: () => {
+            void dispatch(blockEditorStore).insertBlock(
+              createBlock('core/paragraph', {
+                className: 'has-small-font-size',
+                content: `<a href="[link:subscription_unsubscribe_url]">${__(
+                  'Unsubscribe',
+                  'mailpoet',
+                )}</a> | <a href="[link:subscription_manage_url]">${__(
+                  'Manage subscription',
+                  'mailpoet',
+                )}</a>`,
+              }),
+              undefined,
+              contentBlockId,
+            );
+          },
+        },
+      ],
+    },
+  ];
 
   const validateContent = useCallback((): boolean => {
     let isValid = true;

--- a/mailpoet/assets/js/src/email-editor/engine/hooks/use-content-validation.ts
+++ b/mailpoet/assets/js/src/email-editor/engine/hooks/use-content-validation.ts
@@ -13,6 +13,8 @@ export type ContentValidationData = {
   validateContent: () => boolean;
 };
 
+let contentBlockId;
+
 const rules = [
   {
     id: 'missing-unsubscribe-link',
@@ -33,6 +35,8 @@ const rules = [
                 'mailpoet',
               )}</a>`,
             }),
+            undefined,
+            contentBlockId,
           );
         },
       },
@@ -41,6 +45,10 @@ const rules = [
 ];
 
 export const useContentValidation = (): ContentValidationData => {
+  contentBlockId = useSelect((select) => {
+    // @ts-expect-error getBlocksByName is not defined in types
+    return select(blockEditorStore).getBlocksByName('core/post-content')?.[0];
+  });
   const { addValidationNotice, hasValidationNotice, removeValidationNotice } =
     useValidationNotices();
   const { editedContent, editedTemplateContent } = useSelect((mapSelect) => ({


### PR DESCRIPTION
## Description

To reproduce

1. Remove the Unsubscribe link
2. Click “Send”
3. See the error message
4. Click “Insert link”

What is expected: A paragraph block to be added to the content with an unsubscribe link and a manage subscription link.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6254]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6254]: https://mailpoet.atlassian.net/browse/MAILPOET-6254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:unsubscribe-link-action-fix)

_The latest successful build from `unsubscribe-link-action-fix` will be used. If none is available, the link won't work._