### PR TITLE
Email editor - WP 6.7 fixes

### DIFF
--- a/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
+++ b/mailpoet/assets/js/src/email-editor/engine/components/header/header.tsx
@@ -172,14 +172,12 @@ export function Header() {
             />
           </>
         )}
-        {(!isFixedToolbarActive ||
-          !isBlockSelected ||
-          isBlockToolsCollapsed) && (
-          <div className="editor-header__center edit-post-header__center">
-            {hasDocumentNavigationHistory ? <DocumentBar /> : <CampaignName />}
-          </div>
-        )}
       </div>
+      {(!isFixedToolbarActive || !isBlockSelected || isBlockToolsCollapsed) && (
+        <div className="editor-header__center edit-post-header__center">
+          {hasDocumentNavigationHistory ? <DocumentBar /> : <CampaignName />}
+        </div>
+      )}
       <div className="editor-header__settings edit-post-header__settings">
         <SaveButton />
         <PreviewDropdown />

--- a/mailpoet/assets/js/src/email-editor/engine/index.scss
+++ b/mailpoet/assets/js/src/email-editor/engine/index.scss
@@ -5,3 +5,8 @@
   justify-content: center;
   width: 100%;
 }
+
+// Fix editor width. We don't use resizable editor wrapper so we need to set the width manually here
+.editor-visual-editor > div {
+  width: 100%;
+}

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -30,6 +30,7 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Compose an email');
     $i->waitForElement('[name="editor-canvas"]');
+    $i->wait(1); // we need to wait for the iframe to initialize otherwise the switch does not work properly
     $i->switchToIFrame('[name="editor-canvas"]');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
@@ -101,6 +102,7 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Edit an email');
     $i->waitForElement('[name="editor-canvas"]');
+    $i->wait(1); // we need to wait for the iframe to initialize otherwise the switch does not work properly
     $i->switchToIFrame('[name="editor-canvas"]');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');

--- a/packages/php/email-editor/src/Engine/Renderer/template-canvas.css
+++ b/packages/php/email-editor/src/Engine/Renderer/template-canvas.css
@@ -55,6 +55,11 @@ a {
     width: 100% !important;
   }
 
