### PR TITLE
Fix the analytics page when automation has if/else without next steps [MAILPOET-6307]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/automation-flow/statistic-separator.tsx
@@ -67,7 +67,9 @@ export function StatisticSeparator({
     // in an empty if/else branch. To calculate the total we need to subtract
     // totalEntered of the sibling step from totalEntered of previousStep
     const siblingStep = previousStep.next_steps.find((step) => step.id);
-    const totalEnteredSibling = calculateTotals(siblingStep.id);
+    const totalEnteredSibling = siblingStep
+      ? calculateTotals(siblingStep.id)
+      : 0;
     const totalEnteredPrevious = completed[previousStep.id] ?? 0;
     totalEntered = totalEnteredPrevious - totalEnteredSibling;
   } else {


### PR DESCRIPTION
## Description

The PR fixes an error that prevented rendering the analytics page in case an if/else step had no next steps.

## Code review notes
_N/A_

## QA notes

#### Replication

1. Create a new empty automation
2. Add a trigger
3. Add an if/else step
4. Save draft
5. Go to analytics page and observe the issue

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6307]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6307]: https://mailpoet.atlassian.net/browse/MAILPOET-6307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-empty-ifelse-analytics)

_The latest successful build from `fix-empty-ifelse-analytics` will be used. If none is available, the link won't work._