### PR TITLE
Email editor - add @woocommerce/eslint-plugin [MAILPOET-6438]

### DIFF
--- a/packages/js/email-editor/.eslintrc.js
+++ b/packages/js/email-editor/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 			files: [ '**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx' ],
 			rules: {
 				'react/react-in-jsx-scope': 'off',
+				'@wordpress/no-unsafe-wp-apis': 'off',
 				'@wordpress/i18n-text-domain': [
 					'error',
 					{

--- a/packages/js/email-editor/.eslintrc.js
+++ b/packages/js/email-editor/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
+	overrides: [
+		{
+			files: [ '**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx' ],
+			rules: {
+				'react/react-in-jsx-scope': 'off',
+			},
+		},
+	],
+};

--- a/packages/js/email-editor/.eslintrc.js
+++ b/packages/js/email-editor/.eslintrc.js
@@ -5,6 +5,12 @@ module.exports = {
 			files: [ '**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx' ],
 			rules: {
 				'react/react-in-jsx-scope': 'off',
+				'@wordpress/i18n-text-domain': [
+					'error',
+					{
+						allowedTextDomain: [ 'mailpoet' ],
+					},
+				],
 			},
 		},
 	],

--- a/packages/js/email-editor/package.json
+++ b/packages/js/email-editor/package.json
@@ -69,9 +69,11 @@
 		"@types/wordpress__edit-post": "^7.5.7",
 		"@types/wordpress__editor": "^13.6.8",
 		"@types/wordpress__media-utils": "^4.14.4",
+		"@woocommerce/eslint-plugin": "^2.3.0",
 		"@wordpress/prettier-config": "^4.11.0",
 		"@wordpress/scripts": "27.9.0",
 		"core-js": "^3.37.1",
+		"eslint-import-resolver-typescript": "^3.7.0",
 		"prettier": "npm:wp-prettier@^3.0.3",
 		"wp-types": "^3.65.0"
 	},

--- a/packages/js/email-editor/src/blocks/core/button.ts
+++ b/packages/js/email-editor/src/blocks/core/button.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { addFilter } from '@wordpress/hooks';
 import { Block } from '@wordpress/blocks/index';
 

--- a/packages/js/email-editor/src/blocks/core/buttons.ts
+++ b/packages/js/email-editor/src/blocks/core/buttons.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { addFilter } from '@wordpress/hooks';
 import { Block } from '@wordpress/blocks/index';
 

--- a/packages/js/email-editor/src/blocks/core/column.ts
+++ b/packages/js/email-editor/src/blocks/core/column.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { addFilter } from '@wordpress/hooks';
 import { Block } from '@wordpress/blocks/index';
 

--- a/packages/js/email-editor/src/blocks/core/columns.tsx
+++ b/packages/js/email-editor/src/blocks/core/columns.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Block } from '@wordpress/blocks/index';

