### PR TITLE
Email Editor - Add feedback survey [MAILPOET-6418]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -296,4 +296,5 @@ interface Window {
     [key: string]: number;
   };
   mailpoet_block_email_editor_enabled: boolean;
+  satismeter: (action: string, data: Record<string, unknown>) => void;
 }

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -297,4 +297,5 @@ interface Window {
   };
   mailpoet_block_email_editor_enabled: boolean;
   satismeter: (action: string, data: Record<string, unknown>) => void;
+  mailpoet_display_nps_email_editor: boolean;
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.scss
@@ -24,3 +24,6 @@
 // Actual UI components.
 @import '../../../css/src/components-plugin/legacy-modal';
 @import '../../../css/src/components-plugin/review-request.scss';
+
+//Integration
+@import './integration';

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -4,11 +4,11 @@
 
 import { addFilter, addAction } from '@wordpress/hooks';
 import { MailPoet } from 'mailpoet';
-import { withNpsPoll } from '../nps-poll';
+import { withSatismeterSurvey } from './satismeter-survey';
 import './index.scss';
 
 addFilter('mailpoet_email_editor_wrap_editor_component', 'mailpoet', (editor) =>
-  withNpsPoll(editor),
+  withSatismeterSurvey(editor),
 );
 
 const EVENTS_TO_TRACK = [

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -1,0 +1,10 @@
+.mailpoet-editor-feedback-button {
+  bottom: 5px;
+  position: absolute;
+  right: 5px;
+}
+// To be able to scroll up a bit more in case the sidebar content is long button is displayed over it.
+.edit-post-sidebar {
+  box-sizing: border-box;
+  padding-bottom: 40px;
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
@@ -22,6 +22,12 @@ export function withSatismeterSurvey(Component) {
             return;
           }
           setSurveyAvailable(true);
+
+          // We want to show the survey immediately when there has been enough usage
+          if (window.mailpoet_display_nps_email_editor) {
+            window.mailpoet_display_nps_email_editor = false;
+            triggerSurvey();
+          }
         })
         // Survey may fail to initialize when 3rd party libs are not allowed. It is OK we don't need to react.
         .catch(() => {});

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { initializeSatismeterSurvey } from 'nps-poll';
 
