### PR TITLE
Expand System Info report with details from System Status [MAILPOET-6302]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -298,15 +298,17 @@ class Services extends APIEndpoint {
   }
 
   public function pingBridge() {
-    try {
-      $bridgePingResponse = $this->bridge->pingBridge();
-    } catch (\Exception $e) {
+    $response = $this->bridge->pingBridge();
+    if ($this->wp->isWpError($response)) {
+      /** @var \WP_Error $response */
+      $errorDesc = $this->getErrorDescriptionByCode(Bridge::CHECK_ERROR_UNKNOWN);
       return $this->errorResponse([
-        APIError::UNKNOWN => $e->getMessage(),
+        APIError::UNKNOWN => "{$errorDesc}: {$response->get_error_message()}",
       ]);
     }
-    if (!$this->bridge->validateBridgePingResponse($bridgePingResponse)) {
-      $code = $bridgePingResponse ?: Bridge::CHECK_ERROR_UNKNOWN;
+
+    if (!$this->bridge->validateBridgePingResponse($response)) {
+      $code = $this->wp->wpRemoteRetrieveResponseCode($response) ?: Bridge::CHECK_ERROR_UNKNOWN;
       return $this->errorResponse([
         APIError::UNKNOWN => $this->getErrorDescriptionByCode($code),
       ]);

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -52,9 +52,10 @@ class Help {
      * @param array<string, string> $systemInfoData The system info data array.
      */
     $systemInfoData = WPFunctions::get()->applyFilters('mailpoet_system_info_data', $this->systemReportCollector->getData(true));
+
     try {
       $cronPingUrl = $this->cronHelper->getCronUrl(CronDaemon::ACTION_PING);
-      $cronPingResponse = $this->cronHelper->pingDaemon();
+      $cronPingResponse = $this->systemReportCollector->getCronPingResponse();
     } catch (\Exception $e) {
       $cronPingResponse = __('Can‘t generate cron URL.', 'mailpoet') . ' (' . $e->getMessage() . ')';
       $cronPingUrl = $cronPingResponse;
@@ -62,6 +63,7 @@ class Help {
 
     $mailerLog = MailerLog::getMailerLog();
     $mailerLog['sent'] = MailerLog::sentSince();
+    $bridgePingResponse = $this->systemReportCollector->getBridgePingResponse();
     $systemStatusData = [
       'cron' => [
         'url' => $cronPingUrl,
@@ -70,16 +72,18 @@ class Help {
       ],
       'mss' => [
         'enabled' => $this->bridge->isMailpoetSendingServiceEnabled(),
-        'isReachable' => $this->bridge->validateBridgePingResponse($this->bridge->pingBridge()),
+        'isReachable' => $this->bridge->validateBridgePingResponse($bridgePingResponse),
       ],
       'cronStatus' => $this->cronHelper->getDaemon(),
       'queueStatus' => $mailerLog,
     ];
+
     $systemStatusData['cronStatus']['accessible'] = $this->cronHelper->isDaemonAccessible();
     $systemStatusData['queueStatus']['tasksStatusCounts'] = $this->scheduledTasksRepository->getCountsPerStatus();
-    $systemStatusData['queueStatus']['latestTasks'] = array_map(function ($task) {
-      return $this->buildTaskData($task);
-    }, $this->scheduledTasksRepository->getLatestTasks(SendingQueue::TASK_TYPE));
+
+    $scheduledTasks = $this->scheduledTasksRepository->getLatestTasks(SendingQueue::TASK_TYPE);
+    $systemStatusData['queueStatus']['latestTasks'] = array_map(fn($task) => $this->buildTaskData($task), $scheduledTasks);
+
     $this->pageRenderer->displayPage(
       'help.html',
       [
@@ -132,6 +136,7 @@ class Help {
         $subscriber = $subscribers->first() ? $subscribers->first()->getSubscriber() : null;
       }
     }
+
     return [
       'id' => $task->getId(),
       'type' => $task->getType(),

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -61,8 +61,8 @@ class Bridge {
   }
 
   /**
-   * @deprecated Use non-static function isMailpoetSendingServiceEnabled instead
    * @return bool
+   * @deprecated Use non-static function isMailpoetSendingServiceEnabled instead
    */
   public static function isMPSendingServiceEnabled() {
     try {
@@ -99,18 +99,24 @@ class Bridge {
     return !empty($key);
   }
 
+  /**
+   * @return array|\WP_Error
+   */
   public function pingBridge() {
     $params = [
       'blocking' => true,
       'timeout' => 10,
     ];
     $wp = new WPFunctions();
-    $result = $wp->wpRemoteGet(self::BRIDGE_URL, $params);
-    return $wp->wpRemoteRetrieveResponseCode($result);
+    return $wp->wpRemoteGet(self::BRIDGE_URL, $params);
   }
 
-  public function validateBridgePingResponse($responseCode) {
-    return $responseCode === 200;
+  /**
+   * @return bool
+   */
+  public function validateBridgePingResponse($response) {
+    $wp = new WPFunctions();
+    return $wp->wpRemoteRetrieveResponseCode($response) === 200;
   }
 
   /**

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -81,10 +81,18 @@ class SystemReportCollector {
       'Database version' => $dbVersion,
       'Web server' => (!empty($_SERVER["SERVER_SOFTWARE"])) ? sanitize_text_field(wp_unslash($_SERVER["SERVER_SOFTWARE"])) : 'N/A',
       'Server OS' => (function_exists('php_uname')) ? php_uname() : 'N/A',
-      'WP info' => 'WP_MEMORY_LIMIT: ' . WP_MEMORY_LIMIT . ' - WP_MAX_MEMORY_LIMIT: ' . WP_MAX_MEMORY_LIMIT . ' - WP_DEBUG: ' . WP_DEBUG .
-        ' - WordPress language: ' . $this->wp->getLocale() . ' - WordPress timezone: ' . $this->wp->wpTimezoneString(),
-      'PHP info' => 'PHP max_execution_time: ' . ini_get('max_execution_time') . ' - PHP memory_limit: ' . ini_get('memory_limit') .
-        ' - PHP upload_max_filesize: ' . ini_get('upload_max_filesize') . ' - PHP post_max_size: ' . ini_get('post_max_size'),
+      'WP info' => $this->formatCompositeField([
+        'WP_MEMORY_LIMIT' => WP_MEMORY_LIMIT,
+        'WP_MAX_MEMORY_LIMIT' => WP_MAX_MEMORY_LIMIT, 'WP_DEBUG' => WP_DEBUG,
+        'WordPress language' => $this->wp->getLocale(),
+        'WordPress timezone' => $this->wp->wpTimezoneString(),
+      ]),
+      'PHP info' => $this->formatCompositeField([
+        'PHP max_execution_time' => ini_get('max_execution_time'),
+        'PHP memory_limit' => ini_get('memory_limit'),
+        'PHP upload_max_filesize' => ini_get('upload_max_filesize'),
+        'PHP post_max_size' => ini_get('post_max_size'),
+      ]),
       'Multisite environment?' => (is_multisite() ? 'Yes' : 'No'),
       'Current Theme' => $currentTheme->get('Name') .
         ' (version ' . $currentTheme->get('Version') . ')',
@@ -95,13 +103,24 @@ class SystemReportCollector {
         $mta['frequency']['emails'],
         $mta['frequency']['interval']
       ),
-      'MailPoet sending info' => "Send all site's emails with: " . ($this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method') .
-        ' - Task Scheduler method: ' . $this->settings->get('cron_trigger.method') . ' - Cron ping URL: ' . $cronPingUrl . ' - Default FROM address: ' . $this->settings->get('sender.address') .
-        ' - Default Reply-To address: ' . $this->settings->get('reply_to.address') . ' - Bounce Email Address: ' . $this->settings->get('bounce.address'),
+      'MailPoet sending info' => $this->formatCompositeField([
+        "Send all site's emails with" => ($this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method'),
+        'Task Scheduler method' => $this->settings->get('cron_trigger.method'),
+        'Cron ping URL' => $cronPingUrl,
+        'Default FROM address' => $this->settings->get('sender.address'),
+        'Default Reply-To address' => $this->settings->get('reply_to.address'),
+        'Bounce Email Address' => $this->settings->get('bounce.address'),
+      ]),
       'Total number of subscribers' => $this->subscribersFeature->getSubscribersCount(),
       'Plugin installed at' => $this->settings->get('installed_at'),
       'Installed via WooCommerce onboarding wizard' => $this->wooCommerceHelper->wasMailPoetInstalledViaWooCommerceOnboardingWizard(),
     ];
+  }
+
+  private function formatCompositeField($fields) {
+    return implode(' - ', array_map(function ($key, $value) {
+      return $key . ': ' . $value;
+    }, array_keys($fields), array_values($fields)));
   }
 
   protected function maskApiKey($key) {

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -99,6 +99,9 @@ class SystemReportCollector {
       ? $pingBridgeResponse->get_error_message()
       : $this->wp->wpRemoteRetrieveResponseCode($pingBridgeResponse) . ' HTTP status code';
 
+    $ApiKeyState = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME . '.state');
+    $premiumKeyState = $this->settings->get(Bridge::PREMIUM_KEY_STATE_SETTING_NAME . '.state');
+
     // the HelpScout Beacon API has a limit of 20 attribute-value pairs (https://developer.helpscout.com/beacon-2/web/javascript-api/#beacon-session-data)
     return [
       'PHP version' => PHP_VERSION,
@@ -129,6 +132,8 @@ class SystemReportCollector {
       'MailPoet Sending Service' => $this->formatCompositeField([
         'Is reachable' => $this->bridge->validateBridgePingResponse($pingBridgeResponse) ? 'Yes' : 'No',
         'Ping response' => $pingResponse,
+        'API key state' => $ApiKeyState ?? 'Unset',
+        'Premium key state' => $premiumKeyState ?? 'Unset',
       ]),
       'Sending Frequency' => sprintf(
         '%d emails every %d minutes',

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -95,8 +95,8 @@ class SystemReportCollector {
     unset($inconsistencyStatus['total']);
 
     $pingBridgeResponse = $this->bridge->pingBridge();
-    $pingResponse = is_wp_error($pingBridgeResponse)
-      ? $pingBridgeResponse->get_error_message()
+    $pingResponse = $this->wp->isWpError($pingBridgeResponse)
+      ? $pingBridgeResponse->get_error_message() // @phpstan-ignore-line
       : $this->wp->wpRemoteRetrieveResponseCode($pingBridgeResponse) . ' HTTP status code';
 
     $ApiKeyState = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME . '.state');

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -114,7 +114,8 @@ class SystemReportCollector {
       'Server OS' => (function_exists('php_uname')) ? php_uname() : 'N/A',
       'WP info' => $this->formatCompositeField([
         'WP_MEMORY_LIMIT' => WP_MEMORY_LIMIT,
-        'WP_MAX_MEMORY_LIMIT' => WP_MAX_MEMORY_LIMIT, 'WP_DEBUG' => WP_DEBUG,
+        'WP_MAX_MEMORY_LIMIT' => WP_MAX_MEMORY_LIMIT,
+        'WP_DEBUG' => WP_DEBUG,
         'WordPress language' => $this->wp->getLocale(),
         'WordPress timezone' => $this->wp->wpTimezoneString(),
       ]),
@@ -172,7 +173,11 @@ class SystemReportCollector {
     ];
   }
 
-  private function formatCompositeField($fields) {
+  /**
+   * @param $fields array of key-value pairs
+   * @return string in the format "key1: value1 - key2: value2 - ..."
+   */
+  private function formatCompositeField(array $fields) {
     if (empty($fields)) {
       return '';
     }

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -271,6 +271,18 @@ class SystemReportCollectorTest extends \MailPoetTest {
     verify($systemInfoData['MailPoet Sending Service'])->stringContainsString('Ping response: ' . $errorMessage);
   }
 
+  public function testItReturnsMSSKeyState() {
+    $this->settings->set(Bridge::API_KEY_STATE_SETTING_NAME . '.state', Bridge::KEY_VALID);
+    $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
+    verify($systemInfoData['MailPoet Sending Service'])->stringContainsString('API key state: ' . Bridge::KEY_VALID);
+  }
+
+  public function testItReturnsPremiumKeyState() {
+    $this->settings->set(Bridge::PREMIUM_KEY_STATE_SETTING_NAME . '.state', Bridge::KEY_VALID);
+    $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
+    verify($systemInfoData['MailPoet Sending Service'])->stringContainsString('Premium key state: ' . Bridge::KEY_VALID);
+  }
+
   private function createSystemReporterWithMockedBridge($bridge) {
     $settings = $this->diContainer->get(SettingsController::class);
     $wp = $this->diContainer->get(WPFunctions::class);

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -289,6 +289,16 @@ class SystemReportCollectorTest extends \MailPoetTest {
     $subscribersFeature = $this->diContainer->get(SubscribersFeature::class);
     $wooCommerceHelper = $this->diContainer->get(WooCommerceHelper::class);
     $dataInconsistencyController = $this->diContainer->get(DataInconsistencyController::class);
-    return new SystemReportCollector($settings, $wp, $subscribersFeature, $wooCommerceHelper, $dataInconsistencyController, $bridge);
+    $cronHelper = $this->diContainer->get(CronHelper::class);
+
+    return new SystemReportCollector(
+      $settings,
+      $wp,
+      $subscribersFeature,
+      $wooCommerceHelper,
+      $dataInconsistencyController,
+      $bridge,
+      $cronHelper
+    );
   }
 }

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -237,4 +237,15 @@ class SystemReportCollectorTest extends \MailPoetTest {
     $subjectField = $systemInfoData['Sending queue status'];
     verify($subjectField)->stringContainsString('Status: ' . MailerLog::STATUS_PAUSED);
   }
+
+  public function testItReturnsDataInconsistencyStatus() {
+    $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
+    $subjectField = $systemInfoData['Data inconsistency status'];
+    verify($subjectField)->stringContainsString('Orphaned sending tasks: 0');
+    verify($subjectField)->stringContainsString('Orphaned sending task subscribers: 0');
+    verify($subjectField)->stringContainsString('Sending queue without newsletter: 0');
+    verify($subjectField)->stringContainsString('Orphaned subscriptions: 0');
+    verify($subjectField)->stringContainsString('Orphaned links: 0');
+    verify($subjectField)->stringContainsString('Orphaned newsletter posts: 0');
+  }
 }


### PR DESCRIPTION
## Description

The System Info report that can be found at `MailPoet > Help > System Info` tab provides very valuable information when assessing an issue. We want to improve it, adding more informations to reduce back-and-forth with customers. HEs, and our AI assistant, will be able to give a more meaningful reply if we can provide more infos right when a user first contacts us sharing the System Info report with us.

Please refer to the [parent ticket](https://mailpoet.atlassian.net/browse/MAILPOET-6302) for detailed description.

As per the discussion [here](https://a8c.slack.com/archives/C07SYRS5YNS/p1733150674384159), I've aimed to include as much details of value as possible. That might come as inconsistent with the specification.

## Code review notes

[Bridge ping](https://github.com/mailpoet/mailpoet/blob/1ca30446399efc30ec5bd34b84096c8980ed5080/mailpoet/lib/API/JSON/v1/Services.php#L300-L315) API action was flawed prior to this PR, specifically these lines:

 ```
try {
  $bridgePingResponse = $this->bridge->pingBridge();
} catch (xception $e) {
  return $this->errorResponse([
    APIError::UNKNOWN => $e->getMessage(),
  ]);
}
```

Tracing the call, `$this->bridge->pingBridge()` does not seem to throw an exception on failure, instead, it would return `null`. Hence, the `catch` block is unreachable. In such cases, the response would be "unknown" with a generic "contact your hosting support..." error message without any details about the specific error:

```
if (!$this->bridge->validateBridgePingResponse($bridgePingResponse)) {
  $code = $bridgePingResponse ?: Bridge::CHECK_ERROR_UNKNOWN;
  return $this->errorResponse([
    APIError::UNKNOWN => $this->getErrorDescriptionByCode($code),
  ]);
}
```

This has been fixed in [this commit](https://github.com/mailpoet/mailpoet/commit/263f19b4eec19b3456f26832f5505396b6363f34), along with some follow-up changes that I [missed to address](https://github.com/mailpoet/mailpoet/commit/9b0b43fb9950474a1f53c509809bf7f16b26b970).

## QA notes

_N/A_

## Linked tickets

[MAILPOET-6378]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript


[MAILPOET-6378]: https://mailpoet.atlassian.net/browse/MAILPOET-6378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:expand-system-info-tab)

_The latest successful build from `expand-system-info-tab` will be used. If none is available, the link won't work._