### PR TITLE
Fix TypeError in test in the latest WooCommerce version [MAILPOET-6244]

### DIFF
--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -168,6 +168,7 @@ wp config set WP_DEBUG_LOG true --raw
 wp config set COOKIE_DOMAIN \$_SERVER[\'HTTP_HOST\'] --raw
 wp config set DISABLE_WP_CRON true --raw
 wp config set MAILPOET_USE_CDN false --raw
+wp config set FS_METHOD \'direct\' --raw
 
 # activate theme
 wp theme install twentytwentyone --activate


### PR DESCRIPTION
## Description

Fixes `[TypeError] ftp_nlist(): Argument #1 ($ftp) must be of type FTP\Connection, null given` error with the latest WooCommerce.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6244]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫  I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6244]: https://mailpoet.atlassian.net/browse/MAILPOET-6244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:ftp-nlist-type-error)

_The latest successful build from `ftp-nlist-type-error` will be used. If none is available, the link won't work._