### PR TITLE
Email Editor - Add support for the stable border feature name [MAILPOET-6359]

### DIFF
--- a/packages/js/email-editor/src/components/sidebar/block-compatibility-warnings.tsx
+++ b/packages/js/email-editor/src/components/sidebar/block-compatibility-warnings.tsx
@@ -20,12 +20,20 @@ export function BlockCompatibilityWarnings(): JSX.Element {
 	);
 
 	// Check if the selected block has enabled border configuration
-	const hasBorderSupport = hasBlockSupport(
-		selectedBlock?.name,
-		// @ts-expect-error Border is not yet supported in the types
-		'__experimentalBorder',
-		false
-	);
+	const hasBorderSupport =
+		hasBlockSupport(
+			selectedBlock?.name,
+			// @ts-expect-error Border is not yet supported in the types
+			'border',
+			false
+		) ||
+		// We can remove the check for __experimentalBorder after we support WordPress 6.8+.
+		hasBlockSupport(
+			selectedBlock?.name,
+			// @ts-expect-error Border is not yet supported in the types
+			'__experimentalBorder',
+			false
+		);
 
 	return (
 		<>


### PR DESCRIPTION
## Description

The border feature name was stabilized in Gutenberg. This PR adds support for the stable version while retaining support for the experimental version.

## Code review notes

_N/A_

## QA notes

I think we can skip QA for this one.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6359]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6359]: https://mailpoet.atlassian.net/browse/MAILPOET-6359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/border-property)

_The latest successful build from `email-editor/border-property` will be used. If none is available, the link won't work._