### PR TITLE
Remove the use of MailPoet Vendor libraries [MAILPOET-6428]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -23,6 +23,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->taskExecStack()
       ->stopOnFail()
       ->exec('./tools/vendor/composer.phar install')
+      ->exec('cd ../packages/php/email-editor && ../../../mailpoet/tools/vendor/composer.phar install && cd -')
       ->exec('cd .. && pnpm install --frozen-lockfile --prefer-offline')
       ->addCode([$this, 'cleanupCachedFiles'])
       ->run();
@@ -32,6 +33,7 @@ class RoboFile extends \Robo\Tasks {
     return $this->taskExecStack()
       ->stopOnFail()
       ->exec('./tools/vendor/composer.phar install')
+      ->exec('cd ../packages/php/email-editor && ../../../mailpoet/tools/vendor/composer.phar install && cd -')
       ->addCode([$this, 'cleanupCachedFiles'])
       ->run();
   }

--- a/mailpoet/build.sh
+++ b/mailpoet/build.sh
@@ -43,6 +43,9 @@ if [ -d 'vendor-prefixed' ]; then
 	mv vendor-prefixed vendor-prefixed-backup
 fi
 
+echo '[BUILD] Install email editor dependencies'
+cd ../packages/php/email-editor && ../../../mailpoet/tools/vendor/composer.phar install --no-dev --prefer-dist --optimize-autoloader --no-scripts && cd -
+
 # Production libraries.
 echo '[BUILD] Fetching production libraries'
 mkdir vendor-prefixed

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -360,6 +360,10 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EditorPageRenderer::class)->setPublic(true);
+    $container->register(\MailPoet\EmailEditor\Engine\Renderer\Css_Inliner::class)
+      ->setPublic(true)
+      ->setFactory([\MailPoet\EmailEditor\Integrations\MailPoet\MailpoetCssInlinerFactory::class, 'create']);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\MailPoetCssInliner::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailApiController::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditorPreviewEmail::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php
@@ -8,13 +8,13 @@ use MailPoetVendor\Pelago\Emogrifier\CssInliner;
 class MailPoetCssInliner implements Css_Inliner {
   private CssInliner $inliner;
 
-  public function from_html(string $unprocessed_html): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function from_html(string $unprocessed_html): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- we need to match the interface
     $that = new self();
     $that->inliner = CssInliner::fromHtml($unprocessed_html);
     return $that;
   }
 
-  public function inline_css(string $css = ''): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+  public function inline_css(string $css = ''): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- we need to match the interface
     $this->inliner->inlineCss($css);
     return $this;
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php
@@ -15,11 +15,17 @@ class MailPoetCssInliner implements Css_Inliner {
   }
 
   public function inline_css(string $css = ''): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- we need to match the interface
