### PR TITLE
Update k6 to 0.55 version

### DIFF
--- a/mailpoet/tests/performance/utils/helpers.js
+++ b/mailpoet/tests/performance/utils/helpers.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { sleep } from 'k6';
-
-/**
  * Internal dependencies
  */
 import {

--- a/mailpoet/tools/k6.php
+++ b/mailpoet/tools/k6.php
@@ -22,7 +22,7 @@ if (!file_exists($vendorDir)) {
 }
 
 // paths
-$version = 'v0.53.0';
+$version = 'v0.55.0';
 $extension = $os === 'macos' || $os === 'windows' ? 'zip' : 'tar.gz';
 $name = "k6-$version-$os-$arch";
 $url = "https://github.com/grafana/k6/releases/download/$version/$name.$extension";


### PR DESCRIPTION
## Description

Update k6 to its latest 0.55 version and remove unnecessary code from the helper (leftover from previous PR).

## Code review notes

Skipping PR review - tiny code change. Tested locally against nightly and it all went well with passed 41 checks.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/update-k6)

_The latest successful build from `performance/update-k6` will be used. If none is available, the link won't work._