### PR TITLE
Disable Coming Soon mode in tests [MAILPOET-6408]

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -435,6 +435,7 @@ class AcceptanceTester extends \Codeception\Actor {
   public function activateWooCommerce() {
     $i = $this;
     $i->cli(['plugin', 'activate', self::WOO_COMMERCE_PLUGIN]);
+    $i->cli(['option', 'update', 'woocommerce_coming_soon', 'no']);
   }
 
   public function deactivateWooCommerce() {


### PR DESCRIPTION
## Description

Fixes nightly tests against WooCommerce 9.6 beta 2. 

With Coming Soon mode on, tests can't check the frontend unless logged in. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6408]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6408]: https://mailpoet.atlassian.net/browse/MAILPOET-6408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:nightly-tests)

_The latest successful build from `nightly-tests` will be used. If none is available, the link won't work._