### PR TITLE
Fix PHP fatal errors - MAILPOET-6382

### DIFF
--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -159,7 +159,12 @@ class Hooks {
   }
 
   public function setupSubscriptionEvents() {
-    $subscribe = $this->settings->get('subscribe', []);
+    // In some cases on multisite instance, this code may run before DB migrator and settings table is not ready at that time
+    try {
+      $subscribe = $this->settings->get('subscribe', []);
+    } catch (\Exception $e) {
+      $subscribe = [];
+    }
     // Subscribe in comments
     if (
       isset($subscribe['on_comment']['enabled'])
@@ -325,7 +330,12 @@ class Hooks {
   }
 
   public function setupWooCommerceSubscriptionEvents() {
-    $optInEnabled = (bool)$this->settings->get(Subscription::OPTIN_ENABLED_SETTING_NAME, false);
+    // In some cases on multisite instance, this code may run before DB migrator and settings table is not ready at that time
+    try {
+      $optInEnabled = (bool)$this->settings->get(Subscription::OPTIN_ENABLED_SETTING_NAME, false);
+    } catch (\Exception $e) {
+      $optInEnabled = false;
+    }
     // WooCommerce: subscribe on checkout
     if ($optInEnabled) {
       $optInPosition = $this->settings->get(Subscription::OPTIN_POSITION_SETTING_NAME, self::DEFAULT_OPTIN_POSITION);

--- a/mailpoet/lib/Statistics/Track/SubscriberHandler.php
+++ b/mailpoet/lib/Statistics/Track/SubscriberHandler.php
@@ -32,7 +32,11 @@ class SubscriberHandler {
     $this->wp = $wp;
   }
 
-  public function identifyByLogin(string $login): void {
+  public function identifyByLogin(?string $login): void {
+    if (is_null($login)) {
+      return;
+    }
+
     if (!$this->trackingConfig->isCookieTrackingEnabled()) {
       return;
     }

--- a/mailpoet/lib/WooCommerce/WooCommerceSubscriptions/Helper.php
+++ b/mailpoet/lib/WooCommerce/WooCommerceSubscriptions/Helper.php
@@ -29,7 +29,10 @@ class Helper {
     return wcs_get_subscription_statuses();
   }
 
-  public function wcsGetBillingPeriodStrings(): array {
+  /**
+   * @return array
+   */
+  public function wcsGetBillingPeriodStrings() {
     if (!function_exists('wcs_get_subscription_period_strings')) {
       return [];
     }


### PR DESCRIPTION


## Description

Fixing some PHP fatal errors observed on grafana

## Code review notes

_N/A_

## QA notes

We can skip QA

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6382](https://mailpoet.atlassian.net/browse/MAILPOET-6382)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6382]: https://mailpoet.atlassian.net/browse/MAILPOET-6382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-php-fatal-error-caused-by-using-mailpoet_settings-db-table-before-it-s-available)

_The latest successful build from `fix-php-fatal-error-caused-by-using-mailpoet_settings-db-table-before-it-s-available` will be used. If none is available, the link won't work._