### PR TITLE
Change release reviewer from Veljko to Alexey

### DIFF
--- a/mailpoet/tasks/release/GitHubController.php
+++ b/mailpoet/tasks/release/GitHubController.php
@@ -16,7 +16,7 @@ class GitHubController {
 
   const RELEASE_SOURCE_BRANCH = 'release';
 
-  const QA_GITHUB_LOGIN = 'veljkho';
+  const QA_GITHUB_LOGIN = 'Aschepikov';
 
   private const API_BASE_URI = 'https://api.github.com/repos/mailpoet';
   private const API_SEARCH_URI = 'https://api.github.com/search/issues';


### PR DESCRIPTION
## Description

When creating a release, the script auto-assign reviewer and assignee. This PR changes it from @veljkho to @Aschepikov.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
