### PR TITLE
Email Editor – update send/save button behavior  [MAILPOET-6342]

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -46,8 +46,8 @@ class EmailTemplatesCest {
 
     $i->wantTo('Return to editor and save all');
     $i->click('Back', '.editor-document-bar');
-    $i->waitForText('Save email & template');
-    $i->click('Save email & template');
+    $i->waitForText('Save', 10, '.edit-post-header__settings');
+    $i->click('Save', '.edit-post-header__settings');
     $i->waitForText('Save', 10, '.entities-saved-states__panel');
     $i->click('Save', '.entities-saved-states__panel');
     $i->waitForText('Saved');

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -24,7 +24,7 @@ import classnames from 'classnames';
 import { storeName } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';
-import { SaveButton } from './save-button';
+import { SaveEmailButton } from './save-email-button';
 import { CampaignName } from './campaign-name';
 import { SendButton } from './send-button';
 import { useEditorMode } from '../../hooks';
@@ -208,7 +208,7 @@ export function Header() {
 				</div>
 			) }
 			<div className="editor-header__settings edit-post-header__settings">
-				<SaveButton />
+				<SaveEmailButton />
 				<PreviewDropdown />
 				<SendButton />
 				<PinnedItems.Slot scope={ storeName } />

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -11,8 +11,13 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
-// @ts-expect-error DocumentBar types are not available
-import { DocumentBar, store as editorStore } from '@wordpress/editor';
+import {
+	// @ts-expect-error DocumentBar types are not available
+	DocumentBar,
+	store as editorStore,
+	// @ts-expect-error useEntitiesSavedStatesIsDirty types are not available
+	useEntitiesSavedStatesIsDirty,
+} from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { __ } from '@wordpress/i18n';
 import { plus, listView, undo, redo, next, previous } from '@wordpress/icons';
@@ -27,6 +32,7 @@ import { PreviewDropdown } from '../preview';
 import { SaveEmailButton } from './save-email-button';
 import { CampaignName } from './campaign-name';
 import { SendButton } from './send-button';
+import { SaveAllButton } from './save-all-button';
 import { useEditorMode } from '../../hooks';
 
 // Build type for ToolbarItem contains only "as" and "children" properties but it takes all props from
@@ -83,6 +89,11 @@ export function Header() {
 	}, [] );
 
 	const [ editorMode ] = useEditorMode();
