### PR TITLE
Fix the failing trunk branch

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -41,10 +41,13 @@ e66c76133ec3ef667e382203426d91a4b4aa5174
 ab27eaee2df740c0add4331a7f8c115a87ecfa2b
 
 # Move email editor to JS packages folder
-374a79c49b6051a2cb2dc7b5cee5c6e69de16aba
+912282f57ccc839491ff951ec5cf7aa10c14f429
 
 # Switch email editor js packages to WP coding style
-d8ba1af97864e373b81dd08bd884055a138e1306
+b2fb96f8793b63db629d5237010d87332330c51e
 
 # Email editor Prettier autoformatting
-cdf89c46599e68648a4522d968a0d1948895060a
+8c604453b1d82e3a2c731241e1c96ea8b32ec716
+
+# Move email editor components out of the engine folder
+1c3ea9cd0a5fc8848a64d840e2fa16a6c7d8c1fe

--- a/packages/php/email-editor/tests/integration/Engine/Templates/Templates_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Templates/Templates_Test.php
@@ -38,6 +38,7 @@ class Templates_Test extends \MailPoetTest {
 		$template_id = 'mailpoet/mailpoet//email-general';
 		$template    = $this->templates->get_block_template( $template_id );
 
+		self::assertInstanceOf( \WP_Block_Template::class, $template );
 		verify( $template->slug )->equals( 'email-general' );
 		verify( $template->id )->equals( 'mailpoet/mailpoet//email-general' );
 		verify( $template->title )->equals( 'General Email' );


### PR DESCRIPTION
## Description

Fix the failing trunk branch.
This PR mainly fixes the PHPStan error and updates the git-blame-ignore

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-trunk)

_The latest successful build from `fix-trunk` will be used. If none is available, the link won't work._