### PR TITLE
Fix browse all in email editor - MAILPOET-6303

### DIFF
--- a/packages/js/email-editor/src/components/block-editor/layout.tsx
+++ b/packages/js/email-editor/src/components/block-editor/layout.tsx
@@ -1,5 +1,5 @@
 import { BlockSelectionClearer } from '@wordpress/block-editor';
-import { UnsavedChangesWarning } from '@wordpress/editor';
+import { store as editorStore, UnsavedChangesWarning } from '@wordpress/editor';
 import { uploadMedia } from '@wordpress/media-utils';
 import classnames from 'classnames';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -42,10 +42,10 @@ export function Layout() {
 			isFullscreenActive:
 				select( storeName ).isFeatureActive( 'fullscreenMode' ),
 			isSidebarOpened: select( storeName ).isSidebarOpened(),
-			isInserterSidebarOpened:
-				select( storeName ).isInserterSidebarOpened(),
-			isListviewSidebarOpened:
-				select( storeName ).isListviewSidebarOpened(),
+			// @ts-expect-error isInserterOpened is missing in types.
+			isInserterSidebarOpened: select( editorStore ).isInserterOpened(),
+			// @ts-expect-error isListViewOpened is missing in types.
+			isListviewSidebarOpened: select( editorStore ).isListViewOpened(),
 			initialSettings: select( storeName ).getInitialEditorSettings(),
 			previewDeviceType: select( storeName ).getDeviceType(),
 			canUserEditMedia: select( coreStore ).canUser( 'create', 'media' ),
@@ -57,7 +57,8 @@ export function Layout() {
 		[]
 	);
 
-	const { toggleInserterSidebar } = useDispatch( storeName );
+	// @ts-expect-error isInserterOpened is missing in types.
+	const { setIsInserterOpened } = useDispatch( editorStore );
 
 	const [ emailCss ] = useEmailCss();
 	const className = classnames( 'edit-post-layout', {
@@ -105,7 +106,7 @@ export function Layout() {
 							onClick={ () => {
 								// Clear inserter sidebar when canvas is clicked.
 								if ( isInserterSidebarOpened ) {
-									void toggleInserterSidebar();
+									void setIsInserterOpened( false );
 								}
 							} }
 						>

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -48,9 +48,10 @@ export function Header() {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( false );
 
-	const { toggleInserterSidebar, toggleListviewSidebar } =
-		useDispatch( storeName );
 	const { undo: undoAction, redo: redoAction } = useDispatch( coreDataStore );
+	// @ts-expect-error missing types.
+	const { setIsInserterOpened, setIsListViewOpened } =
+		useDispatch( editorStore );
 	const {
 		isInserterSidebarOpened,
 		isListviewSidebarOpened,
@@ -67,10 +68,10 @@ export function Header() {
 		const editorSettings = _getEditorSettings();
 
 		return {
-			isInserterSidebarOpened:
-				select( storeName ).isInserterSidebarOpened(),
-			isListviewSidebarOpened:
-				select( storeName ).isListviewSidebarOpened(),
+			// @ts-expect-error missing types.
+			isInserterSidebarOpened: select( editorStore ).isInserterOpened(),
+			// @ts-expect-error missing types.
+			isListviewSidebarOpened: select( editorStore ).isListViewOpened(),
 			isFixedToolbarActive: select( preferencesStore ).get(
 				'core',
 				'fixedToolbar'
@@ -86,6 +87,20 @@ export function Header() {
 
 	const preventDefault = ( event ) => {
 		event.preventDefault();
+	};
+
+	const toggleTheInserterSidebar = () => {
+		if ( isInserterSidebarOpened ) {
+			return setIsInserterOpened( false );
+		}
+		return setIsInserterOpened( true );
+	};
+
+	const toggleTheListviewSidebar = () => {
+		if ( isListviewSidebarOpened ) {
+			return setIsListViewOpened( false );
+		}
+		return setIsListViewOpened( true );
 	};
 
 	const shortLabelInserter = ! isInserterSidebarOpened
@@ -107,7 +122,7 @@ export function Header() {
 							variant="primary"
 							isPressed={ isInserterSidebarOpened }
 							onMouseDown={ preventDefault }
-							onClick={ toggleInserterSidebar }
+							onClick={ toggleTheInserterSidebar }
 							disabled={ false }
 							icon={ plus }
 							label={ shortLabelInserter }
@@ -144,7 +159,7 @@ export function Header() {
 							className="editor-header-toolbar__document-overview-toggle edit-post-header-toolbar__document-overview-toggle"
 							isPressed={ isListviewSidebarOpened }
 							onMouseDown={ preventDefault }
-							onClick={ toggleListviewSidebar }
+							onClick={ toggleTheListviewSidebar }
 							disabled={ false }
 							icon={ listView }
 							label={ __( 'List view', 'mailpoet' ) }

--- a/packages/js/email-editor/src/components/inserter-sidebar/inserter-sidebar.tsx
+++ b/packages/js/email-editor/src/components/inserter-sidebar/inserter-sidebar.tsx
@@ -4,7 +4,6 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { storeName } from '../../store';
 
 export function InserterSidebar() {
 	const { postContentId, isEditingEmailContent } = useSelect( ( select ) => {
@@ -18,7 +17,8 @@ export function InserterSidebar() {
 		};
 	} );
 
-	const { toggleInserterSidebar } = useDispatch( storeName );
+	// @ts-expect-error missing types.
+	const { setIsInserterOpened } = useDispatch( editorStore );
 
 	return (
 		<div className="editor-inserter-sidebar">
@@ -30,7 +30,7 @@ export function InserterSidebar() {
 					rootClientId={
 						isEditingEmailContent ? postContentId : null
 					}
-					onClose={ toggleInserterSidebar }
+					onClose={ () => setIsInserterOpened( false ) }
 				/>
 			</div>
 		</div>

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -14,20 +14,6 @@ export const toggleFeature =
 	( { registry } ): unknown =>
 		registry.dispatch( preferencesStore ).toggle( storeName, feature );
 
-export const toggleInserterSidebar =
-	() =>
-	( { registry } ) => {
-		const status = registry.select( editorStore ).isInserterOpened();
-		void registry.dispatch( editorStore ).setIsInserterOpened( ! status );
-	};
-
-export const toggleListviewSidebar =
-	() =>
-	( { registry } ) => {
-		const status = registry.select( editorStore ).isListViewOpened();
-		void registry.dispatch( editorStore ).setIsListViewOpened( ! status );
-	};
-
 export const changePreviewDeviceType =
 	( deviceType: string ) =>
 	( { registry } ) =>

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -14,11 +14,12 @@ export const toggleFeature =
 	( { registry } ): unknown =>
 		registry.dispatch( preferencesStore ).toggle( storeName, feature );
 
-export function toggleInserterSidebar() {
-	return {
-		type: 'TOGGLE_INSERTER_SIDEBAR',
-	} as const;
-}
+export const toggleInserterSidebar =
+	() =>
+	( { registry } ) => {
+		const status = registry.select( editorStore ).isInserterOpened();
+		void registry.dispatch( editorStore ).setIsInserterOpened( ! status );
+	};
 
 export function toggleListviewSidebar() {
 	return {

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -21,11 +21,12 @@ export const toggleInserterSidebar =
 		void registry.dispatch( editorStore ).setIsInserterOpened( ! status );
 	};
 
-export function toggleListviewSidebar() {
-	return {
-		type: 'TOGGLE_LISTVIEW_SIDEBAR',
-	} as const;
-}
+export const toggleListviewSidebar =
+	() =>
+	( { registry } ) => {
+		const status = registry.select( editorStore ).isListViewOpened();
+		void registry.dispatch( editorStore ).setIsListViewOpened( ! status );
+	};
 
 export const changePreviewDeviceType =
 	( deviceType: string ) =>

--- a/packages/js/email-editor/src/store/reducer.ts
+++ b/packages/js/email-editor/src/store/reducer.ts
@@ -2,18 +2,6 @@ import { State } from './types';
 
 export function reducer( state: State, action ): State {
 	switch ( action.type ) {
-		case 'TOGGLE_INSERTER_SIDEBAR':
-			return {
-				...state,
-				inserterSidebar: {
-					...state.inserterSidebar,
-					isOpened: ! state.inserterSidebar.isOpened,
-				},
-				listviewSidebar: {
-					...state.listviewSidebar,
-					isOpened: false,
-				},
-			};
 		case 'TOGGLE_LISTVIEW_SIDEBAR':
 			return {
 				...state,

--- a/packages/js/email-editor/src/store/reducer.ts
+++ b/packages/js/email-editor/src/store/reducer.ts
@@ -2,18 +2,6 @@ import { State } from './types';
 
 export function reducer( state: State, action ): State {
 	switch ( action.type ) {
-		case 'TOGGLE_LISTVIEW_SIDEBAR':
-			return {
-				...state,
-				inserterSidebar: {
-					...state.inserterSidebar,
-					isOpened: false,
-				},
-				listviewSidebar: {
-					...state.listviewSidebar,
-					isOpened: ! state.listviewSidebar.isOpened,
-				},
-			};
 		case 'CHANGE_PREVIEW_STATE':
 			return {
 				...state,

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -231,18 +231,6 @@ export function getEmailPostId( state: State ): number {
 	return state.postId;
 }
 
-export const isInserterSidebarOpened = createRegistrySelector(
-	( select ) => () =>
-		// @ts-expect-error isInserterOpened is missing in types.
-		select( editorStore ).isInserterOpened() as boolean
-);
-
-export const isListviewSidebarOpened = createRegistrySelector(
-	( select ) => () =>
-		// @ts-expect-error isListViewOpened is missing in types.
-		select( editorStore ).isListViewOpened() as boolean
-);
-
 export function getSettingsSidebarActiveTab( state: State ): string {
 	return state.settingsSidebar.activeTab;
 }

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -231,9 +231,11 @@ export function getEmailPostId( state: State ): number {
 	return state.postId;
 }
 
-export function isInserterSidebarOpened( state: State ): boolean {
-	return state.inserterSidebar.isOpened;
-}
+export const isInserterSidebarOpened = createRegistrySelector(
+	( select ) => () =>
+		// @ts-expect-error isInserterOpened is missing in types.
+		select( editorStore ).isInserterOpened() as boolean
+);
 
 export function isListviewSidebarOpened( state: State ): boolean {
 	return state.listviewSidebar.isOpened;

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -237,9 +237,11 @@ export const isInserterSidebarOpened = createRegistrySelector(
 		select( editorStore ).isInserterOpened() as boolean
 );
 
-export function isListviewSidebarOpened( state: State ): boolean {
-	return state.listviewSidebar.isOpened;
-}
+export const isListviewSidebarOpened = createRegistrySelector(
+	( select ) => () =>
+		// @ts-expect-error isListViewOpened is missing in types.
+		select( editorStore ).isListViewOpened() as boolean
+);
 
 export function getSettingsSidebarActiveTab( state: State ): string {
 	return state.settingsSidebar.activeTab;


### PR DESCRIPTION
## Description

Fix "Browse all" button not opening sidebar in the email editor.

This PR converts the store for the Sidebar and Listview components to allow the email editor component to work seamlessly with other core WordPress components.

## Code review notes

Please check the commits.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6303](https://mailpoet.atlassian.net/browse/MAILPOET-6303)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6303]: https://mailpoet.atlassian.net/browse/MAILPOET-6303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-browse-all-in-email-editor)

_The latest successful build from `fix-browse-all-in-email-editor` will be used. If none is available, the link won't work._