### PR TITLE
Update number of MailPoet users in copy [MAILPOET-6344]

### DIFF
--- a/mailpoet/assets/js/src/landingpage/content.tsx
+++ b/mailpoet/assets/js/src/landingpage/content.tsx
@@ -38,7 +38,7 @@ function Content() {
                 'Powerful email marketing, trusted by %s websites',
                 'mailpoet',
               ),
-              '700,000+',
+              '600,000+',
             )
           }
         </Heading>

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -26,7 +26,7 @@ Our newsletter builder integrates perfectly with WordPress so any website owner 
 
 Schedule your newsletters, send them right away, or set up new blog post notifications to send automatically, in just a few clicks.
 
-Trusted by 700,000 WordPress websites since 2011.
+Trusted by 600,000 WordPress websites since 2011.
 
 **With a free plan to get started, and scaling paid plans with enhanced functionality available, MailPoet is an email marketing solution suitable for both beginners and proficient email marketers.**
 

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -113,7 +113,7 @@
       <%= __('Get started today!') %>
     </h1>
     <p class="mailpoet-premium-page-text-large">
-      <%= __('Over 700,000 people trust MailPoet to power their email marketing campaigns – why not join them?!') %>
+      <%= __('Over %s people trust MailPoet to power their email marketing campaigns – why not join them?!')|replace({'%s': '600,000'}) %>
       <%= __('Upgrade now to grow your business and achieve your business goals.') %>
     </p>
     <a

--- a/mailpoet/views/upgrade.html
+++ b/mailpoet/views/upgrade.html
@@ -19,17 +19,17 @@
   <% if (subscriber_count < 1000 and not has_valid_api_key) %>
   <div class="mailpoet-premium-page-section mailpoet-premium-page-section-narrow mailpoet-premium-page-text-center">
     <h1 class="mailpoet-h0">
