### PR TITLE
MAILPOET-6447 GATracking escapes shortcodes

### DIFF
--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -95,7 +95,7 @@ class GATracking {
 
       $processedLink = $this->wp->applyFilters(
         'mailpoet_ga_tracking_link',
-        $this->wp->addQueryArg($linkParams, $link),
+        urldecode($this->wp->addQueryArg($linkParams, $link)),
         $extractedLink['link'],
         $linkParams,
         $extractedLink['type']

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -21,7 +21,7 @@ class GATracking {
   private $wp;
 
   /** @var TrackingConfig */
-  private $tackingConfig;
+  private $trackingConfig;
 
   public function __construct(
     NewsletterLinks $newsletterLinks,
@@ -31,11 +31,11 @@ class GATracking {
     $this->secondLevelDomainNames = new SecondLevelDomainNames();
     $this->newsletterLinks = $newsletterLinks;
     $this->wp = $wp;
-    $this->tackingConfig = $trackingConfig;
+    $this->trackingConfig = $trackingConfig;
   }
 
   public function applyGATracking($renderedNewsletter, NewsletterEntity $newsletter, $internalHost = null) {
-    if (!$this->tackingConfig->isEmailTrackingEnabled()) {
+    if (!$this->trackingConfig->isEmailTrackingEnabled()) {
       return $renderedNewsletter;
     }
     if ($newsletter->getType() == NewsletterEntity::TYPE_NOTIFICATION_HISTORY && $newsletter->getParent() instanceof NewsletterEntity) {

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -31,7 +31,7 @@ class GATrackingTest extends \MailPoetTest {
     $this->tracking = $this->diContainer->get(GATracking::class);
     $this->internalHost = 'newsletters.mailpoet.com';
     $this->gaCampaign = 'SpringEmail';
-    $this->link = add_query_arg(['foo' => 'bar', 'baz' => 'xyz'], 'https://www.mailpoet.com/');
+    $this->link = add_query_arg(['foo' => 'bar', 'baz' => 'xyz', 'quux' => '[subscriber:email]'], 'https://www.mailpoet.com/');
     $this->renderedNewsletter = [
       'html' => '<p><a href="' . $this->link . '">Click here</a>. <a href="http://somehost.com/fff/?abc=123&email=[subscriber:email]">Do not process this</a> [link:some_link_shortcode]</p>',
       'text' => '[Click here](' . $this->link . '). [Do not process this](http://somehost.com/fff/?abc=123&email=[subscriber:email]) [link:some_link_shortcode]',
@@ -86,10 +86,16 @@ class GATrackingTest extends \MailPoetTest {
     verify($result['html'])->stringContainsString('utm_campaign=' . urlencode($this->gaCampaign));
   }
 
-  public function testItKeepsShorcodes() {
+  public function testItKeepsShortcodes() {
     $result = $this->tracking->applyGATracking($this->renderedNewsletter, $this->newsletter, $this->internalHost);
     verify($result['text'])->stringContainsString('email=[subscriber:email]');
     verify($result['html'])->stringContainsString('email=[subscriber:email]');
+  }
+
+  public function testItPreservesShortcodesForSiteLinks() {
+    $result = $this->tracking->applyGATracking($this->renderedNewsletter, $this->newsletter, $this->internalHost);
+    verify($result['text'])->stringContainsString('quux=[subscriber:email]');
+    verify($result['html'])->stringContainsString('quux=[subscriber:email]');
   }
 
   public function testItDoesntBreakSpecialHtmlComments() {

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -53,21 +53,35 @@ class GATrackingTest extends \MailPoetTest {
 
     $settings->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
     $result = $this->tracking->applyGATracking($this->renderedNewsletter, $this->newsletter, $this->internalHost);
-    verify($result['text'])->stringContainsString(add_query_arg([
-      'utm_source' => 'mailpoet',
-      'utm_medium' => 'email',
-      'utm_source_platform' => 'mailpoet',
-      'utm_campaign' => $this->gaCampaign,
-    ], $this->link));
+    verify($result['text'])->stringContainsString(
+      urldecode(
+        add_query_arg(
+          [
+            'utm_source' => 'mailpoet',
+            'utm_medium' => 'email',
+            'utm_source_platform' => 'mailpoet',
+            'utm_campaign' => $this->gaCampaign,
+          ],
+          $this->link
+        )
+      )
+    );
 
     $settings->set('tracking.level', TrackingConfig::LEVEL_FULL);
     $result = $this->tracking->applyGATracking($this->renderedNewsletter, $this->newsletter, $this->internalHost);
-    verify($result['text'])->stringContainsString(add_query_arg([
-      'utm_source' => 'mailpoet',
-      'utm_medium' => 'email',
-      'utm_source_platform' => 'mailpoet',
-      'utm_campaign' => $this->gaCampaign,
-    ], $this->link));
+    verify($result['text'])->stringContainsString(
+      urldecode(
+        add_query_arg(
+          [
+            'utm_source' => 'mailpoet',
+            'utm_medium' => 'email',
+            'utm_source_platform' => 'mailpoet',
+            'utm_campaign' => $this->gaCampaign,
+          ],
+          $this->link
+        )
+      )
+    );
   }
 
   public function testItGetsGACampaignFromParentNewsletterForPostNotifications() {


### PR DESCRIPTION
> [!IMPORTANT]
> Don't merge this. 😉

## Description

When Google Analytics tracking is active, and a user adds link to their own domain featuring shortcodes ([example on Zendesk](https://a8c.zendesk.com/agent/tickets/9286619)), our GATracking component can change these links by URL-encoding query parameters. This breaks links with shortcodes in newsletters.

For example, after adding tracking parameters, this URL `https://example.com.com/hi/?u=[subscriber:cf_10]` becomes `https://example.com.com/hi/?u=%5Bsubscriber%3Acf_10%5D&utm_source=mailpoet&utm_m...`

The `u=` value is encoded before the shortcode is expanded ; making the resulting link useless in lots of cases.

## Can we decode these params after adding tracking links?

This is what's done here. It's rather exploratory, but I wanted to verify whether decoding the URL *after* adding Google's tracking parameters would work. It does, kind of… but it introduces a different a bug by giving up on correct URL encoding. So, nope. 😏

It's easy to see that a subscriber could inject arbitrary content a break the URLs. For example, a with a first name like `M&M’s`, if we insert a link with a shortcode like `[subscriber:firstname]`, we could end up with a broken redirection URL like `http://site/?u=M&amp;M&#039;s&utm_source=mailpoet&...` 💣 

## Can we *not* encode these params?

From [a73e614](https://github.com/mailpoet/mailpoet/pull/6072/commits/a73e614dc0a81822452044aa0126ea136a1e9b57), we see that WP's `add_query_arg` encodes our URL, and I think it's fine as it prevents unencoded query params in the emails (which can easily result in invalid links as we've seen).

We rely on `add_query_arg` to add 3 query parameters to our URL, so it looks like maybe we could do without it, somehow... It's a battle tested utility function though, with lots of edge cases, so rewriting without it seems less safe.

## Can we expand shortcodes before adding tracking?

It seems like the most robust solution IMHO, but it requires a few changes to how we currently generate newsletters, and add our own tracking links. 