--- a/packages/js/email-editor/src/blocks/core/general-block-support.ts
+++ b/packages/js/email-editor/src/blocks/core/general-block-support.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { addFilter } from '@wordpress/hooks';
 import {
 	Block as WPBlock,

--- a/packages/js/email-editor/src/blocks/core/group.tsx
+++ b/packages/js/email-editor/src/blocks/core/group.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { addFilter } from '@wordpress/hooks';
 
 /**

--- a/packages/js/email-editor/src/blocks/core/image.tsx
+++ b/packages/js/email-editor/src/blocks/core/image.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';

--- a/packages/js/email-editor/src/blocks/core/post-content.tsx
+++ b/packages/js/email-editor/src/blocks/core/post-content.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { addFilter } from '@wordpress/hooks';
 import { Block } from '@wordpress/blocks/index';
 import { __ } from '@wordpress/i18n';

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import {
 	registerFormatType,
 	unregisterFormatType,
@@ -10,16 +13,20 @@ import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import * as React from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import {
 	getCursorPosition,
 	replacePersonalizationTagsWithHTMLComments,
 } from '../../components/personalization-tags/rich-text-utils';
 import { PersonalizationTagsModal } from '../../components/personalization-tags/personalization-tags-modal';
-import { useCallback, useState } from '@wordpress/element';
-import { addFilter } from '@wordpress/hooks';
-import * as React from 'react';
 import { storeName } from '../../store';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { PersonalizationTagsPopover } from '../../components/personalization-tags/personalization-tags-popover';
 import { PersonalizationTagsLinkPopover } from '../../components/personalization-tags/personalization-tags-link-popover';
 import { recordEvent } from '../../events';

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -67,7 +67,7 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 	// Get the current block content
 	const blockContent: string = useSelect( ( select ) => {
 		const attributes =
-			// @ts-ignore
+			// @ts-expect-error getBlockAttributes expects one argument, but TS thinks it expects none
 			select( 'core/block-editor' ).getBlockAttributes( selectedBlockId );
 		return attributes?.content?.originalHTML || attributes?.content || ''; // After first saving the content does not have property originalHTML, so we need to check for content as well
 	} );

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -90,7 +90,7 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 					richTextValue,
 					{
 						type: 'mailpoet-email-editor/link-shortcode',
-						// @ts-expect-error
+						// @ts-expect-error attributes property is missing in build type for WPFormat type
 						attributes: {
 							'data-link-href': tag,
 							contenteditable: 'false',
@@ -193,7 +193,7 @@ function extendRichTextFormats() {
 		title: __( 'Personalization Tags', 'mailpoet' ),
 		className: 'mailpoet-email-editor-personalization-tags',
 		tagName: 'span',
-		// @ts-expect-error
+		// @ts-expect-error attributes property is missing in build type for WPFormat type
 		attributes: {},
 		edit: PersonalizationTagsButton,
 	} );
@@ -204,7 +204,7 @@ function extendRichTextFormats() {
 		title: __( 'Personalization Tags Link', 'mailpoet' ),
 		className: 'mailpoet-email-editor__personalization-tags-link',
 		tagName: 'a',
-		// @ts-expect-error
+		// @ts-expect-error attributes property is missing in build type for WPFormat type
 		attributes: {
 			'data-link-href': 'data-link-href',
 			contenteditable: 'contenteditable',

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
 import { enhanceColumnBlock } from './core/column';
 import {
 	disableColumnsLayout,

--- a/packages/js/email-editor/src/components/autosave/autosave-monitor.tsx
+++ b/packages/js/email-editor/src/components/autosave/autosave-monitor.tsx
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useSelect } from '@wordpress/data';
 import {
@@ -13,16 +13,12 @@ import { store as coreStore } from '@wordpress/core-data';
 import { Post } from '@wordpress/core-data/build-types/entity-types/post';
 
 /**
- * WordPress private dependencies
- */
-import { unlockPatternsRelatedSelectorsFromCoreStore } from '../../private-apis';
-
-/**
  * Internal dependencies
  */
 import { storeName } from '../../store';
 import { Layout } from './layout';
 import { useNavigateToEntityRecord } from '../../hooks/use-navigate-to-entity-record';
+import { unlockPatternsRelatedSelectorsFromCoreStore } from '../../private-apis';
 
 export function InnerEditor( {
 	postId: initialPostId,

--- a/packages/js/email-editor/src/components/block-editor/layout.tsx
+++ b/packages/js/email-editor/src/components/block-editor/layout.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { BlockSelectionClearer } from '@wordpress/block-editor';
 import { store as editorStore, UnsavedChangesWarning } from '@wordpress/editor';
 import { uploadMedia } from '@wordpress/media-utils';
@@ -9,9 +12,12 @@ import {
 	InterfaceSkeleton,
 } from '@wordpress/interface';
 import { useRef } from '@wordpress/element';
-
-import './index.scss';
 import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
 import { storeName } from '../../store';
 import { useEmailCss } from '../../hooks';
 import { AutosaveMonitor } from '../autosave';

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -7,6 +7,10 @@ import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { recordEvent, recordEventOnce } from '../../../events'; // eslint-disable-line
 
 /**

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
@@ -5,7 +5,6 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-// eslint-disable-next-line
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 
 /**

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
@@ -35,7 +35,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 		return {
 			// onNavigateToEntityRecord is missing in EditorSettings.
 			// prettier-ignore
-			onNavigateToEntityRecord: // @ts-expect-error
+			onNavigateToEntityRecord: // @ts-expect-error onNavigateToEntityRecord is not typed on EditorSettings.
 				getEditorSettings().onNavigateToEntityRecord,
 			templateId: getCurrentTemplateId(),
 		};

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/edit-template-blocks-notification.tsx
@@ -62,7 +62,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 	return (
 		<ConfirmDialog
 			isOpen={ isDialogOpen }
-			confirmButtonText={ __( 'Edit template' ) }
+			confirmButtonText={ __( 'Edit template', 'mailpoet' ) }
 			onConfirm={ () => {
 				setIsDialogOpen( false );
 				onNavigateToEntityRecord( {

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/use-select-nearest-editable-block.ts
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/use-select-nearest-editable-block.ts
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/visual-editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/visual-editor.tsx
@@ -1,7 +1,11 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import classnames from 'classnames';
+import { useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useMergeRefs } from '@wordpress/compose';
+import { store as editorStore } from '@wordpress/editor';
 import {
 	BlockList,
 	// @ts-expect-error No types for this exist yet.
@@ -11,21 +15,13 @@ import {
 	// @ts-expect-error No types for this exist yet.
 	__experimentalUseResizeCanvas as useResizeCanvas, // eslint-disable-line
 } from '@wordpress/block-editor';
-import { useRef } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { useMergeRefs } from '@wordpress/compose';
-import { store as editorStore } from '@wordpress/editor';
-
-/**
- * WordPress private dependencies
- */
-import { BlockCanvas } from '../../../private-apis';
 
 /**
  * Internal dependencies
  */
 import EditTemplateBlocksNotification from './edit-template-blocks-notification';
 import useSelectNearestEditableBlock from './use-select-nearest-editable-block';
+import { BlockCanvas } from '../../../private-apis';
 
 export const TEMPLATE_POST_TYPE = 'wp_template';
 export const TEMPLATE_PART_POST_TYPE = 'wp_template_part';

--- a/packages/js/email-editor/src/components/header/campaign-name.tsx
+++ b/packages/js/email-editor/src/components/header/campaign-name.tsx
@@ -10,7 +10,7 @@ import {
 	Button,
 	Dropdown,
 	VisuallyHidden,
-	__experimentalText as Text, // eslint-disable-line
+	__experimentalText as Text,
 	TextControl,
 } from '@wordpress/components';
 

--- a/packages/js/email-editor/src/components/header/campaign-name.tsx
+++ b/packages/js/email-editor/src/components/header/campaign-name.tsx
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 import {
 	Button,
 	Dropdown,
@@ -6,10 +13,10 @@ import {
 	__experimentalText as Text, // eslint-disable-line
 	TextControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { chevronDown } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { recordEvent, recordEventOnce } from '../../events';
 

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -1,6 +1,7 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
+import classnames from 'classnames';
 import { useRef, useState } from '@wordpress/element';
 import { PinnedItems } from '@wordpress/interface';
 import { Button, ToolbarItem as WpToolbarItem } from '@wordpress/components';
@@ -11,6 +12,9 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { __ } from '@wordpress/i18n';
+import { plus, listView, undo, redo, next, previous } from '@wordpress/icons';
 import {
 	// @ts-expect-error DocumentBar types are not available
 	DocumentBar,
@@ -18,14 +22,11 @@ import {
 	// @ts-expect-error useEntitiesSavedStatesIsDirty types are not available
 	useEntitiesSavedStatesIsDirty,
 } from '@wordpress/editor';
-import { store as preferencesStore } from '@wordpress/preferences';
-import { __ } from '@wordpress/i18n';
-import { plus, listView, undo, redo, next, previous } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import classnames from 'classnames';
+
 import { storeName } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';

--- a/packages/js/email-editor/src/components/header/more-menu.tsx
+++ b/packages/js/email-editor/src/components/header/more-menu.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { MenuGroup, MenuItem, DropdownMenu } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { displayShortcut } from '@wordpress/keycodes';
@@ -6,6 +9,10 @@ import { useEntityProp } from '@wordpress/core-data';
 import { __, _x } from '@wordpress/i18n';
 import { PreferenceToggleMenuItem } from '@wordpress/preferences';
 import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { TrashModal } from './trash-modal';
 import { recordEvent } from '../../events';

--- a/packages/js/email-editor/src/components/header/save-all-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-all-button.tsx
@@ -1,11 +1,18 @@
+/**
+ * External dependencies
+ */
 import { useRef, useEffect } from '@wordpress/element';
 import { Button, Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 import {
 	// @ts-expect-error Our current version of packages doesn't have EntitiesSavedStates export
 	EntitiesSavedStates,
 } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/header/save-email-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-email-button.tsx
@@ -1,7 +1,14 @@
+/**
+ * External dependencies
+ */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { check, cloud, Icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -1,12 +1,19 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import {
 	// @ts-expect-error No types available for useEntitiesSavedStatesIsDirty
 	useEntitiesSavedStatesIsDirty,
 } from '@wordpress/editor';
-import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
 import { MailPoetEmailData, storeName } from '../../store';
-import { useSelect } from '@wordpress/data';
 import { useEditorMode } from '../../hooks';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/header/trash-modal.tsx
+++ b/packages/js/email-editor/src/components/header/trash-modal.tsx
@@ -1,8 +1,15 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
 import { recordEvent } from '../../events';
 
 export function TrashModal( {

--- a/packages/js/email-editor/src/components/inserter-sidebar/inserter-sidebar.tsx
+++ b/packages/js/email-editor/src/components/inserter-sidebar/inserter-sidebar.tsx
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import {
 	__experimentalLibrary as Library, // eslint-disable-line
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies

--- a/packages/js/email-editor/src/components/keybord-shortcuts/index.tsx
+++ b/packages/js/email-editor/src/components/keybord-shortcuts/index.tsx
@@ -67,7 +67,7 @@ export function KeyboardShortcuts(): null {
 		void registerShortcut( {
 			name: 'mailpoet/email-editor/undo',
 			category: 'block',
-			description: __( 'Undo your last changes.' ),
+			description: __( 'Undo your last changes.', 'mailpoet' ),
 			keyCombination: {
 				modifier: 'primary',
 				character: 'z',
@@ -77,7 +77,7 @@ export function KeyboardShortcuts(): null {
 		void registerShortcut( {
 			name: 'mailpoet/email-editor/redo',
 			category: 'block',
-			description: __( 'Redo your last undo.' ),
+			description: __( 'Redo your last undo.', 'mailpoet' ),
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: 'z',

--- a/packages/js/email-editor/src/components/keybord-shortcuts/index.tsx
+++ b/packages/js/email-editor/src/components/keybord-shortcuts/index.tsx
@@ -1,11 +1,18 @@
+/**
+ * External dependencies
+ */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 import {
 	useShortcut,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
-import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/listview-sidebar/listview-sidebar.tsx
+++ b/packages/js/email-editor/src/components/listview-sidebar/listview-sidebar.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 // eslint-disable-next-line
 import { __experimentalListView as ListView } from '@wordpress/block-editor';
 

--- a/packages/js/email-editor/src/components/notices/notices.tsx
+++ b/packages/js/email-editor/src/components/notices/notices.tsx
@@ -1,6 +1,13 @@
+/**
+ * External dependencies
+ */
 import { NoticeList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
 import { ValidationNotices } from './validation-notices';
 import { EditorSnackbars } from './snackbars';
 

--- a/packages/js/email-editor/src/components/notices/sent-email-notice.tsx
+++ b/packages/js/email-editor/src/components/notices/sent-email-notice.tsx
@@ -1,8 +1,14 @@
+/**
+ * External dependencies
+ */
 import { dispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/notices/snackbars.tsx
+++ b/packages/js/email-editor/src/components/notices/snackbars.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { useMemo } from '@wordpress/element';
 import { SnackbarList } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/js/email-editor/src/components/notices/validation-notices.tsx
+++ b/packages/js/email-editor/src/components/notices/validation-notices.tsx
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Notice, Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { useValidationNotices } from '../../hooks';
 
 export function ValidationNotices() {

--- a/packages/js/email-editor/src/components/personalization-tags/category-menu.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-menu.tsx
@@ -25,7 +25,7 @@ const CategoryMenu = ( {
 				onClick={ () => onCategorySelect( null ) }
 				className={ getMenuItemClass( null ) }
 			>
-				{ __( 'All' ) }
+				{ __( 'All', 'mailpoet' ) }
 			</MenuItem>
 			<div
 				className="mailpoet-personalization-tags-modal__menu-separator"

--- a/packages/js/email-editor/src/components/personalization-tags/category-menu.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-menu.tsx
@@ -10,7 +10,7 @@ const CategoryMenu = ( {
 	activeCategory,
 	onCategorySelect,
 }: {
-	groupedTags: Record< string, any[] >;
+	groupedTags: Record< string, unknown[] >;
 	activeCategory: string | null;
 	onCategorySelect: ( category: string | null ) => void;
 } ) => {

--- a/packages/js/email-editor/src/components/personalization-tags/category-menu.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-menu.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import * as React from '@wordpress/element';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -65,9 +65,10 @@ const CategorySection = ( {
 												}
 											} }
 										>
-											{ __( 'Insert' ) }
+											{ __( 'Insert', 'mailpoet' ) }
 										</Button>
-										{ category === __( 'Link' ) &&
+										{ category ===
+											__( 'Link', 'mailpoet' ) &&
 											canInsertLink && (
 												<>
 													<Button
@@ -80,7 +81,8 @@ const CategorySection = ( {
 														} }
 													>
 														{ __(
-															'Insert as link'
+															'Insert as link',
+															'mailpoet'
 														) }
 													</Button>
 												</>

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { PersonalizationTag } from '../../store';
 
 const CategorySection = ( {

--- a/packages/js/email-editor/src/components/personalization-tags/link-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/link-modal.tsx
@@ -1,7 +1,14 @@
+/**
+ * External dependencies
+ */
 import { Button, Modal, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import './index.scss';
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
 
 const LinkModal = ( { onInsert, isOpened, closeCallback, tag } ) => {
 	const [ linkText, setLinkText ] = useState( __( 'Link', 'mailpoet' ) );

--- a/packages/js/email-editor/src/components/personalization-tags/link-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/link-modal.tsx
@@ -36,7 +36,7 @@ const LinkModal = ( { onInsert, isOpened, closeCallback, tag } ) => {
 					}
 				} }
 			>
-				{ __( 'Insert' ) }
+				{ __( 'Insert', 'mailpoet' ) }
 			</Button>
 		</Modal>
 	);

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-link-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-link-popover.tsx
@@ -1,12 +1,19 @@
+/**
+ * External dependencies
+ */
 import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 import {
 	Popover,
 	Button,
 	TextControl,
 	SelectControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 
 type PersonalizationTagsLinkPopoverProps = {

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-modal.tsx
@@ -1,13 +1,20 @@
+/**
+ * External dependencies
+ */
 import { ExternalLink, Modal, SearchControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PersonalizationTag, storeName } from '../../store';
-import { useSelect } from '@wordpress/data';
-import './index.scss';
 import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
 import { CategoryMenu } from './category-menu';
 import { CategorySection } from './category-section';
 import { LinkModal } from './link-modal';
 import { recordEvent, recordEventOnce } from '../../events';
+import { PersonalizationTag, storeName } from '../../store';
 
 const PersonalizationTagsModal = ( {
 	onInsert,

--- a/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/personalization-tags-popover.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { useEffect, useState } from '@wordpress/element';
 import { Popover, Button, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
@@ -10,6 +10,11 @@ import { RichTextFormatList } from '@wordpress/rich-text/build-types/types';
  */
 import { PersonalizationTag } from '../../store';
 
+type Replacement = {
+	attributes: Record< string, string >;
+	type: string;
+};
+
 function getChildElement( rootElement: HTMLElement ): HTMLElement | null {
 	let currentElement: HTMLElement | null = rootElement;
 
@@ -23,10 +28,7 @@ function getChildElement( rootElement: HTMLElement ): HTMLElement | null {
 
 function findReplacementIndex(
 	element: HTMLElement,
-	replacements: ( null | {
-		attributes: Record< string, string >;
-		type: string;
-	} )[]
+	replacements: ( null | Replacement )[]
 ): number | null {
 	// Iterate over the replacements array
 	for ( const [ index, replacement ] of replacements.entries() ) {
@@ -66,13 +68,13 @@ function findLatestFormatIndex(
 		// Check each format within the format list at the current index
 		for ( const format of formatList ) {
 			if (
-				// @ts-expect-error
+				// @ts-expect-error attributes property is missing in build type for RichTextFormatList type
 				format?.attributes &&
 				element.tagName.toLowerCase() ===
-					// @ts-expect-error
+					// @ts-expect-error tagName property is missing in build type for RichTextFormatList type
 					format.tagName?.toLowerCase() &&
 				element.getAttribute( 'data-link-href' ) ===
-					// @ts-expect-error
+					// @ts-expect-error attributes property is missing in build type for RichTextFormatList type
 					format?.attributes[ 'data-link-href' ]
 			) {
 				latestFormatIndex = index;
@@ -131,8 +133,7 @@ const getCursorPosition = (
 
 	const replacementIndex = findReplacementIndex(
 		previousSibling,
-		// @ts-expect-error
-		richTextValue.replacements
+		richTextValue.replacements as Replacement[]
 	);
 	if ( replacementIndex !== null ) {
 		return {

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
@@ -1,7 +1,14 @@
+/**
+ * External dependencies
+ */
 import * as React from '@wordpress/element';
-import { PersonalizationTag } from '../../store';
 import { create } from '@wordpress/rich-text';
 import { RichTextFormatList } from '@wordpress/rich-text/build-types/types';
+
+/**
+ * Internal dependencies
+ */
+import { PersonalizationTag } from '../../store';
 
 function getChildElement( rootElement: HTMLElement ): HTMLElement | null {
 	let currentElement: HTMLElement | null = rootElement;

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -1,17 +1,24 @@
+/**
+ * External dependencies
+ */
 import { BaseControl, Button } from '@wordpress/components';
-import { PersonalizationTagsModal } from './personalization-tags-modal';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
+import { useEntityProp } from '@wordpress/core-data';
+import { create, insert, toHTMLString } from '@wordpress/rich-text';
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PersonalizationTagsModal } from './personalization-tags-modal';
 import {
 	getCursorPosition,
 	replacePersonalizationTagsWithHTMLComments,
 } from './rich-text-utils';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 import { storeName } from '../../store';
-import { RichText } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 import { PersonalizationTagsPopover } from './personalization-tags-popover';
-import { create, insert, toHTMLString } from '@wordpress/rich-text';
 import { recordEvent, recordEventOnce } from '../../events';
 
 export function RichTextWithButton( {

--- a/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
+++ b/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import {
 	MenuGroup,
 	MenuItem,
@@ -8,6 +11,10 @@ import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, external, check, mobile, desktop } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
 import { SendPreviewEmail } from './send-preview-email';
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';

--- a/packages/js/email-editor/src/components/preview/send-preview-email.tsx
+++ b/packages/js/email-editor/src/components/preview/send-preview-email.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { Button, Modal, TextControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { check, Icon } from '@wordpress/icons';
@@ -11,6 +14,10 @@ import {
 import { ENTER } from '@wordpress/keycodes';
 import { isEmail } from '@wordpress/url';
 import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
 import {
 	MailPoetEmailData,
 	SendingPreviewStatus,

--- a/packages/js/email-editor/src/components/sidebar/block-compatibility-warnings.tsx
+++ b/packages/js/email-editor/src/components/sidebar/block-compatibility-warnings.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { hasBlockSupport, getBlockSupport } from '@wordpress/blocks';
 import { Fill, Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -1,8 +1,15 @@
+/**
+ * External dependencies
+ */
 import { ExternalLink, PanelBody } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
 import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
 import { recordEvent } from '../../events';
 

--- a/packages/js/email-editor/src/components/sidebar/edit-template-modal.tsx
+++ b/packages/js/email-editor/src/components/sidebar/edit-template-modal.tsx
@@ -1,8 +1,15 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { storeName } from '../../store';
 import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { storeName } from '../../store';
 import { recordEvent, recordEventOnce } from '../../events';
 
 export function EditTemplateModal( { close } ) {

--- a/packages/js/email-editor/src/components/sidebar/email-settings.tsx
+++ b/packages/js/email-editor/src/components/sidebar/email-settings.tsx
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { Panel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { DetailsPanel } from './details-panel';
 import { EmailTypeInfo } from './email-type-info';
 

--- a/packages/js/email-editor/src/components/sidebar/email-type-info.tsx
+++ b/packages/js/email-editor/src/components/sidebar/email-type-info.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import {
 	Panel,

--- a/packages/js/email-editor/src/components/sidebar/header.tsx
+++ b/packages/js/email-editor/src/components/sidebar/header.tsx
@@ -1,19 +1,15 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { __ } from '@wordpress/i18n';
 import * as React from '@wordpress/element';
-
-/**
- * WordPress private dependencies
- */
-import { Tabs } from '../../private-apis';
 
 /**
  * Internal dependencies
  */
 import { mainSidebarDocumentTab, mainSidebarBlockTab } from '../../store';
 import { useEditorMode } from '../../hooks';
+import { Tabs } from '../../private-apis';
 
 export function HeaderTabs( _, ref ) {
 	const [ editorMode ] = useEditorMode();

--- a/packages/js/email-editor/src/components/sidebar/header.tsx
+++ b/packages/js/email-editor/src/components/sidebar/header.tsx
@@ -20,7 +20,9 @@ export function HeaderTabs( _, ref ) {
 					? __( 'Template', 'mailpoet' )
 					: __( 'Email', 'mailpoet' ) }
 			</Tabs.Tab>
-			<Tabs.Tab tabId={ mainSidebarBlockTab }>{ __( 'Block' ) }</Tabs.Tab>
+			<Tabs.Tab tabId={ mainSidebarBlockTab }>
+				{ __( 'Block', 'mailpoet' ) }
+			</Tabs.Tab>
 		</Tabs.TabList>
 	);
 }

--- a/packages/js/email-editor/src/components/sidebar/sidebar.tsx
+++ b/packages/js/email-editor/src/components/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useContext, useRef, useEffect, memo } from '@wordpress/element';
@@ -10,11 +10,6 @@ import {
 } from '@wordpress/block-editor';
 import { ComplementaryArea } from '@wordpress/interface';
 import { drawerRight } from '@wordpress/icons';
-
-/**
- * WordPress private dependencies
- */
-import { Tabs } from '../../private-apis';
 
 /**
  * Internal dependencies
@@ -29,6 +24,7 @@ import { Header } from './header';
 import { EmailSettings } from './email-settings';
 import { TemplateSettings } from './template-settings';
 import { useEditorMode } from '../../hooks';
+import { Tabs } from '../../private-apis';
 
 import './index.scss';
 import { recordEvent } from '../../events';

--- a/packages/js/email-editor/src/components/sidebar/template-info.tsx
+++ b/packages/js/email-editor/src/components/sidebar/template-info.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import {
 	Panel,
 	PanelBody,
@@ -9,6 +12,10 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { Icon, layout, moreVertical } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { TemplateRevertModal } from './template-revert-modal';
 

--- a/packages/js/email-editor/src/components/sidebar/template-revert-modal.tsx
+++ b/packages/js/email-editor/src/components/sidebar/template-revert-modal.tsx
@@ -1,6 +1,13 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 
 export function TemplateRevertModal( { close } ) {

--- a/packages/js/email-editor/src/components/sidebar/template-settings.tsx
+++ b/packages/js/email-editor/src/components/sidebar/template-settings.tsx
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { Panel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { TemplateInfo } from './template-info';
 
 export function TemplateSettings() {

--- a/packages/js/email-editor/src/components/styles-sidebar/panels/dimensions-panel.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/panels/dimensions-panel.tsx
@@ -1,16 +1,24 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { isEqual } from 'lodash';
 import {
 	// We can remove the ts-expect-error comments once the types are available.
 	// @ts-expect-error TS7016: Could not find a declaration file for module '@wordpress/block-editor'.
 	__experimentalSpacingSizesControl as SpacingSizesControl, // eslint-disable-line
 	useSettings,
 } from '@wordpress/block-editor';
+// eslint-disable-next-line
 import {
 	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line
 	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line
 	__experimentalUseCustomUnits as useCustomUnits, // eslint-disable-line
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { isEqual } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import { useEmailStyles } from '../../../hooks';
 import { recordEvent, debouncedRecordEvent } from '../../../events';
 

--- a/packages/js/email-editor/src/components/styles-sidebar/panels/typography-element-panel.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/panels/typography-element-panel.tsx
@@ -1,5 +1,14 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
+import {
+	FontSizePicker,
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line
+} from '@wordpress/components';
+// eslint-disable-next-line
 import {
 	useSettings,
 	// We can remove the ts-expect-error comments once the types are available.
@@ -17,11 +26,10 @@ import {
 	// @ts-expect-error TS7016: Could not find a declaration file for module '@wordpress/block-editor'.
 	__experimentalTextTransformControl as TextTransformControl, // eslint-disable-line
 } from '@wordpress/block-editor';
-import {
-	FontSizePicker,
-	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line
-	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line
-} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { useEmailStyles } from '../../../hooks';
 import { getElementStyles } from '../utils';
 import { recordEvent, debouncedRecordEvent } from '../../../events';

--- a/packages/js/email-editor/src/components/styles-sidebar/panels/typography-panel.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/panels/typography-panel.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -13,6 +13,10 @@ import {
 	Card,
 	CardBody,
 } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { useEmailStyles } from '../../../hooks';
 import { getElementStyles } from '../utils';
 import { recordEvent } from '../../../events';

--- a/packages/js/email-editor/src/components/styles-sidebar/previews/typography-preview.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/previews/typography-preview.tsx
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { useEmailStyles } from '../../../hooks';
 import { getElementStyles } from '../utils';
 

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/preview.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/preview.tsx
@@ -1,10 +1,17 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line
 	__experimentalVStack as VStack, // eslint-disable-line
 	__unstableMotion as motion, // eslint-disable-line
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../../store';
 
 const firstFrame = {

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-colors.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-colors.tsx
@@ -1,13 +1,8 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-
-/**
- * WordPress private dependencies
- */
-import { StylesColorPanel } from '../../../private-apis';
 
 /**
  * Internal dependencies
@@ -16,6 +11,7 @@ import ScreenHeader from './screen-header';
 import { useEmailStyles } from '../../../hooks';
 import { storeName } from '../../../store';
 import { recordEvent, recordEventOnce } from '../../../events';
+import { StylesColorPanel } from '../../../private-apis';
 
 export function ScreenColors(): JSX.Element {
 	recordEventOnce( 'styles_sidebar_screen_colors_opened' );

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-header.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-header.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line
 	__experimentalVStack as VStack, // eslint-disable-line
@@ -6,8 +11,6 @@ import {
 	__experimentalView as View, // eslint-disable-line
 	__experimentalNavigatorToParentButton as NavigatorToParentButton, // eslint-disable-line
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { chevronLeft } from '@wordpress/icons';
 
 type Props = {
 	title: string;

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-layout.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-layout.tsx
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { DimensionsPanel } from '../panels/dimensions-panel';
 import { ScreenHeader } from './screen-header';
 import { recordEventOnce } from '../../../events';

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-root.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-root.tsx
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { typography, color, layout } from '@wordpress/icons';
 import {
 	__experimentalVStack as VStack, // eslint-disable-line
 	Card,
@@ -10,8 +15,10 @@ import {
 	Icon,
 	FlexItem,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { typography, color, layout } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
 import { Preview } from './preview';
 import { recordEvent } from '../../../events';
 

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-typography-element.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-typography-element.tsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { __, _x } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import {
@@ -5,6 +8,10 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line
 	__experimentalSpacer as Spacer, // eslint-disable-line
 } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import TypographyElementPanel, {
 	DEFAULT_CONTROLS,
 } from '../panels/typography-element-panel';

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/screen-typography.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/screen-typography.tsx
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import TypographyPanel from '../panels/typography-panel';
 import ScreenHeader from './screen-header';
 import { recordEventOnce } from '../../../events';

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -7,8 +7,8 @@ import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
 import {
-	__experimentalNavigatorProvider as NavigatorProvider, // eslint-disable-line
-	__experimentalNavigatorScreen as NavigatorScreen, // eslint-disable-line
+	__experimentalNavigatorProvider as NavigatorProvider,
+	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
 
 /**

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -1,12 +1,19 @@
+/**
+ * External dependencies
+ */
 import { memo } from '@wordpress/element';
-import {
-	__experimentalNavigatorProvider as NavigatorProvider, // eslint-disable-line
-	__experimentalNavigatorScreen as NavigatorScreen, // eslint-disable-line
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
+import {
+	__experimentalNavigatorProvider as NavigatorProvider, // eslint-disable-line
+	__experimentalNavigatorScreen as NavigatorScreen, // eslint-disable-line
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { storeName, stylesSidebarId } from '../../store';
 import {
 	ScreenTypography,

--- a/packages/js/email-editor/src/components/styles-sidebar/utils.ts
+++ b/packages/js/email-editor/src/components/styles-sidebar/utils.ts
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import deepmerge from 'deepmerge';
+
+/**
+ * Internal dependencies
+ */
 import { StyleProperties } from '../../hooks/use-email-styles';
 
 const defaultStyleObject = {

--- a/packages/js/email-editor/src/components/template-select/async.ts
+++ b/packages/js/email-editor/src/components/template-select/async.ts
@@ -1,9 +1,9 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useEffect, useState, flushSync } from '@wordpress/element';
 // @ts-expect-error TS7016 Could not find a declaration file for module '@wordpress/priority-queue'
-import { createQueue } from '@wordpress/priority-queue';
+import { createQueue } from '@wordpress/priority-queue'; // eslint-disable-line
 
 const blockPreviewQueue = createQueue();
 

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useState, useEffect, memo } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';

--- a/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-categories-list-sidebar.tsx
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { TemplateCategory } from '../../store';
 
 type Props = {

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -33,10 +33,11 @@ function TemplateNoResults() {
 				className="block-editor-inserter__no-results-icon"
 				icon={ blockDefault }
 			/>
-			<p>{ __( 'No recent templates.' ) }</p>
+			<p>{ __( 'No recent templates.', 'mailpoet' ) }</p>
 			<p>
 				{ __(
-					'Your recent creations will appear here as soon as you begin.'
+					'Your recent creations will appear here as soon as you begin.',
+					'mailpoet'
 				) }
 			</p>
 		</div>

--- a/packages/js/email-editor/src/components/template-select/template-list.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-list.tsx
@@ -1,13 +1,21 @@
+/**
+ * External dependencies
+ */
 import { useMemo, memo } from '@wordpress/element';
-// @ts-expect-error No types available for this component
-import { BlockPreview } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
+import { Icon, info, blockDefault } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line
 } from '@wordpress/components';
-import { Icon, info, blockDefault } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+// @ts-expect-error No types available for this component
+// eslint-disable-next-line
+import { BlockPreview } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
 import { Async } from './async';
 import { TemplateCategory, TemplatePreview } from '../../store';
 import { useEmailCss } from '../../hooks';

--- a/packages/js/email-editor/src/components/template-select/template-selection.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-selection.tsx
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from '../../store';
 import { SelectTemplateModal } from './select-modal';
 

--- a/packages/js/email-editor/src/editor-hooks.ts
+++ b/packages/js/email-editor/src/editor-hooks.ts
@@ -1,5 +1,7 @@
+/**
+ * External dependencies
+ */
 import { ComponentType } from 'react';
-
 import { MediaUpload } from '@wordpress/media-utils';
 import { addFilter } from '@wordpress/hooks';
 

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -1,7 +1,14 @@
-import '@wordpress/format-library'; // Enables text formatting capabilities
+/**
+ * External dependencies
+ */
 import { useSelect } from '@wordpress/data';
 import { StrictMode, createRoot } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
+import '@wordpress/format-library'; // Enables text formatting capabilities
+
+/**
+ * Internal dependencies
+ */
 import { initBlocks } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { InnerEditor } from './components/block-editor';

--- a/packages/js/email-editor/src/events/event-collector.ts
+++ b/packages/js/email-editor/src/events/event-collector.ts
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { doAction } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
 import {
 	EMAIL_STRING,
 	dispatcher,

--- a/packages/js/email-editor/src/events/event-pipeline.ts
+++ b/packages/js/email-editor/src/events/event-pipeline.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { debounce } from 'lodash';
 import { applyFilters } from '@wordpress/hooks';
 

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -1,10 +1,17 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 import { dispatch, useSelect, subscribe } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { storeName as emailEditorStore } from '../store';
 import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { storeName as emailEditorStore } from '../store';
 import { useShallowEqual } from './use-shallow-equal';
 import { useValidationNotices } from './use-validation-notices';
 

--- a/packages/js/email-editor/src/hooks/use-editor-mode.ts
+++ b/packages/js/email-editor/src/hooks/use-editor-mode.ts
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -1,20 +1,16 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-
-/**
- * WordPress private dependencies
- */
-import { useGlobalStylesOutputWithConfig } from '../private-apis';
+import deepmerge from 'deepmerge';
 
 /**
  * Internal dependencies
  */
-import deepmerge from 'deepmerge';
 import { EmailStyles, storeName } from '../store';
 import { useUserTheme } from './use-user-theme';
+import { useGlobalStylesOutputWithConfig } from '../private-apis';
 
 export function useEmailCss() {
 	const { userTheme } = useUserTheme();

--- a/packages/js/email-editor/src/hooks/use-email-styles.ts
+++ b/packages/js/email-editor/src/hooks/use-email-styles.ts
@@ -1,6 +1,13 @@
+/**
+ * External dependencies
+ */
 import deepmerge from 'deepmerge';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { storeName, TypographyProperties } from '../store';
 import { useUserTheme } from './use-user-theme';
 

--- a/packages/js/email-editor/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/js/email-editor/src/hooks/use-navigate-to-entity-record.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useCallback, useReducer } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -1,8 +1,15 @@
+/**
+ * External dependencies
+ */
 import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
 import {
 	storeName,
 	EmailTemplatePreview,

--- a/packages/js/email-editor/src/hooks/use-user-theme.ts
+++ b/packages/js/email-editor/src/hooks/use-user-theme.ts
@@ -1,6 +1,13 @@
+/**
+ * External dependencies
+ */
 import { useCallback } from '@wordpress/element';
 import { useSelect, dispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
 import { EmailTheme, storeName } from '../store';
 
 export function useUserTheme() {

--- a/packages/js/email-editor/src/hooks/use-validation-notices.ts
+++ b/packages/js/email-editor/src/hooks/use-validation-notices.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { useCallback } from '@wordpress/element';
 import { dispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';

--- a/packages/js/email-editor/src/index.ts
+++ b/packages/js/email-editor/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { initialize } from './editor';
 
 window.addEventListener( 'DOMContentLoaded', () => {

--- a/packages/js/email-editor/src/layouts/flex-email.tsx
+++ b/packages/js/email-editor/src/layouts/flex-email.tsx
@@ -9,19 +9,18 @@ import { Block } from '@wordpress/blocks/index';
 import { __ } from '@wordpress/i18n';
 import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
 import {
+	Flex,
+	FlexItem,
+	PanelBody,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+} from '@wordpress/components';
+import {
 	BlockControls,
 	InspectorControls,
 	// @ts-expect-error No types for this exist yet.
 	JustifyContentControl,
 } from '@wordpress/block-editor';
-// eslint-disable-next-line @woocommerce/dependency-group
-import {
-	Flex,
-	FlexItem,
-	PanelBody,
-	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line
-	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon, // eslint-disable-line
-} from '@wordpress/components';
 
 const layoutBlockSupportKey = '__experimentalEmailFlexLayout';
 

--- a/packages/js/email-editor/src/layouts/flex-email.tsx
+++ b/packages/js/email-editor/src/layouts/flex-email.tsx
@@ -169,7 +169,7 @@ export function addAttribute( settings: Block ) {
  * @return {Function} Wrapped component.
  */
 export const withLayoutControls = createHigherOrderComponent(
-	// @ts-ignore No types for this exist yet.
+	// @ts-expect-error No types for this exist yet.
 	( BlockEdit ) => ( props ) => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		const supportLayout = hasLayoutBlockSupport( props.name );

--- a/packages/js/email-editor/src/layouts/flex-email.tsx
+++ b/packages/js/email-editor/src/layouts/flex-email.tsx
@@ -2,23 +2,19 @@
  * External dependencies
  */
 import classnames from 'classnames';
-
-/**
- * WordPress dependencies
- */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { Block } from '@wordpress/blocks/index';
-
+import { __ } from '@wordpress/i18n';
+import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
 import {
 	BlockControls,
 	InspectorControls,
 	// @ts-expect-error No types for this exist yet.
 	JustifyContentControl,
 } from '@wordpress/block-editor';
-import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
-
+// eslint-disable-next-line @woocommerce/dependency-group
 import {
 	Flex,
 	FlexItem,
@@ -26,7 +22,6 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon, // eslint-disable-line
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 const layoutBlockSupportKey = '__experimentalEmailFlexLayout';
 

--- a/packages/js/email-editor/src/private-apis/index.ts
+++ b/packages/js/email-editor/src/private-apis/index.ts
@@ -1,13 +1,13 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import {
 	// @ts-expect-error No types for privateApis.
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -17,7 +17,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
 	// @ts-expect-error No types for __unstableSerializeAndClean
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__unstableSerializeAndClean,
 	parse,
 } from '@wordpress/blocks';

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { dispatch, select } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import {
@@ -10,6 +13,18 @@ import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { apiFetch } from '@wordpress/data-controls';
 import wpApiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
+import {
+	// @ts-expect-error No types for __unstableSerializeAndClean
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__unstableSerializeAndClean,
+	parse,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
 import { storeName, mainSidebarDocumentTab } from './constants';
 import {
 	SendingPreviewStatus,
@@ -17,14 +32,6 @@ import {
 	Feature,
 	PersonalizationTag,
 } from './types';
-import { addQueryArgs } from '@wordpress/url';
-import {
-	// @ts-expect-error No types for __unstableSerializeAndClean
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__unstableSerializeAndClean,
-	parse,
-} from '@wordpress/blocks';
-import { decodeEntities } from '@wordpress/html-entities';
 import { recordEvent } from '../events';
 
 export const toggleFeature =

--- a/packages/js/email-editor/src/store/index.ts
+++ b/packages/js/email-editor/src/store/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 export * from './constants';
 export * from './store';
 export * from './types';

--- a/packages/js/email-editor/src/store/initial-state.ts
+++ b/packages/js/email-editor/src/store/initial-state.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { mainSidebarDocumentTab } from './constants';
 import { State } from './types';
 import {

--- a/packages/js/email-editor/src/store/reducer.ts
+++ b/packages/js/email-editor/src/store/reducer.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { State } from './types';
 
 export function reducer( state: State, action ): State {

--- a/packages/js/email-editor/src/store/resolvers.ts
+++ b/packages/js/email-editor/src/store/resolvers.ts
@@ -1,10 +1,17 @@
+/**
+ * External dependencies
+ */
 import { apiFetch } from '@wordpress/data-controls';
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import {
 	setPersonalizationTagsList,
 	setIsFetchingPersonalizationTags,
 } from './actions';
 import { storeName } from './constants';
-import { select } from '@wordpress/data';
 
 export function* getPersonalizationTagsList() {
 	// Access the state to check if already fetching

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { createRegistrySelector } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -5,9 +8,13 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { serialize } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
+import { Post } from '@wordpress/core-data/build-types/entity-types/post';
+
+/**
+ * Internal dependencies
+ */
 import { storeName } from './constants';
 import { State, Feature, EmailTemplate, EmailEditorPostType } from './types';
-import { Post } from '@wordpress/core-data/build-types/entity-types/post';
 
 function getContentFromEntity( entity ): string {
 	if ( entity?.content && typeof entity.content === 'function' ) {

--- a/packages/js/email-editor/src/store/settings.ts
+++ b/packages/js/email-editor/src/store/settings.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { EmailEditorSettings, EmailTheme, EmailEditorUrls } from './types';
 
 export function getEditorSettings(): EmailEditorSettings {

--- a/packages/js/email-editor/src/store/store.ts
+++ b/packages/js/email-editor/src/store/store.ts
@@ -1,9 +1,16 @@
+/**
+ * External dependencies
+ */
 import { createReduxStore, register } from '@wordpress/data';
 import {
 	ReduxStoreConfig,
 	StoreDescriptor as GenericStoreDescriptor,
 } from '@wordpress/data/build-types/types';
 import { controls } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
 import * as actions from './actions';
 import { storeName } from './constants';
 import { getInitialState } from './initial-state';

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { EditorSettings, EditorColor } from '@wordpress/block-editor/index';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { Post } from '@wordpress/core-data/build-types/entity-types/post';

--- a/packages/js/email-editor/src/types/index.ts
+++ b/packages/js/email-editor/src/types/index.ts
@@ -1,10 +1,7 @@
-import {
-	Color,
-	Gradient,
-} from '@wordpress/components/build-types/palette-edit/types';
+/**
+ * External dependencies
+ */
 import { FontSize } from '@wordpress/components/build-types/font-size-picker/types';
-
-// eslint-disable-next-line import/no-named-default
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as keyboardShortutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -18,7 +15,14 @@ import {
 	StoreDescriptor as GenericStoreDescriptor,
 	UseSelectReturn,
 } from '@wordpress/data/build-types/types';
+import {
+	Color,
+	Gradient,
+} from '@wordpress/components/build-types/palette-edit/types';
 
+/**
+ * Internal dependencies
+ */
 import './wordpress-modules';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- some general types in this file need to use "any"  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
     devDependencies:
       '@wordpress/scripts':
         specifier: 27.9.0
-        version: 27.9.0(@types/node@18.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.0.2)
+        version: 27.9.0(@types/node@18.6.1)(eslint-import-resolver-typescript@3.7.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.0.2)
       lint-staged:
         specifier: ^12.5.0
         version: 12.5.0
@@ -695,15 +695,21 @@ importers:
       '@types/wordpress__media-utils':
         specifier: ^4.14.4
         version: 4.14.4(react-dom@18.3.1)(react@18.3.1)
+      '@woocommerce/eslint-plugin':
+        specifier: ^2.3.0
+        version: 2.3.0(eslint-import-resolver-typescript@3.7.0)(typescript@5.0.2)
       '@wordpress/prettier-config':
         specifier: ^4.11.0
         version: 4.11.0(wp-prettier@3.0.3)
       '@wordpress/scripts':
         specifier: 27.9.0
-        version: 27.9.0(@types/node@18.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.0.2)
+        version: 27.9.0(@types/node@18.6.1)(eslint-import-resolver-typescript@3.7.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.0.2)
       core-js:
         specifier: ^3.37.1
         version: 3.37.1
+      eslint-import-resolver-typescript:
+        specifier: ^3.7.0
+        version: 3.7.0
       prettier:
         specifier: npm:wp-prettier@^3.0.3
         version: /wp-prettier@3.0.3
@@ -986,7 +992,7 @@ packages:
       '@wordpress/primitives': 3.56.0
       '@wordpress/react-i18n': 3.36.0
       classnames: 2.5.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.3.1)(react@18.3.1)
@@ -1162,7 +1168,7 @@ packages:
       '@babel/core': 7.24.7
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -2522,7 +2528,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3103,7 +3109,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3486,6 +3492,11 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+    dev: true
+
+  /@nolyfill/is-core-module@1.0.39:
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
     dev: true
 
   /@pkgr/core@0.1.1:
@@ -4624,6 +4635,33 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.1
+      '@typescript-eslint/parser': 5.62.0(typescript@5.0.2)
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/type-utils': 5.62.0(typescript@5.0.2)
+      '@typescript-eslint/utils': 5.62.0(typescript@5.0.2)
+      debug: 4.4.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare-lite: 1.4.0
+      semver: 7.6.2
+      tsutils: 3.21.0(typescript@5.0.2)
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.36.0)(typescript@5.0.2):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -4641,7 +4679,7 @@ packages:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       eslint: 8.36.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -4673,6 +4711,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser@5.62.0(typescript@5.0.2):
+    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.2)
+      debug: 4.4.0
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@6.21.0(eslint@8.36.0)(typescript@5.0.2):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -4687,7 +4744,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.0.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       eslint: 8.36.0
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -4700,6 +4757,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
+    dev: true
+
+  /@typescript-eslint/scope-manager@5.62.0:
+    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
   /@typescript-eslint/scope-manager@6.21.0:
@@ -4722,8 +4787,27 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.2)
       '@typescript-eslint/utils': 5.56.0(eslint@8.36.0)(typescript@5.0.2)
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       eslint: 8.36.0
+      tsutils: 3.21.0(typescript@5.0.2)
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/type-utils@5.62.0(typescript@5.0.2):
+    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.2)
+      '@typescript-eslint/utils': 5.62.0(typescript@5.0.2)
+      debug: 4.4.0
       tsutils: 3.21.0(typescript@5.0.2)
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -4742,7 +4826,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.0.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       eslint: 8.36.0
       ts-api-utils: 1.3.0(typescript@5.0.2)
       typescript: 5.0.2
@@ -4752,6 +4836,11 @@ packages:
 
   /@typescript-eslint/types@5.56.0:
     resolution: {integrity: sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types@5.62.0:
+    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -4771,7 +4860,28 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.6.2
+      tsutils: 3.21.0(typescript@5.0.2)
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.2):
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -4792,7 +4902,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -4816,6 +4926,25 @@ packages:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.2)
       eslint: 8.36.0
+      eslint-scope: 5.1.1
+      semver: 7.6.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@5.62.0(typescript@5.0.2):
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.36.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.2)
       eslint-scope: 5.1.1
       semver: 7.6.2
     transitivePeerDependencies:
@@ -4847,6 +4976,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.56.0
+      eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@5.62.0:
+    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -5239,6 +5376,27 @@ packages:
       moment-timezone: 0.5.45
       qs: 6.12.1
     dev: false
+
+  /@woocommerce/eslint-plugin@2.3.0(eslint-import-resolver-typescript@3.7.0)(typescript@5.0.2):
+    resolution: {integrity: sha512-2TZOWyFI3HiM1bI06NQNMGpOp9PmzwrgdD5Fwv7x37RYcKgy9FDx5WPT4PF+8yr3L31QbRaavyJvr2Lp65Nwww==}
+    engines: {node: ^20.11.1, pnpm: ^9.1.0}
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 5.62.0(typescript@5.0.2)
+      '@wordpress/eslint-plugin': 18.1.0(eslint-import-resolver-typescript@3.7.0)(typescript@5.0.2)(wp-prettier@2.8.5)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.36.0)
+      eslint-plugin-testing-library: 5.11.1(typescript@5.0.2)
+      prettier: /wp-prettier@2.8.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/eslint'
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+      - typescript
+    dev: true
 
   /@woocommerce/navigation@8.1.0(@types/react@18.3.3)(lodash@4.17.21)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Ifl8IYRLYlbxk6RNuuVorMaCoOs8aFWEo8oSU++SqFfyjPi893Nuk6NJYVvAVhxFdwPfw9RptvQ/q8sIusPihA==}
@@ -6792,7 +6950,7 @@ packages:
       '@babel/runtime': 7.25.7
     dev: false
 
-  /@wordpress/eslint-plugin@18.1.0(@babel/core@7.24.7)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)(wp-prettier@3.0.3):
+  /@wordpress/eslint-plugin@18.1.0(@babel/core@7.24.7)(eslint-import-resolver-typescript@3.7.0)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)(wp-prettier@3.0.3):
     resolution: {integrity: sha512-5eGpXEwaZsKbEh9040nVr4ggmrpPmltP+Ie4iGruWvCme6ZIFYw70CyWEV8S102IkqjH/BaH6d+CWg8tN7sc/g==}
     engines: {node: '>=14', npm: '>=6.14.4'}
     peerDependencies:
@@ -6815,7 +6973,7 @@ packages:
       cosmiconfig: 7.1.0
       eslint: 8.36.0
       eslint-config-prettier: 8.8.0(eslint@8.36.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.36.0)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.36.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.36.0)
@@ -6825,6 +6983,47 @@ packages:
       eslint-plugin-react-hooks: 4.6.0(eslint@8.36.0)
       globals: 13.24.0
       prettier: /wp-prettier@3.0.3
+      requireindex: 1.2.0
+      typescript: 5.0.2
+    transitivePeerDependencies:
+      - '@types/eslint'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+    dev: true
+
+  /@wordpress/eslint-plugin@18.1.0(eslint-import-resolver-typescript@3.7.0)(typescript@5.0.2)(wp-prettier@2.8.5):
+    resolution: {integrity: sha512-5eGpXEwaZsKbEh9040nVr4ggmrpPmltP+Ie4iGruWvCme6ZIFYw70CyWEV8S102IkqjH/BaH6d+CWg8tN7sc/g==}
+    engines: {node: '>=14', npm: '>=6.14.4'}
+    peerDependencies:
+      '@babel/core': '>=7'
+      eslint: '>=8'
+      prettier: '>=3'
+      typescript: ^5.0.2
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/eslint-parser': 7.21.3(@babel/core@7.24.7)(eslint@8.36.0)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.36.0)(typescript@5.0.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
+      '@wordpress/babel-preset-default': 7.42.0
+      '@wordpress/prettier-config': 3.15.0(wp-prettier@2.8.5)
+      cosmiconfig: 7.1.0
+      eslint-config-prettier: 8.8.0(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)
+      eslint-plugin-jsdoc: 46.10.1(eslint@8.36.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.36.0)
+      eslint-plugin-playwright: 0.15.3(eslint-plugin-jest@27.9.0)(eslint@8.36.0)
+      eslint-plugin-prettier: 5.2.1(eslint-config-prettier@8.8.0)(wp-prettier@2.8.5)
+      eslint-plugin-react: 7.32.2(eslint@8.36.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.36.0)
+      globals: 13.24.0
+      prettier: /wp-prettier@2.8.5
       requireindex: 1.2.0
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -7384,6 +7583,15 @@ packages:
       - supports-color
     dev: false
 
+  /@wordpress/prettier-config@3.15.0(wp-prettier@2.8.5):
+    resolution: {integrity: sha512-exC2rkEioTt//AnzPRyaaFv8FNYIvamPDytNol5bKQ6Qh65QSdZZE9V+GtRCrIPL7/Bq6xba03XuRVxl9TjtJg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      prettier: '>=3'
+    dependencies:
+      prettier: /wp-prettier@2.8.5
+    dev: true
+
   /@wordpress/prettier-config@3.15.0(wp-prettier@3.0.3):
     resolution: {integrity: sha512-exC2rkEioTt//AnzPRyaaFv8FNYIvamPDytNol5bKQ6Qh65QSdZZE9V+GtRCrIPL7/Bq6xba03XuRVxl9TjtJg==}
     engines: {node: '>=14'}
@@ -7650,7 +7858,7 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@wordpress/scripts@27.9.0(@types/node@18.6.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.0.2):
+  /@wordpress/scripts@27.9.0(@types/node@18.6.1)(eslint-import-resolver-typescript@3.7.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.0.2):
     resolution: {integrity: sha512-ohiDHMnfTTBTi7qS7AVJZUi1dxwg0k3Aav1a8CzUoOE8YoT8tvMQ3W89H9XgqMgMTWUCdgTUBYLTJTivfVVbXQ==}
     engines: {node: '>=18', npm: '>=6.14.4'}
     hasBin: true
@@ -7666,7 +7874,7 @@ packages:
       '@wordpress/browserslist-config': 5.41.0
       '@wordpress/dependency-extraction-webpack-plugin': 5.9.0(webpack@5.94.0)
       '@wordpress/e2e-test-utils-playwright': 0.26.0(typescript@5.0.2)
-      '@wordpress/eslint-plugin': 18.1.0(@babel/core@7.24.7)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)(wp-prettier@3.0.3)
+      '@wordpress/eslint-plugin': 18.1.0(@babel/core@7.24.7)(eslint-import-resolver-typescript@3.7.0)(eslint@8.36.0)(jest@29.7.0)(typescript@5.0.2)(wp-prettier@3.0.3)
       '@wordpress/jest-preset-default': 11.29.0(@babel/core@7.24.7)(jest@29.7.0)
       '@wordpress/npm-package-json-lint-config': 4.43.0(npm-package-json-lint@6.4.0)
       '@wordpress/postcss-plugins-preset': 4.42.0(postcss@8.4.49)
@@ -8064,7 +8272,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8073,7 +8281,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10141,6 +10349,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.3.1
+    dev: true
 
   /debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -10152,7 +10361,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: false
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -10915,6 +11123,31 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-import-resolver-typescript@3.7.0:
+    resolution: {integrity: sha512-Vrwyi8HHxY97K5ebydMtffsWAn1SCR9eol49eCd5fJS4O1WV7PaAjbcjmbfJJSMz/t4Mal212Uz/fQZrOB8mow==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0
+      enhanced-resolve: 5.17.1
+      fast-glob: 3.3.2
+      get-tsconfig: 4.8.1
+      is-bun-module: 1.3.0
+      is-glob: 4.0.3
+      stable-hash: 0.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-import-resolver-webpack@0.13.2(eslint-plugin-import@2.27.5):
     resolution: {integrity: sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==}
     engines: {node: '>= 6'}
@@ -10968,7 +11201,36 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint@8.36.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.7.0):
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
+      debug: 3.2.7
+      eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.7.0)(eslint@8.36.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10993,6 +11255,7 @@ packages:
       debug: 3.2.7
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.7.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11040,7 +11303,39 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.21.0)(eslint@8.36.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.36.0)(typescript@5.0.2)
+      array-includes: 3.1.7
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.7.0)
+      has: 1.0.3
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.7
+      resolve: 1.22.8
+      semver: 6.3.1
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.36.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -11058,7 +11353,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint@8.36.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.7.0)(eslint@8.36.0)
       has: 1.0.3
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11104,7 +11399,7 @@ packages:
       '@es-joy/jsdoccomment': 0.41.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint: 8.36.0
       esquery: 1.5.0
@@ -11179,6 +11474,26 @@ packages:
       synckit: 0.9.1
     dev: true
 
+  /eslint-plugin-prettier@5.2.1(eslint-config-prettier@8.8.0)(wp-prettier@2.8.5):
+    resolution: {integrity: sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint-config-prettier: 8.8.0(eslint@8.36.0)
+      prettier: /wp-prettier@2.8.5
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.9.1
+    dev: true
+
   /eslint-plugin-react-hooks@4.6.0(eslint@8.36.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -11210,6 +11525,18 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
+    dev: true
+
+  /eslint-plugin-testing-library@5.11.1(typescript@5.0.2):
+    resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
+    peerDependencies:
+      eslint: ^7.5.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(typescript@5.0.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: true
 
   /eslint-scope@5.1.1:
@@ -11464,7 +11791,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -11668,7 +11995,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12031,13 +12358,19 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
 
+  /get-tsconfig@4.8.1:
+    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
   /get-uri@6.0.3:
     resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
     engines: {node: '>= 14'}
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color
@@ -12553,7 +12886,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12563,7 +12896,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12603,7 +12936,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12613,7 +12946,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12638,7 +12971,7 @@ packages:
       '@babel/runtime': 7.24.7
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 5.20.0(react@18.3.1)
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       events: 3.3.0
       hash.js: 1.1.7
       lodash: 4.17.21
@@ -12912,6 +13245,12 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       builtin-modules: 3.3.0
+    dev: true
+
+  /is-bun-module@1.3.0:
+    resolution: {integrity: sha512-DgXeu5UWI0IsMQundYb5UAOzm6G2eVnarJ0byP6Tm55iZNKceD59LNPA2L4VvsScTtHcw0yEkVwSf7PC+QoLSA==}
+    dependencies:
+      semver: 7.6.3
     dev: true
 
   /is-callable@1.2.7:
@@ -13225,7 +13564,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -15219,7 +15558,7 @@ packages:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
@@ -15413,7 +15752,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.7
       crc32: 0.2.2
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       seed-random: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -16095,7 +16434,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       lru-cache: 7.18.3
@@ -16971,6 +17310,10 @@ packages:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
     dev: false
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
@@ -17240,6 +17583,12 @@ packages:
     hasBin: true
     dev: true
 
+  /semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -17417,7 +17766,7 @@ packages:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
     dependencies:
       buffer: 6.0.3
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       err-code: 3.0.1
       get-browser-rtc: 1.1.0
       queue-microtask: 1.2.3
@@ -17529,7 +17878,7 @@ packages:
       base64-arraybuffer: 0.1.5
       component-bind: 1.0.0
       component-emitter: 1.2.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       engine.io-client: 3.4.4
       has-binary2: 1.0.3
       has-cors: 1.1.0
@@ -17568,7 +17917,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -17688,7 +18037,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -17702,7 +18051,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -17731,6 +18080,10 @@ packages:
 
   /sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  /stable-hash@0.0.4:
+    resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
+    dev: true
 
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -18150,6 +18503,7 @@ packages:
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
+    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -19371,6 +19725,12 @@ packages:
       uppercamelcase: 1.1.0
     dev: false
 
+  /wp-prettier@2.8.5:
+    resolution: {integrity: sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
   /wp-prettier@3.0.3:
     resolution: {integrity: sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==}
     engines: {node: '>=14'}
@@ -19387,7 +19747,7 @@ packages:
     resolution: {integrity: sha512-NMp0YsBM40CuI5vWtHpjWOuf96rPfbpGkamlJpVwYvgenIh1ynRzqVnGfsnjofgz13T2qcKkdwJY0Y2X7z+W+w==}
     dependencies:
       '@babel/runtime': 7.24.7
-      debug: 4.3.5(supports-color@9.3.1)
+      debug: 4.4.0
       progress-event: 1.0.0
       uuid: 7.0.3
       wp-error: 1.3.0


### PR DESCRIPTION
## Description

This PR adds @woocommerce/eslint-plugin and fixes issues reported after adding the plugin.
The motivation was adding a check that would enforce comments and grouping of imports. The [@woocommerce/eslint-plugin](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/eslint-plugin) contains [a rule for checking dependency groups](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/eslint-plugin/docs/rules/dependency-group.md) and is used by most of the packages in the Woo monorepo. As we plan to move the package to the monorepo, I think it makes sense to start using the whole package.

- When fixing the groups in the email editor codebase, I found that the rule for grouping reports an error when import contains a comment. We have a couple of comments in imports, mostly to suppress TS warnings. I worked around the issues by adding eslint ignore comments
- Apart from the import groups, I had to fix a couple of missing domains in translation functions and add comments to suppressed TS errors.
- I chose to disable @wordpress/no-unsafe-wp-apis check so that we don't need to use eslint ignore when we import an export with a name prefixed by __. This helps a bit with the problem with the import group check because we can remove some comments from imports. I think it is relatively safe to do because Gutenberg now uses private API instead of legacy unsafe exports, and most of these exports have remained unchanged for a long time.
- We can also disable `react/react-in-jsx-scope` because we use wordpress/scripts that [use the new JSX Transform](https://github.com/WordPress/gutenberg/pull/61692) and [it is recommended to disable it](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint) for the new transform


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6438]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6438]: https://mailpoet.atlassian.net/browse/MAILPOET-6438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/woo-eslint-plugin)

_The latest successful build from `email-editor/woo-eslint-plugin` will be used. If none is available, the link won't work._