### PR TITLE
Remove default align center from group block [MAILPOET-6412]

### DIFF
--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-group.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-group.php
@@ -85,14 +85,13 @@ class Group extends Abstract_Block_Renderer {
 		)['declarations'];
 
 		$table_styles['background-size'] = empty( $table_styles['background-size'] ) ? 'cover' : $table_styles['background-size'];
-		$justify_content                 = $block_attributes['layout']['justifyContent'] ?? 'center';
 		$width                           = $parsed_block['email_attrs']['width'] ?? '100%';
 
 		return sprintf(
-			'<table class="email-block-group %3$s" style="%1$s" width="100%%" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+			'<table class="email-block-group %3$s" style="%1$s" width="100%%" border="0" cellpadding="0" cellspacing="0" role="presentation">
         <tbody>
           <tr>
-            <td class="email-block-group-content" style="%2$s" align="%4$s" width="%5$s">
+            <td class="email-block-group-content" style="%2$s" width="%4$s">
               {group_content}
             </td>
           </tr>
@@ -101,7 +100,6 @@ class Group extends Abstract_Block_Renderer {
 			esc_attr( WP_Style_Engine::compile_css( $table_styles, '' ) ),
 			esc_attr( WP_Style_Engine::compile_css( $cell_styles, '' ) ),
 			esc_attr( $original_classname ),
-			esc_attr( $justify_content ),
 			esc_attr( $width ),
 		);
 	}


### PR DESCRIPTION
## Description

Because the group block has deactivated layout settings in the email editor, content alignment cannot be configured. The default value center could break blocks inside the group. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6412]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6412]: https://mailpoet.atlassian.net/browse/MAILPOET-6412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:list-align-fix)

_The latest successful build from `list-align-fix` will be used. If none is available, the link won't work._