### PR TITLE
Prevent incorrect newsletter sending status [MAILPOET-6241]

### DIFF
--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -23,8 +23,11 @@ class ListingComponent extends Component {
   }
 
   componentDidMount() {
-    const { params: propsParams, auto_refresh: autoRefresh = false } =
-      this.props;
+    const {
+      params: propsParams,
+      auto_refresh: autoRefresh = false,
+      refreshRef = null,
+    } = this.props;
     this.isComponentMounted = true;
     const params = propsParams || {};
     this.initWithParams(params);
@@ -33,6 +36,10 @@ class ListingComponent extends Component {
       jQuery(document).on('heartbeat-tick.mailpoet', () => {
         this.getItems();
       });
+    }
+
+    if (refreshRef) {
+      refreshRef.current = () => this.getItems();
     }
   }
 
@@ -751,6 +758,7 @@ ListingComponent.propTypes = {
   isItemDeletable: PropTypes.func,
   isItemToggleable: PropTypes.func,
   className: PropTypes.string,
+  refreshRef: PropTypes.shape({ current: PropTypes.func }),
 };
 
 ListingComponent.displayName = 'Listing';

--- a/mailpoet/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/mailpoet/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -127,7 +127,10 @@ class SendingTaskSubscribers extends APIEndpoint {
 
     $taskSubscriber->resetToUnprocessed();
     $taskSubscriber->getTask()->setStatus(null);
-    $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
+    $newsletter->setStatus(
+      $newsletter->canBeSetActive() ? NewsletterEntity::STATUS_ACTIVE : NewsletterEntity::STATUS_SENDING
+    );
+
     // Each repository flushes all changes
     $this->scheduledTaskSubscribersRepository->flush();
     return $this->successResponse([]);

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -65,6 +65,16 @@ class NewsletterEntity {
   // automatic newsletters status
   const STATUS_ACTIVE = 'active';
 
+  /**
+   * Newsletters that use status "active"
+   */
+  const ACTIVABLE_EMAILS = [
+    NewsletterEntity::TYPE_NOTIFICATION,
+    NewsletterEntity::TYPE_WELCOME,
+    NewsletterEntity::TYPE_AUTOMATIC,
+    NewsletterEntity::TYPE_AUTOMATION,
+  ];
+
   use AutoincrementedIdTrait;
   use CreatedAtTrait;
   use UpdatedAtTrait;
@@ -300,12 +310,10 @@ class NewsletterEntity {
 
     // activate/deactivate unfinished tasks
     $newTaskStatus = null;
-    $typesWithActivation = [self::TYPE_NOTIFICATION, self::TYPE_WELCOME, self::TYPE_AUTOMATIC, self::TYPE_AUTOMATION];
-
-    if (($status === self::STATUS_DRAFT) && in_array($this->type, $typesWithActivation)) {
+    if (($status === self::STATUS_DRAFT) && $this->canBeSetActive()) {
       $newTaskStatus = ScheduledTaskEntity::STATUS_PAUSED;
     }
-    if (($status === self::STATUS_ACTIVE) && in_array($this->type, $typesWithActivation)) {
+    if (($status === self::STATUS_ACTIVE) && $this->canBeSetActive()) {
       $newTaskStatus = ScheduledTaskEntity::STATUS_SCHEDULED;
     }
 
@@ -585,6 +593,10 @@ class NewsletterEntity {
    */
   public function canBeSetSent(): bool {
     return in_array($this->getType(), [self::TYPE_NOTIFICATION_HISTORY, self::TYPE_STANDARD], true);
+  }
+
+  public function canBeSetActive(): bool {
+    return in_array($this->getType(), self::ACTIVABLE_EMAILS, true);
   }
 
   public function getWpPost(): ?WpPostEntity {

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -300,7 +300,7 @@ class NewsletterEntity {
 
     // activate/deactivate unfinished tasks
     $newTaskStatus = null;
-    $typesWithActivation = [self::TYPE_NOTIFICATION, self::TYPE_WELCOME, self::TYPE_AUTOMATIC];
+    $typesWithActivation = [self::TYPE_NOTIFICATION, self::TYPE_WELCOME, self::TYPE_AUTOMATIC, self::TYPE_AUTOMATION];
 
     if (($status === self::STATUS_DRAFT) && in_array($this->type, $typesWithActivation)) {
       $newTaskStatus = ScheduledTaskEntity::STATUS_PAUSED;

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -73,6 +73,7 @@ class NewsletterEntity {
     NewsletterEntity::TYPE_WELCOME,
     NewsletterEntity::TYPE_AUTOMATIC,
     NewsletterEntity::TYPE_AUTOMATION,
+    NewsletterEntity::TYPE_RE_ENGAGEMENT,
   ];
 
   use AutoincrementedIdTrait;

--- a/mailpoet/lib/Migrations/App/Migration_20241128_114257_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20241128_114257_App.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Migrator\AppMigration;
+use MailPoet\Newsletter\NewslettersRepository;
+
+/**
+ * Some newsletters might have an incorrect status due to a bug where we set the status 'sending'
+ * to automation emails.
+ *
+ * See https://mailpoet.atlassian.net/browse/MAILPOET-6241
+ */
+class Migration_20241128_114257_App extends AppMigration {
+  public function run(): void {
+    $newsletterRepository = $this->container->get(NewslettersRepository::class);
+    $newsletters = $newsletterRepository->findBy([
+      'type' => NewsletterEntity::ACTIVABLE_EMAILS,
+      'status' => NewsletterEntity::STATUS_SENDING,
+    ]);
+
+    foreach ($newsletters as $newsletter) {
+      $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+      // As a consequence of the bug, some tasks might be paused, we need to unpause them
+      $this->unpauseTasks($newsletter);
+      $this->entityManager->flush();
+    }
+  }
+
+  private function unpauseTasks(NewsletterEntity $newsletter): void {
+    $queues = $newsletter->getUnfinishedQueues();
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      if ($task && $task->getStatus() === ScheduledTaskEntity::STATUS_PAUSED) {
+        $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+      }
+    }
+  }
+}

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -327,7 +327,7 @@ class NewsletterSaveController {
     }
 
     if ($newsletter->getStatus() === NewsletterEntity::STATUS_CORRUPT) {
-      $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
+      $newsletter->setStatus($newsletter->canBeSetActive() ? NewsletterEntity::STATUS_ACTIVE : NewsletterEntity::STATUS_SENDING);
     }
   }
 

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -197,7 +197,7 @@ class SendingQueuesRepository extends Repository {
         $queue->setNewsletterRenderedBody(null);
         $this->persist($queue);
       }
-      $newsletter->setStatus(NewsletterEntity::STATUS_SENDING);
+      $newsletter->setStatus($newsletter->canBeSetActive() ? NewsletterEntity::STATUS_ACTIVE : NewsletterEntity::STATUS_SENDING);
       $task->setStatus(null);
       $this->flush();
     }

--- a/mailpoet/tests/DataFactories/Newsletter.php
+++ b/mailpoet/tests/DataFactories/Newsletter.php
@@ -507,6 +507,9 @@ class Newsletter {
       if ($queue['processed_at'] ?? null) {
         $scheduledTask->setProcessedAt($queue['processed_at']);
       }
+      if ($queue['scheduled_at'] ?? null) {
+        $scheduledTask->setScheduledAt($queue['scheduled_at']);
+      }
       if (isset($queue['meta'])) {
         $sendingQueue->setMeta($queue['meta']);
       }

--- a/mailpoet/tests/integration/Migrations/App/Migration_20241128_114257_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20241128_114257_App_Test.php
@@ -4,42 +4,105 @@ namespace MailPoet\Migrations\App;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\ScheduledTaskSubscriber;
+use MailPoet\Test\DataFactories\Subscriber;
+use MailPoetVendor\Carbon\Carbon;
 
 // phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
 class Migration_20241128_114257_App_Test extends \MailPoetTest {
   public function testItMigratesActivableEmailsWithStatusSending(): void {
     $migration = new Migration_20241128_114257_App($this->diContainer);
+    $newlyScheduledAt = (new Carbon())->subDays(1);
+    $oldScheduledAt = (new Carbon())->subDays(31);
+    $subscriber = (new Subscriber())->create();
 
     $pausedStandardNewsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_STANDARD)
       ->withStatus(NewsletterEntity::STATUS_SENDING)
-      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_PAUSED, 'count_processed' => 0, 'count_to_process' => 1])
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_PAUSED,
+        'count_processed' => 0,
+        'count_to_process' => 1,
+        'scheduled_at' => $newlyScheduledAt,
+      ])
       ->create();
 
     $runningStandardNewsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_STANDARD)
       ->withStatus(NewsletterEntity::STATUS_SENDING)
-      ->withSendingQueue(['status' => null, 'count_processed' => 0])
+      ->withSendingQueue([
+        'status' => null,
+        'count_processed' => 0,
+        'scheduled_at' => $newlyScheduledAt,
+      ])
       ->create();
 
     $sentStandardNewsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_STANDARD)
       ->withStatus(NewsletterEntity::STATUS_SENT)
-      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED, 'count_processed' => 1, 'count_to_process' => 0])
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_COMPLETED,
+        'count_processed' => 1,
+        'count_to_process' => 0,
+        'scheduled_at' => $newlyScheduledAt,
+      ])
       ->create();
 
     $completedAutomationEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)
       ->withStatus(NewsletterEntity::STATUS_ACTIVE)
