### PR TITLE
Add support for Personalization tags as links [MAILPOET-6394]

### DIFF
--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -289,7 +289,11 @@ class Newsletter {
     }
     $preparedNewsletter = Helpers::splitObject($preparedNewsletter);
     if ($newsletter->getWpPostId() !== null) {
-      $this->personalizer->set_context(['recipient_email' => $subscriber->getEmail() ?? null]);
+      $this->personalizer->set_context([
+        'recipient_email' => $subscriber->getEmail(),
+        'newsletter_id' => $newsletter->getId(),
+        'queue_id' => $queue->getId(),
+      ]);
       foreach ($preparedNewsletter as $key => $content) {
         $preparedNewsletter[$key] = $this->personalizer->personalize_content($content);
       }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -365,6 +365,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Personalizer::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTagManager::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -366,6 +366,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Personalizer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTagManager::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -4,19 +4,23 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\EmailEditor\Engine\PersonalizationTags\Personalization_Tag;
 use MailPoet\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
 
 class PersonalizationTagManager {
   private Subscriber $subscriber;
   private Site $site;
+  private Link $link;
 
   public function __construct(
     Subscriber $subscriber,
-    Site $site
+    Site $site,
+    Link $link
   ) {
     $this->subscriber = $subscriber;
     $this->site = $site;
+    $this->link = $link;
   }
 
   public function initialize() {
@@ -42,6 +46,7 @@ class PersonalizationTagManager {
         __('Subscriber', 'mailpoet'),
         [$this->subscriber, 'getEmail'],
       ));
+
       // Site Personalization Tags
       $registry->register(new Personalization_Tag(
         __('Site Title', 'mailpoet'),
@@ -54,6 +59,26 @@ class PersonalizationTagManager {
         'mailpoet/site-homepage-url',
         __('Site', 'mailpoet'),
         [$this->site, 'getHomepageURL'],
+      ));
+
+      // Links registration
+      $registry->register(new Personalization_Tag(
+        __('Unsubscribe URL', 'mailpoet'),
+        'mailpoet/subscription-unsubscribe-url',
+        __('Link', 'mailpoet'),
+        [$this->link, 'getSubscriptionUnsubscribeUrl'],
+      ));
+      $registry->register(new Personalization_Tag(
+        __('Manage subscription URL', 'mailpoet'),
+        'mailpoet/subscription-manage-url',
+        __('Link', 'mailpoet'),
+        [$this->link, 'getSubscriptionManageUrl'],
+      ));
+      $registry->register(new Personalization_Tag(
+        __('View in browser URL', 'mailpoet'),
+        'mailpoet/newsletter-view-in-browser-url',
+        __('Link', 'mailpoet'),
+        [$this->link, 'getNewsletterViewInBrowserUrl'],
       ));
       return $registry;
     });

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -5,26 +5,34 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 use MailPoet\EmailEditor\Engine\PersonalizationTags\Personalization_Tag;
 use MailPoet\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
+use MailPoet\WP\Functions as WPFunctions;
 
 class PersonalizationTagManager {
   private Subscriber $subscriber;
   private Site $site;
   private Link $link;
+  private WPFunctions $wp;
+  private LinksToShortcodesConvertor $linksToShortcodesConvertor;
 
   public function __construct(
     Subscriber $subscriber,
     Site $site,
-    Link $link
+    Link $link,
+    WPFunctions $wp,
+    LinksToShortcodesConvertor $linksToShortcodesConvertor
   ) {
     $this->subscriber = $subscriber;
     $this->site = $site;
     $this->link = $link;
+    $this->wp = $wp;
+    $this->linksToShortcodesConvertor = $linksToShortcodesConvertor;
   }
 
   public function initialize() {
-    add_filter('mailpoet_email_editor_register_personalization_tags', function( Personalization_Tags_Registry $registry ): Personalization_Tags_Registry {
+    $this->wp->addFilter('mailpoet_email_editor_register_personalization_tags', function( Personalization_Tags_Registry $registry ): Personalization_Tags_Registry {
       // Subscriber Personalization Tags
       $registry->register(new Personalization_Tag(
         __('First Name', 'mailpoet'),
@@ -82,5 +90,21 @@ class PersonalizationTagManager {
       ));
       return $registry;
     });
+
+    // Convert links to shortcodes before sending the email
+    // This is a temporary solution so that we are able to integrate the new personalization tags
+    // It is needed until we have a proper solution for the personalization tags in the MailPoet Link tracking system
+    $this->wp->addFilter(
+      'mailpoet_sending_newsletter_render_after_pre_process',
+      [$this, 'convertLinksToShortcodes']
+    );
+  }
+
+  public function convertLinksToShortcodes(array $emailContent): array {
+    if (!isset($emailContent['html'])) {
+      return $emailContent;
+    }
+    $emailContent['html'] = $this->linksToShortcodesConvertor->convertLinkTagsToShortcodes($emailContent['html']);
+    return $emailContent;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Link.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Link.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscription\SubscriptionUrlFactory;
+
+class Link {
+
+  private SubscriptionUrlFactory $subscriptionUrlFactory;
+  private SubscribersRepository $subscribersRepository;
+  private SendingQueuesRepository $sendingQueuesRepository;
+  private NewsletterUrl $newsletterUrl;
+  private NewslettersRepository $newslettersRepository;
+
+  public function __construct(
+    SubscriptionUrlFactory $subscriptionUrlFactory,
+    SubscribersRepository $subscribersRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
+    NewslettersRepository $newslettersRepository,
+    NewsletterUrl $newsletterUrl
+  ) {
+    $this->subscriptionUrlFactory = $subscriptionUrlFactory;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->newslettersRepository = $newslettersRepository;
+    $this->newsletterUrl = $newsletterUrl;
+  }
+
+  public function getSubscriptionUnsubscribeUrl(array $context, array $args = []): string {
+    $isPreview = $context['is_preview'] ?? false;
+    $subscriber = $isPreview ? $this->getSubscriber($context) : null;
+    $queue = $this->getSendingQueue($context);
+
+    return $this->subscriptionUrlFactory->getConfirmUnsubscribeUrl(
+      $subscriber,
+      $queue ? $queue->getId() : null
+    );
+  }
+
+  public function getSubscriptionManageUrl(array $context, array $args = []): string {
+    $isPreview = $context['is_preview'] ?? false;
+    $subscriber = $isPreview ? $this->getSubscriber($context) : null;
+
+    return $this->subscriptionUrlFactory->getManageUrl(
+      $subscriber
+    );
+  }
+
+  public function getNewsletterViewInBrowserUrl(array $context, array $args = []): string {
+    $isPreview = $context['is_preview'] ?? false;
+    $subscriber = $isPreview ? $this->getSubscriber($context) : null;
+    $queue = $this->getSendingQueue($context);
+    $newsletter = $this->getNewsletter($context);
+
+    return $this->newsletterUrl->getViewInBrowserUrl(
+      $newsletter,
+      $subscriber,
+      $queue,
+      $isPreview
+    );
+  }
+
+  private function getNewsletter(array $context): ?NewsletterEntity {
+    $newsletterId = $context['newsletter_id'] ?? null;
+    return $newsletterId ? $this->newslettersRepository->findOneById($newsletterId) : null;
+  }
+
+  private function getSendingQueue(array $context): ?SendingQueueEntity {
+    $queueId = $context['queue_id'] ?? null;
+    return $queueId ? $this->sendingQueuesRepository->findOneById($queueId) : null;
+  }
+
+  private function getSubscriber(array $context): ?SubscriberEntity {
+    $subscriberEmail = $context['recipient_email'] ?? null;
+    return $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Link.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Link.php
@@ -35,7 +35,7 @@ class Link {
 
   public function getSubscriptionUnsubscribeUrl(array $context, array $args = []): string {
     $isPreview = $context['is_preview'] ?? false;
-    $subscriber = $isPreview ? $this->getSubscriber($context) : null;
+    $subscriber = !$isPreview ? $this->getSubscriber($context) : null;
     $queue = $this->getSendingQueue($context);
 
     return $this->subscriptionUrlFactory->getConfirmUnsubscribeUrl(
@@ -46,7 +46,7 @@ class Link {
 
   public function getSubscriptionManageUrl(array $context, array $args = []): string {
     $isPreview = $context['is_preview'] ?? false;
-    $subscriber = $isPreview ? $this->getSubscriber($context) : null;
+    $subscriber = !$isPreview ? $this->getSubscriber($context) : null;
 
     return $this->subscriptionUrlFactory->getManageUrl(
       $subscriber
@@ -55,7 +55,7 @@ class Link {
 
   public function getNewsletterViewInBrowserUrl(array $context, array $args = []): string {
     $isPreview = $context['is_preview'] ?? false;
-    $subscriber = $isPreview ? $this->getSubscriber($context) : null;
+    $subscriber = !$isPreview ? $this->getSubscriber($context) : null;
     $queue = $this->getSendingQueue($context);
     $newsletter = $this->getNewsletter($context);
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/LinksToShortcodesConvertor.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
+
+use MailPoet\EmailEditor\Engine\PersonalizationTags\HTML_Tag_Processor;
+
+/**
+ * Converts link tags to shortcodes.
+ *
+ * This is a temporary solution so that we are able to integrate the new personalization tags
+ * with the MailPoet Link tracking system which is based on shortcodes.
+ *
+ */
+class LinksToShortcodesConvertor {
+  private const TOKEN_MAP = [
+    '[mailpoet/subscription-unsubscribe-url]' => '[link:subscription_unsubscribe_url]',
+    '[mailpoet/subscription-manage-url]' => '[link:subscription_manage_url]',
+    '[mailpoet/newsletter-view-in-browser-url]' => '[link:newsletter_view_in_browser_url]',
+  ];
+
+  public function convertLinkTagsToShortcodes(string $content): string {
+    $contentProcessor = new HTML_Tag_Processor($content);
+    while ($contentProcessor->next_token()) {
+      if ($contentProcessor->get_token_type() === '#tag' && $contentProcessor->get_tag() === 'A' && $contentProcessor->get_attribute('data-link-href')) {
+        $href = $contentProcessor->get_attribute('data-link-href');
+        if (!isset(self::TOKEN_MAP[$href])) {
+          continue;
+        }
+        $contentProcessor->set_attribute('href', 'http://' . self::TOKEN_MAP[$href]);
+        $contentProcessor->remove_attribute('data-link-href');
+        $contentProcessor->remove_attribute('contenteditable');
+      }
+    }
+    $contentProcessor->flush_updates();
+    $updated = $contentProcessor->get_updated_html();
+    // Remove temporary prefix. It was needed so hat the HTML_Tag_Processor could add value to href.
+    $updated = str_replace('http://[', '[', $updated);
+    return $updated;
+  }
+}

--- a/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
+++ b/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Newsletter\Preview;
 
+use MailPoet\EmailEditor\Engine\Personalizer;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\MailerFactory;
@@ -30,13 +31,17 @@ class SendPreviewController {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var Personalizer */
+  private $personalizer;
+
   public function __construct(
     MailerFactory $mailerFactory,
     MetaInfo $mailerMetaInfo,
     Renderer $renderer,
     WPFunctions $wp,
     SubscribersRepository $subscribersRepository,
-    Shortcodes $shortcodes
+    Shortcodes $shortcodes,
+    Personalizer $personalizer
   ) {
     $this->mailerFactory = $mailerFactory;
     $this->mailerMetaInfo = $mailerMetaInfo;
@@ -44,6 +49,7 @@ class SendPreviewController {
     $this->renderer = $renderer;
     $this->shortcodes = $shortcodes;
     $this->subscribersRepository = $subscribersRepository;
+    $this->personalizer = $personalizer;
   }
 
   public function sendPreview(NewsletterEntity $newsletter, string $emailAddress) {
@@ -68,6 +74,18 @@ class SendPreviewController {
       $renderedNewsletter['body']['html'],
       $renderedNewsletter['body']['text'],
     ] = explode($divider, $this->shortcodes->replace($body));
+
+    if ($newsletter->getWpPostId()) {
+      $this->personalizer->set_context([
+        'recipient_email' => $subscriber ? $subscriber->getEmail() : $emailAddress,
+        'newsletter_id' => $newsletter->getId(),
+        'is_preview' => true,
+      ]);
+      $renderedNewsletter['subject'] = $this->personalizer->personalize_content($renderedNewsletter['subject']);
+      $renderedNewsletter['body']['html'] = $this->personalizer->personalize_content($renderedNewsletter['body']['html']);
+      $renderedNewsletter['body']['text'] = $this->personalizer->personalize_content($renderedNewsletter['body']['text']);
+    }
+
     $renderedNewsletter['id'] = $newsletter->getId();
 
     $extraParams = [

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -98,7 +98,12 @@ class ViewInBrowserRenderer {
       );
     }
     if ($newsletter->getWpPostId() !== null) {
-      $this->personalizer->set_context(['recipient_email' => $subscriber ? $subscriber->getEmail() : null]);
+      $this->personalizer->set_context([
+        'recipient_email' => $subscriber ? $subscriber->getEmail() : null,
+        'is_user_preview' => $wpUserPreview,
+        'newsletter_id' => $newsletter->getId(),
+        'queue_id' => $queue ? $queue->getId() : null,
+      ]);
       $renderedNewsletter = $this->personalizer->personalize_content($renderedNewsletter);
     }
     return $renderedNewsletter;

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/PersonalizationTagManagerTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use Codeception\Util\Fixtures;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
+use MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter as NewsletterTask;
+use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
+
+class PersonalizationTagManagerTest extends \MailPoetTest {
+  private NewsletterTask $newsletterTask;
+  private NewsletterEntity $newsletter;
+  private SendingQueueEntity $sendingQueueEntity;
+  private ScheduledTaskEntity $scheduledTaskEntity;
+
+  public function _before() {
+    parent::_before();
+    $this->newsletterTask = new NewsletterTask();
+    $this->newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withStatus(NewsletterEntity::STATUS_ACTIVE)
+      ->withSubject(Fixtures::get('newsletter_subject_template'))
+      ->create();
+
+    $this->scheduledTaskEntity = (new ScheduledTaskFactory())->create(SendingQueue::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->sendingQueueEntity = (new SendingQueueFactory())->create($this->scheduledTaskEntity, $this->newsletter);
+  }
+
+  public function testItHooksToPostRenderToReplaceLinksInHrefByShortcodes() {
+    $body = json_decode(Fixtures::get('newsletter_body_template'), true);
+    // @phpstan-ignore-next-line The structure is hardcoded in the fixture
+    $body['content']['blocks'][0]['blocks'][0]['blocks'][0]['text'] = '
+        <a data-link-href="[mailpoet/subscription-unsubscribe-url]">Unsubscribe</a>
+        <a data-link-href="[mailpoet/subscription-manage-url]">Manage</a>
+        <a data-link-href="[mailpoet/newsletter-view-in-browser-url]">View in browser</a>
+        <!--[mailpoet/subscription-unsubscribe-url]-->
+      ';
+    $this->newsletter->setBody((array)$body);
+    $personalizationManager = $this->diContainer->get(PersonalizationTagManager::class);
+    $personalizationManager->initialize();
+
+    $newsletterEntity = $this->newsletterTask->preProcessNewsletter($this->newsletter, $this->scheduledTaskEntity);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletterEntity);
+
+    $newsletterLinkRepository = $this->diContainer->get(NewsletterLinkRepository::class);
+
+    /** @var array{html: string, text: string}  $rendered */
+    $rendered = $this->sendingQueueEntity->getNewsletterRenderedBody();
+
+    // Ensure link were properly extracted and replaced in email body
+    $unsubscribeLink = $newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter, 'queue' => $this->sendingQueueEntity, 'url' => '[link:subscription_unsubscribe_url]']);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $unsubscribeLink);
+    $this->assertStringContainsString('<a href="[mailpoet_click_data]-' . $unsubscribeLink->getHash() . '">Unsubscribe</a>', $rendered['html']);
+
+    $manageLink = $newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter, 'queue' => $this->sendingQueueEntity, 'url' => '[link:subscription_manage_url]']);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $manageLink);
+    $this->assertStringContainsString('<a href="[mailpoet_click_data]-' . $manageLink->getHash() . '">Manage</a>', $rendered['html']);
+
+    $viewInBrowserLink = $newsletterLinkRepository->findOneBy(['newsletter' => $this->newsletter, 'queue' => $this->sendingQueueEntity, 'url' => '[link:newsletter_view_in_browser_url]']);
+    $this->assertInstanceOf(NewsletterLinkEntity::class, $viewInBrowserLink);
+    $this->assertStringContainsString('<a href="[mailpoet_click_data]-' . $viewInBrowserLink->getHash() . '">View in browser</a>', $rendered['html']);
+
+    // Tag placed out of href was not replaced
+    $this->assertStringContainsString('<!--[mailpoet/subscription-unsubscribe-url]-->', $rendered['html']);
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Newsletter\Preview;
 
 use Codeception\Stub\Expected;
 use Codeception\Util\Fixtures;
+use MailPoet\EmailEditor\Engine\Personalizer;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Mailer;
@@ -90,7 +91,8 @@ class SendPreviewControllerTest extends \MailPoetTest {
       $this->diContainer->get(Renderer::class),
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
-      $shortcodes
+      $shortcodes,
+      $this->diContainer->get(Personalizer::class)
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }
@@ -121,7 +123,8 @@ class SendPreviewControllerTest extends \MailPoetTest {
       $this->diContainer->get(Renderer::class),
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(Shortcodes::class)
+      $this->diContainer->get(Shortcodes::class),
+      $this->diContainer->get(Personalizer::class)
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -23,6 +23,7 @@ import * as React from 'react';
 import { storeName } from '../../store';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { PersonalizationTagsPopover } from '../../components/personalization-tags/personalization-tags-popover';
+import { PersonalizationTagsLinkPopover } from '../../components/personalization-tags/personalization-tags-link-popover';
 
 /**
  * Disable Rich text formats we currently cannot support
@@ -141,6 +142,30 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 						const updatedContent = blockContent.replace(
 							`<!--[${ originalTag }]-->`,
 							`<!--[${ updatedTag }]-->`
+						);
+						updateBlockAttributes( selectedBlockId, {
+							content: updatedContent,
+						} );
+					} }
+				/>
+				<PersonalizationTagsLinkPopover
+					contentRef={ contentRef }
+					onUpdate={ ( htmlElement, newTag, newText ) => {
+						const oldTag = htmlElement
+							.getAttribute( 'data-link-href' )
+							.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+						const regex = new RegExp(
+							`<a([^>]*?)data-link-href="${ oldTag }"([^>]*?)>${ htmlElement.textContent }</a>`,
+							'gi'
+						);
+
+						// Replace the matched link with the new link
+						const updatedContent = blockContent.replace(
+							regex,
+							( _, beforeAttrs, afterAttrs ) => {
+								// Construct the new <a> tag
+								return `<a${ beforeAttrs }data-link-href="${ newTag }"${ afterAttrs }>${ newText }</a>`;
+							}
 						);
 						updateBlockAttributes( selectedBlockId, {
 							content: updatedContent,

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -6,10 +6,16 @@ const CategorySection = ( {
 	groupedTags,
 	activeCategory,
 	onInsert,
+	canInsertLink,
+	closeCallback,
+	openLinkModal,
 }: {
 	groupedTags: Record< string, PersonalizationTag[] >;
 	activeCategory: string | null;
-	onInsert: ( tag: string ) => void;
+	onInsert: ( tag: string, isLink: boolean ) => void;
+	canInsertLink: boolean;
+	closeCallback: () => void;
+	openLinkModal: ( tag: PersonalizationTag ) => void;
 } ) => {
 	const categoriesToRender: [ string, PersonalizationTag[] ][] =
 		activeCategory === null
@@ -34,16 +40,45 @@ const CategorySection = ( {
 										<strong>{ item.name }</strong>
 										{ item.valueToInsert }
 									</div>
-									<Button
-										variant="link"
-										onClick={ () => {
-											if ( onInsert ) {
-												onInsert( item.valueToInsert );
-											}
+									<div
+										style={ {
+											display: 'flex',
+											flexDirection: 'column',
+											alignItems: 'flex-end',
 										} }
 									>
-										{ __( 'Insert' ) }
-									</Button>
+										<Button
+											variant="link"
+											onClick={ () => {
+												if ( onInsert ) {
+													onInsert(
+														item.token,
+														false
+													);
+												}
+											} }
+										>
+											{ __( 'Insert' ) }
+										</Button>
+										{ category === __( 'Link' ) &&
+											canInsertLink && (
+												<>
+													<Button
+														variant="link"
+														onClick={ () => {
+															closeCallback();
+															openLinkModal(
+																item
+															);
+														} }
+													>
+														{ __(
+															'Insert as link'
+														) }
+													</Button>
+												</>
+											) }
+									</div>
 								</div>
 							) ) }
 						</div>

--- a/packages/js/email-editor/src/components/personalization-tags/index.scss
+++ b/packages/js/email-editor/src/components/personalization-tags/index.scss
@@ -86,6 +86,7 @@
       margin: 16px;
     }
   }
+
   .mailpoet-personalization-tag-popover__content-buttons {
     margin: 16px;
     text-align: right;
@@ -94,4 +95,10 @@
       margin-left: 8px;
     }
   }
+}
+
+a.mailpoet-email-editor__personalization-tags-link {
+  color: LinkText;
+  cursor: pointer;
+  text-decoration: underline;
 }

--- a/packages/js/email-editor/src/components/personalization-tags/index.scss
+++ b/packages/js/email-editor/src/components/personalization-tags/index.scss
@@ -86,7 +86,6 @@
       margin: 16px;
     }
   }
-
   .mailpoet-personalization-tag-popover__content-buttons {
     margin: 16px;
     text-align: right;

--- a/packages/js/email-editor/src/components/personalization-tags/link-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/link-modal.tsx
@@ -1,0 +1,38 @@
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import './index.scss';
+import { useState } from '@wordpress/element';
+
+const LinkModal = ( { onInsert, isOpened, closeCallback, tag } ) => {
+	const [ linkText, setLinkText ] = useState( __( 'Link', 'mailpoet' ) );
+	if ( ! isOpened ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			size="small"
+			title={ __( 'Insert Link', 'mailpoet' ) }
+			onRequestClose={ closeCallback }
+			className="mailpoet-personalization-tags-modal"
+		>
+			<TextControl
+				label={ __( 'Link Text', 'mailpoet' ) }
+				value={ linkText }
+				onChange={ setLinkText }
+			/>
+			<Button
+				isPrimary
+				onClick={ () => {
+					if ( onInsert ) {
+						onInsert( tag.token, linkText );
+					}
+				} }
+			>
+				{ __( 'Insert' ) }
+			</Button>
+		</Modal>
+	);
+};
+
+export { LinkModal };

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-link-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-link-popover.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from '@wordpress/element';
+import {
+	Popover,
+	Button,
+	TextControl,
+	SelectControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { storeName } from '../../store';
+
+type PersonalizationTagsLinkPopoverProps = {
+	contentRef: React.RefObject< HTMLElement >;
+	onUpdate: (
+		htmlElement: HTMLElement,
+		newTag: string,
+		newText: string
+	) => void;
+};
+const PersonalizationTagsLinkPopover = ( {
+	contentRef,
+	onUpdate,
+}: PersonalizationTagsLinkPopoverProps ) => {
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const [ linkElement, setLinkElement ] = useState< HTMLElement | null >(
+		null
+	);
+	const [ linkText, setLinkText ] = useState( '' );
+	const [ linkHref, setLinkHref ] = useState( '' );
+
+	const list = useSelect(
+		( select ) => select( storeName ).getPersonalizationTagsList(),
+		[]
+	);
+
+	useEffect( () => {
+		if ( ! contentRef || ! contentRef.current ) {
+			return undefined;
+		}
+
+		const container = contentRef.current;
+
+		// Handle clicks within the referenced container
+		const handleContainerClick = ( event: Event ) => {
+			const target = event.target as HTMLElement;
+			const element = target.closest(
+				'a[data-link-href]'
+			) as HTMLElement;
+
+			if ( element ) {
+				// Remove brackets from the text content for better user experience
+				setLinkElement( element );
+				setLinkHref( element.getAttribute( 'data-link-href' ) || '' );
+				setLinkText( element.textContent || '' );
+				setIsPopoverVisible( true );
+			}
+		};
+
+		// Add the event listener to the container
+		container.addEventListener( 'click', handleContainerClick );
+
+		// Cleanup function to remove the event listener on unmount
+		return () => {
+			container.removeEventListener( 'click', handleContainerClick );
+		};
+	}, [ contentRef ] );
+
+	return (
+		<>
+			{ isPopoverVisible && linkElement && (
+				<Popover
+					position="bottom left"
+					onClose={ () => setIsPopoverVisible( false ) }
+					anchor={ linkElement } // Directly use commentSpan as the anchor
+					className="mailpoet-personalization-tag-popover"
+				>
+					<div className="mailpoet-personalization-tag-popover__content">
+						<TextControl
+							label={ __( 'Link Text', 'mailpoet' ) }
+							value={ linkText }
+							onChange={ ( value ) => setLinkText( value ) }
+							__nextHasNoMarginBottom // To avoid warning about deprecation in console
+							autoComplete="off"
+						/>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label="Label"
+							value={ linkHref }
+							onChange={ ( value ) => {
+								setLinkHref( value );
+							} }
+							options={ list
+								.filter( ( tag ) => {
+									return (
+										tag.category ===
+										__( 'Link', 'mailpoet' )
+									);
+								} )
+								.map( ( tag ) => {
+									return {
+										label: tag.name,
+										value: tag.token,
+									};
+								} ) }
+						/>
+						<div className="mailpoet-personalization-tag-popover__content-button">
+							<Button
+								isPrimary
+								onClick={ () => {
+									setIsPopoverVisible( false );
+									onUpdate( linkElement, linkHref, linkText );
+								} }
+							>
+								{ __( 'Update link', 'mailpoet' ) }
+							</Button>
+						</div>
+					</div>
+				</Popover>
+			) }
+		</>
+	);
+};
+
+export { PersonalizationTagsLinkPopover };

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-link-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-link-popover.tsx
@@ -80,12 +80,13 @@ const PersonalizationTagsLinkPopover = ( {
 							value={ linkText }
 							onChange={ ( value ) => setLinkText( value ) }
 							__nextHasNoMarginBottom // To avoid warning about deprecation in console
+							__next40pxDefaultSize
 							autoComplete="off"
 						/>
 						<SelectControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label="Label"
+							label={ __( 'Link tag', 'mailpoet' ) }
 							value={ linkHref }
 							onChange={ ( value ) => {
 								setLinkHref( value );
@@ -104,7 +105,15 @@ const PersonalizationTagsLinkPopover = ( {
 									};
 								} ) }
 						/>
-						<div className="mailpoet-personalization-tag-popover__content-button">
+						<div className="mailpoet-personalization-tag-popover__content-buttons">
+							<Button
+								isTertiary
+								onClick={ () => {
+									setIsPopoverVisible( false );
+								} }
+							>
+								{ __( 'Cancel', 'mailpoet' ) }
+							</Button>
 							<Button
 								isPrimary
 								onClick={ () => {

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
@@ -6,15 +6,37 @@ import './index.scss';
 import { useState } from '@wordpress/element';
 import { CategoryMenu } from './category-menu';
 import { CategorySection } from './category-section';
+import { LinkModal } from './link-modal';
 
-const PersonalizationTagsModal = ( { onInsert, isOpened, closeCallback } ) => {
+const PersonalizationTagsModal = ( {
+	onInsert,
+	isOpened,
+	closeCallback,
+	canInsertLink = false,
+} ) => {
 	const [ activeCategory, setActiveCategory ] = useState( null );
 	const [ searchQuery, setSearchQuery ] = useState( '' );
+	const [ selectedTag, setSelectedTag ] = useState( null );
+	const [ isLinkModalOpened, setIsLinkModalOpened ] = useState( false );
 
 	const list = useSelect(
 		( select ) => select( storeName ).getPersonalizationTagsList(),
 		[]
 	);
+
+	if ( isLinkModalOpened ) {
+		return (
+			<LinkModal
+				onInsert={ ( tag, linkText ) => {
+					onInsert( tag, linkText );
+					setIsLinkModalOpened( false );
+				} }
+				isOpened={ isLinkModalOpened }
+				closeCallback={ () => setIsLinkModalOpened( false ) }
+				tag={ selectedTag }
+			/>
+		);
+	}
 
 	if ( ! isOpened ) {
 		return null;
@@ -65,6 +87,12 @@ const PersonalizationTagsModal = ( { onInsert, isOpened, closeCallback } ) => {
 				groupedTags={ groupedTags }
 				activeCategory={ activeCategory }
 				onInsert={ onInsert }
+				closeCallback={ closeCallback }
+				canInsertLink={ canInsertLink }
+				openLinkModal={ ( tag ) => {
+					setSelectedTag( tag );
+					setIsLinkModalOpened( true );
+				} }
 			/>
 		</Modal>
 	);

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -92,6 +92,23 @@ class Personalizer {
 				// The title tag contains the subject of the email which should be personalized. HTML_Tag_Processor does parse the header tags.
 				$title = $this->personalize_content( $content_processor->get_modifiable_text() );
 				$content_processor->set_modifiable_text( $title );
+
+			} elseif ( $content_processor->get_token_type() === '#tag' && $content_processor->get_tag() === 'A' && $content_processor->get_attribute( 'data-link-href' ) ) {
+				// The anchor tag contains the data-link-href attribute which should be personalized.
+				$href  = $content_processor->get_attribute( 'data-link-href' );
+				$token = $this->parse_token( $href );
+				$tag   = $this->tags_registry->get_by_token( $token['token'] );
+				if ( ! $tag ) {
+					continue;
+				}
+
+				$value = $tag->execute_callback( $this->context, $token['arguments'] );
+				$value = $this->replace_link_href( $href, $tag->get_token(), $value );
+				if ( $value ) {
+					$content_processor->set_attribute( 'href', $value );
+					$content_processor->remove_attribute( 'data-link-href' );
+					$content_processor->remove_attribute( 'contenteditable' );
+				}
 			}
 		}
 
@@ -125,5 +142,24 @@ class Personalizer {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Replace the href attribute of the anchor tag with the personalized value.
+	 * The replacement uses regular expression to match the shortcode and its attributes.
+	 *
+	 * @param string $content The content to replace the link href.
+	 * @param string $token Personalization tag token.
+	 * @param string $replacement The callback output to replace the link href.
+	 * @return string
+	 */
+	private function replace_link_href( string $content, string $token, string $replacement ) {
+		// Escape the shortcode name for safe regex usage and strip the brackets.
+		$escaped_shortcode = preg_quote( substr( $token, 1, strlen( $token ) - 2 ), '/' );
+
+		// Create a regex pattern dynamically.
+		$pattern = '/\[' . $escaped_shortcode . '(?:\s+[^\]]+)?\]/';
+
+		return trim( (string) preg_replace( $pattern, $replacement, $content ) );
 	}
 }


### PR DESCRIPTION
## Description

This PR registers new Personalization tags from the category links. Tags from this category can be inserted differently. The new method offers inserting a link when a user can specify the displayed text.

## Code review notes

- I used a similar approach for editing personalization tags with links when a user can change the text or the used tag.
I refactored the work with selection when I focused more on converting the content to the RichTextValu object. This approach seems more stable.
- Personalized links are inserted as anchors, and the link format does not match them.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6394]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6394]: https://mailpoet.atlassian.net/browse/MAILPOET-6394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/link-tags)

_The latest successful build from `email-editor/link-tags` will be used. If none is available, the link won't work._