### PR TITLE
Update the personalization tags guide [MAILPOET-6386]

### DIFF
--- a/packages/js/email-editor/src/components/block-editor/index.scss
+++ b/packages/js/email-editor/src/components/block-editor/index.scss
@@ -65,6 +65,10 @@
   }
 }
 
+.mailpoet-settings-panel__preheader-text {
+  margin-top: 9px;
+}
+
 .mailpoet-email-editor__settings-panel {
   .mailpoet-settings-panel__richtext {
     border: 1px solid var(--wp-components-color-gray-600, #949494);

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
@@ -70,7 +70,7 @@ const PersonalizationTagsModal = ( {
 		>
 			<p>
 				{ __(
-					'Insert shortcodes to dynamically fill in information and personalize your emails.',
+					'Insert personalization tags to dynamically fill in information and personalize your emails.',
 					'mailpoet'
 				) }{ ' ' }
 				<ExternalLink href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes#list">

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
@@ -73,7 +73,7 @@ const PersonalizationTagsModal = ( {
 					'Insert personalization tags to dynamically fill in information and personalize your emails.',
 					'mailpoet'
 				) }{ ' ' }
-				<ExternalLink href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes#list">
+				<ExternalLink href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list">
 					{ __( 'Learn more', 'mailpoet' ) }
 				</ExternalLink>
 			</p>

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -17,7 +17,7 @@ export function DetailsPanel() {
 
 	const subjectHelp = createInterpolateElement(
 		__(
-			'Use shortcodes to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
+			'Use personalization tags to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
 			'mailpoet'
 		),
 		{
@@ -73,7 +73,7 @@ export function DetailsPanel() {
 				label={ __( 'Subject', 'mailpoet' ) }
 				labelSuffix={
 					<ExternalLink href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes#list">
-						{ __( 'Shortcode guide', 'mailpoet' ) }
+						{ __( 'Guide', 'mailpoet' ) }
 					</ExternalLink>
 				}
 				help={ subjectHelp }

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -72,7 +72,7 @@ export function DetailsPanel() {
 				attributeName="subject"
 				label={ __( 'Subject', 'mailpoet' ) }
 				labelSuffix={
-					<ExternalLink href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes#list">
+					<ExternalLink href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list">
 						{ __( 'Guide', 'mailpoet' ) }
 					</ExternalLink>
 				}


### PR DESCRIPTION
## Description

Replace the links to old shortcodes to the new personalization tags guide

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-6386]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6386]: https://mailpoet.atlassian.net/browse/MAILPOET-6386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:personalization-tags-guide)

_The latest successful build from `personalization-tags-guide` will be used. If none is available, the link won't work._