### PR TITLE
Update the dev env, tests and Circle CI to run with PHP 8.2 as default [MAILPOET-4620]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,12 +99,12 @@ executors:
   wpcli_php_max_wporg:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.1_20230307.1
+      - image: mailpoet/wordpress:8.2_20231016.1
 
   wpcli_php_latest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.1_20230307.1
+      - image: mailpoet/wordpress:8.2_20231016.1
 
   wpcli_php_mysql_oldest:
     <<: *default_job_config
@@ -115,7 +115,7 @@ executors:
   wpcli_php_mysql_latest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.1_20230307.1
+      - image: mailpoet/wordpress:8.2_20231016.1
       - image: cimg/mysql:8.0
         command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_520_ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ executors:
   wpcli_php_max_wporg:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.2_20231016.1
+      - image: mailpoet/wordpress:8.1_20230307.1 # We need to use 8.1 to emulate the WP.org environment
 
   wpcli_php_latest:
     <<: *default_job_config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     container_name: mp-wp
     build:
       context: .
-      dockerfile: dev/php81/Dockerfile
+      dockerfile: dev/php82/Dockerfile
       args:
         UID: ${UID:-1000}
         GID: ${GID:-1000}

--- a/mailpoet/tasks/fix-php82-robo.php
+++ b/mailpoet/tasks/fix-php82-robo.php
@@ -34,6 +34,19 @@ $replacements = [
       '$stopRunningJobs = Closure::fromCallable(self::class.\'::stopRunningJobs\');',
     ],
   ],
+  [
+    'file' => __DIR__ . '/../vendor/consolidation/robo/src/Config/Config.php',
+    'find' => [
+      "const DECORATED = 'options.decorated';
+
+    /**",
+    ],
+    'replace' => [
+      "const DECORATED = 'options.decorated';
+       private \$defaults = [];
+    /**",
+    ],
+  ],
 ];
 
 // Apply replacements

--- a/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscriberCookieCest.php
@@ -165,6 +165,7 @@ class SubscriberCookieCest {
   private function checkSubscriberCookie(AcceptanceTester $i, string $email): void {
     $subscribersTableName = ContainerWrapper::getInstance()->get(SubscribersRepository::class)->getTableName();
     $subscriberId = $i->grabFromDatabase($subscribersTableName, 'id', ['email' => $email]);
+    $subscriberId = is_int($subscriberId) ? (string)$subscriberId : $subscriberId;
     Assert::assertIsString($subscriberId);
     $i->canSeeCookie(self::SUBSCRIBER_COOKIE_NAME);
     $cookie = $i->grabCookie(self::SUBSCRIBER_COOKIE_NAME);

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   codeception_acceptance:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2-cli_20231016.1}
     depends_on:
       - smtp
       - wordpress
@@ -30,7 +30,7 @@ services:
       PHP_IDE_CONFIG: 'serverName=MailPoetTest'
 
   codeception_integration:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.0-cli_20220605.0}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2-cli_20231016.1}
     depends_on:
       - smtp
       - wordpress


### PR DESCRIPTION
## Description

This PR updates the dev env, tests, and Circle CI to run with PHP 8.2 as the default

## Code review notes

I hope I have addressed all related places.

## QA notes

I think we can skip QA.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/920

## Linked tickets

[MAILPOET-4620]

## After-merge notes

Ping #mailpoet-dev to rebuild their container in dev-env. Run `docker compose build wordpress`

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4620]: https://mailpoet.atlassian.net/browse/MAILPOET-4620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-php-to-82)

_The latest successful build from `update-php-to-82` will be used. If none is available, the link won't work._