### PR TITLE
Hide coupon block in sign-up confirmation template [MAILPOET-6338]

### DIFF
--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -1542,7 +1542,7 @@
       hiddenWidgets: ['automatedLatestContentLayout', 'header', 'footer', 'posts', 'products'],
       <% endif %>
       <% if is_confirmation_email_template %>
-      hiddenWidgets: ['automatedLatestContentLayout', 'header', 'footer', 'posts', 'products'],
+      hiddenWidgets: ['automatedLatestContentLayout', 'coupon', 'header', 'footer', 'posts', 'products'],
       <% endif %>
       coupon: <%= json_encode(woocommerce.coupon.config) %>,
     };


### PR DESCRIPTION
## Description

Convo in Slack (p1736283400824779-slack-C01GH764202).

This PR hides the coupon block when editing the sign-up confirmation email. We don't yet have the consent for marketing emails when sending the confirmation. Hence, we shouldn't allow marketing messaging (a coupon code) to be sent to such emails. 

## Code review notes

_N/A_

## QA notes

QA review can be skipped.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6338]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-6338]: https://mailpoet.atlassian.net/browse/MAILPOET-6338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:coupon-block-on-confirmation)

_The latest successful build from `coupon-block-on-confirmation` will be used. If none is available, the link won't work._