### PR TITLE
Allow using classes in custom checkboxes in the forms [MAILPOET-6360]

### DIFF
--- a/mailpoet/lib/Form/FormHtmlSanitizer.php
+++ b/mailpoet/lib/Form/FormHtmlSanitizer.php
@@ -14,6 +14,7 @@ class FormHtmlSanitizer {
    */
   const ALLOWED_HTML = [
     'a' => [
+      'class' => true,
       'href' => true,
       'title' => true,
       'data-id' => true,


### PR DESCRIPTION
## Description

For security reasons, we strip almost all HTML attributes from rendered forms. There are exceptions to this rule. Let us allow class in the HTML links. So users can add classes when adding links to their custom checkboxes. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-6360]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6360]: https://mailpoet.atlassian.net/browse/MAILPOET-6360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-class-link)

_The latest successful build from `add-class-link` will be used. If none is available, the link won't work._