### PR TITLE
Fixing trunk

### DIFF
--- a/.github/workflows/email-editor-package.yml
+++ b/.github/workflows/email-editor-package.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: mailpoet/vendor-prefixed
-          key: ${{ runner.os }}-vendor-prefixed-${{ matrix.php-version }}-${{ hashFiles('mailpoet/prefixer/composer.lock') }}-${{ hashFiles('mailpoet/composer.json') }}
+          key: ${{ runner.os }}-vendor-prefixed-${{ matrix.php-version }}-${{ hashFiles('mailpoet/prefixer/composer.lock') }}-${{ hashFiles('mailpoet/prefixer/composer.json') }}
 
       - name: Cache Composer vendor for test environment
         id: composer-tests-env-cache
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/php/email-editor/vendor
-          key: ${{ runner.os }}-composer-email-editor-${{ matrix.php-version }}-${{ hashFiles('packages/php/email-editor/composer.lock') }}-${{ hashFiles('mailpoet/composer.json') }}
+          key: ${{ runner.os }}-composer-email-editor-${{ matrix.php-version }}-${{ hashFiles('packages/php/email-editor/composer.lock') }}-${{ hashFiles('packages/php/email-editor/composer.json') }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -63,7 +63,8 @@ jobs:
 
       # Install MailPoet dependencies only if the cache was not hit
       - name: Install mailpoet dependencies
-        if: steps.composer-mailpoet-cache.outputs.cache-hit != 'true'
+        if: |
+          steps.composer-mailpoet-cache.outputs.cache-hit != 'true' && steps.vendor-prefixed-cache.outputs.cache-hit != 'true'
         run: ./tools/vendor/composer.phar install
         working-directory: mailpoet
 
@@ -143,7 +144,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: mailpoet/vendor-prefixed
-          key: ${{ runner.os }}-vendor-prefixed-${{ matrix.php-version }}-${{ hashFiles('mailpoet/prefixer/composer.lock') }}-${{ hashFiles('mailpoet/composer.json') }}
+          key: ${{ runner.os }}-vendor-prefixed-${{ matrix.php-version }}-${{ hashFiles('mailpoet/prefixer/composer.lock') }}-${{ hashFiles('mailpoet/prefixer/composer.json') }}
 
       - name: Cache Composer vendor for test environment
         id: composer-tests-env-cache
@@ -157,7 +158,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/php/email-editor/vendor
-          key: ${{ runner.os }}-composer-email-editor-${{ matrix.php-version }}-${{ hashFiles('packages/php/email-editor/composer.lock') }}-${{ hashFiles('mailpoet/composer.json') }}
+          key: ${{ runner.os }}-composer-email-editor-${{ matrix.php-version }}-${{ hashFiles('packages/php/email-editor/composer.lock') }}-${{ hashFiles('packages/php/email-editor/composer.json') }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -179,7 +180,8 @@ jobs:
 
       # Install MailPoet dependencies only if the cache was not hit
       - name: Install mailpoet dependencies
-        if: steps.composer-mailpoet-cache.outputs.cache-hit != 'true'
+        if: |
+          steps.composer-mailpoet-cache.outputs.cache-hit != 'true' && steps.vendor-prefixed-cache.outputs.cache-hit != 'true'
         run: ./tools/vendor/composer.phar install
         working-directory: mailpoet
 

--- a/.github/workflows/email-editor-package.yml
+++ b/.github/workflows/email-editor-package.yml
@@ -64,7 +64,7 @@ jobs:
       # Install MailPoet dependencies only if the cache was not hit
       - name: Install mailpoet dependencies
         if: |
-          steps.composer-mailpoet-cache.outputs.cache-hit != 'true' && steps.vendor-prefixed-cache.outputs.cache-hit != 'true'
+          steps.composer-mailpoet-cache.outputs.cache-hit != 'true' || steps.vendor-prefixed-cache.outputs.cache-hit != 'true'
         run: ./tools/vendor/composer.phar install
         working-directory: mailpoet
 
@@ -181,7 +181,7 @@ jobs:
       # Install MailPoet dependencies only if the cache was not hit
       - name: Install mailpoet dependencies
         if: |
-          steps.composer-mailpoet-cache.outputs.cache-hit != 'true' && steps.vendor-prefixed-cache.outputs.cache-hit != 'true'
+          steps.composer-mailpoet-cache.outputs.cache-hit != 'true' || steps.vendor-prefixed-cache.outputs.cache-hit != 'true'
         run: ./tools/vendor/composer.phar install
         working-directory: mailpoet
 


### PR DESCRIPTION
## Description

This PR https://github.com/mailpoet/mailpoet/pull/6046 updates the vendor-prefix folder, but we don't check for it in the cache. GitHub action skips the install process because of that.

## Code review notes

_N/A_

## QA notes

We can skip QA

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fixing-trunk)

_The latest successful build from `fixing-trunk` will be used. If none is available, the link won't work._