### PR TITLE
Use default WP Admin colours for Tags [MAILPOET-6409]

### DIFF
--- a/packages/js/email-editor/src/components/block-editor/index.scss
+++ b/packages/js/email-editor/src/components/block-editor/index.scss
@@ -171,11 +171,11 @@
 }
 
 [data-rich-text-comment] {
-  background-color: currentColor;
+  background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 
   span {
-    color: currentColor;
-    filter: invert(100%);
+    color: var(--wp-components-color-accent-inverted, #fff);
+    filter: none;
     padding: 0 2px;
   }
 }


### PR DESCRIPTION
## Description

In order to improve the readability we will use the default button colours from WordPress for Personalization Tags.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6409]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6409]: https://mailpoet.atlassian.net/browse/MAILPOET-6409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:personalization-tags-colour)

_The latest successful build from `personalization-tags-colour` will be used. If none is available, the link won't work._