### PR TITLE
Email editor - replace shortcodes with personalization tags [MAILPOET-6393]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
@@ -73,7 +73,7 @@ class Newsletter {
               padding-top: var(--wp--preset--spacing--20);
               padding-bottom: var(--wp--preset--spacing--20);
             "
-              >' . $footerText . '<br /><a href="[link:subscription_unsubscribe_url]">' . __('Unsubscribe', 'mailpoet') . '</a> | <a href="[link:subscription_manage_url]">' . __('Manage subscription', 'mailpoet') . '</a>
+              >' . $footerText . '<br /><a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">' . __('Unsubscribe', 'mailpoet') . '</a> | <a data-link-href="[mailpoet/subscription-manage-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">' . __('Manage subscription', 'mailpoet') . '</a>
           </p>
           <!-- /wp:paragraph -->
         </div>

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -36,8 +36,7 @@ class EmailTemplatesCest {
     $i->wait(1); // we need to wait for the iframe to initialize otherwise the switch does not work properly
     $i->switchToIFrame('[name="editor-canvas"]');
     $i->waitForElementVisible('.is-root-container', 20);
-    $i->click('[aria-label="Block: Paragraph"]');
-    $i->type($textInTemplate);
+    $i->pressKey('[aria-label="Block: Paragraph"]', $textInTemplate);
     $i->switchToIFrame();
 
     $i->wantTo('Return to editor and save all');

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -33,7 +33,7 @@ import { SaveEmailButton } from './save-email-button';
 import { CampaignName } from './campaign-name';
 import { SendButton } from './send-button';
 import { SaveAllButton } from './save-all-button';
-import { useEditorMode } from '../../hooks';
+import { useContentValidation, useEditorMode } from '../../hooks';
 import { recordEvent } from '../../events';
 
 // Build type for ToolbarItem contains only "as" and "children" properties but it takes all props from
@@ -90,6 +90,7 @@ export function Header() {
 	}, [] );
 
 	const [ editorMode ] = useEditorMode();
+	const { validateContent, isInvalid } = useContentValidation();
 
 	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
 	const hasNonEmailEdits = dirtyEntityRecords.some(
@@ -236,7 +237,14 @@ export function Header() {
 			<div className="editor-header__settings edit-post-header__settings">
 				<SaveEmailButton />
 				<PreviewDropdown />
-				{ hasNonEmailEdits ? <SaveAllButton /> : <SendButton /> }
+				{ hasNonEmailEdits ? (
+					<SaveAllButton />
+				) : (
+					<SendButton
+						validateContent={ validateContent }
+						isContentInvalid={ isInvalid }
+					/>
+				) }
 				<PinnedItems.Slot scope={ storeName } />
 				<MoreMenu />
 			</div>

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -7,10 +7,10 @@ import {
 import { useEntityProp } from '@wordpress/core-data';
 import { MailPoetEmailData, storeName } from '../../store';
 import { useSelect } from '@wordpress/data';
-import { useContentValidation, useEditorMode } from '../../hooks';
+import { useEditorMode } from '../../hooks';
 import { recordEvent } from '../../events';
 
-export function SendButton() {
+export function SendButton( { validateContent, isContentInvalid } ) {
 	const [ mailpoetEmail ] = useEntityProp(
 		'postType',
 		'mailpoet_email',
@@ -19,7 +19,6 @@ export function SendButton() {
 
 	const { isDirty } = useEntitiesSavedStatesIsDirty();
 
-	const { validateContent, isValid } = useContentValidation();
 	const { hasEmptyContent, isEmailSent } = useSelect(
 		( select ) => ( {
 			hasEmptyContent: select( storeName ).hasEmptyContent(),
@@ -34,7 +33,7 @@ export function SendButton() {
 		editorMode === 'template' ||
 		hasEmptyContent ||
 		isEmailSent ||
-		isValid ||
+		isContentInvalid ||
 		isDirty;
 
 	const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -38,9 +38,9 @@ export const useContentValidation = (): ContentValidationData => {
 			editedContent:
 				mapSelect( emailEditorStore ).getEditedEmailContent(),
 			editedTemplateContent:
-				mapSelect( emailEditorStore ).getTemplateContent(),
+				mapSelect( emailEditorStore ).getCurrentTemplate()?.content,
 			postTemplateId:
-				mapSelect( emailEditorStore ).getEditedPostTemplate()?.id,
+				mapSelect( emailEditorStore ).getCurrentTemplate()?.id,
 		} )
 	);
 

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -9,7 +9,7 @@ import { useShallowEqual } from './use-shallow-equal';
 import { useValidationNotices } from './use-validation-notices';
 
 export type ContentValidationData = {
-	isValid: boolean;
+	isInvalid: boolean;
 	validateContent: () => boolean;
 };
 
@@ -141,7 +141,7 @@ export const useContentValidation = (): ContentValidationData => {
 	}, emailEditorStore );
 
 	return {
-		isValid: hasValidationNotice(),
+		isInvalid: hasValidationNotice(),
 		validateContent,
 	};
 };

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -38,7 +38,7 @@ export const useContentValidation = (): ContentValidationData => {
 			editedContent:
 				mapSelect( emailEditorStore ).getEditedEmailContent(),
 			editedTemplateContent:
-				mapSelect( emailEditorStore ).getCurrentTemplate()?.content,
+				mapSelect( emailEditorStore ).getCurrentTemplateContent(),
 			postTemplateId:
 				mapSelect( emailEditorStore ).getCurrentTemplate()?.id,
 		} )

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -68,7 +68,7 @@ export const useContentValidation = (): ContentValidationData => {
 				id: 'missing-unsubscribe-link',
 				test: ( emailContent ) =>
 					! emailContent.includes(
-						'[link:subscription_unsubscribe_url]'
+						'[mailpoet/subscription-unsubscribe-url]'
 					),
 				message: __(
 					'All emails must include an "Unsubscribe" link.',

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -33,26 +33,24 @@ export const useContentValidation = (): ContentValidationData => {
 
 	const { addValidationNotice, hasValidationNotice, removeValidationNotice } =
 		useValidationNotices();
-	const { editedContent, editedTemplateContent, defaultTemplateId } =
-		useSelect( ( mapSelect ) => ( {
+	const { editedContent, editedTemplateContent, postTemplateId } = useSelect(
+		( mapSelect ) => ( {
 			editedContent:
 				mapSelect( emailEditorStore ).getEditedEmailContent(),
 			editedTemplateContent:
 				mapSelect( emailEditorStore ).getTemplateContent(),
-			defaultTemplateId: mapSelect( coreDataStore ).getDefaultTemplateId(
-				{
-					slug: 'email-general',
-				}
-			),
-		} ) );
+			postTemplateId:
+				mapSelect( emailEditorStore ).getEditedPostTemplate()?.id,
+		} )
+	);
 
 	const content = useShallowEqual( editedContent );
 	const templateContent = useShallowEqual( editedTemplateContent );
 
-	const contentLink = `<a href='[link:subscription_unsubscribe_url]'>${ __(
+	const contentLink = `<a data-link-href='[mailpoet/subscription-unsubscribe-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${ __(
 		'Unsubscribe',
 		'mailpoet'
-	) }</a> | <a href='[link:subscription_manage_url]'>${ __(
+	) }</a> | <a data-link-href='[mailpoet/subscription-manage-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${ __(
 		'Manage subscription',
 		'mailpoet'
 	) }</a>`;
@@ -88,7 +86,7 @@ export const useContentValidation = (): ContentValidationData => {
 								void dispatch( coreDataStore ).editEntityRecord(
 									'postType',
 									'wp_template',
-									defaultTemplateId,
+									postTemplateId,
 									{
 										content: `
                       ${ editedTemplateContent }
@@ -108,7 +106,7 @@ export const useContentValidation = (): ContentValidationData => {
 		contentBlockId,
 		hasFooter,
 		contentLink,
-		defaultTemplateId,
+		postTemplateId,
 		editedTemplateContent,
 	] );
 

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -57,7 +57,8 @@ export const useContentValidation = (): ContentValidationData => {
 
 	const rules = useMemo( () => {
 		const linksParagraphBlock = createBlock( 'core/paragraph', {
-			className: 'has-small-font-size',
+			align: 'center',
+			fontSize: 'small',
 			content: contentLink,
 		} );
 
@@ -90,7 +91,7 @@ export const useContentValidation = (): ContentValidationData => {
 									{
 										content: `
                       ${ editedTemplateContent }
-                      <!-- wp:paragraph -->
+                      <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
                       ${ contentLink }
                       <!-- /wp:paragraph -->
                     `,

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -82,3 +82,4 @@ We may add, update and delete any of them.
 - Fix the use of MailPoet vendor packages in the Email editor. We currently use `Emogrifier` and `Html2Text`.
 - Fix the Send button (button to send email) or redirect it elsewhere. It is currently pointing to the `mailpoet-newsletter` page.
 - We currently support post editing context (a post has to be created before we can use the editor). We need to add support for creation context.
+- The content validation in the editor looks for the unsubscribe link tag, which is registered in the MailPoet plugin. We need either introduce generic unsubscribe link tag or move the validation to the MailPoet plugin.


### PR DESCRIPTION
## Description

This PR replaces the old shortcodes in the "Newsletter" template with the new personalization tags and also updates the validation of the email content to look for the new tags instead of the old short codes.

When working on the ticket, I ran into a couple of issues with the validation notice and its action for inserting missing links. I addressed most of them, but there is still an issue that sometimes when switching between template and content mode, the insert link action stops working. I find it rather an edge case, and for time reasons, I didn't debug this further.

It seems that this change also fixes the issue with broken unsubscribe links in duplicated emails [MAILPOET-6395]

## Code review notes

_N/A_

## QA notes

- Please check that the unsubscribe links in the emails created via the new editor work as expected.
- Try deleting the unsubscribe link and sending email without it. You should see an error notice when clicking on the send button, and the "add link" action in the notice should insert the notice at the end of the document.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6393] , [MAILPOET-6395]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6393]: https://mailpoet.atlassian.net/browse/MAILPOET-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/replace-shortcodes)

_The latest successful build from `email-editor/replace-shortcodes` will be used. If none is available, the link won't work._

[MAILPOET-6395]: https://mailpoet.atlassian.net/browse/MAILPOET-6395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