### PR TITLE
Fix eslint warnings in the email editor js package - MAILPOET-6316

### DIFF
--- a/packages/js/email-editor/src/blocks/core/button.ts
+++ b/packages/js/email-editor/src/blocks/core/button.ts
@@ -1,5 +1,5 @@
 import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 
 /**
  * Disables Styles for button

--- a/packages/js/email-editor/src/blocks/core/buttons.ts
+++ b/packages/js/email-editor/src/blocks/core/buttons.ts
@@ -1,5 +1,5 @@
 import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 
 /**
  * Switch layout to reduced flex email layout

--- a/packages/js/email-editor/src/blocks/core/column.ts
+++ b/packages/js/email-editor/src/blocks/core/column.ts
@@ -1,5 +1,5 @@
 import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 
 function enhanceColumnBlock() {
 	addFilter(

--- a/packages/js/email-editor/src/blocks/core/columns.tsx
+++ b/packages/js/email-editor/src/blocks/core/columns.tsx
@@ -1,6 +1,6 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { Block } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 import { addFilter } from '@wordpress/hooks';
 
 const columnsEditCallback = createHigherOrderComponent(

--- a/packages/js/email-editor/src/blocks/core/general-block-support.ts
+++ b/packages/js/email-editor/src/blocks/core/general-block-support.ts
@@ -2,7 +2,7 @@ import { addFilter } from '@wordpress/hooks';
 import {
 	Block as WPBlock,
 	BlockSupports as WPBlockSupports,
-} from '@wordpress/blocks';
+} from '@wordpress/blocks/index';
 
 // Extend the BlockSupports type to include shadow
 // The shadow is not included in WP6.4 but it is in WP6.5

--- a/packages/js/email-editor/src/blocks/core/image.tsx
+++ b/packages/js/email-editor/src/blocks/core/image.tsx
@@ -1,7 +1,7 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 
 const imageEditCallback = createHigherOrderComponent(
 	( BlockEdit ) =>

--- a/packages/js/email-editor/src/blocks/core/post-content.tsx
+++ b/packages/js/email-editor/src/blocks/core/post-content.tsx
@@ -1,5 +1,5 @@
 import { addFilter } from '@wordpress/hooks';
-import { Block } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -10,7 +10,8 @@ import {
 } from '@wordpress/editor';
 import { useMemo } from '@wordpress/element';
 import { SlotFillProvider, Spinner } from '@wordpress/components';
-import { Post, store as coreStore } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
+import { Post } from '@wordpress/core-data/build-types/entity-types/post';
 
 /**
  * WordPress private dependencies

--- a/packages/js/email-editor/src/components/notices/snackbars.tsx
+++ b/packages/js/email-editor/src/components/notices/snackbars.tsx
@@ -9,7 +9,7 @@ export function EditorSnackbars( { context = 'email-editor' } ) {
 		( select ) => ( {
 			notices: select( noticesStore ).getNotices( context ),
 		} ),
-		[]
+		[ context ]
 	);
 
 	const { removeNotice } = useDispatch( noticesStore );

--- a/packages/js/email-editor/src/components/sidebar/templates-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/templates-panel.tsx
@@ -10,8 +10,8 @@ import {
 	parse,
 	// @ts-expect-error No types available for this yet.
 	__unstableSerializeAndClean, // eslint-disable-line
-	BlockInstance,
 } from '@wordpress/blocks';
+import { BlockInstance } from '@wordpress/blocks/index';
 import { addQueryArgs } from '@wordpress/url';
 import { storeName } from '../../store';
 

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -1,4 +1,5 @@
-import { BlockInstance, parse } from '@wordpress/blocks';
+import { parse } from '@wordpress/blocks';
+import { BlockInstance } from '@wordpress/blocks/index';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { storeName, EmailTemplatePreview, TemplatePreview } from '../store';

--- a/packages/js/email-editor/src/layouts/flex-email.tsx
+++ b/packages/js/email-editor/src/layouts/flex-email.tsx
@@ -8,7 +8,8 @@ import classnames from 'classnames';
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { Block, getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { Block } from '@wordpress/blocks/index';
 
 import {
 	BlockControls,

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -3,7 +3,8 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { serialize, BlockInstance } from '@wordpress/blocks';
+import { serialize } from '@wordpress/blocks';
+import { BlockInstance } from '@wordpress/blocks/index';
 import { storeName } from './constants';
 import { State, Feature, EmailTemplate } from './types';
 

--- a/packages/js/email-editor/src/store/store.ts
+++ b/packages/js/email-editor/src/store/store.ts
@@ -28,8 +28,8 @@ export const createStore = () => {
 };
 
 export interface EmailEditorStore {
-	getActions(): EditorStoreConfig[ 'actions' ];
-	getSelectors(): EditorStoreConfig[ 'selectors' ];
+	getActions: () => EditorStoreConfig[ 'actions' ];
+	getSelectors: () => EditorStoreConfig[ 'selectors' ];
 }
 
 declare module '@wordpress/data' {

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -1,5 +1,5 @@
-import { EditorSettings, EditorColor } from '@wordpress/block-editor';
-import { BlockInstance } from '@wordpress/blocks';
+import { EditorSettings, EditorColor } from '@wordpress/block-editor/index';
+import { BlockInstance } from '@wordpress/blocks/index';
 
 export enum SendingPreviewStatus {
 	SUCCESS = 'success',

--- a/packages/js/email-editor/src/types/wordpress-modules.ts
+++ b/packages/js/email-editor/src/types/wordpress-modules.ts
@@ -119,14 +119,14 @@ declare module '@wordpress/notices' {
 			) => void;
 		};
 		selectors: {
-			getNotices( state: unknown, context?: string ): Notice[];
-			removeNotice( id: string, context?: string ): void;
+			getNotices: ( state: unknown, context?: string ) => Notice[];
+			removeNotice: ( id: string, context?: string ) => void;
 		};
 	} >;
 }
 
 declare module '@wordpress/core-data' {
-	import { BlockInstance } from '@wordpress/blocks';
+	import { BlockInstance } from '@wordpress/blocks/index';
 
 	export function useEntityBlockEditor(
 		kind: string,


### PR DESCRIPTION


## Description

Fix eslint warnings in the email editor js package

## Code review notes

Run eslint from the email editor JS package directory `/packages/js/email-editor`
```bash
npm run lint:js
```

Note: I dropped the `@wordpress` package update [commit](https://github.com/mailpoet/mailpoet/pull/5954/commits/dfc644f1201815dca5e6a3f6076e33e99b93bf3b) because it's causing conflict with [pnpm](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/19562/workflows/ce04388d-9a70-4ba8-88eb-941c85207ff2/jobs/333956) and fixing the pnpm error stopped webpack from [working](<!-- Uploading d.pr/i/6aVHoq to GitHub… -->). It appears we have to update both the Email Editor JS package and the MailPoet `@wordpress` libraries together.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6316](https://mailpoet.atlassian.net/browse/MAILPOET-6316)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6316]: https://mailpoet.atlassian.net/browse/MAILPOET-6316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-eslint-warnings-in-the-email-editor-js-package)

_The latest successful build from `fix-eslint-warnings-in-the-email-editor-js-package` will be used. If none is available, the link won't work._