### PR TITLE
Update k6 tests to add alternative option suggested by k6 support

### DIFF
--- a/mailpoet/tests/performance/README.md
+++ b/mailpoet/tests/performance/README.md
@@ -148,10 +148,25 @@ To make assertions, we are using `k6chai.js` library, here is an example how you
 
 ```js
 describe(subscribersPageTitle, () => {
-    describe('should be able to see Lists Filter', () => {
-      expect(page.locator('[data-automation-id="listing_filter_segment"]')).to
-        .exist;
-    });
+  describe('should be able to see Lists Filter', async () => {
+    expect(await page.locator('[data-automation-id="listing_filter_segment"]'))
+      .to.exist;
+  });
+});
+```
+
+However, if you have k6 0.53+ version installed, there is confirmed issue between `chaijs` and `k6` where it is impossible to see output results properly printed like the above code wanted to show a single check inside 2 describe blocks (or even 1 if you'd like).
+To avoid that, we have alternative option to add `const` before the describe block and just link it like this:
+
+```js
+const element = await page.locator(
+  '[data-automation-id="listing_filter_segment"]',
+);
+describe(subscribersPageTitle, () => {
+  describe('should be able to see Lists Filter', async () => {
+    expect(element).to.exist;
+  });
+});
 ```
 
 In order to keep the output results in a clear view, we use `describe` to group them.
@@ -193,5 +208,5 @@ If you find less than this in our CI runs over to Grafana streaming, that means 
 
 ## Other Resources
 
-[k6 documention](https://k6.io/docs/) is a very useful resource for test creation and execution.
-[using k6 browser doc](https://k6.io/docs/using-k6-browser/overview/) is a very useful resource for test creation and execution.
+[k6 documention](https://grafana.com/docs/k6/latest/) is a very useful resource for test creation and execution.
+[using k6 browser doc](https://grafana.com/docs/k6/latest/using-k6-browser/) is a very useful resource for test creation and execution.

--- a/mailpoet/tests/performance/tests/automation-analytics.js
+++ b/mailpoet/tests/performance/tests/automation-analytics.js
@@ -56,9 +56,10 @@ export async function automationAnalytics() {
     const message =
       'In this time period, the automation structure did change and therefore some numbers in the flow chart might not be accurate.';
     const locator = `//div[@class='components-notice__content'].//p[starts-with(text(),${message})]`;
+    const noticeElement = await page.locator(locator);
     describe(automationsPageTitle, () => {
       describe('settings-basic: should be able to see inaccurate data message', async () => {
-        expect(await page.locator(locator)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 
@@ -72,10 +73,12 @@ export async function automationAnalytics() {
       fullPage: fullPageSet,
     });
 
+    const emailNameElement = await page.$$(
+      '.mailpoet-automation-analytics-email-name',
+    );
     describe(automationsPageTitle, () => {
       describe('automation-analytics: should be able to see Emails tab loaded', async () => {
-        expect(await page.$$('.mailpoet-automation-analytics-email-name')).to
-          .exist;
+        expect(emailNameElement).to.exist;
       });
     });
 
@@ -84,9 +87,12 @@ export async function automationAnalytics() {
     await page.waitForSelector('.mailpoet-analytics-filter-controls');
     await page.waitForLoadState('networkidle');
 
+    const filtersControlElement = await page.$$(
+      '.mailpoet-analytics-filter-controls',
+    );
     describe(automationsPageTitle, () => {
       describe('automation-analytics: should be able to see Orders tab loaded', async () => {
-        expect(await page.$$('.mailpoet-analytics-filter-controls')).to.exist;
+        expect(filtersControlElement).to.exist;
       });
     });
 
@@ -98,9 +104,13 @@ export async function automationAnalytics() {
     await page.locator('.components-text-control__input').click();
     await page.waitForLoadState('networkidle');
 
+    await page.waitForSelector('.mailpoet-analytics-orders__customer');
+    const customerOrderElement = await page.locator(
+      '.mailpoet-analytics-orders__customer',
+    );
     describe(automationsPageTitle, () => {
       describe('automation-analytics: should be able to see Subscribers items loaded', async () => {
-        expect(await page.$$('.woocommerce-table__item')[0]).to.exist;
+        expect(customerOrderElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-create-custom.js
+++ b/mailpoet/tests/performance/tests/automation-create-custom.js
@@ -64,9 +64,10 @@ export async function automationCreateCustom() {
     );
     await page.waitForLoadState('networkidle');
 
+    const triggerButtonElement = await page.locator(triggerbutton);
     describe(automationsPageTitle, () => {
       describe('automation-create-custom: should be able to see Add Trigger button', async () => {
-        expect(await page.locator(triggerbutton)).to.exist;
+        expect(triggerButtonElement).to.exist;
       });
     });
 
@@ -112,11 +113,14 @@ export async function automationCreateCustom() {
     // Activate the automation workflow
     await activateWorkflow(page);
 
+    const noticeElement = await page
+      .locator('.components-snackbar__content')
+      .innerText();
     describe(automationsPageTitle, () => {
       describe('automation-create-custom: should be able to see Automation added message', async () => {
-        expect(
-          await page.locator('.components-snackbar__content').innerText(),
-        ).to.contain('Well done! Automation is now activated!');
+        expect(noticeElement).to.contain(
+          'Well done! Automation is now activated!',
+        );
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-create-welcome.js
+++ b/mailpoet/tests/performance/tests/automation-create-welcome.js
@@ -66,10 +66,12 @@ export async function automationCreateWelcome() {
     ]);
     await page.waitForLoadState('networkidle');
 
+    const automationEditorRowElement = await page.locator(
+      '.mailpoet-automation-editor-automation-row',
+    );
     describe(automationsPageTitle, () => {
       describe('automation-create-welcome: should be able to see items in the workflow', async () => {
-        expect(await page.locator('.mailpoet-automation-editor-automation-row'))
-          .to.exist;
+        expect(automationEditorRowElement).to.exist;
       });
     });
 
@@ -92,11 +94,14 @@ export async function automationCreateWelcome() {
     // Activate the automation workflow
     await activateWorkflow(page);
 
+    const automationSnackbarElement = await page
+      .locator('.components-snackbar__content')
+      .innerText();
     describe(automationsPageTitle, () => {
       describe('automation-create-welcome: should be able to see Automation added message', async () => {
-        expect(
-          await page.locator('.components-snackbar__content').innerText(),
-        ).to.contain('Well done! Automation is now activated!');
+        expect(automationSnackbarElement).to.contain(
+          'Well done! Automation is now activated!',
+        );
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-create-woocommerce.js
+++ b/mailpoet/tests/performance/tests/automation-create-woocommerce.js
@@ -66,10 +66,12 @@ export async function automationCreateWooCommerce() {
     ]);
     await page.waitForLoadState('networkidle');
 
+    const automationEditorRowElement = await page.locator(
+      '.mailpoet-automation-editor-automation-row',
+    );
     describe(automationsPageTitle, () => {
       describe('automation-create-woocommerce: should be able to see items in the workflow', async () => {
-        expect(await page.locator('.mailpoet-automation-editor-automation-row'))
-          .to.exist;
+        expect(automationEditorRowElement).to.exist;
       });
     });
 
@@ -92,11 +94,14 @@ export async function automationCreateWooCommerce() {
     // Activate the automation workflow
     await activateWorkflow(page);
 
+    const automationSnackbarElement = await page
+      .locator('.components-snackbar__content')
+      .innerText();
     describe(automationsPageTitle, () => {
       describe('automation-create-woocommerce: should be able to see Automation added message', async () => {
-        expect(
-          await page.locator('.components-snackbar__content').innerText(),
-        ).to.contain('Well done! Automation is now activated!');
+        expect(automationSnackbarElement).to.contain(
+          'Well done! Automation is now activated!',
+        );
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-trash-restore.js
+++ b/mailpoet/tests/performance/tests/automation-trash-restore.js
@@ -55,9 +55,10 @@ export async function automationTrashRestore() {
     // Wait for the success notice message and confirm it
     const movedToTrashNotice =
       "//div[@class='notice-success'].//p[contains(text(),'was moved to the trash')]";
+    const noticeElement = await page.locator(movedToTrashNotice);
     describe(automationsPageTitle, () => {
       describe('automation-trash-restore: should be able to see moved to trash notice', async () => {
-        expect(await page.locator(movedToTrashNotice)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 
@@ -80,9 +81,10 @@ export async function automationTrashRestore() {
     // Wait for the success notice message and confirm it
     const restoredFromTrashNotice =
       "//div[@class='notice-success'].//p[contains(text(),'was restored from the trash')]";
+    const noticeElementTwo = await page.locator(restoredFromTrashNotice);
     describe(automationsPageTitle, () => {
       describe('automation-trash-restore: should be able to see restored from trash notice', async () => {
-        expect(await page.locator(restoredFromTrashNotice)).to.exist;
+        expect(noticeElementTwo).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/automation-trigger-workflow.js
+++ b/mailpoet/tests/performance/tests/automation-trigger-workflow.js
@@ -58,9 +58,10 @@ export async function automationTriggerWorkflow() {
     // Verify you see the success message and the filter is visible
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
+    const noticeElement = await page.locator(locator);
     describe(automationsPageTitle, () => {
       describe('automation-trigger-workflow: should be able to see success notice for adding subscriber', async () => {
-        expect(await page.locator(locator)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 
@@ -118,13 +119,12 @@ export async function automationTriggerWorkflow() {
       fullPage: fullPageSet,
     });
 
+    const customerOrdersElement = await page
+      .locator('.mailpoet-analytics-orders__customer')
+      .innerText();
     describe(automationsPageTitle, () => {
       describe('automation-trigger-workflow: should be able to see subscriber in the results', async () => {
-        expect(
-          await page
-            .locator('.mailpoet-analytics-orders__customer')
-            .innerText(),
-        ).to.contain(subscriberEmail);
+        expect(customerOrdersElement).to.contain(subscriberEmail);
       });
     });
 

--- a/mailpoet/tests/performance/tests/forms-adding.js
+++ b/mailpoet/tests/performance/tests/forms-adding.js
@@ -67,11 +67,12 @@ export async function formsAdding() {
     await page.waitForSelector('[data-automation-id="form_save_button"]');
     await page.locator('[data-automation-id="form_save_button"]').click();
     await page.waitForSelector('.components-notice');
+    const noticeElement = await page
+      .locator('.components-notice__content')
+      .innerText();
     describe(formsPageTitle, () => {
       describe('forms-adding: should be able to see Forms Saved message', async () => {
-        expect(
-          await page.locator('.components-notice__content').innerText(),
-        ).to.contain(
+        expect(noticeElement).to.contain(
           'Form saved. Cookies reset — you will see all your dismissed popup forms again.',
         );
       });

--- a/mailpoet/tests/performance/tests/forms-subscribing.js
+++ b/mailpoet/tests/performance/tests/forms-subscribing.js
@@ -56,11 +56,12 @@ export async function formsSubscribing() {
       .locator('[data-automation-id="subscribe-submit-button"]')
       .click();
     await waitForSelectorToBeVisible(page, '.mailpoet_validate_success');
+    const successMessageElement = await page
+      .locator('.mailpoet_validate_success')
+      .innerText();
     describe(formsPageTitle, () => {
       describe('forms-subscribing: should be able to see successfully subscribed message', async () => {
-        expect(
-          await page.locator('.mailpoet_validate_success').innerText(),
-        ).to.contain('Successfully subscribed!');
+        expect(successMessageElement).to.contain('Successfully subscribed!');
       });
     });
 
@@ -80,11 +81,12 @@ export async function formsSubscribing() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     await page.waitForLoadState('networkidle');
+    const listingTitleElement = await page
+      .locator('.mailpoet-listing-title')
+      .innerText();
     describe(formsPageTitle, () => {
       describe('forms-subscribing: should be able to search for a new subscriber', async () => {
-        expect(
-          await page.locator('.mailpoet-listing-title').innerText(),
-        ).to.contain(subscriberEmail);
+        expect(listingTitleElement).to.contain(subscriberEmail);
       });
     });
 

--- a/mailpoet/tests/performance/tests/lists-view-subscribers.js
+++ b/mailpoet/tests/performance/tests/lists-view-subscribers.js
@@ -58,11 +58,12 @@ export async function listsViewSubscribers() {
     // Wait for the page to load
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
+    const listingFilterElement = await page.locator(
+      '[data-automation-id="listing_filter_segment"]',
+    );
     describe(listsPageTitle, () => {
       describe('lists-view-subscribers: should be able to see Lists Filter', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
     await page.waitForLoadState('networkidle');

--- a/mailpoet/tests/performance/tests/newsletter-listing.js
+++ b/mailpoet/tests/performance/tests/newsletter-listing.js
@@ -44,10 +44,12 @@ export async function newsletterListing() {
     // Check if there is element present and visible
     await page.waitForSelector('[data-automation-id="filters_all"]');
     await page.waitForLoadState('networkidle');
+    const allFilterElement = await page.locator(
+      '[data-automation-id="filters_all"]',
+    );
     describe(emailsPageTitle, () => {
       describe('newsletter-listing: should be able to see All Filter', async () => {
-        expect(await page.locator('[data-automation-id="filters_all"]')).to
-          .exist;
+        expect(allFilterElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-reengagement.js
+++ b/mailpoet/tests/performance/tests/newsletter-reengagement.js
@@ -108,9 +108,10 @@ export async function newsletterReEngagement() {
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Your Re-engagement Email is now activated!')]";
     await page.waitForSelector('#mailpoet_notices');
+    const noticeElement = await page.locator(locator);
     describe(emailsPageTitle, () => {
       describe('newsletter-re-engagement: should be able to see Re-engagement is active message', async () => {
-        expect(await page.locator(locator)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-searching.js
+++ b/mailpoet/tests/performance/tests/newsletter-searching.js
@@ -46,11 +46,12 @@ export async function newsletterSearching() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="listing_filter_segment"]');
     await page.waitForLoadState('networkidle');
+    const listingTitleElement = await page
+      .locator('.mailpoet-listing-title')
+      .innerText();
     describe(emailsPageTitle, () => {
       describe('newsletter-searching: should be able to search for Newsletter 1st', async () => {
-        expect(
-          await page.locator('.mailpoet-listing-title').innerText(),
-        ).to.contain('Newsletter 1st');
+        expect(listingTitleElement).to.contain('Newsletter 1st');
       });
     });
 
@@ -61,11 +62,12 @@ export async function newsletterSearching() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="listing_filter_segment"]');
     await page.waitForLoadState('networkidle');
+    const listingFilterElement = await page.locator(
+      '[data-automation-id="listing_filter_segment"]',
+    );
     describe(emailsPageTitle, () => {
       describe('newsletter-searching: should be able to see Lists Filter', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-sending.js
+++ b/mailpoet/tests/performance/tests/newsletter-sending.js
@@ -93,9 +93,10 @@ export async function newsletterSending() {
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
     await page.waitForSelector('#mailpoet_notices');
+    const noticeElement = await page.locator(locator);
     describe(emailsPageTitle, () => {
       describe('newsletter-sending: should be able to see Newsletter Sent message', async () => {
-        expect(await page.locator(locator)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletter-statistics.js
+++ b/mailpoet/tests/performance/tests/newsletter-statistics.js
@@ -56,13 +56,12 @@ export async function newsletterStatistics() {
       page,
       '[data-acceptance-id="purchased-product-Simple Product"]',
     );
+    const soldProductElement = await page.locator(
+      '[data-acceptance-id="purchased-product-Simple Product"]',
+    );
     describe(emailsPageTitle, () => {
       describe('newsletter-statistics: should be able to see the product as sold', async () => {
-        expect(
-          await page.locator(
-            '[data-acceptance-id="purchased-product-Simple Product"]',
-          ),
-        ).to.exist;
+        expect(soldProductElement).to.exist;
       });
     });
 
@@ -70,10 +69,12 @@ export async function newsletterStatistics() {
     await page.locator('[data-automation-id="engagement-tab"]').click();
     await page.waitForSelector('[data-automation-id="filters_all_engaged"]');
     await page.waitForLoadState('networkidle');
+    const filtersEngagedElement = await page.locator(
+      '[data-automation-id="filters_all_engaged"]',
+    );
     describe(emailsPageTitle, () => {
       describe('newsletter-statistics: should be able to see Link Clicked filter', async () => {
-        expect(await page.locator('[data-automation-id="filters_all_engaged"]'))
-          .to.exist;
+        expect(filtersEngagedElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/newsletters-post-notification.js
+++ b/mailpoet/tests/performance/tests/newsletters-post-notification.js
@@ -113,11 +113,14 @@ export async function newsletterPostNotification() {
     if (page.url().includes('localhost')) {
       // Wait for the success page and confirm it
       await page.waitForSelector('.mailpoet-wizard-step');
+      const headingElement = await page
+        .locator('.mailpoet-congratulate > h1')
+        .innerText();
       describe(emailsPageTitle, () => {
         describe('newsletter-post-notification: should be able to see confirmation page for the first time', async () => {
-          expect(
-            await page.locator('.mailpoet-congratulate > h1').innerText(),
-          ).to.contain('You are all set up and ready to go!');
+          expect(headingElement).to.contain(
+            'You are all set up and ready to go!',
+          );
         });
       });
 
@@ -133,9 +136,10 @@ export async function newsletterPostNotification() {
       const locator =
         "//div[@class='notice-success'].//p[starts-with(text(),'Your post notification is now active!')]";
       await page.waitForSelector('#mailpoet_notices');
+      const noticeElement = await page.locator(locator);
       describe(emailsPageTitle, () => {
         describe('newsletter-post-notification: should be able to see Post Notification is active message', async () => {
-          expect(await page.locator(locator)).to.exist;
+          expect(noticeElement).to.exist;
         });
       });
     }

--- a/mailpoet/tests/performance/tests/onboarding-wizard.js
+++ b/mailpoet/tests/performance/tests/onboarding-wizard.js
@@ -93,13 +93,12 @@ export async function onboardingWizard() {
     });
 
     // Check if you see Send With tab at the end
+    const sendWithTabElement = await page
+      .locator('[data-automation-id="send_with_settings_tab"]')
+      .innerText();
     describe(settingsPageTitle, () => {
       describe('onboarding-wizard: should be able to see Send With tab present', async () => {
-        expect(
-          await page
-            .locator('[data-automation-id="send_with_settings_tab"]')
-            .innerText(),
-        ).to.contain('Send With...');
+        expect(sendWithTabElement).to.contain('Send With...');
       });
     });
 

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -61,11 +61,12 @@ export async function segmentsCreateCustom() {
     await selectInReact(page, '#react-select-2-input', 'subscribed to list');
     await selectInReact(page, '#react-select-4-input', defaultListName);
     await page.waitForSelector('.mailpoet-form-notice-message');
+    const noticeElement = await page
+      .locator('.mailpoet-form-notice-message')
+      .innerText();
     describe(segmentsPageTitle, () => {
       describe('segments-create-custom: should be able to see calculating message 1st time', async () => {
-        expect(
-          await page.locator('.mailpoet-form-notice-message').innerText(),
-        ).to.contain('Calculating segment size…');
+        expect(noticeElement).to.contain('Calculating segment size…');
       });
     });
     await page.waitForLoadState('networkidle');
@@ -85,9 +86,7 @@ export async function segmentsCreateCustom() {
     await page.waitForSelector('.mailpoet-form-notice-message');
     describe(segmentsPageTitle, () => {
       describe('segments-create-custom: should be able to see calculating message 2nd time', async () => {
-        expect(
-          await page.locator('.mailpoet-form-notice-message').innerText(),
-        ).to.contain('Calculating segment size…');
+        expect(noticeElement).to.contain('Calculating segment size…');
       });
     });
 
@@ -108,9 +107,7 @@ export async function segmentsCreateCustom() {
     await page.waitForLoadState('networkidle');
     describe(segmentsPageTitle, () => {
       describe('segments-create-custom: should be able to see Calculating message 3rd time', async () => {
-        expect(
-          await page.locator('.mailpoet-form-notice-message').innerText(),
-        ).to.contain('Calculating segment size…');
+        expect(noticeElement).to.contain('Calculating segment size…');
       });
     });
     await page
@@ -136,9 +133,10 @@ export async function segmentsCreateCustom() {
     await page.waitForLoadState('networkidle');
     const segmentAddedMessage =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully added!')]";
+    const segmentNoticeMessage = await page.locator(segmentAddedMessage);
     describe(segmentsPageTitle, () => {
       describe('segments-create-custom: should be able to see Segment Added message', async () => {
-        expect(await page.locator(segmentAddedMessage)).to.exist;
+        expect(segmentNoticeMessage).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/segments-select-template.js
+++ b/mailpoet/tests/performance/tests/segments-select-template.js
@@ -67,9 +67,10 @@ export async function segmentsSelectTemplate() {
     await page.waitForSelector('[data-automation-id="select_all"]');
     const segmentUpdatedMessage =
       "//div[@class='notice-success'].//p[starts-with(text(),'Segment successfully updated!')]";
+    const noticeElement = await page.locator(segmentUpdatedMessage);
     describe(segmentsPageTitle, () => {
       describe('segments-select-template: should be able to see Segment Updated message', async () => {
-        expect(await page.locator(segmentUpdatedMessage)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -51,9 +51,10 @@ export async function settingsBasic() {
     // Check if there's notice about saved settings
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Settings saved')]";
+    const noticeElement = await page.locator(locator);
     describe(settingsPageTitle, () => {
       describe('settings-basic: should be able to see Settings Saved message', async () => {
-        expect(await page.locator(locator)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-adding.js
+++ b/mailpoet/tests/performance/tests/subscribers-adding.js
@@ -62,18 +62,20 @@ export async function subscribersAdding() {
     // Verify you see the success message and the filter is visible
     const locator =
       "//div[@class='notice-success'].//p[starts-with(text(),'Subscriber was added successfully!')]";
+    const noticeElement = await page.locator(locator);
     describe(subscribersPageTitle, () => {
       describe('subscribers-adding: should be able to see Subscriber Added message', async () => {
-        expect(await page.locator(locator)).to.exist;
+        expect(noticeElement).to.exist;
       });
     });
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
+    const listingFilterElement = await page.locator(
+      '[data-automation-id="listing_filter_segment"]',
+    );
     describe(subscribersPageTitle, () => {
       describe('subscribers-adding: should be able to see Lists Filter', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
     await page.waitForLoadState('networkidle');
@@ -88,11 +90,12 @@ export async function subscribersAdding() {
     await page.waitForSelector('.mailpoet-listing-no-items');
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     await page.waitForLoadState('networkidle');
+    const listingTitleElement = await page
+      .locator('.mailpoet-listing-title')
+      .innerText();
     describe(subscribersPageTitle, () => {
       describe('subscribers-adding: should be able to search for Newly Added Subscriber', async () => {
-        expect(
-          await page.locator('.mailpoet-listing-title').innerText(),
-        ).to.contain(subscriberEmail);
+        expect(listingTitleElement).to.contain(subscriberEmail);
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-filtering.js
+++ b/mailpoet/tests/performance/tests/subscribers-filtering.js
@@ -25,6 +25,9 @@ import { login } from '../utils/helpers.js';
 
 export async function subscribersFiltering() {
   const page = await browser.newPage();
+  const listingFilterElement = await page.locator(
+    '[data-automation-id="listing_filter_segment"]',
+  );
 
   try {
     // Log in to WP Admin
@@ -46,9 +49,7 @@ export async function subscribersFiltering() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-filtering: should be able to see Lists Filter 1st time', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
 
@@ -66,9 +67,7 @@ export async function subscribersFiltering() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-filtering: should be able to see Lists Filter 2nd time', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
 
@@ -84,9 +83,7 @@ export async function subscribersFiltering() {
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
     describe(subscribersPageTitle, () => {
       describe('subscribers-filtering: should be able to see Lists Filter 3rd time', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-listing.js
+++ b/mailpoet/tests/performance/tests/subscribers-listing.js
@@ -43,10 +43,12 @@ export async function subscribersListing() {
 
     // Verify filter, tag and listing are loaded and visible
     await page.waitForLoadState('networkidle');
+    const tagsFilterElement = await page.locator(
+      '[data-automation-id="listing_filter_tag"]',
+    );
     describe(subscribersPageTitle, () => {
       describe('subscribers-listing: should be able to see Tags Filter', async () => {
-        expect(await page.locator('[data-automation-id="listing_filter_tag"]'))
-          .to.exist;
+        expect(tagsFilterElement).to.exist;
       });
     });
 

--- a/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
+++ b/mailpoet/tests/performance/tests/subscribers-trashing-restoring.js
@@ -42,11 +42,12 @@ export async function subscribersTrashingRestoring() {
 
     // Check the subscribers filter is present
     await page.waitForSelector('[data-automation-id="filters_subscribed"]');
+    const listingFilterElement = await page.locator(
+      '[data-automation-id="listing_filter_segment"]',
+    );
     describe(subscribersPageTitle, () => {
       describe('subscribers-trashing-restoring: should be able to see Lists Filter', async () => {
-        expect(
-          await page.locator('[data-automation-id="listing_filter_segment"]'),
-        ).to.exist;
+        expect(listingFilterElement).to.exist;
       });
     });
 
@@ -60,11 +61,10 @@ export async function subscribersTrashingRestoring() {
     await page.locator('[data-automation-id="action-trash"]').click();
     await page.waitForSelector('.notice-success');
     await page.waitForSelector('.colspanchange');
+    const noticeElement = await page.locator('.colspanchange').innerText();
     describe(subscribersPageTitle, () => {
       describe('subscribers-trashing-restoring: should be able to see the message', async () => {
-        expect(await page.locator('.colspanchange').innerText()).to.contain(
-          'No items found.',
-        );
+        expect(noticeElement).to.contain('No items found.');
       });
     });
 


### PR DESCRIPTION
## Description

As explained in the Jira ticket, there is no way to see the output printed as before using the standard code to have check inside describe block due to incompatibility between latest k6 version and chaijs latest version (as explained by k6 support), they suggested adding the alternative way of placing `const` before the describe blocks.

## Code review notes

I executed nightly tests twice from the local, and they went well [with 41 checkmarks and 6m44s](https://d.pr/i/FBPuEe).

Now the output is [printed correctly](https://d.pr/i/9M8egb).

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6321]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6321]: https://mailpoet.atlassian.net/browse/MAILPOET-6321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/fix/update-tests-and-readme)

_The latest successful build from `performance/fix/update-tests-and-readme` will be used. If none is available, the link won't work._