+  /* Ensure proper width of columns on mobile when we set 100% and a border is set */
+  .email-block-column {
+    box-sizing: border-box;
+  }
+
   /* We set width to some tables e.g. for wrappers of horizontally aligned images and we force width 100% on mobile */
   .email-table-with-width {
     width: 100% !important;

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -23,7 +23,7 @@
       "units": ["px"],
       "blockGap": false,
       "padding": true,
-      "margin": true,
+      "margin": false,
       "spacingSizes": [
         {
           "name": "1",

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/Group.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/Group.php
@@ -44,6 +44,7 @@ class Group extends AbstractBlockRenderer {
       'border' => $blockAttributes['style']['border'] ?? [],
       'spacing' => [ 'padding' => $blockAttributes['style']['spacing']['margin'] ?? [] ],
     ])['declarations'];
+    $tableStyles['border-collapse'] = 'separate'; // Needed for the border radius to work.
 
     // Padding properties need to be added to the table cell.
     $cellStyles = $this->getStylesFromBlock([

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/Image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/Image.php
@@ -7,7 +7,7 @@ use MailPoet\EmailEditor\Integrations\Utils\DomDocumentHelper;
 
 class Image extends AbstractBlockRenderer {
   protected function renderContent($blockContent, array $parsedBlock, SettingsController $settingsController): string {
-    $parsedHtml = $this->parseBlockContent($this->cleanupContent($blockContent));
+    $parsedHtml = $this->parseBlockContent($blockContent);
 
     if (!$parsedHtml) {
       return '';
@@ -16,28 +16,31 @@ class Image extends AbstractBlockRenderer {
     $imageUrl = $parsedHtml['imageUrl'];
     $image = $parsedHtml['image'];
     $caption = $parsedHtml['caption'];
-
+    $class = $parsedHtml['class'];
     $parsedBlock = $this->addImageSizeWhenMissing($parsedBlock, $imageUrl, $settingsController);
     $image = $this->addImageDimensions($image, $parsedBlock, $settingsController);
-    $image = $this->applyImageBorderStyle($image, $parsedBlock, $settingsController);
-    $image = $this->applyRoundedStyle($image, $parsedBlock);
 
-    return str_replace(
+    $imageWithWrapper = str_replace(
       ['{image_content}', '{caption_content}'],
       [$image, $caption],
       $this->getBlockWrapper($parsedBlock, $settingsController)
     );
+
+    $imageWithWrapper = $this->applyRoundedStyle($imageWithWrapper, $parsedBlock);
+    $imageWithWrapper = $this->applyImageBorderStyle($imageWithWrapper, $parsedBlock, $class);
+    return $imageWithWrapper;
   }
 
   private function applyRoundedStyle(string $blockContent, array $parsedBlock): string {
     // Because the isn't an attribute for definition of rounded style, we have to check the class name
     if (isset($parsedBlock['attrs']['className']) && strpos($parsedBlock['attrs']['className'], 'is-style-rounded') !== false) {
       // If the image should be in a circle, we need to set the border-radius to 9999px to make it the same as is in the editor
-      // This style cannot be applied on the wrapper, and we need to set it directly on the image
+      // This style is applied to both wrapper and the image
+      $blockContent = $this->removeStyleAttributeFromElement($blockContent, ['tag_name' => 'td', 'class_name' => 'email-image-cell'], 'border-radius');
+      $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'td', 'class_name' => 'email-image-cell'], 'border-radius: 9999px;');
       $blockContent = $this->removeStyleAttributeFromElement($blockContent, ['tag_name' => 'img'], 'border-radius');
       $blockContent = $this->addStyleToElement($blockContent, ['tag_name' => 'img'], 'border-radius: 9999px;');
     }
-
     return $blockContent;
   }
 
@@ -55,19 +58,14 @@ class Image extends AbstractBlockRenderer {
     $maxWidth = $settingsController->parseNumberFromStringWithPixels($parsedBlock['email_attrs']['width']);
     $imageSize = wp_getimagesize($imageUrl);
     $imageSize = $imageSize ? $imageSize[0] : $maxWidth;
-    // Because width is primarily used for the max-width property, we need to add the left and right border width to it
-    $borderWidth = $parsedBlock['attrs']['style']['border']['width'] ?? '0px';
-    $borderLeftWidth = $parsedBlock['attrs']['style']['border']['left']['width'] ?? $borderWidth;
-    $borderRightWidth = $parsedBlock['attrs']['style']['border']['right']['width'] ?? $borderWidth;
     $width = min($imageSize, $maxWidth);
-    $width += $settingsController->parseNumberFromStringWithPixels($borderLeftWidth ?? '0px');
-    $width += $settingsController->parseNumberFromStringWithPixels($borderRightWidth ?? '0px');
     $parsedBlock['attrs']['width'] = "{$width}px";
     return $parsedBlock;
 
   }
 
-  private function applyImageBorderStyle(string $blockContent, array $parsedBlock, SettingsController $settingsController): string {
+  private function applyImageBorderStyle(string $blockContent, array $parsedBlock, string $class): string {
+
     // Getting individual border properties
     $borderStyles = wp_style_engine_get_styles(['border' => $parsedBlock['attrs']['style']['border'] ?? []]);
     $borderStyles = $borderStyles['declarations'] ?? [];
@@ -75,8 +73,19 @@ class Image extends AbstractBlockRenderer {
       $borderStyles['border-style'] = 'solid';
       $borderStyles['box-sizing'] = 'border-box';
     }
-
-    return $this->addStyleToElement($blockContent, ['tag_name' => 'img'], \WP_Style_Engine::compile_css($borderStyles, ''));
+    $borderElementTag = ['tag_name' => 'td', 'class_name' => 'email-image-cell'];
+    $contentWithBorderStyles = $this->addStyleToElement($blockContent, $borderElementTag, \WP_Style_Engine::compile_css($borderStyles, ''));
+    // Add Border related classes to proper element. This is required for inlined border-color styles when defined via class
+    $borderClasses = array_filter(explode(' ', $class), function($className) {
+      return strpos($className, 'border') !== false;
+    });
+    $html = new \WP_HTML_Tag_Processor($contentWithBorderStyles);
+    if ($html->next_tag($borderElementTag)) {
+      $class = $html->get_attribute('class') ?? '';
+      $borderClasses[] = $class;
+      $html->set_attribute('class', implode(' ', $borderClasses));
+    }
+    return $html->get_updated_html();
   }
 
   /**
@@ -112,7 +121,7 @@ class Image extends AbstractBlockRenderer {
     $themeData = $settingsController->getTheme()->get_data();
 
     $styles = [
-      'text-align' => 'center',
+      'text-align' => isset($parsedBlock['attrs']['align']) ? 'center' : 'left',
     ];
 
     $styles['font-size'] = $parsedBlock['email_attrs']['font-size'] ?? $themeData['styles']['typography']['fontSize'];
@@ -131,11 +140,16 @@ class Image extends AbstractBlockRenderer {
       'width' => '100%',
     ];
 
-    // When the image is not aligned, the wrapper is set to 100% width due to caption that can be longer than the image
-    $wrapperWidth = isset($parsedBlock['attrs']['align']) ? ($parsedBlock['attrs']['width'] ?? '100%') : '100%';
+    $width = $parsedBlock['attrs']['width'] ?? '100%';
+    $wrapperWidth = ($width && $width !== '100%') ? $width : 'auto';
     $wrapperStyles = $styles;
     $wrapperStyles['width'] = $wrapperWidth;
+    $wrapperStyles['border-collapse'] = 'separate'; // Needed because of border radius
 
+    // When the image is not aligned, the wrapper is set to 100% width due to caption that can be longer than the image
+    $captionWidth = isset($parsedBlock['attrs']['align']) ? ($parsedBlock['attrs']['width'] ?? '100%') : '100%';
+    $captionWrapperStyles = $styles;
+    $captionWrapperStyles['width'] = $captionWidth;
     $captionStyles = $this->getCaptionStyles($settingsController, $parsedBlock);
 
     $styles['width'] = '100%';
@@ -162,11 +176,21 @@ class Image extends AbstractBlockRenderer {
               width="' . esc_attr($wrapperWidth) . '"
             >
               <tr>
-                <td>{image_content}</td>
+                <td class="email-image-cell">{image_content}</td>
               </tr>
+            </table>
+            <table
+              role="presentation"
+              class="email-table-with-width"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              style="' . esc_attr(\WP_Style_Engine::compile_css($captionWrapperStyles, '')) . '"
+              width="' . esc_attr($captionWidth) . '"
+            >
               <tr>
-                <td style="' . esc_attr($captionStyles) . '">{caption_content}</td>
-              </tr>
+                  <td style="' . esc_attr($captionStyles) . '">{caption_content}</td>
+               </tr>
             </table>
           </td>
         </tr>
@@ -229,21 +253,21 @@ class Image extends AbstractBlockRenderer {
     }
 
     $imageSrc = $domHelper->getAttributeValue($imgTag, 'src');
+    $imageClass = $domHelper->getAttributeValue($imgTag, 'class');
     $imageHtml = $domHelper->getOuterHtml($imgTag);
-
     $figcaption = $domHelper->findElement('figcaption');
     $figcaptionHtml = $figcaption ? $domHelper->getOuterHtml($figcaption) : '';
     $figcaptionHtml = str_replace(['<figcaption', '</figcaption>'], ['<span', '</span>'], $figcaptionHtml);
 
-
     return [
       'imageUrl' => $imageSrc ?: '',
-      'image' => $imageHtml,
+      'image' => $this->cleanupImageHtml($imageHtml),
       'caption' => $figcaptionHtml ?: '',
+      'class' => $imageClass ?: '',
     ];
   }
 
-  private function cleanupContent(string $contentHtml): string {
+  private function cleanupImageHtml(string $contentHtml): string {
     $html = new \WP_HTML_Tag_Processor($contentHtml);
     if ($html->next_tag(['tag_name' => 'img'])) {
       $html->remove_attribute('srcset');

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/Text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/Text.php
@@ -25,7 +25,10 @@ class Text extends AbstractBlockRenderer {
       $blockClasses = $html->get_attribute('class') ?? '';
       $classes .= ' ' . $blockClasses;
       // remove has-background to prevent double padding applied for wrapper and inner element
-      $html->set_attribute('class', str_replace('has-background', '', $blockClasses));
+      $blockClasses = str_replace('has-background', '', $blockClasses);
+      // remove border related classes because we handle border on wrapping table cell
+      $blockClasses = preg_replace('/[a-z-]+-border-[a-z-]+/', '', $blockClasses);
+      $html->set_attribute('class', trim($blockClasses));
       $blockContent = $html->get_updated_html();
     }
 
@@ -33,6 +36,7 @@ class Text extends AbstractBlockRenderer {
       'color' => $blockAttributes['style']['color'] ?? [],
       'spacing' => $blockAttributes['style']['spacing'] ?? [],
       'typography' => $blockAttributes['style']['typography'] ?? [],
+      'border' => $blockAttributes['style']['border'] ?? [],
     ]);
 
     $styles = [
@@ -47,6 +51,7 @@ class Text extends AbstractBlockRenderer {
     }
 
     $compiledStyles = $this->compileCss($blockStyles['declarations'], $styles);
+    $tableStyles = 'border-collapse: separate;'; // Needed because of border radius
 
     return sprintf(
       '<table
@@ -55,11 +60,13 @@ class Text extends AbstractBlockRenderer {
             cellpadding="0"
             cellspacing="0"
             width="100%%"
+            style="%1$s"
           >
             <tr>
-              <td class="%1$s" style="%2$s" align="%3$s">%4$s</td>
+              <td class="%2$s" style="%3$s" align="%4$s">%5$s</td>
             </tr>
           </table>',
+      esc_attr($tableStyles),
       esc_attr($classes),
       esc_attr($compiledStyles),
       esc_attr($styles['text-align'] ?? 'left'),
@@ -80,6 +87,9 @@ class Text extends AbstractBlockRenderer {
       $elementStyle = $html->get_attribute('style') ?? '';
       // Padding may contain value like 10px or variable like var(--spacing-10)
       $elementStyle = preg_replace('/padding[^:]*:.?[0-9a-z-()]+;?/', '', $elementStyle);
+
+      // Remove border styles. We apply border styles on the wrapping table cell
+      $elementStyle = preg_replace('/border[^:]*:.?[0-9a-z-()#]+;?/', '', $elementStyle);
 
       // We define the font-size on the wrapper element, but we need to keep font-size definition here
       // to prevent CSS Inliner from adding a default value and overriding the value set by user, which is on the wrapper element.

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/ImageTest.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/ImageTest.php
@@ -96,4 +96,45 @@ class ImageTest extends \MailPoetTest {
     $this->assertStringContainsString('height:300px;', $rendered);
     $this->assertStringContainsString('width:400px;', $rendered);
   }
+
+  public function testItRendersBorders(): void {
+    $imageContent = $this->imageContent;
+    $parsedImage = $this->parsedImage;
+    $parsedImage['attrs']['style']['border'] = [
+      'width' => '10px',
+      'color' => '#000001',
+      'radius' => '20px',
+    ];
+
+    $rendered = $this->imageRenderer->render($imageContent, $parsedImage, $this->settingsController);
+    $html = new \WP_HTML_Tag_Processor($rendered);
+    // Border is rendered on the wrapping table cell
+    $html->next_tag(['tag_name' => 'td', 'class_name' => 'email-image-cell']);
+    $tableCellStyle = $html->get_attribute('style');
+    $this->assertStringContainsString('border-color:#000001', $tableCellStyle);
+    $this->assertStringContainsString('border-radius:20px', $tableCellStyle);
+    $this->assertStringContainsString('border-style:solid;', $tableCellStyle);
+    $html->next_tag(['tag_name' => 'img']);
+    $imgStyle = $html->get_attribute('style');
+    $this->assertStringNotContainsString('border', $imgStyle);
+  }
+
+  public function testItMovesBorderRelatedClasses(): void {
+    $imageContent = str_replace('<img', '<img class="custom-class has-border-color has-border-red-color"',$this->imageContent);
+    $parsedImage = $this->parsedImage;
+    $parsedImage['attrs']['style']['border'] = [
+      'width' => '10px',
+      'color' => '#000001',
+      'radius' => '20px',
+    ];
+
+    $rendered = $this->imageRenderer->render($imageContent, $parsedImage, $this->settingsController);
+    $html = new \WP_HTML_Tag_Processor($rendered);
+    // Border is rendered on the wrapping table cell and the border classes are moved to the wrapping table cell
+    $html->next_tag(['tag_name' => 'td', 'class_name' => 'email-image-cell']);
+    $tableCellClass = $html->get_attribute('class');
+    $this->assertStringContainsString('has-border-red-color', $tableCellClass);
+    $this->assertStringContainsString('has-border-color', $tableCellClass);
+    $this->assertStringNotContainsString('custom-class', $tableCellClass);
+  }
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/ParagraphTest.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/ParagraphTest.php
@@ -62,6 +62,36 @@ class ParagraphTest extends \MailPoetTest {
     $this->assertStringContainsString('Lorem Ipsum', $rendered);
   }
 
+  public function testItRendersBorders(): void {
+    $parsedParagraph = $this->parsedParagraph;
+    $parsedParagraph['attrs']['style']['border']['width'] = '10px';
+    $parsedParagraph['attrs']['style']['border']['color'] = '#000001';
+    $parsedParagraph['attrs']['style']['border']['radius'] = '20px';
+
+    $content = '<p class="has-border-color test-class has-red-border-color">Lorem Ipsum</p>';
+    $parsedParagraph['innerHTML'] = $content;
+    $parsedParagraph['innerContent'] = [$content];
+
+    $rendered = $this->paragraphRenderer->render($content, $parsedParagraph, $this->settingsController);
+    $html = new \WP_HTML_Tag_Processor($rendered);
+    $html->next_tag(['tag_name' => 'table']);
+    $tableStyle = $html->get_attribute('style');
+    // Table needs to have border-collapse: separate to make border-radius work
+    $this->assertStringContainsString('border-collapse: separate', $tableStyle);
+    $html->next_tag(['tag_name' => 'td']);
+    $tableCellStyle = $html->get_attribute('style');
+    // Border styles are applied to the table cell
+    $this->assertStringContainsString('border-color:#000001', $tableCellStyle);
+    $this->assertStringContainsString('border-radius:20px', $tableCellStyle);
+    $this->assertStringContainsString('border-width:10px', $tableCellStyle);
+    $tableCellClasses = $html->get_attribute('class');
+    $this->assertStringContainsString('has-border-color test-class has-red-border-color', $tableCellClasses);
+    $html->next_tag(['tag_name' => 'p']);
+    // There are no border styles on the paragraph
+    $paragraphStyle = $html->get_attribute('style');
+    $this->assertStringNotContainsString('border', $paragraphStyle);
+  }
+
   public function testItConvertsBlockTypography(): void {
     $parsedParagraph = $this->parsedParagraph;
     $parsedParagraph['attrs']['style']['typography'] = [


### PR DESCRIPTION
## Description

This PR contains the following changes:
- fixes visual issues in the editor present with WP 6.7 RC
- disables margins globally - they are not supported in the renderer
- adds/fixes border support for supported blocks
- fixes acceptance test for WP 6.7

## Code review notes

As for now, there is not a new lock/unlock message available, so I didn't add it. 

## QA notes

I guess we can skip it as we do with other editor tickets for now.
## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6280]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/wp-6-7-fixes)

_The latest successful build from `email-editor/wp-6-7-fixes` will be used. If none is available, the link won't work._

[MAILPOET-6280]: https://mailpoet.atlassian.net/browse/MAILPOET-6280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