### PR TITLE
Switching to @wordpress/edit-site to fix incompatibility issues with Jetpack - MAILPOET-6410

### DIFF
--- a/packages/js/email-editor/src/private-apis/index.ts
+++ b/packages/js/email-editor/src/private-apis/index.ts
@@ -11,7 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-	'@wordpress/edit-post' // The module name must be in the list of allowed, so for now I used the package name of the post editor
+	'@wordpress/edit-site' // The module name must be in the list of allowed, so for now I used the package name of the post editor
 );
 
 /**


### PR DESCRIPTION

## Description

Switching to @wordpress/edit-site to fix incompatibility issues with Jetpack

Jetpack and Woo seem to prefer using `@wordpress/edit-site` to access the lock-unlock API.

## Code review notes

* Install Jetpack and a different version of MailPoet
* Enable the Gutenberg block editor 
* Try to create or edit a Newsletter using the block editor
* Notice a blank screen, check browser console for errors
* Install the release zip from this PR and test again

## QA notes

We can skip QA

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6410](https://mailpoet.atlassian.net/browse/MAILPOET-6410)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6410]: https://mailpoet.atlassian.net/browse/MAILPOET-6410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-issues-with-jetpack)

_The latest successful build from `fix-issues-with-jetpack` will be used. If none is available, the link won't work._