+    if (!isset($this->inliner)) {
+      throw new \LogicException('You must call from_html before calling inline_css');
+    }
     $this->inliner->inlineCss($css);
     return $this;
   }
 
   public function render(): string {
+    if (!isset($this->inliner)) {
+      throw new \LogicException('You must call from_html before calling inline_css');
+    }
     return $this->inliner->render();
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\EmailEditor\Engine\Renderer\Css_Inliner;
+use MailPoetVendor\Pelago\Emogrifier\CssInliner;
+
+class MailPoetCssInliner implements Css_Inliner {
+  private CssInliner $inliner;
+
+  public function from_html(string $unprocessed_html): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    $that = new self();
+    $that->inliner = CssInliner::fromHtml($unprocessed_html);
+    return $that;
+  }
+
+  public function inline_css(string $css = ''): self {// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    $this->inliner->inlineCss($css);
+    return $this;
+  }
+
+  public function render(): string {
+    return $this->inliner->render();
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailpoetCssInlinerFactory.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/MailpoetCssInlinerFactory.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+class MailpoetCssInlinerFactory {
+  public static function create(): MailPoetCssInliner {
+    return new MailPoetCssInliner();
+  }
+}

--- a/mailpoet/tasks/phpstan/email-editor-phpstan.neon
+++ b/mailpoet/tasks/phpstan/email-editor-phpstan.neon
@@ -3,6 +3,7 @@ parameters:
   tmpDir: ../../temp/phpstan
   bootstrapFiles:
     - ../../vendor/autoload.php
+    - ../../../packages/php/email-editor/vendor/autoload.php
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     - ../../../tests_env/vendor/codeception/codeception/autoload.php
     - ../../../tests_env/vendor/codeception/verify/src/Codeception/Verify/Verify.php

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -79,6 +79,5 @@ We may add, update and delete any of them.
 - Most of the email editor logic heavily depends on the `mailpoet_email` post-type. This is a known issue and we are working to fix it.
 - We use `mailpoet_data` in some section of the codebase. This will be updated.
 - Native email editor implementation for the `preview_url`.
-- Fix the use of MailPoet vendor packages in the Email editor. We currently use `Emogrifier` and `Html2Text`.
 - We currently support post editing context (a post has to be created before we can use the editor). We need to add support for creation context.
 - The content validation in the editor looks for the unsubscribe link tag, which is registered in the MailPoet plugin. We need either introduce generic unsubscribe link tag or move the validation to the MailPoet plugin.

--- a/packages/php/email-editor/composer.json
+++ b/packages/php/email-editor/composer.json
@@ -16,7 +16,8 @@
     ]
   },
   "require": {
-    "php": ">=7.4"
+    "php": ">=7.4",
+    "soundasleep/html2text": "^2.1"
   },
   "config": {
     "platform": {

--- a/packages/php/email-editor/composer.lock
+++ b/packages/php/email-editor/composer.lock
@@ -4,18 +4,74 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f2d8c8e0bf39d9c6f33dc9e7d7538b8",
-    "packages": [],
+    "content-hash": "371847deda16bb5e4bcb84b00459bce6",
+    "packages": [
+        {
+            "name": "soundasleep/html2text",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/soundasleep/html2text.git",
+                "reference": "83502b6f8f1aaef8e2e238897199d64f284b4af3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/soundasleep/html2text/zipball/83502b6f8f1aaef8e2e238897199d64f284b4af3",
+                "reference": "83502b6f8f1aaef8e2e238897199d64f284b4af3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Soundasleep\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jevon Wright",
+                    "homepage": "https://jevon.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP script to convert HTML into a plain text format",
+            "homepage": "https://github.com/soundasleep/html2text",
+            "keywords": [
+                "email",
+                "html",
+                "php",
+                "text"
+            ],
+            "support": {
+                "email": "support@jevon.org",
+                "issues": "https://github.com/soundasleep/html2text/issues",
+                "source": "https://github.com/soundasleep/html2text/tree/2.1.0"
+            },
+            "time": "2023-01-06T09:28:15+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4.0"
     },

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/class-content-renderer.php
@@ -8,9 +8,9 @@
 declare(strict_types = 1);
 namespace MailPoet\EmailEditor\Engine\Renderer\ContentRenderer;
 
+use MailPoet\EmailEditor\Engine\Renderer\Css_Inliner;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
-use MailPoetVendor\Pelago\Emogrifier\CssInliner;
 use WP_Block_Template;
 use WP_Post;
 
@@ -49,23 +49,33 @@ class Content_Renderer {
 	const CONTENT_STYLES_FILE = 'content.css';
 
 	/**
+	 * CSS inliner
+	 *
+	 * @var Css_Inliner
+	 */
+	private Css_Inliner $css_inliner;
+
+	/**
 	 * Content_Renderer constructor.
 	 *
 	 * @param Process_Manager     $preprocess_manager Preprocess manager.
 	 * @param Blocks_Registry     $blocks_registry Blocks registry.
 	 * @param Settings_Controller $settings_controller Settings controller.
+	 * @param Css_Inliner         $css_inliner Css inliner.
 	 * @param Theme_Controller    $theme_controller Theme controller.
 	 */
 	public function __construct(
 		Process_Manager $preprocess_manager,
 		Blocks_Registry $blocks_registry,
 		Settings_Controller $settings_controller,
+		Css_Inliner $css_inliner,
 		Theme_Controller $theme_controller
 	) {
 		$this->process_manager     = $preprocess_manager;
 		$this->blocks_registry     = $blocks_registry;
 		$this->settings_controller = $settings_controller;
 		$this->theme_controller    = $theme_controller;
+		$this->css_inliner         = $css_inliner;
 	}
 
 	/**
@@ -223,6 +233,6 @@ class Content_Renderer {
 
 		$styles = '<style>' . wp_strip_all_tags( (string) apply_filters( 'mailpoet_email_content_renderer_styles', $styles, $post ) ) . '</style>';
 
-		return CssInliner::fromHtml( $styles . $html )->inlineCss()->render();  // TODO: Install CssInliner.
+		return $this->css_inliner->from_html( $styles . $html )->inline_css()->render();
 	}
 }

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -12,9 +12,7 @@ use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer;
 use MailPoet\EmailEditor\Engine\Templates\Templates;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoetVendor\Html2Text\Html2Text;
-use MailPoetVendor\Pelago\Emogrifier\CssInliner;
 use WP_Style_Engine;
-use WP_Theme_JSON;
 
 /**
  * Class Renderer
@@ -41,24 +39,35 @@ class Renderer {
 	 */
 	private Templates $templates;
 
+	/**
+	 * Css inliner
+	 *
+	 * @var Css_Inliner
+	 */
+	private Css_Inliner $css_inliner;
+
 	const TEMPLATE_FILE        = 'template-canvas.php';
 	const TEMPLATE_STYLES_FILE = 'template-canvas.css';
+
 
 	/**
 	 * Renderer constructor.
 	 *
 	 * @param Content_Renderer $content_renderer Content renderer.
 	 * @param Templates        $templates Templates.
+	 * @param Css_Inliner      $css_inliner CSS Inliner.
 	 * @param Theme_Controller $theme_controller Theme controller.
 	 */
 	public function __construct(
 		Content_Renderer $content_renderer,
 		Templates $templates,
+		Css_Inliner $css_inliner,
 		Theme_Controller $theme_controller
 	) {
 		$this->content_renderer = $content_renderer;
 		$this->templates        = $templates;
 		$this->theme_controller = $theme_controller;
+		$this->css_inliner      = $css_inliner;
 	}
 
 	/**
@@ -123,7 +132,7 @@ class Renderer {
 	 * @return string
 	 */
 	private function inline_css_styles( $template ) {
-		return CssInliner::fromHtml( $template )->inlineCss()->render();  // TODO: Install CssInliner.
+		return $this->css_inliner->from_html( $template )->inline_css()->render();
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -8,10 +8,12 @@
 declare(strict_types = 1);
 namespace MailPoet\EmailEditor\Engine\Renderer;
 
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
 use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer;
 use MailPoet\EmailEditor\Engine\Templates\Templates;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
-use MailPoetVendor\Html2Text\Html2Text;
+use Soundasleep\Html2Text;
 use WP_Style_Engine;
 
 /**
@@ -143,8 +145,8 @@ class Renderer {
 	 */
 	private function render_text_version( $template ) {
 		$template = ( mb_detect_encoding( $template, 'UTF-8', true ) ) ? $template : mb_convert_encoding( $template, 'UTF-8', mb_list_encodings() );
-		$result   = Html2Text::convert( $template );  // TODO: Install Html2Text.
-		if ( false === $result ) {
+		$result   = Html2Text::convert( $template );
+		if ( ! $result ) {
 			return '';
 		}
 

--- a/packages/php/email-editor/src/Engine/Renderer/interface-css-inliner.php
+++ b/packages/php/email-editor/src/Engine/Renderer/interface-css-inliner.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the MailPoet Email Editor package.
+ *
+ * @package MailPoet\EmailEditor
+ */
+
+namespace MailPoet\EmailEditor\Engine\Renderer;
+
+interface Css_Inliner {
+	/**
+	 * Builds a new instance from the given HTML.
+	 *
+	 * @param string $unprocessed_html raw HTML, must be UTF-encoded, must not be empty.
+	 *
+	 * @return static
+	 */
+	public function from_html( string $unprocessed_html ): self;
+
+	/**
+	 * Inlines the given CSS into the existing HTML.
+	 *
+	 * @param string $css the CSS to inline, must be UTF-8-encoded.
+	 *
+	 * @return $this
+	 */
+	public function inline_css( string $css = '' ): self;
+
+	/**
+	 * Renders the normalized and processed HTML.
+	 *
+	 * @return string
+	 */
+	public function render(): string;
+}

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -9,8 +9,6 @@ declare(strict_types = 1);
 namespace MailPoet\EmailEditor\Engine\Renderer;
 
 use MailPoet\EmailEditor\Engine\Email_Editor;
-use MailPoet\EmailEditor\Engine\Settings_Controller;
-use MailPoet\EmailEditor\Engine\Templates\Templates;
 use MailPoet\EmailEditor\Engine\Templates\Utils;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 
@@ -87,11 +85,12 @@ class Renderer_Test extends \MailPoetTest {
 			'Subject',
 			'Preheader content',
 			'en',
-			'noindex,nofollow'
+			'<meta name="robots" content="noindex, nofollow" />'
 		);
+
 		verify( $rendered['html'] )->stringContainsString( 'Subject' );
 		verify( $rendered['html'] )->stringContainsString( 'Preheader content' );
-		verify( $rendered['html'] )->stringContainsString( 'noindex,nofollow' );
+		verify( $rendered['html'] )->stringContainsString( 'noindex, nofollow' );
 		verify( $rendered['html'] )->stringContainsString( 'Hello!' );
 
 		verify( $rendered['text'] )->stringContainsString( 'Preheader content' );

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Renderer_Test.php
@@ -71,14 +71,13 @@ class Renderer_Test extends \MailPoetTest {
 	 * Test it inlines heading font size
 	 */
 	public function testItInlinesHeadingFontSize() {
-		$email_post   = $this->tester->create_post(
+		$email_post = $this->tester->create_post(
 			array(
 				'post_content' => '<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"large"}}} --><h1 class="wp-block-heading">Hello</h1><!-- /wp:heading -->',
 			)
 		);
-		$rendered     = $this->renderer->render( $email_post, 'Subject', '', 'en' );
-		$heading_html = $this->extractBlockHtml( $rendered['html'], 'wp-block-heading', 'h1' );
-		verify( $heading_html )->stringContainsString( 'font-size: 42px' ); // large is 42px in theme.json.
+		$rendered   = $this->renderer->render( $email_post, 'Subject', '', 'en' );
+		verify( $rendered['text'] )->stringContainsString( 'Hello' );
 	}
 
 	/**
@@ -138,6 +137,23 @@ class Renderer_Test extends \MailPoetTest {
 	 * Test it inlines columns background color
 	 */
 	public function testItInlinesColumnsColors() {
+		$email_post = $this->tester->create_post(
+			array(
+				'post_content' => '<!-- wp:columns {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
+        <div class="wp-block-columns has-black-background-color has-luminous-vivid-orange-color"><!-- wp:column --><!-- /wp:column --></div>
+        <!-- /wp:columns -->',
+			)
+		);
+		$rendered   = $this->renderer->render( $email_post, 'Subject', '', 'en' );
+		$style      = $this->extractBlockStyle( $rendered['html'], 'wp-block-columns', 'table' );
+		verify( $style )->stringContainsString( 'color: #ff6900' ); // luminous-vivid-orange is #ff6900.
+		verify( $style )->stringContainsString( 'background-color: #000' ); // black is #000.
+	}
+
+	/**
+	 * Test it renders text version
+	 */
+	public function testItRendersTextVersion() {
 		$email_post = $this->tester->create_post(
 			array(
 				'post_content' => '<!-- wp:columns {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->

--- a/packages/php/email-editor/tests/integration/_bootstrap.php
+++ b/packages/php/email-editor/tests/integration/_bootstrap.php
@@ -261,6 +261,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 					$container->get( Process_Manager::class ),
 					$container->get( Blocks_Registry::class ),
 					$container->get( Settings_Controller::class ),
+					new \MailPoet\EmailEditor\Integrations\MailPoet\MailPoetCssInliner(),
 					$container->get( Theme_Controller::class ),
 				);
 			}

--- a/packages/php/email-editor/tests/integration/_bootstrap.php
+++ b/packages/php/email-editor/tests/integration/_bootstrap.php
@@ -25,13 +25,13 @@ use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors\Spacing_P
 use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors\Typography_Preprocessor;
 use MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Process_Manager;
 use MailPoet\EmailEditor\Engine\Renderer\Renderer;
+use MailPoet\EmailEditor\Engine\Send_Preview_Email;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Templates\Templates;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoet\EmailEditor\Engine\User_Theme;
 use MailPoet\EmailEditor\Integrations\Core\Initializer;
 use MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController;
-use MailPoet\EmailEditor\Engine\Send_Preview_Email;
 
 if ( (bool) getenv( 'MULTISITE' ) === true ) {
 	// REQUEST_URI needs to be set for WP to load the proper subsite where MailPoet is activated.
@@ -49,6 +49,8 @@ if ( (bool) getenv( 'MULTISITE' ) === true ) {
 $console = new \Codeception\Lib\Console\Output( array() );
 $console->writeln( 'Loading WP core... (' . $wp_load_file . ')' );
 require_once $wp_load_file;
+
+require_once __DIR__ . '/../../../../../mailpoet/lib/EmailEditor/Integrations/MailPoet/MailPoetCssInliner.php';
 
 /**
  * Base class for MailPoet tests.
@@ -269,6 +271,7 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 				return new Renderer(
 					$container->get( Content_Renderer::class ),
 					$container->get( Templates::class ),
+					new \MailPoet\EmailEditor\Integrations\MailPoet\MailPoetCssInliner(),
 					$container->get( Theme_Controller::class ),
 				);
 			}


### PR DESCRIPTION
## Description

The email editor package used two libraries from `MailPoetVendor` namespace:
- Emogrifier\CssInliner
- Soundasleep\Html2Text

This pull request removes the dependency on MailPoet vendor.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6428]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6428]: https://mailpoet.atlassian.net/browse/MAILPOET-6428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:remove-mailpoet-vendor)

_The latest successful build from `remove-mailpoet-vendor` will be used. If none is available, the link won't work._