### PR TITLE
Don't limit admin when resending confirmation emails [MAILPOET-6329]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -281,7 +281,6 @@ interface Window {
   mailpoet_brand_styles?: {
     available: boolean;
   };
-  mailpoet_max_confirmation_emails: number;
   mailpoet_segments: Array<{
     id: string;
     name: string;

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -419,10 +419,7 @@ const itemActions = [
     className: 'mailpoet-hide-on-mobile',
     label: MailPoet.I18n.t('resendConfirmationEmail'),
     display: function display(subscriber: Subscriber) {
-      return (
-        subscriber.status === 'unconfirmed' &&
-        subscriber.count_confirmations < window.mailpoet_max_confirmation_emails
-      );
+      return subscriber.status === 'unconfirmed';
     },
     onClick: function onClick(subscriber) {
       return MailPoet.Ajax.post({

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -245,7 +245,7 @@ const bulkActions = [
         name: 'remove_from_segment',
         endpoint: 'segments',
         filter: function filter(segment) {
-          return !!(segment.type === 'default');
+          return segment.type === 'default';
         },
       };
 
@@ -442,12 +442,9 @@ const itemActions = [
   },
 ];
 
-const isItemDeletable = (subscriber) => {
-  const isDeletable =
-    Number(subscriber.wp_user_id) === 0 &&
-    Number(subscriber.is_woocommerce_user) === 0;
-  return isDeletable;
-};
+const isItemDeletable = (subscriber) =>
+  Number(subscriber.wp_user_id) === 0 &&
+  Number(subscriber.is_woocommerce_user) === 0;
 
 const getSegmentFromId = (segmentId): Segment => {
   let result: Segment | null = null;
@@ -513,7 +510,7 @@ function SubscriberList() {
     }
 
     return (
-      <div>
+      <>
         <td className={rowClasses}>
           <Link
             className="mailpoet-listing-title"
@@ -584,7 +581,7 @@ function SubscriberList() {
             </>
           ) : null}
         </td>
-      </div>
+      </>
     );
   };
 

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -9,7 +9,6 @@ use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Form\Block;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Segments\SegmentsSimpleListRepository;
-use MailPoet\Subscribers\ConfirmationEmailMailer;
 
 class Subscribers {
   /** @var PageRenderer */
@@ -68,7 +67,6 @@ class Subscribers {
 
     $data['date_formats'] = $this->dateBlock->getDateFormats();
     $data['month_names'] = $this->dateBlock->getMonthNames();
-    $data['max_confirmation_emails'] = ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS;
     $this->pageRenderer->displayPage('subscribers/subscribers.html', $data);
   }
 }

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -62,11 +62,11 @@ class SubscribersListingCest {
   public function sendConfirmationEmail(\AcceptanceTester $i) {
     $i->wantTo('Send confirmation email');
 
-    $disallowedEmail = 'disallowed@example.com';
+    $maxConfirmationsEmail = 'disallowed@example.com';
     $allowedEmail = 'allowed@example.com';
 
     $subscriberResendDisallowed = (new Subscriber())
-      ->withEmail($disallowedEmail)
+      ->withEmail($maxConfirmationsEmail)
       ->withStatus('unconfirmed')
       ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
       ->create();
@@ -80,9 +80,10 @@ class SubscribersListingCest {
     $i->login();
     $i->amOnMailpoetPage('Subscribers');
 
-    $i->waitForText($disallowedEmail);
-    $i->moveMouseOver(['xpath' => '//*[text()="' . $disallowedEmail . '"]//ancestor::tr']);
-    $i->dontSee('Resend confirmation email', '//*[text()="' . $disallowedEmail . '"]//ancestor::tr');
+    $i->waitForText($maxConfirmationsEmail);
+    $i->moveMouseOver(['xpath' => '//*[text()="' . $maxConfirmationsEmail . '"]//ancestor::tr']);
+    // Admins can resend confirmation emails even when the subscriber reached the limit
+    $i->see('Resend confirmation email', '//*[text()="' . $maxConfirmationsEmail . '"]//ancestor::tr');
 
     $i->clickItemRowActionByItemName($allowedEmail, 'Resend confirmation email');
     $i->waitForText('1 confirmation email has been sent.');

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -9,7 +9,6 @@
     var mailpoet_custom_fields = <%= json_encode(custom_fields) %>;
     var mailpoet_month_names = <%= json_encode(month_names) %>;
     var mailpoet_date_formats = <%= json_encode(date_formats) %>;
-    var mailpoet_max_confirmation_emails = <%= max_confirmation_emails %>;
   </script>
 
   <%= localize({


### PR DESCRIPTION
## Description

When the subscriber is unconfirmed, they can resubmit the signup form to receive a confirmation email. They can do this up to 3 times, after which no further confirmation email is sent.

Admins also have the option to resend a confirmation email from the Subscribers listing page. The backend doesn't limit how many emails the admin can resend, but the UI does. Normally, when the subscriber reaches the limit, the admin no longer see the option in the UI (even though backend would allow it). 

This PR changes the condition in the UI so that the admin always sees the option to resend a confirmation email, even if the subscriber has reached the maximum number of confirmation emails. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6329]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫  I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6329]: https://mailpoet.atlassian.net/browse/MAILPOET-6329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:resend-confirmation-email-ui-limit)

_The latest successful build from `resend-confirmation-email-ui-limit` will be used. If none is available, the link won't work._