### PR TITLE
Improve Banned Message [MAILPOET-6357]

### DIFF
--- a/mailpoet/assets/js/src/notices/mailer-error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer-error.tsx
@@ -228,6 +228,13 @@ export function MailerError({
     );
   }
 
+  let checkSettingsNotice = null;
+  if (mtaMethod === 'PHPMail') {
+    checkSettingsNotice = <PHPMailerCheckSettingsNotice />;
+  } else if (mtaMethod !== 'MailPoet') {
+    checkSettingsNotice = <MailerCheckSettingsNotice />;
+  }
+
   return (
     <div className={className}>
       <p>
@@ -242,11 +249,7 @@ export function MailerError({
             )}
         : <i>{message}</i>
       </p>
-      {mtaMethod === 'PHPMail' ? (
-        <PHPMailerCheckSettingsNotice />
-      ) : (
-        <MailerCheckSettingsNotice />
-      )}
+      {checkSettingsNotice}
       <p>
         <a
           href="#"

--- a/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
+++ b/mailpoet/lib/Mailer/Methods/ErrorMappers/MailPoetMapper.php
@@ -160,7 +160,7 @@ class MailPoetMapper {
   }
 
   private function getAccountBannedMessage(): string {
-    $message = __('MailPoet Sending Service has been temporarily suspended for your site due to [link1]degraded email deliverability[/link1]. Please [link2]contact our support team[/link2] to resolve the issue.', 'mailpoet');
+    $message = __('The MailPoet Sending Service has been temporarily suspended for your site due to a high number of [link1]undeliverable emails or emails marked as unwanted by recipients[/link1]. Please [link2]contact our support team[/link2] to resolve the issue.', 'mailpoet');
     $message = Helpers::replaceLinkTags(
       $message,
       'https://kb.mailpoet.com/article/231-sending-does-not-work#suspended',

--- a/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
+++ b/mailpoet/tests/unit/Mailer/Methods/ErrorMappers/MailPoetMapperTest.php
@@ -80,7 +80,7 @@ class MailPoetMapperTest extends \MailPoetUnitTest {
     verify($error)->instanceOf(MailerError::class);
     verify($error->getOperation())->equals(MailerError::OPERATION_SEND);
     verify($error->getLevel())->equals(MailerError::LEVEL_HARD);
-    verify($error->getMessage())->stringContainsString('MailPoet Sending Service has been temporarily suspended for your site due to');
+    verify($error->getMessage())->stringContainsString('The MailPoet Sending Service has been temporarily suspended for your site due to');
   }
 
   public function testGetErrorInsufficientPrivileges(): void {


### PR DESCRIPTION
## Description
Improves the notice informing a user that they are banned and need to contact support.

**Before**
![image](https://github.com/user-attachments/assets/626fbd37-dd86-4e9b-9b68-4828aa0294d7)

**After**
![image](https://github.com/user-attachments/assets/0843c4c6-9045-4cd2-9a0d-3e1fa929092f)


## Code review notes
Skipping

## QA notes
Skipping

## Linked tickets

[MAILPOET-6357]

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6357]: https://mailpoet.atlassian.net/browse/MAILPOET-6357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6357-improve-banned-message)

_The latest successful build from `MAILPOET-6357-improve-banned-message` will be used. If none is available, the link won't work._