### PR TITLE
Show deprecation warning when accessing Newsletter, SendingQueue, or Subscriber properties directly [MAILPOET-4160]

### DIFF
--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -207,12 +207,18 @@ class NewsletterEntity {
 
   /**
    * @deprecated This is here only for backward compatibility with custom shortcodes https://kb.mailpoet.com/article/160-create-a-custom-shortcode
-   * This can be removed after 2021-08-01
+   * This can be removed after 2026-01-01
    */
   public function __get($key) {
     $getterName = 'get' . Helpers::underscoreToCamelCase($key, $capitaliseFirstChar = true);
     $callable = [$this, $getterName];
     if (is_callable($callable)) {
+      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      trigger_error(
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- if the function is callable, it's safe to output
+        "Direct access to \$newsletter->{$key} is deprecated and will be removed after 2026-01-01. Use \$newsletter->{$getterName}() instead.",
+        E_USER_DEPRECATED
+      );
       return call_user_func($callable);
     }
   }

--- a/mailpoet/lib/Entities/SendingQueueEntity.php
+++ b/mailpoet/lib/Entities/SendingQueueEntity.php
@@ -86,12 +86,18 @@ class SendingQueueEntity {
 
   /**
    * @deprecated This is here only for backward compatibility with custom shortcodes https://kb.mailpoet.com/article/160-create-a-custom-shortcode
-   * This can be removed after 2021-08-01
+   * This can be removed after 2026-01-01
    */
   public function __get($key) {
     $getterName = 'get' . Helpers::underscoreToCamelCase($key, $capitaliseFirstChar = true);
     $callable = [$this, $getterName];
     if (is_callable($callable)) {
+      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      trigger_error(
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- if the function is callable, it's safe to output
+        "Direct access to \$sendingQueue->{$key} is deprecated and will be removed after 2026-01-01. Use \$sendingQueue->{$getterName}() instead.",
+        E_USER_DEPRECATED
+      );
       return call_user_func($callable);
     }
   }

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -232,12 +232,18 @@ class SubscriberEntity {
 
   /**
    * @deprecated This is here only for backward compatibility with custom shortcodes https://kb.mailpoet.com/article/160-create-a-custom-shortcode
-   * This can be removed after 2021-08-01
+   * This can be removed after 2026-01-01
    */
   public function __get($key) {
     $getterName = 'get' . Helpers::underscoreToCamelCase($key, $capitaliseFirstChar = true);
     $callable = [$this, $getterName];
     if (is_callable($callable)) {
+      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      trigger_error(
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- if the function is callable, it's safe to output
+        "Direct access to \$subscriber->{$key} is deprecated and will be removed after 2026-01-01. Use \$subscriber->{$getterName}() instead.",
+        E_USER_DEPRECATED
+      );
       return call_user_func($callable);
     }
   }

--- a/mailpoet/tests/unit/Entities/SubscriberEntityTest.php
+++ b/mailpoet/tests/unit/Entities/SubscriberEntityTest.php
@@ -9,6 +9,21 @@ class SubscriberEntityTest extends \MailPoetUnitTest {
     verify($subscriber->wp_user_id)->equals(4);// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
+  public function testMagicGetterThrowsDeprecationWarning() {
+    $expectedMessage = 'Direct access to $subscriber->wp_user_id is deprecated and will be removed after 2026-01-01. Use $subscriber->getWpUserId() instead.';
+    $caughtError = null;
+    set_error_handler(function ($errno, $errstr) use (&$caughtError) {
+      if ($errno === E_USER_DEPRECATED) {
+        $caughtError = $errstr;
+      }
+    });
+    $subscriber = new SubscriberEntity();
+    $subscriber->setWpUserId(4);
+    $subscriber->wp_user_id;// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    restore_error_handler();
+    verify($caughtError)->equals($expectedMessage);
+  }
+
   public function testMagicGetterReturnsNullForUnknown() {
     $subscriber = new SubscriberEntity();
     verify($subscriber->non_existing_property)->null();// phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps


### PR DESCRIPTION
## Description

Show deprecation warnings for the remaining three entities where magic getters are allowed. These will be removed in 2026.

## Code review notes

Related Slack convo - p1736166761885049-slack-C01GH835U90.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-4160]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-4160]: https://mailpoet.atlassian.net/browse/MAILPOET-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:deprecation-errors)

_The latest successful build from `deprecation-errors` will be used. If none is available, the link won't work._