### PR TITLE
Email editor - Improve swap template modal [MAILPOET-6425]

### DIFF
--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -123,7 +123,11 @@ export function SelectTemplateModal( {
 
 	return (
 		<Modal
-			title={ __( 'Start with an email preset', 'mailpoet' ) }
+			title={
+				templateSelectMode === 'new'
+					? __( 'Start with an email preset', 'mailpoet' )
+					: __( 'Select a template', 'mailpoet' )
+			}
 			onRequestClose={ () => {
 				recordEvent( 'template_select_modal_closed', {
 					templateSelectMode,

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -36,9 +36,16 @@ function SelectTemplateBody( {
 	hasEmailPosts,
 	templates,
 	handleTemplateSelection,
+	templateSelectMode,
 } ) {
 	const [ selectedCategory, setSelectedCategory ] = useState(
 		TemplateCategories[ 1 ].name // Show the “Basic” category by default
+	);
+
+	const hideRecentCategory = templateSelectMode === 'swap';
+
+	const displayCategories = TemplateCategories.filter(
+		( { name } ) => name !== 'recent' || ! hideRecentCategory
 	);
 
 	const handleCategorySelection = ( category: TemplateCategory ) => {
@@ -48,7 +55,7 @@ function SelectTemplateBody( {
 
 	useEffect( () => {
 		setTimeout( () => {
-			if ( hasEmailPosts ) {
+			if ( hasEmailPosts && ! hideRecentCategory ) {
 				setSelectedCategory( TemplateCategories[ 0 ].name );
 			}
 		}, 1000 ); // using setTimeout to ensure the template styles are available before block preview
@@ -57,7 +64,7 @@ function SelectTemplateBody( {
 	return (
 		<div className="block-editor-block-patterns-explorer">
 			<TemplateCategoriesListSidebar
-				templateCategories={ TemplateCategories }
+				templateCategories={ displayCategories }
 				selectedCategory={ selectedCategory }
 				onClickCategory={ handleCategorySelection }
 			/>
@@ -142,6 +149,7 @@ export function SelectTemplateModal( {
 				hasEmailPosts={ hasEmailPosts }
 				templates={ [ ...templates, ...emailPosts ] }
 				handleTemplateSelection={ handleTemplateSelection }
+				templateSelectMode={ templateSelectMode }
 			/>
 
 			<Flex className="email-editor-modal-footer" justify="flex-end">


### PR DESCRIPTION
## Description

This PR changes the template select modal when displayed in template swap content. When a user clicks on the Swap template button:

- the modal heading is "Select a template"
- we don't display the Recent category
- each template is displayed only once with the actual email content instead of a pattern (this was implemented earlier)

<img width="1007" alt="Screenshot 2025-01-16 at 15 50 07" src="https://github.com/user-attachments/assets/ac1de34b-b5d7-4e9f-8984-ccd39dea72b6" />


## Code review notes

_N/A_

## QA notes

Please test the swap template functionality. Right now we actually offer only one template so there should be only one so basically there is nothing to switch but the recent category should be hidden and the content of the single template should use the current edited content.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6425]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6425]: https://mailpoet.atlassian.net/browse/MAILPOET-6425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/improve-swap-modal)

_The latest successful build from `email-editor/improve-swap-modal` will be used. If none is available, the link won't work._