### PR TITLE
Add conversion Personalization Tags into HTML comments [MAILPOET-6376]

### DIFF
--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -138,7 +138,7 @@ const personalizationTagsLiveContentUpdate = createHigherOrderComponent(
 		);
 
 		// Memoized function to replace content tags
-		const updatedContent = useCallback( () => {
+		const updateContent = useCallback( () => {
 			if ( ! content ) {
 				return '';
 			}
@@ -176,7 +176,7 @@ const personalizationTagsLiveContentUpdate = createHigherOrderComponent(
 					{ ...props }
 					attributes={ {
 						...attributes,
-						content: updatedContent(),
+						content: updateContent(),
 					} }
 					setAttributes={ handleSetAttributes }
 				/>
@@ -192,7 +192,7 @@ const personalizationTagsLiveContentUpdate = createHigherOrderComponent(
 /**
  * Replace written personalization tags with HTML comments in real-time.
  */
-function replaceWrittenPersonalizationTags() {
+function activatePersonalizationTagsReplacing() {
 	addFilter(
 		'editor.BlockEdit',
 		'mailpoet-email-editor/with-live-content-update',
@@ -203,5 +203,5 @@ function replaceWrittenPersonalizationTags() {
 export {
 	disableCertainRichTextFormats,
 	extendRichTextFormats,
-	replaceWrittenPersonalizationTags,
+	activatePersonalizationTagsReplacing,
 };

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -11,7 +11,7 @@ import { disableImageFilter, hideExpandOnClick } from './core/image';
 import {
 	disableCertainRichTextFormats,
 	extendRichTextFormats,
-	replaceWrittenPersonalizationTags,
+	activatePersonalizationTagsReplacing,
 } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
 import { enhanceButtonsBlock } from './core/buttons';
@@ -30,7 +30,7 @@ export function initBlocks() {
 	enhanceColumnsBlock();
 	enhancePostContentBlock();
 	extendRichTextFormats();
-	replaceWrittenPersonalizationTags();
+	activatePersonalizationTagsReplacing();
 	alterSupportConfiguration();
 	registerCoreBlocks();
 }

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -11,6 +11,7 @@ import { disableImageFilter, hideExpandOnClick } from './core/image';
 import {
 	disableCertainRichTextFormats,
 	extendRichTextFormats,
+	replaceWrittenPersonalizationTags,
 } from './core/rich-text';
 import { enhanceButtonBlock } from './core/button';
 import { enhanceButtonsBlock } from './core/buttons';
@@ -29,6 +30,7 @@ export function initBlocks() {
 	enhanceColumnsBlock();
 	enhancePostContentBlock();
 	extendRichTextFormats();
+	replaceWrittenPersonalizationTags();
 	alterSupportConfiguration();
 	registerCoreBlocks();
 }

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -32,13 +32,13 @@ const CategorySection = ( {
 								>
 									<div className="mailpoet-personalization-tags-modal__item-text">
 										<strong>{ item.name }</strong>
-										{ item.token }
+										{ item.valueToInsert }
 									</div>
 									<Button
 										variant="link"
 										onClick={ () => {
 											if ( onInsert ) {
-												onInsert( item.token );
+												onInsert( item.valueToInsert );
 											}
 										} }
 									>

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
@@ -195,17 +195,26 @@ const replacePersonalizationTagsWithHTMLComments = (
 	tags: PersonalizationTag[]
 ) => {
 	tags.forEach( ( tag ) => {
-		if ( ! content.includes( tag.token ) ) {
-			// Skip if the token is not in the content
+		// Skip if the token is not in the content
+		if (
+			! content.includes( tag.token.slice( 0, tag.token.length - 1 ) )
+		) {
 			return;
 		}
 
-		const escapedRegExp = tag.token.replace(
-			/[.*+?^${}()|[\]\\]/g,
-			'\\$&'
-		); // Escape special characters
-		const regex = new RegExp( `(?<!<!--)${ escapedRegExp }(?!-->)`, 'g' ); // Match token not inside HTML comments
-		content = content.replace( regex, `<!--${ tag.token }-->` );
+		// Match the token with optional attributes like [mailpoet/subscriber-firstname default="user"]
+		const baseToken = tag.token
+			.substring( 1, tag.token.length - 1 )
+			.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ); // Escape base token and remove brackets
+		const regex = new RegExp(
+			`(?<!<!--)\\[(${ baseToken }(\\s[^\\]]*)?)\\](?!-->)`, // Match full token with optional attributes
+			'g'
+		);
+
+		content = content.replace( regex, ( match ) => {
+			// Use the exact text inside the brackets for the replacement
+			return `<!--${ match }-->`;
+		} );
 	} );
 	return content;
 };

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
@@ -1,4 +1,5 @@
 import * as React from '@wordpress/element';
+import { PersonalizationTag } from '../../store';
 
 /**
  * Maps indices of characters in HTML representation of the value to corresponding characters of stored value in RichText content. The stored value doesn't contain tags.
@@ -184,9 +185,35 @@ const isMatchingComment = (
 	return htmlCommentRegex.test( substring );
 };
 
+/**
+ * Replace registered personalization tags with HTML comments in content.
+ * @param content string The content to replace the tags in.
+ * @param tags    PersonalizationTag[] The tags to replace in the content.
+ */
+const replacePersonalizationTagsWithHTMLComments = (
+	content: string,
+	tags: PersonalizationTag[]
+) => {
+	tags.forEach( ( tag ) => {
+		if ( ! content.includes( tag.token ) ) {
+			// Skip if the token is not in the content
+			return;
+		}
+
+		const escapedRegExp = tag.token.replace(
+			/[.*+?^${}()|[\]\\]/g,
+			'\\$&'
+		); // Escape special characters
+		const regex = new RegExp( `(?<!<!--)${ escapedRegExp }(?!-->)`, 'g' ); // Match token not inside HTML comments
+		content = content.replace( regex, `<!--${ tag.token }-->` );
+	} );
+	return content;
+};
+
 export {
 	isMatchingComment,
 	getCursorPosition,
 	createTextToHtmlMap,
 	mapRichTextToValue,
+	replacePersonalizationTagsWithHTMLComments,
 };

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -5,8 +5,9 @@ import {
 	createTextToHtmlMap,
 	getCursorPosition,
 	isMatchingComment,
+	replacePersonalizationTagsWithHTMLComments,
 } from './rich-text-utils';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { storeName } from '../../store';
 import { RichText } from '@wordpress/block-editor';
@@ -29,6 +30,10 @@ export function RichTextWithButton( {
 
 	const [ selectionRange, setSelectionRange ] = useState( null );
 	const [ isModalOpened, setIsModalOpened ] = useState( false );
+	const list = useSelect(
+		( select ) => select( storeName ).getPersonalizationTagsList(),
+		[]
+	);
 
 	const richTextRef = useRef( null );
 
@@ -127,9 +132,13 @@ export function RichTextWithButton( {
 						)
 					);
 				} }
-				onChange={ ( value ) =>
-					updateEmailMailPoetProperty( attributeName, value )
-				}
+				onChange={ ( value ) => {
+					value = replacePersonalizationTagsWithHTMLComments(
+						value ?? '',
+						list
+					);
+					updateEmailMailPoetProperty( attributeName, value );
+				} }
 				value={ mailpoetEmailData[ attributeName ] ?? '' }
 				data-automation-id={ `email_${ attributeName }` }
 			/>

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -171,6 +171,7 @@ export type PersonalizationTag = {
 	token: string;
 	category: string;
 	attributes: string[];
+	valueToInsert: string;
 };
 
 export type State = {

--- a/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tag.php
+++ b/packages/php/email-editor/src/Engine/PersonalizationTags/class-personalization-tag.php
@@ -44,6 +44,12 @@ class Personalization_Tag {
 	 * @var array
 	 */
 	private array $attributes;
+	/**
+	 * The value that is inserted via the UI. When the value is null the token is generated based on $token attribute and $attributes.
+	 *
+	 * @var string
+	 */
+	private string $value_to_insert;
 
 	/**
 	 * Personalization_Tag constructor.
@@ -56,21 +62,24 @@ class Personalization_Tag {
 	 *      function( $context, $args ) {
 	 *        return $context['user_firstname'] ?? 'user';
 	 *      },
-	 *      array( default => 'user' )
+	 *      array( default => 'user' ),
+	 *      'user:first default="user"'
 	 *   );
 	 *
-	 * @param string   $name The name of the tag displayed in the UI.
-	 * @param string   $token The token used in HTML_Tag_Processor to replace the tag with its value.
-	 * @param string   $category The category of the personalization tag for categorization on the UI.
-	 * @param callable $callback The callback function which returns the value of the personalization tag.
-	 * @param array    $attributes The attributes which are used in the Personalization Tag UI.
+	 * @param string      $name The name of the tag displayed in the UI.
+	 * @param string      $token The token used in HTML_Tag_Processor to replace the tag with its value.
+	 * @param string      $category The category of the personalization tag for categorization on the UI.
+	 * @param callable    $callback The callback function which returns the value of the personalization tag.
+	 * @param array       $attributes The attributes which are used in the Personalization Tag UI.
+	 * @param string|null $value_to_insert The value that is inserted via the UI. When the value is null the token is generated based on $token attribute and $attributes.
 	 */
 	public function __construct(
 		string $name,
 		string $token,
 		string $category,
 		callable $callback,
-		array $attributes = array()
+		array $attributes = array(),
+		?string $value_to_insert = null
 	) {
 		$this->name = $name;
 		// Because Gutenberg does not wrap the token with square brackets, we need to add them here.
@@ -78,6 +87,24 @@ class Personalization_Tag {
 		$this->category   = $category;
 		$this->callback   = $callback;
 		$this->attributes = $attributes;
+		// Composing token to insert based on the token and attributes if it is not set.
+		if ( ! $value_to_insert ) {
+			if ( $this->attributes ) {
+				$value_to_insert = substr( $this->token, 0, -1 ) . ' ' .
+					implode(
+						' ',
+						array_map(
+							function ( $key ) {
+								return $key . '="' . esc_attr( $this->attributes[ $key ] ) . '"';
+							},
+							array_keys( $this->attributes )
+						)
+					) . ']';
+			} else {
+				$value_to_insert = $this->token;
+			}
+		}
+		$this->value_to_insert = $value_to_insert;
 	}
 
 	/**
@@ -114,6 +141,15 @@ class Personalization_Tag {
 	 */
 	public function get_attributes(): array {
 		return $this->attributes;
+	}
+
+	/**
+	 * Returns the token to insert via UI in the editor.
+	 *
+	 * @return string
+	 */
+	public function get_value_to_insert(): string {
+		return $this->value_to_insert;
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/class-email-api-controller.php
+++ b/packages/php/email-editor/src/Engine/class-email-api-controller.php
@@ -99,10 +99,11 @@ class Email_Api_Controller {
 					array_map(
 						function ( Personalization_Tag $tag ) {
 							return array(
-								'name'       => $tag->get_name(),
-								'token'      => $tag->get_token(),
-								'category'   => $tag->get_category(),
-								'attributes' => $tag->get_attributes(),
+								'name'          => $tag->get_name(),
+								'token'         => $tag->get_token(),
+								'category'      => $tag->get_category(),
+								'attributes'    => $tag->get_attributes(),
+								'valueToInsert' => $tag->get_value_to_insert(),
 							);
 						},
 						$tags

--- a/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tags_Registry_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/PersonalizationTags/Personalization_Tags_Registry_Test.php
@@ -58,6 +58,7 @@ class PersonalizationTagsRegistryTest extends TestCase {
 		$this->assertSame( 'Subscriber Info', $tag->get_category() );
 		$this->assertSame( 'Personalized Value', $tag->execute_callback( array(), array() ) );
 		$this->assertSame( array( 'description' => 'First name of the subscriber' ), $tag->get_attributes() );
+		$this->assertSame( '[first_name description="First name of the subscriber"]', $tag->get_value_to_insert() );
 	}
 
 	/**
@@ -74,7 +75,9 @@ class PersonalizationTagsRegistryTest extends TestCase {
 				'Last Name',
 				'[last_name]',
 				'Subscriber Info',
-				$callback
+				$callback,
+				array( 'default' => 'subscriber' ),
+				'[last_name default="user"]'
 			)
 		);
 
@@ -87,6 +90,8 @@ class PersonalizationTagsRegistryTest extends TestCase {
 		$this->assertSame( '[last_name]', $tag->get_token() );
 		$this->assertSame( 'Subscriber Info', $tag->get_category() );
 		$this->assertSame( 'Personalized Value', $tag->execute_callback( array(), array() ) );
+		$this->assertSame( array( 'default' => 'subscriber' ), $tag->get_attributes() );
+		$this->assertSame( '[last_name default="user"]', $tag->get_value_to_insert() );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR converts written Personalization Tags registered in the email editor into HTML Comments, which should improve user experience.

## Code review notes

As part of those changes, it inserts Personalization tags with their attributes. The value for inserting is composed but can be overridden as a constructor parameter.

## QA notes

How to test it:
- Known personalization tags can be written, and they should be converted into HTML comments, which are highlighted with an inverted background and font color.
- The conversion happens in the subject, the preheader, and blocks.

Known issue:
- When a conversion happens, the cursor is moved to the start of the rich text. This is something that I was not able to solve, but I would like to check again later.
 
## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6376]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6376]: https://mailpoet.atlassian.net/browse/MAILPOET-6376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/written-tags)

_The latest successful build from `email-editor/written-tags` will be used. If none is available, the link won't work._