### PR TITLE
Fix an error in nighlty tests caused by a skipped test [MAILPOET-6374]

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -57,6 +57,7 @@ class AcceptanceTester extends \Codeception\Actor {
   const AUTOMATE_WOO_PLUGIN = 'automatewoo';
   const MAILHOG_DATA_PATH = '/mailhog-data';
   const ADMIN_EMAIL = 'test@test.com';
+  const EMAIL_EDITOR_MINIMAL_WP_VERSION = '6.7';
 
   /**
    * Define custom actions here
@@ -951,5 +952,15 @@ class AcceptanceTester extends \Codeception\Actor {
     $segmentName = Locator::contains('.mailpoet-templates-card-header-title', $templateName);
     $i->waitForElement($segmentName);
     $i->click($segmentName);
+  }
+
+  public function checkEmailEditorRequiredWordpressVersion(): bool {
+    $i = $this;
+    $wordPressVersion = $i->getWordPressVersion();
+    // New email editor is not compatible with WP versions below 6.7
+    if (version_compare($wordPressVersion, self::EMAIL_EDITOR_MINIMAL_WP_VERSION, '<')) {
+      return false;
+    }
+    return true;
   }
 }

--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -22,9 +22,10 @@ class CheckSkippedTestsExtension extends Extension {
       'testAllSubscribersFoundWithOperatorAllOf',
       'automationTriggeredByRegistrationWitConfirmationNeeded',
       'automationTriggeredByRegistrationWithoutConfirmationNeeded',
-      // The next two tests can be removed after dropping support for WP 6.4
+      // Email editor works with the latest WP version only
       'createAndSendStandardNewsletter',
       'displayNewsletterPreview',
+      'selectEditSwapAndResetEmailTemplate',
     ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -8,8 +8,8 @@ use MailPoet\Test\DataFactories\Settings;
 
 class CreateAndSendEmailUsingGutenbergCest {
   public function createAndSendStandardNewsletter(\AcceptanceTester $i, $scenario) {
-    if (!$this->checkRequiredWordpressVersion($i)) {
-      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4 and higher than 6.5');
+    if (!$i->checkEmailEditorRequiredWordpressVersion()) {
+      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
     }
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
@@ -81,9 +81,9 @@ class CreateAndSendEmailUsingGutenbergCest {
   }
 
   public function displayNewsletterPreview(\AcceptanceTester $i, $scenario) {
-    if (!$this->checkRequiredWordpressVersion($i))
-      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4 and higher than 6.5');
-
+    if (!$i->checkEmailEditorRequiredWordpressVersion()) {
+      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
+    }
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
     $settings->withSender('John Doe', 'john@doe.com');
@@ -134,15 +134,6 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForText('Test email sent successfully!');
     $i->click('//button[text()="Close"]');
     $i->waitForElementNotVisible('//button[text()="Send test email"]');
-  }
-
-  private function checkRequiredWordpressVersion(\AcceptanceTester $i): bool {
-    $wordPressVersion = $i->getWordPressVersion();
-    // New email editor is not compatible with WP versions below 6.7
-    if (version_compare($wordPressVersion, '6.7', '<')) {
-      return false;
-    }
-    return true;
   }
 
   private function closeTemplateSelectionModal(\AcceptanceTester $i): void {

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -7,8 +7,8 @@ use MailPoet\Test\DataFactories\Features;
 
 class EmailTemplatesCest {
   public function selectEditSwapAndResetEmailTemplate(\AcceptanceTester $i, $scenario) {
-    if (!$this->checkRequiredWordpressVersion($i)) {
-      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below 6.4 and higher than 6.5');
+    if (!$i->checkEmailEditorRequiredWordpressVersion()) {
+      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
     }
     (new Features())->withFeatureEnabled(FeaturesController::GUTENBERG_EMAIL_EDITOR);
 
@@ -82,15 +82,6 @@ class EmailTemplatesCest {
     $i->click('Reset');
     $i->waitForText('"Simple Light" reset.');
     $this->checkTextIsNotInEmail($i, $textInTemplate);
-  }
-
-  private function checkRequiredWordpressVersion(\AcceptanceTester $i): bool {
-    $wordPressVersion = $i->getWordPressVersion();
-    // New email editor is not compatible with WP versions below 6.7
-    if (version_compare($wordPressVersion, '6.7', '<')) {
-      return false;
-    }
-    return true;
   }
 
   private function selectTemplate(\AcceptanceTester $i, string $template): void {


### PR DESCRIPTION
## Description

A newly added test for the email editor was not on the whitelist of tests we allow you to skip. We need to skip it for the oldest tests.

## Code review notes

You can test the skipping works locally by editing the `\AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION` constant.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6374]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6374]: https://mailpoet.atlassian.net/browse/MAILPOET-6374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-nighlty-skipped-test)

_The latest successful build from `fix-nighlty-skipped-test` will be used. If none is available, the link won't work._