### PR TITLE
Switch to using `getBlockPatterns` and update implementation - MAILPOET-6444

### DIFF
--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -5,7 +5,6 @@ import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { useSelect } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -16,6 +15,10 @@ import {
 	TemplatePreview,
 	EmailEditorPostType,
 } from '../store';
+
+// Shared reference to an empty array for cases where it is important to avoid
+// returning a new array reference on every invocation
+const EMPTY_ARRAY = [];
 
 /**
  * We need to merge pattern blocks and template blocks for BlockPreview component.
@@ -96,21 +99,12 @@ export function usePreviewTemplates(
 ): [ TemplatePreview[], TemplatePreview[], boolean ] {
 	const { templates, patterns, emailPosts, hasEmailPosts } = useSelect(
 		( select ) => {
-			const contentBlockId =
-				// @ts-expect-error getBlocksByName is not defined in types
-				select( blockEditorStore ).getBlocksByName(
-					'core/post-content'
-				)?.[ 0 ];
-
 			const rawEmailPosts = select( storeName ).getSentEmailEditorPosts();
+
 			return {
 				templates: select( storeName ).getEmailTemplates(),
 				patterns:
-					// @ts-expect-error getPatternsByBlockTypes is not defined in types
-					select( blockEditorStore ).getPatternsByBlockTypes(
-						[ 'core/post-content' ],
-						contentBlockId
-					),
+					select( storeName ).getBlockPatternsForEmailTemplate(),
 				emailPosts: rawEmailPosts,
 				hasEmailPosts: !! ( rawEmailPosts && rawEmailPosts?.length ),
 			};
@@ -128,15 +122,11 @@ export function usePreviewTemplates(
 		if ( parsedCustomEmailContent ) {
 			contentPatterns = [ { blocks: parsedCustomEmailContent } ];
 		} else {
-			contentPatterns = patterns.filter(
-				( pattern ) =>
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-					pattern?.templateTypes?.includes( 'email-template' )
-			);
+			contentPatterns = patterns;
 		}
 
 		if ( ! contentPatterns || ! templates ) {
-			return [];
+			return EMPTY_ARRAY;
 		}
 
 		const templateToPreview = [];
@@ -208,5 +198,9 @@ export function usePreviewTemplates(
 		} ) as unknown as TemplatePreview[];
 	}, [ emailPosts, allTemplates ] );
 
-	return [ allTemplates || [], allEmailPosts || [], hasEmailPosts ];
+	return [
+		allTemplates || EMPTY_ARRAY,
+		allEmailPosts || EMPTY_ARRAY,
+		hasEmailPosts,
+	];
 }


### PR DESCRIPTION
## Description

Remove dependency on `getPatternsByBlockTypes` and switch to using `getBlockPatterns`


## Code review notes

I reused some of the stuff from Gutenberg core. Let me know if you noticed any issues.

The PR essentially tries to fetch all patterns and filter for `email-template` which is much faster than the previous [implementation](https://github.com/mailpoet/mailpoet/blob/0c478691bb909b3d504467ba421755e79c53f251/packages/js/email-editor/src/hooks/use-preview-templates.ts#L99-L112) where we get `contentBlockId` and use that to fetch all patterns and filter by `BlockTypes`.

## QA notes

* Ensure you test on WPCOM Simple sites

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6444](https://mailpoet.atlassian.net/browse/MAILPOET-6444)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6444]: https://mailpoet.atlassian.net/browse/MAILPOET-6444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fixing-email-editor-for-wpcom)

_The latest successful build from `fixing-email-editor-for-wpcom` will be used. If none is available, the link won't work._