### PR TITLE
Improve scheduled subscribers count check for PN and automation emails [MAILPOET-6346]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -166,7 +166,8 @@ class SendingQueue extends APIEndpoint {
         $segments = $newsletter->getSegmentIds();
 
         $this->scheduledTasksRepository->refresh($scheduledTask);
-        $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($scheduledTask, $segments, $newsletter->getFilterSegmentId());
+        $this->subscribersFinder->addSubscribersToTaskFromSegments($scheduledTask, $segments, $newsletter->getFilterSegmentId());
+        $subscribersCount = $scheduledTask->getSubscribers()->count();
 
         if (!$subscribersCount) {
           return $this->errorResponse([

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -193,7 +193,8 @@ class Scheduler {
     }
 
     // ensure that subscribers are in segments
-    $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, $segments, $newsletter->getFilterSegmentId());
+    $this->subscribersFinder->addSubscribersToTaskFromSegments($task, $segments, $newsletter->getFilterSegmentId());
+    $subscribersCount = $task->getSubscribers()->count();
     if (empty($subscribersCount)) {
       $this->loggerFactory->getLogger(LoggerFactory::TOPIC_POST_NOTIFICATIONS)->info(
         'post notification no subscribers',

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -240,9 +240,8 @@ class Scheduler {
     if ($newsletter->getOptionValue('sendTo') === 'segment') {
       $segment = $this->segmentsRepository->findOneById($newsletter->getOptionValue('segment'));
       if ($segment instanceof SegmentEntity) {
-        $result = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [(int)$segment->getId()]);
-
-        if (empty($result)) {
+        $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [(int)$segment->getId()]);
+        if (!$task->getSubscribers()->count()) {
           $this->deleteByTask($task);
           return false;
         }

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -68,15 +68,15 @@ class SubscribersFinder {
    * @param ScheduledTaskEntity $task
    * @param array<int>    $segmentIds
    *
-   * @return float|int
+   * @return void
    */
-  public function addSubscribersToTaskFromSegments(ScheduledTaskEntity $task, array $segmentIds, ?int $filterSegmentId = null) {
+  public function addSubscribersToTaskFromSegments(ScheduledTaskEntity $task, array $segmentIds, ?int $filterSegmentId = null): void {
     // Prepare subscribers on the DB side for performance reasons
     if (is_int($filterSegmentId)) {
       try {
         $this->segmentsRepository->verifyDynamicSegmentExists($filterSegmentId);
       } catch (InvalidStateException $exception) {
-        return 0;
+        return;
       }
     }
     $staticSegmentIds = [];
@@ -101,7 +101,6 @@ class SubscribersFinder {
     if ($count > 0) {
       $this->entityManager->refresh($task);
     }
-    return $count;
   }
 
   /**

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -17,13 +17,13 @@ use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class SubscribersFinderTest extends \MailPoetTest {
-  public $scheduledTask;
-  public $subscriber3;
-  public $subscriber2;
-  public $subscriber1;
-  public $segment3;
-  public $segment2;
-  public $segment1;
+  private ScheduledTaskEntity $scheduledTask;
+  private SubscriberEntity $subscriber3;
+  private SubscriberEntity $subscriber2;
+  private SubscriberEntity $subscriber1;
+  private SegmentEntity $segment3;
+  private SegmentEntity $segment2;
+  private SegmentEntity $segment1;
 
   /** @var SubscribersFinder */
   private $subscribersFinder;
@@ -96,26 +96,28 @@ class SubscribersFinderTest extends \MailPoetTest {
   }
 
   public function testItAddsSubscribersToTaskFromStaticSegments() {
-    $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments(
+    $this->subscribersFinder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
-        $this->segment1->getId(),
-        $this->segment2->getId(),
+        (int)$this->segment1->getId(),
+        (int)$this->segment2->getId(),
       ]
     );
+    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
     verify($subscribersCount)->equals(1);
-    $subscribersIds = $this->getScheduledTasksSubscribers($this->scheduledTask->getId());
+    $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
     verify($subscribersIds)->equals([$this->subscriber2->getId()]);
   }
 
   public function testItDoesNotAddSubscribersToTaskFromNoSegment() {
     $this->segment3->setType('Invalid type');
-    $subscribersCount = $this->subscribersFinder->addSubscribersToTaskFromSegments(
+    $this->subscribersFinder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
-        $this->segment3->getId(),
+        (int)$this->segment3->getId(),
       ]
     );
+    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
     verify($subscribersCount)->equals(0);
   }
 
@@ -129,14 +131,15 @@ class SubscribersFinderTest extends \MailPoetTest {
     $this->segment2->setType(SegmentEntity::TYPE_DYNAMIC);
 
     $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
-    $subscribersCount = $finder->addSubscribersToTaskFromSegments(
+    $finder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
-        $this->segment2->getId(),
+        (int)$this->segment2->getId(),
       ]
     );
+    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
     verify($subscribersCount)->equals(1);
-    $subscribersIds = $this->getScheduledTasksSubscribers($this->scheduledTask->getId());
+    $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
     verify($subscribersIds)->equals([$this->subscriber1->getId()]);
   }
 
@@ -150,17 +153,17 @@ class SubscribersFinderTest extends \MailPoetTest {
     $this->segment3->setType(SegmentEntity::TYPE_DYNAMIC);
 
     $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
-    $subscribersCount = $finder->addSubscribersToTaskFromSegments(
+    $finder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
-        $this->segment1->getId(),
-        $this->segment2->getId(),
-        $this->segment3->getId(),
+        (int)$this->segment1->getId(),
+        (int)$this->segment2->getId(),
+        (int)$this->segment3->getId(),
       ]
     );
-
+    $subscribersCount = $this->scheduledTask->getSubscribers()->count();
     verify($subscribersCount)->equals(1);
-    $subscribersIds = $this->getScheduledTasksSubscribers($this->scheduledTask->getId());
+    $subscribersIds = $this->getScheduledTasksSubscribers((int)$this->scheduledTask->getId());
     verify($subscribersIds)->equals([$this->subscriber2->getId()]);
   }
 
@@ -179,20 +182,24 @@ class SubscribersFinderTest extends \MailPoetTest {
 
     // Without filtering
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
-    $staticCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()]);
+    $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()]);
+    $staticCount = $task->getSubscribers()->count();
     verify($staticCount)->equals(2);
 
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
-    $dynamicCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()]);
+    $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()]);
+    $dynamicCount = $task->getSubscribers()->count();
     verify($dynamicCount)->equals(4);
 
     // With filtering
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
-    $staticCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()], $filterSegment->getId());
+    $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$staticSegment->getId()], $filterSegment->getId());
+    $staticCount = $task->getSubscribers()->count();
     verify($staticCount)->equals(1);
 
     $task = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED, new Carbon());
