### PR TITLE
Add reCAPTCHA to WP & WC registration form [MAILPOET-6282]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       NPM_CONFIG_CACHE: '/tmp/.npm'
       XDG_CACHE_HOME: '/tmp/.cache'
       MAILPOET_DEV_SITE: 1
+      MP_ENV: development
     volumes:
       - './wordpress:/var/www/html'
       - './tsconfig.base.json:/var/www/html/wp-content/plugins/tsconfig.base.json:ro'
@@ -79,6 +80,7 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       PHP_IDE_CONFIG: 'serverName=Mailpoet'
+      MP_ENV: test
     volumes:
       - './mailpoet:/var/www/html/wp-content/plugins/mailpoet'
       - './mailpoet-premium:/var/www/html/wp-content/plugins/mailpoet-premium'

--- a/mailpoet/assets/css/src/components-public/captcha.scss
+++ b/mailpoet/assets/css/src/components-public/captcha.scss
@@ -10,3 +10,10 @@
     }
   }
 }
+
+// WP registration form
+form#registerform .g-recaptcha:not([data-size='invisible']) {
+  scale: 0.9;
+  -webkit-transform-origin: 0 0;
+  transform-origin: 0 0;
+}

--- a/mailpoet/assets/css/src/components-public/captcha.scss
+++ b/mailpoet/assets/css/src/components-public/captcha.scss
@@ -17,3 +17,8 @@ form#registerform .g-recaptcha:not([data-size='invisible']) {
   -webkit-transform-origin: 0 0;
   transform-origin: 0 0;
 }
