### PR TITLE
Update PHP8.2 images to the latest version [MAILPOET-6347]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ executors:
   wpcli_php_latest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.2_20231016.1
+      - image: mailpoet/wordpress:8.2_20241126.1
 
   wpcli_php_mysql_oldest:
     <<: *default_job_config
@@ -115,7 +115,7 @@ executors:
   wpcli_php_mysql_latest:
     <<: *default_job_config
     docker:
-      - image: mailpoet/wordpress:8.2_20231016.1
+      - image: mailpoet/wordpress:8.2_20241126.1
       - image: cimg/mysql:8.0
         command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_520_ci
 

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   codeception_acceptance:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2-cli_20231016.1}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2-cli_20241126.1}
     depends_on:
       - smtp
       - wordpress
@@ -31,7 +31,7 @@ services:
       PHP_IDE_CONFIG: 'serverName=MailPoetTest'
 
   codeception_integration:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2-cli_20231016.1}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.2-cli_20241126.1}
     depends_on:
       - smtp
       - wordpress


### PR DESCRIPTION
## Description

This PR is an attempt to fix failing nightly tests. We use PHP 8.2.11, which was released a year ago, and we started experiencing issues in nightly tests after we switched to it. I built newer images with the most recent PHP8.2.26. Locally, it fixed the issue, and when I temporarily added `acceptance_latest` to the suite, [it was green in the feature branch](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/19584/workflows/8949dd0a-1475-421d-9f73-d4190d348f79/jobs/334343). 
I was not able to find the exact cause of the timeout error. It seems to be something low-level. It makes not harm to update anyway...

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6347]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-nightly-cli)

_The latest successful build from `fix-nightly-cli` will be used. If none is available, the link won't work._

[MAILPOET-6347]: https://mailpoet.atlassian.net/browse/MAILPOET-6347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