-      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED, 'count_processed' => 1, 'count_to_process' => 0])
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_COMPLETED,
+        'count_processed' => 1,
+        'count_to_process' => 0,
+        'scheduled_at' => $newlyScheduledAt,
+      ])
       ->create();
 
     $pausedAutomationEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)
       ->withStatus(NewsletterEntity::STATUS_SENDING)
-      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_PAUSED, 'count_processed' => 0, 'count_to_process' => 1])
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_PAUSED,
+        'count_processed' => 0,
+        'count_to_process' => 1,
+        'scheduled_at' => $newlyScheduledAt,])
       ->create();
 
     $pausedLegacyWelcomeEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_WELCOME)
       ->withStatus(NewsletterEntity::STATUS_SENDING)
-      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_PAUSED, 'count_processed' => 0, 'count_to_process' => 1])
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_PAUSED,
+        'count_processed' => 0,
+        'count_to_process' => 1,
+        'scheduled_at' => $newlyScheduledAt,
+      ])
       ->create();
+
+    $oldPausedAutomationEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_PAUSED,
+        'count_processed' => 0,
+        'count_to_process' => 1,
+        'scheduled_at' => $oldScheduledAt,
+      ])
+      ->create();
+    $task = $oldPausedAutomationEmail->getLatestQueue()->getTask();
+    $taskSubscriber = (new ScheduledTaskSubscriber())->createUnprocessed($task, $subscriber);
+    $task->getSubscribers()->add($taskSubscriber);
+
+
+    $oldPausedWelcomeEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue([
+        'status' => ScheduledTaskEntity::STATUS_PAUSED,
+        'count_processed' => 0,
+        'count_to_process' => 1,
+        'scheduled_at' => $oldScheduledAt,
+        ])
+      ->create();
+    $task = $oldPausedWelcomeEmail->getLatestQueue()->getTask();
+    $taskSubscriber = (new ScheduledTaskSubscriber())->createUnprocessed($task, $subscriber);
+    $task->getSubscribers()->add($taskSubscriber);
+    $this->entityManager->flush();
 
     $migration->run();
 
