### PR TITLE
Soft deactivation of MailPoet [MAILPOET-6389]

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -30,12 +30,6 @@ $mailpoetPlugin = [
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.6';
 const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.3';
 
-function mailpoet_deactivate_plugin() {
-  deactivate_plugins(plugin_basename(__FILE__));
-  if (!empty($_GET['activate'])) {
-    unset($_GET['activate']);
-  }
-}
 
 // Display WP version error notice
 function mailpoet_wp_version_notice() {

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -115,7 +115,7 @@ function mailpoet_php_version_notice() {
     ],
   ];
   printf(
-    '<div class="error"><p><strong>%s</strong></p><p>%s</p><p>%s</p></div>',
+    '<div class="error"><p><strong>%s</strong></p><p>%s</p></div>',
     esc_html($noticeP1),
     wp_kses(
       $noticeP2,

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -97,8 +97,14 @@ function mailpoet_core_dependency_notice() {
 
 // Display PHP version error notice
 function mailpoet_php_version_notice() {
-  $noticeP1 = __('MailPoet requires PHP version 7.4 or newer (8.1 recommended). You are running version [version].', 'mailpoet');
-  $noticeP1 = str_replace('[version]', phpversion(), $noticeP1);
+  $noticeP1 = sprintf(
+    // translators: %1$s is the plugin name (MailPoet or MailPoet Premium), %2$s, %3$s, and %4$s are PHP version (e.g. "8.1.30")
+    __('%1$s requires PHP version %2$s or newer (%3$s recommended). You are running version %4$s.', 'mailpoet'),
+    'MailPoet',
+    '7.4',
+    '8.1',
+    phpversion()
+  );
 
   $noticeP2 = __('Please read our [link]instructions[/link] on how to upgrade your site.', 'mailpoet');
   $noticeP2 = str_replace(

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -108,14 +108,6 @@ function mailpoet_php_version_notice() {
   );
   $noticeP2 = str_replace('[/link]', '</a>', $noticeP2);
 
-  $noticeP3 = __('If you can’t upgrade the PHP version, [link]install this version[/link] of MailPoet. Remember to not update MailPoet ever again!', 'mailpoet');
-  $noticeP3 = str_replace(
-    '[link]',
-    '<a href="https://downloads.wordpress.org/plugin/mailpoet.4.38.0.zip" target="_blank">',
-    $noticeP3
-  );
-  $noticeP3 = str_replace('[/link]', '</a>', $noticeP3);
-
   $allowedTags = [
     'a' => [
       'href' => true,
@@ -127,10 +119,6 @@ function mailpoet_php_version_notice() {
     esc_html($noticeP1),
     wp_kses(
       $noticeP2,
-      $allowedTags
-    ),
-    wp_kses(
-      $noticeP3,
       $allowedTags
     )
   );

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -119,6 +119,18 @@ function mailpoet_woocommerce_version_notice() {
   );
 }
 
+// Display IIS server error notice
+function mailpoet_microsoft_iis_notice() {
+  $notice = __("MailPoet plugin cannot run under Microsoft's Internet Information Services (IIS) web server. We recommend that you use a web server powered by Apache or NGINX.", 'mailpoet');
+  printf('<div class="error"><p>%1$s</p></div>', esc_html($notice));
+}
+
+// Display missing core dependencies error notice
+function mailpoet_core_dependency_notice() {
+  $notice = __('MailPoet cannot start because it is missing core files. Please reinstall the plugin.', 'mailpoet');
+  printf('<div class="error"><p>%1$s</p></div>', esc_html($notice));
+}
+
 // Display PHP version error notice
 function mailpoet_php_version_notice() {
   $noticeP1 = __('MailPoet requires PHP version 7.4 or newer (8.1 recommended). You are running version [version].', 'mailpoet');
@@ -167,11 +179,6 @@ if (isset($_SERVER['SERVER_SOFTWARE']) && strpos(strtolower(sanitize_text_field(
   return;
 }
 
-// Display IIS server error notice
-function mailpoet_microsoft_iis_notice() {
-  $notice = __("MailPoet plugin cannot run under Microsoft's Internet Information Services (IIS) web server. We recommend that you use a web server powered by Apache or NGINX.", 'mailpoet');
-  printf('<div class="error"><p>%1$s</p></div>', esc_html($notice));
-}
 
 // Check for presence of core dependencies
 if (!file_exists($mailpoetPlugin['autoloader']) || !file_exists($mailpoetPlugin['initializer'])) {
@@ -179,12 +186,6 @@ if (!file_exists($mailpoetPlugin['autoloader']) || !file_exists($mailpoetPlugin[
   // deactivate the plugin
   add_action('admin_init', 'mailpoet_deactivate_plugin');
   return;
-}
-
-// Display missing core dependencies error notice
-function mailpoet_core_dependency_notice() {
-  $notice = __('MailPoet cannot start because it is missing core files. Please reinstall the plugin.', 'mailpoet');
-  printf('<div class="error"><p>%1$s</p></div>', esc_html($notice));
 }
 
 // Initialize plugin


### PR DESCRIPTION
## Description
If the current WP, Woo or PHP version is lower than needed, MailPoet deactivates itself. With this PR we will "soft-deactivate". This means, every code except for the mailpoet.php code will not be executed. Yet, as soon as the problem is resolved, MailPoet works as expected and you do not need to reactivate the plugin again. It also means that the notices we show like e.g.

![image](https://github.com/user-attachments/assets/06eb720e-997a-4038-99f4-d7ef10079f30)

will be permanently visible and inform the user about the underlying issue.

When testing, one problem I saw:
In that "soft-deactivated" mode we do not declare capability e.g. with HPOS. Therefore, WooCommerce will start to declare our plugin would not be compatible with HPOS. I believe, since we display our error message as well63, that is okay.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs
https://github.com/mailpoet/mailpoet-premium/pull/929
## Linked tickets

[MAILPOET-6389]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6389]: https://mailpoet.atlassian.net/browse/MAILPOET-6389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6389-soft-deactivation)

_The latest successful build from `MAILPOET-6389-soft-deactivation` will be used. If none is available, the link won't work._