### PR TITLE
Fix nightly tests issues [MAILPOET-6353]

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -471,6 +471,19 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->cli(['plugin', 'deactivate', self::AUTOMATE_WOO_PLUGIN]);
   }
 
+  public function deactivateMailpoetFreeFromPluginPage(): void {
+    $i = $this;
+    $i->amOnPluginsPage();
+    if ($i->checkPluginIsActive('mailpoet-premium/mailpoet-premium.php')) {
+      $i->click('#deactivate-mailpoet-premium');
+      $i->waitForElementClickable('#deactivate-mailpoet');
+    }
+    $i->click('#deactivate-mailpoet');
+    $i->wantTo('Close the poll about MailPoet deactivation.');
+    $i->pressKey('body', WebDriverKeys::ESCAPE);
+    $i->waitForText('Plugin deactivated.');
+  }
+
   public function checkPluginIsActive(string $plugin): bool {
     $i = $this;
     $activePlugins = $i->grabOptionFromDatabase('active_plugins', true);

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -138,8 +138,8 @@ class CreateAndSendEmailUsingGutenbergCest {
 
   private function checkRequiredWordpressVersion(\AcceptanceTester $i): bool {
     $wordPressVersion = $i->getWordPressVersion();
-    // New email editor is not compatible with WP versions below 6.6
-    if (version_compare($wordPressVersion, '6.6', '<')) {
+    // New email editor is not compatible with WP versions below 6.7
+    if (version_compare($wordPressVersion, '6.7', '<')) {
       return false;
     }
     return true;

--- a/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
+++ b/mailpoet/tests/acceptance/Homepage/HomepageLandingAfterActivatingMailPoetCest.php
@@ -6,7 +6,7 @@ class HomepageLandingAfterActivatingMailPoetCest {
   public function _before(\AcceptanceTester $i) {
     $i->activateWooCommerce();
   }
-  
+
   public function homepageLanding(\AcceptanceTester $i) {
     $i->wantTo('Check that Homepage is shown after activating fresh new MailPoet plugin'); // ref: [MAILPOET-5020]
 
@@ -19,20 +19,17 @@ class HomepageLandingAfterActivatingMailPoetCest {
     $i->acceptPopup();
     $i->waitForText('Better email — without leaving WordPress');
 
-    $i->amOnPluginsPage();
-    $i->deactivatePlugin('mailpoet');
-    $i->waitForNoticeAndClose('Selected plugins deactivated.');
+    $i->deactivateMailpoetFreeFromPluginPage();
 
     $i->click('#activate-mailpoet');
-    
+
     // Sometimes it is "flaky" and shows the my plugins page instead homepage
     try {
       $i->waitForText('Better email — without leaving WordPress', 10);
       $i->seeInCurrentUrl('mailpoet-landingpage');
     } catch (\Exception $e) {
       $i->waitForNoticeAndClose('Plugin activated.');
-      $i->deactivatePlugin('mailpoet');
-      $i->waitForNoticeAndClose('Selected plugins deactivated.');
+      $i->deactivateMailpoetFreeFromPluginPage();
       $i->click('#activate-mailpoet');
       $i->waitForText('Better email — without leaving WordPress', 10);
       $i->seeInCurrentUrl('mailpoet-landingpage');

--- a/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
+++ b/mailpoet/tests/acceptance/Landingpage/LandingpageBasicsCest.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Test\DataFactories\Settings;
 
 class LandingpageBasicsCest {
@@ -29,11 +28,8 @@ class LandingpageBasicsCest {
     // show welcome wizard & landing page
     $settings = new Settings();
     $settings->withWelcomeWizard();
+    $i->deactivateMailpoetFreeFromPluginPage();
 
-    $i->click('#deactivate-mailpoet');
-    $i->wantTo('Close the poll about MailPoet deactivation.');
-    $i->pressKey('body', WebDriverKeys::ESCAPE);
-    $i->waitForText('Plugin deactivated.');
     $i->click('#activate-mailpoet');
     $i->waitForText('Better email — without leaving WordPress');
   }


### PR DESCRIPTION
## Description

This PR addresses two issues in the nightly build.

1) Most recent changes in the email editor need WP6.7 and higher. I've updated the test skip condition accordingly.
2) After https://github.com/mailpoet/mailpoet-premium/pull/924 it is no longer possible to deactivate free plugin when premium is active - fixed via adding a custom method that checks both.

[Here is testing run where the issues are fixed](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/19630/workflows/57d6956f-453a-42b9-b4bb-639cff505697).

Note: There is still a failure related to Woo 9.5.0 Beta. This one needs further investigation.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6353]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6353]: https://mailpoet.atlassian.net/browse/MAILPOET-6353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-nightly-tests)

_The latest successful build from `fix-nightly-tests` will be used. If none is available, the link won't work._