### PR TITLE
Fix flaky ClickTest [MAILPOET-6322]

### DIFF
--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -584,8 +584,8 @@ class ClicksTest extends \MailPoetTest {
     $savedClickTime = $this->subscriber->getLastClickAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
     $this->assertInstanceOf(\DateTimeInterface::class, $savedClickTime);
-    verify($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
-    verify($savedClickTime->getTimestamp())->equals($now->getTimestamp());
+    $this->assertEqualsWithDelta($savedEngagementTime->getTimestamp(), $now->getTimestamp(), 1);
+    $this->assertEqualsWithDelta($savedClickTime->getTimestamp(), $now->getTimestamp(), 1);
   }
 
   public function testItUpdatesSubscriberEngagementForMachineAgent() {
@@ -628,8 +628,8 @@ class ClicksTest extends \MailPoetTest {
     $savedClickTime = $this->subscriber->getLastClickAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $savedEngagementTime);
     $this->assertInstanceOf(\DateTimeInterface::class, $savedClickTime);
-    verify($savedEngagementTime->getTimestamp())->equals($now->getTimestamp());
-    verify($savedClickTime->getTimestamp())->equals($now->getTimestamp());
+    $this->assertEqualsWithDelta($savedEngagementTime->getTimestamp(), $now->getTimestamp(), 1);
+    $this->assertEqualsWithDelta($savedClickTime->getTimestamp(), $now->getTimestamp(), 1);
   }
 
   public function testItWontUpdateSubscriberThatWasRecentlyUpdated() {


### PR DESCRIPTION
## Description

This is the same fix I did in https://github.com/mailpoet/mailpoet/pull/5920. In the original PR I fixed only the one test case and forgot to check other cases. This PR applies the same fix for other test cases in the file.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6322]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6322]: https://mailpoet.atlassian.net/browse/MAILPOET-6322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-click-test)

_The latest successful build from `fix-click-test` will be used. If none is available, the link won't work._