@@ -7,6 +7,8 @@ const emailEditorSatismeterWriteId = '9qCj2SJBE1s5OhnX5NYfRXu82pEDUB9x';
 
 export function withSatismeterSurvey(Component) {
   return function WrappedBySurvey(props) {
+    const [surveyAvailable, setSurveyAvailable] = useState(false);
+
     const triggerSurvey = () => {
       // The survey is configured to open when we track the 'Request feedback' event
       window.satismeter('track', { event: 'Request feedback' });
@@ -14,19 +16,29 @@ export function withSatismeterSurvey(Component) {
 
     useLayoutEffect(() => {
       // Initialize Satismeter Survey for the email editor
-      initializeSatismeterSurvey(emailEditorSatismeterWriteId);
+      void initializeSatismeterSurvey(emailEditorSatismeterWriteId)
+        .then(() => {
+          if (!window.satismeter) {
+            return;
+          }
+          setSurveyAvailable(true);
+        })
+        // Survey may fail to initialize when 3rd party libs are not allowed. It is OK we don't need to react.
+        .catch(() => {});
     }, []);
 
     return (
       <>
         <Component {...props} />
-        <Button
-          isPrimary
-          style={{ position: 'absolute', right: '10px', bottom: '10px' }}
-          onClick={triggerSurvey}
-        >
-          {__('Share feedback', 'mailpoet')}
-        </Button>
+        {surveyAvailable && (
+          <Button
+            isPrimary
+            style={{ position: 'absolute', right: '10px', bottom: '10px' }}
+            onClick={triggerSurvey}
+          >
+            {__('Share feedback', 'mailpoet')}
+          </Button>
+        )}
       </>
     );
   };

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
@@ -1,3 +1,4 @@
+import { MailPoet } from 'mailpoet';
 import { Button } from '@wordpress/components';
 import { useLayoutEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -26,7 +27,16 @@ export function withSatismeterSurvey(Component) {
           // We want to show the survey immediately when there has been enough usage
           if (window.mailpoet_display_nps_email_editor) {
             window.mailpoet_display_nps_email_editor = false;
-            triggerSurvey();
+            void MailPoet.Ajax.post({
+              api_version: MailPoet.apiVersion,
+              endpoint: 'user_flags',
+              action: 'set',
+              data: {
+                email_editor_survey_seen: MailPoet.Date.toGmtDatetimeString(
+                  new Date(),
+                ),
+              },
+            }).then(triggerSurvey);
           }
         })
         // Survey may fail to initialize when 3rd party libs are not allowed. It is OK we don't need to react.

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@wordpress/components';
+import { useLayoutEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { initializeSatismeterSurvey } from 'nps-poll';
+
+const emailEditorSatismeterWriteId = '9qCj2SJBE1s5OhnX5NYfRXu82pEDUB9x';
+
+export function withSatismeterSurvey(Component) {
+  return function WrappedBySurvey(props) {
+    const triggerSurvey = () => {
+      // The survey is configured to open when we track the 'Request feedback' event
+      window.satismeter('track', { event: 'Request feedback' });
+    };
+
+    useLayoutEffect(() => {
+      // Initialize Satismeter Survey for the email editor
+      initializeSatismeterSurvey(emailEditorSatismeterWriteId);
+    }, []);
+
+    return (
+      <>
+        <Component {...props} />
+        <Button
+          isPrimary
+          style={{ position: 'absolute', right: '10px', bottom: '10px' }}
+          onClick={triggerSurvey}
+        >
+          {__('Share feedback', 'mailpoet')}
+        </Button>
+      </>
+    );
+  };
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/satismeter-survey.tsx
@@ -1,6 +1,7 @@
 import { MailPoet } from 'mailpoet';
 import { Button } from '@wordpress/components';
 import { useLayoutEffect, useState } from '@wordpress/element';
+import { commentContent } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { initializeSatismeterSurvey } from 'nps-poll';
 
@@ -48,8 +49,9 @@ export function withSatismeterSurvey(Component) {
         <Component {...props} />
         {surveyAvailable && (
           <Button
-            isPrimary
-            style={{ position: 'absolute', right: '10px', bottom: '10px' }}
+            icon={commentContent}
+            variant="tertiary"
+            className="mailpoet-editor-feedback-button"
             onClick={triggerSurvey}
           >
             {__('Share feedback', 'mailpoet')}

--- a/mailpoet/assets/js/src/nps-poll.jsx
+++ b/mailpoet/assets/js/src/nps-poll.jsx
@@ -5,7 +5,7 @@ import satismeter from 'satismeter-loader';
 import { ReviewRequest } from 'review-request';
 import { getTrackingData } from 'analytics.js';
 
-export const initializeSatismeterSurvey = () => {
+export const initializeSatismeterSurvey = (writeId = null) => {
   const showReviewRequestModal = () => {
     MailPoet.Modal.popup({
       width: 800,
@@ -27,14 +27,13 @@ export const initializeSatismeterSurvey = () => {
     });
   };
 
-  const callSatismeter = (trackingData) => {
+  const callSatismeter = (trackingData, customWriteId) => {
     const newUsersPollId = '6L479eVPXk7pBn6S';
     const oldUsersPollId = 'k0aJAsQAWI2ERyGv';
     const formPollId = 'EqOgKsgZd832Sz9w';
-    const emailEditorPollId = '9qCj2SJBE1s5OhnX5NYfRXu82pEDUB9x';
     let writeKey;
-    if (window.mailpoet_display_nps_email_editor) {
-      writeKey = emailEditorPollId;
+    if (customWriteId) {
+      writeKey = customWriteId;
     } else if (window.mailpoet_display_nps_form) {
       writeKey = formPollId;
     } else if (window.mailpoet_is_new_user) {
@@ -74,7 +73,7 @@ export const initializeSatismeterSurvey = () => {
     window.mailpoet_display_nps_poll &&
     window.mailpoet_3rd_party_libs_enabled
   ) {
-    getTrackingData().then(({ data }) => callSatismeter(data));
+    getTrackingData().then(({ data }) => callSatismeter(data, writeId));
   }
 };
 

--- a/mailpoet/assets/js/src/nps-poll.jsx
+++ b/mailpoet/assets/js/src/nps-poll.jsx
@@ -5,78 +5,82 @@ import satismeter from 'satismeter-loader';
 import { ReviewRequest } from 'review-request';
 import { getTrackingData } from 'analytics.js';
 
+export const initializeSatismeterSurvey = () => {
+  const showReviewRequestModal = () => {
+    MailPoet.Modal.popup({
+      width: 800,
+      template: ReactDOMServer.renderToString(
+        ReviewRequest({
+          username:
+            window.mailpoet_current_wp_user_firstname ||
+            window.mailpoet_current_wp_user.user_login,
+          reviewRequestIllustrationUrl:
+            window.mailpoet_review_request_illustration_url,
+          installedDaysAgo: window.mailpoet_installed_days_ago,
+        }),
+      ),
+      onInit: () => {
+        document
+          .getElementById('mailpoet_review_request_not_now')
+          .addEventListener('click', () => MailPoet.Modal.close());
+      },
+    });
+  };
+
+  const callSatismeter = (trackingData) => {
+    const newUsersPollId = '6L479eVPXk7pBn6S';
+    const oldUsersPollId = 'k0aJAsQAWI2ERyGv';
+    const formPollId = 'EqOgKsgZd832Sz9w';
+    const emailEditorPollId = '9qCj2SJBE1s5OhnX5NYfRXu82pEDUB9x';
+    let writeKey;
+    if (window.mailpoet_display_nps_email_editor) {
+      writeKey = emailEditorPollId;
+    } else if (window.mailpoet_display_nps_form) {
+      writeKey = formPollId;
+    } else if (window.mailpoet_is_new_user) {
+      writeKey = newUsersPollId;
+    } else {
+      writeKey = oldUsersPollId;
+    }
+    satismeter({
+      writeKey,
+      userId: window.mailpoet_current_wp_user.ID + window.mailpoet_site_url,
+      traits: {
+        name: window.mailpoet_current_wp_user.user_nicename,
+        email: window.mailpoet_current_wp_user.user_email,
+        mailpoetVersion: window.mailpoet_version,
+        mailpoetPremiumIsActive: window.mailpoet_premium_active,
+        createdAt: trackingData.installedAtIso,
+        newslettersSent: trackingData.newslettersSent,
+        welcomeEmails: trackingData.welcomeEmails,
+        postnotificationEmails: trackingData.postnotificationEmails,
+        woocommerceEmails: trackingData.woocommerceEmails,
+        subscribers: trackingData.subscribers,
+        lists: trackingData.lists,
+        sendingMethod: trackingData.sendingMethod,
+        woocommerceIsInstalled: trackingData.woocommerceIsInstalled,
+      },
+      events: {
+        submit: (response) => {
+          if (response.rating >= 9 && response.completed) {
+            showReviewRequestModal();
+          }
+        },
+      },
+    });
+  };
+
+  if (
+    window.mailpoet_display_nps_poll &&
+    window.mailpoet_3rd_party_libs_enabled
+  ) {
+    getTrackingData().then(({ data }) => callSatismeter(data));
+  }
+};
+
 const useNpsPoll = () => {
   useLayoutEffect(() => {
-    const showReviewRequestModal = () => {
-      MailPoet.Modal.popup({
-        width: 800,
-        template: ReactDOMServer.renderToString(
-          ReviewRequest({
-            username:
-              window.mailpoet_current_wp_user_firstname ||
-              window.mailpoet_current_wp_user.user_login,
-            reviewRequestIllustrationUrl:
-              window.mailpoet_review_request_illustration_url,
-            installedDaysAgo: window.mailpoet_installed_days_ago,
-          }),
-        ),
-        onInit: () => {
-          document
-            .getElementById('mailpoet_review_request_not_now')
-            .addEventListener('click', () => MailPoet.Modal.close());
-        },
-      });
-    };
-
-    const callSatismeter = (trackingData) => {
-      const newUsersPollId = '6L479eVPXk7pBn6S';
-      const oldUsersPollId = 'k0aJAsQAWI2ERyGv';
-      const formPollId = 'EqOgKsgZd832Sz9w';
-      const emailEditorPollId = '9qCj2SJBE1s5OhnX5NYfRXu82pEDUB9x';
-      let writeKey;
-      if (window.mailpoet_display_nps_email_editor) {
-        writeKey = emailEditorPollId;
-      } else if (window.mailpoet_display_nps_form) {
-        writeKey = formPollId;
-      } else if (window.mailpoet_is_new_user) {
-        writeKey = newUsersPollId;
-      } else {
-        writeKey = oldUsersPollId;
-      }
-      satismeter({
-        writeKey,
-        userId: window.mailpoet_current_wp_user.ID + window.mailpoet_site_url,
-        traits: {
-          name: window.mailpoet_current_wp_user.user_nicename,
-          email: window.mailpoet_current_wp_user.user_email,
-          mailpoetVersion: window.mailpoet_version,
-          mailpoetPremiumIsActive: window.mailpoet_premium_active,
-          createdAt: trackingData.installedAtIso,
-          newslettersSent: trackingData.newslettersSent,
-          welcomeEmails: trackingData.welcomeEmails,
-          postnotificationEmails: trackingData.postnotificationEmails,
-          woocommerceEmails: trackingData.woocommerceEmails,
-          subscribers: trackingData.subscribers,
-          lists: trackingData.lists,
-          sendingMethod: trackingData.sendingMethod,
-          woocommerceIsInstalled: trackingData.woocommerceIsInstalled,
-        },
-        events: {
-          submit: (response) => {
-            if (response.rating >= 9 && response.completed) {
-              showReviewRequestModal();
-            }
-          },
-        },
-      });
-    };
-
-    if (
-      window.mailpoet_display_nps_poll &&
-      window.mailpoet_3rd_party_libs_enabled
-    ) {
-      getTrackingData().then(({ data }) => callSatismeter(data));
-    }
+    initializeSatismeterSurvey();
   }, []);
 
   return null;

--- a/mailpoet/assets/js/src/nps-poll.jsx
+++ b/mailpoet/assets/js/src/nps-poll.jsx
@@ -69,17 +69,25 @@ export const initializeSatismeterSurvey = (writeId = null) => {
     });
   };
 
-  if (
-    window.mailpoet_display_nps_poll &&
-    window.mailpoet_3rd_party_libs_enabled
-  ) {
-    getTrackingData().then(({ data }) => callSatismeter(data, writeId));
-  }
+  return new Promise((resolve, reject) => {
+    if (
+      window.mailpoet_display_nps_poll &&
+      window.mailpoet_3rd_party_libs_enabled
+    ) {
+      getTrackingData().then(({ data }) => {
+        callSatismeter(data, writeId);
+        resolve();
+      });
+    } else {
+      reject();
+    }
+  });
 };
 
 const useNpsPoll = () => {
   useLayoutEffect(() => {
-    initializeSatismeterSurvey();
+    // Survey may fail to initialize when 3rd party libs are not allowed. It is OK. We don't need to react.
+    initializeSatismeterSurvey().catch(() => {});
   }, []);
 
   return null;

--- a/mailpoet/lib/Settings/UserFlagsController.php
+++ b/mailpoet/lib/Settings/UserFlagsController.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\UserFlagEntity;
 use MailPoet\WP\Functions as WPFunctions;
 
 class UserFlagsController {
+  const EMAIL_EDITOR_SURVEY = 'email_editor_survey_seen';
 
   /** @var array|null */
   private $data = null;
@@ -26,6 +27,7 @@ class UserFlagsController {
       'transactional_emails_opt_in_notice_dismissed' => false,
       'legacy_automations_notice_dismissed' => false,
       'legacy_automatic_emails_notice_dismissed' => false,
+      self::EMAIL_EDITOR_SURVEY => null,
     ];
     $this->userFlagsRepository = $userFlagsRepository;
   }


### PR DESCRIPTION
## Description

This PR adds a feedback button to the email editor. The button triggers a Satismeter survey. It also refactors the mechanism for automatically displaying the survey to users who have two or more emails.

#### Share feedback button displayed in the bottom right corner
![Screenshot 2025-01-13 at 10 23 09](https://github.com/user-attachments/assets/8b335e0b-8ee8-4485-ab8a-d71ec5ff53ea)
#### Feedback form is displayed in the bottom center of the page
![Screenshot 2025-01-13 at 10 24 31](https://github.com/user-attachments/assets/36725bc1-43d2-4d9e-8561-6d67447b9b5f)


## Code review notes

- To make things easier, I chose not to add any extension points to the editor package but created a component that wraps the editor in the plugin integration code.
- The Satismeter controls displaying the survey via API. The only way I found to display the survey manually is by [configuring it to display on user event](https://support.satismeter.com/hc/en-us/articles/6980449391891-User-events).
- To be able to use the same survey for the feedback button and automatic survey, I used MailPoet's user flags mechanism to track whether the automatic survey was displayed.
- The button is placed absolutely. It may be displayed over some content in the right sidebar. I added additional padding to the sidebar so that the user is able to scroll all the content above the button. 


## QA notes

- Please verify that the automatic Satismeter survey works as expected
  - It should display to users who have two or more emails created via the new editor
  - It should display only once
  - It requires MailPoet > Settings > Load 3rd-party libraries to be set to true
- Please verify that the feedback button works as expected
  -  It requires MailPoet > Settings > Load 3rd-party libraries to be set to true to display
  - A user can submit multiple feedback via the button 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6418]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6418]: https://mailpoet.atlassian.net/browse/MAILPOET-6418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-feedback-survey)

_The latest successful build from `add-feedback-survey` will be used. If none is available, the link won't work._