### PR TITLE
Branch out of AbandonedCart jobs earlier

### DIFF
--- a/mailpoet/lib/Cron/Workers/Automations/AbandonedCartWorker.php
+++ b/mailpoet/lib/Cron/Workers/Automations/AbandonedCartWorker.php
@@ -45,16 +45,16 @@ class AbandonedCartWorker extends SimpleWorker {
 
     $subscribers = $task->getSubscribers();
     if ($subscribers->count() !== 1) {
-      return false;
+      return true;
     }
     $subscriber = isset($subscribers[0]) ? $subscribers[0]->getSubscriber() : null;
     if (!$subscriber) {
-      return false;
+      return true;
     }
 
     $automation = $this->automationStorage->getAutomation((int)$automationId, (int)$automationVersion);
     if (!$automation || $automation->getStatus() !== Automation::STATUS_ACTIVE) {
-      return false;
+      return true;
     }
 
     $this->wp->doAction(


### PR DESCRIPTION
## Description

If the AbandonedCart automation is inactive or there are no subscribers matching when the cron-worker schedules this job, the worker can consider its job done, and return true earlier.

As I understand it, if `false` is returned, then the cron-worker will enqueue more similar jobs, clogging the queue.

See p1735156774223359-slack-C01H71ZLBGQ.

## Code review notes

_N/A_

## QA notes

Testing instructions:
1. Create an abandoned cart automation.
2. Put something in a cart to trigger the automation.
3. Disable the automation.
4. Wait until the scheduled task for the abandoned cart is triggered and see that it's marked as completed and not iterated over and over again.
5. You can also try to repeat the above steps, but delete the customer from the `mailpoet_subscribers` table instead of disabling the automation.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6435]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6435]: https://mailpoet.atlassian.net/browse/MAILPOET-6435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6435_stuck-abandoned-cart)

_The latest successful build from `MAILPOET-6435_stuck-abandoned-cart` will be used. If none is available, the link won't work._