### PR TITLE
Fix timezone issue when fetching alc posts [MAILPOET-6234]

### DIFF
--- a/mailpoet/lib/Newsletter/BlockPostQuery.php
+++ b/mailpoet/lib/Newsletter/BlockPostQuery.php
@@ -29,7 +29,7 @@ class BlockPostQuery {
   public $newsletterId = false;
 
   /***
-   * Translates to \WP_Query::date_query => array{'column': 'post_date', 'after': date string}
+   * Translates to \WP_Query::date_query => array{'column': 'post_date_gmt', 'after': date string}
    *
    * @var bool|DateTimeInterface|null
    */
@@ -168,10 +168,13 @@ class BlockPostQuery {
     $parameters['suppress_filters'] = false;
 
     if ($this->newerThanTimestamp instanceof DateTimeInterface) {
+      //Ensure UTC timezone
+      $after = new \DateTime('now', new \DateTimeZone('UTC'));
+      $after->setTimestamp($this->newerThanTimestamp->getTimestamp());
       $parameters['date_query'] = [
         [
-          'column' => 'post_date',
-          'after' => $this->newerThanTimestamp->format('Y-m-d H:i:s'),
+          'column' => 'post_date_gmt',
+          'after' => $after->format('Y-m-d H:i:s'),
         ],
       ];
     }


### PR DESCRIPTION
## Description
To figure out whether we have new posts to send in post notifications, we take the date of the last post we did send out and tell WordPress to give us all newer posts. Unfortunately, the date of the last post is a UTC date while the comparator `post_date` is a localized date. This means that e.g. in UTC-7 posts which are published in the seven hours after a post notification is send out will not be in the selection for the next post notification.

This PR fixes this issue.

## Code review notes
1. In L171 I ensure that the date is actually a UTC date. I think that makes sense.
2. In the test I manually update the options to switch into a different timezone. I switch them back before I evaluate the results. Not sure, if you know a better way to do that

## QA notes
1. Setup a WordPress website in UTC-7
3. Create a post notification, sent out immediately
4. Publish a post
5. See the post notification
6. Publish another post in the next 7 hours (can be done immediately)
7. See the beautiful post notification
8. Compare with trunk and 🕺 

## Linked tickets
[MAILPOET-6234]

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-6234]: https://mailpoet.atlassian.net/browse/MAILPOET-6234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