### PR TITLE
Remove style affecting images in email editor mobile preview [MAILPOET-6368]

### DIFF
--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -109,17 +109,6 @@ ol.has-background {
  * Mobile preview fixes
  */
 .is-mobile-preview figure > div {
+	max-width: 100% !important;
 	height: auto !important;
-	width: auto !important;
-}
-
-.is-mobile-preview .wp-block-columns {
-	display: flex;
-	flex-direction: column;
-}
-
-.is-mobile-preview .wp-block-column {
-	box-sizing: border-box;
-	/* override flex-basis set in style attribute to fix the height of the column in mobile preview. Blocks overriding is as a part of style.css in blocks-library */
-	flex-basis: auto !important;
 }


### PR DESCRIPTION
## Description

This PR removes styles that changed image size in the email preview for mobiles in the new email editor.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6368]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6368]: https://mailpoet.atlassian.net/browse/MAILPOET-6368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/fix-image-mobile-preview)

_The latest successful build from `email-editor/fix-image-mobile-preview` will be used. If none is available, the link won't work._