### PR TITLE
Templates-recent templates behavior - MAILPOET-5949

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -98,8 +98,8 @@ class EmailTemplatesCest {
     $i->waitForElementClickable('.email-editor-start_from_scratch_button');
     $i->click('[aria-label="Basic"]');
     $i->waitForElement('.block-editor-block-patterns-list__item-title');
-    $i->waitForText($template);
-    $i->click("//div[@class='block-editor-block-patterns-list__item-title' and text()='$template']");
+    $i->waitForText($template, 5);
+    $i->click("//h4[@class='block-editor-block-patterns-list__item-title' and text()='$template']");
   }
 
   private function checkTextIsInEmail(\AcceptanceTester $i, string $text): void {

--- a/packages/js/email-editor/src/components/template-select/index.scss
+++ b/packages/js/email-editor/src/components/template-select/index.scss
@@ -11,3 +11,26 @@
 .block-editor-block-patterns-list__list-item {
   overflow: hidden;
 }
+
+.email-editor-recent-templates-info {
+  background-color: #F0F6FC;
+  margin-bottom: 1.5rem;
+  padding: 0.5rem;
+
+  path { fill: #007CBA; }
+}
+
+.email-editor-pattern__list-item {
+  border: 1px solid #DDD;
+  border-radius: 4px;
+
+  .block-editor-block-preview__container:after {
+    outline: unset !important;
+    outline-offset: unset !important;
+  }
+
+  .block-editor-block-patterns-list__item-title {
+    font-size: unset !important;
+    padding-left: 1rem;
+  }
+}

--- a/packages/js/email-editor/src/components/template-select/index.scss
+++ b/packages/js/email-editor/src/components/template-select/index.scss
@@ -34,3 +34,11 @@
     padding-left: 1rem;
   }
 }