@@ -49,7 +112,10 @@ class Migration_20241128_114257_App_Test extends \MailPoetTest {
     $this->entityManager->refresh($completedAutomationEmail);
     $this->entityManager->refresh($pausedAutomationEmail);
     $this->entityManager->refresh($pausedLegacyWelcomeEmail);
+    $this->entityManager->refresh($oldPausedAutomationEmail);
+    $this->entityManager->refresh($oldPausedWelcomeEmail);
 
+    // Newsletter statuses wchich we don't touch
     $this->assertEquals(NewsletterEntity::STATUS_SENDING, $pausedStandardNewsletter->getStatus());
     $queue = $pausedStandardNewsletter->getLatestQueue();
     $this->assertEquals(ScheduledTaskEntity::STATUS_PAUSED, $queue->getTask()->getStatus());
@@ -66,6 +132,7 @@ class Migration_20241128_114257_App_Test extends \MailPoetTest {
     $queue = $completedAutomationEmail->getLatestQueue();
     $this->assertEquals(ScheduledTaskEntity::STATUS_COMPLETED, $queue->getTask()->getStatus());
 
+    // Newsletter we switch to active
     $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $pausedAutomationEmail->getStatus());
     $queue = $pausedAutomationEmail->getLatestQueue();
     $this->entityManager->refresh($queue);
@@ -75,5 +142,27 @@ class Migration_20241128_114257_App_Test extends \MailPoetTest {
     $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $pausedLegacyWelcomeEmail->getStatus());
     $queue = $pausedLegacyWelcomeEmail->getLatestQueue();
     $this->assertEquals(ScheduledTaskEntity::STATUS_SCHEDULED, $queue->getTask()->getStatus());
+
+    // Old paused tasks are switched to completed and scheduled task subscribers marked as failed
+    $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $oldPausedAutomationEmail->getStatus());
+    $queue = $oldPausedAutomationEmail->getLatestQueue();
+    $this->assertEquals(ScheduledTaskEntity::STATUS_COMPLETED, $queue->getTask()->getStatus());
+    $taskSubscriber = $queue->getTask()->getSubscribers()->first();
+    $this->entityManager->refresh($taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertEquals($taskSubscriber->getFailed(), 1);
+    $this->assertEquals($taskSubscriber->getProcessed(), 1);
+    $this->assertEquals($taskSubscriber->getError(), 'Sending timed out for being paused too long.');
+
+    $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $oldPausedWelcomeEmail->getStatus());
+    $queue = $oldPausedWelcomeEmail->getLatestQueue();
+    $this->assertEquals(ScheduledTaskEntity::STATUS_COMPLETED, $queue->getTask()->getStatus());
+    $taskSubscriber = $queue->getTask()->getSubscribers()->first();
+    $this->entityManager->refresh($taskSubscriber);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    $this->assertEquals($taskSubscriber->getFailed(), 1);
+    $this->assertEquals($taskSubscriber->getFailed(), 1);
+    $this->assertEquals($taskSubscriber->getProcessed(), 1);
+    $this->assertEquals($taskSubscriber->getError(), 'Sending timed out for being paused too long.');
   }
 }

