### PR TITLE
Disable block patterns caching [MAILPOET-6353]

### DIFF
--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -122,6 +122,13 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     unzip -q -o "$AUTOMATEWOO_ZIP" -d /wp-core/wp-content/plugins/
   fi
 
+  # Install MU plugin that disables blocks patterns caching – it's needed for acceptance tests
+  # caching is dependent on the path, however it differs for the test run and wp-cli so it produces notices and tests fail
+  if [[ ! -f "/wp-core/wp-content/mu-plugins/woo-cache-disable.php" ]]; then
+    mkdir -p /wp-core/wp-content/mu-plugins
+    echo "<?php add_filter('site_transient_woocommerce_blocks_patterns', '__return_false');" > "/wp-core/wp-content/mu-plugins/woo-cache-disable.php"
+  fi
+
   ACTIVATION_CONTEXT=$HTTP_HOST
   # For integration tests in multisite environment we need to activate the plugin for correct site that is loaded in tests
   # The acceptance tests activate/deactivate plugins using a helper.


### PR DESCRIPTION
## Description

In our test environment, we have two containers with WordPress (test suite container and test site container). They share the same DB but WordPress is installed in different paths. When we run a WP CLI command in the suite container, it caches the Woo patterns data, and then we get the notices when we access the test site on the site container. This caused many PHP Notices `User Notice: Function WP_Block_Patterns_Registry::register was called incorrectly. Pattern content must be a string`. For more details, see the linked ticket. 

The solution now is to create a MU plugin that disables the caching behaviour.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

[MAILPOET-6353]

## Linked tickets

Related: https://github.com/woocommerce/woocommerce/issues/53345

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6353]: https://mailpoet.atlassian.net/browse/MAILPOET-6353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-nightly-tests)

_The latest successful build from `fix-nightly-tests` will be used. If none is available, the link won't work._