### PR TITLE
Fix copy of the pattern names

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ThreeColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ThreeColumn.php
@@ -53,6 +53,6 @@ class ThreeColumn extends Pattern {
 
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     /* translators: Name of a content pattern used as starting content of an email */
-    return __('3 Column', 'mailpoet');
+    return __('3 Columns', 'mailpoet');
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TwoColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TwoColumn.php
@@ -69,6 +69,6 @@ class TwoColumn extends Pattern {
 
   protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     /* translators: Name of a content pattern used as starting content of an email */
-    return __('2 Column', 'mailpoet');
+    return __('2 Columns', 'mailpoet');
   }
 }

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -23,7 +23,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertArrayHasKey('categories', $threeColumnContent);
     $this->assertEquals('mailpoet/3-column-content', $threeColumnContent['name']);
     $this->assertStringContainsString('A three-column layout organizes information into sections', $threeColumnContent['content']);
-    $this->assertEquals('3 Column', $threeColumnContent['title']);
+    $this->assertEquals('3 Columns', $threeColumnContent['title']);
     $this->assertEquals(['email-contents'], $threeColumnContent['categories']);
 
     $twoColumnContent = array_pop($blockPatterns);
@@ -34,7 +34,7 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertArrayHasKey('categories', $twoColumnContent);
     $this->assertEquals('mailpoet/2-column-content', $twoColumnContent['name']);
     $this->assertStringContainsString('A two-column layout organizes information into sections', $twoColumnContent['content']);
-    $this->assertEquals('2 Column', $twoColumnContent['title']);
+    $this->assertEquals('2 Columns', $twoColumnContent['title']);
     $this->assertEquals(['email-contents'], $twoColumnContent['categories']);
 
     $oneColumnContent = array_pop($blockPatterns);


### PR DESCRIPTION
## Description

Based on the feedback from the translation team

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-copy)

_The latest successful build from `fix-copy` will be used. If none is available, the link won't work._