--- a/mailpoet/tests/integration/Migrations/App/Migration_20241128_114257_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20241128_114257_App_Test.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\Newsletter;
+
+// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20241128_114257_App_Test extends \MailPoetTest {
+  public function testItMigratesActivableEmailsWithStatusSending(): void {
+    $migration = new Migration_20241128_114257_App($this->diContainer);
+
+    $pausedStandardNewsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_PAUSED, 'count_processed' => 0, 'count_to_process' => 1])
+      ->create();
+
+    $runningStandardNewsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue(['status' => null, 'count_processed' => 0])
+      ->create();
+
+    $sentStandardNewsletter = (new Newsletter())->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withStatus(NewsletterEntity::STATUS_SENT)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED, 'count_processed' => 1, 'count_to_process' => 0])
+      ->create();
+
+    $completedAutomationEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_COMPLETED, 'count_processed' => 1, 'count_to_process' => 0])
+      ->create();
+
+    $pausedAutomationEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_AUTOMATION)
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_PAUSED, 'count_processed' => 0, 'count_to_process' => 1])
+      ->create();
+
+    $pausedLegacyWelcomeEmail = (new Newsletter())->withType(NewsletterEntity::TYPE_WELCOME)
+      ->withStatus(NewsletterEntity::STATUS_SENDING)
+      ->withSendingQueue(['status' => ScheduledTaskEntity::STATUS_PAUSED, 'count_processed' => 0, 'count_to_process' => 1])
+      ->create();
+
+    $migration->run();
+
+    $this->entityManager->refresh($pausedStandardNewsletter);
+    $this->entityManager->refresh($runningStandardNewsletter);
+    $this->entityManager->refresh($sentStandardNewsletter);
+    $this->entityManager->refresh($completedAutomationEmail);
+    $this->entityManager->refresh($pausedAutomationEmail);
+    $this->entityManager->refresh($pausedLegacyWelcomeEmail);
+
+    $this->assertEquals(NewsletterEntity::STATUS_SENDING, $pausedStandardNewsletter->getStatus());
+    $queue = $pausedStandardNewsletter->getLatestQueue();
+    $this->assertEquals(ScheduledTaskEntity::STATUS_PAUSED, $queue->getTask()->getStatus());
+
+    $this->assertEquals(NewsletterEntity::STATUS_SENDING, $runningStandardNewsletter->getStatus());
+    $queue = $runningStandardNewsletter->getLatestQueue();
+    $this->assertEquals(null, $queue->getTask()->getStatus());
+
+    $this->assertEquals(NewsletterEntity::STATUS_SENT, $sentStandardNewsletter->getStatus());
+    $queue = $sentStandardNewsletter->getLatestQueue();
+    $this->assertEquals(ScheduledTaskEntity::STATUS_COMPLETED, $queue->getTask()->getStatus());
+
+    $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $completedAutomationEmail->getStatus());
+    $queue = $completedAutomationEmail->getLatestQueue();
+    $this->assertEquals(ScheduledTaskEntity::STATUS_COMPLETED, $queue->getTask()->getStatus());
+
+    $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $pausedAutomationEmail->getStatus());
+    $queue = $pausedAutomationEmail->getLatestQueue();
+    $this->entityManager->refresh($queue);
+    $this->entityManager->refresh($queue->getTask());
+    $this->assertEquals(ScheduledTaskEntity::STATUS_SCHEDULED, $queue->getTask()->getStatus());
+
+    $this->assertEquals(NewsletterEntity::STATUS_ACTIVE, $pausedLegacyWelcomeEmail->getStatus());
+    $queue = $pausedLegacyWelcomeEmail->getLatestQueue();
+    $this->assertEquals(ScheduledTaskEntity::STATUS_SCHEDULED, $queue->getTask()->getStatus());
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -411,6 +411,18 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($newsletter->getReplyToAddress())->same('reply@test.com');
   }
 
