### PR TITLE
Move k6 test settings basic to the top of the nightly tests

### DIFF
--- a/mailpoet/tests/performance/scenarios.js
+++ b/mailpoet/tests/performance/scenarios.js
@@ -108,6 +108,7 @@ export async function pullRequests() {
 // Run those tests against trunk in a nightly build
 // Note: there are 41 checks in total
 export async function nightly() {
+  await settingsBasic();
   await newsletterListing();
   await newsletterStatistics();
   await newsletterSearching();
@@ -127,7 +128,6 @@ export async function nightly() {
   await listsViewSubscribers();
   await segmentsCreateCustom();
   await segmentsSelectTemplate();
-  await settingsBasic();
   await formsAdding();
   await formsSubscribing();
 }


### PR DESCRIPTION
## Description

Tiny change that doesn't require review.

Moving settings basic test to the top of the list of nightly tests.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/maintenance/move-settings-test-to-the-top)

_The latest successful build from `performance/maintenance/move-settings-test-to-the-top` will be used. If none is available, the link won't work._