### PR TITLE
Fix race condition [MAILPOET-6304]

### DIFF
--- a/mailpoet/lib/Statistics/UserAgentsRepository.php
+++ b/mailpoet/lib/Statistics/UserAgentsRepository.php
@@ -22,6 +22,7 @@ class UserAgentsRepository extends Repository {
   public function create(string $userAgent): UserAgentEntity {
     $userAgentEntity = new UserAgentEntity($userAgent);
     $this->persist($userAgentEntity);
+    $this->flush();
     return $userAgentEntity;
   }
 }

--- a/mailpoet/lib/Statistics/UserAgentsRepository.php
+++ b/mailpoet/lib/Statistics/UserAgentsRepository.php
@@ -21,8 +21,17 @@ class UserAgentsRepository extends Repository {
 
   public function create(string $userAgent): UserAgentEntity {
     $userAgentEntity = new UserAgentEntity($userAgent);
-    $this->persist($userAgentEntity);
-    $this->flush();
+
+    $this->entityManager->getConnection()->executeStatement(
+      'INSERT INTO ' . $this->getTableName() . ' (user_agent, hash) VALUES (:user_agent, :hash) ON DUPLICATE KEY UPDATE id = id',
+      [
+        'user_agent' => $userAgentEntity->getUserAgent(),
+        'hash' => $userAgentEntity->getHash(),
+      ]
+    );
+
+    /** @var UserAgentEntity $userAgentEntity */
+    $userAgentEntity = $this->findOneBy(['hash' => $userAgentEntity->getHash()]);
     return $userAgentEntity;
   }
 }

--- a/mailpoet/lib/Statistics/UserAgentsRepository.php
+++ b/mailpoet/lib/Statistics/UserAgentsRepository.php
@@ -16,7 +16,10 @@ class UserAgentsRepository extends Repository {
   public function findOrCreate(string $userAgent): UserAgentEntity {
     $hash = (string)crc32($userAgent);
     $userAgentEntity = $this->findOneBy(['hash' => $hash]);
-    if ($userAgentEntity) return $userAgentEntity;
+    return $userAgentEntity ?? $this->create($userAgent);
+  }
+
+  public function create(string $userAgent): UserAgentEntity {
     $userAgentEntity = new UserAgentEntity($userAgent);
     $this->persist($userAgentEntity);
     return $userAgentEntity;

--- a/mailpoet/tests/integration/Statistics/UserAgentRepositoryTest.php
+++ b/mailpoet/tests/integration/Statistics/UserAgentRepositoryTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Statistics;
+
+class UserAgentRepositoryTest extends \MailPoetTest {
+
+  private $testee;
+
+  public function _before() {
+    $this->testee = $this->diContainer->get(\MailPoet\Statistics\UserAgentsRepository::class);
+  }
+
+  public function testItCreatesAUserAgent() {
+    $userAgent = 'testItCreatesAUserAgent';
+    $userAgentEntity = $this->testee->create($userAgent);
+    verify($userAgentEntity->getUserAgent())->equals($userAgent);
+  }
+
+  public function testItFindsOrCreateUserAgent() {
+    $userAgent = 'testItFindsOrCreateUserAgent';
+    $userAgentEntity = $this->testee->findOrCreate($userAgent);
+    verify($userAgentEntity->getUserAgent())->equals($userAgent);
+
+    $userAgentEntity = $this->testee->findOrCreate($userAgent);
+    verify($userAgentEntity->getUserAgent())->equals($userAgent);
+  }
+
+  public function testItDoesNotFailWhenTryingToCreateAnExistingUserAgent() {
+    $userAgent = 'testItDoesNotFailWhenTryingToCreateAnExistingUserAgent_1';
+    $userAgentEntity = $this->testee->create($userAgent);
+    verify($userAgentEntity->getUserAgent())->equals($userAgent);
+
+    $userAgentEntity = $this->testee->create($userAgent);
+    verify($userAgentEntity->getUserAgent())->equals($userAgent);
+
+    $userAgent = 'testItDoesNotFailWhenTryingToCreateAnExistingUserAgent_2';
+    $userAgentEntity = $this->testee->create($userAgent);
+    verify($userAgentEntity->getUserAgent())->equals($userAgent);
+  }
+}


### PR DESCRIPTION
## Description
It was discovered that the insert from the UserAgent can provoke the attempt to insert duplicate entries. This PR addresses the issue.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6304]
## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6304]: https://mailpoet.atlassian.net/browse/MAILPOET-6304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6304-fix-race-condition)

_The latest successful build from `MAILPOET-6304-fix-race-condition` will be used. If none is available, the link won't work._