### PR TITLE
Fix flaky Statistics/Track/ClicksTest  [MAILPOET-6306]

### DIFF
--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -540,8 +540,8 @@ class ClicksTest extends \MailPoetTest {
     $savedClickTime = $this->subscriber->getLastClickAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
     $this->assertInstanceOf(\DateTimeInterface::class, $savedClickTime);
-    verify($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
-    verify($savedClickTime->getTimestamp())->equals($now->getTimestamp());
+    $this->assertEqualsWithDelta($savedEngagementTime->getTimestamp(), $now->getTimestamp(), 1);
+    $this->assertEqualsWithDelta($savedClickTime->getTimestamp(), $now->getTimestamp(), 1);
   }
 
   public function testItUpdatesSubscriberEngagementForUnknownAgent() {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

The test was flaky because the assertion was sometimes missed by one second. This commit reduces the flakiness by allowing a one-second difference when comparing the values.

Example of [a failed build](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/19366/workflows/ef085a15-2105-4d60-8426-b09bfe91eb56/jobs/330213)

## QA notes

We can skip QA.

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-6306]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6306]: https://mailpoet.atlassian.net/browse/MAILPOET-6306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-flaky-click-test)

_The latest successful build from `fix-flaky-click-test` will be used. If none is available, the link won't work._