+
+.email-editor-modal-footer {
+  background-color: #fff;
+  bottom: 0;
+  padding: 1rem 2rem;
+  position: absolute;
+  right: 0;
+}

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -47,8 +47,7 @@ export function SelectTemplateModal( {
 	const hasTemplates = templates?.length > 0;
 
 	const handleTemplateSelection = ( template: TemplatePreview ) => {
-		const templateIsPostContent =
-			template.template.type === 'mailpoet_email';
+		const templateIsPostContent = template.type === 'mailpoet_email';
 
 		const postContent = template.template as unknown as EmailEditorPostType;
 

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -42,7 +42,7 @@ export function SelectTemplateModal( {
 	closeCallback = null,
 	previewContent = '',
 } ) {
-	const [ templates ] = usePreviewTemplates( previewContent );
+	let [ templates, emailPosts ] = usePreviewTemplates( previewContent );
 
 	const hasTemplates = templates?.length > 0;
 
@@ -82,6 +82,12 @@ export function SelectTemplateModal( {
 		},
 	];
 
+	let initialCategory = dummyTemplateCategories[ 0 ]; // Show the “Recent” category by default
+	if ( ! emailPosts || emailPosts?.length === 0 ) {
+		emailPosts = [];
+		initialCategory = dummyTemplateCategories[ 1 ]; // user does not recent category, show basic category
+	}
+
 	return (
 		<Modal
 			title={ __( 'Select a template', 'mailpoet' ) }
@@ -91,9 +97,9 @@ export function SelectTemplateModal( {
 			isFullScreen
 		>
 			<SelectTemplateBody
-				initialCategory={ dummyTemplateCategories[ 0 ] }
+				initialCategory={ initialCategory }
 				templateCategories={ dummyTemplateCategories }
-				templates={ templates }
+				templates={ [ ...templates, ...emailPosts ] }
 				handleTemplateSelection={ handleTemplateSelection }
 			/>
 

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -32,13 +32,15 @@ function SelectTemplateBody( {
 	handleTemplateSelection,
 } ) {
 	const [ selectedCategory, setSelectedCategory ] = useState(
-		TemplateCategories[ 0 ].name // Show the “Recent” category by default
+		TemplateCategories[ 1 ].name // Show the “Basic” category by default
 	);
 
 	useEffect( () => {
-		if ( ! hasEmailPosts ) {
-			setSelectedCategory( TemplateCategories[ 1 ].name );
-		}
+		setTimeout( () => {
+			if ( hasEmailPosts ) {
+				setSelectedCategory( TemplateCategories[ 0 ].name );
+			}
+		}, 1000 ); // using setTimeout to ensure the template styles are available before block preview
 	}, [ hasEmailPosts ] );
 
 	return (

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -59,9 +59,9 @@ export function SelectTemplateModal( {
 		}
 
 		void dispatch( storeName ).setTemplateToPost(
-			templateIsPostContent ? postContent?.template : template.slug,
+			templateIsPostContent ? postContent.template : template.slug,
 			templateIsPostContent
-				? {}
+				? template?.template?.mailpoet_email_theme || {}
 				: template.template.mailpoet_email_theme ?? {}
 		);
 		onSelectCallback();

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -103,7 +103,7 @@ export function SelectTemplateModal( {
 
 	return (
 		<Modal
-			title={ __( 'Select a template', 'mailpoet' ) }
+			title={ __( 'Start with an email preset', 'mailpoet' ) }
 			onRequestClose={ () =>
 				closeCallback ? closeCallback() : handleCloseWithoutSelection()
 			}
@@ -115,7 +115,7 @@ export function SelectTemplateModal( {
 				handleTemplateSelection={ handleTemplateSelection }
 			/>
 
-			<Flex justify="flex-end">
+			<Flex className="email-editor-modal-footer" justify="flex-end">
 				<FlexItem>
 					<Button
 						variant="tertiary"

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -4,7 +4,7 @@ import { dispatch } from '@wordpress/data';
 import { Modal, Button, Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { usePreviewTemplates } from '../../hooks';
-import { storeName, TemplatePreview } from '../../store';
+import { EmailEditorPostType, storeName, TemplatePreview } from '../../store';
 import { TemplateList } from './template-list';
 import { TemplateCategoriesListSidebar } from './template-categories-list-sidebar';
 
@@ -47,6 +47,11 @@ export function SelectTemplateModal( {
 	const hasTemplates = templates?.length > 0;
 
 	const handleTemplateSelection = ( template: TemplatePreview ) => {
+		const templateIsPostContent =
+			template.template.type === 'mailpoet_email';
+
+		const postContent = template.template as unknown as EmailEditorPostType;
+
 		// When we provide previewContent, we don't want to reset the blocks
 		if ( ! previewContent ) {
 			void dispatch( editorStore ).resetEditorBlocks(
@@ -55,8 +60,10 @@ export function SelectTemplateModal( {
 		}
 
 		void dispatch( storeName ).setTemplateToPost(
-			template.slug,
-			template.template.mailpoet_email_theme ?? {}
+			templateIsPostContent ? postContent?.template : template.slug,
+			templateIsPostContent
+				? {}
+				: template.template.mailpoet_email_theme ?? {}
 		);
 		onSelectCallback();
 	};

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -75,7 +75,7 @@ function TemplateListBox( {
 								minHeight={ 300 }
 								additionalStyles={ [
 									{
-										css: template.template.email_theme_css,
+										css: template.template?.email_theme_css,
 									},
 								] }
 							/>

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -46,7 +46,7 @@ function TemplateListBox( {
 		<div className="block-editor-block-patterns-list" role="listbox">
 			{ templates.map( ( template ) => (
 				<div
-					key={ template.slug }
+					key={ `${ template.slug }_${ template.id }` }
 					className="block-editor-block-patterns-list__list-item"
 				>
 					<div

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -3,7 +3,6 @@ import { useMemo, memo } from '@wordpress/element';
 import { BlockPreview } from '@wordpress/block-editor';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line
-	Notice,
 } from '@wordpress/components';
 import { Icon, info, blockDefault } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -47,7 +46,7 @@ function TemplateListBox( {
 			{ templates.map( ( template ) => (
 				<div
 					key={ `${ template.slug }_${ template.id }` }
-					className="block-editor-block-patterns-list__list-item"
+					className="block-editor-block-patterns-list__list-item email-editor-pattern__list-item"
 				>
 					<div
 						className="block-editor-block-patterns-list__item"
@@ -81,9 +80,9 @@ function TemplateListBox( {
 							/>
 
 							<HStack className="block-editor-patterns__pattern-details">
-								<div className="block-editor-block-patterns-list__item-title">
+								<h4 className="block-editor-block-patterns-list__item-title">
 									{ template.template.title.rendered }
-								</div>
+								</h4>
 							</HStack>
 						</Async>
 					</div>
@@ -115,7 +114,7 @@ export function TemplateList( {
 	return (
 		<div className="block-editor-block-patterns-explorer__list">
 			{ selectedCategory === 'recent' && (
-				<Notice isDismissible={ false }>
+				<div className="email-editor-recent-templates-info">
 					<HStack spacing={ 1 } expanded={ false } justify="start">
 						<Icon icon={ info } />
 						<p>
@@ -125,7 +124,7 @@ export function TemplateList( {
 							) }
 						</p>
 					</HStack>
-				</Notice>
+				</div>
 			) }
 
 			<MemorizedTemplateListBox

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -1,4 +1,4 @@
-// import { useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { useSelect } from '@wordpress/data';
@@ -89,84 +89,87 @@ function generateTemplateCssTheme(
 
 export function usePreviewTemplates(
 	customEmailContent = ''
-): TemplatePreview[][] {
-	const { templates, patterns, emailPosts } = useSelect( ( select ) => {
-		const contentBlockId =
-			// @ts-expect-error getBlocksByName is not defined in types
-			select( blockEditorStore ).getBlocksByName(
-				'core/post-content'
-			)?.[ 0 ];
-		return {
-			templates: select( storeName ).getEmailTemplates(),
-			patterns:
-				// @ts-expect-error getPatternsByBlockTypes is not defined in types
-				select( blockEditorStore ).getPatternsByBlockTypes(
-					[ 'core/post-content' ],
-					contentBlockId
-				),
-			emailPosts: select( storeName ).getSentEmailEditorPosts(),
-		};
-	}, [] );
+): [ TemplatePreview[], TemplatePreview[], boolean ] {
+	const { templates, patterns, emailPosts, hasEmailPosts } = useSelect(
+		( select ) => {
+			const contentBlockId =
+				// @ts-expect-error getBlocksByName is not defined in types
+				select( blockEditorStore ).getBlocksByName(
+					'core/post-content'
+				)?.[ 0 ];
 
-	if ( ! templates || ( ! patterns.length && ! customEmailContent ) ) {
-		return [ [] ];
-	}
-
-	let contentPatternBlocksGeneral = null;
-	let contentPatternBlocks = null;
-	const parsedCustomEmailContent =
-		customEmailContent && parse( customEmailContent );
-
-	// If there is a custom email content passed from outside we use it as email content for preview
-	// otherwise we pick first suitable from patterns
-	if ( parsedCustomEmailContent ) {
-		contentPatternBlocksGeneral = parsedCustomEmailContent;
-		contentPatternBlocks = parsedCustomEmailContent;
-	} else {
-		// Pick first pattern that comes from mailpoet and is for general email template
-		contentPatternBlocksGeneral = patterns.find(
-			( pattern ) =>
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				pattern?.templateTypes?.includes( 'email-general-template' )
-		)?.blocks as BlockInstance[];
-
-		// Pick first pattern that comes from mailpoet and is for template with header and footer content separated
-		contentPatternBlocks = patterns.find(
-			( pattern ) =>
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				pattern?.templateTypes?.includes( 'email-template' )
-		)?.blocks as BlockInstance[];
-	}
-
-	const allTemplates = templates.map(
-		( template: EmailTemplatePreview ): TemplatePreview => {
-			let parsedTemplate = parse( template.content?.raw );
-			parsedTemplate = setPostContentInnerBlocks(
-				parsedTemplate,
-				template.slug === 'email-general'
-					? contentPatternBlocksGeneral
-					: contentPatternBlocks
-			);
-
+			const rawEmailPosts = select( storeName ).getSentEmailEditorPosts();
 			return {
-				id: template.id,
-				slug: template.slug,
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-				previewContentParsed: parsedTemplate,
-				emailParsed:
-					template.slug === 'email-general'
-						? contentPatternBlocksGeneral
-						: contentPatternBlocks,
-				template,
-				category: 'basic', // TODO: This will be updated once template category is implemented
-				type: template.type,
+				templates: select( storeName ).getEmailTemplates(),
+				patterns:
+					// @ts-expect-error getPatternsByBlockTypes is not defined in types
+					select( blockEditorStore ).getPatternsByBlockTypes(
+						[ 'core/post-content' ],
+						contentBlockId
+					),
+				emailPosts: rawEmailPosts,
+				hasEmailPosts: !! ( rawEmailPosts && rawEmailPosts?.length ),
 			};
-		}
+		},
+		[]
 	);
 
-	return [
-		allTemplates,
-		emailPosts?.map( ( post: EmailEditorPostType ) => {
+	const allTemplates = useMemo( () => {
+		let contentPatternBlocksGeneral = null;
+		let contentPatternBlocks = null;
+		const parsedCustomEmailContent =
+			customEmailContent && parse( customEmailContent );
+
+		// If there is a custom email content passed from outside we use it as email content for preview
+		// otherwise we pick first suitable from patterns
+		if ( parsedCustomEmailContent ) {
+			contentPatternBlocksGeneral = parsedCustomEmailContent;
+			contentPatternBlocks = parsedCustomEmailContent;
+		} else {
+			// Pick first pattern that comes from mailpoet and is for general email template
+			contentPatternBlocksGeneral = patterns.find(
+				( pattern ) =>
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+					pattern?.templateTypes?.includes( 'email-general-template' )
+			)?.blocks as BlockInstance[];
+
+			// Pick first pattern that comes from mailpoet and is for template with header and footer content separated
+			contentPatternBlocks = patterns.find(
+				( pattern ) =>
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+					pattern?.templateTypes?.includes( 'email-template' )
+			)?.blocks as BlockInstance[];
+		}
+
+		return templates?.map(
+			( template: EmailTemplatePreview ): TemplatePreview => {
+				let parsedTemplate = parse( template.content?.raw );
+				parsedTemplate = setPostContentInnerBlocks(
+					parsedTemplate,
+					template.slug === 'email-general'
+						? contentPatternBlocksGeneral
+						: contentPatternBlocks
+				);
+
+				return {
+					id: template.id,
+					slug: template.slug,
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+					previewContentParsed: parsedTemplate,
+					emailParsed:
+						template.slug === 'email-general'
+							? contentPatternBlocksGeneral
+							: contentPatternBlocks,
+					template,
+					category: 'basic', // TODO: This will be updated once template category is implemented
+					type: template.type,
+				};
+			}
+		);
+	}, [ templates, patterns, customEmailContent ] );
+
+	const allEmailPosts = useMemo( () => {
+		return emailPosts?.map( ( post: EmailEditorPostType ) => {
 			const parsedPostContent = parse( post.content?.raw );
 			const cssThemeData = generateTemplateCssTheme( post, allTemplates );
 			return {
@@ -186,6 +189,8 @@ export function usePreviewTemplates(
 				category: 'recent',
 				type: post.type,
 			};
-		} ) as unknown as TemplatePreview[],
-	];
+		} ) as unknown as TemplatePreview[];
+	}, [ emailPosts, allTemplates ] );
+
+	return [ allTemplates || [], allEmailPosts || [], hasEmailPosts ];
 }

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -100,6 +100,7 @@ export function usePreviewTemplates( customEmailContent = '' ) {
 			);
 
 			return {
+				id: template.id,
 				slug: template.slug,
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 				previewContentParsed: parsedTemplate,
@@ -109,11 +110,13 @@ export function usePreviewTemplates( customEmailContent = '' ) {
 						: contentPatternBlocks,
 				template,
 				category: 'basic', // TODO: This will be updated once template category is implemented
+				type: template.type,
 			};
 		} ),
 		emailPosts?.map( ( post: EmailEditorPostType ) => {
 			const parsedPostContent = parse( post.content?.raw );
 			return {
+				id: post.id,
 				slug: post.slug,
 				previewContentParsed: parsedPostContent,
 				emailParsed: parsedPostContent,
@@ -128,6 +131,7 @@ export function usePreviewTemplates( customEmailContent = '' ) {
 					email_theme_css: '',
 				},
 				category: 'recent',
+				type: post.type,
 			};
 		} ) as unknown as TemplatePreview[],
 	];

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -117,9 +117,18 @@ export function usePreviewTemplates( customEmailContent = '' ) {
 				slug: post.slug,
 				previewContentParsed: parsedPostContent,
 				emailParsed: parsedPostContent,
-				template: post,
+				template: {
+					...post,
+					title: {
+						raw: post?.mailpoet_data?.subject || post.title.raw,
+						rendered:
+							post?.mailpoet_data?.subject || post.title.rendered, // use MailPoet subject as title
+					},
+					mailpoet_email_theme: null,
+					email_theme_css: '',
+				},
 				category: 'recent',
 			};
-		} ),
+		} ) as unknown as TemplatePreview[],
 	];
 }

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -1,8 +1,14 @@
+// import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { storeName, EmailTemplatePreview, TemplatePreview } from '../store';
+import {
+	storeName,
+	EmailTemplatePreview,
+	TemplatePreview,
+	EmailEditorPostType,
+} from '../store';
 
 /**
  * We need to merge pattern blocks and template blocks for BlockPreview component.
@@ -34,10 +40,8 @@ function setPostContentInnerBlocks(
 	} );
 }
 
-export function usePreviewTemplates(
-	customEmailContent = ''
-): TemplatePreview[][] {
-	const { templates, patterns } = useSelect( ( select ) => {
+export function usePreviewTemplates( customEmailContent = '' ) {
+	const { templates, patterns, emailPosts } = useSelect( ( select ) => {
 		const contentBlockId =
 			// @ts-expect-error getBlocksByName is not defined in types
 			select( blockEditorStore ).getBlocksByName(
@@ -51,6 +55,7 @@ export function usePreviewTemplates(
 					[ 'core/post-content' ],
 					contentBlockId
 				),
+			emailPosts: select( storeName ).getSentEmailEditorPosts(),
 		};
 	}, [] );
 
@@ -104,6 +109,16 @@ export function usePreviewTemplates(
 						: contentPatternBlocks,
 				template,
 				category: 'basic', // TODO: This will be updated once template category is implemented
+			};
+		} ),
+		emailPosts?.map( ( post: EmailEditorPostType ) => {
+			const parsedPostContent = parse( post.content?.raw );
+			return {
+				slug: post.slug,
+				previewContentParsed: parsedPostContent,
+				emailParsed: parsedPostContent,
+				template: post,
+				category: 'recent',
 			};
 		} ),
 	];

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -148,7 +148,7 @@ export const getSentEmailEditorPosts = createRegistrySelector(
 			} )
 			?.filter(
 				( post: EmailEditorPostType ) => post?.content?.raw !== '' // filter out empty content
-			)
+			) || []
 );
 
 /**

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -140,16 +140,15 @@ export const getEditedEmailContent = createRegistrySelector(
 );
 
 export const getSentEmailEditorPosts = createRegistrySelector(
-	( select ) => () => {
-		const posts: EmailEditorPostType[] = select(
-			coreDataStore
-		).getEntityRecords( 'postType', 'mailpoet_email', {
-			per_page: 30, // show a maximum of 30 for now
-			status: 'publish,sent', // show only sent emails
-		} );
-
-		return posts;
-	}
+	( select ) => () =>
+		select( coreDataStore )
+			.getEntityRecords( 'postType', 'mailpoet_email', {
+				per_page: 30, // show a maximum of 30 for now
+				status: 'publish,sent', // show only sent emails
+			} )
+			?.filter(
+				( post: EmailEditorPostType ) => post?.content?.raw !== '' // filter out empty content
+			)
 );
 
 /**

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -6,7 +6,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { serialize } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { storeName } from './constants';
-import { State, Feature, EmailTemplate } from './types';
+import { State, Feature, EmailTemplate, EmailEditorPostType } from './types';
 
 export const isFeatureActive = createRegistrySelector(
 	( select ) =>
@@ -51,7 +51,7 @@ export const isSaving = createRegistrySelector( ( select ) => (): boolean => {
 export const isEmpty = createRegistrySelector( ( select ) => (): boolean => {
 	const postId = select( storeName ).getEmailPostId();
 
-	const post = select( coreDataStore ).getEntityRecord(
+	const post: EmailEditorPostType = select( coreDataStore ).getEntityRecord(
 		'postType',
 		'mailpoet_email',
 		postId
@@ -60,7 +60,6 @@ export const isEmpty = createRegistrySelector( ( select ) => (): boolean => {
 		return true;
 	}
 
-	// @ts-expect-error Missing property in type
 	const { content, mailpoet_data: mailpoetData, title } = post;
 	return (
 		! content.raw &&
@@ -137,6 +136,19 @@ export const getEditedEmailContent = createRegistrySelector(
 			}
 		}
 		return '';
+	}
+);
+
+export const getSentEmailEditorPosts = createRegistrySelector(
+	( select ) => () => {
+		const posts: EmailEditorPostType[] = select(
+			coreDataStore
+		).getEntityRecords( 'postType', 'mailpoet_email', {
+			per_page: 30, // show a maximum of 30 for now
+			status: 'publish,sent', // show only sent emails
+		} );
+
+		return posts;
 	}
 );
 

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -225,11 +225,13 @@ export type EmailTemplatePreview = Omit<
 };
 
 export type TemplatePreview = {
+	id: string;
 	slug: string;
 	previewContentParsed: BlockInstance[];
 	emailParsed: BlockInstance[];
 	template: EmailTemplatePreview;
 	category?: TemplateCategory;
+	type: string;
 };
 
 export type TemplateCategory = 'recent' | 'basic';

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -1,5 +1,6 @@
 import { EditorSettings, EditorColor } from '@wordpress/block-editor/index';
 import { BlockInstance } from '@wordpress/blocks/index';
+import { Post } from '@wordpress/core-data/build-types/entity-types/post';
 
 export enum SendingPreviewStatus {
 	SUCCESS = 'success',
@@ -238,3 +239,16 @@ export type Feature =
 	| 'showIconLabels'
 	| 'fixedToolbar'
 	| 'focusMode';
+
+export type MailPoetEmailPostContentExtended = {
+	id?: string;
+	subject: string;
+	preheader: string;
+	preview_url: string;
+	deleted_at?: string;
+};
+
+export type EmailEditorPostType = Omit< Post, 'type' > & {
+	type: 'mailpoet_email';
+	mailpoet_data?: MailPoetEmailPostContentExtended;
+};


### PR DESCRIPTION
## Description

Continuation of https://github.com/mailpoet/mailpoet/pull/5975

In this PR, we update the recent template behavior by pulling emails sent from the new email editor and using its post content as an email preset (template) for new emails.

![Screenshot 2024-12-05 at 11 09 46 PM](https://github.com/user-attachments/assets/8aa7a572-1c61-49fd-b3b2-fb8c690e166e)
![Screenshot 2024-12-05 at 11 09 56 PM](https://github.com/user-attachments/assets/c7d6d66c-ef80-4dcd-b024-5f917418ac74)


## Code review notes

Please start review from https://github.com/mailpoet/mailpoet/pull/5980/commits/2bc05534c72a96ac6952d71bcd445eb9a4ea4e0b

## QA notes

For testing: You can add `draft` to this list https://github.com/mailpoet/mailpoet/blob/95a8b9bf0be8ea2bcabf5c810238609e1d765b6d/packages/js/email-editor/src/store/selectors.ts#L147
e.g.
```
status: 'publish,sent,draft',
```


## Linked PRs

Related to https://github.com/mailpoet/mailpoet/pull/5975

## Linked tickets

[MAILPOET-5949](https://mailpoet.atlassian.net/browse/MAILPOET-5949)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:templates-recent-templates-behaviour)

_The latest successful build from `templates-recent-templates-behaviour` will be used. If none is available, the link won't work._

[MAILPOET-5949]: https://mailpoet.atlassian.net/browse/MAILPOET-5949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