-      <%= _x('MailPoet Starter plan is yours for free', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('MailPoet Starter plan is yours for free') %>
     </h1>
     <p class="mailpoet-premium-page-section-large">
-      <%= _x('Website owners with less than 1,000 subscribers, like you, can get their emails delivered reliably for free with MailPoet Sending Service.', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Website owners with less than 1,000 subscribers, like you, can get their emails delivered reliably for free with MailPoet Sending Service.') %>
     </p>
     <a
       target="_blank"
       href="<%= "https://account.mailpoet.com/?s=" ~ subscriber_count ~ "&g=starter&billing=monthly&utm_source=plugin&utm_medium=premium&utm_campaign=purchase&ref=plugin-upgrade-page&email=" ~ current_wp_user.user_email | escape() %>"
       class="mailpoet-button button button-primary button-hero mailpoet-premium-shop-link"
     >
-      <%= _x('Sign up for free', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Sign up for free') %>
     </a>
   </div>
 
@@ -38,33 +38,33 @@
 
   <div class="mailpoet-premium-page-get-started mailpoet-premium-page-section mailpoet-premium-page-text-center">
     <h1 class="mailpoet-h0">
-      <%= _x('Take your email marketing strategy<br> to the next level', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Take your email marketing strategy<br> to the next level') %>
     </h1>
     <p class="mailpoet-premium-page-section-narrow">
-      <%= _x('Ready to level up your email marketing efforts?', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %><br>
-      <%= _x('Upgrade your plan to unlock MailPoet’s <b>advanced features</b>, access to <b>detailed analytics</b>, and <b>priority support</b>.', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Ready to level up your email marketing efforts?') %><br>
+      <%= __('Upgrade your plan to unlock MailPoet’s <b>advanced features</b>, access to <b>detailed analytics</b>, and <b>priority support</b>.') %>
     </p>
     <div class="mailpoet-premium-page-options mailpoet-grid-two-columns">
       <div>
         <div class="mailpoet-premium-page-options-label-wrap">
           <div class="mailpoet-premium-page-options-label">
-            <%= _x('Recommended', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+            <%= __('Recommended') %>
           </div>
         </div>
         <h1 class="mailpoet-h0">
-          <b><%= _x('Business', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></b>
+          <b><%= __('Business') %></b>
         </h1>
         <p class="mailpoet-premium-page-text-large">
-          <%= _x('From <b>$10/month</b><br>for 500 contacts', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+          <%= __('From <b>$10/month</b><br>for 500 contacts') %>
         </h3>
         <ul>
-          <li><%= _x('MailPoet Sending Service', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
-          <li><%= _x('Send unlimited emails per month', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
-          <li><%= _x('Remove MailPoet branding', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
-          <li><%= _x('Priority customer support', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
-          <li><%= _x('Subscriber segmentation', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
-          <li><%= _x('Targeted marketing automation', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
-          <li><%= _x('Detailed email engagement and ecommerce statistics', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></li>
+          <li><%= __('MailPoet Sending Service') %></li>
+          <li><%= __('Send unlimited emails per month') %></li>
+          <li><%= __('Remove MailPoet branding') %></li>
+          <li><%= __('Priority customer support') %></li>
+          <li><%= __('Subscriber segmentation') %></li>
+          <li><%= __('Targeted marketing automation') %></li>
+          <li><%= __('Detailed email engagement and ecommerce statistics') %></li>
         </ul>
         <a
           target="_blank"
@@ -75,20 +75,20 @@
           <% endif %>
         class="mailpoet-button button button-primary button-hero mailpoet-premium-shop-link"
         >
-          <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+          <%= __('Get started') %>
         </a>
       </div>
       <div>
         <div class="mailpoet-premium-page-options-label-wrap"></div>
         <h1 class="mailpoet-h0">
-          <b><%= _x('Creator', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %></b>
+          <b><%= __('Creator') %></b>
         </h1>
         <p class="mailpoet-premium-page-text-large">
-          <%= _x('From <b>$8/month</b><br>for 500 contacts', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+          <%= __('From <b>$8/month</b><br>for 500 contacts') %>
         </p>
         <div class="mailpoet-premium-page-options-divider"></div>
         <p>
-          <%= _x('Want to manage your own email sending? Our Creator plan offers all the features of the Business plan <b>without the MailPoet Sending Service</b>.', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+          <%= __('Want to manage your own email sending? Our Creator plan offers all the features of the Business plan <b>without the MailPoet Sending Service</b>.') %>
         </p>
         <div class="mailpoet-premium-page-options-divider"></div>
         <a
@@ -100,7 +100,7 @@
           <% endif %>
           class="mailpoet-button button button-primary button-hero mailpoet-premium-shop-link"
         >
-          <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+          <%= __('Get started') %>
         </a>
       </div>
     </div>
@@ -110,11 +110,11 @@
 
   <div class="mailpoet-premium-page-section mailpoet-premium-page-section-narrow mailpoet-premium-page-text-center">
     <h1 class="mailpoet-h0">
-      <%= _x('Get started today!', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Get started today!') %>
     </h1>
     <p class="mailpoet-premium-page-text-large">
-      <%= _x('Over 700,000 people trust MailPoet to power their email marketing campaigns – why not join them?!', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
-      <%= _x('Upgrade now to grow your business and achieve your business goals.', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Over 700,000 people trust MailPoet to power their email marketing campaigns – why not join them?!') %>
+      <%= __('Upgrade now to grow your business and achieve your business goals.') %>
     </p>
     <a
       target="_blank"
@@ -125,12 +125,12 @@
       <% endif %>
       class="mailpoet-button button button-primary button-hero mailpoet-premium-shop-link"
     >
-      <%= _x('Get started', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade') %>
+      <%= __('Get started') %>
     </a>
     <p>
       <% set allowedHtml = {'a': {'href': [], 'target': []}} %>
       <%=
-        _x('And if you’re not sure which plan is the right one for you, our [link]Customer Support team[/link] are on hand to help you decide.', 'This text resides in the Upgrade page: /wp-admin/admin.php?page=mailpoet-upgrade')
+        __('And if you’re not sure which plan is the right one for you, our [link]Customer Support team[/link] are on hand to help you decide.')
         |replaceLinkTags('https://www.mailpoet.com/support/sales-pre-sales-questions/?ref=plugin-upgrade-page', {'target': '_blank'})
         |wpKses(allowedHtml)
       %>


### PR DESCRIPTION
## Description

Update the number of MailPoet users from 700,000+ to 600,000+, and replace this number with a variable in strings so that translators don't have to translate it again next time. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6344]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6344]: https://mailpoet.atlassian.net/browse/MAILPOET-6344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:number-of-users)

_The latest successful build from `number-of-users` will be used. If none is available, the link won't work._