### PR TITLE
Update k6 login helper with waiting for page to load before navigating further

### DIFF
--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { sleep } from 'k6';
+
+/**
  * Internal dependencies
  */
 import {
@@ -28,6 +33,7 @@ export async function login(page) {
     page.waitForNavigation(),
     page.locator('input[name="wp-submit"]').click(),
   ]);
+  await page.waitForLoadState('networkidle');
 }
 
 // Select a segment or a list from a select2 search field


### PR DESCRIPTION
## Description

I've made a tiny change in the login helper for the K6 performance test suite to fix an issue with being caught in promise timeout before navigating further. Usually, after logging in, there is a go-to method for navigating to MailPoet's page. Sometimes, however, it fails to navigate further, and the page breaks.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/update/login-helper)

_The latest successful build from `performance/update/login-helper` will be used. If none is available, the link won't work._