+
+	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
+	const hasNonEmailEdits = dirtyEntityRecords.some(
+		( entity ) => entity.name !== 'mailpoet_email'
+	);
 
 	const preventDefault = ( event ) => {
 		event.preventDefault();
@@ -210,7 +221,7 @@ export function Header() {
 			<div className="editor-header__settings edit-post-header__settings">
 				<SaveEmailButton />
 				<PreviewDropdown />
-				<SendButton />
+				{ hasNonEmailEdits ? <SaveAllButton /> : <SendButton /> }
 				<PinnedItems.Slot scope={ storeName } />
 				<MoreMenu />
 			</div>

--- a/packages/js/email-editor/src/components/header/index.scss
+++ b/packages/js/email-editor/src/components/header/index.scss
@@ -44,3 +44,10 @@
 .editor-document-bar__shortcut {
   display: none !important;
 }
+
+// Temporarily hide text about amount of changes to save. The wording is not great for email context.
+.entities-saved-states__text-prompt {
+ p {
+   display: none;
+ }
+}

--- a/packages/js/email-editor/src/components/header/save-all-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-all-button.tsx
@@ -1,4 +1,4 @@
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { Button, Dropdown } from '@wordpress/components';
 import {
 	// @ts-expect-error Our current version of packages doesn't have EntitiesSavedStates export
@@ -7,6 +7,33 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { storeName } from '../../store';
+
+const SaveAllContent = ( { onToggle } ) => {
+	// Hacky way to change the text in the templates row of the save dropdown
+	useEffect( () => {
+		const panels = document.querySelectorAll(
+			'.mailpoet-email-editor-save-button__dropdown  .components-panel__body'
+		);
+		panels.forEach( ( panel ) => {
+			const titleButton = panel.querySelector(
+				'.components-panel__body-title button'
+			);
+			if (
+				titleButton &&
+				titleButton.textContent.trim() === __( 'Templates', 'mailpoet' )
+			) {
+				const rows = panel.querySelectorAll( '.components-panel__row' );
+				if ( rows.length ) {
+					rows[ 0 ].textContent = __(
+						'This change will affect emails that use this template.',
+						'mailpoet'
+					);
+				}
+			}
+		} );
+	}, [] );
+	return <EntitiesSavedStates close={ onToggle } />;
+};
 
 export function SaveAllButton() {
 	const { isSaving } = useSelect(
@@ -41,7 +68,7 @@ export function SaveAllButton() {
 					</Button>
 				) }
 				renderContent={ ( { onToggle } ) => (
-					<EntitiesSavedStates close={ onToggle } />
+					<SaveAllContent onToggle={ onToggle } />
 				) }
 			/>
 		</div>

--- a/packages/js/email-editor/src/components/header/save-all-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-all-button.tsx
@@ -1,0 +1,49 @@
+import { useRef } from '@wordpress/element';
+import { Button, Dropdown } from '@wordpress/components';
+import {
+	// @ts-expect-error Our current version of packages doesn't have EntitiesSavedStates export
+	EntitiesSavedStates,
+} from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { storeName } from '../../store';
+
+export function SaveAllButton() {
+	const { isSaving } = useSelect(
+		( select ) => ( {
+			isSaving: select( storeName ).isSaving(),
+		} ),
+		[]
+	);
+
+	const buttonRef = useRef( null );
+
+	let label = __( 'Save', 'mailpoet' );
+	if ( isSaving ) {
+		label = __( 'Saving', 'mailpoet' );
+	}
+
+	return (
+		<div ref={ buttonRef }>
+			<Dropdown
+				popoverProps={ {
+					placement: 'bottom',
+					anchor: buttonRef.current,
+				} }
+				contentClassName="mailpoet-email-editor-save-button__dropdown"
+				renderToggle={ ( { onToggle } ) => (
+					<Button
+						onClick={ onToggle }
+						variant="primary"
+						disabled={ isSaving }
+					>
+						{ label }
+					</Button>
+				) }
+				renderContent={ ( { onToggle } ) => (
+					<EntitiesSavedStates close={ onToggle } />
+				) }
+			/>
+		</div>
+	);
+}

--- a/packages/js/email-editor/src/components/header/save-email-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-email-button.tsx
@@ -11,7 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { check, cloud, Icon } from '@wordpress/icons';
 import { storeName } from '../../store';
 
-export function SaveButton() {
+export function SaveEmailButton() {
 	const { saveEditedEmail } = useDispatch( storeName );
 
 	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();

--- a/packages/js/email-editor/src/components/header/save-email-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-email-button.tsx
@@ -1,11 +1,4 @@
-import { useRef } from '@wordpress/element';
-import { Button, Dropdown } from '@wordpress/components';
-import {
-	// @ts-expect-error No types available for useEntitiesSavedStatesIsDirty
-	useEntitiesSavedStatesIsDirty,
-	// @ts-expect-error Our current version of packages doesn't have EntitiesSavedStates export
-	EntitiesSavedStates,
-} from '@wordpress/editor';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { check, cloud, Icon } from '@wordpress/icons';
@@ -14,8 +7,6 @@ import { storeName } from '../../store';
 export function SaveEmailButton() {
 	const { saveEditedEmail } = useDispatch( storeName );
 
-	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
-
 	const { hasEdits, isEmpty, isSaving } = useSelect(
 		( select ) => ( {
 			hasEdits: select( storeName ).hasEdits(),
@@ -23,12 +14,6 @@ export function SaveEmailButton() {
 			isSaving: select( storeName ).isSaving(),
 		} ),
 		[]
-	);
-
-	const buttonRef = useRef( null );
-
-	const hasNonEmailEdits = dirtyEntityRecords.some(
-		( entity ) => entity.name !== 'mailpoet_email'
 	);
 
 	const isSaved = ! isEmpty && ! isSaving && ! hasEdits;
@@ -41,27 +26,7 @@ export function SaveEmailButton() {
 		label = __( 'Saving', 'mailpoet' );
 	}
 
-	return hasNonEmailEdits ? (
-		<div ref={ buttonRef }>
-			<Dropdown
-				popoverProps={ {
-					placement: 'bottom',
-					anchor: buttonRef.current,
-				} }
-				contentClassName="mailpoet-email-editor-save-button__dropdown"
-				renderToggle={ ( { onToggle } ) => (
-					<Button onClick={ onToggle } variant="tertiary">
-						{ hasEdits
-							? __( 'Save email & template', 'mailpoet' )
-							: __( 'Save template', 'mailpoet' ) }
-					</Button>
-				) }
-				renderContent={ ( { onToggle } ) => (
-					<EntitiesSavedStates close={ onToggle } />
-				) }
-			/>
-		</div>
-	) : (
+	return (
 		<Button
 			variant="tertiary"
 			disabled={ isDisabled }


### PR DESCRIPTION
## Description

This PR updates the Send button and Save Draft link button to behave similarly to the Save Draft and Publish buttons in the native post editor.

### Both email and template have no changes
<img width="329" alt="Screenshot 2024-12-05 at 10 30 53" src="https://github.com/user-attachments/assets/b8665bc4-129c-4d28-bdf3-11f56ad91dba">

### Only email has changes
<img width="338" alt="Screenshot 2024-12-05 at 10 31 08" src="https://github.com/user-attachments/assets/aa0d2a05-bde2-4a24-83a6-143dda6d2855">

### Both email and template have changes
<img width="331" alt="Screenshot 2024-12-05 at 17 08 51" src="https://github.com/user-attachments/assets/da62d16b-ac22-4469-a311-c8bf28a61723">


## Code review notes

- I kept the list of modified entities inside a dropdown. In the native editor, it is in a sidebar, but implementing this actions sidebar is more complex due to its closing mechanism. I tried to add it but didn't make it work in a reasonable time, so after discussing it with @pavel-mailpoet I'm keeping the dropdown.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6342]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6342]: https://mailpoet.atlassian.net/browse/MAILPOET-6342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/save-button)

_The latest successful build from `email-editor/save-button` will be used. If none is available, the link won't work._