### PR TITLE
Email editor - Remove CSS for classic themes from email editor iframe styles [MAILPOET-6390]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
@@ -73,10 +73,7 @@ class Newsletter {
               padding-top: var(--wp--preset--spacing--20);
               padding-bottom: var(--wp--preset--spacing--20);
             "
-              >
-              ' . $footerText . '
-            <br /><a href="[link:subscription_unsubscribe_url]">' . __('Unsubscribe', 'mailpoet') . '</a> |
-            <a href="[link:subscription_manage_url]">' . __('Manage subscription', 'mailpoet') . '</a>
+              >' . $footerText . '<br /><a href="[link:subscription_unsubscribe_url]">' . __('Unsubscribe', 'mailpoet') . '</a> | <a href="[link:subscription_manage_url]">' . __('Manage subscription', 'mailpoet') . '</a>
           </p>
           <!-- /wp:paragraph -->
         </div>

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -68,6 +68,20 @@ class Settings_Controller {
 		 * in the post editor this is called directly in post.php.
 		 */
 		$this->iframe_assets = _wp_get_iframed_editor_assets();
+
+		// Remove layout styles and block library for classic themes. They are added only when a classic theme is active
+		// and they add unwanted margins and paddings in the editor content.
+		$cleaned_styles = array();
+		foreach ( explode( "\n", (string) $this->iframe_assets['styles'] ) as $asset ) {
+			if ( strpos( $asset, 'wp-editor-classic-layout-styles-css' ) !== false ) {
+				continue;
+			}
+			if ( strpos( $asset, 'wp-block-library-theme-css' ) !== false ) {
+				continue;
+			}
+			$cleaned_styles[] = $asset;
+		}
+		$this->iframe_assets['styles'] = implode( "\n", $cleaned_styles );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The PR removes the CSS file that is automatically added for classic themes. The styles were causing visual issues in the editor content, breaking the WYSIWYG experience.

## Code review notes

I also noticed a formatting issue in the template footer. All new lines in the template HTML code are interpreted as br tags in the editor. 

## QA notes

#### Replication
1) Create a new email
2) Switch the site to a classic theme e.g. twenty-nineteen
3) Observe that email in editor has for example bigger gaps between blocks

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6390]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6390]: https://mailpoet.atlassian.net/browse/MAILPOET-6390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/remove-classic-css)

_The latest successful build from `email-editor/remove-classic-css` will be used. If none is available, the link won't work._