+
+// WC registration form
+form.woocommerce-form-register .g-recaptcha {
+  padding-inline-start: 3px;
+}

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -167,6 +167,7 @@ interface Window {
   mailpoet_urls: Record<string, string>;
   recaptcha?: unknown;
   grecaptcha?: any;
+  onInvisibleReCaptchaSubmit?: () => void;
   MailPoetForm?: {
     ajax_url: string;
     ajax_common_error_message: string;

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -527,5 +527,21 @@ jQuery(($) => {
       }
       $('.mailpoet-manage-subscription .mailpoet-submit-success').hide();
     });
+
+    // reCAPTCHA on WP registration form
+    if ($('.g-recaptcha[data-size="invisible"]').length) {
+      const wpRegisterForm: JQuery<HTMLFormElement> = $('form#registerform');
+      if (wpRegisterForm.length) {
+        wpRegisterForm.parsley().on('form:submit', () => {
+          void grecaptcha.execute();
+          return false; // disable submission
+        });
+
+        // Triggered by invisible reCAPTCHA
+        window.onInvisibleReCaptchaSubmit = () => {
+          wpRegisterForm[0].submit();
+        };
+      }
+    }
   })();
 });

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -536,10 +536,13 @@ jQuery(($) => {
       );
 
       let registerForm: JQuery<HTMLFormElement>;
+      let submitInput: object;
       if (wpRegisterForm.length) {
         registerForm = wpRegisterForm;
+        submitInput = { type: 'hidden', name: 'wp-submit', value: 'Register' };
       } else if (wcRegisterForm.length) {
         registerForm = wcRegisterForm;
+        submitInput = { type: 'hidden', name: 'register', value: 'Register' };
       }
 
       if (registerForm) {
@@ -550,6 +553,11 @@ jQuery(($) => {
 
         // Triggered by invisible reCAPTCHA
         window.onInvisibleReCaptchaSubmit = () => {
+          // A workaround to include the submit button's field in form data.
+          // This field is included when the form is submitted by the user.
+          // Yet, it is omitted when the form is submitted programmatically.
+          $('<input>').attr(submitInput).appendTo(registerForm);
+
           registerForm[0].submit();
         };
       }

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -536,13 +536,13 @@ jQuery(($) => {
       );
 
       let registerForm: JQuery<HTMLFormElement>;
-      let submitInput: object;
+      let submitBtnSelector: string;
       if (wpRegisterForm.length) {
         registerForm = wpRegisterForm;
-        submitInput = { type: 'hidden', name: 'wp-submit', value: 'Register' };
+        submitBtnSelector = 'input[type="submit"]';
       } else if (wcRegisterForm.length) {
         registerForm = wcRegisterForm;
-        submitInput = { type: 'hidden', name: 'register', value: 'Register' };
+        submitBtnSelector = 'button[type="submit"]';
       }
 
       if (registerForm) {
@@ -556,7 +556,15 @@ jQuery(($) => {
           // A workaround to include the submit button's field in form data.
           // This field is included when the form is submitted by the user.
           // Yet, it is omitted when the form is submitted programmatically.
-          $('<input>').attr(submitInput).appendTo(registerForm);
+          const field = registerForm.find(
+            submitBtnSelector,
+          )[0] as HTMLButtonElement;
+          const attrs = {
+            type: 'hidden',
+            name: field.name,
+            value: field.value,
+          };
+          $('<input>').attr(attrs).appendTo(registerForm);
 
           registerForm[0].submit();
         };

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -528,18 +528,29 @@ jQuery(($) => {
       $('.mailpoet-manage-subscription .mailpoet-submit-success').hide();
     });
 
-    // reCAPTCHA on WP registration form
+    // reCAPTCHA on WP & WC registration form
     if ($('.g-recaptcha[data-size="invisible"]').length) {
       const wpRegisterForm: JQuery<HTMLFormElement> = $('form#registerform');
+      const wcRegisterForm: JQuery<HTMLFormElement> = $(
+        'form.woocommerce-form-register',
+      );
+
+      let registerForm: JQuery<HTMLFormElement>;
       if (wpRegisterForm.length) {
-        wpRegisterForm.parsley().on('form:submit', () => {
+        registerForm = wpRegisterForm;
+      } else if (wcRegisterForm.length) {
+        registerForm = wcRegisterForm;
+      }
+
+      if (registerForm) {
+        registerForm.parsley().on('form:submit', () => {
           void grecaptcha.execute();
           return false; // disable submission
         });
 
         // Triggered by invisible reCAPTCHA
         window.onInvisibleReCaptchaSubmit = () => {
-          wpRegisterForm[0].submit();
+          registerForm[0].submit();
         };
       }
     }

--- a/mailpoet/lib/Captcha/ReCaptchaRenderer.php
+++ b/mailpoet/lib/Captcha/ReCaptchaRenderer.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Captcha;
+
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha\CaptchaConstants;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ReCaptchaRenderer {
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    SettingsController $settings,
+    WPFunctions $wp
+  ) {
+    $this->settings = $settings;
+    $this->wp = $wp;
+  }
+
+  public function render(): string {
+    $captchaSettings = $this->settings->get('captcha');
+    $isInvisible = $captchaSettings['type'] === CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE;
+
+    if ($isInvisible) {
+      $siteKey = $this->wp->escAttr($captchaSettings['recaptcha_invisible_site_token']);
+      $html = '<div class="g-recaptcha" data-size="invisible" data-callback="onInvisibleReCaptchaSubmit" data-sitekey="' . $siteKey . '"></div>';
+    } else {
+      $siteKey = $this->wp->escAttr($captchaSettings['recaptcha_site_token']);
+      $html = '<div class="g-recaptcha" data-sitekey="' . $siteKey . '"></div>';
+    }
+
+    return $html;
+  }
+}

--- a/mailpoet/lib/Captcha/ReCaptchaValidator.php
+++ b/mailpoet/lib/Captcha/ReCaptchaValidator.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Captcha;
+
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha\CaptchaConstants;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ReCaptchaValidator {
+
+  private const ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify';
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function __construct(
+    WPFunctions $wp,
+    SettingsController $settings
+  ) {
+    $this->wp = $wp;
+    $this->settings = $settings;
+  }
+
+  /**
+   * @throws \Exception response token is missing or invalid.
+   */
+  public function validate(string $responseToken) {
+    $captchaSettings = $this->settings->get('captcha');
+    if (empty($responseToken)) {
+      throw new \Exception(__('Please check the CAPTCHA.', 'mailpoet'));
+    }
+
+    $secretToken = $captchaSettings['type'] === CaptchaConstants::TYPE_RECAPTCHA
+      ? $captchaSettings['recaptcha_secret_token']
+      : $captchaSettings['recaptcha_invisible_secret_token'];
+
+    $response = $this->wp->wpRemotePost(self::ENDPOINT, [
+      'body' => [
+        'secret' => $secretToken,
+        'response' => $responseToken,
+      ],
+    ]);
+
+    if ($this->wp->isWpError($response)) {
+      throw new \Exception(__('Error while validating the CAPTCHA.', 'mailpoet'));
+    }
+
+    /** @var \stdClass $response */
+    $response = json_decode($this->wp->wpRemoteRetrieveBody($response));
+    if (empty($response->success)) {
+      throw new \Exception(__('Invalid CAPTCHA. Try again.', 'mailpoet'));
+    }
+  }
+}

--- a/mailpoet/lib/Captcha/ReCaptchaValidator.php
+++ b/mailpoet/lib/Captcha/ReCaptchaValidator.php
@@ -50,7 +50,9 @@ class ReCaptchaValidator {
 
     /** @var \stdClass $response */
     $response = json_decode($this->wp->wpRemoteRetrieveBody($response));
-    if (empty($response->success)) {
+    if ($response === null) { // invalid JSON
+      throw new \Exception(__('Error while validating the CAPTCHA.', 'mailpoet'));
+    } else if (empty($response->success)) { // missing or false
       throw new \Exception(__('Invalid CAPTCHA. Try again.', 'mailpoet'));
     }
   }

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -250,6 +250,24 @@ class Hooks {
         10,
         3
       );
+
+      // reCAPTCHA on WC registration form
+      if (class_exists('WooCommerce')) {
+        $this->wp->addAction(
+          'woocommerce_before_customer_login_form',
+          [$this->reCaptcha, 'enqueueScripts']
+        );
+
+        $this->wp->addAction(
+          'woocommerce_register_form',
+          [$this->reCaptcha, 'render']
+        );
+
+        $this->wp->addAction(
+          'woocommerce_process_registration_errors',
+          [$this->reCaptcha, 'validate']
+        );
+      }
     }
 
     // Manage subscription

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -13,6 +13,7 @@ use MailPoet\Subscription\Comment;
 use MailPoet\Subscription\Form;
 use MailPoet\Subscription\Manage;
 use MailPoet\Subscription\Registration;
+use MailPoet\WooCommerce\Helper as WooHelper;
 use MailPoet\WooCommerce\Integrations\AutomateWooHooks;
 use MailPoet\WooCommerce\Subscription;
 use MailPoet\WooCommerce\WooSystemInfoController;
@@ -88,6 +89,9 @@ class Hooks {
   /** @var CronTrigger */
   private $cronTrigger;
 
+  /** @var WooHelper */
+  private $wooHelper;
+
   public function __construct(
     Form $subscriptionForm,
     Comment $subscriptionComment,
@@ -106,7 +110,8 @@ class Hooks {
     DotcomLicenseProvisioner $dotcomLicenseProvisioner,
     AutomateWooHooks $automateWooHooks,
     WooSystemInfoController $wooSystemInfoController,
-    CronTrigger $cronTrigger
+    CronTrigger $cronTrigger,
+    WooHelper $wooHelper
   ) {
     $this->subscriptionForm = $subscriptionForm;
     $this->subscriptionComment = $subscriptionComment;
@@ -126,6 +131,7 @@ class Hooks {
     $this->automateWooHooks = $automateWooHooks;
     $this->wooSystemInfoController = $wooSystemInfoController;
     $this->cronTrigger = $cronTrigger;
+    $this->wooHelper = $wooHelper;
   }
 
   public function init() {
@@ -252,7 +258,7 @@ class Hooks {
       );
 
       // reCAPTCHA on WC registration form
-      if (class_exists('WooCommerce')) {
+      if ($this->wooHelper->isWooCommerceActive()) {
         $this->wp->addAction(
           'woocommerce_before_customer_login_form',
           [$this->reCaptcha, 'enqueueScripts']

--- a/mailpoet/lib/Config/HooksReCaptcha.php
+++ b/mailpoet/lib/Config/HooksReCaptcha.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\Captcha\ReCaptchaRenderer;
+use MailPoet\Captcha\ReCaptchaValidator;
+use MailPoet\Config\Renderer as BasicRenderer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha\CaptchaConstants;
+use MailPoet\WP\Functions as WPFunctions;
+
+class HooksReCaptcha {
+
+  const RECAPTCHA_LIB_URL = 'https://www.google.com/recaptcha/api.js';
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var BasicRenderer */
+  private $renderer;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var ReCaptchaValidator */
+  private $reCaptchaValidator;
+
+  /** @var ReCaptchaRenderer */
+  private $reCaptchaRenderer;
+
+  public function __construct(
+    WPFunctions $wp,
+    BasicRenderer $renderer,
+    SettingsController $settings,
+    ReCaptchaValidator $reCaptchaValidator,
+    ReCaptchaRenderer $reCaptchaRenderer
+  ) {
+    $this->wp = $wp;
+    $this->renderer = $renderer;
+    $this->settings = $settings;
+    $this->reCaptchaValidator = $reCaptchaValidator;
+    $this->reCaptchaRenderer = $reCaptchaRenderer;
+  }
+
+  public function isEnabled(): bool {
+    // A transient code to enable incremental development of the feature.
+    // Later when a setting is introduced, this function will be adjusted.
+    if (!in_array(getenv('MP_ENV'), ['development', 'test'])) {
+      return false;
+    }
+
+    return CaptchaConstants::isReCaptcha(
+      $this->settings->get('captcha.type')
+    );
+  }
+
+  public function enqueueScripts() {
+    $this->wp->wpEnqueueScript('mailpoet_recaptcha', self::RECAPTCHA_LIB_URL);
+
+    $this->wp->wpEnqueueStyle(
+      'mailpoet_public',
+      Env::$assetsUrl . '/dist/css/' . $this->renderer->getCssAsset('mailpoet-public.css')
+    );
+
+    $this->wp->wpEnqueueScript(
+      'mailpoet_public',
+      Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('public.js'),
+      ['jquery'],
+      Env::$version,
+      [
+        'in_footer' => true,
+        'strategy' => 'defer',
+      ]
+    );
+
+    // necessary for public.js script
+    $ajaxFailedErrorMessage = __('An error has happened while performing a request, please try again later.', 'mailpoet');
+    $this->wp->wpLocalizeScript('mailpoet_public', 'MailPoetForm', [
+      'ajax_url' => $this->wp->adminUrl('admin-ajax.php'),
+      'is_rtl' => (function_exists('is_rtl') && is_rtl()),
+      'ajax_common_error_message' => esc_js($ajaxFailedErrorMessage),
+    ]);
+  }
+
+  public function render() {
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo $this->reCaptchaRenderer->render();
+  }
+
+  public function validate(\WP_Error $errors) {
+    try {
+      // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+      $responseToken = $_POST['g-recaptcha-response'] ?? '';
+      $this->reCaptchaValidator->validate($responseToken);
+    } catch (\Throwable $e) {
+      $errors->add('recaptcha_failed', $e->getMessage());
+    }
+
+    return $errors;
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -672,6 +672,10 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cache\TransientCache::class)->setPublic(true);
     // Tags
     $container->autowire(\MailPoet\Tags\TagRepository::class)->setPublic(true);
+    // CAPTCHA
+    $container->autowire(\MailPoet\Config\HooksReCaptcha::class)->setPublic(true);
+    $container->autowire(\MailPoet\Captcha\ReCaptchaValidator::class)->setPublic(true);
+    $container->autowire(\MailPoet\Captcha\ReCaptchaRenderer::class)->setPublic(true);
     return $container;
   }
 

--- a/mailpoet/lib/Subscription/Captcha/Validator/BuiltInCaptchaValidator.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/BuiltInCaptchaValidator.php
@@ -10,19 +10,19 @@ use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
 
 class BuiltInCaptchaValidator implements CaptchaValidator {
-  /** @var SubscriptionUrlFactory  */
+  /** @var SubscriptionUrlFactory */
   private $subscriptionUrlFactory;
 
-  /** @var CaptchaPhrase  */
+  /** @var CaptchaPhrase */
   private $captchaPhrase;
 
-  /** @var WPFunctions  */
+  /** @var WPFunctions */
   private $wp;
 
-  /** @var SubscriberIPsRepository  */
+  /** @var SubscriberIPsRepository */
   private $subscriberIPsRepository;
 
-  /** @var SubscribersRepository  */
+  /** @var SubscribersRepository */
   private $subscribersRepository;
 
   public function __construct(
@@ -81,7 +81,6 @@ class BuiltInCaptchaValidator implements CaptchaValidator {
     }
 
     return true;
-
   }
 
   public function isRequired($subscriberEmail = null) {

--- a/mailpoet/lib/Subscription/Captcha/Validator/RecaptchaValidator.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/RecaptchaValidator.php
@@ -2,49 +2,26 @@
 
 namespace MailPoet\Subscription\Captcha\Validator;
 
-use MailPoet\Settings\SettingsController;
-use MailPoet\Subscription\Captcha\CaptchaConstants;
-use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\Captcha\ReCaptchaValidator as Validator;
 
 class RecaptchaValidator implements CaptchaValidator {
 
-  /** @var SettingsController */
-  private $settings;
-
-  /** @var WPFunctions */
-  private $wp;
-
-  private const ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify';
+  /** @var Validator */
+  private $validator;
 
   public function __construct(
-    SettingsController $settings,
-    WPFunctions $wp
+    Validator $validator
   ) {
-    $this->settings = $settings;
-    $this->wp = $wp;
+    $this->validator = $validator;
   }
 
   public function validate(array $data): bool {
-    $captchaSettings = $this->settings->get('captcha');
-    if (empty($data['recaptchaResponseToken'])) {
-      throw new ValidationError(__('Please check the CAPTCHA.', 'mailpoet'));
-    }
+    $token = $data['recaptchaResponseToken'] ?? '';
 
-    $secretToken = $captchaSettings['type'] === CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE ? $captchaSettings['recaptcha_invisible_secret_token'] : $captchaSettings['recaptcha_secret_token'];
-
-    $response = $this->wp->wpRemotePost(self::ENDPOINT, [
-      'body' => [
-        'secret' => $secretToken,
-        'response' => $data['recaptchaResponseToken'],
-      ],
-    ]);
-    if ($this->wp->isWpError($response)) {
-      throw new ValidationError(__('Error while validating the CAPTCHA.', 'mailpoet'));
-    }
-    /** @var \stdClass $response */
-    $response = json_decode($this->wp->wpRemoteRetrieveBody($response));
-    if (empty($response->success)) {
-      throw new ValidationError(__('Error while validating the CAPTCHA.', 'mailpoet'));
+    try {
+      $this->validator->validate($token);
+    } catch (\Exception $e) {
+      throw new ValidationError($e->getMessage());
     }
 
     return true;

--- a/mailpoet/lib/Subscription/Captcha/Validator/RecaptchaValidator.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/RecaptchaValidator.php
@@ -8,11 +8,10 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class RecaptchaValidator implements CaptchaValidator {
 
-
-  /** @var SettingsController  */
+  /** @var SettingsController */
   private $settings;
 
-  /** @var WPFunctions  */
+  /** @var WPFunctions */
   private $wp;
 
   private const ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify';
@@ -26,7 +25,6 @@ class RecaptchaValidator implements CaptchaValidator {
   }
 
   public function validate(array $data): bool {
-
     $captchaSettings = $this->settings->get('captcha');
     if (empty($data['recaptchaResponseToken'])) {
       throw new ValidationError(__('Please check the CAPTCHA.', 'mailpoet'));

--- a/mailpoet/lib/Subscription/Captcha/Validator/ValidationError.php
+++ b/mailpoet/lib/Subscription/Captcha/Validator/ValidationError.php
@@ -4,7 +4,6 @@ namespace MailPoet\Subscription\Captcha\Validator;
 
 class ValidationError extends \RuntimeException {
 
-
   private $meta = [];
 
   public function __construct(

--- a/mailpoet/lib/Subscription/Form.php
+++ b/mailpoet/lib/Subscription/Form.php
@@ -30,13 +30,13 @@ class Form {
     $response = $this->api->processRoute();
     if ($response->status !== APIResponse::STATUS_OK) {
       return (isset($response->meta['redirect_url'])) ?
-      $this->urlHelper->redirectTo($response->meta['redirect_url']) :
-      $this->urlHelper->redirectBack(
-        [
-          'mailpoet_error' => ($formId) ? $formId : true,
-          'mailpoet_success' => null,
-        ]
-      );
+        $this->urlHelper->redirectTo($response->meta['redirect_url']) :
+        $this->urlHelper->redirectBack(
+          [
+            'mailpoet_error' => ($formId) ? $formId : true,
+            'mailpoet_success' => null,
+          ]
+        );
     } else {
       return (isset($response->meta['redirect_url'])) ?
         $this->urlHelper->redirectTo($response->meta['redirect_url']) :

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -86,7 +86,7 @@ class Manage {
       $this->urlHelper->redirectBack();
     }
 
-    $sanitize = function($value) {
+    $sanitize = function ($value) {
       if (is_array($value)) {
         foreach ($value as $k => $v) {
           $value[sanitize_text_field($k)] = sanitize_text_field($v);

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -124,7 +124,7 @@ class ManageSubscriptionFormRenderer {
 
       $customFieldValues[$customField->getId()] = $subscriberCustomField->getValue();
     }
-    return array_map(function(CustomFieldEntity $customFieldEntity) use($customFieldValues) {
+    return array_map(function (CustomFieldEntity $customFieldEntity) use ($customFieldValues) {
       $customField = [
         'id' => 'cf_' . $customFieldEntity->getId(),
         'name' => $customFieldEntity->getName(),
@@ -226,7 +226,7 @@ class ManageSubscriptionFormRenderer {
       'type' => SegmentEntity::TYPE_DEFAULT,
       'deletedAt' => null,
       'displayInManageSubscriptionPage' => true,
-      ];
+    ];
     $segments = $this->segmentsRepository->findBy($criteria, ['name' => Criteria::ASC]);
 
     $subscribedSegmentIds = [];
@@ -239,7 +239,7 @@ class ManageSubscriptionFormRenderer {
       }
     }
 
-    $segments = array_map(function(SegmentEntity $segment) use($subscribedSegmentIds) {
+    $segments = array_map(function (SegmentEntity $segment) use ($subscribedSegmentIds) {
       return [
         'id' => $segment->getId(),
         'name' => $segment->getName(),

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -491,7 +491,7 @@ class Pages {
 
     // get label or display default label
     $text = (
-      isset($params['text'])
+    isset($params['text'])
       ? htmlspecialchars($params['text'])
       : __('Manage your subscription', 'mailpoet')
     );

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -490,11 +490,9 @@ class Pages {
     if (!$subscriber instanceof SubscriberEntity) return __('Link to subscription management page is only available to mailing lists subscribers.', 'mailpoet');
 
     // get label or display default label
-    $text = (
-    isset($params['text'])
+    $text = isset($params['text'])
       ? htmlspecialchars($params['text'])
-      : __('Manage your subscription', 'mailpoet')
-    );
+      : __('Manage your subscription', 'mailpoet');
 
     return '<a href="' . $this->subscriptionUrlFactory->getManageUrl($subscriber) . '">' . $text . '</a>';
   }

--- a/mailpoet/tasks/code_sniffer/MailPoet/shared-ruleset.xml
+++ b/mailpoet/tasks/code_sniffer/MailPoet/shared-ruleset.xml
@@ -29,6 +29,7 @@
   <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceAfterOpen"><severity>0</severity></rule>
   <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceBeforeClose"><severity>0</severity></rule>
   <rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"><severity>0</severity></rule>
+  <rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsedHeredocCloser"><severity>0</severity></rule>
   <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing.SpaceAfterIncrement"><severity>0</severity></rule>
   <rule ref="Modernize.FunctionCalls.Dirname.FileConstant"><severity>0</severity></rule>
   <rule ref="NormalizedArrays.Arrays.ArrayBraceSpacing.EmptyArraySpacing"><severity>0</severity></rule>

--- a/mailpoet/tasks/lint-staged-css.sh
+++ b/mailpoet/tasks/lint-staged-css.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source $PWD/.env
+. $PWD/.env
 
 if [ "$MP_GIT_HOOKS_ENABLE" != "true" ]; then
   echo "MP_GIT_HOOKS_ENABLE is not set to 'true', skipping lint-staged-css."

--- a/mailpoet/tasks/lint-staged-js.sh
+++ b/mailpoet/tasks/lint-staged-js.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source $PWD/.env
+. $PWD/.env
 
 if [ "$MP_GIT_HOOKS_ENABLE" != "true" ]; then
   echo "MP_GIT_HOOKS_ENABLE is not set to 'true', skipping lint-staged-js"

--- a/mailpoet/tests/unit/Captcha/ReCaptchaRendererTest.php
+++ b/mailpoet/tests/unit/Captcha/ReCaptchaRendererTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace unit\Captcha;
+
+use MailPoet\Captcha\ReCaptchaRenderer;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha\CaptchaConstants;
+use MailPoet\Test\Form\HtmlParser;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../Form/HtmlParser.php';
+
+class ReCaptchaRendererTest extends \MailPoetUnitTest {
+
+  /** @var HtmlParser */
+  private $htmlParser;
+
+  /** @var MockObject & SettingsController */
+  private $settingsMock;
+
+  /** @var ReCaptchaRenderer */
+  private $renderer;
+
+  public function _before() {
+    $this->htmlParser = new HtmlParser();
+    $this->settingsMock = $this->createMock(SettingsController::class);
+    $this->renderer = new ReCaptchaRenderer($this->settingsMock, new WPFunctions());
+  }
+
+  public function testRenderingCheckbox() {
+    $expectedSiteToken = 'expected_value';
+    $this->settingsMock
+      ->method('get')
+      ->with('captcha')
+      ->willReturn([
+        'type' => CaptchaConstants::TYPE_RECAPTCHA,
+        'recaptcha_site_token' => $expectedSiteToken,
+        'recaptcha_invisible_site_token' => 'unexpected_value',
+      ]);
+
+    $html = $this->renderer->render();
+    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and not(@data-size)]");
+    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and @data-sitekey='$expectedSiteToken']");
+  }
+
+  public function testRenderingInvisible() {
+    $expectedSiteToken = 'expected_value';
+    $this->settingsMock
+      ->method('get')
+      ->with('captcha')
+      ->willReturn([
+        'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
+        'recaptcha_site_token' => 'unexpected_value',
+        'recaptcha_invisible_site_token' => $expectedSiteToken,
+      ]);
+
+    $html = $this->renderer->render();
+    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and @data-size='invisible']");
+    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and @data-sitekey='$expectedSiteToken']");
+  }
+}

--- a/mailpoet/tests/unit/Captcha/ReCaptchaRendererTest.php
+++ b/mailpoet/tests/unit/Captcha/ReCaptchaRendererTest.php
@@ -28,35 +28,43 @@ class ReCaptchaRendererTest extends \MailPoetUnitTest {
     $this->renderer = new ReCaptchaRenderer($this->settingsMock, new WPFunctions());
   }
 
-  public function testRenderingCheckbox() {
-    $expectedSiteToken = 'expected_value';
+  public function testItRendersCheckbox() {
+    $siteToken = 'expected_value';
     $this->settingsMock
       ->method('get')
       ->with('captcha')
       ->willReturn([
         'type' => CaptchaConstants::TYPE_RECAPTCHA,
-        'recaptcha_site_token' => $expectedSiteToken,
+        'recaptcha_site_token' => $siteToken,
         'recaptcha_invisible_site_token' => 'unexpected_value',
       ]);
 
     $html = $this->renderer->render();
-    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and not(@data-size)]");
-    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and @data-sitekey='$expectedSiteToken']");
+    $matches = $this->htmlParser->findByXpath(
+      $html,
+      "//div[@class='g-recaptcha' and not(@data-size) and @data-sitekey='$siteToken']"
+    );
+
+    verify($matches->length)->equals(1);
   }
 
-  public function testRenderingInvisible() {
-    $expectedSiteToken = 'expected_value';
+  public function testItRendersInvisible() {
+    $siteToken = 'expected_value';
     $this->settingsMock
       ->method('get')
       ->with('captcha')
       ->willReturn([
         'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
         'recaptcha_site_token' => 'unexpected_value',
-        'recaptcha_invisible_site_token' => $expectedSiteToken,
+        'recaptcha_invisible_site_token' => $siteToken,
       ]);
 
     $html = $this->renderer->render();
-    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and @data-size='invisible']");
-    $this->htmlParser->findByXpath($html, "//div[@class='g-recaptcha' and @data-sitekey='$expectedSiteToken']");
+    $matches = $this->htmlParser->findByXpath(
+      $html,
+      "//div[@class='g-recaptcha' and @data-size='invisible' and @data-sitekey='$siteToken']"
+    );
+
+    verify($matches->length)->equals(1);
   }
 }

--- a/mailpoet/tests/unit/Captcha/ReCaptchaValidatorTest.php
+++ b/mailpoet/tests/unit/Captcha/ReCaptchaValidatorTest.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types = 1);
+
+namespace unit\Captcha;
+
+use Codeception\Stub;
+use MailPoet\Captcha\ReCaptchaValidator;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Subscription\Captcha\CaptchaConstants;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ReCaptchaValidatorTest extends \MailPoetUnitTest {
+  public function testSuccessfulValidationForInvisible() {
+    $captchaSettings = [
+      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
+      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
+      'recaptcha_secret_token' => 'recaptcha_secret_token',
+    ];
+
+    $responseToken = 'recaptchaResponseToken';
+    $response = json_encode(['success' => true]);
+    $settings = Stub::make(
+      SettingsController::class,
+      [
+        'get' => function ($key) use ($captchaSettings) {
+          if ($key === 'captcha') {
+            return $captchaSettings;
+          }
+        },
+      ],
+      $this
+    );
+
+    $wp = Stub::make(
+      WPFunctions::class,
+      [
+        'isWpError' => false,
+        'wpRemotePost' => function ($url, $args) use ($responseToken, $captchaSettings, $response) {
+          verify($url)->equals('https://www.google.com/recaptcha/api/siteverify');
+          verify($args['body']['secret'])->equals($captchaSettings['recaptcha_invisible_secret_token']);
+          verify($args['body']['response'])->equals($responseToken);
+          return $response;
+        },
+        'wpRemoteRetrieveBody' => function ($data) use ($response) {
+          verify($data)->equals($response);
+          return $response;
+        },
+      ],
+      $this
+    );
+
+    $testee = new ReCaptchaValidator($wp, $settings);
+    verify($testee->validate($responseToken))->null();
+  }
+
+  public function testSuccessfulValidationForCheckbox() {
+    $captchaSettings = [
+      'type' => CaptchaConstants::TYPE_RECAPTCHA,
+      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
+      'recaptcha_secret_token' => 'recaptcha_secret_token',
+    ];
+
+    $responseToken = 'recaptchaResponseToken';
+    $response = json_encode(['success' => true]);
+    $settings = Stub::make(
+      SettingsController::class,
+      [
+        'get' => function ($key) use ($captchaSettings) {
+          if ($key === 'captcha') {
+            return $captchaSettings;
+          }
+        },
+      ],
+      $this
+    );
+
+    $wp = Stub::make(
+      WPFunctions::class,
+      [
+        'isWpError' => false,
+        'wpRemotePost' => function ($url, $args) use ($responseToken, $captchaSettings, $response) {
+          verify($url)->equals('https://www.google.com/recaptcha/api/siteverify');
+          verify($args['body']['secret'])->equals($captchaSettings['recaptcha_secret_token']);
+          verify($args['body']['response'])->equals($responseToken);
+          return $response;
+        },
+        'wpRemoteRetrieveBody' => function ($data) use ($response) {
+          verify($data)->equals($response);
+          return $response;
+        },
+      ],
+      $this
+    );
+
+    $testee = new RecaptchaValidator($wp, $settings);
+    verify($testee->validate($responseToken))->null();
+  }
+
+  public function testFailingValidationDueToMissingToken() {
+    $captchaSettings = [
+      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
+      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
+      'recaptcha_secret_token' => 'recaptcha_secret_token',
+    ];
+
+    $settings = Stub::make(
+      SettingsController::class,
+      [
+        'get' => function ($key) use ($captchaSettings) {
+          if ($key === 'captcha') {
+            return $captchaSettings;
+          }
+        },
+      ],
+      $this
+    );
+
+    $wp = Stub::make(WPFunctions::class);
+    $testee = new RecaptchaValidator($wp, $settings);
+    try {
+      $testee->validate('');
+    } catch (\Exception $error) {
+      verify($error)->instanceOf(\Exception::class);
+      verify($error->getMessage())->equals('Please check the CAPTCHA.');
+    }
+  }
+
+  public function testFailingValidationDueToInvalidToken() {
+    $captchaSettings = [
+      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
+      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
+      'recaptcha_secret_token' => 'recaptcha_secret_token',
+    ];
+
+    $responseToken = 'recaptchaResponseToken';
+    $response = json_encode(['success' => false]);
+    $settings = Stub::make(
+      SettingsController::class,
+      [
+        'get' => function ($key) use ($captchaSettings) {
+          if ($key === 'captcha') {
+            return $captchaSettings;
+          }
+        },
+      ],
+      $this
+    );
+
+    $wp = Stub::make(
+      WPFunctions::class,
+      [
+        'isWpError' => false,
+        'wpRemotePost' => function () use ($response) {
+          return $response;
+        },
+        'wpRemoteRetrieveBody' => function () use ($response) {
+          return $response;
+        },
+      ],
+      $this
+    );
+
+    $testee = new RecaptchaValidator($wp, $settings);
+    try {
+      $testee->validate($responseToken);
+    } catch (\Exception $error) {
+      verify($error)->instanceOf(\Exception::class);
+      verify($error->getMessage())->equals('Invalid CAPTCHA. Try again.');
+    }
+  }
+
+  public function testFailingValidationDueToHttpError() {
+    $captchaSettings = [
+      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
+      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
+      'recaptcha_secret_token' => 'recaptcha_secret_token',
+    ];
+
+    $responseToken = 'recaptchaResponseToken';
+    $response = (object)['wp-error'];
+    $settings = Stub::make(
+      SettingsController::class,
+      [
+        'get' => function ($key) use ($captchaSettings) {
+          if ($key === 'captcha') {
+            return $captchaSettings;
+          }
+        },
+      ],
+      $this
+    );
+
+    $wp = Stub::make(
+      WPFunctions::class,
+      [
+        'isWpError' => true,
+        'wpRemotePost' => function () use ($response) {
+          return $response;
+        },
+      ],
+      $this
+    );
+
+    $testee = new RecaptchaValidator($wp, $settings);
+    try {
+      $testee->validate($responseToken);
+    } catch (\Exception $error) {
+      verify($error)->instanceOf(\Exception::class);
+      verify($error->getMessage())->equals('Error while validating the CAPTCHA.');
+    }
+  }
+}

--- a/mailpoet/tests/unit/Subscription/Captcha/Validator/RecaptchaValidatorTest.php
+++ b/mailpoet/tests/unit/Subscription/Captcha/Validator/RecaptchaValidatorTest.php
@@ -3,189 +3,52 @@
 namespace MailPoet\Subscription\Captcha\Validator;
 
 use Codeception\Stub;
-use MailPoet\Settings\SettingsController;
-use MailPoet\Subscription\Captcha\CaptchaConstants;
-use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\Captcha\ReCaptchaValidator as Validator;
 
 class RecaptchaValidatorTest extends \MailPoetUnitTest {
-  public function testSuccessfulInvisibleValidation() {
-
-    $captchaSettings = [
-      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
-      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
-      'recaptcha_secret_token' => 'recaptcha_secret_token',
-    ];
-    $recaptchaResponseToken = 'recaptchaResponseToken';
-    $response = json_encode(['success' => true]);
-    $settings = Stub::make(
-      SettingsController::class,
-      [
-        'get' => function($key) use ($captchaSettings) {
-          if ($key === 'captcha') {
-            return $captchaSettings;
-          }
-        },
-      ],
-      $this
-    );
-    $wp = Stub::make(
-      WPFunctions::class,
-      [
-        'wpRemotePost' => function($url, $args) use ($recaptchaResponseToken, $captchaSettings, $response) {
-          verify($url)->equals('https://www.google.com/recaptcha/api/siteverify');
-          verify($args['body']['secret'])->equals($captchaSettings['recaptcha_invisible_secret_token']);
-          verify($args['body']['response'])->equals($recaptchaResponseToken);
-          return $response;
-        },
-        'isWpError' => false,
-        'wpRemoteRetrieveBody' => function($data) use ($response) {
-          verify($data)->equals($response);
-          return $response;
-        },
-      ],
-      $this
-    );
-
-    $testee = new RecaptchaValidator($settings, $wp);
-    $data = [
-      'recaptchaResponseToken' => $recaptchaResponseToken,
-    ];
-    verify($testee->validate($data))->true();
-  }
-
   public function testSuccessfulValidation() {
-
-    $captchaSettings = [
-      'type' => CaptchaConstants::TYPE_RECAPTCHA,
-      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
-      'recaptcha_secret_token' => 'recaptcha_secret_token',
-    ];
-    $recaptchaResponseToken = 'recaptchaResponseToken';
-    $response = json_encode(['success' => true]);
-    $settings = Stub::make(
-      SettingsController::class,
+    $responseToken = 'recaptchaResponseToken';
+    $validator = Stub::make(
+      Validator::class,
       [
-        'get' => function($key) use ($captchaSettings) {
-          if ($key === 'captcha') {
-            return $captchaSettings;
-          }
-        },
-      ],
-      $this
-    );
-    $wp = Stub::make(
-      WPFunctions::class,
-      [
-        'wpRemotePost' => function($url, $args) use ($recaptchaResponseToken, $captchaSettings, $response) {
-          verify($url)->equals('https://www.google.com/recaptcha/api/siteverify');
-          verify($args['body']['secret'])->equals($captchaSettings['recaptcha_secret_token']);
-          verify($args['body']['response'])->equals($recaptchaResponseToken);
-          return $response;
-        },
-        'isWpError' => false,
-        'wpRemoteRetrieveBody' => function($data) use ($response) {
-          verify($data)->equals($response);
-          return $response;
+        'validate' => function ($responseToken) {
+          return null;
         },
       ],
       $this
     );
 
-    $testee = new RecaptchaValidator($settings, $wp);
+    $testee = new RecaptchaValidator($validator);
     $data = [
-      'recaptchaResponseToken' => $recaptchaResponseToken,
+      'recaptchaResponseToken' => $responseToken,
     ];
+
     verify($testee->validate($data))->true();
   }
 
   public function testFailingValidation() {
-
-    $captchaSettings = [
-      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
-      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
-      'recaptcha_secret_token' => 'recaptcha_secret_token',
-    ];
-    $recaptchaResponseToken = 'recaptchaResponseToken';
-    $response = json_encode(['success' => false]);
-    $settings = Stub::make(
-      SettingsController::class,
+    $responseToken = 'recaptchaResponseToken';
+    $exceptionErr = 'Error while validating the CAPTCHA.';
+    $validator = Stub::make(
+      Validator::class,
       [
-        'get' => function($key) use ($captchaSettings) {
-          if ($key === 'captcha') {
-            return $captchaSettings;
-          }
-        },
-      ],
-      $this
-    );
-    $wp = Stub::make(
-      WPFunctions::class,
-      [
-        'wpRemotePost' => function() use ($response) {
-          return $response;
-        },
-        'isWpError' => false,
-        'wpRemoteRetrieveBody' => function() use ($response) {
-          return $response;
+        'validate' => function ($responseToken) use ($exceptionErr) {
+          throw new \Exception($exceptionErr);
         },
       ],
       $this
     );
 
-    $testee = new RecaptchaValidator($settings, $wp);
+    $testee = new RecaptchaValidator($validator);
     $data = [
-      'recaptchaResponseToken' => $recaptchaResponseToken,
+      'recaptchaResponseToken' => $responseToken,
     ];
-    $error = null;
+
     try {
       $testee->validate($data);
-    } catch (ValidationError $error) {
-      verify($error->getMessage())->equals('Error while validating the CAPTCHA.');
+    } catch (\Exception $e) {
+      verify($e)->instanceOf(ValidationError::class);
+      verify($e->getMessage())->equals($exceptionErr);
     }
-    verify($error)->instanceOf(ValidationError::class);
-  }
-
-  public function testConnectionError() {
-
-    $captchaSettings = [
-      'type' => CaptchaConstants::TYPE_RECAPTCHA_INVISIBLE,
-      'recaptcha_invisible_secret_token' => 'recaptcha_invisible_secret_token',
-      'recaptcha_secret_token' => 'recaptcha_secret_token',
-    ];
-    $recaptchaResponseToken = 'recaptchaResponseToken';
-    $response = (object)['wp-error'];
-    $settings = Stub::make(
-      SettingsController::class,
-      [
-        'get' => function($key) use ($captchaSettings) {
-          if ($key === 'captcha') {
-            return $captchaSettings;
-          }
-        },
-      ],
-      $this
-    );
-    $wp = Stub::make(
-      WPFunctions::class,
-      [
-        'wpRemotePost' => function() use ($response) {
-          return $response;
-        },
-        'isWpError' => true,
-      ],
-      $this
-    );
-
-    $testee = new RecaptchaValidator($settings, $wp);
-    $data = [
-      'recaptchaResponseToken' => $recaptchaResponseToken,
-    ];
-    $error = null;
-    try {
-      $testee->validate($data);
-    } catch (ValidationError $error) {
-      verify($error->getMessage())->equals('Error while validating the CAPTCHA.');
-    }
-    verify($error)->instanceOf(ValidationError::class);
   }
 }

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       WORDPRESS_TABLE_PREFIX: mp_
       MAILPOET_TRACY_PRODUCTION_MODE: 1
       MAILPOET_TRACY_LOG_DIR: /var/www/html/wp-content/plugins/mailpoet/tests/_output/exceptions
+      MP_ENV: test
     command: ['docker-entrypoint.sh', 'apache2-foreground']
     networks:
       default:


### PR DESCRIPTION
## Description

A partial implementation of the referenced ticket. This PR adds a Google's reCAPTCHA to WordPress and WooCommerce registration form. It supports both checkbox and invisible reCAPTCHA, based on the user settings. Read Jira description for more details.

I've opted for incremental implementation to make smaller PRs. After this, I'll push another one for built-in CAPTCHA. Once both are merged, I'll add a setting to make it accessible to end users.

## Rendering

In WordPress registration form:

![wp-register-form](https://github.com/user-attachments/assets/21d22e7a-246f-4248-8c36-ff49276f9540)

In WooCommerce registration form:

![wc-register-form](https://github.com/user-attachments/assets/9af06429-fc0f-4f07-9c41-05ca346a8ad3)

## Code review notes

The setting for this feature, as per the Jira spec, has not been introduced here. Instead, I've added a `MP_ENV` env variable to activate the logic in testing and development ONLY.

I highly recommend reviewing by commit. I've added commit messages to explain some of the least obvious changes.

If you are not familiar with reCAPTCHA, I recommend reviewing the [official doc](https://developers.google.com/recaptcha/docs/display).

## QA notes

In the development environment, make sure of the following on **both WordPress & WooCommerce** registration forms:

- When "Google reCAPTCHA v2 Checkbox" option of "Protect your forms against spam signups" setting is selected,
  - The reCAPTCHA is rendered as checkbox, and
  - When unchecked, it breaks the registration, displaying CAPTCHA-specific error.
  - When checked, it should not break the registration.

- When "Google reCAPTCHA v2 Invisible" option is selected,
  - The reCAPTCHA should not be visible.
  - A reCAPTCHA badge in the bottom right [should be visible](https://wpblog.com/wp-content/uploads/2018/01/recaptcha-860x599.png).
  - It should not break registration on form submission.

- When any other option is selected, the reCAPTCHA should not be rendered in WordPress & WooCommerce registration forms. The reCAPTCHA root div has `g-recaptcha` class.

I've adjusted the reCAPTCHA validation logic on MP subscription forms. To ensure no regression, verify that checkbox and invisible reCAPTCHA still works there. 

## Linked tickets

[MAILPOET-6282]

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript


[MAILPOET-6282]: https://mailpoet.atlassian.net/browse/MAILPOET-6282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-captcha-register-form)

_The latest successful build from `add-captcha-register-form` will be used. If none is available, the link won't work._