### PR TITLE
Make API key input password type with the option to reveal it [MAILPOET-6419]

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_settings.scss
+++ b/mailpoet/assets/css/src/components-plugin/_settings.scss
@@ -161,3 +161,7 @@ ul.sending-method-benefits {
 .mailpoet_install_premium_message {
   margin-bottom: $grid-gap-medium;
 }
+
+.mailpoet-verify-key-button {
+  height: 36px;
+}

--- a/mailpoet/assets/css/src/components-plugin/_settings.scss
+++ b/mailpoet/assets/css/src/components-plugin/_settings.scss
@@ -165,3 +165,8 @@ ul.sending-method-benefits {
 .mailpoet-verify-key-button {
   height: 36px;
 }
+
+.mailpoet-premium-key-toggle {
+  height: 34px;
+  padding: 0 10px !important;
+}

--- a/mailpoet/assets/js/src/common/premium-key/key-input.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-input.tsx
@@ -24,12 +24,11 @@ export function KeyInput({
       variant="tertiary"
       onClick={() => setIsRevealed(!isRevealed)}
     >
-      {
-        // translators: Used as a button to show or hide the premium key
-        isRevealed
-          ? _x('Hide', 'verb', 'mailpoet')
-          : _x('Show', 'verb', 'mailpoet')
-      }
+      {isRevealed
+        ? // translators: Used as a button to show or hide the premium key
+          _x('Hide', 'verb', 'mailpoet')
+        : // translators: Used as a button to show or hide the premium key
+          _x('Show', 'verb', 'mailpoet')}
     </Button>
   );
 

--- a/mailpoet/assets/js/src/common/premium-key/key-input.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-input.tsx
@@ -6,17 +6,19 @@ import { useState } from 'react';
 type KeyInputPropType = {
   placeholder?: string;
   isFullWidth?: boolean;
+  forceRevealed?: boolean;
 };
 
 export function KeyInput({
   placeholder,
   isFullWidth = false,
+  forceRevealed = false,
 }: KeyInputPropType) {
   const state = useSelector('getKeyActivationState')();
   const setState = useAction('updateKeyActivationState');
   const [isRevealed, setIsRevealed] = useState(false);
-  const inputType = isRevealed ? 'text' : 'password';
-  const toggleButton = (
+  const inputType = forceRevealed || isRevealed ? 'text' : 'password';
+  const toggleButton = !forceRevealed && (
     <Button
       className="mailpoet-premium-key-toggle"
       variant="tertiary"

--- a/mailpoet/assets/js/src/common/premium-key/key-input.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-input.tsx
@@ -1,5 +1,7 @@
-import { Input } from 'common/index';
+import { _x } from '@wordpress/i18n';
+import { Button, Input } from 'common/index';
 import { useAction, useSelector } from 'settings/store/hooks';
+import { useState } from 'react';
 
 type KeyInputPropType = {
   placeholder?: string;
@@ -12,10 +14,26 @@ export function KeyInput({
 }: KeyInputPropType) {
   const state = useSelector('getKeyActivationState')();
   const setState = useAction('updateKeyActivationState');
+  const [isRevealed, setIsRevealed] = useState(false);
+  const inputType = isRevealed ? 'text' : 'password';
+  const toggleButton = (
+    <Button
+      className="mailpoet-premium-key-toggle"
+      variant="tertiary"
+      onClick={() => setIsRevealed(!isRevealed)}
+    >
+      {
+        // translators: Used as a button to show or hide the premium key
+        isRevealed
+          ? _x('Hide', 'verb', 'mailpoet')
+          : _x('Show', 'verb', 'mailpoet')
+      }
+    </Button>
+  );
 
   return (
     <Input
-      type="text"
+      type={inputType}
       id="mailpoet_premium_key"
       name="premium[premium_key]"
       placeholder={placeholder}
@@ -29,6 +47,7 @@ export function KeyInput({
           key: event.target.value.trim() || null,
         })
       }
+      iconEnd={toggleButton}
     />
   );
 }

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/second-part.tsx
@@ -55,6 +55,7 @@ function MSSStepSecondPart(): JSX.Element {
             'welcomeWizardMSSSecondPartInputPlaceholder',
           )}
           isFullWidth
+          forceRevealed
         />
       </label>
 

--- a/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
+++ b/mailpoet/tests/acceptance/Settings/AddSendingKeyCest.php
@@ -20,6 +20,11 @@ class AddSendingKeyCest {
     $i->amOnMailPoetPage('Settings');
     $i->click($keyActivationTab);
     $i->fillField(['name' => 'premium[premium_key]'], $mailPoetSendingKey);
+    $i->seeElement('[name="premium[premium_key]"][type="password"]');
+    $i->dontSeeElement('[name="premium[premium_key]"][type="text"]');
+    $i->click('Show');
+    $i->seeElement('[name="premium[premium_key]"][type="text"]');
+    $i->dontSeeElement('[name="premium[premium_key]"][type="password"]');
     $i->click('Verify');
 
     // validate key, activate MSS, install & activate Premium plugin


### PR DESCRIPTION
## Description

This PR makes the API key input hidden by default (via `type="password"`) with the option to reveal it, e.g. to verify that a proper key is used).

<img width="984" alt="Screenshot 2025-01-11 at 23 03 25" src="https://github.com/user-attachments/assets/e0c3e1aa-ea6f-4f5a-a3f1-c738c614856d" />

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6419]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6419]: https://mailpoet.atlassian.net/browse/MAILPOET-6419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:api-key-input)

_The latest successful build from `api-key-input` will be used. If none is available, the link won't work._