### PR TITLE
Retry email sending automation for unconfirmed subscribers [MAILPOET-6176]

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/StepHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepHandler.php
@@ -148,7 +148,7 @@ class StepHandler {
     }, $subjectEntries));
 
     $step->validate($validationArgs);
-    $step->run($args, $this->stepRunControllerFactory->createController($args));
+    $step->run($args, $this->stepRunControllerFactory->createController($args, $logger));
 
     // check if run is not completed by now (e.g., one of if/else branches is empty)
     $automationRun = $this->automationRunStorage->getAutomationRun($runId);

--- a/mailpoet/lib/Automation/Engine/Control/StepRunController.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use MailPoet\Automation\Engine\Control\StepRunLogger;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 
 class StepRunController {
@@ -11,12 +12,17 @@ class StepRunController {
   /** @var StepRunArgs */
   private $stepRunArgs;
 
+  /** @var StepRunLogger */
+  private $stepRunLogger;
+
   public function __construct(
     StepScheduler $stepScheduler,
-    StepRunArgs $stepRunArgs
+    StepRunArgs $stepRunArgs,
+    StepRunLogger $stepRunLogger
   ) {
     $this->stepScheduler = $stepScheduler;
     $this->stepRunArgs = $stepRunArgs;
+    $this->stepRunLogger = $stepRunLogger;
   }
 
   public function scheduleProgress(int $timestamp = null): int {
@@ -33,5 +39,9 @@ class StepRunController {
 
   public function hasScheduledNextStep(): bool {
     return $this->stepScheduler->hasScheduledNextStep($this->stepRunArgs);
+  }
+
+  public function getRunLog(): StepRunLogger {
+    return $this->stepRunLogger;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/StepRunControllerFactory.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunControllerFactory.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Engine\Control;
 
+use MailPoet\Automation\Engine\Control\StepRunLogger;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 
 class StepRunControllerFactory {
@@ -14,7 +15,7 @@ class StepRunControllerFactory {
     $this->stepScheduler = $stepScheduler;
   }
 
-  public function createController(StepRunArgs $args): StepRunController {
-    return new StepRunController($this->stepScheduler, $args);
+  public function createController(StepRunArgs $args, StepRunLogger $logger): StepRunController {
+    return new StepRunController($this->stepScheduler, $args, $logger);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
@@ -100,7 +100,15 @@ class StepRunLogger {
     $this->automationRunLogStorage->updateAutomationRunLog($log);
   }
 
-  private function getLog(): AutomationRunLog {
+  public function saveLogData(array $data): void {
+    $log = $this->getLog();
+    foreach ($data as $key => $value) {
+      $log->setData($key, $value);
+    }
+    $this->automationRunLogStorage->updateAutomationRunLog($log);
+  }
+
+  public function getLog(): AutomationRunLog {
     if (!$this->log) {
       $this->log = $this->automationRunLogStorage->getAutomationRunLogByRunAndStepId($this->runId, $this->stepId);
     }

--- a/mailpoet/lib/Automation/Engine/Data/AutomationRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationRunLog.php
@@ -77,7 +77,7 @@ class AutomationRunLog {
     }
   }
 
-  public function getId(): int {
+  public function getId(): ?int {
     return $this->id;
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -296,7 +296,8 @@ class SendEmailAction implements Action {
 
   private function isOptInRequired(NewsletterEntity $newsletter, SubscriberEntity $subscriber): bool {
     $subscriberStatus = $subscriber->getStatus();
-    return ($newsletter->getType() !== NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL && $subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED);
+    if ($newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL) return false;
+    return $subscriberStatus !== SubscriberEntity::STATUS_SUBSCRIBED;
   }
 
   /** @param mixed $data */

--- a/mailpoet/tests/integration/Automation/Integrations/Core/Actions/IfElseActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/Core/Actions/IfElseActionTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Automation\Integrations\Core\Actions;
 use ActionScheduler_Action;
 use ActionScheduler_Store;
 use MailPoet\Automation\Engine\Control\StepRunControllerFactory;
+use MailPoet\Automation\Engine\Control\StepRunLoggerFactory;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Field;
@@ -96,7 +97,8 @@ class IfElseActionTest extends MailPoetTest {
     // run
     $run = new AutomationRun(1, 1, 'trigger-key', [$subject], 1);
     $args = new StepRunArgs($automation, $run, $step, [new SubjectEntry($this->subscriberSubject, $subject)], 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
     $this->action->run($args, $controller);
 
     // check

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Builder\UpdateAutomationController;
 use MailPoet\Automation\Engine\Control\ActionScheduler;
 use MailPoet\Automation\Engine\Control\AutomationController;
 use MailPoet\Automation\Engine\Control\StepRunControllerFactory;
+use MailPoet\Automation\Engine\Control\StepRunLoggerFactory;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
@@ -130,7 +131,8 @@ class SendEmailActionTest extends \MailPoetTest {
 
     // first run
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
     $this->action->run($args, $controller);
 
     // scheduled task
@@ -151,7 +153,8 @@ class SendEmailActionTest extends \MailPoetTest {
 
     // progress — won't throw an exception when the email was sent (= step will be completed)
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 2);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 2);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
     $this->action->run($args, $controller);
   }
 
@@ -170,7 +173,8 @@ class SendEmailActionTest extends \MailPoetTest {
 
     // progress run step args
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 2);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 2);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     // email was never scheduled
     $this->assertThrowsExceptionWithMessage(
@@ -265,7 +269,7 @@ class SendEmailActionTest extends \MailPoetTest {
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
     $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User());
-    $run = new AutomationRun(1, 1, 'trigger-key', $subjects);
+    $run = new AutomationRun(1, 1, 'trigger-key', $subjects, 1);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
     verify($scheduled)->arrayCount(0);
@@ -273,7 +277,8 @@ class SendEmailActionTest extends \MailPoetTest {
     $this->segmentsRepository->bulkDelete([$segment->getId()]);
     $action = ContainerWrapper::getInstance()->get(SendEmailAction::class);
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     try {
       $action->run($args, $controller);
@@ -296,7 +301,7 @@ class SendEmailActionTest extends \MailPoetTest {
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
     $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User());
-    $run = new AutomationRun(1, 1, 'trigger-key', $subjects);
+    $run = new AutomationRun(1, 1, 'trigger-key', $subjects, 1);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
     verify($scheduled)->arrayCount(0);
@@ -304,7 +309,8 @@ class SendEmailActionTest extends \MailPoetTest {
     $this->subscribersRepository->bulkDelete([$subscriber->getId()]);
     $action = ContainerWrapper::getInstance()->get(SendEmailAction::class);
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     try {
       $action->run($args, $controller);
@@ -336,7 +342,7 @@ class SendEmailActionTest extends \MailPoetTest {
 
       $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
       $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User());
-      $run = new AutomationRun(1, 1, 'trigger-key', $subjects);
+      $run = new AutomationRun(1, 1, 'trigger-key', $subjects, 1);
 
       $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
       verify($scheduled)->arrayCount(0);
@@ -344,7 +350,8 @@ class SendEmailActionTest extends \MailPoetTest {
       $this->subscribersRepository->bulkDelete([$subscriber->getId()]);
       $action = ContainerWrapper::getInstance()->get(SendEmailAction::class);
       $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 1);
-      $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+      $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+      $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
       try {
         $action->run($args, $controller);
@@ -381,7 +388,9 @@ class SendEmailActionTest extends \MailPoetTest {
 
     // Prepare action run.
     $args = new StepRunArgs($automation, $run, end($steps), $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $step = end($steps);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     // First run: with no opt-in => schedule a retry
     $actionScheduler = $this->diContainer->get(ActionScheduler::class);
@@ -425,7 +434,9 @@ class SendEmailActionTest extends \MailPoetTest {
 
     // Prepare action run.
     $args = new StepRunArgs($automation, $run, end($steps), $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $step = end($steps);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     // First run: with no opt-in => schedule a retry
     $actionScheduler = $this->diContainer->get(ActionScheduler::class);
@@ -455,14 +466,15 @@ class SendEmailActionTest extends \MailPoetTest {
 
     $step = new Step('step-id', Step::TYPE_ACTION, 'step-key', ['email_id' => $email->getId()], []);
     $automation = new Automation('some-automation', [$step->getId() => $step], new \WP_User());
-    $run = new AutomationRun(1, 1, 'trigger-key', $subjects);
+    $run = new AutomationRun(1, 1, 'trigger-key', $subjects, 1);
 
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());
     verify($scheduled)->arrayCount(0);
 
     $action = ContainerWrapper::getInstance()->get(SendEmailAction::class);
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     try {
       $action->run($args, $controller);
@@ -502,7 +514,8 @@ class SendEmailActionTest extends \MailPoetTest {
 
     $action = ContainerWrapper::getInstance()->get(SendEmailAction::class);
     $args = new StepRunArgs($automation, $run, $step, $this->getSubjectEntries($subjects), 1);
-    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args);
+    $logger = $this->diContainer->get(StepRunLoggerFactory::class)->createLogger($run->getId(), $step->getId(), $step->getType(), 1);
+    $controller = $this->diContainer->get(StepRunControllerFactory::class)->createController($args, $logger);
 
     $action->run($args, $controller);
     $scheduled = $this->scheduledTasksRepository->findByNewsletterAndSubscriberId($email, (int)$subscriber->getId());


### PR DESCRIPTION
## Description

When a subscriber isn’t already “Subscribed”, and some automation runs without any delay (to allow the subscriber to confirm their subscription), then any Send-Email actions will fail.

This PR fixes the issue by retrying the "Send Email Action" a couple of times if opt-in is required, and the subscriber has not yet confirmed their subscription.

## Code review notes

I discussed a bit of the approach with @JanJakes, and we found it was probably okay to re-schedule the "SendEmailAction" action a few times to wait for opt-in, and store state in the automation's run log. 💭 

> [!IMPORTANT]
> I'd like to get feedback on the current state of this PR, before spending a bit more time to improve the retry mechanism (see comments in code), or add more tests maybe. 😄 

## QA notes

Testing instructions:
1. Make sure signup confirmation is enabled in Settings.
2. Create a new automation with two steps, "Tag Added to Subscriber" as a trigger and "Send email" as an action. Activate it.
3. Add a new unconfirmed subscriber.
4. Add a tag to this subscriber on the subscriber edit page.
5. Wait until cron execution and observe that the automation run is in progress. Wait for some time to see that it is not advancing further.
6. Confirm the subscriber.
7. Check that the automation run is now completed.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6176](https://mailpoet.atlassian.net/browse/MAILPOET-6176)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6176]: https://mailpoet.atlassian.net/browse/MAILPOET-6176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6176_automations-subscribed-only)

_The latest successful build from `MAILPOET-6176_automations-subscribed-only` will be used. If none is available, the link won't work._