### PR TITLE
Add component for editing Personalization tags [MAILPOET-6379]

### DIFF
--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -15,6 +15,7 @@ import { addFilter } from '@wordpress/hooks';
 import * as React from 'react';
 import { storeName } from '../../store';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { PersonalizationTagsPopover } from '../../components/personalization-tags/personalization-tags-popover';
 
 /**
  * Disable Rich text formats we currently cannot support
@@ -98,6 +99,19 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 					icon="shortcode"
 					title={ __( 'Personalization Tags', 'mailpoet' ) }
 					onClick={ () => setIsModalOpened( true ) }
+				/>
+				<PersonalizationTagsPopover
+					contentRef={ contentRef }
+					onUpdate={ ( originalTag, updatedTag ) => {
+						// When we update the tag, we need to add brackets to the tag, because the popover removes them
+						const updatedContent = blockContent.replace(
+							`<!--[${ originalTag }]-->`,
+							`<!--[${ updatedTag }]-->`
+						);
+						updateBlockAttributes( selectedBlockId, {
+							content: updatedContent,
+						} );
+					} }
 				/>
 				<PersonalizationTagsModal
 					isOpened={ isModalOpened }

--- a/packages/js/email-editor/src/components/personalization-tags/index.scss
+++ b/packages/js/email-editor/src/components/personalization-tags/index.scss
@@ -71,3 +71,17 @@
     }
   }
 }
+
+.mailpoet-personalization-tag-popover {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+
+  .mailpoet-personalization-tag-popover__content {
+    padding: 8px;
+    width: 400px;
+  }
+  .mailpoet-personalization-tag-popover__content-button {
+    text-align: center;
+  }
+}

--- a/packages/js/email-editor/src/components/personalization-tags/index.scss
+++ b/packages/js/email-editor/src/components/personalization-tags/index.scss
@@ -78,11 +78,20 @@
   justify-content: center;
 
   .mailpoet-personalization-tag-popover__content {
-    padding: 8px;
-    width: 400px;
+    max-width: 350px;
+    min-width: auto;
+    width: 90vw;
+
+    .components-base-control {
+      margin: 16px;
+    }
   }
-  .mailpoet-personalization-tag-popover__content-button {
-    padding-top: 10px;
-    text-align: center;
+  .mailpoet-personalization-tag-popover__content-buttons {
+    margin: 16px;
+    text-align: right;
+
+    .components-button {
+      margin-left: 8px;
+    }
   }
 }

--- a/packages/js/email-editor/src/components/personalization-tags/index.scss
+++ b/packages/js/email-editor/src/components/personalization-tags/index.scss
@@ -82,6 +82,7 @@
     width: 400px;
   }
   .mailpoet-personalization-tag-popover__content-button {
+    padding-top: 10px;
     text-align: center;
   }
 }

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
@@ -19,9 +19,7 @@ const PersonalizationTagsPopover = ( {
 	onUpdate,
 }: PersonalizationTagsPopoverProps ) => {
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
-	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
-		null
-	);
+	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
 	const [ updatedValue, setUpdatedValue ] = useState( '' );
 	const [ originalValue, setOriginalValue ] = useState( '' );
 
@@ -47,7 +45,7 @@ const PersonalizationTagsPopover = ( {
 				);
 				setOriginalValue( textContent );
 				setUpdatedValue( textContent );
-				setPopoverAnchor( commentSpan );
+				setAnchor( commentSpan );
 				setIsPopoverVisible( true );
 			}
 		};
@@ -63,11 +61,11 @@ const PersonalizationTagsPopover = ( {
 
 	return (
 		<>
-			{ isPopoverVisible && (
+			{ isPopoverVisible && anchor && (
 				<Popover
 					position="bottom right"
 					onClose={ () => setIsPopoverVisible( false ) }
-					anchorRef={ popoverAnchor }
+					anchor={ anchor } // Directly use commentSpan as the anchor
 					className="mailpoet-personalization-tag-popover"
 				>
 					<div className="mailpoet-personalization-tag-popover__content">
@@ -75,6 +73,7 @@ const PersonalizationTagsPopover = ( {
 							label={ __( 'Personalization Tag', 'mailpoet' ) }
 							value={ updatedValue }
 							onChange={ ( value ) => setUpdatedValue( value ) }
+							__nextHasNoMarginBottom // To avoid warning about deprecation in console
 						/>
 						<div className="mailpoet-personalization-tag-popover__content-button">
 							<Button

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
@@ -74,8 +74,17 @@ const PersonalizationTagsPopover = ( {
 							value={ updatedValue }
 							onChange={ ( value ) => setUpdatedValue( value ) }
 							__nextHasNoMarginBottom // To avoid warning about deprecation in console
+							__next40pxDefaultSize
 						/>
-						<div className="mailpoet-personalization-tag-popover__content-button">
+						<div className="mailpoet-personalization-tag-popover__content-buttons">
+							<Button
+								isTertiary
+								onClick={ () => {
+									setIsPopoverVisible( false );
+								} }
+							>
+								{ __( 'Cancel', 'mailpoet' ) }
+							</Button>
 							<Button
 								isPrimary
 								onClick={ () => {

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from '@wordpress/element';
+import { Popover, Button, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+type PersonalizationTagsPopoverProps = {
+	contentRef: React.RefObject< HTMLElement >;
+	onUpdate: ( originalValue: string, updatedValue: string ) => void;
+};
+
+/**
+ * Component to display a popover with a text control to update personalization tags.
+ * The popover is displayed when a user clicks on a personalization tag in the editor.
+ * @param root0
+ * @param root0.contentRef Reference to the container where the popover should be displayed
+ * @param root0.onUpdate   Callback to update the personalization tag
+ */
+const PersonalizationTagsPopover = ( {
+	contentRef,
+	onUpdate,
+}: PersonalizationTagsPopoverProps ) => {
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState< HTMLElement | null >(
+		null
+	);
+	const [ updatedValue, setUpdatedValue ] = useState( '' );
+	const [ originalValue, setOriginalValue ] = useState( '' );
+
+	useEffect( () => {
+		if ( ! contentRef || ! contentRef.current ) {
+			return undefined;
+		}
+
+		const container = contentRef.current;
+
+		// Handle clicks within the referenced container
+		const handleContainerClick = ( event: Event ) => {
+			const target = event.target as HTMLElement;
+			const commentSpan = target.closest(
+				'span[data-rich-text-comment]'
+			) as HTMLElement;
+
+			if ( commentSpan ) {
+				// Remove brackets from the text content for better user experience
+				const textContent = commentSpan.innerText.replace(
+					/^\[|\]$/g,
+					''
+				);
+				setOriginalValue( textContent );
+				setUpdatedValue( textContent );
+				setPopoverAnchor( commentSpan );
+				setIsPopoverVisible( true );
+			}
+		};
+
+		// Add the event listener to the container
+		container.addEventListener( 'click', handleContainerClick );
+
+		// Cleanup function to remove the event listener on unmount
+		return () => {
+			container.removeEventListener( 'click', handleContainerClick );
+		};
+	}, [ contentRef ] );
+
+	return (
+		<>
+			{ isPopoverVisible && (
+				<Popover
+					position="bottom right"
+					onClose={ () => setIsPopoverVisible( false ) }
+					anchorRef={ popoverAnchor }
+					className="mailpoet-personalization-tag-popover"
+				>
+					<div className="mailpoet-personalization-tag-popover__content">
+						<TextControl
+							label={ __( 'Personalization Tag', 'mailpoet' ) }
+							value={ updatedValue }
+							onChange={ ( value ) => setUpdatedValue( value ) }
+						/>
+						<div className="mailpoet-personalization-tag-popover__content-button">
+							<Button
+								isPrimary
+								onClick={ () => {
+									onUpdate( originalValue, updatedValue );
+									setIsPopoverVisible( false );
+								} }
+							>
+								{ __( 'Update', 'mailpoet' ) }
+							</Button>
+						</div>
+					</div>
+				</Popover>
+			) }
+		</>
+	);
+};
+
+export { PersonalizationTagsPopover };

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -92,6 +92,7 @@ export function RichTextWithButton( {
 			label={ finalLabel }
 			className={ `mailpoet-settings-panel__${ attributeName }-text` }
 			help={ help }
+			__nextHasNoMarginBottom // To avoid warning about deprecation in console
 		>
 			<PersonalizationTagsModal
 				isOpened={ isModalOpened }

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -12,6 +12,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { storeName } from '../../store';
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { PersonalizationTagsPopover } from './personalization-tags-popover';
 
 export function RichTextWithButton( {
 	label,
@@ -103,6 +104,22 @@ export function RichTextWithButton( {
 					setIsModalOpened( false );
 				} }
 				closeCallback={ () => setIsModalOpened( false ) }
+			/>
+			<PersonalizationTagsPopover
+				contentRef={ richTextRef }
+				onUpdate={ ( originalTag, updatedTag ) => {
+					const currentValue =
+						mailpoetEmailData[ attributeName ] ?? '';
+					// When we update the tag, we need to add brackets to the tag, because the popover removes them
+					const updatedContent = currentValue.replace(
+						`<!--[${ originalTag }]-->`,
+						`<!--[${ updatedTag }]-->`
+					);
+					updateEmailMailPoetProperty(
+						attributeName,
+						updatedContent
+					);
+				} }
 			/>
 			<RichText
 				ref={ richTextRef }


### PR DESCRIPTION
## Description

The new popover component is displayed after the click on the highlighted personalization tag. Editing is also possible in the subject and the preheader.

## Code review notes

I used a similar approach as for the modal that allows inserting.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6379]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6379]: https://mailpoet.atlassian.net/browse/MAILPOET-6379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/tags-edit)

_The latest successful build from `email-editor/tags-edit` will be used. If none is available, the link won't work._