### PR TITLE
Fix type in Initializer::allow_styles() [MAILPOET-6426]

### DIFF
--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -64,9 +64,13 @@ class Initializer {
 	/**
 	 * Allow styles for the email editor.
 	 *
-	 * @param array $allowed_styles Allowed styles.
+	 * @param array|null $allowed_styles Allowed styles.
 	 */
-	public function allow_styles( array $allowed_styles ): array {
+	public function allow_styles( ?array $allowed_styles ): array {
+		// The styles can be null in some cases.
+		if ( ! is_array( $allowed_styles ) ) {
+			$allowed_styles = array();
+		}
 		$allowed_styles[] = 'display';
 		$allowed_styles[] = 'mso-padding-alt';
 		$allowed_styles[] = 'mso-font-width';


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

I think QA can be skipped here.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6426]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6426]: https://mailpoet.atlassian.net/browse/MAILPOET-6426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:initializer-type-fix)

_The latest successful build from `initializer-type-fix` will be used. If none is available, the link won't work._