### PR TITLE
Display personalization tags properly in listings [MAILPOET-6385]

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -4,3 +4,5 @@
 [ "$MP_GIT_HOOKS_ENABLE" != "true" ] && exit 0
 
 installIfUpdates
+
+./do cleanup:cached-files

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -113,7 +113,10 @@ class NewslettersResponseBuilder {
     return $data;
   }
 
-  private function processPersonalizationTags(string $content): string {
+  private function processPersonalizationTags(?string $content): ?string {
+    if (is_null($content) || strlen($content) === 0) {
+      return $content;
+    }
     if (strpos($content, '<!--') === false) {
       // we don't need to parse anything if there are no personalization tags
       return $content;
@@ -278,7 +281,7 @@ class NewslettersResponseBuilder {
       'meta' => $queue->getMeta(),
       'task_id' => (string)$task->getId(), // (string) for BC
       'newsletter_id' => ($newsletter = $queue->getNewsletter()) ? (string)$newsletter->getId() : null, // (string) for BC
-      'newsletter_rendered_subject' => $queue->getNewsletterRenderedSubject(),
+      'newsletter_rendered_subject' => $this->processPersonalizationTags($queue->getNewsletterRenderedSubject()),
       'count_total' => (string)$queue->getCountTotal(), // (string) for BC
       'count_processed' => (string)$queue->getCountProcessed(), // (string) for BC
       'count_to_process' => (string)$queue->getCountToProcess(), // (string) for BC

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -135,10 +135,6 @@ class NewslettersResponseBuilder {
     return $content_processor->get_updated_html();
   }
 
-  /**
-   * @param NewsletterEntity[] $newsletters
-   * @return mixed[]
-   */
   public function buildForListing(array $newsletters): array {
     $statistics = $this->newslettersStatsRepository->getBatchStatistics($newsletters);
     $latestQueues = $this->getBatchLatestQueuesWithTasks($newsletters);
@@ -153,6 +149,12 @@ class NewslettersResponseBuilder {
     return $data;
   }
 
+  /**
+   * @param NewsletterEntity $newsletter
+   * @param NewsletterStatistics|null $statistics
+   * @param SendingQueueEntity|null $latestQueue
+   * @return array<string, mixed>
+   */
   private function buildListingItem(NewsletterEntity $newsletter, NewsletterStatistics $statistics = null, SendingQueueEntity $latestQueue = null): array {
     $couponBlockLogs = array_map(function ($item) {
       return "Coupon block: $item";

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -57,4 +57,22 @@ class NewslettersResponseBuilderTest extends \MailPoetTest {
     $em->remove($newsletter);
     $em->flush();
   }
+
+  public function testItReplacesPersonalizationTags() {
+    $em = $this->diContainer->get(EntityManager::class);
+    $responseBuilder = $this->diContainer->get(NewslettersResponseBuilder::class);
+    $em->persist($newsletter = new NewsletterEntity);
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+    $newsletter->setSubject('Subject');
+    $em->flush();
+
+    $newsletter->setSubject('Subject');
+    $response = $responseBuilder->buildForListing([$newsletter]);
+    verify($response[0]['subject'])->equals('Subject');
+
+    $newsletter->setSubject('Hello <!--[mailpoet/subscriber-firstname default="subscriber"]-->!');
+    $response = $responseBuilder->buildForListing([$newsletter]);
+    verify($response[0]['subject'])->equals('Hello [mailpoet/subscriber-firstname default="subscriber"]!');
+  }
 }


### PR DESCRIPTION
## Description

Personalization tags use HTML comments internally. This could be confusing to users. We want to display the tags without HTML comments in the listings.

## Code review notes

_N/A_

## QA notes

1. Create an email containing a Personalization tag in the subject
2. Check that on the email's subject on the listing page does not contain HTML comment format (`<!--` and `-->`)
3. Test it also for sent emails

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6385]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:personalization-tags-listings)

_The latest successful build from `personalization-tags-listings` will be used. If none is available, the link won't work._

[MAILPOET-6385]: https://mailpoet.atlassian.net/browse/MAILPOET-6385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