### PR TITLE
Update translations in readme [MAILPOET-6373]

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -111,12 +111,12 @@ Please note:
 * Czech
 * Danish
 * Dutch
-* Dutch → Dutch (Formal)
+* Dutch (Formal)
 * French (Canada)
 * French (France)
 * German
 * German (Switzerland)
-* German → German (Formal)
+* German (Formal)
 * Greek
 * Hindi
 * Italian

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -105,39 +105,33 @@ Please note:
 
 = Translations =
 
-**Official translations**
-
+* Albanian
 * Arabic
 * Catalan
-* Chinese
 * Czech
 * Danish
 * Dutch
-* French (FR)
+* Dutch → Dutch (Formal)
+* French (Canada)
+* French (France)
 * German
+* German (Switzerland)
+* German → German (Formal)
 * Greek
+* Hindi
 * Italian
 * Japanese
-* Mexican
-* Persian (IR)
 * Polish
-* Portuguese (BR and PT)
+* Portuguese (Brazil)
+* Portuguese (Portugal)
+* Romanian
 * Russian
 * Serbian
-* Spanish
+* Slovak
+* Spanish (Mexico)
+* Spanish (Spain)
 * Swedish
 * Turkish
-
-**Community translations**
-
-* Albanian
-* British
-* French (CA)
-* Hebrew
-* Hungarian
-* Norwegian
-* Persian
-* Romanian
 * Ukrainian
 
 We welcome experienced translators to translate directly on [our Transifex project](https://www.transifex.com/wysija/mp3/). Please note that any translations submitted via the "Translating WordPress" website will not work.


### PR DESCRIPTION
## Description
Updates the languages to the one supported here: https://translate.wordpress.com/projects/mailpoet/mailpoet/

## Code review notes
I couldn't really distinguish between official and community. So I just removed that distinction. Wdyt?

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-6373]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6373]: https://mailpoet.atlassian.net/browse/MAILPOET-6373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6373-fix-translations-in-readme)

_The latest successful build from `MAILPOET-6373-fix-translations-in-readme` will be used. If none is available, the link won't work._