### PR TITLE
Sanitise post id before constructing URL

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -874,7 +874,7 @@ class NewsletterSendComponent extends Component<
                     MailPoet.FeaturesController.isSupported(
                       'gutenberg_email_editor',
                     ) && wpPostId
-                      ? MailPoet.getBlockEmailEditorUrl(wpPostId)
+                      ? MailPoet.getBlockEmailEditorUrl(Number(wpPostId))
                       : `?page=mailpoet-newsletter-editor&id=${Number(
                           this.props.params.id,
                         )}`


### PR DESCRIPTION
## Description

Make sure the post id is sanitised before it is used in DOM

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Fixes: https://github.com/mailpoet/mailpoet/security/code-scanning/17

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:sanitise-post-id)

_The latest successful build from `sanitise-post-id` will be used. If none is available, the link won't work._