### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 9.3.3
+            ./do download:woo-commerce-zip 9.4.1
             ./do download:woo-commerce-subscriptions-zip 6.8.0
             ./do download:woo-commerce-memberships-zip 1.26.5
             ./do download:automate-woo-zip 6.1.0
@@ -1076,7 +1076,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 9.2.3
+          woo_core_version: 9.3.3
           woo_subscriptions_version: 6.7.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
@@ -1117,7 +1117,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 9.2.3
+          woo_core_version: 9.3.3
           woo_subscriptions_version: 6.7.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
@@ -1180,7 +1180,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
-          woo_core_version: 9.2.3
+          woo_core_version: 9.3.3
           woo_subscriptions_version: 6.7.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
@@ -1192,7 +1192,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
-          woo_core_version: 9.2.3
+          woo_core_version: 9.3.3
           woo_subscriptions_version: 6.7.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._