-    $dynamicCount = $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()], $filterSegment->getId());
+    $this->subscribersFinder->addSubscribersToTaskFromSegments($task, [$dynamicSegment->getId()], $filterSegment->getId());
+    $dynamicCount = $task->getSubscribers()->count();
     verify($dynamicCount)->equals(2);
   }
 


### PR DESCRIPTION
## Description

When the scheduler worker processes a post notification email or automation email, it enqueues subscribers by adding them to the scheduled_task_subscribers table. After it adds subscribers, there is a logic checking if there are any subscribers in the queue or not. The problem was that in case the subscribers were already enqueued (could be from a previous run if the multi insert timeouted), the method for adding subscribers would return 0 because all rows were already in the DB, and the logic for checking subscribers count would cancel or reschedule sending.

This PR fixes this by checking for the count of enqueued subscribers in the DB rather then looking at the number of newly inserted. 

## Code review notes

Scheduled task subscribers relation [is set EXTRA_LAZY](https://github.com/mailpoet/mailpoet/blob/7bacd887a9d0bc60280afa54173068d41afacf84/mailpoet/lib/Entities/ScheduledTaskEntity.php#L93-L97). 
That means we can call `$task->getSubscribers()->count();` and it will run an SQL query to get count instead of fetching them all. See [docs](https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/tutorials/extra-lazy-associations.html).

## QA notes

Please test sending immediate and scheduled post notifications.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6346]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6346]: https://mailpoet.atlassian.net/browse/MAILPOET-6346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-scheduled-count-check)

_The latest successful build from `fix-scheduled-count-check` will be used. If none is available, the link won't work._