### PR TITLE
Increase timeout to the first k6 test settings basic

### DIFF
--- a/mailpoet/tests/performance/tests/settings-basic.js
+++ b/mailpoet/tests/performance/tests/settings-basic.js
@@ -34,6 +34,7 @@ export async function settingsBasic() {
       `${baseURL}/wp-admin/admin.php?page=mailpoet-settings#/basics`,
       {
         waitUntil: 'networkidle',
+        timeout: 120000,
       },
     );
 


### PR DESCRIPTION
## Description

Tiny update to k6 test to add timeout manually.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:performance/fix/settings-basic-test)

_The latest successful build from `performance/fix/settings-basic-test` will be used. If none is available, the link won't work._