### PR TITLE
Remove unwanted email templates from template selector [MAILPOET-6445]

### DIFF
--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -126,7 +126,7 @@ class Templates {
 		if ( isset( $response_object['plugin'] ) && $response_object['plugin'] === $this->template_prefix ) {
 			return $this->post_types;
 		}
-		return array();
+		return $response_object['post_types'] ?? array();
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -123,10 +123,10 @@ class Templates {
 	 * @return array
 	 */
 	public function get_post_types( $response_object ): array {
-		if ( isset( $response_object['plugin'] ) && $response_object['plugin'] !== $this->template_prefix ) {
-			return array();
+		if ( isset( $response_object['plugin'] ) && $response_object['plugin'] === $this->template_prefix ) {
+			return $this->post_types;
 		}
-		return $this->post_types;
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR fixes an issue that a template from Woo was displayed among email templates in the template selection modal in the new email editor.

## Code review notes

The wrong condition was causing we added the post_type data to more even incorrect templates. They were then displayed in the select template modal. 

## QA notes

#### Replication
1) Install Woo
2) Create a new email in the new email editor
3) Observe the issue in the Basic category of the select template modal

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6445]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6445]: https://mailpoet.atlassian.net/browse/MAILPOET-6445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-unwanted-templates)

_The latest successful build from `fix-unwanted-templates` will be used. If none is available, the link won't work._