### PR TITLE
Fix CSS selectors for spacing inside columns and group blocks [MAILPOET-6364]

### DIFF
--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -31,15 +31,15 @@
  */
 .wp-block-columns:not(.is-not-stacked-on-mobile)
 > .wp-block-column
-> .wp-block:not([aria-hidden="true"]):first-of-type,
-.wp-block-group > .wp-block:not([aria-hidden="true"]):first-of-type {
+> .wp-block:first-child,
+.wp-block-group > .wp-block:first-child {
 	margin-top: 0;
 }
 
 .wp-block-columns:not(.is-not-stacked-on-mobile)
 > .wp-block-column
-> .wp-block:not([aria-hidden="true"]),
-.wp-block-group > .wp-block:not([aria-hidden="true"]) {
+> .wp-block,
+.wp-block-group > .wp-block {
 	margin-bottom: var(--wp--style--block-gap, 16px);
 	margin-top: var(--wp--style--block-gap, 16px);
 }


### PR DESCRIPTION
## Description

The stricter conditions did not work correctly for the group block, and the default column patterns were broken.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/6034

## Linked tickets

[MAILPOET-6364]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6364]: https://mailpoet.atlassian.net/browse/MAILPOET-6364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:block-spacing-fix)

_The latest successful build from `block-spacing-fix` will be used. If none is available, the link won't work._