### PR TITLE
Make the send component independent on MailPoet [MAILPOET-6429]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -11,6 +11,7 @@ use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoet\EmailEditor\Engine\User_Theme;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as EditorInitController;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Settings\SettingsController as MailPoetSettings;
 use MailPoet\Settings\UserFlagsController;
@@ -75,6 +76,10 @@ class EditorPageRenderer {
     $postId = isset($_GET['post']) ? intval($_GET['post']) : 0;
     $post = $this->wp->getPost($postId);
     if (!$post instanceof \WP_Post || $post->post_type !== EditorInitController::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return;
+    }
+    $newsletter = $this->newslettersRepository->findOneBy(['wpPost' => $postId]);
+    if (!$newsletter instanceof NewsletterEntity) {
       return;
     }
     $this->dependencyNotice->checkDependenciesAndEventuallyShowNotice();
@@ -148,6 +153,7 @@ class EditorPageRenderer {
         'user_theme_post_id' => $this->userTheme->get_user_theme_post()->ID,
         'urls' => [
           'listings' => admin_url('admin.php?page=mailpoet-newsletters'),
+          'send' => admin_url('admin.php?page=mailpoet-newsletters#/send/' . $newsletter->getId()),
         ],
       ]
     );

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { applyFilters } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
 import {
@@ -14,30 +13,26 @@ import {
 /**
  * Internal dependencies
  */
-import { MailPoetEmailData, storeName } from '../../store';
+import { storeName } from '../../store';
 import { useEditorMode } from '../../hooks';
 import { recordEvent } from '../../events';
 
 export function SendButton( { validateContent, isContentInvalid } ) {
-	const [ mailpoetEmail ] = useEntityProp(
-		'postType',
-		'mailpoet_email',
-		'mailpoet_data'
-	);
-
 	const { isDirty } = useEntitiesSavedStatesIsDirty();
 
-	const { hasEmptyContent, isEmailSent } = useSelect(
+	const { hasEmptyContent, isEmailSent, urls } = useSelect(
 		( select ) => ( {
 			hasEmptyContent: select( storeName ).hasEmptyContent(),
 			isEmailSent: select( storeName ).isEmailSent(),
+			urls: select( storeName ).getUrls(),
 		} ),
 		[]
 	);
 
-	const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
 	function sendAction() {
-		window.location.href = `admin.php?page=mailpoet-newsletters#/send/${ mailpoetEmailData.id }`;
+		if ( urls.send ) {
+			window.location.href = urls.send;
+		}
 	}
 
 	const [ editorMode ] = useEditorMode();

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -35,6 +35,11 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 		[]
 	);
 
+	const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
+	function sendAction() {
+		window.location.href = `admin.php?page=mailpoet-newsletters#/send/${ mailpoetEmailData.id }`;
+	}
+
 	const [ editorMode ] = useEditorMode();
 
 	const isDisabled =
@@ -44,7 +49,6 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 		isContentInvalid ||
 		isDirty;
 
-	const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
 	const label = applyFilters(
 		'mailpoet_email_editor_send_button_label',
 		__( 'Send', 'mailpoet' )
@@ -56,7 +60,11 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 			onClick={ () => {
 				recordEvent( 'header_send_button_clicked' );
 				if ( validateContent() ) {
-					window.location.href = `admin.php?page=mailpoet-newsletters#/send/${ mailpoetEmailData.id }`;
+					const action = applyFilters(
+						'mailpoet_email_editor_send_action_callback',
+						sendAction
+					) as () => void;
+					action();
 				}
 			} }
 			disabled={ isDisabled }

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
+import { applyFilters } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
 import {
 	// @ts-expect-error No types available for useEntitiesSavedStatesIsDirty
@@ -44,6 +45,11 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 		isDirty;
 
 	const mailpoetEmailData: MailPoetEmailData = mailpoetEmail;
+	const label = applyFilters(
+		'mailpoet_email_editor_send_button_label',
+		__( 'Send', 'mailpoet' )
+	) as string;
+
 	return (
 		<Button
 			variant="primary"
@@ -55,7 +61,7 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 			} }
 			disabled={ isDisabled }
 		>
-			{ __( 'Send', 'mailpoet' ) }
+			{ label }
 		</Button>
 	);
 }

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -166,6 +166,7 @@ export type EmailEditorLayout = {
 };
 
 export type EmailEditorUrls = {
+	send?: string;
 	listings: string;
 };
 

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -80,6 +80,5 @@ We may add, update and delete any of them.
 - We use `mailpoet_data` in some section of the codebase. This will be updated.
 - Native email editor implementation for the `preview_url`.
 - Fix the use of MailPoet vendor packages in the Email editor. We currently use `Emogrifier` and `Html2Text`.
-- Fix the Send button (button to send email) or redirect it elsewhere. It is currently pointing to the `mailpoet-newsletter` page.
 - We currently support post editing context (a post has to be created before we can use the editor). We need to add support for creation context.
 - The content validation in the editor looks for the unsubscribe link tag, which is registered in the MailPoet plugin. We need either introduce generic unsubscribe link tag or move the validation to the MailPoet plugin.


### PR DESCRIPTION
## Description

To prepare the email editor package on the MailPoet code I removed all usage of it from the send component and made it configurable. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6429]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6429]: https://mailpoet.atlassian.net/browse/MAILPOET-6429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:configure-send)

_The latest successful build from `configure-send` will be used. If none is available, the link won't work._