+  public function testItResetCorruptedState(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_CORRUPT);
+    $data = ['subject' => 'My First Newsletter', 'id' => $newsletter->getId()];
+    $newsletter = $this->saveController->save($data);
+    verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
+
+    $activableNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_CORRUPT);
+    $data = ['subject' => 'My Automation Newsletter', 'id' => $activableNewsletter->getId()];
+    $activableNewsletter = $this->saveController->save($data);
+    verify($activableNewsletter->getStatus())->equals(NewsletterEntity::STATUS_ACTIVE);
+  }
+
   private function createNewsletter(string $type, string $status = NewsletterEntity::STATUS_DRAFT): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType($type);

--- a/mailpoet/tests/integration/Newsletter/Sending/SendingQueuesRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/SendingQueuesRepositoryTest.php
@@ -91,6 +91,25 @@ class SendingQueuesRepositoryTest extends \MailPoetTest {
     verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
   }
 
+  public function testItResumesSendingOfActivableNewsletter() {
+    $task = $this->createTask();
+    $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+    $queue = $this->createQueue($task);
+    $newsletter = $queue->getNewsletter();
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+    $queue->setCountTotal(1);
+    $queue->setCountProcessed(2);
+    $this->entityManager->flush();
+
+    $this->repository->resume($queue);
+    $this->entityManager->refresh($task);
+
+    verify($task->getStatus())->null();
+    verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_ACTIVE);
+  }
+
   public function testItReturnsCountOfQueuesByNewsletter() {
     $taskStatus = ScheduledTaskEntity::STATUS_PAUSED;
 


### PR DESCRIPTION
## Description

This PR fixes an issue: the Resend button on the Sending Status page switched the newsletter status to `sending` regardless of type.

<img width="1497" alt="Screenshot 2024-11-27 at 17 48 25" src="https://github.com/user-attachments/assets/e2ea323b-9812-44c4-9e3b-3d50a4c112ba">

It also fixes the list refresh after the Resend button is clicked. The functionality has been broken for some time.


## Code review notes

I found two more potentially problematic places in https://github.com/mailpoet/mailpoet/commit/76baf9f4817ed8108f02c49ba96be9d1757d746e. I was not able to replicate the incorrect state for these two by any user action, but I still updated them to be safe.

## QA notes

### Replication

It is better to start with a clean plugin.

1) Create and automation that sends emails
2) Make it send a couple of emails
3) Go to DB admin and in the `wp_mailpoet_scheduled_task_subscribers` table set a couple of records as failed by adding 1 to `fail` column and a random error message to the `error` columns. 
4) Go to the Sending status page (Automation > Analytics > Click sent number in email step – see on the screenshot)

<img width="525" alt="Screenshot 2024-11-29 at 9 33 17" src="https://github.com/user-attachments/assets/b4d49aaa-3647-4438-a429-d5a30f4109f2">

5) Click the resend button
6) Observe 2 issues: I) The list doesn't refresh, II) Go to `wp_mailpoet_newsletters` and observe that the automation email has status `sending` (correct is `active`).

After installing and the plugin with fix. The incorrect state should be fixed via a migration. Note: to run migration you may need to deactivate and reactivate the plugin. Also the resend button shouldn't set the incorrect state any more. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6241]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6241]: https://mailpoet.atlassian.net/browse/MAILPOET-6241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:incorrect-newsletter-state)

_The latest successful build from `incorrect-newsletter-state` will be used. If none is available, the link won't work._