### PR TITLE
Email Editor - Remove font size styles from headings in email patterns [MAILPOET-6414]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/OneColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/OneColumn.php
@@ -13,8 +13,8 @@ class OneColumn extends Pattern {
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"fontSize":"large"} -->
-    <h2 class="wp-block-heading has-large-font-size">' . __('1 column layout', 'mailpoet') . '</h2>
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading -->
+    <h2 class="wp-block-heading">' . __('1 column layout', 'mailpoet') . '</h2>
     <!-- /wp:heading -->
 
     <!-- wp:paragraph -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ThreeColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ThreeColumn.php
@@ -12,8 +12,8 @@ class ThreeColumn extends Pattern {
 
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
-      <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"fontSize":"large"} -->
-      <h2 class="wp-block-heading has-large-font-size">' . __('3 column layout', 'mailpoet') . '</h2>
+      <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading -->
+      <h2 class="wp-block-heading">' . __('3 column layout', 'mailpoet') . '</h2>
       <!-- /wp:heading --></div>
       <!-- /wp:group -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TwoColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TwoColumn.php
@@ -12,8 +12,8 @@ class TwoColumn extends Pattern {
 
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
-      <div class="wp-block-group" style="padding-top:0;padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"fontSize":"large"} -->
-      <h2 class="wp-block-heading has-large-font-size">' . __('2 column layout', 'mailpoet') . '</h2>
+      <div class="wp-block-group" style="padding-top:0;padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading -->
+      <h2 class="wp-block-heading">' . __('2 column layout', 'mailpoet') . '</h2>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->
@@ -33,8 +33,8 @@ class TwoColumn extends Pattern {
       <!-- /wp:button --></div>
       <!-- /wp:buttons -->
 
-      <!-- wp:heading {"level":3,"fontSize":"large"} -->
-      <h3 class="wp-block-heading has-large-font-size">' . __('Heading', 'mailpoet') . '</h3>
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Heading', 'mailpoet') . '</h3>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph -->


### PR DESCRIPTION
## Description

This PR removes the font size set on heading blocks in the email content patterns. When the styles are present, the global heading size setting has no effect.

## Code review notes

_N/A_

## QA notes

We can skip QA for this one.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6414]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/fix-patterns-headings)

_The latest successful build from `email-editor/fix-patterns-headings` will be used. If none is available, the link won't work._

[MAILPOET-6414]: https://mailpoet.atlassian.net/browse/MAILPOET-6414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