### PR TITLE
Reload page to avoid Woo beta bug [MAILPOET-6448]

### DIFF
--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -189,6 +189,12 @@ class WooCheckoutBlocksCest {
   private function orderProduct(\AcceptanceTester $i, string $userEmail, bool $doRegister = true, bool $doSubscribe = true): void {
     $i->addProductToCart($this->product);
     $i->amOnPage("/?p={$this->checkoutPostId}");
+
+    // refresh the page to fix https://github.com/woocommerce/woocommerce/issues/54805
+    // this can be removed after the above is released
+    // should be done in Woo 9.7 (release date 24th Feb 2025)
+    $i->reloadPage();
+
     $this->fillBlocksCustomerInfo($i, $userEmail);
     if ($doSubscribe) {
       $settings = (ContainerWrapper::getInstance())->get(SettingsController::class);


### PR DESCRIPTION
## Description

Add a temporary fix for the issue with the nightly build. 

Here is a build that passes: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20141/workflows/7852d18d-d788-4fa4-9a39-c61419f0579a

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6448]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-woo-beta-tests)

_The latest successful build from `fix-woo-beta-tests` will be used. If none is available, the link won't work._

[MAILPOET-6448]: https://mailpoet.atlassian.net/browse/MAILPOET-6448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