### PR TITLE
Fix QIT false positive [MAILPOET-6398]

### DIFF
--- a/mailpoet/lib/API/REST/API.php
+++ b/mailpoet/lib/API/REST/API.php
@@ -72,7 +72,7 @@ class API {
       },
       'permission_callback' => function () use ($endpointClass) {
         $endpoint = $this->endpointContainer->get($endpointClass);
-        return $endpoint->checkPermissions();
+        return $endpoint->checkPermissions(); // nosemgrep: scanner.php.wp.security.rest-route.permission-callback.incorrect-return
       },
       'args' => $schema,
     ]);


### PR DESCRIPTION
The endpoint container can only return a Endpoint instance and checkPermissions returns always a boolean. The QIT check therefore is a false positive.

## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6398]
## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6398]: https://mailpoet.atlassian.net/browse/MAILPOET-6398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6398-fix-false-positive-in-qit)

_The latest successful build from `MAILPOET-6398-fix-false-positive-in-qit` will be used. If none is available, the link won't work._