### PR TITLE
Fix inserting personalization tags [MAILPOET-6443]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
@@ -18,14 +18,14 @@ class Subscriber {
     $subscriberEmail = $context['recipient_email'] ?? null;
     $subscriber = $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
 
-    return $subscriber ? $subscriber->getFirstName() : $args['default'] ?? '';
+    return ($subscriber && $subscriber->getFirstName()) ? $subscriber->getFirstName() : $args['default'] ?? '';
   }
 
   public function getLastName(array $context, array $args = []): string {
     $subscriberEmail = $context['recipient_email'] ?? null;
     $subscriber = $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
 
-    return $subscriber ? $subscriber->getLastName() : $args['default'] ?? '';
+    return ($subscriber && $subscriber->getLastName()) ? $subscriber->getLastName() : $args['default'] ?? '';
   }
 
   public function getEmail(array $context, array $args = []): string {

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -59,7 +59,7 @@ const CategorySection = ( {
 											onClick={ () => {
 												if ( onInsert ) {
 													onInsert(
-														item.token,
+														item.valueToInsert,
 														false
 													);
 												}


### PR DESCRIPTION
## Description

Personalization tags should be inserted with default attribute values. 

## Code review notes

_N/A_

## QA notes

1. Insert a personalization tag and check that the inserted value matches the value in the line bellow tag name

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6443]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6443]: https://mailpoet.atlassian.net/browse/MAILPOET-6443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:tags-attributes)

_The latest successful build from `tags-attributes` will be used. If none is available, the link won't work._