### PR TITLE
Fix logged PHP type errors [MAILPOET-6348]

### DIFF
--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -122,20 +122,20 @@ class API {
   }
 
   public function setRequestData($data, $requestType) {
-    $this->requestApiVersion = !empty($data['api_version']) ? $data['api_version'] : false;
+    $this->requestApiVersion = (!empty($data['api_version']) && is_string($data['api_version'])) ? $data['api_version'] : false;
 
-    $this->requestEndpoint = isset($data['endpoint'])
+    $this->requestEndpoint = (isset($data['endpoint']) && is_string($data['endpoint']))
       ? Helpers::underscoreToCamelCase(trim($data['endpoint']))
       : null;
 
     // JS part of /wp-admin/customize.php does not like a 'method' field in a form widget
     $methodParamName = isset($data['mailpoet_method']) ? 'mailpoet_method' : 'method';
-    $this->requestMethod = isset($data[$methodParamName])
+    $this->requestMethod = (isset($data[$methodParamName]) && is_string($data[$methodParamName]))
       ? Helpers::underscoreToCamelCase(trim($data[$methodParamName]))
       : null;
     $this->requestType = $requestType;
 
-    $this->requestToken = isset($data['token'])
+    $this->requestToken = (isset($data['token']) && is_string($data['token']))
       ? trim($data['token'])
       : null;
 

--- a/mailpoet/lib/Router/Router.php
+++ b/mailpoet/lib/Router/Router.php
@@ -28,10 +28,10 @@ class Router {
   ) {
     $apiData = ($apiData) ? $apiData : $_GET;
     $this->apiRequest = is_array($apiData) && array_key_exists(self::NAME, $apiData);
-    $this->endpoint = isset($apiData['endpoint']) ?
+    $this->endpoint = (isset($apiData['endpoint']) && is_string($apiData['endpoint'])) ?
       Helpers::underscoreToCamelCase($apiData['endpoint']) :
       false;
-    $this->endpointAction = isset($apiData['action']) ?
+    $this->endpointAction = (isset($apiData['action']) && is_string($apiData['action'])) ?
       Helpers::underscoreToCamelCase($apiData['action']) :
       false;
     $this->data = isset($apiData['data']) ?

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -328,7 +328,10 @@ class Pages {
 
       switch ($this->action) {
         case self::ACTION_CAPTCHA:
-          $captchaSessionId = $this->data['captcha_session_id'] ?? null;
+          $captchaSessionId =
+            (isset($this->data['captcha_session_id']) && is_string($this->data['captcha_session_id']))
+            ? $this->data['captcha_session_id']
+            : null;
           if (!$captchaSessionId) {
             return false;
           }

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -122,6 +122,37 @@ class APITest extends \MailPoetTest {
     verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
   }
 
+  public function testItReturns400ErrorWhenInvalidDataTypeInEndpoint() {
+    $data = [
+      'endpoint' => ['a_p_i_test_namespaced_endpoint_stub_v1'],
+      'method' => 'test',
+    ];
+
+    $response = $this->api->setRequestData($data, Endpoint::TYPE_POST);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+  }
+
+  public function testItReturns400ErrorWhenInvalidDataTypeInMethod() {
+    $data = [
+      'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+      'method' => ['test'],
+    ];
+
+    $response = $this->api->setRequestData($data, Endpoint::TYPE_POST);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+  }
+
+  public function testItReturns400ErrorWhenInvalidDataTypeInToken() {
+    $data = [
+      'endpoint' => 'a_p_i_test_namespaced_endpoint_stub_v1',
+      'method' => 'test',
+      'token' => ['test'],
+    ];
+
+    $response = $this->api->setRequestData($data, Endpoint::TYPE_POST);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+  }
+
   public function testItAcceptsAndProcessesAPIVersion() {
     $namespace = [
       'name' => 'MailPoet\API\JSON\v2',

--- a/mailpoet/tests/integration/Router/RouterTest.php
+++ b/mailpoet/tests/integration/Router/RouterTest.php
@@ -83,9 +83,57 @@ class RouterTest extends \MailPoetTest {
     );
   }
 
+  public function testItTerminatesRequestForIncorrectEndpointDataType() {
+    $routerData = $this->routerData;
+    $routerData['endpoint'] = ['invalid_endpoint'];
+    $router = Stub::construct(
+      '\MailPoet\Router\Router',
+      [$this->accessControl, $this->container, $routerData],
+      [
+        'terminateRequest' => function($code, $error) {
+          return [
+            $code,
+            $error,
+          ];
+        },
+      ]
+    );
+    $result = $router->init();
+    verify($result)->equals(
+      [
+        404,
+        'Invalid router endpoint',
+      ]
+    );
+  }
+
   public function testItTerminatesRequestWhenEndpointActionNotFound() {
     $routerData = $this->routerData;
     $routerData['action'] = 'invalid_action';
+    $router = Stub::construct(
+      '\MailPoet\Router\Router',
+      [$this->accessControl, $this->container, $routerData],
+      [
+        'terminateRequest' => function($code, $error) {
+          return [
+            $code,
+            $error,
+          ];
+        },
+      ]
+    );
+    $result = $router->init();
+    verify($result)->equals(
+      [
+        404,
+        'Invalid router endpoint action',
+      ]
+    );
+  }
+
+  public function testItTerminatesRequestForIncorrectActionDataType() {
+    $routerData = $this->routerData;
+    $routerData['action'] = ['invalid_action'];
     $router = Stub::construct(
       '\MailPoet\Router\Router',
       [$this->accessControl, $this->container, $routerData],


### PR DESCRIPTION
## Description

This PR prevents a couple of type errors I found in logs.

## Code review notes

_N/A_

## QA notes

This changes the renderer and captcha – can you please check that the links (tracked and untracked) from emails work and that captcha is still functional?

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-6348]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6348]: https://mailpoet.atlassian.net/browse/MAILPOET-6348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:type-errors)

_The latest successful build from `type-errors` will be used. If none is available, the link won't work._