### PR TITLE
Email Editor - Refactor .scss files import [MAILPOET-6320]

### DIFF
--- a/packages/js/email-editor/src/components/block-editor/index.scss
+++ b/packages/js/email-editor/src/components/block-editor/index.scss
@@ -1,5 +1,18 @@
 @import '~@wordpress/base-styles/colors';
 
+.spinner-container {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+
+// Fix editor width. We don't use resizable editor wrapper so we need to set the width manually here
+.editor-visual-editor > div {
+  width: 100%;
+}
+
 #mailpoet-email-editor {
   .editor-header__toolbar {
     flex-grow: 1;

--- a/packages/js/email-editor/src/components/block-editor/index.ts
+++ b/packages/js/email-editor/src/components/block-editor/index.ts
@@ -1,4 +1,2 @@
-import './index.scss';
-
 export * from './editor';
 export * from './layout';

--- a/packages/js/email-editor/src/components/header/index.ts
+++ b/packages/js/email-editor/src/components/header/index.ts
@@ -1,3 +1,1 @@
-import './index.scss';
-
 export * from './header';

--- a/packages/js/email-editor/src/components/notices/index.ts
+++ b/packages/js/email-editor/src/components/notices/index.ts
@@ -1,5 +1,3 @@
-import './index.scss';
-
 export { EditorNotices } from './notices';
 export { EditorSnackbars } from './snackbars';
 export { SentEmailNotice } from './sent-email-notice';

--- a/packages/js/email-editor/src/components/preview/index.ts
+++ b/packages/js/email-editor/src/components/preview/index.ts
@@ -1,4 +1,2 @@
-import './index.scss';
-
 export * from './preview-dropdown';
 export * from './send-preview-email';

--- a/packages/js/email-editor/src/components/sidebar/index.ts
+++ b/packages/js/email-editor/src/components/sidebar/index.ts
@@ -1,4 +1,2 @@
-import './index.scss';
-
 export * from './block-compatibility-warnings';
 export * from './sidebar';

--- a/packages/js/email-editor/src/components/styles-sidebar/index.ts
+++ b/packages/js/email-editor/src/components/styles-sidebar/index.ts
@@ -1,3 +1,1 @@
-import './index.scss';
-
 export * from './styles-sidebar';

--- a/packages/js/email-editor/src/components/template-select/index.ts
+++ b/packages/js/email-editor/src/components/template-select/index.ts
@@ -1,4 +1,2 @@
-import './index.scss';
-
 export * from './select-modal';
 export * from './template-selection';

--- a/packages/js/email-editor/src/index.scss
+++ b/packages/js/email-editor/src/index.scss
@@ -1,12 +1,7 @@
-.spinner-container {
-  align-items: center;
-  display: flex;
-  height: 100%;
-  justify-content: center;
-  width: 100%;
-}
-
-// Fix editor width. We don't use resizable editor wrapper so we need to set the width manually here
-.editor-visual-editor > div {
-  width: 100%;
-}
+@import "./components/block-editor/index.scss";
+@import "./components/header/index.scss";
+@import "./components/notices/index.scss";
+@import "./components/preview/index.scss";
+@import "./components/sidebar/index.scss";
+@import "./components/styles-sidebar/index.scss";
+@import "./components/template-select/index.scss";


### PR DESCRIPTION
## Description

This PR changes how we import styles for components. This centralized approach is used in the Gutenberg repository. Our original approach, where we imported styles in index files in subdirectories, was fragile because such a file might be skipped in case a component is imported directly.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6320]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6320]: https://mailpoet.atlassian.net/browse/MAILPOET-6320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/fix-missing-styles)

_The latest successful build from `email-editor/fix-missing-styles` will be used. If none is available, the link won't work._