### PR TITLE
Improve email reactivation performance  [MAILPOET-6310]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -215,7 +215,7 @@ class Newsletters extends APIEndpoint {
 
     // if there are paused tasks unpause them
     if ($newsletter->getStatus() === NewsletterEntity::STATUS_ACTIVE) {
-      $queues = $newsletter->getQueues();
+      $queues = $newsletter->getUnfinishedQueues();
       foreach ($queues as $queue) {
         $task = $queue->getTask();
         if ($task && $task->getStatus() === ScheduledTaskEntity::STATUS_PAUSED) {

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -537,7 +537,7 @@ class NewsletterEntity {
   /**
    * @return Collection<int, SendingQueueEntity>
    */
-  private function getUnfinishedQueues(): Collection {
+  public function getUnfinishedQueues(): Collection {
     $criteria = new Criteria();
     $expr = Criteria::expr();
     $criteria->where($expr->neq('countToProcess', 0));

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -290,7 +290,8 @@ class NewslettersTest extends \MailPoetTest {
         SendingQueueWorker::TASK_TYPE,
         ScheduledTaskEntity::STATUS_PAUSED,
       );
-    (new SendingQueueFactory())->create($scheduledTask1, $this->postNotification);
+    $queue = (new SendingQueueFactory())->create($scheduledTask1, $this->postNotification);
+    $queue->setCountToProcess(1);
     $segment = $this->segmentRepository->createOrUpdate('Segment 1');
     $this->createNewsletterSegment($this->postNotification, $segment);
 


### PR DESCRIPTION
## Description

This PR addresses an issue that may cause the reactivation of emails with a long sending history to fail.

## Code review notes

In https://github.com/mailpoet/mailpoet/pull/5881, we added reactivation of all paused sending queues. The code fetches all the queues into memory and may fail for emails with many queues. As a fix, I limited queues, and currently we fetch only unfinished queues. I explained more details in the commit message.

## QA notes

Please test welcome emails with some history of sending

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6310]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6310]: https://mailpoet.atlassian.net/browse/MAILPOET-6310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-email-reactivation)

_The latest successful build from `fix-email-reactivation` will be used. If none is available, the link won't work._