### PR TITLE
Remove feature flag for the Gutenberg email editor - MAILPOET-6366

### DIFF
--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -34,10 +34,7 @@ const redirectToNewsletterHome = () => {
 
 const getEditorLink = (newsletter: NewsletterType) => {
   let editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  if (
-    MailPoet.FeaturesController.isSupported('gutenberg_email_editor') &&
-    newsletter.wp_post_id
-  ) {
+  if (newsletter.wp_post_id) {
     editorHref = MailPoet.getBlockEmailEditorUrl(newsletter.wp_post_id);
   }
   return editorHref;

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -76,12 +76,8 @@ const messages = {
 
 const columns = [
   {
-    name: MailPoet.FeaturesController.isSupported('gutenberg_email_editor')
-      ? 'name'
-      : 'subject',
-    label: MailPoet.FeaturesController.isSupported('gutenberg_email_editor')
-      ? __('Name', 'mailpoet')
-      : __('Subject', 'mailpoet'),
+    name: 'name',
+    label: __('Name', 'mailpoet'),
     sortable: true,
   },
   {
@@ -114,10 +110,7 @@ const bulkActions = [
 
 const confirmEdit = (newsletter) => {
   let editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  if (
-    MailPoet.FeaturesController.isSupported('gutenberg_email_editor') &&
-    newsletter.wp_post_id
-  ) {
+  if (newsletter.wp_post_id) {
     editorHref = MailPoet.getBlockEmailEditorUrl(newsletter.wp_post_id);
   }
 

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -75,10 +75,7 @@ function validateNewsletter(newsletter: NewsLetter) {
   // Don't validate emails created in the new editor.
   // The editor uses a different data format and will have own validation and also own send panel.
   // We are using the send page for the new editor only temporarily.
-  if (
-    MailPoet.FeaturesController.isSupported('gutenberg_email_editor') &&
-    newsletter.wp_post_id !== null
-  ) {
+  if (newsletter.wp_post_id !== null) {
     return undefined;
   }
 
@@ -881,9 +878,7 @@ class NewsletterSendComponent extends Component<
                 <a
                   className="mailpoet-link"
                   href={
-                    MailPoet.FeaturesController.isSupported(
-                      'gutenberg_email_editor',
-                    ) && wpPostId
+                    wpPostId
                       ? MailPoet.getBlockEmailEditorUrl(Number(wpPostId))
                       : `?page=mailpoet-newsletter-editor&id=${Number(
                           this.props.params.id,

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -36,9 +36,7 @@ export function NewsletterTypes({
   const [isCreating, setIsCreating] = useState(false);
 
   const [isSelectEditorModalOpen, setIsSelectEditorModalOpen] = useState(false);
-  const isNewEmailEditorEnabled =
-    MailPoet.FeaturesController.isSupported('gutenberg_email_editor') &&
-    window.mailpoet_block_email_editor_enabled;
+  const isNewEmailEditorEnabled = window.mailpoet_block_email_editor_enabled;
 
   const setupNewsletter = (type): void => {
     if (type !== undefined) {

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -15,7 +15,6 @@ use MailPoet\EmailEditor\Engine\Email_Editor;
 use MailPoet\EmailEditor\Integrations\Core\Initializer as CoreEmailEditorIntegration;
 use MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEditorIntegration;
-use MailPoet\Features\FeaturesController;
 use MailPoet\InvalidStateException;
 use MailPoet\Migrator\Cli as MigratorCli;
 use MailPoet\PostEditorBlocks\PostEditorBlock;
@@ -132,9 +131,6 @@ class Initializer {
   /** @var BlockTypesController */
   private $blockTypesController;
 
-  /** @var FeaturesController */
-  private $featureController;
-
   /** @var Url */
   private $urlHelper;
 
@@ -175,7 +171,6 @@ class Initializer {
     BlockTypesController $blockTypesController,
     MailpoetEmailEditorIntegration $mailpoetEmailEditorIntegration,
     CoreEmailEditorIntegration $coreEmailEditorIntegration,
-    FeaturesController $featureController,
     Url $urlHelper
   ) {
     $this->rendererFactory = $rendererFactory;
@@ -210,7 +205,6 @@ class Initializer {
     $this->mailpoetEmailEditorIntegration = $mailpoetEmailEditorIntegration;
     $this->coreEmailEditorIntegration = $coreEmailEditorIntegration;
     $this->blockTypesController = $blockTypesController;
-    $this->featureController = $featureController;
     $this->urlHelper = $urlHelper;
   }
 
@@ -366,10 +360,8 @@ class Initializer {
       $this->subscriberActivityTracker->trackActivity();
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();
-      if ($this->featureController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR)) {
-        $this->blockTypesController->initialize();
-        $this->emailEditor->initialize();
-      }
+      $this->blockTypesController->initialize();
+      $this->emailEditor->initialize();
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {
       return $this->handleRunningMigration($e);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/AbstractBlock.php
@@ -3,14 +3,24 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes;
 
 use MailPoet\Config\Env;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use WP_Style_Engine;
 
 abstract class AbstractBlock {
   protected $namespace = 'mailpoet';
   protected $blockName = '';
+  private EmailEditor $emailEditor;
+
+  public function __construct(
+    EmailEditor $emailEditor
+  ) {
+    $this->emailEditor = $emailEditor;
+  }
 
   public function initialize() {
-    $this->registerAssets();
+    if ($this->emailEditor->isEditorPage(false)) {
+      $this->registerAssets();
+    }
     $this->registerBlockType();
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/PoweredByMailpoet.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/PoweredByMailpoet.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypes;
 
 use MailPoet\Config\ServicesChecker;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Util\CdnAssetUrl;
 
 class PoweredByMailpoet extends AbstractBlock {
@@ -12,10 +13,12 @@ class PoweredByMailpoet extends AbstractBlock {
 
   public function __construct(
     ServicesChecker $servicesChecker,
-    CdnAssetUrl $cdnAssetUrl
+    CdnAssetUrl $cdnAssetUrl,
+    EmailEditor $emailEditor
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->servicesChecker = $servicesChecker;
+    parent::__construct($emailEditor);
   }
 
   public function render($attributes, $content, $block) {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -4,15 +4,12 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
 use MailPoet\EmailEditor\Integrations\MailPoet\Templates\TemplatesController;
-use MailPoet\Features\FeaturesController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditor {
   const MAILPOET_EMAIL_POST_TYPE = 'mailpoet_email';
 
   private WPFunctions $wp;
-
-  private FeaturesController $featuresController;
 
   private EmailApiController $emailApiController;
 
@@ -30,7 +27,6 @@ class EmailEditor {
 
   public function __construct(
     WPFunctions $wp,
-    FeaturesController $featuresController,
     EmailApiController $emailApiController,
     EditorPageRenderer $editorPageRenderer,
     EmailEditorPreviewEmail $emailEditorPreviewEmail,
@@ -40,7 +36,6 @@ class EmailEditor {
     PersonalizationTagManager $personalizationTagManager
   ) {
     $this->wp = $wp;
-    $this->featuresController = $featuresController;
     $this->emailApiController = $emailApiController;
     $this->editorPageRenderer = $editorPageRenderer;
     $this->patternsController = $patternsController;
@@ -51,9 +46,6 @@ class EmailEditor {
   }
 
   public function initialize(): void {
-    if (!$this->featuresController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR)) {
-      return;
-    }
     $this->cli->initialize();
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
     $this->wp->addAction('rest_delete_mailpoet_email', [$this->emailApiController, 'trashEmail'], 10, 1);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
@@ -26,8 +26,15 @@ class TemplatesController {
 
   public function registerTemplates() {
     $newsletter = new Newsletter($this->cdnAssetUrl);
+    $templateName = $this->templatePrefix . '//' . $newsletter->getSlug();
+
+    if (\WP_Block_Templates_Registry::get_instance()->is_registered($templateName)) {
+      // skip registration if the template was already registered.
+      return;
+    }
+
     register_block_template(
-      $this->templatePrefix . '//' . $newsletter->getSlug(),
+      $templateName,
       [
         'title' => $newsletter->getTitle(),
         'description' => $newsletter->getDescription(),

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -6,13 +6,11 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
-  const GUTENBERG_EMAIL_EDITOR = 'gutenberg_email_editor';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
-    self::GUTENBERG_EMAIL_EDITOR => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/Newsletter/NewsletterValidator.php
+++ b/mailpoet/lib/Newsletter/NewsletterValidator.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Newsletter;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Validator\ValidationException;
@@ -16,23 +15,17 @@ class NewsletterValidator {
   /** @var TrackingConfig */
   private $trackingConfig;
 
-  /** @var FeaturesController */
-  private $featuresController;
-
   public function __construct(
     Bridge $bridge,
-    TrackingConfig $trackingConfig,
-    FeaturesController $featuresController
+    TrackingConfig $trackingConfig
   ) {
     $this->bridge = $bridge;
     $this->trackingConfig = $trackingConfig;
-    $this->featuresController = $featuresController;
   }
 
   public function validate(NewsletterEntity $newsletterEntity): ?string {
     if (
-      $this->featuresController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR)
-      && $newsletterEntity->getWpPostId() !== null
+      $newsletterEntity->getWpPostId() !== null
     ) {
       // Temporarily skip validation for emails created via Gutenberg editor
       return null;

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -6,7 +6,6 @@ use MailPoet\Config\Env;
 use MailPoet\EmailEditor\Engine\Renderer\Renderer as GuntenbergRenderer;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\EscapeHelper as EHelper;
@@ -45,9 +44,6 @@ class Renderer {
   /*** @var SendingQueuesRepository */
   private $sendingQueuesRepository;
 
-  /** @var FeaturesController */
-  private $featuresController;
-
   private CapabilitiesManager $capabilitiesManager;
 
   public function __construct(
@@ -59,7 +55,6 @@ class Renderer {
     LoggerFactory $loggerFactory,
     NewslettersRepository $newslettersRepository,
     SendingQueuesRepository $sendingQueuesRepository,
-    FeaturesController $featuresController,
     CapabilitiesManager $capabilitiesManager
   ) {
     $this->bodyRenderer = $bodyRenderer;
@@ -70,7 +65,6 @@ class Renderer {
     $this->loggerFactory = $loggerFactory;
     $this->newslettersRepository = $newslettersRepository;
     $this->sendingQueuesRepository = $sendingQueuesRepository;
-    $this->featuresController = $featuresController;
     $this->capabilitiesManager = $capabilitiesManager;
   }
 
@@ -88,7 +82,7 @@ class Renderer {
     $subject = $subject ?: $newsletter->getSubject();
     $wpPostEntity = $newsletter->getWpPost();
     $wpPost = $wpPostEntity ? $wpPostEntity->getWpPostInstance() : null;
-    if ($this->featuresController->isSupported(FeaturesController::GUTENBERG_EMAIL_EDITOR) && $wpPost instanceof \WP_Post) {
+    if ($wpPost instanceof \WP_Post) {
       $renderedNewsletter = $this->guntenbergRenderer->render($wpPost, $subject, $newsletter->getPreheader(), $language, $metaRobots);
     } else {
       $body = (is_array($newsletter->getBody()))

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -2,8 +2,6 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
-use MailPoet\Test\DataFactories\Features;
 use MailPoet\Test\DataFactories\Settings;
 
 class CreateAndSendEmailUsingGutenbergCest {
@@ -14,7 +12,6 @@ class CreateAndSendEmailUsingGutenbergCest {
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
     $settings->withSender('John Doe', 'john@doe.com');
-    (new Features())->withFeatureEnabled(FeaturesController::GUTENBERG_EMAIL_EDITOR);
     $segmentName = $i->createListWithSubscriber();
 
     $i->wantTo('Create standard newsletter using Gutenberg editor');
@@ -87,7 +84,6 @@ class CreateAndSendEmailUsingGutenbergCest {
     $settings = new Settings();
     $settings->withCronTriggerMethod('Action Scheduler');
     $settings->withSender('John Doe', 'john@doe.com');
-    (new Features())->withFeatureEnabled(FeaturesController::GUTENBERG_EMAIL_EDITOR);
 
     $i->wantTo('Open standard newsletter using Gutenberg editor');
     $i->login();

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -2,15 +2,11 @@
 
 namespace MailPoet\Test\Acceptance;
 
-use MailPoet\Features\FeaturesController;
-use MailPoet\Test\DataFactories\Features;
-
 class EmailTemplatesCest {
   public function selectEditSwapAndResetEmailTemplate(\AcceptanceTester $i, $scenario) {
     if (!$i->checkEmailEditorRequiredWordpressVersion()) {
       $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
     }
-    (new Features())->withFeatureEnabled(FeaturesController::GUTENBERG_EMAIL_EDITOR);
 
     $i->wantTo('Create standard newsletter using Gutenberg editor');
     $i->login();

--- a/mailpoet/tests/acceptance/Newsletters/NewslettersListingCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewslettersListingCest.php
@@ -38,7 +38,8 @@ class NewslettersListingCest {
   }
 
   public function statisticsColumn(\AcceptanceTester $i) {
-    (new Newsletter())->create();
+    $subject = 'Statistics column subject';
+    (new Newsletter())->withSubject($subject)->create();
 
     $i->wantTo('Check if statistics column is visible depending on tracking option');
 
@@ -52,7 +53,7 @@ class NewslettersListingCest {
     $i->waitForText('Settings saved');
 
     $i->amOnMailpoetPage('Emails');
-    $i->waitForText('Subject');
+    $i->waitForText($subject);
     $i->dontSee('Clicked, Opened');
 
     // column is visible when tracking is enabled
@@ -63,7 +64,7 @@ class NewslettersListingCest {
     $i->waitForText('Settings saved');
 
     $i->amOnMailpoetPage('Emails');
-    $i->waitForText('Subject');
+    $i->waitForText($subject);
     $i->see('Clicked, Opened');
     $i->seeNoJSErrors();
   }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailEditorTest.php
@@ -3,20 +3,13 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeatureFlagsController;
-use MailPoet\Features\FeaturesController;
 
 class EmailEditorTest extends \MailPoetTest {
   /** @var EmailEditor */
   private $emailEditor;
 
-  /** @var FeatureFlagsController */
-  private $featureFlagsController;
-
   public function _before() {
     $this->emailEditor = $this->diContainer->get(EmailEditor::class);
-    $this->featureFlagsController = $this->diContainer->get(FeatureFlagsController::class);
-    $this->featureFlagsController->set(FeaturesController::GUTENBERG_EMAIL_EDITOR, true);
   }
 
   public function testItRegistersMailPoetEmailPostType() {
@@ -30,6 +23,5 @@ class EmailEditorTest extends \MailPoetTest {
     parent::_after();
     remove_filter('mailpoet_email_editor_post_types', [$this->emailEditor, 'addEmailPostType']);
     $this->truncateEntity(NewsletterEntity::class);
-    $this->featureFlagsController->set(FeaturesController::GUTENBERG_EMAIL_EDITOR, false);
   }
 }

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\Test\Newsletter;
 
 use Codeception\Util\Fixtures;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewsletterHtmlSanitizer;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -66,7 +65,6 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(LoggerFactory::class),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
-      $this->diContainer->get(FeaturesController::class),
       $this->capabilitiesManager
     );
     $this->columnRenderer = new ColumnRenderer();
@@ -639,7 +637,6 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(LoggerFactory::class),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
-      $this->diContainer->get(FeaturesController::class),
       $capabilitiesManager
     );
     $body = json_decode(Fixtures::get('newsletter_body_template'), true);
@@ -661,7 +658,6 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(LoggerFactory::class),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
-      $this->diContainer->get(FeaturesController::class),
       $capabilitiesManager
     );
 

--- a/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
+++ b/mailpoet/tests/integration/WooCommerce/TransactionalEmails/RendererTest.php
@@ -4,7 +4,6 @@ namespace MailPoet\WooCommerce\TransactionalEmails;
 
 use Codeception\Stub;
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Features\FeaturesController;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\Editor\LayoutHelper as L;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -268,7 +267,6 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(LoggerFactory::class),
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(SendingQueuesRepository::class),
-      $this->diContainer->get(FeaturesController::class),
       $this->diContainer->get(CapabilitiesManager::class)
     );
   }

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -74,15 +74,20 @@ class Templates {
 		);
 		$template_filename = $general_email['slug'] . '.html';
 
-		register_block_template(
-			$this->template_prefix . '//' . $general_email['slug'],
-			array(
-				'title'       => $general_email['title'],
-				'description' => $general_email['description'],
-				'content'     => (string) file_get_contents( $this->template_directory . $template_filename ),
-				'post_types'  => $this->post_types,
-			)
-		);
+		$template_name = $this->template_prefix . '//' . $general_email['slug'];
+
+		if ( ! \WP_Block_Templates_Registry::get_instance()->is_registered( $template_name ) ) {
+			// skip registration if the template was already registered.
+			register_block_template(
+				$template_name,
+				array(
+					'title'       => $general_email['title'],
+					'description' => $general_email['description'],
+					'content'     => (string) file_get_contents( $this->template_directory . $template_filename ),
+					'post_types'  => $this->post_types,
+				)
+			);
+		}
 
 		do_action( 'mailpoet_email_editor_register_templates' );
 	}


### PR DESCRIPTION
## Description

Remove feature flag for the Gutenberg email editor 

## Code review notes

_N/A_

## QA notes

We can skip QA.

## Linked PRs

Related to https://github.com/mailpoet/mailpoet/pull/6018

## Linked tickets

[MAILPOET-6366](https://mailpoet.atlassian.net/browse/MAILPOET-6366)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6366]: https://mailpoet.atlassian.net/browse/MAILPOET-6366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:remove-feature-flag)

_The latest successful build from `remove-feature-flag` will be used. If none is available, the link won't work._