### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 9.5.1
+            ./do download:woo-commerce-zip 9.5.2
             ./do download:woo-commerce-subscriptions-zip 7.0.0
             ./do download:woo-commerce-memberships-zip 1.26.5
             ./do download:automate-woo-zip 6.1.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           name: Download additional WP Plugins for tests
           command: |
             ./do download:woo-commerce-zip 9.5.2
-            ./do download:woo-commerce-subscriptions-zip 7.0.0
+            ./do download:woo-commerce-subscriptions-zip 7.1.0
             ./do download:woo-commerce-memberships-zip 1.26.5
             ./do download:automate-woo-zip 6.1.4
       - run:
@@ -1083,7 +1083,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_oldest
           woo_core_version: 9.4.3
-          woo_subscriptions_version: 6.9.1
+          woo_subscriptions_version: 7.0.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
@@ -1124,7 +1124,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           woo_core_version: 9.4.3
-          woo_subscriptions_version: 6.9.1
+          woo_subscriptions_version: 7.0.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
@@ -1187,7 +1187,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
           woo_core_version: 9.4.3
-          woo_subscriptions_version: 6.9.1
+          woo_subscriptions_version: 7.0.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
@@ -1199,7 +1199,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
           woo_core_version: 9.4.3
-          woo_subscriptions_version: 6.9.1
+          woo_subscriptions_version: 7.0.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._