### PR TITLE
Improve CSS selectors for spacing inside columns and group blocks [MAILPOET-6364]

### DIFF
--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -30,22 +30,24 @@
  * This is needed because we disable layout for core/group, core/column and core/columns blocks, and .is-layout-flex is not applied.
  */
 .wp-block-columns:not(.is-not-stacked-on-mobile)
-	> .wp-block-column
-	> .wp-block:first-child,
-.wp-block-group > .wp-block:first-child {
+> .wp-block-column
+> .wp-block:not([aria-hidden="true"]):first-of-type,
+.wp-block-group > .wp-block:not([aria-hidden="true"]):first-of-type {
 	margin-top: 0;
 }
 
-.wp-block-columns:not(.is-not-stacked-on-mobile) > .wp-block-column > .wp-block,
-.wp-block-group > .wp-block {
+.wp-block-columns:not(.is-not-stacked-on-mobile)
+> .wp-block-column
+> .wp-block:not([aria-hidden="true"]),
+.wp-block-group > .wp-block:not([aria-hidden="true"]) {
 	margin-bottom: var(--wp--style--block-gap, 16px);
 	margin-top: var(--wp--style--block-gap, 16px);
 }
 
 .wp-block-columns:not(.is-not-stacked-on-mobile)
-	> .wp-block-column
-	> .wp-block:last-child,
-.wp-block-group > .wp-block:last-child {
+> .wp-block-column
+> .wp-block:not([aria-hidden="true"]):last-of-type,
+.wp-block-group > .wp-block:not([aria-hidden="true"]):last-of-type {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Description

The editor adds a hidden empty div with the class `wp-block`, which causes the issue. This PR makes our CSS selectors more specific to avoid making the last block inside a column/group block bigger when the last block is selected.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6364]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6364]: https://mailpoet.atlassian.net/browse/MAILPOET-6364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-jumping-selected-block)

_The latest successful build from `fix-jumping-selected-block` will be used. If none is available, the link won't work._