### PR TITLE
Enable h5 and h6 in the styles panel [MAILPOET-6411]

### DIFF
--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-typography-element.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-typography-element.tsx
@@ -102,6 +102,14 @@ export function ScreenTypographyElement( {
 							value="h4"
 							label={ _x( 'H4', 'Heading Level', 'mailpoet' ) }
 						/>
+						<ToggleGroupControlOption
+							value="h5"
+							label={ _x( 'H5', 'Heading Level', 'mailpoet' ) }
+						/>
+						<ToggleGroupControlOption
+							value="h6"
+							label={ _x( 'H6', 'Heading Level', 'mailpoet' ) }
+						/>
 					</ToggleGroupControl>
 				</Spacer>
 			) }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6411]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:heading-styles)

_The latest successful build from `heading-styles` will be used. If none is available, the link won't work._

[MAILPOET-6411]: https://mailpoet.atlassian.net/browse/MAILPOET-6411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