### PR TITLE
Add categories to the select a template dialogue - MAILPOET-6331

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -147,6 +147,8 @@ class CreateAndSendEmailUsingGutenbergCest {
 
   private function closeTemplateSelectionModal(\AcceptanceTester $i): void {
     $i->wantTo('Close template selector');
+    $i->waitForElementClickable('.email-editor-start_from_scratch_button');
+    $i->click('[aria-label="Basic"]');
     $i->waitForElementVisible('.block-editor-block-preview__container');
     $i->click('[aria-label="Close"]');
   }

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -95,6 +95,8 @@ class EmailTemplatesCest {
 
   private function selectTemplate(\AcceptanceTester $i, string $template): void {
     $i->wantTo("Select template $template");
+    $i->waitForElementClickable('.email-editor-start_from_scratch_button');
+    $i->click('[aria-label="Basic"]');
     $i->waitForElement('.block-editor-block-patterns-list__item-title');
     $i->waitForText($template);
     $i->click("//div[@class='block-editor-block-patterns-list__item-title' and text()='$template']");

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -1,4 +1,4 @@
-
+import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { dispatch } from '@wordpress/data';
 import {
@@ -15,12 +15,39 @@ import { TemplateCategoriesListSidebar } from './template-categories-list-sideba
 
 const BLANK_TEMPLATE = 'email-general';
 
-export function SelectTemplateModal( {
-	onSelectCallback,
-	closeCallback = null,
-	previewContent = '',
+function SelectTemplateBody( {
+	initialCategory,
+	templateCategories,
+	templates,
+	handleTemplateSelection,
 } ) {
-	const [ templates ] = usePreviewTemplates( previewContent );
+	const [ selectedCategory, setSelectedCategory ] = useState(
+		initialCategory?.name
+	);
+
+	return (
+		<div className="block-editor-block-patterns-explorer">
+			<TemplateCategoriesListSidebar
+				templateCategories={ templateCategories }
+				selectedCategory={ selectedCategory }
+				onClickCategory={ setSelectedCategory }
+			/>
+
+			<TemplateList
+				templates={ templates }
+				onTemplateSelection={ handleTemplateSelection }
+				selectedCategory={ selectedCategory }
+			/>
+		</div>
+	);
+}
+
+export function SelectTemplateModal( {
+                                       onSelectCallback,
+                                       closeCallback = null,
+                                       previewContent = '',
+                                     } ) {
+  const [ templates ] = usePreviewTemplates( previewContent );
 
 	const hasTemplates = templates?.length > 0;
 
@@ -49,44 +76,43 @@ export function SelectTemplateModal( {
 		handleTemplateSelection( blankTemplate );
 	};
 
-  const dummyTemplateCategories = [
-    {
-      name: 'recent',
-      label: 'Recent'
-    },
-    {
-      name: 'basic',
-      label: 'Basic'
-    }
-  ];
-
-  const onClickCategory = () => {}
+	const dummyTemplateCategories = [
+		{
+			name: 'recent',
+			label: 'Recent',
+		},
+		{
+			name: 'basic',
+			label: 'Basic',
+		},
+	];
 
 	return (
 		<Modal
-			title="Select a template"
-			onRequestClose={ () =>
-				closeCallback ? closeCallback() : handleCloseWithoutSelection()
-			}
+			title={ __( 'Select a template', 'mailpoet' ) }
+      onRequestClose={ () =>
+        closeCallback ? closeCallback() : handleCloseWithoutSelection()
+      }
 			isFullScreen
 		>
-			<div className="block-editor-block-patterns-explorer">
-        <TemplateCategoriesListSidebar templateCategories={dummyTemplateCategories} selectedCategory={dummyTemplateCategories[0].name} onClickCategory={onClickCategory} />
+			<SelectTemplateBody
+				initialCategory={ dummyTemplateCategories[ 0 ] }
+				templateCategories={ dummyTemplateCategories }
+				templates={ templates }
+				handleTemplateSelection={ handleTemplateSelection }
+			/>
 
-        <TemplateList templates={templates} onTemplateSelection={ handleTemplateSelection} />
-
-        <Flex justify="flex-end">
-          <FlexItem>
-            <Button
-              variant="tertiary"
-              onClick={ () => handleCloseWithoutSelection() }
-              isBusy={ ! hasTemplates }
-            >
-              { __( 'Start from scratch', 'mailpoet' ) }
-            </Button>
-          </FlexItem>
-        </Flex>
-			</div>
+      <Flex justify="flex-end">
+        <FlexItem>
+          <Button
+            variant="tertiary"
+            onClick={ () => handleCloseWithoutSelection() }
+            isBusy={ ! hasTemplates }
+          >
+            { __( 'Start from scratch', 'mailpoet' ) }
+          </Button>
+        </FlexItem>
+      </Flex>
 		</Modal>
 	);
 }

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -1,12 +1,7 @@
 import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { dispatch } from '@wordpress/data';
-import {
-	Modal,
-	Button,
-	Flex,
-	FlexItem,
-} from '@wordpress/components';
+import { Modal, Button, Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { usePreviewTemplates } from '../../hooks';
 import { storeName, TemplatePreview } from '../../store';

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -1,19 +1,17 @@
-// @ts-expect-error No types available for this component
-import { BlockPreview } from '@wordpress/block-editor';
+
 import { store as editorStore } from '@wordpress/editor';
 import { dispatch } from '@wordpress/data';
 import {
 	Modal,
-	__experimentalHStack as HStack, // eslint-disable-line
 	Button,
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-import { Async } from './async';
 import { usePreviewTemplates } from '../../hooks';
 import { storeName, TemplatePreview } from '../../store';
+import { TemplateList } from './template-list';
+import { TemplateCategoriesListSidebar } from './template-categories-list-sidebar';
 
 const BLANK_TEMPLATE = 'email-general';
 
@@ -51,6 +49,19 @@ export function SelectTemplateModal( {
 		handleTemplateSelection( blankTemplate );
 	};
 
+  const dummyTemplateCategories = [
+    {
+      name: 'recent',
+      label: 'Recent'
+    },
+    {
+      name: 'basic',
+      label: 'Basic'
+    }
+  ];
+
+  const onClickCategory = () => {}
+
 	return (
 		<Modal
 			title="Select a template"
@@ -60,90 +71,21 @@ export function SelectTemplateModal( {
 			isFullScreen
 		>
 			<div className="block-editor-block-patterns-explorer">
-				<div className="block-editor-block-patterns-explorer__sidebar">
-					<div className="block-editor-block-patterns-explorer__sidebar__categories-list">
-						<Button
-							key="category"
-							label="Category"
-							className="block-editor-block-patterns-explorer__sidebar__categories-list__item"
-							isPressed
-							onClick={ () => {} }
-						>
-							Dummy Category
-						</Button>
-					</div>
-				</div>
-				<div className="block-editor-block-patterns-explorer__list">
-					<div
-						className="block-editor-block-patterns-list"
-						role="listbox"
-					>
-						{ templates.map( ( template ) => (
-							<div
-								key={ template.slug }
-								className="block-editor-block-patterns-list__list-item"
-							>
-								<div
-									className="block-editor-block-patterns-list__item"
-									role="button"
-									tabIndex={ 0 }
-									onClick={ () => {
-										handleTemplateSelection( template );
-									} }
-									onKeyPress={ ( event ) => {
-										if (
-											event.key === 'Enter' ||
-											event.key === ' '
-										) {
-											handleTemplateSelection( template );
-										}
-									} }
-								>
-									<Async
-										placeholder={
-											<p>rendering template</p>
-										}
-									>
-										<BlockPreview
-											blocks={
-												template.previewContentParsed
-											}
-											viewportWidth={ 900 }
-											minHeight={ 300 }
-											additionalStyles={ [
-												{
-													css: template.template
-														.email_theme_css,
-												},
-											] }
-										/>
+        <TemplateCategoriesListSidebar templateCategories={dummyTemplateCategories} selectedCategory={dummyTemplateCategories[0].name} onClickCategory={onClickCategory} />
 
-										<HStack className="block-editor-patterns__pattern-details">
-											<div className="block-editor-block-patterns-list__item-title">
-												{
-													template.template.title
-														.rendered
-												}
-											</div>
-										</HStack>
-									</Async>
-								</div>
-							</div>
-						) ) }
-					</div>
+        <TemplateList templates={templates} onTemplateSelection={ handleTemplateSelection} />
 
-					<Flex justify="flex-end">
-						<FlexItem>
-							<Button
-								variant="tertiary"
-								onClick={ () => handleCloseWithoutSelection() }
-								isBusy={ ! hasTemplates }
-							>
-								{ __( 'Start from scratch', 'mailpoet' ) }
-							</Button>
-						</FlexItem>
-					</Flex>
-				</div>
+        <Flex justify="flex-end">
+          <FlexItem>
+            <Button
+              variant="tertiary"
+              onClick={ () => handleCloseWithoutSelection() }
+              isBusy={ ! hasTemplates }
+            >
+              { __( 'Start from scratch', 'mailpoet' ) }
+            </Button>
+          </FlexItem>
+        </Flex>
 			</div>
 		</Modal>
 	);

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -38,11 +38,11 @@ function SelectTemplateBody( {
 }
 
 export function SelectTemplateModal( {
-                                       onSelectCallback,
-                                       closeCallback = null,
-                                       previewContent = '',
-                                     } ) {
-  const [ templates ] = usePreviewTemplates( previewContent );
+	onSelectCallback,
+	closeCallback = null,
+	previewContent = '',
+} ) {
+	const [ templates ] = usePreviewTemplates( previewContent );
 
 	const hasTemplates = templates?.length > 0;
 
@@ -85,9 +85,9 @@ export function SelectTemplateModal( {
 	return (
 		<Modal
 			title={ __( 'Select a template', 'mailpoet' ) }
-      onRequestClose={ () =>
-        closeCallback ? closeCallback() : handleCloseWithoutSelection()
-      }
+			onRequestClose={ () =>
+				closeCallback ? closeCallback() : handleCloseWithoutSelection()
+			}
 			isFullScreen
 		>
 			<SelectTemplateBody
@@ -97,17 +97,18 @@ export function SelectTemplateModal( {
 				handleTemplateSelection={ handleTemplateSelection }
 			/>
 
-      <Flex justify="flex-end">
-        <FlexItem>
-          <Button
-            variant="tertiary"
-            onClick={ () => handleCloseWithoutSelection() }
-            isBusy={ ! hasTemplates }
-          >
-            { __( 'Start from scratch', 'mailpoet' ) }
-          </Button>
-        </FlexItem>
-      </Flex>
+			<Flex justify="flex-end">
+				<FlexItem>
+					<Button
+						variant="tertiary"
+						className="email-editor-start_from_scratch_button"
+						onClick={ () => handleCloseWithoutSelection() }
+						isBusy={ ! hasTemplates }
+					>
+						{ __( 'Start from scratch', 'mailpoet' ) }
+					</Button>
+				</FlexItem>
+			</Flex>
 		</Modal>
 	);
 }

--- a/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
@@ -1,6 +1,4 @@
 import { Button } from '@wordpress/components';
-import { info } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
 import { TemplateCategory } from '../../store';
 
 type Props = {
@@ -19,7 +17,6 @@ export function TemplateCategoriesListSidebar( {
 		<div className={ baseClassName }>
 			<div className={ `${ baseClassName }__categories-list` }>
 				{ templateCategories.map( ( { name, label } ) => {
-					const isRecentButton = name === 'recent';
 					return (
 						<Button
 							key={ name }
@@ -29,19 +26,6 @@ export function TemplateCategoriesListSidebar( {
 							onClick={ () => {
 								onClickCategory( name );
 							} }
-							showTooltip={ isRecentButton }
-							tooltipPosition="top"
-							aria-label="This is some content"
-							icon={ isRecentButton ? info : null }
-							iconPosition="right"
-							describedBy={
-								isRecentButton
-									? __(
-											'Templates created on the legacy editor will not appear here',
-											'mailpoet'
-									  )
-									: null
-							}
 						>
 							{ label }
 						</Button>

--- a/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@wordpress/components';
+
+export function TemplateCategoriesListSidebar( {
+                                                 selectedCategory,
+                                                 templateCategories,
+                                                 onClickCategory,
+                                               } ) {
+  const baseClassName = 'block-editor-block-patterns-explorer__sidebar';
+  return (
+    <div className={baseClassName}>
+      <div className={`${baseClassName}__categories-list`}>
+        {templateCategories.map(({ name, label }) => {
+          return (
+            <Button
+              key={name}
+              label={label}
+              className={`${baseClassName}__categories-list__item`}
+              isPressed={selectedCategory === name}
+              onClick={() => {
+                onClickCategory(name);
+              }}
+            >
+              {label}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
@@ -1,30 +1,53 @@
 import { Button } from '@wordpress/components';
+import { info } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { TemplateCategory } from '../../store';
+
+type Props = {
+	selectedCategory?: TemplateCategory;
+	templateCategories: Array< { name: TemplateCategory; label: string } >;
+	onClickCategory: ( name: TemplateCategory ) => void;
+};
 
 export function TemplateCategoriesListSidebar( {
-                                                 selectedCategory,
-                                                 templateCategories,
-                                                 onClickCategory,
-                                               } ) {
-  const baseClassName = 'block-editor-block-patterns-explorer__sidebar';
-  return (
-    <div className={baseClassName}>
-      <div className={`${baseClassName}__categories-list`}>
-        {templateCategories.map(({ name, label }) => {
-          return (
-            <Button
-              key={name}
-              label={label}
-              className={`${baseClassName}__categories-list__item`}
-              isPressed={selectedCategory === name}
-              onClick={() => {
-                onClickCategory(name);
-              }}
-            >
-              {label}
-            </Button>
-          );
-        })}
-      </div>
-    </div>
-  );
+	selectedCategory,
+	templateCategories,
+	onClickCategory,
+}: Props ) {
+	const baseClassName = 'block-editor-block-patterns-explorer__sidebar';
+	return (
+		<div className={ baseClassName }>
+			<div className={ `${ baseClassName }__categories-list` }>
+				{ templateCategories.map( ( { name, label } ) => {
+					const isRecentButton = name === 'recent';
+					return (
+						<Button
+							key={ name }
+							label={ label }
+							className={ `${ baseClassName }__categories-list__item` }
+							isPressed={ selectedCategory === name }
+							onClick={ () => {
+								onClickCategory( name );
+							} }
+							showTooltip={ isRecentButton }
+							tooltipPosition="top"
+							aria-label="This is some content"
+							icon={ isRecentButton ? info : null }
+							iconPosition="right"
+							describedBy={
+								isRecentButton
+									? __(
+											'Templates created on the legacy editor will not appear here',
+											'mailpoet'
+									  )
+									: null
+							}
+						>
+							{ label }
+						</Button>
+					);
+				} ) }
+			</div>
+		</div>
+	);
 }

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -1,0 +1,67 @@
+// @ts-expect-error No types available for this component
+import { BlockPreview } from '@wordpress/block-editor';
+import {
+  __experimentalHStack as HStack, // eslint-disable-line
+} from '@wordpress/components';
+import { Async } from './async';
+
+export function TemplateList({templates, onTemplateSelection}) {
+
+  return (
+    <div className="block-editor-block-patterns-explorer__list">
+      <div
+        className="block-editor-block-patterns-list"
+        role="listbox"
+      >
+        {templates.map((template) => (
+          <div
+            key={template.slug}
+            className="block-editor-block-patterns-list__list-item"
+          >
+            <div
+              className="block-editor-block-patterns-list__item"
+              role="button"
+              tabIndex={0}
+              onClick={() => {
+                onTemplateSelection(template);
+              }}
+              onKeyPress={(event) => {
+                if (
+                  event.key === 'Enter' ||
+                  event.key === ' '
+                ) {
+                  onTemplateSelection(template);
+                }
+              }}
+            >
+              <Async
+                placeholder={
+                  <p>rendering template</p>
+                }
+              >
+                <BlockPreview
+                  blocks={template.previewContentParsed}
+                  viewportWidth={900}
+                  minHeight={300}
+                  additionalStyles={[
+                    {
+                      css: template.template.email_theme_css,
+                    },
+                  ]}
+                />
+
+                <HStack className="block-editor-patterns__pattern-details">
+                  <div className="block-editor-block-patterns-list__item-title">
+                    {
+                      template.template.title.rendered
+                    }
+                  </div>
+                </HStack>
+              </Async>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -6,8 +6,15 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Async } from './async';
+import { TemplateCategory, TemplatePreview } from '../../store';
 
-function TemplateListBox( { templates, onTemplateSelection } ) {
+type Props = {
+	templates: TemplatePreview[];
+	onTemplateSelection: ( template: TemplatePreview ) => void;
+	selectedCategory?: TemplateCategory;
+};
+
+function TemplateListBox( { templates, onTemplateSelection }: Props ) {
 	return (
 		<div className="block-editor-block-patterns-list" role="listbox">
 			{ templates.map( ( template ) => (
@@ -63,7 +70,7 @@ export function TemplateList( {
 	templates,
 	onTemplateSelection,
 	selectedCategory,
-} ) {
+}: Props ) {
 	const filteredTemplates = useMemo(
 		() =>
 			templates.filter(

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -1,67 +1,83 @@
+import { useMemo } from '@wordpress/element';
 // @ts-expect-error No types available for this component
 import { BlockPreview } from '@wordpress/block-editor';
 import {
-  __experimentalHStack as HStack, // eslint-disable-line
+	__experimentalHStack as HStack, // eslint-disable-line
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Async } from './async';
 
-export function TemplateList({templates, onTemplateSelection}) {
+function TemplateListBox( { templates, onTemplateSelection } ) {
+	return (
+		<div className="block-editor-block-patterns-list" role="listbox">
+			{ templates.map( ( template ) => (
+				<div
+					key={ template.slug }
+					className="block-editor-block-patterns-list__list-item"
+				>
+					<div
+						className="block-editor-block-patterns-list__item"
+						role="button"
+						tabIndex={ 0 }
+						onClick={ () => {
+							onTemplateSelection( template );
+						} }
+						onKeyPress={ ( event ) => {
+							if ( event.key === 'Enter' || event.key === ' ' ) {
+								onTemplateSelection( template );
+							}
+						} }
+					>
+						<Async
+							placeholder={
+								<p>
+									{ __( 'rendering template', 'mailpoet' ) }
+								</p>
+							}
+						>
+							<BlockPreview
+								blocks={ template.previewContentParsed }
+								viewportWidth={ 900 }
+								minHeight={ 300 }
+								additionalStyles={ [
+									{
+										css: template.template.email_theme_css,
+									},
+								] }
+							/>
 
-  return (
-    <div className="block-editor-block-patterns-explorer__list">
-      <div
-        className="block-editor-block-patterns-list"
-        role="listbox"
-      >
-        {templates.map((template) => (
-          <div
-            key={template.slug}
-            className="block-editor-block-patterns-list__list-item"
-          >
-            <div
-              className="block-editor-block-patterns-list__item"
-              role="button"
-              tabIndex={0}
-              onClick={() => {
-                onTemplateSelection(template);
-              }}
-              onKeyPress={(event) => {
-                if (
-                  event.key === 'Enter' ||
-                  event.key === ' '
-                ) {
-                  onTemplateSelection(template);
-                }
-              }}
-            >
-              <Async
-                placeholder={
-                  <p>rendering template</p>
-                }
-              >
-                <BlockPreview
-                  blocks={template.previewContentParsed}
-                  viewportWidth={900}
-                  minHeight={300}
-                  additionalStyles={[
-                    {
-                      css: template.template.email_theme_css,
-                    },
-                  ]}
-                />
+							<HStack className="block-editor-patterns__pattern-details">
+								<div className="block-editor-block-patterns-list__item-title">
+									{ template.template.title.rendered }
+								</div>
+							</HStack>
+						</Async>
+					</div>
+				</div>
+			) ) }
+		</div>
+	);
+}
 
-                <HStack className="block-editor-patterns__pattern-details">
-                  <div className="block-editor-block-patterns-list__item-title">
-                    {
-                      template.template.title.rendered
-                    }
-                  </div>
-                </HStack>
-              </Async>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+export function TemplateList( {
+	templates,
+	onTemplateSelection,
+	selectedCategory,
+} ) {
+	const filteredTemplates = useMemo(
+		() =>
+			templates.filter(
+				( template ) => template.category === selectedCategory
+			),
+		[ selectedCategory, templates ]
+	);
+
+	return (
+		<div className="block-editor-block-patterns-explorer__list">
+			<TemplateListBox
+				templates={ filteredTemplates }
+				onTemplateSelection={ onTemplateSelection }
+			/>
+		</div>
+	);
 }

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -1,9 +1,11 @@
-import { useMemo } from '@wordpress/element';
+import { useMemo, memo } from '@wordpress/element';
 // @ts-expect-error No types available for this component
 import { BlockPreview } from '@wordpress/block-editor';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line
+	Notice,
 } from '@wordpress/components';
+import { Icon, info, blockDefault } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Async } from './async';
 import { TemplateCategory, TemplatePreview } from '../../store';
@@ -14,7 +16,32 @@ type Props = {
 	selectedCategory?: TemplateCategory;
 };
 
-function TemplateListBox( { templates, onTemplateSelection }: Props ) {
+function TemplateNoResults() {
+	return (
+		<div className="block-editor-inserter__no-results">
+			<Icon
+				className="block-editor-inserter__no-results-icon"
+				icon={ blockDefault }
+			/>
+			<p>{ __( 'No recent templates.' ) }</p>
+			<p>
+				{ __(
+					'Your recent creations will appear here as soon as you begin.'
+				) }
+			</p>
+		</div>
+	);
+}
+
+function TemplateListBox( {
+	templates,
+	onTemplateSelection,
+	selectedCategory,
+}: Props ) {
+	if ( selectedCategory === 'recent' && templates.length === 0 ) {
+		return <TemplateNoResults />;
+	}
+
 	return (
 		<div className="block-editor-block-patterns-list" role="listbox">
 			{ templates.map( ( template ) => (
@@ -66,6 +93,12 @@ function TemplateListBox( { templates, onTemplateSelection }: Props ) {
 	);
 }
 
+const compareProps = ( prev, next ) =>
+	prev.templates.length === next.templates.length &&
+	prev.selectedCategory === next.selectedCategory;
+
+const MemorizedTemplateListBox = memo( TemplateListBox, compareProps );
+
 export function TemplateList( {
 	templates,
 	onTemplateSelection,
@@ -81,9 +114,24 @@ export function TemplateList( {
 
 	return (
 		<div className="block-editor-block-patterns-explorer__list">
-			<TemplateListBox
+			{ selectedCategory === 'recent' && (
+				<Notice isDismissible={ false }>
+					<HStack spacing={ 1 } expanded={ false } justify="start">
+						<Icon icon={ info } />
+						<p>
+							{ __(
+								'Templates created on the legacy editor will not appear here.',
+								'mailpoet'
+							) }
+						</p>
+					</HStack>
+				</Notice>
+			) }
+
+			<MemorizedTemplateListBox
 				templates={ filteredTemplates }
 				onTemplateSelection={ onTemplateSelection }
+				selectedCategory={ selectedCategory }
 			/>
 		</div>
 	);

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -35,7 +35,7 @@ function Editor() {
 const WrappedEditor = applyFilters(
 	'mailpoet_email_editor_wrap_editor_component',
 	Editor
-);
+) as typeof Editor;
 
 export function initialize( elementId: string ) {
 	const container = document.getElementById( elementId );
@@ -47,6 +47,5 @@ export function initialize( elementId: string ) {
 	initBlocks();
 	initHooks();
 	const root = createRoot( container );
-	// @ts-ignore We don't have a type for WrappedEditor.
 	root.render( <WrappedEditor /> );
 }

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -103,6 +103,7 @@ export function usePreviewTemplates(
 						? contentPatternBlocksGeneral
 						: contentPatternBlocks,
 				template,
+				category: 'basic', // TODO: This will be updated once template category is implemented
 			};
 		} ),
 	];

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -228,7 +228,10 @@ export type TemplatePreview = {
 	previewContentParsed: BlockInstance[];
 	emailParsed: BlockInstance[];
 	template: EmailTemplatePreview;
+	category?: TemplateCategory;
 };
+
+export type TemplateCategory = 'recent' | 'basic';
 
 export type Feature =
 	| 'fullscreenMode'


### PR DESCRIPTION
## Description

This PR adds basic support for template categories within the "Select template modal"

## Code review notes

Note: we are currently hardcoding the template category. This process will be refined and updated in the [Templates: Recent templates behavior-MAILPOET-5949](https://mailpoet.atlassian.net/browse/MAILPOET-5949)

Note: The header style was updated in the child PR https://github.com/mailpoet/mailpoet/pull/5980

## QA notes

_N/A_

## Linked PRs

Related to https://github.com/mailpoet/mailpoet/pull/5980

## Linked tickets

[MAILPOET-6331](https://mailpoet.atlassian.net/browse/MAILPOET-6331)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-categories-to-the-select-a-template-dialogue)

_The latest successful build from `add-categories-to-the-select-a-template-dialogue` will be used. If none is available, the link won't work._

[MAILPOET-6331]: https://mailpoet.atlassian.net/browse/MAILPOET-6331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