### PR TITLE
Bump supported WooCommerce version to 9.4+ [MAILPOET-6406]

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 9.3.3
- * WC tested up to: 9.4.2
+ * WC requires at least: 9.4.3
+ * WC tested up to: 9.5.1
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.6'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.3'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.4'; // L-1 version, not the latest
 
 
 // Display WP version error notice

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -27,8 +27,8 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.6';
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.3';
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.6'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.3'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Skipping code review.

## QA notes

Skipping QA review.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6406]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6406]: https://mailpoet.atlassian.net/browse/MAILPOET-6406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wc-9.5)

_The latest successful build from `wc-9.5` will be used. If none is available, the link won't work._