### PR TITLE
Ensure wcsGetBillingPeriodStrings always returns an array [PREMIUM-288]

### DIFF
--- a/mailpoet/lib/WooCommerce/WooCommerceSubscriptions/Helper.php
+++ b/mailpoet/lib/WooCommerce/WooCommerceSubscriptions/Helper.php
@@ -29,14 +29,15 @@ class Helper {
     return wcs_get_subscription_statuses();
   }
 
-  /**
-   * @return array
-   */
-  public function wcsGetBillingPeriodStrings() {
+  public function wcsGetBillingPeriodStrings(): array {
     if (!function_exists('wcs_get_subscription_period_strings')) {
       return [];
     }
-    return wcs_get_subscription_period_strings();
+    $strings = wcs_get_subscription_period_strings();
+    if (!is_array($strings)) {
+      return [];
+    }
+    return $strings;
   }
 
   public function wcsGetSubscriptionTrialPeriodStrings(): array {


### PR DESCRIPTION
## Description
When we removed the return type-hint in https://github.com/mailpoet/mailpoet/commit/1c8771efef36b37605d005ec6816faee612064aa it broke an itegration test in the premium plugin because an automatic Codeception mock relied on that tyhehint. This PR fixes the same issue that was fixed by https://github.com/mailpoet/mailpoet/commit/1c8771efef36b37605d005ec6816faee612064aa but in a way that it ensures the return value is an array and we can keep the typehint.

## Code review notes

It can be tested locally by checking this branch and running the test in premium
`./do test:integration --debug --skip-deps --file tests/integration/Automation/Integrations/WooCommerceSubscriptions/Fields/WooSubscriptionFieldsTest.php:testStatusField`

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[PREMIUM-288]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[PREMIUM-288]: https://mailpoet.atlassian.net/browse/PREMIUM-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-WooSubscriptionFieldsTest)

_The latest successful build from `fix-WooSubscriptionFieldsTest` will be used. If none is available, the link won't work._