### PR TITLE
Fix misaligned opt-in checkbox on block checkout [MAILPOET-6436]

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -39,13 +39,13 @@ interface JQuery {
 declare module '@woocommerce/blocks-checkout' {
   type CheckboxControlProps = {
     className?: string;
-    label?: string;
+    label?: string | React.ReactNode;
     id?: string;
-    instanceId?: string;
-    onChange?: (value: boolean) => void;
-    children?: React.ReactChildren | React.ReactElement;
+    onChange: (value: boolean) => void;
+    children?: React.ReactChildren;
     hasError?: boolean;
     checked?: boolean;
+    disabled?: string | boolean | undefined;
   };
   export const CheckboxControl: (props: CheckboxControlProps) => JSX.Element;
 }

--- a/mailpoet/assets/js/src/marketing-optin-block/block.tsx
+++ b/mailpoet/assets/js/src/marketing-optin-block/block.tsx
@@ -30,8 +30,10 @@ export function FrontendBlock({
   }
 
   return (
-    <CheckboxControl checked={checked} onChange={setChecked}>
-      <RawHTML>{text || defaultText}</RawHTML>
-    </CheckboxControl>
+    <CheckboxControl
+      checked={checked}
+      onChange={setChecked}
+      label={<RawHTML>{text || defaultText}</RawHTML>}
+    />
   );
 }

--- a/mailpoet/assets/js/src/marketing-optin-block/edit.tsx
+++ b/mailpoet/assets/js/src/marketing-optin-block/edit.tsx
@@ -56,7 +56,11 @@ export function Edit({
     <div {...blockProps}>
       {optinEnabled ? (
         <div className="wc-block-checkout__marketing">
-          <CheckboxControl id="mailpoet-marketing-optin" checked={false} />
+          <CheckboxControl
+            id="mailpoet-marketing-optin"
+            checked={false}
+            onChange={() => {}}
+          />
           <RichText
             value={currentText}
             onChange={(value) => setAttributes({ text: value })}


### PR DESCRIPTION
## Description

Fixes opt-in checkbox's label not vertically centered with the checkbox. 

![Captura de pantalla de 2025-01-14 16-43-31](https://github.com/user-attachments/assets/89f13fa2-6753-4cc1-b5bd-ff786ee9df65)

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6436]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6436]: https://mailpoet.atlassian.net/browse/MAILPOET-6436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:block-checkout-optin-alignment)

_The latest successful build from `block-checkout-optin-alignment` will be used. If none is available, the link won't work._