### PR TITLE
Fix detection of an existing index in the table in migrations [MAILPOET-6314]

### DIFF
--- a/mailpoet/lib/Migrator/DbMigration.php
+++ b/mailpoet/lib/Migrator/DbMigration.php
@@ -74,6 +74,22 @@ abstract class DbMigration {
     try {
       $this->connection->executeStatement("ALTER TABLE $tableName ADD INDEX $indexName (__non__existent__column__name__)");
     } catch (Exception $e) {
+      // Index creating index failed on not existing column we use a fallback. This can happen on MySQL 5.7 and lower and on some MariaDB versions.
+      if ($e->getCode() === 1072) {
+        $database = $wpdb->dbname;
+        $result = $wpdb->get_var($wpdb->prepare(
+          "SELECT count(*)
+         FROM information_schema.statistics
+         WHERE table_schema = COALESCE(DATABASE(), %s)
+         AND table_name = %s
+         AND index_name = %s",
+          $database,
+          $tableName,
+          $indexName
+        ));
+
+        return $result > 0;
+      }
       // Index exists when the error message contains its name. Otherwise, it's the non-existent column error.
       return strpos($e->getMessage(), $indexName) !== false;
     } finally {

--- a/mailpoet/tests/integration/Migrator/DbMigrationTest.php
+++ b/mailpoet/tests/integration/Migrator/DbMigrationTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrator;
+
+use MailPoet\Config\Env;
+use MailPoet\DI\ContainerWrapper;
+use MailPoetTest;
+
+class DbMigrationTest extends MailPoetTest {
+  private $migration;
+  /** @var string */
+  private $tableName = 'test_users';
+
+  public function _before() {
+    parent::_before();
+    $container = ContainerWrapper::getInstance();
+
+    // Subclass with public accessors for testing
+    $this->migration = new class($container) extends DbMigration {
+      public function run(): void {
+      }
+
+      public function publicCreateTable(string $tableName, array $attributes): void {
+        $this->createTable($tableName, $attributes);
+      }
+
+      public function publicTableExists(string $tableName): bool {
+        return $this->tableExists($tableName);
+      }
+
+      public function publicColumnExists(string $tableName, string $columnName): bool {
+        return $this->columnExists($tableName, $columnName);
+      }
+
+      public function publicIndexExists(string $tableName, string $indexName): bool {
+        return $this->indexExists($tableName, $indexName);
+      }
+    };
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->connection->executeStatement("DROP TABLE IF EXISTS {$this->tableName};");
+  }
+
+  public function testCreateTable(): void {
+    $attributes = [
+      'id INT PRIMARY KEY AUTO_INCREMENT',
+      'name VARCHAR(255) NOT NULL',
+    ];
+    $this->migration->publicCreateTable($this->tableName, $attributes);
+
+    // Verify that the table was created by querying the database
+    $tableExists = $this->connection->executeQuery("SHOW TABLES LIKE ?", [Env::$dbPrefix . $this->tableName])->rowCount() > 0;
+
+    // Assert that the table exists
+    $this->assertTrue($tableExists, "The table '$this->tableName' was not created.");
+  }
+
+  public function testTableExists(): void {
+    $attributes = [
+      'id INT PRIMARY KEY AUTO_INCREMENT',
+      'name VARCHAR(255) NOT NULL',
+    ];
+    $this->migration->publicCreateTable($this->tableName, $attributes);
+
+    $this->assertTrue($this->migration->publicTableExists(Env::$dbPrefix . $this->tableName));
+    $this->assertFalse($this->migration->publicTableExists('non_existent_table'));
+  }
+
+  public function testColumnExists(): void {
+    $attributes = [
+      'id INT PRIMARY KEY AUTO_INCREMENT',
+      'name VARCHAR(255) NOT NULL',
+    ];
+    $this->migration->publicCreateTable($this->tableName, $attributes);
+
+    $this->assertTrue($this->migration->publicColumnExists(Env::$dbPrefix . $this->tableName, 'name'));
+    $this->assertFalse($this->migration->publicColumnExists(Env::$dbPrefix . $this->tableName, 'non_existent_column'));
+  }
+
+  public function testIndexExists(): void {
+    $attributes = [
+      'id INT PRIMARY KEY AUTO_INCREMENT',
+      'name VARCHAR(255) NOT NULL',
+    ];
+    $this->migration->publicCreateTable($this->tableName, $attributes);
+
+    // Add an index for testing
+    $this->connection->executeStatement("CREATE INDEX test_index ON " . Env::$dbPrefix . $this->tableName . " (name);");
+
+    $this->assertTrue($this->migration->publicIndexExists(Env::$dbPrefix . $this->tableName, 'test_index'));
+    $this->assertFalse($this->migration->publicIndexExists(Env::$dbPrefix . $this->tableName, 'non_existent_index'));
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes the incorrect detection of an existing index in a table for MySQL 5.7. 

## Code review notes

The problem is that the detection of existing indexes was changed to catch an error when the plugin tries to create an index with the same name for a non-existing column. Unfortunately, this does not work for MySQL 5.7 and some MariaDB versions because it returns an error about no existing column.
This PR adds a fallback when the DB returns an error about the non-existing column, and the error code matches the expected value.

I also added a new integration test, and this test failed before adding a fix.

## QA notes

Because the tests are passing, I think we can skip QA here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6314]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6314]: https://mailpoet.atlassian.net/browse/MAILPOET-6314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:migrations-old-mysql)

_The latest successful build from `migrations-old-mysql` will be used. If none is available, the link won't work._