### PR TITLE
Add abandoned cart worker to simple workers list [MAILPOET-6404]

### DIFF
--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -31,6 +31,7 @@ class WorkersFactory {
     StatsNotificationsWorker::TASK_TYPE,
     BackfillEngagementData::TASK_TYPE,
     Mixpanel::TASK_TYPE,
+    AbandonedCartWorker::TASK_TYPE,
   ];
 
   /** @var ContainerWrapper */

--- a/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
+++ b/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron\Triggers;
 
 use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck;
+use MailPoet\Cron\Workers\Automations\AbandonedCartWorker;
 use MailPoet\Cron\Workers\Bounce as BounceWorker;
 use MailPoet\Cron\Workers\InactiveSubscribers;
 use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
@@ -217,6 +218,11 @@ class WordPressTest extends \MailPoetTest {
 
   public function testItExecutesWhenAutomatedEmailsTaskIsDue() {
     $this->addScheduledTask(AutomatedEmails::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
+    verify($this->wordpressTrigger->checkExecutionRequirements())->true();
+  }
+
+  public function testItExecutesWhenAbandonedCartTaskIsDue() {
+    $this->addScheduledTask(AbandonedCartWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_SCHEDULED);
     verify($this->wordpressTrigger->checkExecutionRequirements())->true();
   }
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

Please verify that abandoned cart automations are processed on time (e.g. 30 minutes after cart update).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6404]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6404]: https://mailpoet.atlassian.net/browse/MAILPOET-6404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-abandoned-cart-to-workers-list)

_The latest successful build from `add-abandoned-cart-to-workers-list` will be used. If none is available, the link won't work._