### PR TITLE
Release 5.5.0

### DIFF
--- a/mailpoet/CHANGELOG.md
+++ b/mailpoet/CHANGELOG.md
@@ -1,5 +1,10 @@
 == Changelog ==
 
+= 5.5.0 - 2024-12-09 =
+
+- Added the Polish translation as an officially maintained translation;
+- Added: classes now allowed in links of HTML forms.
+
 = 5.4.2 - 2024-12-02 =
 
 - Improved: stability of post notification scheduling;

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.4.2
+ * Version: 5.5.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.4.2',
+  'version' => '5.5.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.6
 Tested up to: 6.7
-Stable tag: 5.4.2
+Stable tag: 5.5.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -230,8 +230,8 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.4.2 - 2024-12-02 =
-* Improved: stability of post notification scheduling;
-* Changed: minimum required WordPress version to 6.6 and WooCommerce to 9.3.
+= 5.5.0 - 2024-12-09 =
+* Added the Polish translation as an officially maintained translation;
+* Added: classes now allowed in links of HTML forms.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/CHANGELOG.md)


### PR DESCRIPTION

Premium: https://github.com/mailpoet/mailpoet-premium/pull/927

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._