### PR TITLE
Add start from scratch to the template selector - MAILPOET-6333

### DIFF
--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -6,7 +6,11 @@ import {
 	Modal,
 	__experimentalHStack as HStack, // eslint-disable-line
 	Button,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
 import { Async } from './async';
 import { usePreviewTemplates } from '../../hooks';
 import { storeName, TemplatePreview } from '../../store';
@@ -113,6 +117,17 @@ export function SelectTemplateModal( { onSelectCallback } ) {
 							</div>
 						) ) }
 					</div>
+
+					<Flex justify="flex-end">
+						<FlexItem>
+							<Button
+								variant="tertiary"
+								onClick={ () => handleCloseWithoutSelection() }
+							>
+								{ __( 'Start from scratch', 'mailpoet' ) }
+							</Button>
+						</FlexItem>
+					</Flex>
 				</div>
 			</div>
 		</Modal>

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -20,6 +20,8 @@ const BLANK_TEMPLATE = 'email-general';
 export function SelectTemplateModal( { onSelectCallback } ) {
 	const [ templates ] = usePreviewTemplates();
 
+	const hasTemplates = templates?.length > 0;
+
 	const handleTemplateSelection = ( template: TemplatePreview ) => {
 		void dispatch( editorStore ).resetEditorBlocks(
 			template.patternParsed
@@ -118,10 +120,12 @@ export function SelectTemplateModal( { onSelectCallback } ) {
 						) ) }
 					</div>
 
-					<Flex justify="flex-end">
+					<Flex justify={ hasTemplates ? 'flex-end' : 'center' }>
 						<FlexItem>
 							<Button
-								variant="tertiary"
+								variant={
+									hasTemplates ? 'tertiary' : 'primary'
+								}
 								onClick={ () => handleCloseWithoutSelection() }
 							>
 								{ __( 'Start from scratch', 'mailpoet' ) }

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -120,13 +120,12 @@ export function SelectTemplateModal( { onSelectCallback } ) {
 						) ) }
 					</div>
 
-					<Flex justify={ hasTemplates ? 'flex-end' : 'center' }>
+					<Flex justify="flex-end">
 						<FlexItem>
 							<Button
-								variant={
-									hasTemplates ? 'tertiary' : 'primary'
-								}
+								variant="tertiary"
 								onClick={ () => handleCloseWithoutSelection() }
+								isBusy={ ! hasTemplates }
 							>
 								{ __( 'Start from scratch', 'mailpoet' ) }
 							</Button>


### PR DESCRIPTION
## Description

Add start from scratch to the template selector.

The button position will change depending on whether a template exists or not.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6333](https://mailpoet.atlassian.net/browse/MAILPOET-6333)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6333]: https://mailpoet.atlassian.net/browse/MAILPOET-6333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-start-from-scratch-to-the-template-selector)

_The latest successful build from `add-start-from-scratch-to-the-template-selector` will be used. If none is available, the link won't work._