### PR TITLE
Add a comment for translators for an error during resending [MAILPOET-6241]

### DIFF
--- a/mailpoet/lib/API/JSON/v1/SendingTaskSubscribers.php
+++ b/mailpoet/lib/API/JSON/v1/SendingTaskSubscribers.php
@@ -128,6 +128,7 @@ class SendingTaskSubscribers extends APIEndpoint {
 
     if ($newsletter->canBeSetActive() && $newsletter->getStatus() !== NewsletterEntity::STATUS_ACTIVE) {
       return $this->errorResponse([
+        // translators: This error occurs when resending a failed email message to a recipient and the associated email definition (e.g., a welcome email, an automation email) is inactive.
         APIError::BAD_REQUEST => __('Failed to resend! The email is not active. Please activate it first.', 'mailpoet'),
       ], [], Response::STATUS_BAD_REQUEST);
     }


### PR DESCRIPTION
## Description

This PR is a follow-up to the original https://github.com/mailpoet/mailpoet/pull/5964. It adds a comment for translators based on the feedback from the translation team.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6241]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6241]: https://mailpoet.atlassian.net/browse/MAILPOET-6241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-translator-comment)

_The latest successful build from `add-translator-comment` will be used. If none is available, the link won't work._