### PR TITLE
Document test commands for editor package in readme.md [MAILPOET-6317]

### DIFF
--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -11,6 +11,23 @@ Anything **MailPoet** specific is in the `integrations/MailPoet` folder.
 
 For the core stuff that goes to the engine folder, avoid using other MailPoet-specific services and modules. The code in the Engine folder should work only with WP code or other stuff from the engine.
 
+## Workflow Commands
+We use `composer` run scripts to run the commands. You can run them using `composer run <command>`.
+If you don't have `composer` installed globally, you can use the `composer.phar` file in `../mailpoet/tools/vendor`.
+
+```bash
+composer run unit-test                             # runs all the unit tests
+composer run unit-test -- [path_to_tests]          # runs a single unit test or a directory of tests
+composer run integration-test                      # runs all the integrations tests
+composer run integration-test -- [path_to_tests]   # run a single integration test or a directory of tests
+composer code-style                                # checks the code style
+```
+Example:
+```bash
+# To run test cases defined in tests/integration/Engine/Theme_Controller_Test.php run
+composer run integration-test -- tests/integration/Engine/Theme_Controller_Test.php
+```
+
 ## Known rendering issues
 
 - In some (not all) Outlook versions the width of columns is not respected. The columns will be rendered with the full width.


### PR DESCRIPTION
## Description

This PR adds a section documenting commands for running tests via composer run.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6317]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6317]: https://mailpoet.atlassian.net/browse/MAILPOET-6317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/run-single-test)

_The latest successful build from `email-editor/run-single-test` will be used. If none is available, the link won't work._