### PR TITLE
Email editor - dependencies check [MAILPOET-6367]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -294,4 +294,5 @@ interface Window {
   dataInconsistencies: {
     [key: string]: number;
   };
+  mailpoet_block_email_editor_enabled: boolean;
 }

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -36,9 +36,9 @@ export function NewsletterTypes({
   const [isCreating, setIsCreating] = useState(false);
 
   const [isSelectEditorModalOpen, setIsSelectEditorModalOpen] = useState(false);
-  const isNewEmailEditorEnabled = MailPoet.FeaturesController.isSupported(
-    'gutenberg_email_editor',
-  );
+  const isNewEmailEditorEnabled =
+    MailPoet.FeaturesController.isSupported('gutenberg_email_editor') &&
+    window.mailpoet_block_email_editor_enabled;
 
   const setupNewsletter = (type): void => {
     if (type !== undefined) {

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -7,6 +7,7 @@ use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
 use MailPoet\Config\Menu;
 use MailPoet\EmailEditor\Engine\Dependency_Check;
+use MailPoet\EmailEditor\Integrations\MailPoet\EditorPageRenderer;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\PageLimit;
@@ -73,6 +74,7 @@ class Newsletters {
     AuthorizedEmailsController $authorizedEmailsController,
     UserFlagsController $userFlagsController,
     WooCommerce $wooCommerceSegment,
+    Dependency_Check $dependencyCheck,
     CapabilitiesManager $capabilitiesManager
   ) {
     $this->pageRenderer = $pageRenderer;
@@ -165,7 +167,16 @@ class Newsletters {
     $data['legacy_automatic_emails_notice_dismissed'] = (bool)$this->userFlagsController->get('legacy_automatic_emails_notice_dismissed');
 
     $data['block_email_editor_enabled'] = $this->dependencyCheck->are_dependencies_met(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $this->renderBlockEditorDependencyCheckNotice();
     $this->pageRenderer->displayPage('newsletters.html', $data);
+  }
+
+  public function renderBlockEditorDependencyCheckNotice(): void {
+    $message = $this->wp->getTransient(EditorPageRenderer::EMAIL_EDITOR_DEPENDENCY_NOTICE);
+    if ($message) {
+      $this->wp->deleteTransient(EditorPageRenderer::EMAIL_EDITOR_DEPENDENCY_NOTICE);
+      echo '<div class="notice notice-warning is-dismissible"><p>' . esc_html($message) . '</p></div>';
+    }
   }
 
   private function getCorruptNewsletterSubjects(): array {

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -6,6 +6,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
 use MailPoet\Config\Menu;
+use MailPoet\EmailEditor\Engine\Dependency_Check;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\PageLimit;
@@ -53,6 +54,8 @@ class Newsletters {
 
   private WooCommerce $wooCommerceSegment;
 
+  private Dependency_Check $dependencyCheck;
+
   private CapabilitiesManager $capabilitiesManager;
 
   public function __construct(
@@ -86,6 +89,7 @@ class Newsletters {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->userFlagsController = $userFlagsController;
     $this->wooCommerceSegment = $wooCommerceSegment;
+    $this->dependencyCheck = $dependencyCheck;
     $this->capabilitiesManager = $capabilitiesManager;
   }
 
@@ -160,6 +164,7 @@ class Newsletters {
 
     $data['legacy_automatic_emails_notice_dismissed'] = (bool)$this->userFlagsController->get('legacy_automatic_emails_notice_dismissed');
 
+    $data['block_email_editor_enabled'] = $this->dependencyCheck->are_dependencies_met(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $this->pageRenderer->displayPage('newsletters.html', $data);
   }
 

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -7,7 +7,7 @@ use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
 use MailPoet\Config\Menu;
 use MailPoet\EmailEditor\Engine\Dependency_Check;
-use MailPoet\EmailEditor\Integrations\MailPoet\EditorPageRenderer;
+use MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\PageLimit;
@@ -57,6 +57,8 @@ class Newsletters {
 
   private Dependency_Check $dependencyCheck;
 
+  private DependencyNotice $dependencyNotice;
+
   private CapabilitiesManager $capabilitiesManager;
 
   public function __construct(
@@ -75,6 +77,7 @@ class Newsletters {
     UserFlagsController $userFlagsController,
     WooCommerce $wooCommerceSegment,
     Dependency_Check $dependencyCheck,
+    DependencyNotice $dependencyNotice,
     CapabilitiesManager $capabilitiesManager
   ) {
     $this->pageRenderer = $pageRenderer;
@@ -92,6 +95,7 @@ class Newsletters {
     $this->userFlagsController = $userFlagsController;
     $this->wooCommerceSegment = $wooCommerceSegment;
     $this->dependencyCheck = $dependencyCheck;
+    $this->dependencyNotice = $dependencyNotice;
     $this->capabilitiesManager = $capabilitiesManager;
   }
 
@@ -167,16 +171,8 @@ class Newsletters {
     $data['legacy_automatic_emails_notice_dismissed'] = (bool)$this->userFlagsController->get('legacy_automatic_emails_notice_dismissed');
 
     $data['block_email_editor_enabled'] = $this->dependencyCheck->are_dependencies_met(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    $this->renderBlockEditorDependencyCheckNotice();
+    $this->dependencyNotice->displayMessageIfNeeded();
     $this->pageRenderer->displayPage('newsletters.html', $data);
-  }
-
-  public function renderBlockEditorDependencyCheckNotice(): void {
-    $message = $this->wp->getTransient(EditorPageRenderer::EMAIL_EDITOR_DEPENDENCY_NOTICE);
-    if ($message) {
-      $this->wp->deleteTransient(EditorPageRenderer::EMAIL_EDITOR_DEPENDENCY_NOTICE);
-      echo '<div class="notice notice-warning is-dismissible"><p>' . esc_html($message) . '</p></div>';
-    }
   }
 
   private function getCorruptNewsletterSubjects(): array {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -337,6 +337,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\CustomFields\CustomFieldsRepository::class)->setPublic(true);
     // Email Editor
     $container->autowire(\MailPoet\EmailEditor\Engine\Email_Editor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Dependency_Check::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Email_Api_Controller::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Settings_Controller::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Theme_Controller::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -361,6 +361,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EditorPageRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailApiController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditorPreviewEmail::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes\PoweredByMailpoet::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/DependencyNotice.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/DependencyNotice.php
@@ -45,7 +45,7 @@ class DependencyNotice {
   private function displayMessage(): void {
     $dependencyErrorMessage = sprintf(
     // translators: %1$s: WordPress version e.g. 6.7, %2$s: Gutenberg version e.g. 19.3
-      __('This email was created using the new editor, but it requires WordPress version %1$s or higher, or the Gutenberg plugin version %2$s or above. Please update your setup to continue editing or preview this email.', 'mailpoet'),
+      __('This email was created using the new editor, which requires WordPress version %1$s or higher. If you also have the Gutenberg plugin installed, ensure its version is %2$s or above. Please update your setup to continue editing or previewing this email.', 'mailpoet'),
       Dependency_Check::MIN_WP_VERSION,
       Dependency_Check::MIN_GUTENBERG_VERSION
     );

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/DependencyNotice.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/DependencyNotice.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\EmailEditor\Engine\Dependency_Check;
+use MailPoet\WP\Functions as WPFunctions;
+
+class DependencyNotice {
+  private const EMAIL_EDITOR_DEPENDENCY_NOTICE = 'email_editor_dependencies_not_met';
+  private WPFunctions $wp;
+  private Dependency_Check $dependencyCheck;
+
+  public function __construct(
+    WPFunctions $wp,
+    Dependency_Check $dependencyCheck
+  ) {
+    $this->wp = $wp;
+    $this->dependencyCheck = $dependencyCheck;
+  }
+
+  public function checkDependenciesAndEventuallyRedirect(): void {
+    if ($this->dependencyCheck->are_dependencies_met()) {
+      $this->wp->deleteTransient(self::EMAIL_EDITOR_DEPENDENCY_NOTICE);
+      return;
+    }
+    $this->wp->setTransient(self::EMAIL_EDITOR_DEPENDENCY_NOTICE, true);
+    $this->wp->wpSafeRedirect($this->wp->adminUrl('admin.php?page=mailpoet-newsletters'));
+  }
+
+  public function displayMessageIfNeeded(): void {
+    if ($this->wp->getTransient(self::EMAIL_EDITOR_DEPENDENCY_NOTICE)) {
+      $this->displayMessage();
+    }
+    $this->wp->deleteTransient(self::EMAIL_EDITOR_DEPENDENCY_NOTICE);
+  }
+
+  private function displayMessage(): void {
+    $dependencyErrorMessage = sprintf(
+    // translators: %1$s: WordPress version e.g. 6.7, %2$s: Gutenberg version e.g. 19.3
+      __('This email was created using the new editor, but it requires WordPress version %1$s or higher, or the Gutenberg plugin version %2$s or above. Please update your setup to continue editing this email.', 'mailpoet'),
+      Dependency_Check::MIN_WP_VERSION,
+      Dependency_Check::MIN_GUTENBERG_VERSION
+    );
+    echo '<div class="notice notice-warning is-dismissible"><p>' . esc_html($dependencyErrorMessage) . '</p></div>';
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/DependencyNotice.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/DependencyNotice.php
@@ -44,10 +44,9 @@ class DependencyNotice {
 
   private function displayMessage(): void {
     $dependencyErrorMessage = sprintf(
-    // translators: %1$s: WordPress version e.g. 6.7, %2$s: Gutenberg version e.g. 19.3
-      __('This email was created using the new editor, which requires WordPress version %1$s or higher. If you also have the Gutenberg plugin installed, ensure its version is %2$s or above. Please update your setup to continue editing or previewing this email.', 'mailpoet'),
+      // translators: %1$s: WordPress version e.g. 6.7
+      __('This email was created using the new editor, which requires WordPress version %1$s or higher. Please update your setup to continue editing or previewing this email.', 'mailpoet'),
       Dependency_Check::MIN_WP_VERSION,
-      Dependency_Check::MIN_GUTENBERG_VERSION
     );
     echo '<div class="notice notice-warning is-dismissible"><p>' . esc_html($dependencyErrorMessage) . '</p></div>';
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -67,7 +67,7 @@ class EditorPageRenderer {
     if (!$post instanceof \WP_Post || $post->post_type !== EditorInitController::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       return;
     }
-    $this->dependencyNotice->checkDependenciesAndEventuallyRedirect();
+    $this->dependencyNotice->checkDependenciesAndEventuallyShowNotice();
 
     // load mailpoet email editor JS integrations
     $editorIntegrationAssetsParams = require Env::$assetsPath . '/dist/js/email_editor_integration/email_editor_integration.asset.php';

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Newsletter\ViewInBrowser;
 
+use MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
@@ -28,12 +29,16 @@ class ViewInBrowserController {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
+  /** @var DependencyNotice */
+  private $dependencyNotice;
+
   public function __construct(
     LinkTokens $linkTokens,
     NewsletterUrl $newsletterUrl,
     NewslettersRepository $newslettersRepository,
     ViewInBrowserRenderer $viewInBrowserRenderer,
     SendingQueuesRepository $sendingQueuesRepository,
+    DependencyNotice $dependencyNotice,
     SubscribersRepository $subscribersRepository
   ) {
     $this->linkTokens = $linkTokens;
@@ -41,6 +46,7 @@ class ViewInBrowserController {
     $this->subscribersRepository = $subscribersRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->newsletterUrl = $newsletterUrl;
+    $this->dependencyNotice = $dependencyNotice;
     $this->newslettersRepository = $newslettersRepository;
   }
 
@@ -49,6 +55,9 @@ class ViewInBrowserController {
     $isPreview = !empty($data['preview']);
     $newsletter = $this->getNewsletter($data);
     $subscriber = $this->getSubscriber($data);
+    if ($newsletter->getWpPostId() && $this->dependencyNotice->checkDependenciesAndEventuallyShowNotice()) {
+      return '';
+    }
 
     // if queue and subscriber exist, subscriber must have received the newsletter
     $queue = isset($data['queue_id']) ? $this->sendingQueuesRepository->findOneById($data['queue_id']) : null;

--- a/mailpoet/lib/Router/Endpoints/ViewInBrowser.php
+++ b/mailpoet/lib/Router/Endpoints/ViewInBrowser.php
@@ -34,9 +34,11 @@ class ViewInBrowser {
   }
 
   private function displayNewsletter($result) {
-    header('Content-Type: text/html; charset=utf-8');
-    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    echo $result;
+    if ($result) {
+      header('Content-Type: text/html; charset=utf-8');
+      // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+      echo $result;
+    }
     exit;
   }
 

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Newsletter\ViewInBrowser;
 
 use Codeception\Stub\Expected;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
+use MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
@@ -228,6 +229,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
       $this->newslettersRepository,
       $viewInBrowserRenderer,
       $this->sendingQueuesRepository,
+      $this->diContainer->get(DependencyNotice::class),
       $this->subscribersRepository
     );
   }

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -48,6 +48,7 @@
       var mailpoet_partially_verified_sender_domains = <%= json_encode(partially_verified_sender_domains) %>;
       var mailpoet_all_sender_domains = <%= json_encode(all_sender_domains) %>;
       var mailpoet_sender_restrictions = <%= json_encode(sender_restrictions) %>;
+      var mailpoet_block_email_editor_enabled = <%= json_encode(block_email_editor_enabled) %>;
     <% endautoescape %>
 
     var mailpoet_newsletters_templates_recently_sent_count = <%= json_decode(newsletters_templates_recently_sent_count) %>;

--- a/packages/php/email-editor/src/Engine/class-dependency-check.php
+++ b/packages/php/email-editor/src/Engine/class-dependency-check.php
@@ -28,7 +28,13 @@ class Dependency_Check {
 	 * Checks if all dependencies are met.
 	 */
 	public function are_dependencies_met(): bool {
-		return $this->is_gutenberg_version_compatible() || $this->is_wp_version_compatible();
+		if ( ! $this->is_wp_version_compatible() ) {
+			return false;
+		}
+		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+			return $this->is_gutenberg_version_compatible();
+		}
+		return true;
 	}
 
 	/**
@@ -42,9 +48,8 @@ class Dependency_Check {
 	 * Checks if the WordPress version is supported.
 	 */
 	private function is_gutenberg_version_compatible(): bool {
-		if ( defined( 'GUTENBERG_VERSION' ) ) {
-			return version_compare( GUTENBERG_VERSION, self::MIN_GUTENBERG_VERSION, '>=' );
-		}
-		return false;
+		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php', false, false );
+		$version     = $plugin_data['Version'] ?? '0.0.0';
+		return version_compare( $version, self::MIN_GUTENBERG_VERSION, '>=' );
 	}
 }

--- a/packages/php/email-editor/src/Engine/class-dependency-check.php
+++ b/packages/php/email-editor/src/Engine/class-dependency-check.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of the MailPoet Email Editor package.
+ *
+ * @package MailPoet\EmailEditor
+ */
+
+declare(strict_types = 1);
+namespace MailPoet\EmailEditor\Engine;
+
+/**
+ * This class is responsible checking the dependencies of the email editor.
+ */
+class Dependency_Check {
+	/**
+	 * Minimum WordPress version required for the email editor.
+	 */
+	public const MIN_WP_VERSION = '6.7';
+
+	/**
+	 * Minimum Gutenberg version required for the email editor.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/
+	 */
+	public const MIN_GUTENBERG_VERSION = '19.3'; // Version released in WP 6.7.
+
+	/**
+	 * Checks if all dependencies are met.
+	 */
+	public function are_dependencies_met(): bool {
+		return $this->is_gutenberg_version_compatible() || $this->is_wp_version_compatible();
+	}
+
+	/**
+	 * Checks if the WordPress version is supported.
+	 */
+	private function is_wp_version_compatible(): bool {
+		return version_compare( get_bloginfo( 'version' ), self::MIN_WP_VERSION, '>=' );
+	}
+
+	/**
+	 * Checks if the WordPress version is supported.
+	 */
+	private function is_gutenberg_version_compatible(): bool {
+		return version_compare( get_bloginfo( 'version' ), self::MIN_GUTENBERG_VERSION, '>=' );
+	}
+}

--- a/packages/php/email-editor/src/Engine/class-dependency-check.php
+++ b/packages/php/email-editor/src/Engine/class-dependency-check.php
@@ -42,6 +42,9 @@ class Dependency_Check {
 	 * Checks if the WordPress version is supported.
 	 */
 	private function is_gutenberg_version_compatible(): bool {
-		return version_compare( get_bloginfo( 'version' ), self::MIN_GUTENBERG_VERSION, '>=' );
+		if ( defined( 'GUTENBERG_VERSION' ) ) {
+			return version_compare( GUTENBERG_VERSION, self::MIN_GUTENBERG_VERSION, '>=' );
+		}
+		return false;
 	}
 }

--- a/packages/php/email-editor/src/Engine/class-dependency-check.php
+++ b/packages/php/email-editor/src/Engine/class-dependency-check.php
@@ -18,21 +18,11 @@ class Dependency_Check {
 	public const MIN_WP_VERSION = '6.7';
 
 	/**
-	 * Minimum Gutenberg version required for the email editor.
-	 *
-	 * @see https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/
-	 */
-	public const MIN_GUTENBERG_VERSION = '19.3'; // Version released in WP 6.7.
-
-	/**
 	 * Checks if all dependencies are met.
 	 */
 	public function are_dependencies_met(): bool {
 		if ( ! $this->is_wp_version_compatible() ) {
 			return false;
-		}
-		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-			return $this->is_gutenberg_version_compatible();
 		}
 		return true;
 	}
@@ -42,14 +32,5 @@ class Dependency_Check {
 	 */
 	private function is_wp_version_compatible(): bool {
 		return version_compare( get_bloginfo( 'version' ), self::MIN_WP_VERSION, '>=' );
-	}
-
-	/**
-	 * Checks if the WordPress version is supported.
-	 */
-	private function is_gutenberg_version_compatible(): bool {
-		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php', false, false );
-		$version     = $plugin_data['Version'] ?? '0.0.0';
-		return version_compare( $version, self::MIN_GUTENBERG_VERSION, '>=' );
 	}
 }

--- a/packages/php/email-editor/tests/integration/_bootstrap.php
+++ b/packages/php/email-editor/tests/integration/_bootstrap.php
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Codeception\Stub;
 use MailPoet\EmailEditor\Container;
+use MailPoet\EmailEditor\Engine\Dependency_Check;
 use MailPoet\EmailEditor\Engine\Email_Api_Controller;
 use MailPoet\EmailEditor\Engine\Email_Editor;
 use MailPoet\EmailEditor\Engine\Patterns\Patterns;
@@ -291,6 +292,12 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 				return new Email_Api_Controller(
 					$container->get( Personalization_Tags_Registry::class ),
 				);
+			}
+		);
+		$container->set(
+			Dependency_Check::class,
+			function () {
+				return new Dependency_Check();
 			}
 		);
 		$container->set(


### PR DESCRIPTION
## Description

This PR adds a mechanism for checking if a site has the dependencies needed to run the email editor. At this point, we are checking for a minimal WP (6.7).
When the editor can't run, we hide the button for creating an email in the new editor, and in case a user attempts to edit an email previously created in the new editor, they get a notice.

<img width="1017" alt="Screenshot 2025-01-09 at 18 27 14" src="https://github.com/user-attachments/assets/55f7668c-ed29-4423-8bec-7ef6391c7614" />



## Code review notes

Please review commit by commit.

## QA notes

You can use [WP Downgrade](https://wordpress.org/plugins/wp-downgrade/) plugin to install older WP.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6367]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6367]: https://mailpoet.atlassian.net/browse/MAILPOET-6367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/feature-check)

_The latest successful build from `email-editor/feature-check` will be used. If none is available, the link won't work._