### PR TITLE
Add fix storing email links and open tracked links [MAILPOET-6433]

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/behaviors/text-editor-behavior.ts
+++ b/mailpoet/assets/js/src/newsletter-editor/behaviors/text-editor-behavior.ts
@@ -73,10 +73,16 @@ BehaviorsLookup.TextEditorBehavior = Marionette.Behavior.extend({
             return url;
           }
 
-          return this.documentBaseURI.toAbsolute(
+          const result = this.documentBaseURI.toAbsolute(
             url,
             this.options.get('remove_script_host'),
           );
+          // Because TinyMCE contains an issue when inserted URLs ampersands are encoded twice
+          // We remove one of them to store the URL correctly into the database.
+          // related GH issues:
+          // - https://github.com/tinymce/tinymce/issues/9774
+          // - https://github.com/tinymce/tinymce/issues/9618
+          return result.replace('&amp;', '&');
         },
 
         plugins: this.options.plugins,

--- a/mailpoet/lib/Migrations/App/Migration_20250120_094614_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20250120_094614_App.php
@@ -7,8 +7,8 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Migrator\AppMigration;
 
 /**
- * The plugin from the version 5.5.2 to 5.6.1 contained a bug when the `&amp;` in links was stored
- * as `&amp;amp;` in the database. This migration fixes the issue by replacing `&amp;amp;` with `&amp;`.
+ * The plugin from the version 5.5.2 to 5.6.1 contained a bug when we stored links containing &amp; and in some cases also links with `&amp;amp;` in the database.
+ * This migration fixes the issue by replacing `&amp;amp;` with `&amp; and then &amp; with &`.
  *
  * See https://mailpoet.atlassian.net/browse/MAILPOET-6433
  */
@@ -19,7 +19,7 @@ class Migration_20250120_094614_App extends AppMigration {
       $linksTable = $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName();
       $this->entityManager->getConnection()->executeQuery("
         UPDATE {$linksTable}
-        SET url = REPLACE(url, '&amp;amp;', '&amp;')
+        SET url = REPLACE( REPLACE(url, '&amp;amp;', '&amp;'), '&amp;', '&')
         WHERE queue_id >= :queue_id;
       ", ['queue_id' => $sendingQueueId]);
     }

--- a/mailpoet/lib/Migrations/App/Migration_20250120_094614_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20250120_094614_App.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Migrator\AppMigration;
+
+/**
+ * The plugin from the version 5.5.2 and higher contained a bug when the `&amp;` in links was stored
+ * as `&amp;amp;` in the database. This migration fixes the issue by replacing `&amp;amp;` with `&amp;`.
+ *
+ * See https://mailpoet.atlassian.net/browse/MAILPOET-6433
+ */
+class Migration_20250120_094614_App extends AppMigration {
+  public function run(): void {
+    $sendingQueueId = $this->getSendingQueueId();
+    if ($sendingQueueId) {
+      $linksTable = $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName();
+      $this->entityManager->getConnection()->executeQuery("
+        UPDATE {$linksTable}
+        SET url = REPLACE(url, '&amp;amp;', '&amp;')
+        WHERE queue_id >= :queue_id;
+      ", ['queue_id' => $sendingQueueId]);
+    }
+  }
+
+  private function getSendingQueueId(): ?int {
+    $qb = $this->entityManager->createQueryBuilder();
+    /** @var array{id: number}|null $result */
+    $result = $qb->select('sq.id AS id')
+      ->from(SendingQueueEntity::class, 'sq')
+      ->where(
+        $qb->expr()->gt('sq.createdAt', ':date')
+      )
+      ->orderBy('sq.id', 'ASC')
+      ->setMaxResults(1)
+      ->setParameter('date', '2024-12-24:00:00:00')
+      ->getQuery()
+      ->getOneOrNullResult();
+    return $result ? (int)$result['id'] : null;
+  }
+}

--- a/mailpoet/lib/Migrations/App/Migration_20250120_094614_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20250120_094614_App.php
@@ -7,7 +7,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Migrator\AppMigration;
 
 /**
- * The plugin from the version 5.5.2 and higher contained a bug when the `&amp;` in links was stored
+ * The plugin from the version 5.5.2 to 5.6.1 contained a bug when the `&amp;` in links was stored
  * as `&amp;amp;` in the database. This migration fixes the issue by replacing `&amp;amp;` with `&amp;`.
  *
  * See https://mailpoet.atlassian.net/browse/MAILPOET-6433

--- a/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
+++ b/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
@@ -36,7 +36,8 @@ class OpenTracking {
     if (!empty($template)) {
       $template = is_array($template) ? $template : [$template];
       array_map(
-        fn($item) => $item->html($item->toString(true, true, 1) . $openTrackingImage),
+        // Because TinyMCE sometimes converts `&amp;` to `&amp;amp;` we need to replace it back because the previous versions contained a bug which rendered the links correctly.
+        fn($item) => $item->html(str_replace('&amp;amp;', '&amp;', $item->toString(true, true, 1)) . $openTrackingImage),
         $template,
       );
     }

--- a/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
+++ b/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
@@ -38,9 +38,6 @@ class OpenTracking {
       array_map(
         function ($item) use ($openTrackingImage) {
           $itemHtml = $item->toString(true, true, 1);
-          // Because TinyMCE sometimes converts `&amp;` to `&amp;amp;`
-          //we need to replace it back because the previous versions contained a bug which rendered the links correctly.
-          $itemHtml = str_replace('&amp;amp;', '&amp;', $itemHtml);
           $item->html($itemHtml . $openTrackingImage);
           return $item;
         },

--- a/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
+++ b/mailpoet/lib/Newsletter/Renderer/PostProcess/OpenTracking.php
@@ -36,9 +36,15 @@ class OpenTracking {
     if (!empty($template)) {
       $template = is_array($template) ? $template : [$template];
       array_map(
-        // Because TinyMCE sometimes converts `&amp;` to `&amp;amp;` we need to replace it back because the previous versions contained a bug which rendered the links correctly.
-        fn($item) => $item->html(str_replace('&amp;amp;', '&amp;', $item->toString(true, true, 1)) . $openTrackingImage),
-        $template,
+        function ($item) use ($openTrackingImage) {
+          $itemHtml = $item->toString(true, true, 1);
+          // Because TinyMCE sometimes converts `&amp;` to `&amp;amp;`
+          //we need to replace it back because the previous versions contained a bug which rendered the links correctly.
+          $itemHtml = str_replace('&amp;amp;', '&amp;', $itemHtml);
+          $item->html($itemHtml . $openTrackingImage);
+          return $item;
+        },
+        $template
       );
     }
   }

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -216,6 +216,15 @@ class Renderer {
     foreach ($templateDom->query('img') as $image) {
       $image->src = str_replace(' ', '%20', $image->src);
     }
+    foreach ($templateDom->query('a') as $anchor) {
+      // Fix for a TinyMCE bug in smart paste which encodes & as &amp; which is then additionally encoded to &amp;amp;
+      // when saving the text block content in the editor
+      $href = str_replace('&amp;amp;', '&amp;', $anchor->href);
+      // Replace &amp; with & in the href attributes of anchors. URLs are encoded when TinyMCE extracts Text block content via content.innerHTML.
+      // Links containing &amp; work when placed in an anchor tag in a browser, but they don't work when we redirect to them for example in tracking.
+      $href = str_replace('&amp;', '&', $href);
+      $anchor->href = $href;
+    }
     $template = $templateDom->__toString();
     $template = $this->wp->applyFilters(
       self::FILTER_POST_PROCESS,


### PR DESCRIPTION
## Description

When we released version 5.5.2, it contained a fix in rendering links. Nevertheless, we didn't know about another bug in TinyMCE, which can cause doubled encoding & when the link is pasted via `smart_paste`.

- This PR adds a fix for TinyMCE to avoid broken links in stored emails.
- It also adds a change for correct extraction of the broken mails because the broken links can be stored in post notifications, etc.
- A new migration fixes stored incorrect links.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6433]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6433]: https://mailpoet.atlassian.net/browse/MAILPOET-6433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-links-fix)

_The latest successful build from `email-links-fix` will be used. If none is available, the link won't work._