### PR TITLE
Remove -1d modifier [MAILPOET-6440]

### DIFF
--- a/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
+++ b/mailpoet/lib/Newsletter/Scheduler/AutomationEmailScheduler.php
@@ -70,11 +70,7 @@ class AutomationEmailScheduler {
       ->andWhere('st.createdAt >= :runCreatedAt')
       ->setParameter('newsletter', $email)
       ->setParameter('subscriber', $subscriber)
-      // Automation Run is fetched via WPDB and it ignores the gmt_offset. This query is processed via Doctrine.
-      // Doctrine uses PDO connection and uses offset. So the run's created_at is expected to be provided with the offset.
-      // By removing one day we make sure the offset is not a problem. It makes no harm as this is only performance optimization.
-      // After we switch to WPDB we could remove this modification and use the exact created_at.
-      ->setParameter('runCreatedAt', $run->getCreatedAt()->modify('-1 day'))
+      ->setParameter('runCreatedAt', $run->getCreatedAt())
       ->getQuery()
       ->getResult();
     $result = null;


### PR DESCRIPTION
## Description
As discussed, this PR removes the -1d modifier when fetching the scheduled task for an automation email.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-6440]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6440]: https://mailpoet.atlassian.net/browse/MAILPOET-6440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6440-remove--1day-modifier)

_The latest successful build from `MAILPOET-6440-remove--1day-modifier` will be used. If none is available, the link won't work._