### PR TITLE
Improve inserting Personalization tags [MAILPOET-6396]

### DIFF
--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -97,7 +97,7 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 				let richTextValue = create( { html: blockContent } );
 				richTextValue = insert(
 					richTextValue,
-					create( { html: `<!--${ tag }-->` } ),
+					create( { html: `<!--${ tag }-->&nbsp;` } ), // Add a non-breaking space to avoid an issue when WP renderer removes blog containing only a comment
 					start,
 					end
 				);

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
@@ -117,7 +117,7 @@ const getCursorPosition = (
 	);
 	if ( formatIndex !== null ) {
 		return {
-			start: formatIndex + selection.anchorOffset,
+			start: formatIndex + selection.anchorOffset + 1, // We need to add 1 for the format length
 			end: formatIndex + selection.anchorOffset + range.toString().length,
 		};
 	}
@@ -129,7 +129,7 @@ const getCursorPosition = (
 	);
 	if ( replacementIndex !== null ) {
 		return {
-			start: replacementIndex + selection.anchorOffset,
+			start: replacementIndex + selection.anchorOffset + 1, // We need to add 1 for the replacement length
 			end:
 				replacementIndex +
 				selection.anchorOffset +


### PR DESCRIPTION
## Description

This PR fixes two issues:
- Inserting the Personalization tag behind another tag or at the end of the text.
- Rendering the Personalization tag when no other text is in the text block.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6396]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6396]: https://mailpoet.atlassian.net/browse/MAILPOET-6396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/fix-blocks-with-tag)

_The latest successful build from `email-editor/fix-blocks-with-tag` will be used. If none is available, the link won't work._