### PR TITLE
Fix WC Subscriptions status/billing period check always false in automations [PREMIUM-282]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -303,6 +303,10 @@ class OrderFieldsFactory {
     $options = [];
     foreach ($statuses as $id => $name) {
       $options[] = [
+        // WooCommerce order statuses are internally saved with 'wc-' prefix:
+        // https://github.com/woocommerce/woocommerce/blob/9c58f198/plugins/woocommerce/includes/wc-order-functions.php#L98-L109
+        // However, when getting the status from the order object, it doesn't have the prefix.
+        // To make the status codes consistent, we remove the prefix here and only work with unprefixed statuses.
         'id' => substr($id, 0, 3) === 'wc-' ? substr($id, 3) : $id,
         'name' => $name,
       ];

--- a/mailpoet/lib/Migrations/Db/Migration_20241108_103249_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20241108_103249_Db.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Automation\Engine\Utils\Json;
+use MailPoet\Migrator\DbMigration;
+
+/**
+ * Fixes WooCommerce Subscriptions status filter in automations (e.g. trigger filters or if/else conditions)
+ * - Changes `field_type` from `enum_array` to `enum`
+ * - Changes condition from `matches-*` to `is-*`
+ * - Strips `wc-` prefix from values
+ */
+class Migration_20241108_103249_Db extends DbMigration {
+  public function run(): void {
+    global $wpdb;
+    $automationVersionsTable = esc_sql($wpdb->prefix . 'mailpoet_automation_versions');
+
+    $wooSubscriptionAutomations = $wpdb->get_results($wpdb->prepare("
+      SELECT `id`, `steps`
+      FROM %i
+      WHERE `steps` LIKE %s
+    ", $automationVersionsTable, '%woocommerce-subscriptions:subscription:status%'), ARRAY_A);
+
+    foreach ($wooSubscriptionAutomations as $automation) {
+      // Parse JSON encoded automation steps
+      try {
+        $jsonData = Json::decode($automation['steps']);
+      } catch (\Exception $e) {
+        continue;
+      }
+
+      // Iterate over each automation step
+      foreach ($jsonData as $key => &$item) {
+        if (!isset($item['filters']['groups']) || !is_array($item['filters']['groups'])) {
+          continue;
+        }
+
+        // Iterate over each step filter group
+        // This can be e.g. a trigger filter, or if/else condition
+        foreach ($item['filters']['groups'] as &$group) {
+          if (!isset($group['filters']) || !is_array($group['filters'])) {
+            continue;
+          }
+          foreach ($group['filters'] as &$filter_item) {
+            $this->fixWooSubscriptionStatusFilter($filter_item);
+          }
+        }
+      }
+      $updatedJson = json_encode($jsonData);
+      $wpdb->update($automationVersionsTable, ['steps' => $updatedJson], ['id' => $automation['id']]);
+    }
+  }
+
+  private function fixWooSubscriptionStatusFilter(&$filter_item): void {
+    // Only fix WooCommerce Subscriptions status filters
+    if (
+      !isset($filter_item['field_key'])
+      || $filter_item['field_key'] !== 'woocommerce-subscriptions:subscription:status'
+    ) {
+      return;
+    }
+
+    // Fix field_type from enum_array to enum
+    if (isset($filter_item['field_type']) && $filter_item['field_type'] === 'enum_array') {
+      $filter_item['field_type'] = 'enum';
+    }
+
+    // Fix condition
+    if (isset($filter_item['condition'])) {
+      $conditionMap = [
+        'matches-any-of' => 'is-any-of',
+        'matches-all-of' => 'is-any-of',
+        'matches-none-of' => 'is-none-of',
+      ];
+      $filter_item['condition'] = $conditionMap[$filter_item['condition']] ?? $filter_item['condition'];
+    }
+
+    // Strip "wc-" prefix from values
+    if (isset($filter_item['args']['value']) && is_array($filter_item['args']['value'])) {
+      $filter_item['args']['value'] = array_map(function($value) {
+        return preg_replace('/^wc-/', '', $value);
+      }, $filter_item['args']['value']);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a migration to fix existing automations using WooCommerce Subscriptions **status** or **billing period** fields. The fix itself is in https://github.com/mailpoet/mailpoet-premium/pull/921. 

## Code review notes

_N/A_

## QA notes

_Note that while you still need changes from both plugins, the premium plugin has different testing steps._

For migration to work, you first need to prepare "broken" data:
1. Without using changes from this PR and https://github.com/mailpoet/mailpoet-premium/pull/921, create a new automation:
    - Any trigger with WC Subscription status and/or billing period trigger filters.
    - If/else step with WC Subscription status and/or billing period conditions.
    - The rest is optional. I'd recommend any steps in both branches - will be easier to check the fix. 
2. Verify that the filters/conditions are not correctly evaluated - they are always false. 
3. Now update the **premium plugin** with changes from https://github.com/mailpoet/mailpoet-premium/pull/921
4. Open the automation.
5. You should see the `Unknown value` for the status field in the trigger filters and if/else conditions.
6. When clicking on it, the automation editor should blank with a console error. 
7. Now update the free plugin with changes from this PR and run the migration. 
8. Open the automation.
9. You should see both trigger filters and if/else conditions working and editable. 
10. Verify that they are also evaluated correctly when a subscriber runs the automation. 

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/921

## Linked tickets

[PREMIUM-282]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[PREMIUM-282]: https://mailpoet.atlassian.net/browse/PREMIUM-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wc-subs-fixes)

_The latest successful build from `wc-subs-fixes` will be used. If none is available, the link won't work._