### PR TITLE
Remove sale from .org description [MAILPOET-6283]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -12,14 +12,6 @@ Send beautiful newsletters from WordPress. Collect subscribers with signup forms
 
 == Description ==
 
-= Save 40% on all MailPoet annual plans and upgrades =
-
-For a limited time, save 40% when you switch to (or upgrade) an annual plan — no coupon needed. Offer ends at 3 pm UTC, December 3, 2024.
-
-[Pick a plan and save big](https://account.mailpoet.com/?billing=yearly&ref=sale-bfcm-2024-wporg&utm_source=wordpress.org&utm_medium=description&utm_campaign=sale_bfcm_2024)
-
-= What is MailPoet? =
-
 Use MailPoet to create, send, manage, and grow your email marketing campaigns – all without leaving your WordPress dashboard.
 
 Our newsletter builder integrates perfectly with WordPress so any website owner can create beautiful emails from scratch, or by using our responsive templates that display flawlessly across all devices.


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Skipping.

## QA notes

Skipping.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6283]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6283]: https://mailpoet.atlassian.net/browse/MAILPOET-6283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:sale-end)

_The latest successful build from `sale-end` will be used. If none is available, the link won't work._