### PR TITLE
Unify changelog format in readme.txt and changelog.txt [MAILPOET-6446]

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -8,2780 +8,2387 @@
 * Fixed: The swap template behaviour.
 
 = 5.6.2 - 2025-01-21 =
-
-- Added: CAPTCHA protection for WP registration forms.
-- Updated: list of available translations;
-- Improved: more detailed System Info report;
-- Improved: retry email automations for unconfirmed recipients.
-- Fixed: occasional PHP type error in the new email editor.
+* Added: CAPTCHA protection for WP registration forms.
+* Updated: list of available translations;
+* Improved: more detailed System Info report;
+* Improved: retry email automations for unconfirmed recipients.
+* Fixed: occasional PHP type error in the new email editor.
 
 = 5.6.1 - 2025-01-14 =
-
-- Added: deprecation warnings when directly accessing properties on Newsletter, Subscriber, and SendingQueue entities;
-- Added: the alpha version of the new email editor, bringing a fresh and intuitive way to design emails;
-- Improved: Activation Key input hides the characters to increase security, with the option to reveal the key;
-- Changed: it's no longer possible to include Coupon block in confirmation email;
-- Fixed: using font formats in the form editor.
+* Added: deprecation warnings when directly accessing properties on Newsletter, Subscriber, and SendingQueue entities;
+* Added: the alpha version of the new email editor, bringing a fresh and intuitive way to design emails;
+* Improved: Activation Key input hides the characters to increase security, with the option to reveal the key;
+* Changed: it's no longer possible to include Coupon block in confirmation email;
+* Fixed: using font formats in the form editor.
 
 = 5.6.0 - 2025-01-06 =
-
-- Changed: minimum required WooCommerce is 9.4;
-- Changed: when WordPress or WooCommerce version requirements are not met, MailPoet plugin won't deactivate, and instead stop executing. Once the requirements are met, it will start working automatically;
-- Fixed: abandoned cart tasks are processed on time.
+* Changed: minimum required WooCommerce is 9.4;
+* Changed: when WordPress or WooCommerce version requirements are not met, MailPoet plugin won't deactivate, and instead stop executing. Once the requirements are met, it will start working automatically;
+* Fixed: abandoned cart tasks are processed on time.
 
 = 5.5.2 - 2024-12-24 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 5.5.1 - 2024-12-17 =
-
-- Improved: added option to protect WordPress and WooCommerce registration forms with a captcha.
-- Changed: removed 3rd party Beamer integration;
-- Fixed: error when trying to use mailpoet_settings database table before it is available.
+* Improved: added option to protect WordPress and WooCommerce registration forms with a captcha.
+* Changed: removed 3rd party Beamer integration;
+* Fixed: error when trying to use mailpoet_settings database table before it is available.
 
 = 5.5.0 - 2024-12-09 =
-
-- Added the Polish translation as an officially maintained translation;
-- Added: classes now allowed in links of HTML forms.
+* Added the Polish translation as an officially maintained translation;
+* Added: classes now allowed in links of HTML forms.
 
 = 5.4.2 - 2024-12-02 =
-
-- Improved: stability of post notification scheduling;
-- Changed: minimum required WordPress version to 6.6 and WooCommerce to 9.3.
+* Improved: stability of post notification scheduling;
+* Changed: minimum required WordPress version to 6.6 and WooCommerce to 9.3.
 
 = 5.4.1 - 2024-11-25 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 5.4.0 - 2024-11-18 =
-
-- Improved: tested with WooCommerce 9.4;
-- Improved: tested with WordPress 6.7;
-- Improved: tested with PHP 8.2.
+* Improved: tested with WooCommerce 9.4;
+* Improved: tested with WordPress 6.7;
+* Improved: tested with PHP 8.2.
 
 = 5.3.7 - 2024-11-12 =
-
-- Fixed: detecting table index existence in DB migrations for MySQL 5;
-- Fixed: re-activation of welcome emails with long history may take long time or fail.
+* Fixed: detecting table index existence in DB migrations for MySQL 5;
+* Fixed: re-activation of welcome emails with long history may take long time or fail.
 
 = 5.3.6 - 2024-11-05 =
-
-- Fixed: race condition in links tracking;
-- Fixed: WP 6.7 compatibility issues.
+* Fixed: race condition in links tracking;
+* Fixed: WP 6.7 compatibility issues.
 
 = 5.3.5 - 2024-10-30 =
-
-- Fixed: Post notifications now correctly select new posts by ensuring consistent UTC date comparison, preventing posts published within certain time zones from being skipped after a notification is sent.
+* Fixed: Post notifications now correctly select new posts by ensuring consistent UTC date comparison, preventing posts published within certain time zones from being skipped after a notification is sent.
 
 = 5.3.4 - 2024-10-28 =
-
-- Improved: mark required fields in public forms also in screen readers for improved accessibility;
-- Improved: properly connect inputs and labels in public forms for improved accessibility;
-- Changed: when pausing a post notification newsletter, scheduled task is now also paused. This prevents the sending queue from becoming stalled.
+* Improved: mark required fields in public forms also in screen readers for improved accessibility;
+* Improved: properly connect inputs and labels in public forms for improved accessibility;
+* Changed: when pausing a post notification newsletter, scheduled task is now also paused. This prevents the sending queue from becoming stalled.
 
 = 5.3.3 - 2024-10-22 =
-
-- Fixed: error on email statistics page.
+* Fixed: error on email statistics page.
 
 = 5.3.2 - 2024-10-22 =
-
-- Improved: form error messages now use rem instead of px to improve accessibility;
-- Improved: toggle and yes/no controls are focusable;
-- Fixed: Preview of the Sign Up Confirmation email is not working.
+* Improved: form error messages now use rem instead of px to improve accessibility;
+* Improved: toggle and yes/no controls are focusable;
+* Fixed: Preview of the Sign Up Confirmation email is not working.
 
 = 5.3.1 - 2024-10-15 =
-
-- Improved: add validation for re-engagement emails period;
-- Improved: more balanced text wrapping to improve readability;
-- Improved: when the email authentication service is unavailable, use the old authentication status and continue sending.
-- Fixed: some email template previews are too wide;
-- Fixed: remove Google+ icon from email templates;
-- Fixed: Removed a warning when caption is not present on image;
-- Fixed: deprecation warning from mb_convert_encoding.
+* Improved: add validation for re-engagement emails period;
+* Improved: more balanced text wrapping to improve readability;
+* Improved: when the email authentication service is unavailable, use the old authentication status and continue sending.
+* Fixed: some email template previews are too wide;
+* Fixed: remove Google+ icon from email templates;
+* Fixed: Removed a warning when caption is not present on image;
+* Fixed: deprecation warning from mb_convert_encoding.
 
 = 5.3.0 - 2024-10-03 =
-
-- Fixed: abandoned cart automation trigger doesn't work in some cases.
+* Fixed: abandoned cart automation trigger doesn't work in some cases.
 
 = 5.2.3 - 2024-10-01 =
-
-- Fixed: Compatibility with WooCommerce 9.4;
-- Fixed: Percentage in Analytics did not work correctly in if/else condtion.
+* Fixed: Compatibility with WooCommerce 9.4;
+* Fixed: Percentage in Analytics did not work correctly in if/else condtion.
 
 = 5.2.2 - 2024-09-23 =
-
-- Improved: when using FSE theme, link to Site Editor instead of Widgets in MailPoet Forms placement options;
-- Changed: replace deprecated woocommerce_before_cart_item_quantity_zero action with woocommerce_remove_cart_item;
-- Fixed: List-Unsubscribe URL no longer redirects when not using MailPoet Sending Service.
+* Improved: when using FSE theme, link to Site Editor instead of Widgets in MailPoet Forms placement options;
+* Changed: replace deprecated woocommerce_before_cart_item_quantity_zero action with woocommerce_remove_cart_item;
+* Fixed: List-Unsubscribe URL no longer redirects when not using MailPoet Sending Service.
 
 = 5.2.1 - 2024-09-17 =
-
-- Added: WooCommerce email template reset button;
-- Improved: plugin activation and update performance.
+* Added: WooCommerce email template reset button;
+* Improved: plugin activation and update performance.
 
 = 5.2.0 - 2024-09-11 =
-
-- Fixed: incorrect value Last run started in Cron status at the help page;
-- Fixed: The help page loads slowly for sites with long sending history;
-- Fixed: emails with incorrectly nested ALC or WooCommerce placeholder blocks can't be sent.
+* Fixed: incorrect value Last run started in Cron status at the help page;
+* Fixed: The help page loads slowly for sites with long sending history;
+* Fixed: emails with incorrectly nested ALC or WooCommerce placeholder blocks can't be sent.
 
 = 5.1.1 - 2024-09-04 =
-
-- Fixed: broken email rendering when ALC, Products, or WC content blocks are manually dragged into a column block (since 4.56.0). If you experience this issue, please readd these blocks or drag and drop the existing ones which should fix the issue.
+* Fixed: broken email rendering when ALC, Products, or WC content blocks are manually dragged into a column block (since 4.56.0). If you experience this issue, please readd these blocks or drag and drop the existing ones which should fix the issue.
 
 = 5.1.0 - 2024-09-02 =
-
-- Improved: form validation messages;
-- Fixed: using ${var} in strings is deprecated, use {$var} instead.
+* Improved: form validation messages;
+* Fixed: using ${var} in strings is deprecated, use {$var} instead.
 
 = 5.0.2 - 2024-08-26 =
-
-- Added: Ukrainian translations;
-- Improved: error messages in automations;
-- Changed: human and machine opens are merged by default, old behavior can be restored in settings.
+* Added: Ukrainian translations;
+* Improved: error messages in automations;
+* Changed: human and machine opens are merged by default, old behavior can be restored in settings.
 
 = 5.0.1 - 2024-08-23 =
-
-- Fixed: incorrect date in the scheduling calendar on the send page.
+* Fixed: incorrect date in the scheduling calendar on the send page.
 
 = 5.0.0 - 2024-08-19 =
-
-- Changed: replaced PDO database connection in favor of WordPress's native wpdb;
-- Fixed: dual buttons in MS Outlook;
-- Fixed: false error notice about MSS connection for editor users.
+* Changed: replaced PDO database connection in favor of WordPress's native wpdb;
+* Fixed: dual buttons in MS Outlook;
+* Fixed: false error notice about MSS connection for editor users.
 
 = 4.58.2 - 2024-08-13 =
-
-- Added: option to change position of opt-in checkbox on the shortcode checkout page;
-- Added: new table with database inconsistencies in Help section;
-- Improved: more robust race-condition checks in automations;
-- Improved: better checking of email sent status in automations;
-- Fixed: Abandoned cart email is now triggered when user logs in after adding items to cart;
-- Fixed: sending multiple emails to single subscriber in an automation.
+* Added: option to change position of opt-in checkbox on the shortcode checkout page;
+* Added: new table with database inconsistencies in Help section;
+* Improved: more robust race-condition checks in automations;
+* Improved: better checking of email sent status in automations;
+* Fixed: Abandoned cart email is now triggered when user logs in after adding items to cart;
+* Fixed: sending multiple emails to single subscriber in an automation.
 
 = 4.58.1 - 2024-08-05 =
-
-- Fixed: button rendering in Outlook 2023.
+* Fixed: button rendering in Outlook 2023.
 
 = 4.58.0 - 2024-07-30 =
-
-- Added: Method to update a subscriber to our public API;
-- Improved: more styling options of WooCommerce transactional emails;
-- Changed: revert change from 4.56.0 that introduced new detection of shortcodes in post notifications;
-- Fixed: automation is marked as failed when if/else branch is empty;
-- Fixed: too narrow automation action selector on mobile devices.
+* Added: Method to update a subscriber to our public API;
+* Improved: more styling options of WooCommerce transactional emails;
+* Changed: revert change from 4.56.0 that introduced new detection of shortcodes in post notifications;
+* Fixed: automation is marked as failed when if/else branch is empty;
+* Fixed: too narrow automation action selector on mobile devices.
 
 = 4.57.0 - 2024-07-22 =
-
-- Fixed: formatting tags in post titles are allowed;
-- Fixed: externally hosted images are displayed in template thumbnails.
+* Fixed: formatting tags in post titles are allowed;
+* Fixed: externally hosted images are displayed in template thumbnails.
 
 = 4.56.0 - 2024-07-15 =
-
-- Updated: react dependencies;
-- Improved: email validation on email listing page;
-- Improved: email validation in automations editor;
-- Improved: hiding WooCommerce list when WooCommerce plugin is not active;
-- Fixed: stopping automation when it is canceled;
-- Fixed: displaying text in square brackets in post notifications;
-- Fixed: links to privacy policy in forms.
+* Updated: react dependencies;
+* Improved: email validation on email listing page;
+* Improved: email validation in automations editor;
+* Improved: hiding WooCommerce list when WooCommerce plugin is not active;
+* Fixed: stopping automation when it is canceled;
+* Fixed: displaying text in square brackets in post notifications;
+* Fixed: links to privacy policy in forms.
 
 = 4.55.0 - 2024-07-09 =
-
-- Added: cancelling scheduled or running sending tasks;
-- Added: show automations run logs;
-- Fixed: calendar view UI glitch;
-- Fixed: confirmation message in welcome wizard;
-- Fixed: shortcode in email subject rendering.
+* Added: cancelling scheduled or running sending tasks;
+* Added: show automations run logs;
+* Fixed: calendar view UI glitch;
+* Fixed: confirmation message in welcome wizard;
+* Fixed: shortcode in email subject rendering.
 
 = 4.54.0 - 2024-07-02 =
-
-- Updated: composer dependencies;
-- Updated: npm dependencies;
-- Improved: automation is now triggered when tag is added via form submission;
-- Improved: abandoned cart automation is triggered also for non-subscribed contacts;
-- Changed: when automation is reactivated, old runs won't be reactivated;
-- Fixed: misaligned icons in automation steps;
-- Fixed: error when creating a segment with "Subscriber date" condition;
-- Fixed: blurred automation step icons in Firefox;
-- Fixed: changing radio buttons when editing subscriber doesn't work;
-- Fixed: info tooltip for Archive shortcode in Settings doesn't show up;
-- Fixed: subscribers count tooltip is overlayed with Recalculate button.
+* Updated: composer dependencies;
+* Updated: npm dependencies;
+* Improved: automation is now triggered when tag is added via form submission;
+* Improved: abandoned cart automation is triggered also for non-subscribed contacts;
+* Changed: when automation is reactivated, old runs won't be reactivated;
+* Fixed: misaligned icons in automation steps;
+* Fixed: error when creating a segment with "Subscriber date" condition;
+* Fixed: blurred automation step icons in Firefox;
+* Fixed: changing radio buttons when editing subscriber doesn't work;
+* Fixed: info tooltip for Archive shortcode in Settings doesn't show up;
+* Fixed: subscribers count tooltip is overlayed with Recalculate button.
 
 = 4.53.0 - 2024-06-25 =
-
-- Updated: npm dependencies;
-- Improved: Processing Captcha image;
-- Improved: Search for post notification history items now return updated results;
-- Improved: Newsletter social icons style and images;
-- Improved: MailPoet form editor button styles;
-- Fixed: Update abandoned cart email task status;
-- Fixed: link to Setup abandoned cart email from homepage.
+* Updated: npm dependencies;
+* Improved: Processing Captcha image;
+* Improved: Search for post notification history items now return updated results;
+* Improved: Newsletter social icons style and images;
+* Improved: MailPoet form editor button styles;
+* Fixed: Update abandoned cart email task status;
+* Fixed: link to Setup abandoned cart email from homepage.
 
 = 4.52.0 - 2024-06-17 =
-
-- Updated: composer dependencies;
-- Updated: Gutenberg dependencies;
-- Improved: sender domain authentication screen contains more information;
-- Improved: display API connection error notice in more places;
-- Fixed: displaying product discounts in product block;
-- Fixed: display correct time for scheduled newsletters;
-- Fixed: removed WordPress Users list from lists to import to.
+* Updated: composer dependencies;
+* Updated: Gutenberg dependencies;
+* Improved: sender domain authentication screen contains more information;
+* Improved: display API connection error notice in more places;
+* Fixed: displaying product discounts in product block;
+* Fixed: display correct time for scheduled newsletters;
+* Fixed: removed WordPress Users list from lists to import to.
 
 = 4.51.2 - 2024-06-11 =
-
-- Added: an error message when ping is not working;
-- Added: a notice when switching to Creator plan with MailPoet Sending Service active;
-- Added: an error message when cron is disabled;
-- Added: an error message for invalid API endpoints;
-- Improved: an error message when sending through MailPoet Sending Service on a Creator plan;
-- Improved: an error message when sending a campaign from an unauthorized sender domain;
-- Changed: Twitter to X in email editor social icons block;
-- Fixed: potential error when throttling subscriptions signups;
-- Fixed: WooCommerce customers sync breaks when there is an order without a customer.
+* Added: an error message when ping is not working;
+* Added: a notice when switching to Creator plan with MailPoet Sending Service active;
+* Added: an error message when cron is disabled;
+* Added: an error message for invalid API endpoints;
+* Improved: an error message when sending through MailPoet Sending Service on a Creator plan;
+* Improved: an error message when sending a campaign from an unauthorized sender domain;
+* Changed: Twitter to X in email editor social icons block;
+* Fixed: potential error when throttling subscriptions signups;
+* Fixed: WooCommerce customers sync breaks when there is an order without a customer.
 
 = 4.51.1 - 2024-06-03 =
-
-- Updated: composer dependencies;
-- Improved: added URL validator when inserting link in email blocks.
+* Updated: composer dependencies;
+* Improved: added URL validator when inserting link in email blocks.
 
 = 4.51.0 - 2024-05-27 =
-
-- Fixed: marking plugin as incompatible with WooCommerce HPOS on multisite;
-- Fixed: incorrect order links in subscriber stats;
-- Fixed: Overlapping between controlbar and the block in the form editor.
+* Fixed: marking plugin as incompatible with WooCommerce HPOS on multisite;
+* Fixed: incorrect order links in subscriber stats;
+* Fixed: Overlapping between controlbar and the block in the form editor.
 
 = 4.50.1 - 2024-05-21 =
-
-- Added: the date when a subscriber was added to the subscribers' list;
-- Fixed: Public API updateList now accepts the same name but a different description;
-- Fixed: inconsistent subscription state of guest customer after placing an order.
+* Added: the date when a subscriber was added to the subscribers' list;
+* Fixed: Public API updateList now accepts the same name but a different description;
+* Fixed: inconsistent subscription state of guest customer after placing an order.
 
 = 4.50.0 - 2024-05-07 =
-
-- Improved: "Send email" automation step waits for the email to be queued before marking the step as completed;
-- Fixed: Previously, the association of orders to emails in the statistics was incorrect in some cases.
+* Improved: "Send email" automation step waits for the email to be queued before marking the step as completed;
+* Fixed: Previously, the association of orders to emails in the statistics was incorrect in some cases.
 
 = 4.49.1 - 2024-04-29 =
-
-- Improved: Add additional transactional email triggers;
-- Improved: new design of Segments listing page.
+* Improved: Add additional transactional email triggers;
+* Improved: new design of Segments listing page.
 
 = 4.49.0 - 2024-04-23 =
-
-- Fixed: manually confirming a subscriber in the UI doesn't trigger automations;
-- Fixed: some automation filter values rendering as "Unknown value".
+* Fixed: manually confirming a subscriber in the UI doesn't trigger automations;
+* Fixed: some automation filter values rendering as "Unknown value".
 
 = 4.48.2 - 2024-04-08 =
-
-- Improved: 1-click unsubscribe headers for non MailPoet sending methods;
-- Fixed: rare issue of abandoned cart block rendered in preview for non abandoned cart automations.
+* Improved: 1-click unsubscribe headers for non MailPoet sending methods;
+* Fixed: rare issue of abandoned cart block rendered in preview for non abandoned cart automations.
 
 = 4.48.1 - 2024-04-03 =
-
-- Improved: when creating a tag, pressing Enter is no longer required.
+* Improved: when creating a tag, pressing Enter is no longer required.
 
 = 4.48.0 - 2024-03-22 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 4.47.0 - 2024-03-18 =
-
-- Added: Automations are now generally available;
-- Added: new automation templates for WooCommerce marketing flows;
-- Added: Customer fields in automations now work also for guest users;
-- Improved: Optimize loading automation editor for large shops;
-- Improved: Consider tracking settings when adding utm_parameters into links;
-- Improved: new segment "purchased product by tag" introduced;
-- Fixed: filter details in automation template preview are not visible;
-- Fixed: Use less confusing language Segments vs Lists;
-- Fixed: Rare issue when a multi-column popup form was displayed in one column;
-- Fixed: background job runner may get stuck on an invalid email address;
-- Fixed: rendering of some special characters on Lists page.
+* Added: Automations are now generally available;
+* Added: new automation templates for WooCommerce marketing flows;
+* Added: Customer fields in automations now work also for guest users;
+* Improved: Optimize loading automation editor for large shops;
+* Improved: Consider tracking settings when adding utm_parameters into links;
+* Improved: new segment "purchased product by tag" introduced;
+* Fixed: filter details in automation template preview are not visible;
+* Fixed: Use less confusing language Segments vs Lists;
+* Fixed: Rare issue when a multi-column popup form was displayed in one column;
+* Fixed: background job runner may get stuck on an invalid email address;
+* Fixed: rendering of some special characters on Lists page.
 
 = 4.46.0 - 2024-03-11 =
-
-- Improved: new segment "purchased product by attribute" introduced;
-- Improved: trigger filters are now alphabetically sorted;
-- Fixed: Pop-Up forms did not appear on some product pages.
+* Improved: new segment "purchased product by attribute" introduced;
+* Improved: trigger filters are now alphabetically sorted;
+* Fixed: Pop-Up forms did not appear on some product pages.
 
 = 4.45.0 - 2024-03-05 =
-
-- Improved: when the domain authentication service is unavailable, regard the old authentication status as the current one and continue to allow sending for authenticated domains.
-- Improved: when reentering the onboarding flow, continue where the user left the flow.
-- Fixed: a method in the "subscriber counter" background job could get a wrongly typed parameter.
+* Improved: when the domain authentication service is unavailable, regard the old authentication status as the current one and continue to allow sending for authenticated domains.
+* Improved: when reentering the onboarding flow, continue where the user left the flow.
+* Fixed: a method in the "subscriber counter" background job could get a wrongly typed parameter.
 
 = 4.44.1 - 2024-02-26 =
-
-- Improvement: utm_source and utm_type parameters are added to links by default;
-- Fixed: remove HTML tags in subjects derived from post titles.
+* Improvement: utm_source and utm_type parameters are added to links by default;
+* Fixed: remove HTML tags in subjects derived from post titles.
 
 = 4.44.0 - 2024-02-19 =
-
-- Updated: Gutenberg dependencies;
-- Improved: order created/completed/cancelled automation triggers can now send transactional emails;
-- Fixed: transactional emails in automations fail to send in some cases.
+* Updated: Gutenberg dependencies;
+* Improved: order created/completed/cancelled automation triggers can now send transactional emails;
+* Fixed: transactional emails in automations fail to send in some cases.
 
 = 4.43.1 - 2024-02-12 =
-
-- Fixed: automation and legacy emails not rendering if one has an invalid option;
-- Fixed: sending tasks incorrectly marked as invalid;
-- Fixed: tutorial button on email templates and send email pages.
+* Fixed: automation and legacy emails not rendering if one has an invalid option;
+* Fixed: sending tasks incorrectly marked as invalid;
+* Fixed: tutorial button on email templates and send email pages.
 
 = 4.43.0 - 2024-02-05 =
-
-- Improved: during import, "Update existing subscriber status" no longer requires "Update existing subscriber info" to be enabled;
-- Fixed: error "EntityManager is Closed" during sending on MySQL 8;
-- Fixed: error "new entity was found through the relationship" during email sending;
-- Fixed: Some strings where not translateable;
-- Fixed: errors when sending some emails;
-- Fixed: automation listing trash and delete action UI behavior.
+* Improved: during import, "Update existing subscriber status" no longer requires "Update existing subscriber info" to be enabled;
+* Fixed: error "EntityManager is Closed" during sending on MySQL 8;
+* Fixed: error "new entity was found through the relationship" during email sending;
+* Fixed: Some strings where not translateable;
+* Fixed: errors when sending some emails;
+* Fixed: automation listing trash and delete action UI behavior.
 
 = 4.42.1 - 2024-01-30 =
-
-- Improved: Display sender domain authentication notices in Automations;
-- Improved: Added Domain Authentication to the onboarding tasks;
-- Fixed: Post notification emails can become stuck;
-- Fixed: Some legacy automatic emails where not visible in the new automations listing page.
+* Improved: Display sender domain authentication notices in Automations;
+* Improved: Added Domain Authentication to the onboarding tasks;
+* Fixed: Post notification emails can become stuck;
+* Fixed: Some legacy automatic emails where not visible in the new automations listing page.
 
 = 4.42.0 - 2024-01-22 =
-
-- Updated: minimum required WooCommerce version to 8.4;
-- Improved: Made it obvious that list names may be visible to subscribers;
-- Improved: Sending rules for big senders;
-- Improved: AutomateWoo and MailPoet work now together in the Checkout-Block of WooCommerce;
-- Fixed: A notice was not closeable;
-- Fixed: In some instances sending seemed blocked by a SendingQueue error related to a NewsletterLinkEntity.
+* Updated: minimum required WooCommerce version to 8.4;
+* Improved: Made it obvious that list names may be visible to subscribers;
+* Improved: Sending rules for big senders;
+* Improved: AutomateWoo and MailPoet work now together in the Checkout-Block of WooCommerce;
+* Fixed: A notice was not closeable;
+* Fixed: In some instances sending seemed blocked by a SendingQueue error related to a NewsletterLinkEntity.
 
 = 4.41.3 - 2024-01-16 =
-
-- Added: a new segment for "Number of orders with coupon code";
-- Improved: move legacy Welcome and WooCommerce emails to Automations;
-- Improved: Sender email input validation for DMARC and other verification records;
-- Fixed: Some HTML markup fixes in the admin;
-- Fixed: Do not attempt to queue a newsletter notification for already published posts;
-- Fixed: The trash button on the newsletter stats page deleted a newsletter permanently.
+* Added: a new segment for "Number of orders with coupon code";
+* Improved: move legacy Welcome and WooCommerce emails to Automations;
+* Improved: Sender email input validation for DMARC and other verification records;
+* Fixed: Some HTML markup fixes in the admin;
+* Fixed: Do not attempt to queue a newsletter notification for already published posts;
+* Fixed: The trash button on the newsletter stats page deleted a newsletter permanently.
 
 = 4.41.2 - 2024-01-11 =
-
-- Improved: notices in the banners now indicate that the new sending rules will be enforced on February 1st.
+* Improved: notices in the banners now indicate that the new sending rules will be enforced on February 1st.
 
 = 4.41.1 - 2024-01-10 =
-
-- Fixed: Partially verified domains could not be re-verified
+* Fixed: Partially verified domains could not be re-verified
 
 = 4.41.0 - 2024-01-03 =
-
-- Added: notices about new sender domain requirements;
-- Added: support for DMARC record on sender domains;
-- Updated: minimum required WooCommerce version to 8.3;
-- Fixed: incorrect results for "was sent" segment;
-- Fixed: incorrect "Sent on" time displayed on Email listing page;
-- Fixed: error when activating an invalid automation;
-- Fixed: emoji support in email body for DBs with utf8 encoding;
-- Fixed: incorrect results when using "all of" condition for "purchased in category" segment.
+* Added: notices about new sender domain requirements;
+* Added: support for DMARC record on sender domains;
+* Updated: minimum required WooCommerce version to 8.3;
+* Fixed: incorrect results for "was sent" segment;
+* Fixed: incorrect "Sent on" time displayed on Email listing page;
+* Fixed: error when activating an invalid automation;
+* Fixed: emoji support in email body for DBs with utf8 encoding;
+* Fixed: incorrect results when using "all of" condition for "purchased in category" segment.
 
 = 4.40.0 - 2023-12-12 =
-
-- Added: MailPoet integration with WooCommerce Multi-Channel dashboard;
-- Added: automation template detail with steps preview;
-- Updated: minimum required WordPress version to 6.3;
-- Fixed: Email editor text toolbox overlay when browser is zoomed in;
-- Fixed: an error when searching stats for emails sent to large lists.
+* Added: MailPoet integration with WooCommerce Multi-Channel dashboard;
+* Added: automation template detail with steps preview;
+* Updated: minimum required WordPress version to 6.3;
+* Fixed: Email editor text toolbox overlay when browser is zoomed in;
+* Fixed: an error when searching stats for emails sent to large lists.
 
 = 4.39.0 - 2023-12-04 =
-
-- Improved: Some translations got rephrased;
-- Improved: dropped support for PHP 7.3, MailPoet now requires at least PHP 7.4;
-- Fixed: missing gap between date and time when scheduling email;
-- Fixed: too much space on the send page.
+* Improved: Some translations got rephrased;
+* Improved: dropped support for PHP 7.3, MailPoet now requires at least PHP 7.4;
+* Fixed: missing gap between date and time when scheduling email;
+* Fixed: too much space on the send page.
 
 = 4.38.0 - 2023-11-27 =
-
-- Improved: warn users on PHP 7.4 about outdated PHP version;
-- Improved: landing page layout;
-- Improved: the Upgrade page is more concise;
-- Fixed: deprecation warnings.
+* Improved: warn users on PHP 7.4 about outdated PHP version;
+* Improved: landing page layout;
+* Improved: the Upgrade page is more concise;
+* Fixed: deprecation warnings.
 
 = 4.37.0 - 2023-11-20 =
-
-- Updated: upcoming Black Friday sale dates;
-- Improved: add label for remove segment condition button;
-- Improved: link to the upgrade page from Black Friday banner;
-- Improved: automation templates design.
+* Updated: upcoming Black Friday sale dates;
+* Improved: add label for remove segment condition button;
+* Improved: link to the upgrade page from Black Friday banner;
+* Improved: automation templates design.
 
 = 4.36.0 - 2023-11-14 =
-
-- Updated: design of the section that shows multiple conditions when creating or editing segments;
-- Fixed: unsubscriber token issue introduced in the last release;
-- Fixed: automation editing UI issues;
-- Fixed: issue with the formatting of the paragraph block in the form editor.
+* Updated: design of the section that shows multiple conditions when creating or editing segments;
+* Fixed: unsubscriber token issue introduced in the last release;
+* Fixed: automation editing UI issues;
+* Fixed: issue with the formatting of the paragraph block in the form editor.
 
 = 4.35.1 - 2023-11-07 =
-
-- Added: "order created", "order cancelled", and "order completed" automation triggers;
-- Added: when an API key is already connected to another website, link to a support page on how to reset the website;
-- Updated: composer dependencies;
-- Updated: minimum required WooCommerce version to 8.0;
-- Improved: notice when a MailPoet subscription is waiting for review;
-- Improved: prevent invalid segments from breaking MailPoet pages;
-- Improved: importing cleaned list flow;
-- Fixed: error when editing automation with AutomateWoo active;
-- Fixed: link to Lists from Manage Subscription page settings.
+* Added: "order created", "order cancelled", and "order completed" automation triggers;
+* Added: when an API key is already connected to another website, link to a support page on how to reset the website;
+* Updated: composer dependencies;
+* Updated: minimum required WooCommerce version to 8.0;
+* Improved: notice when a MailPoet subscription is waiting for review;
+* Improved: prevent invalid segments from breaking MailPoet pages;
+* Improved: importing cleaned list flow;
+* Fixed: error when editing automation with AutomateWoo active;
+* Fixed: link to Lists from Manage Subscription page settings.
 
 = 4.35.0 - 2023-10-31 =
-
-- Added: "number of emails received", "number of clicks", and "first order" segments.
+* Added: "number of emails received", "number of clicks", and "first order" segments.
 
 = 4.34.0 - 2023-10-25 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 4.33.0 - 2023-10-24 =
-
-- Added: drag-to-scroll in the automation editor;
-- Added: "if/else" automation step to allow branching automations based on subscribers' behaviours and purchase history (paid feature);
-- Updated: composer dependencies;
-- Improved: declared compatibility with Checkout Blocks;
-- Improved: removed "MailPoet account connected" from onboarding step if MailPoet is set up in the background;
-- Improved: segment options are sorted alphabetically in all languages;
-- Changed: replace pQuery's "html" with "toString" method when encoding email content. This can affect how tags and tag-like entries are interpreted;
-- Fixed: missing spacing in Email editor block settings;
-- Fixed: due to some library conflicts, option to insert an image from Media Library is missing in Form editor.
+* Added: drag-to-scroll in the automation editor;
+* Added: "if/else" automation step to allow branching automations based on subscribers' behaviours and purchase history (paid feature);
+* Updated: composer dependencies;
+* Improved: declared compatibility with Checkout Blocks;
+* Improved: removed "MailPoet account connected" from onboarding step if MailPoet is set up in the background;
+* Improved: segment options are sorted alphabetically in all languages;
+* Changed: replace pQuery's "html" with "toString" method when encoding email content. This can affect how tags and tag-like entries are interpreted;
+* Fixed: missing spacing in Email editor block settings;
+* Fixed: due to some library conflicts, option to insert an image from Media Library is missing in Form editor.
 
 = 4.32.0 - 2023-10-16 =
-
-- Added: option to create new segment from the send page;
-- Improved: more robust checks when running migrations;
-- Fixed: in some cases there was no default condition when creating new segment.
+* Added: option to create new segment from the send page;
+* Improved: more robust checks when running migrations;
+* Fixed: in some cases there was no default condition when creating new segment.
 
 = 4.31.1 - 2023-10-13 =
-
-- Fixes: When editing a newsletter the media dialog did not open in some cases.
+* Fixes: When editing a newsletter the media dialog did not open in some cases.
 
 = 4.31.0 - 2023-10-09 =
-
-- Added: show segment filter on email listing and stats pages;
-- Added: automation title on the analytics page;
-- Added: apply segment on top of lists on the send email page;
-- Improved: deferred loading of JS on frontend;
-- Improved: new WordPress-like design when adding or editing a segment;
-- Fixed: plugin conflict with Kubio site builder.
+* Added: show segment filter on email listing and stats pages;
+* Added: automation title on the analytics page;
+* Added: apply segment on top of lists on the send email page;
+* Improved: deferred loading of JS on frontend;
+* Improved: new WordPress-like design when adding or editing a segment;
+* Fixed: plugin conflict with Kubio site builder.
 
 = 4.30.0 - 2023-10-03 =
-
-- Updated: npm dependencies;
-- Fixed: typo in message when creating a segment;
-- Fixed: The automation filter for products works now also with variable products;
-- Fixed: in some themes, pop-up form on mobiles is larger than the screen;
-- Fixed: occasionally, when a different plugin is installed, website redirects to MailPoet landing page.
+* Updated: npm dependencies;
+* Fixed: typo in message when creating a segment;
+* Fixed: The automation filter for products works now also with variable products;
+* Fixed: in some themes, pop-up form on mobiles is larger than the screen;
+* Fixed: occasionally, when a different plugin is installed, website redirects to MailPoet landing page.
 
 = 4.29.0 - 2023-09-26 =
-
-- Added: a filter to remove restrictions on Woo Express;
-- Added: "buys from a category" trigger in automations;
-- Added: "buys a product" trigger in automations;
-- Improved: more robust migrations for automation tables;
-- Improved: skip migration of WooCommerce-related tables, if WooCommerce is no installed;
-- Improved: the premium plugin is now downloaded and installed instead of downloading a .zip file;
-- Fixed: deleting newsletters with relations to WooCommerce purchase stats;
-- Fixed: email editor breaks when the store has many coupons.
+* Added: a filter to remove restrictions on Woo Express;
+* Added: "buys from a category" trigger in automations;
+* Added: "buys a product" trigger in automations;
+* Improved: more robust migrations for automation tables;
+* Improved: skip migration of WooCommerce-related tables, if WooCommerce is no installed;
+* Improved: the premium plugin is now downloaded and installed instead of downloading a .zip file;
+* Fixed: deleting newsletters with relations to WooCommerce purchase stats;
+* Fixed: email editor breaks when the store has many coupons.
 
 = 4.28.0 - 2023-09-18 =
-
-- Fixed: in Styles section in email editor, titles overflow to 2nd line;
-- Fixed: blocked sending after deactivating a welcome email;
-- Fixed: two 100% input fields in two column layout don't occupy the full row in form editor.
-- Added: templates when creating a new segment
+* Fixed: in Styles section in email editor, titles overflow to 2nd line;
+* Fixed: blocked sending after deactivating a welcome email;
+* Fixed: two 100% input fields in two column layout don't occupy the full row in form editor.
+* Added: templates when creating a new segment
 
 = 4.27.0 - 2023-09-11 =
-
-- Improved: [mailpoet_archive] is now filterable (start_date, end_date, in_the_last_days, subject_contains, limit);
-- Improved: run migrations with lower priority to minimize conflitcs with 3rd-party plugins;
-- Changed: "Someone subscribes" automation is no longer triggered by editing a subscriber;
-- Fixed: can't type letter 'n' in chat bot on WordPress.com.
+* Improved: [mailpoet_archive] is now filterable (start_date, end_date, in_the_last_days, subject_contains, limit);
+* Improved: run migrations with lower priority to minimize conflitcs with 3rd-party plugins;
+* Changed: "Someone subscribes" automation is no longer triggered by editing a subscriber;
+* Fixed: can't type letter 'n' in chat bot on WordPress.com.
 
 = 4.26.1 - 2023-09-04 =
-
-- Added: see subscriber stats in the last 30 days, 12 months, and lifetime;
-- Added: compatibility with databases with sql_require_primary_key turned on;
-- Improved: pre-fill "From name" in the onboarding wizard.
+* Added: see subscriber stats in the last 30 days, 12 months, and lifetime;
+* Added: compatibility with databases with sql_require_primary_key turned on;
+* Improved: pre-fill "From name" in the onboarding wizard.
 
 = 4.26.0 - 2023-08-28 =
-
-- Fixed: error "Objects are not valid as a React child" when the premium plugin version is incompatible;
-- Fixed: edge case that could lead to inactive subscribers tasks being blocked in some circumstances;
-- Fixed: incompatibility between the button to close form pop-ups and some themes.
+* Fixed: error "Objects are not valid as a React child" when the premium plugin version is incompatible;
+* Fixed: edge case that could lead to inactive subscribers tasks being blocked in some circumstances;
+* Fixed: incompatibility between the button to close form pop-ups and some themes.
 
 = 4.25.0 - 2023-08-21 =
-
-- Added: "is blank" and "is not blank" option for custom field segments;
-- Updated: minimum required WordPress version to 6.2 and WooCommerce version to 7.9;
-- Improved: add option to segment used shipping/payment method over all time, not just a specific timeframe;
-- Fixed: email previews in automations showing outdated content;
-- Fixed: filtering subscribers by list and by status doesn't work.
+* Added: "is blank" and "is not blank" option for custom field segments;
+* Updated: minimum required WordPress version to 6.2 and WooCommerce version to 7.9;
+* Improved: add option to segment used shipping/payment method over all time, not just a specific timeframe;
+* Fixed: email previews in automations showing outdated content;
+* Fixed: filtering subscribers by list and by status doesn't work.
 
 = 4.24.0 - 2023-08-14 =
-
-- Added: detailed Automation analytics;
-- Added: "used coupon code" segment;
-- Improved: visually align checkboxes in the onboarding wizard;
-- Improved: subscriber engagement score is now recalculated when the underlying data change;
-- Improved: save/update automation button unified with WordPress post editor (including keyboard shortcut);
-- Changed: 3rd-party service to contact support;
-- Changed: when filtering automation trigger by a product category, it will include children categories;
-- Fixed: automation using "is first order" filter fails to trigger for some guest customers;
-- Fixed: tutorial button overlays save button when editing order automation email.
+* Added: detailed Automation analytics;
+* Added: "used coupon code" segment;
+* Improved: visually align checkboxes in the onboarding wizard;
+* Improved: subscriber engagement score is now recalculated when the underlying data change;
+* Improved: save/update automation button unified with WordPress post editor (including keyboard shortcut);
+* Changed: 3rd-party service to contact support;
+* Changed: when filtering automation trigger by a product category, it will include children categories;
+* Fixed: automation using "is first order" filter fails to trigger for some guest customers;
+* Fixed: tutorial button overlays save button when editing order automation email.
 
 = 4.23.0 - 2023-08-08 =
-
-- Added: a notice when paid features are available but the premium plugin is not installed;
-- Added: "number of reviews" segment;
-- Improved: fall back to admin email when setting up MailPoet;
-- Improved: messaging when the free 1,000 contacts limit is reached.
+* Added: a notice when paid features are available but the premium plugin is not installed;
+* Added: "number of reviews" segment;
+* Improved: fall back to admin email when setting up MailPoet;
+* Improved: messaging when the free 1,000 contacts limit is reached.
 
 = 4.22.2 - 2023-08-02 =
-
-- Fixed: error of the subscribedDate filter introduced in MailPoet 4.22.1.
+* Fixed: error of the subscribedDate filter introduced in MailPoet 4.22.1.
 
 = 4.22.1 - 2023-07-31 =
-
-- Added: segments containing "in the last X days" now also include "over all time" option;
-- Added: new segments for last engagement/purchase/open/click/page view/sending date;
-- Improved: header and footer on form template selection page;
-- Improved: onboarding message explaining the use of 3rd-party libraries.
+* Added: segments containing "in the last X days" now also include "over all time" option;
+* Added: new segments for last engagement/purchase/open/click/page view/sending date;
+* Improved: header and footer on form template selection page;
+* Improved: onboarding message explaining the use of 3rd-party libraries.
 
 = 4.22.0 - 2023-07-25 =
-
-- Added: "on or after" and "on or before" options to date-based segments;
-- Fixed: some date formats (e.g., "g:i A") break newsletter scheduling;
-- Fixed: missing translations for month names in custom field segments.
+* Added: "on or after" and "on or before" options to date-based segments;
+* Fixed: some date formats (e.g., "g:i A") break newsletter scheduling;
+* Fixed: missing translations for month names in custom field segments.
 
 = 4.21.0 - 2023-07-17 =
-
-- Added: bulk add or remove tag on Subscribers listing page;
-- Added: saving last purchase, sending, open, and click dates for each subscriber;
-- Added: progress bar when importing subscribers;
-- Added: "entered automation" and "exited automation" segments;
-- Added: MailPoet forms can now be shown on the homepage and category and tag pages;
-- Improved: supporting default value for subscriber's custom fields shortcode;
-- Changed: Segments now have a separate page in the menu;
-- Fixed: can't send email because of websites custom date format;
-- Fixed: in email statistics, sometimes opened + unopened is larger than the total sent.
+* Added: bulk add or remove tag on Subscribers listing page;
+* Added: saving last purchase, sending, open, and click dates for each subscriber;
+* Added: progress bar when importing subscribers;
+* Added: "entered automation" and "exited automation" segments;
+* Added: MailPoet forms can now be shown on the homepage and category and tag pages;
+* Improved: supporting default value for subscriber's custom fields shortcode;
+* Changed: Segments now have a separate page in the menu;
+* Fixed: can't send email because of websites custom date format;
+* Fixed: in email statistics, sometimes opened + unopened is larger than the total sent.
 
 = 4.20.2 - 2023-07-10 =
-
-- Added: "Used shipping method" segment;
-- Fixed: outdated subscriber stats on home page.
+* Added: "Used shipping method" segment;
+* Fixed: outdated subscriber stats on home page.
 
 = 4.20.1 - 2023-07-03 =
-
-- Added: "is in city" and "postal code" segments;
-- Improved: sending speed when using MailPoet Sending Service.
+* Added: "is in city" and "postal code" segments;
+* Improved: sending speed when using MailPoet Sending Service.
 
 = 4.20.0 - 2023-06-26 =
-
-- Updated: list of cookies in Settings > Privacy generated by MailPoet;
-- Improved: avoid calling automation run query on every request. Thanks Jon for reporting this;
-- Improved: automation trigger filters are editable;
-- Improved: format numbers in notice when MailPoet plan limits are reached;
-- Fixed: redirecting to MailPoet landing page when another plugin is activated;
-- Fixed: "is blank" and "is not blank" automation trigger filters can't be saved;
-- Fixed: subscriber count information on Subscribers listing is now correctly recalculated.
+* Updated: list of cookies in Settings > Privacy generated by MailPoet;
+* Improved: avoid calling automation run query on every request. Thanks Jon for reporting this;
+* Improved: automation trigger filters are editable;
+* Improved: format numbers in notice when MailPoet plan limits are reached;
+* Fixed: redirecting to MailPoet landing page when another plugin is activated;
+* Fixed: "is blank" and "is not blank" automation trigger filters can't be saved;
+* Fixed: subscriber count information on Subscribers listing is now correctly recalculated.
 
 = 4.19.0 - 2023-06-19 =
-
-- Added: Automation templates for abandoned cart and first-time buyers;
-- Added: option to filter Automations triggers based on subscriber, customer, or order properties;
-- Updated: minimum required WooCommerce version to 7.6.0;
-- Fixed: depreciation notice in PHP 8 (thank you Drivingralle);
-- Fixed: exporting dynamic segments with custom fields.
+* Added: Automation templates for abandoned cart and first-time buyers;
+* Added: option to filter Automations triggers based on subscriber, customer, or order properties;
+* Updated: minimum required WooCommerce version to 7.6.0;
+* Fixed: depreciation notice in PHP 8 (thank you Drivingralle);
+* Fixed: exporting dynamic segments with custom fields.
 
 = 4.18.1 - 2023-06-12 =
-
-- Fixed: rarely the last page before sending the email can fail to load;
-- Fixed: can't attach image in the email when using betheme theme (error: this.activateMode is not a function).
+* Fixed: rarely the last page before sending the email can fail to load;
+* Fixed: can't attach image in the email when using betheme theme (error: this.activateMode is not a function).
 
 = 4.18.0 - 2023-06-05 =
-
-- Improved: "is in country" segment no longer requires completed WooCommerce order. If the user has country assigned, it will be used for segmenting;
-- Changed: opt-in checkbox in checkout no longer unsubscribes when unchecked;
-- Fixed: Subscriber segmentation can now target contacts who did not open any emails;
-- Fixed: PHP notices and incorrect form styling when not all padding values are specified;
-- Fixed: opt-in checkbox position in checkout when using Twenty Twenty-Two and Three themes.
+* Improved: "is in country" segment no longer requires completed WooCommerce order. If the user has country assigned, it will be used for segmenting;
+* Changed: opt-in checkbox in checkout no longer unsubscribes when unchecked;
+* Fixed: Subscriber segmentation can now target contacts who did not open any emails;
+* Fixed: PHP notices and incorrect form styling when not all padding values are specified;
+* Fixed: opt-in checkbox position in checkout when using Twenty Twenty-Two and Three themes.
 
 = 4.17.1 - 2023-05-31 =
-
-- Fix: Stop adding indexes to first name and name field, when they already have been created.
+* Fix: Stop adding indexes to first name and name field, when they already have been created.
 
 = 4.17.0 - 2023-05-29 =
-
-- Added: subscriber counts caching to improve performance on websites with 2,000+ subscribers;
-- Added: "Used payment method" segment;
-- Added: MailPoet info to WooCommerce System Status Report;
-- Updated: minimum required WooCommerce version to 7.5.0;
-- Improved: "Order status change" trigger works with guest orders;
-- Improved: dropped support for PHP 7.2, MailPoet now requires at least PHP 7.3;
-- Fixed: Automation editor broken on WordPress 6.0;
-- Fixed: MailPoet is not active in WordPress menu when in email/form/automation editor.
+* Added: subscriber counts caching to improve performance on websites with 2,000+ subscribers;
+* Added: "Used payment method" segment;
+* Added: MailPoet info to WooCommerce System Status Report;
+* Updated: minimum required WooCommerce version to 7.5.0;
+* Improved: "Order status change" trigger works with guest orders;
+* Improved: dropped support for PHP 7.2, MailPoet now requires at least PHP 7.3;
+* Fixed: Automation editor broken on WordPress 6.0;
+* Fixed: MailPoet is not active in WordPress menu when in email/form/automation editor.
 
 = 4.16.0 - 2023-05-15 =
-
-- Added: "Subscribed via form" segment;
-- Added: "First name", "Last name", and "Email" segments;
-- Added: "Average order value" segment;
-- Added: abandoned cart trigger in Automations;
-- Added: option to duplicate segments;
-- Improved: more explanatory and actionable notification when MailPoet plan limits are reached;
-- Fixed: display issues of checkout opt-in block in the post editor;
-- Fixed: error loading coupon block when a coupon doesn't have a discount type assigned.
+* Added: "Subscribed via form" segment;
+* Added: "First name", "Last name", and "Email" segments;
+* Added: "Average order value" segment;
+* Added: abandoned cart trigger in Automations;
+* Added: option to duplicate segments;
+* Improved: more explanatory and actionable notification when MailPoet plan limits are reached;
+* Fixed: display issues of checkout opt-in block in the post editor;
+* Fixed: error loading coupon block when a coupon doesn't have a discount type assigned.
 
 = 4.15.0 - 2023-05-08 =
-
-- Updated: minimum required WooCommerce version to 7.4.0;
-- Updated: minimum required WordPress version to 6.0, tested on 6.2;
-- Improved: error handling when updating translations;
-- Improved: More cautious cleanup of the logs table.
+* Updated: minimum required WooCommerce version to 7.4.0;
+* Updated: minimum required WordPress version to 6.0, tested on 6.2;
+* Improved: error handling when updating translations;
+* Improved: More cautious cleanup of the logs table.
 
 = 4.14.0 - 2023-05-01 =
-
-- Added: "was sent email" segment;
-- Improved: SpamAssassin spam filter compliance to reduce spamboxing likelihood;
-- Improved: error messages when verifying an API key with limited access;
-- Fixed: rare "Invalid automation structure" error;
-- Fixed: duplicate newsletter URLs for enhanced SEO;
-- Fixed: deprecation warnings for utf8_encode in PHP 8.2.
+* Added: "was sent email" segment;
+* Improved: SpamAssassin spam filter compliance to reduce spamboxing likelihood;
+* Improved: error messages when verifying an API key with limited access;
+* Fixed: rare "Invalid automation structure" error;
+* Fixed: duplicate newsletter URLs for enhanced SEO;
+* Fixed: deprecation warnings for utf8_encode in PHP 8.2.
 
 = 4.13.0 - 2023-04-24 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 4.12.2 - 2023-04-21 =
-
-- Fixed: shortcode support in button, image and social icons links.
+* Fixed: shortcode support in button, image and social icons links.
 
 = 4.12.1 - 2023-04-19 =
-
-- Fixed: post notifications not sent if scheduled with minutes.
+* Fixed: post notifications not sent if scheduled with minutes.
 
 = 4.12.0 - 2023-04-17 =
-
-- Added: "Order status change" trigger in Automations;
-- Improved: messaging when subscriber limit is reached;
-- Improved: consistent use of order statuses in segment conditions.
+* Added: "Order status change" trigger in Automations;
+* Improved: messaging when subscriber limit is reached;
+* Improved: consistent use of order statuses in segment conditions.
 
 = 4.11.1 - 2023-04-10 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 4.11.0 - 2023-04-04 =
-
-- Added: shortcode support when editing WooCommerce emails;
-- Added: "single order value" segment;
-- Added: "Purchase date" segment;
-- Fixed: an error when you try to duplicate an email, that was sent to a deleted list;
-- Fixed: missing help icon next to subject and preview text explaining the use of shortcodes;
-- Fixed: sending gets stuck if all contacts in a batch unsubscribe between scheduling and sending the email;
-- Fixed: separators (<hr>) are stripped from posts when included in the email.
+* Added: shortcode support when editing WooCommerce emails;
+* Added: "single order value" segment;
+* Added: "Purchase date" segment;
+* Fixed: an error when you try to duplicate an email, that was sent to a deleted list;
+* Fixed: missing help icon next to subject and preview text explaining the use of shortcodes;
+* Fixed: sending gets stuck if all contacts in a batch unsubscribe between scheduling and sending the email;
+* Fixed: separators (<hr>) are stripped from posts when included in the email.
 
 = 4.10.0 - 2023-03-27 =
-
-- Added: WooCommerce version check and notice when using an old version;
-- Added: Emails can now be scheduled to be sent at minute granularity, not only one or more hours later;
-- Improved: prevent forms from showing multiple times when other plugins call the same hooks multiple times;
-- Improved: added HPOS support for WooCommerce Subscription segment;
-- Improved: when editing active email, a warning is shown that it will be deactivated;
-- Fixed: rendering error on home page when there is no change in lists size;
-- Fixed: occasional horizontal scrollbar in popup forms.
+* Added: WooCommerce version check and notice when using an old version;
+* Added: Emails can now be scheduled to be sent at minute granularity, not only one or more hours later;
+* Improved: prevent forms from showing multiple times when other plugins call the same hooks multiple times;
+* Improved: added HPOS support for WooCommerce Subscription segment;
+* Improved: when editing active email, a warning is shown that it will be deactivated;
+* Fixed: rendering error on home page when there is no change in lists size;
+* Fixed: occasional horizontal scrollbar in popup forms.
 
 = 4.9.0 - 2023-03-21 =
-
-- Updated: Gutenberg dependencies.
+* Updated: Gutenberg dependencies.
 
 = 4.8.1 - 2023-03-14 =
-
-- Added: Home page;
-- Improved: custom field validation errors are translated;
-- Fixed: error when sorting sending status page by subscriber name.
+* Added: Home page;
+* Improved: custom field validation errors are translated;
+* Fixed: error when sorting sending status page by subscriber name.
 
 = 4.8.0 - 2023-03-06 =
-
-- Added: option to run an automation multiple times for the same subscriber;
-- Improved: when AutomateWoo is installed, only show one opt-in checkbox on the checkout;
-- Fixed: coupon code block is empty when adding to an existing email;
-- Fixed: "call to undefined function MailPoet\API\JSON\error_log()".
+* Added: option to run an automation multiple times for the same subscriber;
+* Improved: when AutomateWoo is installed, only show one opt-in checkbox on the checkout;
+* Fixed: coupon code block is empty when adding to an existing email;
+* Fixed: "call to undefined function MailPoet\API\JSON\error_log()".
 
 = 4.7.1 - 2023-02-27 =
-
-- Added: filter allowing to configure PHPMailer when sending via SMTP;
-- Added: a coupon block in email editor;
-- Added: notice when a MailPoet subscription is pending approval;
-- Improved: Free plan users are directed to upgrade their plan from the Upgrade page;
-- Improved: email templates now include coupon block;
-- Fixed: inactive subscribers weren't recalculated since August 2022. They'll be again recalculated within one week after updating. Sorry about this bug.
+* Added: filter allowing to configure PHPMailer when sending via SMTP;
+* Added: a coupon block in email editor;
+* Added: notice when a MailPoet subscription is pending approval;
+* Improved: Free plan users are directed to upgrade their plan from the Upgrade page;
+* Improved: email templates now include coupon block;
+* Fixed: inactive subscribers weren't recalculated since August 2022. They'll be again recalculated within one week after updating. Sorry about this bug.
 
 = 4.7.0 - 2023-02-20 =
-
-- Updated: minimum required WordPress version to 5.9;
-- Updated: minimum required WooCommerce version to 7.2;
-- Improved: more explanatory MailPoet task in WooCommerce onboarding;
-- Improved: prevent form listing from crashing when form settings data are missing or malformed;
-- Improved: close button of form popup is focus-able to improve accessibility;
-- Fixed: conflict when loading mixpanel library;
-- Fixed: choices from first steps of welcome wizard are forgotten when MailPoet Sending Service is activated;
-- Fixed: draft products are not showing in email editor.
+* Updated: minimum required WordPress version to 5.9;
+* Updated: minimum required WooCommerce version to 7.2;
+* Improved: more explanatory MailPoet task in WooCommerce onboarding;
+* Improved: prevent form listing from crashing when form settings data are missing or malformed;
+* Improved: close button of form popup is focus-able to improve accessibility;
+* Fixed: conflict when loading mixpanel library;
+* Fixed: choices from first steps of welcome wizard are forgotten when MailPoet Sending Service is activated;
+* Fixed: draft products are not showing in email editor.
 
 = 4.6.2 - 2023-02-14 =
-
-- Improved: explain MailPoet Sending Service during onboarding;
-- Improved: when a subscription is pending approval, you can now recheck the status directly from the notice;
-- Changed: removed "Export" item from the main MailPoet menu;
-- Fixed: after finishing WooCommerce onboarding, the user is redirected to MailPoet;
-- Fixed: migration class not found when data corrupted by another plugin;
-- Fixed: misaligned buttons in "Relax" form template;
-- Fixed: broken built-in CAPTCHA in Safari on macOS.
+* Improved: explain MailPoet Sending Service during onboarding;
+* Improved: when a subscription is pending approval, you can now recheck the status directly from the notice;
+* Changed: removed "Export" item from the main MailPoet menu;
+* Fixed: after finishing WooCommerce onboarding, the user is redirected to MailPoet;
+* Fixed: migration class not found when data corrupted by another plugin;
+* Fixed: misaligned buttons in "Relax" form template;
+* Fixed: broken built-in CAPTCHA in Safari on macOS.
 
 = 4.6.1 - 2023-02-06 =
-
-- Added: "Copy to clipboard" button next to System Info;
-- Improved: warn users on PHP 7.3 about outdated PHP version;
-- Improved: MailPoet now uses a from address to test sending emails instead of "blackhole@mailpoet.com";
-- Improved: post images will now use image attachments' alt text for improved accessibility;
-- Changed: now even logged in user requires a valid token to unsubscribe;
-- Changed: Editor role now has access to Automations;
-- Fixed: color setting in email editor is not saved.
+* Added: "Copy to clipboard" button next to System Info;
+* Improved: warn users on PHP 7.3 about outdated PHP version;
+* Improved: MailPoet now uses a from address to test sending emails instead of "blackhole@mailpoet.com";
+* Improved: post images will now use image attachments' alt text for improved accessibility;
+* Changed: now even logged in user requires a valid token to unsubscribe;
+* Changed: Editor role now has access to Automations;
+* Fixed: color setting in email editor is not saved.
 
 = 4.6.0 - 2023-01-31 =
-
-- Added: anonymized and opt-in tracking of revenue per email campaign;
-- Added: subscription confirmation emails can be previewed during editing;
-- Added: a new item in WooCommerce Task List to finish MailPoet setup;
-- Improved: list visibility explanation when editing a list;
-- Changed: added option to rerun two specific migrations if they failed in the past;
-- Changed: [site:homepage_link] now renders as link in email editor, introduced new [site:homepage_url] shortcode to get just the URL;
-- Fixed: UI issues on WordPress.com;
-- Fixed: multiple popup signup forms when products are added via shortcode;
-- Fixed: multiple signup form on WooCommerce Products page;
-- Fixed: multiple vertical scrollbars in Form editor;
-- Fixed: custom field block hidden behind help icon in Form editor.
+* Added: anonymized and opt-in tracking of revenue per email campaign;
+* Added: subscription confirmation emails can be previewed during editing;
+* Added: a new item in WooCommerce Task List to finish MailPoet setup;
+* Improved: list visibility explanation when editing a list;
+* Changed: added option to rerun two specific migrations if they failed in the past;
+* Changed: [site:homepage_link] now renders as link in email editor, introduced new [site:homepage_url] shortcode to get just the URL;
+* Fixed: UI issues on WordPress.com;
+* Fixed: multiple popup signup forms when products are added via shortcode;
+* Fixed: multiple signup form on WooCommerce Products page;
+* Fixed: multiple vertical scrollbars in Form editor;
+* Fixed: custom field block hidden behind help icon in Form editor.
 
 = 4.5.2 - 2023-01-25 =
-
-- Fixed: issue with new installations of MailPoet on websites with WooCommerce.
+* Fixed: issue with new installations of MailPoet on websites with WooCommerce.
 
 = 4.5.1 - 2023-01-23 =
-
-- Added: a new landing page to explain MailPoet to new users;
-- Added: survey when the plugin is deactivated.
+* Added: a new landing page to explain MailPoet to new users;
+* Added: survey when the plugin is deactivated.
 
 = 4.5.0 - 2023-01-17 =
-
-- Improved: translate error messages from MailPoet Sending Service;
-- Improved: show a loading state when automation is being created;
-- Fixed: shortcodes inserter in the email editor not working.
+* Improved: translate error messages from MailPoet Sending Service;
+* Improved: show a loading state when automation is being created;
+* Fixed: shortcodes inserter in the email editor not working.
 
 = 4.4.0 - 2023-01-10 =
-
-- Updated: TinyMCE editor to v6;
-- Improved: log PHP errors in JSON API calls;
-- Fixed: prevent paused sending without an error message;
-- Fixed: horizontal scrollbar in automation actions popup.
+* Updated: TinyMCE editor to v6;
+* Improved: log PHP errors in JSON API calls;
+* Fixed: prevent paused sending without an error message;
+* Fixed: horizontal scrollbar in automation actions popup.
 
 = 4.3.1 - 2023-01-03 =
-
-- Improved: welcome wizard first step design;
-- Improved: error handling for confirmation emails;
-- Fixed: occasional error on column detection during plugin update;
-- Fixed: occasional call to undefined function error during plugin update.
+* Improved: welcome wizard first step design;
+* Improved: error handling for confirmation emails;
+* Fixed: occasional error on column detection during plugin update;
+* Fixed: occasional call to undefined function error during plugin update.
 
 = 4.3.0 - 2022-12-19 =
-
-- Added: confirmation email can be designed in email editor;
-- Improved: nicer and more understandable onboarding.
+* Added: confirmation email can be designed in email editor;
+* Improved: nicer and more understandable onboarding.
 
 = 4.2.0 - 2022-12-12 =
-
-- Added: link to purchase a MailPoet plan from Key Activation page;
-- Improved: support for ANSI_QUOTES sql mode;
-- Improved: 1-click unsubscribe is also tracked as a click;
-- Improved: "Maximum execution time" error is now more descriptive in MailPoet > Help > System Status;
-- Changed: email language in HTML is set to site's language (Settings > General) instead of English.
+* Added: link to purchase a MailPoet plan from Key Activation page;
+* Improved: support for ANSI_QUOTES sql mode;
+* Improved: 1-click unsubscribe is also tracked as a click;
+* Improved: "Maximum execution time" error is now more descriptive in MailPoet > Help > System Status;
+* Changed: email language in HTML is set to site's language (Settings > General) instead of English.
 
 = 4.1.1 - 2022-12-05 =
-
-- Improved: the 3rd-party libraries description in Welcome Wizard;
-- Improved: display a warning if sending function is not available;
-- Fixed: Column not found error experienced by some users;
-- Fixed: wc_get_page_id causes an error when WooCommerce is not installed;
-- Fixed: block settings in email editor look broken.
+* Improved: the 3rd-party libraries description in Welcome Wizard;
+* Improved: display a warning if sending function is not available;
+* Fixed: Column not found error experienced by some users;
+* Fixed: wc_get_page_id causes an error when WooCommerce is not installed;
+* Fixed: block settings in email editor look broken.
 
 = 4.1.0 - 2022-11-28 =
-
-- Improved: don't automatically activate MailPoet Sending Service for Creator plans;
-- Improved: MailPoet's built-in CAPTCHA now includes audio fallback to improve accessibility;
-- Fixed: automation may not always start if there exists another automation with the same trigger;
-- Fixed: automations beta badge wraps in some languages;
-- Fixed: domain authentication is not shown when sending a preview email.
+* Improved: don't automatically activate MailPoet Sending Service for Creator plans;
+* Improved: MailPoet's built-in CAPTCHA now includes audio fallback to improve accessibility;
+* Fixed: automation may not always start if there exists another automation with the same trigger;
+* Fixed: automations beta badge wraps in some languages;
+* Fixed: domain authentication is not shown when sending a preview email.
 
 = 4.0.1 - 2022-11-22 =
-
-- Improved: when editing a list, you can choose if it should be shown on the Manage Subscription page (on by default);
-- Improved: form templates now link to existing Privacy Page;
-- Changed: [subscriber:count] shortcode now counts only subscribed subscribers (and not unconfirmed or inactive);
-- Fixed: automations beta badge overflows menu in some languages;
-- Fixed: failing to create automation tables with "Base table or view already exists" in rare cases;
-- Fixed: displaying wrong tasks in System Status.
+* Improved: when editing a list, you can choose if it should be shown on the Manage Subscription page (on by default);
+* Improved: form templates now link to existing Privacy Page;
+* Changed: [subscriber:count] shortcode now counts only subscribed subscribers (and not unconfirmed or inactive);
+* Fixed: automations beta badge overflows menu in some languages;
+* Fixed: failing to create automation tables with "Base table or view already exists" in rare cases;
+* Fixed: displaying wrong tasks in System Status.
 
 = 4.0.0 - 2022-11-15 =
-
-- Added: new Automations page (beta version, please share your feedback directly from the plugin);
-- Added: optional support for POST unsubscribe when sending with MailPoet Sending Service, which enables 1-click unsubscribe button in more email clients;
-- Added: engagement badges for opens, unsubscribes, and bounces;
-- Updated: minimum required WordPress version to 5.8;
-- Fixed: "Unknown storage engine 'InnoDB'" error (InnoDB engine is no longer required).
+* Added: new Automations page (beta version, please share your feedback directly from the plugin);
+* Added: optional support for POST unsubscribe when sending with MailPoet Sending Service, which enables 1-click unsubscribe button in more email clients;
+* Added: engagement badges for opens, unsubscribes, and bounces;
+* Updated: minimum required WordPress version to 5.8;
+* Fixed: "Unknown storage engine 'InnoDB'" error (InnoDB engine is no longer required).
 
 = 3.103.1 - 2022-11-08 =
-
-- Fix a database problem that affected some versions of MySQL when creating the new migrations table.
+* Fix a database problem that affected some versions of MySQL when creating the new migrations table.
 
 = 3.103.0 - 2022-11-07 =
-
-- Added: deleteList and updateList API methods (https://github.com/mailpoet/mailpoet/tree/trunk/doc);
-- Added: forms can be configured to show on product pages;
-- Improved: more explanatory automatic emails setup;
-- Improved: consistent case in the form editor labels;
-- Improved: long sign-up button text will wrap to a new line;
-- Improved: confirmation emails can now be personalized;
-- Fixed: MailPoet key validation can fail, if the site URL is configured with uppercase letters;
-- Fixed: required questions in onboarding can be skipped;
-- Declare MailPoet as compatible with the upcoming WooCommerce High Performance Order Storage.
+* Added: deleteList and updateList API methods (https://github.com/mailpoet/mailpoet/tree/trunk/doc);
+* Added: forms can be configured to show on product pages;
+* Improved: more explanatory automatic emails setup;
+* Improved: consistent case in the form editor labels;
+* Improved: long sign-up button text will wrap to a new line;
+* Improved: confirmation emails can now be personalized;
+* Fixed: MailPoet key validation can fail, if the site URL is configured with uppercase letters;
+* Fixed: required questions in onboarding can be skipped;
+* Declare MailPoet as compatible with the upcoming WooCommerce High Performance Order Storage.
 
 = 3.102.1 - 2022-11-03 =
-
-- Fixed: missing 'CheckoutSchema' class error in WooCommerce blocks integration;
-- Fixed: "Class 'Normalizer' not found" error in WP 6.1 when intl extension is missing.
+* Fixed: missing 'CheckoutSchema' class error in WooCommerce blocks integration;
+* Fixed: "Class 'Normalizer' not found" error in WP 6.1 when intl extension is missing.
 
 = 3.102.0 - 2022-11-01 =
-
-- Added: new subscribers hooks (https://github.com/mailpoet/mailpoet/pull/4443);
-- Improved: limit cron runs when execution limit exception is thrown;
-- Improved: list(s) are replaced with the site title on the subscription confirmation page.
+* Added: new subscribers hooks (https://github.com/mailpoet/mailpoet/pull/4443);
+* Improved: limit cron runs when execution limit exception is thrown;
+* Improved: list(s) are replaced with the site title on the subscription confirmation page.
 
 = 3.101.1 - 2022-10-24 =
-
-- Improved: simplified privacy and data sharing section in onboarding;
-- Improved: don't require any newsletter settings when saving a draft;
-- Fixed: an error in the checkout, when the shop has multiple automatic emails set up.
+* Improved: simplified privacy and data sharing section in onboarding;
+* Improved: don't require any newsletter settings when saving a draft;
+* Fixed: an error in the checkout, when the shop has multiple automatic emails set up.
 
 = 3.101.0 - 2022-10-17 =
-
-- Added: new API method getSubscribersCount;
-- Added: new API method getSubscribers;
-- Improved: cron-related tasks;
-- Improved: confirm leaving Settings page when leaving without saving;
-- Improved: messaging when verifying an API key.
+* Added: new API method getSubscribersCount;
+* Added: new API method getSubscribers;
+* Improved: cron-related tasks;
+* Improved: confirm leaving Settings page when leaving without saving;
+* Improved: messaging when verifying an API key.
 
 = 3.100.2 - 2022-10-10 =
-
-- Fixed: scheduled newsletters not sending.
+* Fixed: scheduled newsletters not sending.
 
 = 3.100.1 - 2022-10-06 =
-
-- Fixed: In some instances the sending stuck because the EntityManager was closed.
+* Fixed: In some instances the sending stuck because the EntityManager was closed.
 
 = 3.100.0 - 2022-10-03 =
-
-- Added: tagging subscribers when signed up via a form;
-- Improved: linux cron error message;
-- Fixed: paid MailPoet plan is offered in onboarding instead of a free MailPoet plan.
+* Added: tagging subscribers when signed up via a form;
+* Improved: linux cron error message;
+* Fixed: paid MailPoet plan is offered in onboarding instead of a free MailPoet plan.
 
 = 3.99.1 - 2022-09-29 =
-
-- Fix issue with post notifications in MailPoet 3.99.
+* Fix issue with post notifications in MailPoet 3.99.
 
 = 3.99.0 - 2022-09-27 =
-
-- Added: any email address from a sender domain is automatically allowed for sending (MailPoet Sending Service only);
-- Fixed: some post notifications may fail to send.
+* Added: any email address from a sender domain is automatically allowed for sending (MailPoet Sending Service only);
+* Fixed: some post notifications may fail to send.
 
 = 3.98.1 - 2022-09-21 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.98.0 - 2022-09-19 =
-
-- Added: filter subscribers by clicking on tag badge;
-- Added: tag imported subscribers;
-- Improved: error handling on the send email page;
-- Fixed: possible memory issue on the segments page.
+* Added: filter subscribers by clicking on tag badge;
+* Added: tag imported subscribers;
+* Improved: error handling on the send email page;
+* Fixed: possible memory issue on the segments page.
 
 = 3.97.0 - 2022-09-12 =
-
-- Improved: added a link to start domain authentication when required;
-- Improved: domain and email verification process;
-- Changed: we are dropping number 3 from the plugin name, so from now on, "MailPoet 3" becomes just "MailPoet";
-- Fixed: lists not available when filtering trashed subscribers;
-- Fixed: broken translations when typography quotes changed.
+* Improved: added a link to start domain authentication when required;
+* Improved: domain and email verification process;
+* Changed: we are dropping number 3 from the plugin name, so from now on, "MailPoet 3" becomes just "MailPoet";
+* Fixed: lists not available when filtering trashed subscribers;
+* Fixed: broken translations when typography quotes changed.
 
 = 3.96.1 - 2022-08-31 =
-
-- Fixed: the settings page renders blank in some cases.
+* Fixed: the settings page renders blank in some cases.
 
 = 3.96.0 - 2022-08-29 =
-
-- Improved: don't show spacer after last item in breadcrumbs;
-- Improved: don't require a list to save email draft.
+* Improved: don't show spacer after last item in breadcrumbs;
+* Improved: don't require a list to save email draft.
 
 = 3.95.1 - 2022-08-22 =
-
-- Added: UTM parameters on the MailPoet logo when sending with a free MailPoet plan;
-- Added: button to play video tutorial in email editor;
-- Added: new SMTP filters;
-- Improved: validate sender email immediately on the send page when using MailPoet Sending Service;
-- Improved: share System Info data when contacting MailPoet Support from the plugin;
-- Fixed: wrong position of tags autocomplete.
+* Added: UTM parameters on the MailPoet logo when sending with a free MailPoet plan;
+* Added: button to play video tutorial in email editor;
+* Added: new SMTP filters;
+* Improved: validate sender email immediately on the send page when using MailPoet Sending Service;
+* Improved: share System Info data when contacting MailPoet Support from the plugin;
+* Fixed: wrong position of tags autocomplete.
 
 = 3.95.0 - 2022-08-15 =
-
-- Added: the domain verification process can be performed in the plugin;
-- Updated: Gutenberg dependencies;
-- Fixed: emails are labeled as "Preview" on System Status page;
-- Removed support for migration data from MailPoet2.
+* Added: the domain verification process can be performed in the plugin;
+* Updated: Gutenberg dependencies;
+* Fixed: emails are labeled as "Preview" on System Status page;
+* Removed support for migration data from MailPoet2.
 
 = 3.94.0 - 2022-08-08 =
-
-- Added: filter subscribers by a tag;
-- Added: new WordPress cron task scheduler method;
-- Improved: tooltip content when hovering over list name;
-- Improved: extract name from email when used as first name in welcome wizard;
-- Improved: radio buttons and checkboxes accessibility in forms.
+* Added: filter subscribers by a tag;
+* Added: new WordPress cron task scheduler method;
+* Improved: tooltip content when hovering over list name;
+* Improved: extract name from email when used as first name in welcome wizard;
+* Improved: radio buttons and checkboxes accessibility in forms.
 
 = 3.93.1 - 2022-08-02 =
-
-- Added: link to MailPoet settings from Plugins page;
-- Changed: email signup step removed from the MailPoet setup;
-- Fixed: a notice to send all emails through MailPoet can't be dismissed;
-- Fixed: MailPoet menu icon on WordPress.com.
+* Added: link to MailPoet settings from Plugins page;
+* Changed: email signup step removed from the MailPoet setup;
+* Fixed: a notice to send all emails through MailPoet can't be dismissed;
+* Fixed: MailPoet menu icon on WordPress.com.
 
 = 3.93.0 - 2022-07-25 =
-
-- Added: premium feature: new segment by subscriber tags.
+* Added: premium feature: new segment by subscriber tags.
 
 = 3.92.1 - 2022-07-20 =
-
-- Fixed: A database table could not be created in some installations.
+* Fixed: A database table could not be created in some installations.
 
 = 3.92.0 - 2022-07-19 =
-
-- Added: show tags on Subscribers listing page;
-- Added: tagging subscribers on the edit page;
-- Added: the ability to authorise the email address in the plugin;
-- Improved: when sending with MailPoet Sending Service, show a warning when unauthorized email is used immediately before sending an email;
-- Improved: don't load 3rd-party libraries on new installations unless an active consent is given.
+* Added: show tags on Subscribers listing page;
+* Added: tagging subscribers on the edit page;
+* Added: the ability to authorise the email address in the plugin;
+* Improved: when sending with MailPoet Sending Service, show a warning when unauthorized email is used immediately before sending an email;
+* Improved: don't load 3rd-party libraries on new installations unless an active consent is given.
 
 = 3.91.1 - 2022-07-11 =
-
-- Updated: npm and composer dependencies;
-- Improved: small UI changes to unify spacing and colors;
-- Improved: add "noindex, nofollow" directive on email preview page to prevent search engines to index these pages;
-- Improved: use original $phpmailer as a WordPressMailer fallback;
-- Fixed: date badges in select boxes are not vertically aligned.
+* Updated: npm and composer dependencies;
+* Improved: small UI changes to unify spacing and colors;
+* Improved: add "noindex, nofollow" directive on email preview page to prevent search engines to index these pages;
+* Improved: use original $phpmailer as a WordPressMailer fallback;
+* Fixed: date badges in select boxes are not vertically aligned.
 
 = 3.91.0 - 2022-06-22 =
-
-- Fixed: template caching.
+* Fixed: template caching.
 
 = 3.90.2 - 2022-06-20 =
-
-- Improved: tested up to WordPress 6.0;
-- Improved: when sending with MailPoet Sending Service, show a warning when unauthorized email is used in settings;
-- Fixed: correctly reset error message when sending resumes;
-- Fixed: MailPoet Marketing Opt-in block is not translated in WordPress 6;
-- Fixed: some special characters in WordPress name don't show correctly when synced to MailPoet.
+* Improved: tested up to WordPress 6.0;
+* Improved: when sending with MailPoet Sending Service, show a warning when unauthorized email is used in settings;
+* Fixed: correctly reset error message when sending resumes;
+* Fixed: MailPoet Marketing Opt-in block is not translated in WordPress 6;
+* Fixed: some special characters in WordPress name don't show correctly when synced to MailPoet.
 
 = 3.90.1 - 2022-06-16 =
-
-- Fixed: occasional error related to twig templates when updating the plugin.
+* Fixed: occasional error related to twig templates when updating the plugin.
 
 = 3.90.0 - 2022-06-14 =
-
-- Updated: js-cookie library to version 3;
-- Improved: autocomplete's accessibility for first and last name;
-- Improved: added labels to inputs in public forms to improve accessibility;
-- Improved: list badge now links to its subscribers;
-- Improved: some 3rd party plugins should no longer falsely mark MailPoet as malware;
-- Improved: checkbox and radio buttons are focusable;
-- Fixed: invalid HTML markup in rendered email;
-- Fixed: Unhandled error for inaccessible cron worker.
+* Updated: js-cookie library to version 3;
+* Improved: autocomplete's accessibility for first and last name;
+* Improved: added labels to inputs in public forms to improve accessibility;
+* Improved: list badge now links to its subscribers;
+* Improved: some 3rd party plugins should no longer falsely mark MailPoet as malware;
+* Improved: checkbox and radio buttons are focusable;
+* Fixed: invalid HTML markup in rendered email;
+* Fixed: Unhandled error for inaccessible cron worker.
 
 = 3.89.4 - 2022-06-06 =
-
-- Improved: better handle trying to change a subscriber email to an existing one;
-- Fixed: SMTP configuration doesn't work without authentication;
-- Fixed: subscribers without orders don't show in "0 orders" segment;
-- Fixed: creating custom field can break Form editor;
-- Fixed: Google Fonts libraries loading in iframe even when 3rd-party libraries are disabled.
+* Improved: better handle trying to change a subscriber email to an existing one;
+* Fixed: SMTP configuration doesn't work without authentication;
+* Fixed: subscribers without orders don't show in "0 orders" segment;
+* Fixed: creating custom field can break Form editor;
+* Fixed: Google Fonts libraries loading in iframe even when 3rd-party libraries are disabled.
 
 = 3.89.3 - 2022-05-24 =
-
-- Added: Google reCAPTCHA v2 Invisible;
-- Improved: auto adjust the height of form's iframe;
-- Changed: mailpoet_mailer_smtp_transport_agent filter replaced with mailpoet_mailer_smtp_option;
-- Changed: replaced Swift Mailer with PHPMailer.
+* Added: Google reCAPTCHA v2 Invisible;
+* Improved: auto adjust the height of form's iframe;
+* Changed: mailpoet_mailer_smtp_transport_agent filter replaced with mailpoet_mailer_smtp_option;
+* Changed: replaced Swift Mailer with PHPMailer.
 
 = 3.89.2 - 2022-05-19 =
-
-- Fixed: form editor not opening in some cases.
+* Fixed: form editor not opening in some cases.
 
 = 3.89.1 - 2022-05-17 =
-
-- Improved: performance fixes;
-- Improved: error handling when using MailPoet Sending Service;
-- Changed: removed deprecated code;
-- Changed: automatic emails can no longer be activated without an unsubscribe link when sending with MSS;
-- Fixed: remove unnecessary redirect that in some circumstances prevented displaying a form;
-- Fixed: users added via MemberPress now receive welcome emails targeted to custom roles.
+* Improved: performance fixes;
+* Improved: error handling when using MailPoet Sending Service;
+* Changed: removed deprecated code;
+* Changed: automatic emails can no longer be activated without an unsubscribe link when sending with MSS;
+* Fixed: remove unnecessary redirect that in some circumstances prevented displaying a form;
+* Fixed: users added via MemberPress now receive welcome emails targeted to custom roles.
 
 = 3.89.0 - 2022-05-09 =
-
-- Updated: Removed MailPoet Task Scheduler;
-- Improved: faster page load;
-- Improved: compatibility with WooCommerce Blocks 7.2;
-- Improved: tested with WordPress 6;
-- Fixed: TypeError when calculating lifetime emails takes longer than usual.
+* Updated: Removed MailPoet Task Scheduler;
+* Improved: faster page load;
+* Improved: compatibility with WooCommerce Blocks 7.2;
+* Improved: tested with WordPress 6;
+* Fixed: TypeError when calculating lifetime emails takes longer than usual.
 
 = 3.88.2 - 2022-05-03 =
-
-- Improved: show error message when trying to send confirmation email with signup confirmation disabled;
-- Changed: minimum PHP version bumped to 7.2.5;
-- Fixed: blank page when importing a template;
-- Fixed: drafts and future posts can't be included in newsletter.
+* Improved: show error message when trying to send confirmation email with signup confirmation disabled;
+* Changed: minimum PHP version bumped to 7.2.5;
+* Fixed: blank page when importing a template;
+* Fixed: drafts and future posts can't be included in newsletter.
 
 = 3.88.1 - 2022-04-28 =
-
-- Fixed: Abandoned Cart Email cannot be edited.
+* Fixed: Abandoned Cart Email cannot be edited.
 
 = 3.88.0 - 2022-04-25 =
-
-- Added: new official translations Catalan, Czech and Greek;
-- Fixed: email batches containing invalid addresses lost by MSS.
+* Added: new official translations Catalan, Czech and Greek;
+* Fixed: email batches containing invalid addresses lost by MSS.
 
 = 3.87.2 - 2022-04-19 =
-
-- Added: description of 3rd party libraries usage;
-- Fixed: "none of" condition for "MailPoet custom field" segment doesn't work;
-- Fixed: block toolbar in form editor is not visible for top block.
+* Added: description of 3rd party libraries usage;
+* Fixed: "none of" condition for "MailPoet custom field" segment doesn't work;
+* Fixed: block toolbar in form editor is not visible for top block.
 
 = 3.87.1 - 2022-04-14 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.87.0 - 2022-04-11 =
-
-- Added: new condition (at least 10 emails in lifetime) before marking subscriber as inactive;
-- Added: logging for failed MailPoet key validation checks;
-- Updated: minimum required WordPress version to 5.6;
-- Updated: npm dependencies;
-- Improved: when the subscription requires an upgrade, link directly to the upgrade page;
-- Improved: show notice in the plugin when the subscription is pending approval;
-- Fixed: List-Unsubscribe header format when sending with your host;
-- Fixed: hidden MailPoet fields visible in WooCommerce checkout;
-- Fixed: Manage subscription page doesn't work when all lists are unchecked.
+* Added: new condition (at least 10 emails in lifetime) before marking subscriber as inactive;
+* Added: logging for failed MailPoet key validation checks;
+* Updated: minimum required WordPress version to 5.6;
+* Updated: npm dependencies;
+* Improved: when the subscription requires an upgrade, link directly to the upgrade page;
+* Improved: show notice in the plugin when the subscription is pending approval;
+* Fixed: List-Unsubscribe header format when sending with your host;
+* Fixed: hidden MailPoet fields visible in WooCommerce checkout;
+* Fixed: Manage subscription page doesn't work when all lists are unchecked.
 
 = 3.86.0 - 2022-04-05 =
-
-- Improved: apply form success message styles also on Captcha confirmation page;
-- Fixed: potential "Call to undefined method" error.
+* Improved: apply form success message styles also on Captcha confirmation page;
+* Fixed: potential "Call to undefined method" error.
 
 = 3.85.1 - 2022-03-29 =
-
-- Updated: 1and1 hosting renamed to "IONOS by 1&1";
-- Updated: composer dependencies;
-- Updated: Gutenberg dependencies;
-- Improved: don't count "Pending payment" and "On-hold" orders to purchased segments;
-- Improved: when searching subscribers, update groups counts with found results;
-- Fixed: critical error at checkout with WooCommerce checkout block;
-- Fixed: error preventing sending when line height is set to 0 in email editor;
-- Fixed: shortcode default value not used in Emails opened from a Newsletter Archive page.
+* Updated: 1and1 hosting renamed to "IONOS by 1&1";
+* Updated: composer dependencies;
+* Updated: Gutenberg dependencies;
+* Improved: don't count "Pending payment" and "On-hold" orders to purchased segments;
+* Improved: when searching subscribers, update groups counts with found results;
+* Fixed: critical error at checkout with WooCommerce checkout block;
+* Fixed: error preventing sending when line height is set to 0 in email editor;
+* Fixed: shortcode default value not used in Emails opened from a Newsletter Archive page.
 
 = 3.85.0 - 2022-03-21 =
-
-- Improved: add "Send all site's emails with" to Help → System Status;
-- Fixed: sending limit can be exceeded in some cases.
+* Improved: add "Send all site's emails with" to Help → System Status;
+* Fixed: sending limit can be exceeded in some cases.
 
 = 3.84.1 - 2022-03-14 =
-
-- Added: more engagement checks before marking subscriber as inactive;
-- Fixed: when scheduling an email, button says "Send" instead of "Schedule".
+* Added: more engagement checks before marking subscriber as inactive;
+* Fixed: when scheduling an email, button says "Send" instead of "Schedule".
 
 = 3.84.0 - 2022-03-08 =
-
-- Improved: more robust segment subscribers count calculation in segment form;
-- Improved: include "pending cancellation" subscriptions in WC Subscriptions segment;
-- Fixed: scheduled newsletter might be sent to subscribers who are not subscribed.
+* Improved: more robust segment subscribers count calculation in segment form;
+* Improved: include "pending cancellation" subscriptions in WC Subscriptions segment;
+* Fixed: scheduled newsletter might be sent to subscribers who are not subscribed.
 
 = 3.83.0 - 2022-03-01 =
-
-- Added: a notice when email volume limit is reached;
-- Updated: content of the Upgrade page;
-- Changed: removed deprecated code;
-- Changed: each signup form has its own "seen" cookie and custom expiry interval;
-- Fixed: Turkish translations fail to load.
+* Added: a notice when email volume limit is reached;
+* Updated: content of the Upgrade page;
+* Changed: removed deprecated code;
+* Changed: each signup form has its own "seen" cookie and custom expiry interval;
+* Fixed: Turkish translations fail to load.
 
 = 3.82.0 - 2022-02-22 =
-
-- Improved: monthly stats email now includes unsubscribed and bounced;
-- Improved: use WooCommerce Session to identify subscribers' engagement;
-- Improved: tested on WordPress 5.9;
-- Fixed: error when using empty default value in shortcode.
+* Improved: monthly stats email now includes unsubscribed and bounced;
+* Improved: use WooCommerce Session to identify subscribers' engagement;
+* Improved: tested on WordPress 5.9;
+* Fixed: error when using empty default value in shortcode.
 
 = 3.81.0 - 2022-02-16 =
-
-- Fixed: translations downloading issue.
+* Fixed: translations downloading issue.
 
 = 3.80.0 - 2022-02-15 =
-
-- Added: offer to upgrade subscription and download or activate the premium plugin where needed;
-- Added: mailpoet_subscription_before_subscribe hook;
-- Added: a check that MailPoet can communicate with MailPoet Sending Service;
-- Updated: npm dependencies;
-- Improved: translations are no longer included in the plugin, but are downloaded after activation or update;
-- Improved: update confirmation message when deleting MailPoet so it doesn't say that MailPoet data are deleted (as they are not);
-- Improved: stats email now includes unsubscribed and bounced;
-- Improved: default newsletter schedule time is set to tomorrow 8am;
-- Changed: docs location;
-- Changed: only mark purchased product/category sent when the automatic email is activated;
-- Fixed: filtering "Subscribers without a list" in Trash redirects to All Subscribers;
-- Fixed: shortcode default value is not rendered in archives;
-- Fixed: Incorrect use of $metas[0] index in individual newsletter processing.
+* Added: offer to upgrade subscription and download or activate the premium plugin where needed;
+* Added: mailpoet_subscription_before_subscribe hook;
+* Added: a check that MailPoet can communicate with MailPoet Sending Service;
+* Updated: npm dependencies;
+* Improved: translations are no longer included in the plugin, but are downloaded after activation or update;
+* Improved: update confirmation message when deleting MailPoet so it doesn't say that MailPoet data are deleted (as they are not);
+* Improved: stats email now includes unsubscribed and bounced;
+* Improved: default newsletter schedule time is set to tomorrow 8am;
+* Changed: docs location;
+* Changed: only mark purchased product/category sent when the automatic email is activated;
+* Fixed: filtering "Subscribers without a list" in Trash redirects to All Subscribers;
+* Fixed: shortcode default value is not rendered in archives;
+* Fixed: Incorrect use of $metas[0] index in individual newsletter processing.
 
 = 3.79.0 - 2022-02-09 =
-
-- Added: new segment for WooCommerce Memberships;
-- Improved: only load MailPoet admin styles on MailPoet pages;
-- Improved: added "18 months" option for inactive subscribers;
-- Improved: consider subscriber's page view as an engagement (to prevent them marking as inactive);
-- Fixed: email bounce count shows unsubscribe count instead;
-- Fixed: wrong name and email default values in MailPoet setup wizard.
+* Added: new segment for WooCommerce Memberships;
+* Improved: only load MailPoet admin styles on MailPoet pages;
+* Improved: added "18 months" option for inactive subscribers;
+* Improved: consider subscriber's page view as an engagement (to prevent them marking as inactive);
+* Fixed: email bounce count shows unsubscribe count instead;
+* Fixed: wrong name and email default values in MailPoet setup wizard.
 
 = 3.78.0 - 2022-01-25 =
-
-- Added: new Amazon SES locations;
-- Improved: Gutenberg updated for form editor;
-- Improved: don't show full API key in MailPoet → Help → System Info;
-- Improved: more options for "machine-opened" segment;
-- Improved: more options for "clicked" segment;
-- Improved: show "Today" or "Tomorrow" on email listing for scheduled emails;
-- Changed: when using "none of" option in purchased product/in category segment, also include all subscribers who never purchased;
-- Fixed: "Call to a member function format() on null" error on subscribers page;
-- Fixed: form preview showing a preview from previously edited form.
+* Added: new Amazon SES locations;
+* Improved: Gutenberg updated for form editor;
+* Improved: don't show full API key in MailPoet → Help → System Info;
+* Improved: more options for "machine-opened" segment;
+* Improved: more options for "clicked" segment;
+* Improved: show "Today" or "Tomorrow" on email listing for scheduled emails;
+* Changed: when using "none of" option in purchased product/in category segment, also include all subscribers who never purchased;
+* Fixed: "Call to a member function format() on null" error on subscribers page;
+* Fixed: form preview showing a preview from previously edited form.
 
 = 3.77.1 - 2022-01-20 =
-
-- Fixed: WooCommerce checkout doesn't work with MailPoet enabled.
+* Fixed: WooCommerce checkout doesn't work with MailPoet enabled.
 
 = 3.77.0 - 2022-01-17 =
-
-- Added: client-side validation on Manage subscription page;
-- Updated: composer dependencies;
-- Improved: date input shows full date when creating a segment;
-- Improved: backward compatibility for WooCommerce Blocks;
-- Improved: more comparison options for email and subscriber segments;
-- Improved: more form delay options added;
-- Fixed: opting out on WooCommerce checkout doesn't unsubscribe from other lists configured in MailPoet Settings.
+* Added: client-side validation on Manage subscription page;
+* Updated: composer dependencies;
+* Improved: date input shows full date when creating a segment;
+* Improved: backward compatibility for WooCommerce Blocks;
+* Improved: more comparison options for email and subscriber segments;
+* Improved: more form delay options added;
+* Fixed: opting out on WooCommerce checkout doesn't unsubscribe from other lists configured in MailPoet Settings.
 
 = 3.76.0 - 2022-01-13 =
-
-- Improved: more options for "MailPoet custom field" segment;
-- Improved: more options for "WooCommerce" segments;
-- Improved: select boxes have the same height;
-- Improved: dropped support for PHP 7.1, MailPoet now requires at least PHP 7.2;
-- Improved: more options for "has an active subscription" segment;
-- Improved: more options for "WordPress user role" segment;
-- Improved: more options for "purchased in this category" segment;
-- Improved: more options for "is in country" segment;
-- Improved: more options for "opened" segment;
-- Improved: subscriber cookies are now set on clicks, login, signup, and order checkout;
-- Improved: show full email subject when creating segment based on email;
-- Improved: include guest users in WooCommerce segments;
-- Improved: add link to our knowledge base when segment creation fails;
-- Changed: automatic emails are deactivated when editing;
-- Changed: segments with multiple conditions require the premium plugin;
-- Fixed: cron issues with excessive number of queries in WooCommerce subsriber sync;
-- Fixed: unclosed paragraph tags do not break rendering anymore. Thanks Helene!
-- Fixed: incorrect result for a segment with multiple "purchased product" conditions;
-- Fixed: column search field when importing subscribers not working;
-- Fixed: form messages displayed in wrong place when using multiple forms on the page;
-- Fixed: show correct animation in form editor for slide-in form.
+* Improved: more options for "MailPoet custom field" segment;
+* Improved: more options for "WooCommerce" segments;
+* Improved: select boxes have the same height;
+* Improved: dropped support for PHP 7.1, MailPoet now requires at least PHP 7.2;
+* Improved: more options for "has an active subscription" segment;
+* Improved: more options for "WordPress user role" segment;
+* Improved: more options for "purchased in this category" segment;
+* Improved: more options for "is in country" segment;
+* Improved: more options for "opened" segment;
+* Improved: subscriber cookies are now set on clicks, login, signup, and order checkout;
+* Improved: show full email subject when creating segment based on email;
+* Improved: include guest users in WooCommerce segments;
+* Improved: add link to our knowledge base when segment creation fails;
+* Changed: automatic emails are deactivated when editing;
+* Changed: segments with multiple conditions require the premium plugin;
+* Fixed: cron issues with excessive number of queries in WooCommerce subsriber sync;
+* Fixed: unclosed paragraph tags do not break rendering anymore. Thanks Helene!
+* Fixed: incorrect result for a segment with multiple "purchased product" conditions;
+* Fixed: column search field when importing subscribers not working;
+* Fixed: form messages displayed in wrong place when using multiple forms on the page;
+* Fixed: show correct animation in form editor for slide-in form.
 
 = 3.75.1 - 2021-12-15 =
-
-- Fixed: Issues with rendering full posts in newsletters.
+* Fixed: Issues with rendering full posts in newsletters.
 
 = 3.75.0 - 2021-12-13 =
-
-- Changed: show MailPoet logo in emails when using free MailPoet plan;
-- Fixed: "# of machine opens" segment not working properly.
+* Changed: show MailPoet logo in emails when using free MailPoet plan;
+* Fixed: "# of machine opens" segment not working properly.
 
 = 3.74.3 - 2021-12-07 =
-
-- Added: new segment "subscribed to list";
-- Improved: more options for "purchased product" segment;
-- Improved: more performant WooCommerce customers names sync;
-- Improved: simplified tracking settings in MailPoet > Settings > Advanced;
-- Fixed: issue in WooCommerce checkout integration;
-- Fixed: popup form is displayed again after dismissed when 'After submit' is set to 'Go to Page'.
+* Added: new segment "subscribed to list";
+* Improved: more options for "purchased product" segment;
+* Improved: more performant WooCommerce customers names sync;
+* Improved: simplified tracking settings in MailPoet > Settings > Advanced;
+* Fixed: issue in WooCommerce checkout integration;
+* Fixed: popup form is displayed again after dismissed when 'After submit' is set to 'Go to Page'.
 
 = 3.74.2 - 2021-11-29 =
-
-- Added: new re-engagement email type;
-- Added: integration with new Checkout Block in WooCommerce;
-- Added: new segment by subscriber score;
-- Fixed: high CPU usage caused by a cron job;
-- Fixed: sending not working after unbanning.
+* Added: new re-engagement email type;
+* Added: integration with new Checkout Block in WooCommerce;
+* Added: new segment by subscriber score;
+* Fixed: high CPU usage caused by a cron job;
+* Fixed: sending not working after unbanning.
 
 = 3.74.1 - 2021-11-22 =
-
-- Improved: differentiate inactive forms in Widgets;
-- Fixed: duplicate entries when exporting subscribers in some cases;
-- Fixed: WooCommerce subscription segment doesn't handle when a user changes subscription;
-- Fixed: CSS in form iframe not working when using on different domain;
-- Fixed: potential issue when handling DateTimes.
+* Improved: differentiate inactive forms in Widgets;
+* Fixed: duplicate entries when exporting subscribers in some cases;
+* Fixed: WooCommerce subscription segment doesn't handle when a user changes subscription;
+* Fixed: CSS in form iframe not working when using on different domain;
+* Fixed: potential issue when handling DateTimes.
 
 = 3.74.0 - 2021-11-17 =
-
-- Added: a filter to change reCAPTCHA type;
-- Updated: preparation for Black Friday sale;
-- Updated: npm dependencies;
-- Updated: react-select library;
-- Improved: more explanatory error message when there is a problem with sending method;
-- Improved: include List column when exporting subscribers to Excel;
-- Improved: make logger resilient to "The EntityManager is closed" error;
-- Improved: support d/m/y format when importing subscribers;
-- Improved: import a template form is now centered;
-- Improved: load template thumbnails from file system instead of database to improve templates page performance;
-- Changed: custom field labels can no longer be set per form, but are the same in every form;
-- Changed: limit scheduling email to 5 years in the future;
-- Fixed: high CPU usage for some customers;
-- Fixed: missing "Enable auto-updates" for the premium plugin;
-- Fixed: custom select default values can't be changed on Manage subscription page;
-- Fixed: block toolbar hidden under top bar in form editor;
-- Fixed: unable to place a new form unless it's saved;
-- Fixed: wrong placeholders in translatable strings;
-- Fixed: unable to uncheck a checkbox in Manage Subscriptions when the default value is checked;
-- Fixed: wrong WordPress menu icons for AutomateWoo and WC Payments when on MailPoet pages;
-- Fixed: form confirmation message is not shown in some edge cases;
-- Fixed: extra space in Post Notifications when using double quotes.
+* Added: a filter to change reCAPTCHA type;
+* Updated: preparation for Black Friday sale;
+* Updated: npm dependencies;
+* Updated: react-select library;
+* Improved: more explanatory error message when there is a problem with sending method;
+* Improved: include List column when exporting subscribers to Excel;
+* Improved: make logger resilient to "The EntityManager is closed" error;
+* Improved: support d/m/y format when importing subscribers;
+* Improved: import a template form is now centered;
+* Improved: load template thumbnails from file system instead of database to improve templates page performance;
+* Changed: custom field labels can no longer be set per form, but are the same in every form;
+* Changed: limit scheduling email to 5 years in the future;
+* Fixed: high CPU usage for some customers;
+* Fixed: missing "Enable auto-updates" for the premium plugin;
+* Fixed: custom select default values can't be changed on Manage subscription page;
+* Fixed: block toolbar hidden under top bar in form editor;
+* Fixed: unable to place a new form unless it's saved;
+* Fixed: wrong placeholders in translatable strings;
+* Fixed: unable to uncheck a checkbox in Manage Subscriptions when the default value is checked;
+* Fixed: wrong WordPress menu icons for AutomateWoo and WC Payments when on MailPoet pages;
+* Fixed: form confirmation message is not shown in some edge cases;
+* Fixed: extra space in Post Notifications when using double quotes.
 
 = 3.73.2 - 2021-11-08 =
-
-- Fixed: error on dynamic segments filter query.
+* Fixed: error on dynamic segments filter query.
 
 = 3.73.1 - 2021-11-04 =
-
-- Fixed: segments are not loading.
+* Fixed: segments are not loading.
 
 = 3.73.0 - 2021-11-02 =
-
-- Updated: composer dependencies;
-- Improved: don't allow duplicate sending and sending without an unsubscribe link;
-- Fixed: last engagement date is not calculated for some of the old subscribers.
+* Updated: composer dependencies;
+* Improved: don't allow duplicate sending and sending without an unsubscribe link;
+* Fixed: last engagement date is not calculated for some of the old subscribers.
 
 = 3.72.0 - 2021-10-25 =
-
-- Improved: updated Mixpanel configuration;
-- Improved: refactor CronWorkerRunner and related classes to Doctrine;
-- Improved: removed old StatisticsWooCommercePurchases model and replaced it with code that uses Doctrine;
-- Fixed: mailpoet_register_form_extend filter not working;
-- Fixed: automatic latest content block shows wrong content;
-- Fixed: "Create a new form" link not working in MailPoet widget;
-- Fixed: preselect a first form in form widget.
+* Improved: updated Mixpanel configuration;
+* Improved: refactor CronWorkerRunner and related classes to Doctrine;
+* Improved: removed old StatisticsWooCommercePurchases model and replaced it with code that uses Doctrine;
+* Fixed: mailpoet_register_form_extend filter not working;
+* Fixed: automatic latest content block shows wrong content;
+* Fixed: "Create a new form" link not working in MailPoet widget;
+* Fixed: preselect a first form in form widget.
 
 = 3.71.3 - 2021-10-18 =
-
-- Improved: show email stats with less then 0.1% with two decimal places;
-- Improved: more options when sending is paused because of unauthorized email address;
-- Improved: offer activating premium plugin in settings when already installed;
-- Changed: offer more tools to clean your lists;
-- Fixed: an error when using MySQL in strict mode;
-- Fixed: rare database error when using incompatible collations;
-- Fixed: automatic emails can be set up without providing scheduled time;
-- Fixed: after editing an order the customer is subscribed when they shouldn't be.
+* Improved: show email stats with less then 0.1% with two decimal places;
+* Improved: more options when sending is paused because of unauthorized email address;
+* Improved: offer activating premium plugin in settings when already installed;
+* Changed: offer more tools to clean your lists;
+* Fixed: an error when using MySQL in strict mode;
+* Fixed: rare database error when using incompatible collations;
+* Fixed: automatic emails can be set up without providing scheduled time;
+* Fixed: after editing an order the customer is subscribed when they shouldn't be.
 
 = 3.71.2 - 2021-10-04 =
-
-- Improved: better handle reply-to address with missing reply-to name;
-- Improved: use WordPress functions to get post excerpt and content in post notifications;
-- Changed: inactive subscribers conditions;
-- Fixed: PHP warning about PHPMailer class not found;
-- Fixed: welcome email setup accepts non-numerical values;
-- Fixed: missing space between paragraph and heading in post notifications.
+* Improved: better handle reply-to address with missing reply-to name;
+* Improved: use WordPress functions to get post excerpt and content in post notifications;
+* Changed: inactive subscribers conditions;
+* Fixed: PHP warning about PHPMailer class not found;
+* Fixed: welcome email setup accepts non-numerical values;
+* Fixed: missing space between paragraph and heading in post notifications.
 
 = 3.71.1 - 2021-09-29 =
-
-- Fixed: conflict with Elementor plugin.
+* Fixed: conflict with Elementor plugin.
 
 = 3.71.0 - 2021-09-28 =
-
-- Improved: handling recipient related SMTP errors;
-- Changed: removed "MailPoet Page" from form's "After submit, go to page" options;
-- Changed: don't save a form without assigned list;
-- Fixed: unable to remove description from segments.
+* Improved: handling recipient related SMTP errors;
+* Changed: removed "MailPoet Page" from form's "After submit, go to page" options;
+* Changed: don't save a form without assigned list;
+* Fixed: unable to remove description from segments.
 
 = 3.70.0 - 2021-09-20 =
-
-- Added: filter to alter mailpoet database table prefix;
-- Added: bounced metric on the Email Stats page;
-- Improved: update lucatume/wp-browser;
-- Improved: MailPoet form security against spambots;
-- Improved: coding standards;
-- Improved: refactor to Doctrine;
-- Improved: code comment on warning;
-- Fixed: machine-opened metric on the Email Stats page;
-- Fixed: flaky integration test;
-- Fixed: "Updated at" in the System Status shows time with incorrect time zone;
-- Fixed: horizontal scrollbar in form style settings sidebar.
+* Added: filter to alter mailpoet database table prefix;
+* Added: bounced metric on the Email Stats page;
+* Improved: update lucatume/wp-browser;
+* Improved: MailPoet form security against spambots;
+* Improved: coding standards;
+* Improved: refactor to Doctrine;
+* Improved: code comment on warning;
+* Fixed: machine-opened metric on the Email Stats page;
+* Fixed: flaky integration test;
+* Fixed: "Updated at" in the System Status shows time with incorrect time zone;
+* Fixed: horizontal scrollbar in form style settings sidebar.
 
 = 3.69.1 - 2021-09-13 =
-
-- Added: saving detailed bounce stats;
-- Added: show last engagement date on the Subscriber page;
-- Added: notice when creating opens-related segment;
-- Added: new machine-opened and # of machine-opens segments;
-- Changed: throttle also logged-in users when signing up multiple times;
-- Changed: show CAPTCHA on the first signup, instead on the second;
-- Changed: performance of the queries used to sync WooCommerce data;
-- Changed: display more specific error message for banned users;
-- Fixed: an error when using MySQL in strict mode;
-- Fixed: compatibility with WooCommerce Payments new checkout experience;
-- Fixed: segment counter when using multiple text input fields;
-- Fixed: missing space after signup checkbox on the checkout.
+* Added: saving detailed bounce stats;
+* Added: show last engagement date on the Subscriber page;
+* Added: notice when creating opens-related segment;
+* Added: new machine-opened and # of machine-opens segments;
+* Changed: throttle also logged-in users when signing up multiple times;
+* Changed: show CAPTCHA on the first signup, instead on the second;
+* Changed: performance of the queries used to sync WooCommerce data;
+* Changed: display more specific error message for banned users;
+* Fixed: an error when using MySQL in strict mode;
+* Fixed: compatibility with WooCommerce Payments new checkout experience;
+* Fixed: segment counter when using multiple text input fields;
+* Fixed: missing space after signup checkbox on the checkout.
 
 = 3.69.0 - 2021-09-07 =
-
-- Added: saving subscribers' last engagement date;
-- Added: show machine-opened emails on the subscriber stats page;
-- Improved: performance of subscribers count recalculation;
-- Fixed: heading shortcode not rendered in WooCommerce transactional emails if moved below order content;
-- Fixed: unsubscribing from a preview email when logged out throws fatal error.
+* Added: saving subscribers' last engagement date;
+* Added: show machine-opened emails on the subscriber stats page;
+* Improved: performance of subscribers count recalculation;
+* Fixed: heading shortcode not rendered in WooCommerce transactional emails if moved below order content;
+* Fixed: unsubscribing from a preview email when logged out throws fatal error.
 
 = 3.68.0 - 2021-08-30 =
-
-- Added: show machine-opened percentage on the email stats page;
-- Added: open and click User-agents in Export Personal Data tool;
-- Improved: subscribers in your plan shown on top of the page;
-- Improved: MailPoet will honor the Reply-to address for WordPress emails sent with MailPoet. Thanks, Mark!
-- Improved: Gutenberg updated for form editor;
-- Improved: React updated to v17;
-- Changed: put less emphasis on open metric on the emails listing;
-- Fixed: a conflict if PHPMailer is already loaded by another plugin.
+* Added: show machine-opened percentage on the email stats page;
+* Added: open and click User-agents in Export Personal Data tool;
+* Improved: subscribers in your plan shown on top of the page;
+* Improved: MailPoet will honor the Reply-to address for WordPress emails sent with MailPoet. Thanks, Mark!
+* Improved: Gutenberg updated for form editor;
+* Improved: React updated to v17;
+* Changed: put less emphasis on open metric on the emails listing;
+* Fixed: a conflict if PHPMailer is already loaded by another plugin.
 
 = 3.67.1 - 2021-08-24 =
-
-- Added: differentiating human and machine email opens;
-- Added: saving opens and clicks User-agent;
-- Improved: Unified notice for invalid API key;
-- Fixed: conflict with "Invoices for WooCommerce" plugin when signing up for newsletters on checkout;
-- Fixed: potential error in MailPoet Router;
-- Fixed: cannot edit a subscriber when they are subscribed to a non-existing list.
+* Added: differentiating human and machine email opens;
+* Added: saving opens and clicks User-agent;
+* Improved: Unified notice for invalid API key;
+* Fixed: conflict with "Invoices for WooCommerce" plugin when signing up for newsletters on checkout;
+* Fixed: potential error in MailPoet Router;
+* Fixed: cannot edit a subscriber when they are subscribed to a non-existing list.
 
 = 3.67.0 - 2021-08-17 =
-
-- Improved: better handle potential errors when previewing an email;
-- Improved: "Recalculate" Lists and Segments count button also on Subscribers page;
-- Improved: allow importing subscribers with consent but without IP addresses;
-- Improved: prevent deleting a list if used with a form;
-- Fixed: empty WooCommerce Products block can't be deleted;
-- Fixed: when scheduling email, calendar doesn't respect WordPress "week starts on" setting;
-- Fixed: exporting personal data in WordPress Tools fails with MailPoet error;
-- Fixed: below pages form doesn't show on pages created with WP Job Manager;
-- Fixed: button rendering in Outlook 2016.
+* Improved: better handle potential errors when previewing an email;
+* Improved: "Recalculate" Lists and Segments count button also on Subscribers page;
+* Improved: allow importing subscribers with consent but without IP addresses;
+* Improved: prevent deleting a list if used with a form;
+* Fixed: empty WooCommerce Products block can't be deleted;
+* Fixed: when scheduling email, calendar doesn't respect WordPress "week starts on" setting;
+* Fixed: exporting personal data in WordPress Tools fails with MailPoet error;
+* Fixed: below pages form doesn't show on pages created with WP Job Manager;
+* Fixed: button rendering in Outlook 2016.
 
 = 3.66.0 - 2021-08-09 =
-
-- Improved: tested up to WordPress 5.8;
-- Improved: more consistent behavior when subscribing via different sources;
-- Changed: removed a poll after deactivating MailPoet plugin;
-- Fixed: creating segment from stats page doesn't work;
-- Fixed: WooCommerce customers are moved to trash when WordPress Users list is disabled;
-- Fixed: wrong "recalculated at" time for lists counts in some cases.
+* Improved: tested up to WordPress 5.8;
+* Improved: more consistent behavior when subscribing via different sources;
+* Changed: removed a poll after deactivating MailPoet plugin;
+* Fixed: creating segment from stats page doesn't work;
+* Fixed: WooCommerce customers are moved to trash when WordPress Users list is disabled;
+* Fixed: wrong "recalculated at" time for lists counts in some cases.
 
 = 3.65.1 - 2021-07-20 =
-
-- Fixed: Sign up button in welcome wizard not working.
+* Fixed: Sign up button in welcome wizard not working.
 
 = 3.65.0 - 2021-07-13 =
-
-- Added: Lists and Segments subscribers counts cache to speed up MailPoet pages.
+* Added: Lists and Segments subscribers counts cache to speed up MailPoet pages.
 
 = 3.64.3 - 2021-07-06 =
-
-- Fixed: custom email shortcodes notice cannot be dismissed.
+* Fixed: custom email shortcodes notice cannot be dismissed.
 
 = 3.64.2 - 2021-06-28 =
-
-- Improved: performance of the engagement score calculation;
-- Improved: segment form error handling;
-- Improved: hide help icon in form editor preview;
-- Changed: MailPoet no longer unsubscribes from unchecked lists in signup form;
-- Fixed: rare PHP error when unsubscribing;
-- Fixed: duplicated New Subscriber notification;
-- Fixed: large 3rd-party admin menu icons;
-- Fixed: false-positive registration spam detection.
+* Improved: performance of the engagement score calculation;
+* Improved: segment form error handling;
+* Improved: hide help icon in form editor preview;
+* Changed: MailPoet no longer unsubscribes from unchecked lists in signup form;
+* Fixed: rare PHP error when unsubscribing;
+* Fixed: duplicated New Subscriber notification;
+* Fixed: large 3rd-party admin menu icons;
+* Fixed: false-positive registration spam detection.
 
 = 3.64.1 - 2021-06-22 =
-
-- Added: create complex segments using multiple conditions;
-- Fixed: error when WooCommerce transactional emails template is deleted.
+* Added: create complex segments using multiple conditions;
+* Fixed: error when WooCommerce transactional emails template is deleted.
 
 = 3.64.0 - 2021-06-15 =
-
-- Fixed: rare error when activating MailPoet;
-- Fixed: missing column in DBs running old MySQL;
-- Fixed: WooCommerce emails stay the same when MailPoet customizer is disabled;
-- Fixed: big margins in WooCommerce emails.
+* Fixed: rare error when activating MailPoet;
+* Fixed: missing column in DBs running old MySQL;
+* Fixed: WooCommerce emails stay the same when MailPoet customizer is disabled;
+* Fixed: big margins in WooCommerce emails.
 
 = 3.63.0 - 2021-06-07 =
-
-- Improved: Subscribers page load time for sites with higher number of lists;
-- Improved: unified typography with WordPress admin styles;
-- Improved: unified buttons with WordPress admin styles;
-- Improved: new segment form layout;
-- Changed: removed list migration assistance;
-- Changed: removed PHP migration assistance;
-- Fixed: incorrect form image width in some themes;
-- Fixed: emoji in Subject line not visible in the last step of email creation.
+* Improved: Subscribers page load time for sites with higher number of lists;
+* Improved: unified typography with WordPress admin styles;
+* Improved: unified buttons with WordPress admin styles;
+* Improved: new segment form layout;
+* Changed: removed list migration assistance;
+* Changed: removed PHP migration assistance;
+* Fixed: incorrect form image width in some themes;
+* Fixed: emoji in Subject line not visible in the last step of email creation.
 
 = 3.62.1 - 2021-06-01 =
-
-- Added: logging for failed curl requests;
-- Improved: email editor to gracefully highlight unsupported email blocks;
-- Fixed: missing MailPoet logo in stats emails and MSS setup email;
-- Fixed: Media post type doesn't show results in Automatic Latest Content;
-- Fixed: 1px horizontal line in Outlook 2016.
+* Added: logging for failed curl requests;
+* Improved: email editor to gracefully highlight unsupported email blocks;
+* Fixed: missing MailPoet logo in stats emails and MSS setup email;
+* Fixed: Media post type doesn't show results in Automatic Latest Content;
+* Fixed: 1px horizontal line in Outlook 2016.
 
 = 3.62.0 - 2021-05-25 =
-
-- Added: new segment for MailPoet's custom fields;
-- Improved: segment score calculation performance;
-- Improved: better customization of the opt-in checkbox in the registration form;
-- Fixed: Gutenberg form block to work with latest version of Gutenberg;
-- Fixed: low-probability double sending on high-traffic sites.
-- Fixed: failing to connect to DB when using non-standard port;
-- Fixed: plugin update from timing out on high-traffic sites. Thank you, Edda!
+* Added: new segment for MailPoet's custom fields;
+* Improved: segment score calculation performance;
+* Improved: better customization of the opt-in checkbox in the registration form;
+* Fixed: Gutenberg form block to work with latest version of Gutenberg;
+* Fixed: low-probability double sending on high-traffic sites.
+* Fixed: failing to connect to DB when using non-standard port;
+* Fixed: plugin update from timing out on high-traffic sites. Thank you, Edda!
 
 = 3.61.0 - 2021-05-17 =
-
-- Added: visualize the average "Subscriber score" for an email list to help gauge engagement;
-- Added: new segment for customer's country;
-- Added: welcome emails are now scheduled when subscribing through "Manage subscription" page. Thanks, Ron!
-- Fixed: unable to segment by 0 opened emails;
-- Fixed: broken product attributes in WooCommerce order email.
+* Added: visualize the average "Subscriber score" for an email list to help gauge engagement;
+* Added: new segment for customer's country;
+* Added: welcome emails are now scheduled when subscribing through "Manage subscription" page. Thanks, Ron!
+* Fixed: unable to segment by 0 opened emails;
+* Fixed: broken product attributes in WooCommerce order email.
 
 = 3.60.12 - 2021-05-11 =
-
-- Fixed: a Doctrine error causing some MailPoet functionality to stop working in rare cases;
-- Fixed: transactional emails not counted towards subscribers score;
-- Fixed: broken custom CSS in the form editor when using > in CSS selector;
-- Fixed: custom field created during import does not show up to be selected from the drop-menu list;
-- Fixed: broken debug bar on WordPress.com sites.
+* Fixed: a Doctrine error causing some MailPoet functionality to stop working in rare cases;
+* Fixed: transactional emails not counted towards subscribers score;
+* Fixed: broken custom CSS in the form editor when using > in CSS selector;
+* Fixed: custom field created during import does not show up to be selected from the drop-menu list;
+* Fixed: broken debug bar on WordPress.com sites.
 
 = 3.60.11 - 2021-05-04 =
-
-- Added: new segment for subscribers who clicked on any link in any newsletter;
-- Added: new segment for subscribers' subscribed date;
-- Improved: MailPoet's resilience to network issues when sending emails;
-- Improved: performance of inactive subscribers detection;
-- Improved: allow segmenting by zero opened emails;
-- Improved: Gutenberg updated for form editor;
-- Fixed: subscriber score shows values higher than 100%;
-- Fixed: MailPoet not working when DB used ANSI_QUOTES mode;
-- Fixed: HTML entities in newsletter buttons.
+* Added: new segment for subscribers who clicked on any link in any newsletter;
+* Added: new segment for subscribers' subscribed date;
+* Improved: MailPoet's resilience to network issues when sending emails;
+* Improved: performance of inactive subscribers detection;
+* Improved: allow segmenting by zero opened emails;
+* Improved: Gutenberg updated for form editor;
+* Fixed: subscriber score shows values higher than 100%;
+* Fixed: MailPoet not working when DB used ANSI_QUOTES mode;
+* Fixed: HTML entities in newsletter buttons.
 
 = 3.60.10 - 2021-04-27 =
-
-- Added: a reminder to import the suppression list via "Subscriber Import" when migrating email marketing services;
-- Added: visualize subscriber engagement in the subscriber listing;
-- Added: new segment for subscribers with an active subscription;
-- Added: new segment for total amount spent;
-- Fixed: WP-Admin sidebar overlapping MailPoet's contents on WordPress.com websites.
+* Added: a reminder to import the suppression list via "Subscriber Import" when migrating email marketing services;
+* Added: visualize subscriber engagement in the subscriber listing;
+* Added: new segment for subscribers with an active subscription;
+* Added: new segment for total amount spent;
+* Fixed: WP-Admin sidebar overlapping MailPoet's contents on WordPress.com websites.
 
 = 3.60.9 - 2021-04-20 =
-
-- Added: new segment for a number of orders;
-- Added: new segment for a number of opened emails;
-- Improved: tested up to WordPress 5.7;
-- Fixed: importing subscribers with multiple custom fields;
-- Fixed: slowed down WooCommerce checkout on large stores;
-- Fixed: errors in MailPoet breaking WooCommerce checkout;
-- Fixed: custom date field value not displaying on manage subscription page.
+* Added: new segment for a number of orders;
+* Added: new segment for a number of opened emails;
+* Improved: tested up to WordPress 5.7;
+* Fixed: importing subscribers with multiple custom fields;
+* Fixed: slowed down WooCommerce checkout on large stores;
+* Fixed: errors in MailPoet breaking WooCommerce checkout;
+* Fixed: custom date field value not displaying on manage subscription page.
 
 = 3.60.8 - 2021-04-12 =
-
-- Fixed: editing WooCommerce purchased in category segment;
-- Fixed: handling 3rd-party plugin segments when the plugin is disabled.
+* Fixed: editing WooCommerce purchased in category segment;
+* Fixed: handling 3rd-party plugin segments when the plugin is disabled.
 
 = 3.60.7 - 2021-04-06 =
-
-- Improved: show all segment conditions in one place;
-- Fixed: the collation error in WooCommerce checkout. Thanks Mark!
-- Fixed: email statistics to work on WordPress.com sites. Thanks, Gary!
+* Improved: show all segment conditions in one place;
+* Fixed: the collation error in WooCommerce checkout. Thanks Mark!
+* Fixed: email statistics to work on WordPress.com sites. Thanks, Gary!
 
 = 3.60.6 - 2021-03-29 =
-
-- Improved: don't allow deleting segment with scheduled or active automatic email;
-- Fixed: aligning headings to the center or right in forms;
-- Fixed: first and last name sync in WooCommerce Customers list;
-- Fixed: after saving the segment, redirect to Segments instead of Lists;
-- Fixed: shortcode for total subscribers not working for segments;
-- Fixed: hanging background job for deactivated welcome emails.
+* Improved: don't allow deleting segment with scheduled or active automatic email;
+* Fixed: aligning headings to the center or right in forms;
+* Fixed: first and last name sync in WooCommerce Customers list;
+* Fixed: after saving the segment, redirect to Segments instead of Lists;
+* Fixed: shortcode for total subscribers not working for segments;
+* Fixed: hanging background job for deactivated welcome emails.
 
 = 3.60.5 - 2021-03-22 =
-
-- Added: show number of subscribers when creating or editing a segment;
-- Added: new page with MailPoet logs;
-- Improved: bulk select and delete in segments page;
-- Fixed: loading Media Library in Email Editor on WordPress.com sites;
-- Fixed: pass arguments to shortcodes.
+* Added: show number of subscribers when creating or editing a segment;
+* Added: new page with MailPoet logs;
+* Improved: bulk select and delete in segments page;
+* Fixed: loading Media Library in Email Editor on WordPress.com sites;
+* Fixed: pass arguments to shortcodes.
 
 = 3.60.4 - 2021-03-15 =
-
-- Improved: removed captcha from manage subscription page;
-- Fixed: aligning headings to center or right in emails;
-- Fixed: searching in fields when exporting subscribers;
-- Fixed: saving settings after changing license key restores the old key sometimes;
-- Fixed: schedule emails using UTC instead site's time zone;
-- Fixed: date shortcodes were displaying the current server date in the browser instead of the newsletter sent date.
+* Improved: removed captcha from manage subscription page;
+* Fixed: aligning headings to center or right in emails;
+* Fixed: searching in fields when exporting subscribers;
+* Fixed: saving settings after changing license key restores the old key sometimes;
+* Fixed: schedule emails using UTC instead site's time zone;
+* Fixed: date shortcodes were displaying the current server date in the browser instead of the newsletter sent date.
 
 = 3.60.3 - 2021-03-09 =
-
-- Added: subscription consent when exporting subscribers;
-- Added: subscription consent when importing subscribers;
-- Improved: better wording on automated email activation;
-- Improved: subscriber import to skip disengaged MailChimp subscribers;
-- Fixed: shortcode which displays total subscribed subscribers.
+* Added: subscription consent when exporting subscribers;
+* Added: subscription consent when importing subscribers;
+* Improved: better wording on automated email activation;
+* Improved: subscriber import to skip disengaged MailChimp subscribers;
+* Fixed: shortcode which displays total subscribed subscribers.
 
 = 3.60.2 - 2021-03-01 =
-
-- Fixed: view in browser shortcodes when tracking is disabled;
-- Fixed: searching lists when importing subscribers;
-- Fixed: 3rd party sending credentials always stored.
+* Fixed: view in browser shortcodes when tracking is disabled;
+* Fixed: searching lists when importing subscribers;
+* Fixed: 3rd party sending credentials always stored.
 
 = 3.60.1 - 2021-02-17 =
-
-- Fixed: links in form checkbox labels.
+* Fixed: links in form checkbox labels.
 
 = 3.60.0 - 2021-02-15 =
-
-- Fixed: missing WordPress/WooCommerce Users lists when generating a shortcode in settings;
-- Thank you Foobar7 for your help with testing;
-- Thank you Onizuka (younes_bousfiha) for helping us.
-- Thank you Foobar7 for helping with the testing.
+* Fixed: missing WordPress/WooCommerce Users lists when generating a shortcode in settings;
+* Thank you Foobar7 for your help with testing;
+* Thank you Onizuka (younes_bousfiha) for helping us.
+* Thank you Foobar7 for helping with the testing.
 
 = 3.59.2 - 2021-02-08 =
-
-- Added: allow re-resubscribing through third-party API;
-- Fixed: reCaptcha sometimes not loading;
-- Fixed: Abandoned cart block always displaying options.
+* Added: allow re-resubscribing through third-party API;
+* Fixed: reCaptcha sometimes not loading;
+* Fixed: Abandoned cart block always displaying options.
 
 = 3.59.1 - 2021-02-02 =
-
-- Added: new Amazon SES regions;
-- Fixed: various bugs squashed in form editor;
-- Fixed: form's custom field can be made non mandatory again. Thx Katarzyna!
+* Added: new Amazon SES regions;
+* Fixed: various bugs squashed in form editor;
+* Fixed: form's custom field can be made non mandatory again. Thx Katarzyna!
 
 = 3.59.0 - 2021-01-26 =
-
-- Fixed: missing statistics link in WooCommerce emails listing;
-- Fixed: opening draft email without a template.
+* Fixed: missing statistics link in WooCommerce emails listing;
+* Fixed: opening draft email without a template.
 
 = 3.58.0 - 2021-01-18 =
-
-- Improved: Gutenberg updated for form editor.
+* Improved: Gutenberg updated for form editor.
 
 = 3.57.1 - 2021-01-11 =
-
-- Added: the ability to disable the "WordPress Users" list;
-- Fixed: filtering subscribers without a list;
-- Fixed: incorrect 404 page in some themes.
+* Added: the ability to disable the "WordPress Users" list;
+* Fixed: filtering subscribers without a list;
+* Fixed: incorrect 404 page in some themes.
 
 = 3.57.0 - 2021-01-04 =
-
-- Improved: better customization of subscribe checkbox in checkout;
-- Fixed: issues with saving Lists;
-- Fixed: listing subscribers from dynamic segments;
-- Fixed: list selection block in forms;
-- Fixed: segmenting by specific clicked link;
-- Fixed: custom unsubscribe page being reset after plugin update.
+* Improved: better customization of subscribe checkbox in checkout;
+* Fixed: issues with saving Lists;
+* Fixed: listing subscribers from dynamic segments;
+* Fixed: list selection block in forms;
+* Fixed: segmenting by specific clicked link;
+* Fixed: custom unsubscribe page being reset after plugin update.
 
 = 3.56.2 - 2020-12-22 =
-
-- Fixed: segment description editing.
+* Fixed: segment description editing.
 
 = 3.56.1 - 2020-12-15 =
-
-- Fixed: api key verification issues.
+* Fixed: api key verification issues.
 
 = 3.56.0 - 2020-12-07 =
-
-- Improved: search control when setting up Purchased this Product/Category emails.
+* Improved: search control when setting up Purchased this Product/Category emails.
 
 = 3.55.1 - 2020-11-30 =
-
-- Added: a video tutorial for form editor;
-- Improved: manual download of Premium plugin instead of automatic, as per repository guidelines.
+* Added: a video tutorial for form editor;
+* Improved: manual download of Premium plugin instead of automatic, as per repository guidelines.
 
 = 3.55.0 - 2020-11-23 =
-
-- Added: undo/redo in the form editor;
-- Fixed: some shortcodes in newsletter are not interpreted;
-- Fixed: sent email status sometimes shown as scheduled;
-- Fixed: displaying forms for specific posts/categories;
-- Fixed: blank screen of the newsletter preview.
+* Added: undo/redo in the form editor;
+* Fixed: some shortcodes in newsletter are not interpreted;
+* Fixed: sent email status sometimes shown as scheduled;
+* Fixed: displaying forms for specific posts/categories;
+* Fixed: blank screen of the newsletter preview.
 
 = 3.54.3 - 2020-11-17 =
-
-- Added: button to WooCommerce Email Customizer in WooCommerce Emails settings;
-- Improved: form's success message design;
-- Fixed: showing "Not sent yet" for sent emails in Safari;
-- Fixed: various UI issues;
-- Fixed: subscribers import issue;
-- Fixed: short email templates names.
+* Added: button to WooCommerce Email Customizer in WooCommerce Emails settings;
+* Improved: form's success message design;
+* Fixed: showing "Not sent yet" for sent emails in Safari;
+* Fixed: various UI issues;
+* Fixed: subscribers import issue;
+* Fixed: short email templates names.
 
 = 3.54.2 - 2020-11-10 =
-
-- Improved: fullscreen option added to the form editor;
-- Fixed: Form editor is now again usable on mobile devices.
+* Improved: fullscreen option added to the form editor;
+* Fixed: Form editor is now again usable on mobile devices.
 
 = 3.54.1 - 2020-11-02 =
-
-- Added: option to bulk unsubscribe subscribers;
-- Improved: removed default form, added button to create new form;
-- Improved: new font;
-- Improved: skip form templates, build form from scratch;
-- Improved: you can now disable all 3rd party libraries in settings;
-- Improved: added Abandoned Cart Content block to templates for new users;
-- Improved: redesigned import, export and settings pages.
+* Added: option to bulk unsubscribe subscribers;
+* Improved: removed default form, added button to create new form;
+* Improved: new font;
+* Improved: skip form templates, build form from scratch;
+* Improved: you can now disable all 3rd party libraries in settings;
+* Improved: added Abandoned Cart Content block to templates for new users;
+* Improved: redesigned import, export and settings pages.
 
 = 3.54.0 - 2020-10-27 =
-
-- Added: new form templates;
-- Improved: allow different "Purchased in this Category" emails to be sent to single user;
-- Improved: allow different "Purchased this Product" emails to be sent to a single user;
-- Improved: redesigned listings;
-- Fixed: missing custom color link for some of the form blocks.
+* Added: new form templates;
+* Improved: allow different "Purchased in this Category" emails to be sent to single user;
+* Improved: allow different "Purchased this Product" emails to be sent to a single user;
+* Improved: redesigned listings;
+* Fixed: missing custom color link for some of the form blocks.
 
 = 3.53.0 - 2020-10-20 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.52.0 - 2020-10-12 =
-
-- Added: WooCommerce Abandoned Cart Content;
-- Improved: Gutenberg updated for form editor.
+* Added: WooCommerce Abandoned Cart Content;
+* Improved: Gutenberg updated for form editor.
 
 = 3.51.2 - 2020-10-07 =
-
-- Added: over a dozen beautiful form templates;
-- Improved: PHP 7.1 is now required.
+* Added: over a dozen beautiful form templates;
+* Improved: PHP 7.1 is now required.
 
 = 3.51.1 - 2020-09-29 =
-
-- Added: hooks for changing template cache path and disabling cache on WP Engine;
-- Improved: redesigned congratulation page;
-- Improved: redesigned last step of newsletter creation;
-- Improved: redesigned template selection.
+* Added: hooks for changing template cache path and disabling cache on WP Engine;
+* Improved: redesigned congratulation page;
+* Improved: redesigned last step of newsletter creation;
+* Improved: redesigned template selection.
 
 = 3.51.0 - 2020-09-21 =
-
-- Added: display form on various locations;
-- Added: 8 custom form animations to choose;
-- Fixed: "Normalizer" error on plugin activation/update, once again. Thanks Douglas!
+* Added: display form on various locations;
+* Added: 8 custom form animations to choose;
+* Fixed: "Normalizer" error on plugin activation/update, once again. Thanks Douglas!
 
 = 3.50.1 - 2020-09-14 =
-
-- Added: check for possible image rendering issues;
-- Improved: redesigned email schedule page;
-- Improved: redesigned email type selection;
-- Improved: new design of "Settings > Send with" tab;
-- Fixed: subscriber counts in list filter on subscribers page;
-- Fixed: excessive space at bottom of forms;
-- Fixed: duplicate confirmation emails when registering through WordPress form.
+* Added: check for possible image rendering issues;
+* Improved: redesigned email schedule page;
+* Improved: redesigned email type selection;
+* Improved: new design of "Settings > Send with" tab;
+* Fixed: subscriber counts in list filter on subscribers page;
+* Fixed: excessive space at bottom of forms;
+* Fixed: duplicate confirmation emails when registering through WordPress form.
 
 = 3.50.0 - 2020-09-08 =
-
-- Added: option to display a popup form when a user leaves the page;
-- Improved: email preview button is now located next to Save button;
-- Fixed: filtering on subscribers page;
-- Fixed: Post Notification history showing all post notifications, not just the selected one;
-- Fixed: wrong timezone when importing subscribers.
+* Added: option to display a popup form when a user leaves the page;
+* Improved: email preview button is now located next to Save button;
+* Fixed: filtering on subscribers page;
+* Fixed: Post Notification history showing all post notifications, not just the selected one;
+* Fixed: wrong timezone when importing subscribers.
 
 = 3.49.1 - 2020-08-31 =
-
-- Improved: redesigned email creation flow breadcrumbs;
-- Fixed: rare error caused by MySQL exception.
+* Improved: redesigned email creation flow breadcrumbs;
+* Fixed: rare error caused by MySQL exception.
 
 = 3.49.0 - 2020-08-24 =
-
-- Added: master toggle to display the form;
-- Added: form's master toggle in forms listing;
-- Improved: different heading sizes on mobile form design;
-- Fixed: "Normalizer" error on plugin activation/update. Thanks, Henrik!
-- Fixed: Invalid date shown in Subscriber edit page.
+* Added: master toggle to display the form;
+* Added: form's master toggle in forms listing;
+* Improved: different heading sizes on mobile form design;
+* Fixed: "Normalizer" error on plugin activation/update. Thanks, Henrik!
+* Fixed: Invalid date shown in Subscriber edit page.
 
 = 3.48.1 - 2020-08-10 =
-
-- Added: set subscribers status on import;
-- Improved: remember subscribers listing filters and page after editing a subscriber;
-- Improved: subscriber status is not changed when the same user is added as WordPress user;
-- Improved: redesigned opened/clicked badges on emails listing;
-- Improved: template translations;
-- Fixed: searching in "Sending Status".
+* Added: set subscribers status on import;
+* Improved: remember subscribers listing filters and page after editing a subscriber;
+* Improved: subscriber status is not changed when the same user is added as WordPress user;
+* Improved: redesigned opened/clicked badges on emails listing;
+* Improved: template translations;
+* Fixed: searching in "Sending Status".
 
 = 3.48.0 - 2020-08-04 =
-
-- Added: manage your subscription page is more customizable;
-- Added: additional Type column in forms listing;
-- Improved: modified date column in forms listing;
-- Improved: unsubscribe page is now more customizable.
+* Added: manage your subscription page is more customizable;
+* Added: additional Type column in forms listing;
+* Improved: modified date column in forms listing;
+* Improved: unsubscribe page is now more customizable.
 
 = 3.47.11 - 2020-07-28 =
-
-- Improved: better initial WooCommerce setup.
+* Improved: better initial WooCommerce setup.
 
 = 3.47.10 - 2020-07-21 =
-
-- Added: form width setting;
-- Added: before and after deleting newsletter hooks;
-- Improved: new design for listings header;
-- Improved: API better handles empty lines at the beginning of PHP files.
+* Added: form width setting;
+* Added: before and after deleting newsletter hooks;
+* Improved: new design for listings header;
+* Improved: API better handles empty lines at the beginning of PHP files.
 
 = 3.47.9 - 2020-07-14 =
-
-- Improved: responsiveness of signup forms;
-- Improved: more explanatory option when sending all site's emails through MailPoet;
-- Fixed: missing support details for premium users on some pages.
+* Improved: responsiveness of signup forms;
+* Improved: more explanatory option when sending all site's emails through MailPoet;
+* Fixed: missing support details for premium users on some pages.
 
 = 3.47.8 - 2020-07-07 =
-
-- Added: choice of close button style for forms;
-- Improved: new first-time wizard design;
-- Fixed: filtering newsletters by lists;
-- Fixed: emails of new MailPoet Sending Service users to not be blocked once the subscription is approved;
-- Fixed: custom sign-up confirmation message is not deleted after key verification.
+* Added: choice of close button style for forms;
+* Improved: new first-time wizard design;
+* Fixed: filtering newsletters by lists;
+* Fixed: emails of new MailPoet Sending Service users to not be blocked once the subscription is approved;
+* Fixed: custom sign-up confirmation message is not deleted after key verification.
 
 = 3.47.7 - 2020-06-30 =
-
-- Added: new Amazon SES locations;
-- Added: keep a record when a subscriber is unsubscribed;
-- Improved: new design of Premium page;
-- Fixed: custom links color is correctly shown in email editor;
-- Fixed: conflict with Yoast SEO plugin and MailPoet forms.
+* Added: new Amazon SES locations;
+* Added: keep a record when a subscriber is unsubscribed;
+* Improved: new design of Premium page;
+* Fixed: custom links color is correctly shown in email editor;
+* Fixed: conflict with Yoast SEO plugin and MailPoet forms.
 
 = 3.47.6 - 2020-06-23 =
-
-- Improved: the unsubscription process to avoid security robots accidentally unsubscribing subscribers. Thanks, Mark!
-- Improved: we're now using the latest Gutenberg version;
-- Improved: default animations for forms;
-- Improved: added explanation when sending email to multiple lists;
-- Improved: new design for tabs;
-- Improved: trashing and deleting newsletter performance with large lists;
-- Fixed: shortcodes render default values in previews again;
-- Fixed: occasional conflict with other plugins when sending emails due to Content Type;
-- Fixed: conflict with WishList Members plugin when sending all emails with MailPoet. Thanks, Beit!
-- Fixed: sending HTML email from Contact Form 7 plugin.
+* Improved: the unsubscription process to avoid security robots accidentally unsubscribing subscribers. Thanks, Mark!
+* Improved: we're now using the latest Gutenberg version;
+* Improved: default animations for forms;
+* Improved: added explanation when sending email to multiple lists;
+* Improved: new design for tabs;
+* Improved: trashing and deleting newsletter performance with large lists;
+* Fixed: shortcodes render default values in previews again;
+* Fixed: occasional conflict with other plugins when sending emails due to Content Type;
+* Fixed: conflict with WishList Members plugin when sending all emails with MailPoet. Thanks, Beit!
+* Fixed: sending HTML email from Contact Form 7 plugin.
 
 = 3.47.5 - 2020-06-16 =
-
-- Added: text styles in forms;
-- Added: padding & custom fonts for form's buttons;
-- Improved: miscellaneous changes to forms;
-- Improved: faster emails listing loading with lots of emails;
-- Improved: show hint, that Automated Latest Content posts are only a preview posts;
-- Improved: more meaningful error message when verifying key;
-- Improved: new design for datepickers;
-- Improved: don't allow very long email preview text, which would otherwise be trimmed;
-- Fixed: padding of paragraph block in forms;
-- Fixed: showing multiple MailPoet forms in some themes (e.g. Shapely).
+* Added: text styles in forms;
+* Added: padding & custom fonts for form's buttons;
+* Improved: miscellaneous changes to forms;
+* Improved: faster emails listing loading with lots of emails;
+* Improved: show hint, that Automated Latest Content posts are only a preview posts;
+* Improved: more meaningful error message when verifying key;
+* Improved: new design for datepickers;
+* Improved: don't allow very long email preview text, which would otherwise be trimmed;
+* Fixed: padding of paragraph block in forms;
+* Fixed: showing multiple MailPoet forms in some themes (e.g. Shapely).
 
 = 3.47.4 - 2020-06-09 =
-
-- Added: choose a font for your form;
-- Added: clean your list on import using Clearout service;
-- Improved: sped up installation of MailPoet plugin;
-- Improved: unified design of mobile's fixed-bar, slide-in & popup forms;
-- Improved: new design for modal windows;
-- Improved: show understandable subscribers counts towards MailPoet limits;
-- Improved: more understandable error message when data in database ale malformed;
-- Improved: clarified sending checkbox value in API docs;
-- Fixed: showing wrong default option in "Send all site's emails with..." option;
-- Fixed: all Post Notifications will send an email if set up for the same category.
+* Added: choose a font for your form;
+* Added: clean your list on import using Clearout service;
+* Improved: sped up installation of MailPoet plugin;
+* Improved: unified design of mobile's fixed-bar, slide-in & popup forms;
+* Improved: new design for modal windows;
+* Improved: show understandable subscribers counts towards MailPoet limits;
+* Improved: more understandable error message when data in database ale malformed;
+* Improved: clarified sending checkbox value in API docs;
+* Fixed: showing wrong default option in "Send all site's emails with..." option;
+* Fixed: all Post Notifications will send an email if set up for the same category.
 
 = 3.47.3 - 2020-06-03 =
-
-- Fixed: a bug which caused old posts to be sent.
+* Fixed: a bug which caused old posts to be sent.
 
 = 3.47.2 - 2020-06-02 =
-
-- Added: colors for form confirmation and error;
-- Improved: lowercase all MailPoet related email addresses;
-- Improved: render space between paragraphs when using showing post excerpt;
-- Improved: form width, height and mobile responsiveness;
-- Improved: default padding on form elements updated;
-- Improved: signup to any list on WooCommerce checkout;
-- Improved: border controls for forms;
-- Fixed: typo in woocommerce placeholders. Thanks Sarah!
+* Added: colors for form confirmation and error;
+* Improved: lowercase all MailPoet related email addresses;
+* Improved: render space between paragraphs when using showing post excerpt;
+* Improved: form width, height and mobile responsiveness;
+* Improved: default padding on form elements updated;
+* Improved: signup to any list on WooCommerce checkout;
+* Improved: border controls for forms;
+* Fixed: typo in woocommerce placeholders. Thanks Sarah!
 
 = 3.47.1 - 2020-05-25 =
-
-- Added: background image to form editor;
-- Added: input background color;
-- Fixed: saving should work if the newsletter editor is left open for a long time.
+* Added: background image to form editor;
+* Added: input background color;
+* Fixed: saving should work if the newsletter editor is left open for a long time.
 
 = 3.47.0 - 2020-05-19 =
-
-- Fixed: showing two columns in popup form side by side;
-- Fixed: custom form input padding.
+* Fixed: showing two columns in popup form side by side;
+* Fixed: custom form input padding.
 
 = 3.46.14 - 2020-05-12 =
-
-- Added: show confirmation page when unsubscribing;
-- Improved: divider block in form editor can now be used as a spacer;
-- Improved: MailPoet plugin interface is back to using standard WordPress font;
-- Fixed: conflict with Oxygen Gutenberg integration;
-- Fixed: custom dimensions for the image block in forms;
-- Fixed: saving data for date custom block when subscribed;
-- Fixed: spacing in Form editor sidebar with scrollbar visible.
+* Added: show confirmation page when unsubscribing;
+* Improved: divider block in form editor can now be used as a spacer;
+* Improved: MailPoet plugin interface is back to using standard WordPress font;
+* Fixed: conflict with Oxygen Gutenberg integration;
+* Fixed: custom dimensions for the image block in forms;
+* Fixed: saving data for date custom block when subscribed;
+* Fixed: spacing in Form editor sidebar with scrollbar visible.
 
 = 3.46.13 - 2020-05-04 =
-
-- Added: total number of subscribers counted towards MailPoet plan;
-- Added: form border, alignment, & padding;
-- Improved: help button moved to bottom left corner so it doesn't interfere with sidebar;
-- Improved: allow inserting HTML code to checkbox label in Form editor;
-- Improved: we are now using different font in MailPoet plugin interface;
-- Fixed: sending a test email works for any email address again;
-- Fixed: in Form editor, changing button's font color won't change border color;
-- Fixed: sending new subscriber notification twice in some cases.
+* Added: total number of subscribers counted towards MailPoet plan;
+* Added: form border, alignment, & padding;
+* Improved: help button moved to bottom left corner so it doesn't interfere with sidebar;
+* Improved: allow inserting HTML code to checkbox label in Form editor;
+* Improved: we are now using different font in MailPoet plugin interface;
+* Fixed: sending a test email works for any email address again;
+* Fixed: in Form editor, changing button's font color won't change border color;
+* Fixed: sending new subscriber notification twice in some cases.
 
 = 3.46.12 - 2020-04-27 =
-
-- Added: congrats email received when you successfully applied an API key;
-- Added: slide-in form type is now available;
-- Improved: form previews now use your site's theme;
-- Improved: segments are moved to lists page;
-- Fixed: form custom fields now render correctly in multiple columns. Thanks Ryan!
+* Added: congrats email received when you successfully applied an API key;
+* Added: slide-in form type is now available;
+* Improved: form previews now use your site's theme;
+* Improved: segments are moved to lists page;
+* Fixed: form custom fields now render correctly in multiple columns. Thanks Ryan!
 
 = 3.46.11 - 2020-04-21 =
-
-- Added: fixed bar form type is now available;
-- Fixed: no more false alarms reported by some anti-viruses;
-- Fixed: the "Send a test email" button is now working again;
-- Fixed: iframes in 3rd party plugins (including Divi, Elementor, and others) are no longer broken.
+* Added: fixed bar form type is now available;
+* Fixed: no more false alarms reported by some anti-viruses;
+* Fixed: the "Send a test email" button is now working again;
+* Fixed: iframes in 3rd party plugins (including Divi, Elementor, and others) are no longer broken.
 
 = 3.46.10 - 2020-04-15 =
-
-- Fixed: sending multiple stats emails.
+* Fixed: sending multiple stats emails.
 
 = 3.46.9 - 2020-04-14 =
-
-- Added: new image block in Form Editor;
-- Fixed: newsletter listings is a bit faster now;
-- Fixed: default list is no longer required when List selection added to form;
-- Fixed: last_name block is no longer required by default in Form Editor;
-- Fixed: renamed List is also renamed in Form Editor;
-- Fixed: missing name for custom checkbox in Form Editor.
+* Added: new image block in Form Editor;
+* Fixed: newsletter listings is a bit faster now;
+* Fixed: default list is no longer required when List selection added to form;
+* Fixed: last_name block is no longer required by default in Form Editor;
+* Fixed: renamed List is also renamed in Form Editor;
+* Fixed: missing name for custom checkbox in Form Editor.
 
 = 3.46.8 - 2020-04-07 =
-
-- Improved: email authorization proposed on key activation plugin;
-- Improved: double opt-in is used for the "Subscribe on Checkout" WooCommerce feature;
-- Fixed: list selection autocomplete in subscriber import. Thanks, Matthias!
-- New: pop up form type is now available;
-- All tasks are now unpaused after welcome email reactivation. Thanks Natee!
+* Improved: email authorization proposed on key activation plugin;
+* Improved: double opt-in is used for the "Subscribe on Checkout" WooCommerce feature;
+* Fixed: list selection autocomplete in subscriber import. Thanks, Matthias!
+* New: pop up form type is now available;
+* All tasks are now unpaused after welcome email reactivation. Thanks Natee!
 
 = 3.46.7 - 2020-03-31 =
-
-- Added: new button styles in the form editor;
-- Fixed: badges in newsletter listings are now displayed correctly;
-- Fixed: customised WooCommerce template may cause error;
-- Fixed: UI issue with mobile preview in form editor;
-- Fixed: archive links work for all logged-in users now.
+* Added: new button styles in the form editor;
+* Fixed: badges in newsletter listings are now displayed correctly;
+* Fixed: customised WooCommerce template may cause error;
+* Fixed: UI issue with mobile preview in form editor;
+* Fixed: archive links work for all logged-in users now.
 
 = 3.46.6 - 2020-03-24 =
-
-- Added: support for custom css classes in the form editor;
-- Added: paragraph block in the form editor;
-- Added: input styles settings in the form editor;
-- Improved: form placement section in the form editor has a new look;
-- Fixed: WooCommerce dynamic segments settings are saved correctly.
+* Added: support for custom css classes in the form editor;
+* Added: paragraph block in the form editor;
+* Added: input styles settings in the form editor;
+* Improved: form placement section in the form editor has a new look;
+* Fixed: WooCommerce dynamic segments settings are saved correctly.
 
 = 3.46.5 - 2020-03-23 =
-
-- Fixed: Emptying trash won't delete all newsletters anymore. Sorry about that
+* Fixed: Emptying trash won't delete all newsletters anymore. Sorry about that
 
 = 3.46.4 - 2020-03-19 =
-
-- Added: Columns block in the form editor;
-- Added: Heading block in the form editor.
+* Added: Columns block in the form editor;
+* Added: Heading block in the form editor.
 
 = 3.46.3 - 2020-03-16 =
-
-- Fixed: "Manage subscription" page to not unsubscribe subscribers from hidden lists;
-- Fix custom fields without labels on Manage your Subscription page;
-- New AmazonSES regions added, thanks Martijn (@martijnalexion).
+* Fixed: "Manage subscription" page to not unsubscribe subscribers from hidden lists;
+* Fix custom fields without labels on Manage your Subscription page;
+* New AmazonSES regions added, thanks Martijn (@martijnalexion).
 
 = 3.46.2 - 2020-03-03 =
-
-- Editor: delete block confirmation links are white again.
+* Editor: delete block confirmation links are white again.
 
 = 3.46.1 - 2020-02-25 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.46.0 - 2020-02-17 =
-
-- Added: MailPoet now has a Gutenberg block for subscription forms;
-- Improved: preview links now works publicly;
-- Fixed: MailPoet forms that automatically display under a page or post now always work;
-- Fixed: fatal error when post content is null and auto form placement is set;
-- Fixed: built-in captcha case is fixed. Thanks Richard!
-- Fixed: import works without mbstring extension again. Thanks Michele!
+* Added: MailPoet now has a Gutenberg block for subscription forms;
+* Improved: preview links now works publicly;
+* Fixed: MailPoet forms that automatically display under a page or post now always work;
+* Fixed: fatal error when post content is null and auto form placement is set;
+* Fixed: built-in captcha case is fixed. Thanks Richard!
+* Fixed: import works without mbstring extension again. Thanks Michele!
 
 = 3.45.1 - 2020-02-11 =
-
-- Added: new option to automatically include signup forms below every post and page;
-- Fixed: css editor in form editor now works.
+* Added: new option to automatically include signup forms below every post and page;
+* Fixed: css editor in form editor now works.
 
 = 3.45.0 - 2020-02-04 =
-
-- Improved: PHP 7 is now required. Our team jubilates;
-- Fixed: PHP warning from unauthorized email notice;
-- Removed: old form editor has been removed with a new Gutenberg based replacement.
+* Improved: PHP 7 is now required. Our team jubilates;
+* Fixed: PHP warning from unauthorized email notice;
+* Removed: old form editor has been removed with a new Gutenberg based replacement.
 
 = 3.44.0 - 2020-01-27 =
-
-- Added: all new form editor using Gutenberg;
-- Improved: send subscription confirmation emails to manually added WordPress users;
-- Fixed: importing subscribers broken when importing email address with uppercase and lowercase letters;
-- Fixed: error on MySQL 8.019 or above;
-- Fixed: don't count WP users towards paid plan subscriber limit.
+* Added: all new form editor using Gutenberg;
+* Improved: send subscription confirmation emails to manually added WordPress users;
+* Fixed: importing subscribers broken when importing email address with uppercase and lowercase letters;
+* Fixed: error on MySQL 8.019 or above;
+* Fixed: don't count WP users towards paid plan subscriber limit.
 
 = 3.43.1 - 2020-01-22 =
-
-- Fixed: broken form widget styling.
+* Fixed: broken form widget styling.
 
 = 3.43.0 - 2020-01-21 =
-
-- Improved: clearer messaging and better workflow for activating MailPoet Sending Service and MailPoet Premium;
-- Fixed: syntax error when adding the MailPoet 3 form widget;
-- Fixed: cancelled and incomplete WooCommerce orders from customers no longer show in the segments list;
-- Fixed: hidden lists on the manage subscription page are no longer modified when a user updates their subscription status.
+* Improved: clearer messaging and better workflow for activating MailPoet Sending Service and MailPoet Premium;
+* Fixed: syntax error when adding the MailPoet 3 form widget;
+* Fixed: cancelled and incomplete WooCommerce orders from customers no longer show in the segments list;
+* Fixed: hidden lists on the manage subscription page are no longer modified when a user updates their subscription status.
 
 = 3.42.3 - 2020-01-14 =
-
-- Fixed: subscribers moved to the trash no longer count against the subscribers limit.
+* Fixed: subscribers moved to the trash no longer count against the subscribers limit.
 
 = 3.42.2 - 2020-01-07 =
-
-- Fixed: incorrect subscriber limit being applied to old plans.
+* Fixed: incorrect subscriber limit being applied to old plans.
 
 = 3.42.1 - 2020-01-07 =
-
-- Fixed: inactive subscriber detection.
+* Fixed: inactive subscriber detection.
 
 = 3.42.0 - 2019-12-24 =
-
-- Added: new email customizer to design the transactional emails sent by WooCommerce.
+* Added: new email customizer to design the transactional emails sent by WooCommerce.
 
 = 3.41.2 - 2019-12-17 =
-
-- Improved: Styling for premium page;
-- Fix: Google font not being included correctly;
-- Fix: PHP 7.4 notices.
+* Improved: Styling for premium page;
+* Fix: Google font not being included correctly;
+* Fix: PHP 7.4 notices.
 
 = 3.41.1 - 2019-12-10 =
-
-- Added: MailPoet can now deliver all of your site's emails if enabled in settings.
-- Fixed: incorrect DE Formal translation file name.
+* Added: MailPoet can now deliver all of your site's emails if enabled in settings.
+* Fixed: incorrect DE Formal translation file name.
 
 = 3.41.0 - 2019-12-03 =
-
-- Added: MailPoet is now PHP 7.4 compatible;
-- Fix: shortcodes not working Google Analytics tracking.
+* Added: MailPoet is now PHP 7.4 compatible;
+* Fix: shortcodes not working Google Analytics tracking.
 
 = 3.40.1 - 2019-11-25 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.40.0 - 2019-11-18 =
-
-- Improved: newsletter editor performance;
-- Fix: broken translation string.
+* Improved: newsletter editor performance;
+* Fix: broken translation string.
 
 = 3.39.2 - 2019-11-11 =
-
-- Fixed: missing text domain for translations;
-- Fixed: bulk trashing of subscribers with user ID of 0.
+* Fixed: missing text domain for translations;
+* Fixed: bulk trashing of subscribers with user ID of 0.
 
 = 3.39.1 - 2019-11-05 =
-
-- Added: new premium page in the MailPoet admin;
-- Fixed: Linux cron now only runs when set as the task scheduler method;
-- Fixed: WooCommerce segments are now skipped when WooCommerce is not active.
+* Added: new premium page in the MailPoet admin;
+* Fixed: Linux cron now only runs when set as the task scheduler method;
+* Fixed: WooCommerce segments are now skipped when WooCommerce is not active.
 
 = 3.39.0 - 2019-10-29 =
-
-- Added: Google Analytics tracking is now in free;
-- Fixed: WooCommerce email options not saving;
-- Fixed: the number of posts in a shortcode for emails based on "Clear News" template. Thanks, Gesine!
+* Added: Google Analytics tracking is now in free;
+* Fixed: WooCommerce email options not saving;
+* Fixed: the number of posts in a shortcode for emails based on "Clear News" template. Thanks, Gesine!
 
 = 3.38.1 - 2019-10-22 =
-
-- Improved: optimized query for the inactive subscriber task;
-- Fixed: WooCommerce templates shown under the saved templates section when WooCommerce was not installed/enabled;
-- Fixed: Unsubscribe cron task now skips invalid subscribers.
+* Improved: optimized query for the inactive subscriber task;
+* Fixed: WooCommerce templates shown under the saved templates section when WooCommerce was not installed/enabled;
+* Fixed: Unsubscribe cron task now skips invalid subscribers.
 
 = 3.38.0 - 2019-10-15 =
-
-- Added: WooCommerce functionality is now in free;
-- Added: segmentation is now in free;
-- Fixed: import with custom date fields works again. Thanks Juanjo!
-- Fixed: WooCommerce revenues are now calculated correctly.
+* Added: WooCommerce functionality is now in free;
+* Added: segmentation is now in free;
+* Fixed: import with custom date fields works again. Thanks Juanjo!
+* Fixed: WooCommerce revenues are now calculated correctly.
 
 = 3.37.3 - 2019-10-09 =
-
-- Fixed: fatal error when sending with special characters in the subject line.
+* Fixed: fatal error when sending with special characters in the subject line.
 
 = 3.37.2 - 2019-10-08 =
-
-- Improved: TinyMCE toolbar user experience;
-- Improved: faster loading of the template page when creating a new email;
-- Fixed: assets not loading on the MailPoet captcha page;
-- Fixed: missing translations;
-- Fixed: linux cron now works again;
-- Fixed: blank MailPoet pages on some hosting setups.
+* Improved: TinyMCE toolbar user experience;
+* Improved: faster loading of the template page when creating a new email;
+* Fixed: assets not loading on the MailPoet captcha page;
+* Fixed: missing translations;
+* Fixed: linux cron now works again;
+* Fixed: blank MailPoet pages on some hosting setups.
 
 = 3.37.1 - 2019-10-01 =
-
-- Added: cron execution parameters can now be customized using WordPress filters. Thanks, @deltafactory!
-- Improved: prevent cron workers from running in parallel;
-- Improved: clearer wording for statistics;
-- Fixed: don't allow emails with invalid body to be saved/sent;
-- Fixed: MailPoet router now works on all Nginx configurations;
-- Fixed: broken logo on simple text template.
+* Added: cron execution parameters can now be customized using WordPress filters. Thanks, @deltafactory!
+* Improved: prevent cron workers from running in parallel;
+* Improved: clearer wording for statistics;
+* Fixed: don't allow emails with invalid body to be saved/sent;
+* Fixed: MailPoet router now works on all Nginx configurations;
+* Fixed: broken logo on simple text template.
 
 = 3.37.0 - 2019-09-24 =
-
-- Improved: automatic emails now respect the subscription status of a subscriber;
-- Improved: templates display is now easier to navigate;
-- Fixed: inactive subscribers sync works faster on huge databases. Big thanks to TDN sysadmin!
-- Fixed: Fatal error feature_flags table does not exist;
-- Fixed: intro now works correctly for users with restricted admin capabilities;
-- Fixed: lists can no longer be deleted if they have an assigned automatic email;
-- Fixed: WooCommerce customers are no longer unsubscribed from the WooCommerce customers list when updating their subscription.
+* Improved: automatic emails now respect the subscription status of a subscriber;
+* Improved: templates display is now easier to navigate;
+* Fixed: inactive subscribers sync works faster on huge databases. Big thanks to TDN sysadmin!
+* Fixed: Fatal error feature_flags table does not exist;
+* Fixed: intro now works correctly for users with restricted admin capabilities;
+* Fixed: lists can no longer be deleted if they have an assigned automatic email;
+* Fixed: WooCommerce customers are no longer unsubscribed from the WooCommerce customers list when updating their subscription.
 
 = 3.36.0 - 2019-09-17 =
-
-- Added: SPF check when sending a preview email;
-- Improved: display relevant articles in beacon;
-- Improved: simplified settings for confirmation emails;
-- Fixed: spell check now works in the newsletter editor;
-- Fixed: newsletter editor not loading when parent_id was set to 0.
+* Added: SPF check when sending a preview email;
+* Improved: display relevant articles in beacon;
+* Improved: simplified settings for confirmation emails;
+* Fixed: spell check now works in the newsletter editor;
+* Fixed: newsletter editor not loading when parent_id was set to 0.
 
 = 3.35.4 - 2019-09-10 =
-
-- Improved: resend confirmation emails is now on a subscriber by subscriber basis;
-- Fixed: CSV export no longers require the ZIP extension;
-- Fixed: WooCommerce list counted in List Listings bulk action UI when list is hidden;
-- Fixed: captcha success not being displayed;
-- Fixed: global subscription status for WooCommerce users.
+* Improved: resend confirmation emails is now on a subscriber by subscriber basis;
+* Fixed: CSV export no longers require the ZIP extension;
+* Fixed: WooCommerce list counted in List Listings bulk action UI when list is hidden;
+* Fixed: captcha success not being displayed;
+* Fixed: global subscription status for WooCommerce users.
 
 = 3.35.3 - 2019-09-04 =
-
-- Improved: sent Post Notification UI now allows deleting sent Post Notifications;
-- Improved: translation logic;
-- Improved: subscribers, lists, forms, and subscriber engagement listings doesn't refresh automatically anymore;
-- Improved: read our Knowledge Base articles in the support Beacon, no more new tabs;
-- Improved: processing inactive subscribers;
-- Improved: updated to latest TinyMCE;
-- Fixed: removed WooCommerce checkbox modal for sites where all orders are created with a subscription checkbox on checkout;
-- Fixed: indented lists now display as intended in the designer.
+* Improved: sent Post Notification UI now allows deleting sent Post Notifications;
+* Improved: translation logic;
+* Improved: subscribers, lists, forms, and subscriber engagement listings doesn't refresh automatically anymore;
+* Improved: read our Knowledge Base articles in the support Beacon, no more new tabs;
+* Improved: processing inactive subscribers;
+* Improved: updated to latest TinyMCE;
+* Fixed: removed WooCommerce checkbox modal for sites where all orders are created with a subscription checkbox on checkout;
+* Fixed: indented lists now display as intended in the designer.
 
 = 3.35.2 - 2019-08-27 =
-
-- Added: referral tracking capabilities;
-- Improved: listing page loading speed, now wicked fast;
-- Improved: preview in browser link text in newsletter templates;
-- Improved: timing of when new customer polls are shown for the first time;
-- Improved: easier mouse drag to resize right aligned images;
-- Improved: unsyncing WooCommerce customers without an additional list sets global status to unsubscribed;
-- Improved: removed link to non-existent privacy policy in default forms on new installs;
-- Improved: content of default confirmation email;
-- Improved: updated privacy policy in API for 3rd party developers;
-- Improved: replaced images that looked blurry on high-res displays;
-- Fixed: issue with color-picker for global and content background colors;
-- Fixed: false positive on system status page for cron;
-- Fixed: post excerpts now exclude image captions. Thx Dieter;
-- Fixed: preview in browser button on statistics page for non-Premium users.
+* Added: referral tracking capabilities;
+* Improved: listing page loading speed, now wicked fast;
+* Improved: preview in browser link text in newsletter templates;
+* Improved: timing of when new customer polls are shown for the first time;
+* Improved: easier mouse drag to resize right aligned images;
+* Improved: unsyncing WooCommerce customers without an additional list sets global status to unsubscribed;
+* Improved: removed link to non-existent privacy policy in default forms on new installs;
+* Improved: content of default confirmation email;
+* Improved: updated privacy policy in API for 3rd party developers;
+* Improved: replaced images that looked blurry on high-res displays;
+* Fixed: issue with color-picker for global and content background colors;
+* Fixed: false positive on system status page for cron;
+* Fixed: post excerpts now exclude image captions. Thx Dieter;
+* Fixed: preview in browser button on statistics page for non-Premium users.
 
 = 3.35.1 - 2019-08-20 =
-
-- Improved: remove WooCommerce customers list on non-WooCommerce websites.
+* Improved: remove WooCommerce customers list on non-WooCommerce websites.
 
 = 3.35.0 - 2019-08-13 =
-
-- Improved: background task execution process now uses less CPU to help with CPU-limited hosts. E.g Siteground;
-- Improved: WooCommerce functionality is out of beta.
-- Fixed: incorrect Linux cron path.
-- Fixed: stats emails for post notifications now work;
-- Fixed: re-sending confirmation emails no longer increases the count_confirmations row in the database if the sending address isn't authorized.
-- Fixed: WordPress and WooCommerce users status can now be manually changed if they're unconfirmed.
-- Fixed: php session usage no longer throws a false positive in Health Check that cURL requests timeout.
-- Fixed: WooCommerce customer synchronization task to avoid getting stuck on some sites and use excessive CPU;
-- Fixed: issue where import loader would get stuck while importing a .csv and copying and pasting emails.
+* Improved: background task execution process now uses less CPU to help with CPU-limited hosts. E.g Siteground;
+* Improved: WooCommerce functionality is out of beta.
+* Fixed: incorrect Linux cron path.
+* Fixed: stats emails for post notifications now work;
+* Fixed: re-sending confirmation emails no longer increases the count_confirmations row in the database if the sending address isn't authorized.
+* Fixed: WordPress and WooCommerce users status can now be manually changed if they're unconfirmed.
+* Fixed: php session usage no longer throws a false positive in Health Check that cURL requests timeout.
+* Fixed: WooCommerce customer synchronization task to avoid getting stuck on some sites and use excessive CPU;
+* Fixed: issue where import loader would get stuck while importing a .csv and copying and pasting emails.
 
 = 3.34.4 - 2019-08-01 =
-
-- Fixed: database connection error with MariaDB and MySQL 8 users.
+* Fixed: database connection error with MariaDB and MySQL 8 users.
 
 = 3.34.3 - 2019-07-31 =
-
-- Fixed: some users were experiencing a database issue after latest update.
+* Fixed: some users were experiencing a database issue after latest update.
 
 = 3.34.2 - 2019-07-30 =
-
-- Fixed: issue breaking Email listing page with fatal error.
+* Fixed: issue breaking Email listing page with fatal error.
 
 = 3.34.1 - 2019-07-30 =
-
-- Fixed: issue breaking Email listing page with fatal error.
+* Fixed: issue breaking Email listing page with fatal error.
 
 = 3.34.0 - 2019-07-30 =
-
-- Added: track all WooCommerce revenues generated by your newsletters;
-- Added: zero-configuration captcha to protect MailPoet forms against repeated subscriptions by bots;
-- Added: stats email notifications for all automatic emails;
-- Improved: education of list hygiene on import;
-- Improved: inactive subscriber filtering based on last day subscribed;
-- Fixed: API issue creating subscribers;
-- Fixed: empty [newsletter:post_title] shortcode output when using category exclusion plugins or functions.
+* Added: track all WooCommerce revenues generated by your newsletters;
+* Added: zero-configuration captcha to protect MailPoet forms against repeated subscriptions by bots;
+* Added: stats email notifications for all automatic emails;
+* Improved: education of list hygiene on import;
+* Improved: inactive subscriber filtering based on last day subscribed;
+* Fixed: API issue creating subscribers;
+* Fixed: empty [newsletter:post_title] shortcode output when using category exclusion plugins or functions.
 
 = 3.33.0 - 2019-07-23 =
-
-- Improved: shortcode date formatting;
-- Fixed: users who don't use our sending service or double opt-in can now have WP users added as Confirmed;
-- Fixed: error when importing subscribers from a MailChimp list;
-- Fixed: some users were seeing errors when syncing WooCommerce users due to a mixed-collations database error, it's fixed.
+* Improved: shortcode date formatting;
+* Fixed: users who don't use our sending service or double opt-in can now have WP users added as Confirmed;
+* Fixed: error when importing subscribers from a MailChimp list;
+* Fixed: some users were seeing errors when syncing WooCommerce users due to a mixed-collations database error, it's fixed.
 
 = 3.32.2 - 2019-07-16 =
-
-- Added: notice about inactive subscribers when many users will be marked inactive;
-- Improved: filtering out WP spam users from WordPress Users lists.
+* Added: notice about inactive subscribers when many users will be marked inactive;
+* Improved: filtering out WP spam users from WordPress Users lists.
 
 = 3.32.1 - 2019-07-11 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.32.0 - 2019-07-09 =
-
-- Improved: messages for undo/redo actions.
+* Improved: messages for undo/redo actions.
 
 = 3.31.1 - 2019-07-03 =
-
-- Improved: minor changes and fixes.
+* Improved: minor changes and fixes.
 
 = 3.31.0 - 2019-07-02 =
-
-- Improved: better error reporting and admin messages;
-- Improved: known spam registrations to be automatically removed from your "WordPress Users" list;
-- Improved: rendering shortcodes in Stats emails;
-- Fixed: WordPress users to require confirmed opt-in to join your subscribers list.
+* Improved: better error reporting and admin messages;
+* Improved: known spam registrations to be automatically removed from your "WordPress Users" list;
+* Improved: rendering shortcodes in Stats emails;
+* Fixed: WordPress users to require confirmed opt-in to join your subscribers list.
 
 = 3.30.0 - 2019-06-25 =
-
-- Added: emails can be sent without stopping for certain error types;
-- Added: by popular demand, undo/redo! Use our UI or keyboard shortcuts.
-- Improved: disallow import of role addresses, e.g. postmaster@, to improve deliverability;
-- Improved: notification for users with many inactive subscriber, alerting them that users are being changed to inactive;
-- improved: stats page readability;
-- Improved: bounce sync timing for MSS users;
-- Fixed: misbehaving MailPoet icon in WP Admin now stops hiding itself and other icons;
-- Fixed: some admins were receiving new subscriber notifications twice;
-- Fixed: empty posts widget can now be deleted;
-- Fixed: email rendering was broken for some users when using particular link types;
-- Fixed: display error in sign-up form.
+* Added: emails can be sent without stopping for certain error types;
+* Added: by popular demand, undo/redo! Use our UI or keyboard shortcuts.
+* Improved: disallow import of role addresses, e.g. postmaster@, to improve deliverability;
+* Improved: notification for users with many inactive subscriber, alerting them that users are being changed to inactive;
+* improved: stats page readability;
+* Improved: bounce sync timing for MSS users;
+* Fixed: misbehaving MailPoet icon in WP Admin now stops hiding itself and other icons;
+* Fixed: some admins were receiving new subscriber notifications twice;
+* Fixed: empty posts widget can now be deleted;
+* Fixed: email rendering was broken for some users when using particular link types;
+* Fixed: display error in sign-up form.
 
 = 3.29.0 - 2019-06-18 =
-
-- Fixed: improved timing of subscribing via the WP registration form to reject subscribers rejected by WP registration protection. Special thanks to customer David for helping troubleshoot this issue.
+* Fixed: improved timing of subscribing via the WP registration form to reject subscribers rejected by WP registration protection. Special thanks to customer David for helping troubleshoot this issue.
 
 = 3.28.0 - 2019-06-04 =
-
-- Added: enforcement for authorized sending address for automatic and scheduled emails for new users after March 5;
-- Improvement: authorized sending email enforcement for new users since March 5;
-- Fixed: error when using single or double quotes in sender name.
+* Added: enforcement for authorized sending address for automatic and scheduled emails for new users after March 5;
+* Improvement: authorized sending email enforcement for new users since March 5;
+* Fixed: error when using single or double quotes in sender name.
 
 = 3.27.0 - 2019-05-28 =
-
-- Added: API documentation for developers on github.com/mailpoet/mailpoet;
-- Fixed: email editor's text editing not working due to TinyMCE conflict with some plugins;
-- Fixed: some translations that could previously be only in English;
-- Fixed: duplicating scheduled newsletters to not include the original scheduled date.
+* Added: API documentation for developers on github.com/mailpoet/mailpoet;
+* Fixed: email editor's text editing not working due to TinyMCE conflict with some plugins;
+* Fixed: some translations that could previously be only in English;
+* Fixed: duplicating scheduled newsletters to not include the original scheduled date.
 
 = 3.26.1 - 2019-05-21 =
-
-- Added: Woo Commerce customers now have their own list;
-- Improved: users can now scroll through newsletter content while settings sidebar is open;
-- Fixed: sign-up confirmation no longer overwritten by default sender on page refresh;
-- Fixed: edge cases where blank post notification emails were being sent;
-- Fixed: imported subscribers from MP2 no longer marked inactive by default.
+* Added: Woo Commerce customers now have their own list;
+* Improved: users can now scroll through newsletter content while settings sidebar is open;
+* Fixed: sign-up confirmation no longer overwritten by default sender on page refresh;
+* Fixed: edge cases where blank post notification emails were being sent;
+* Fixed: imported subscribers from MP2 no longer marked inactive by default.
 
 = 3.26.0 - 2019-05-14 =
-
-- Improved: minor change of default email confirmation text;
-- Improved: WooCommerce customer sync with MailPoet lists for stores with 30k or larger customer lists;
-- Fixed: edge case bug where a user with a user_id of 0 would break links in newsletters for some users;
-- Fixed: uncaught TypeError related to deleted segments.
+* Improved: minor change of default email confirmation text;
+* Improved: WooCommerce customer sync with MailPoet lists for stores with 30k or larger customer lists;
+* Fixed: edge case bug where a user with a user_id of 0 would break links in newsletters for some users;
+* Fixed: uncaught TypeError related to deleted segments.
 
 = 3.25.1 - 2019-05-06 =
-
-- Improved: subscriber import speed for users importing many subscribers with many custom fields;
-- Fixed: typo in Product widget;
-- Fixed: conflict with POJO themes in form editor;
-- Fixed: backwards compatibility between wpdb:parse_db_host and WP versions earlier than 4.9;
-- Fixed: bounced subscribers will continue being synchronized when sending is paused and MailPoet Sending Service is used;
-- Fixed: conflict with Thrive Leads where confirmation emails were not being sent.
+* Improved: subscriber import speed for users importing many subscribers with many custom fields;
+* Fixed: typo in Product widget;
+* Fixed: conflict with POJO themes in form editor;
+* Fixed: backwards compatibility between wpdb:parse_db_host and WP versions earlier than 4.9;
+* Fixed: bounced subscribers will continue being synchronized when sending is paused and MailPoet Sending Service is used;
+* Fixed: conflict with Thrive Leads where confirmation emails were not being sent.
 
 = 3.25.0 - 2019-04-29 =
-
-- Improved: ALC post fetching consistency;
-- Improved: template preview display;
-- Improved: now able to turn off inactive subscribers feature;
-- Improved: WooCommerce product widget shows price by default now;
-- Improved: updated links to knowledge base for bounced and inactive users;
-- Improved: clarified how subscribers display within lists when unsubscribed;
-- Fixed: issue where bounce task would not run after a failure;
-- Fixed: scheduling calendar respects "week starts on" WordPress setting;
-- Fixed: links with special characters in email body no longer break sending;
-- Fixed: conflict with third-party plugins that was displaying private posts in ALC blocks.
+* Improved: ALC post fetching consistency;
+* Improved: template preview display;
+* Improved: now able to turn off inactive subscribers feature;
+* Improved: WooCommerce product widget shows price by default now;
+* Improved: updated links to knowledge base for bounced and inactive users;
+* Improved: clarified how subscribers display within lists when unsubscribed;
+* Fixed: issue where bounce task would not run after a failure;
+* Fixed: scheduling calendar respects "week starts on" WordPress setting;
+* Fixed: links with special characters in email body no longer break sending;
+* Fixed: conflict with third-party plugins that was displaying private posts in ALC blocks.
 
 = 3.24.0 - 2019-04-23 =
-
-- Added: add WooCommerce product blocks to your email;
-- Added: an optional way to automatically deactivate inactive subscribers who don't read your emails;
-- Added: setting to stop sending for inactive subscribers who haven't opened newsletters in a span of time.
+* Added: add WooCommerce product blocks to your email;
+* Added: an optional way to automatically deactivate inactive subscribers who don't read your emails;
+* Added: setting to stop sending for inactive subscribers who haven't opened newsletters in a span of time.
 
 = 3.23.2 - 2019-04-16 =
-
-- Improved: UI clarity and user-friendliness;
-- Improved: security of the plugin. Thanks to Jan van der Put and Harm Blankers of REQON Security for the report!
-- Improved: UX for stats reporting emails;
-- Fixed: subscription confirmation email to include a plain text version of the email. Thanks Mathieu!
+* Improved: UI clarity and user-friendliness;
+* Improved: security of the plugin. Thanks to Jan van der Put and Harm Blankers of REQON Security for the report!
+* Improved: UX for stats reporting emails;
+* Fixed: subscription confirmation email to include a plain text version of the email. Thanks Mathieu!
 
 = 3.23.1 - 2019-04-08 =
-
-- Added: new email type icons;
-- Improved: clearer steps in welcome wizard;
-- Fixed: added missing translation string;
-- Fixed: previewing unsubscribe page no longer unsubscribes the viewer;
-- Fixed: form validation error message translation strings.
+* Added: new email type icons;
+* Improved: clearer steps in welcome wizard;
+* Fixed: added missing translation string;
+* Fixed: previewing unsubscribe page no longer unsubscribes the viewer;
+* Fixed: form validation error message translation strings.
 
 = 3.23.0 - 2019-04-02 =
-
-- Added: 12 fresh new templates;
-- Improved: mouse over highlights entire text block instead of partially;
-- Fixed: post titles with single and double quotes break email rendering in ALC and Post blocks;
-- Fixed: "import again" subscriber import errors fixed;
-- Fixed: Twig conflicts with third party plugins.
-- Fixed: import subscribers with custom fields no longer fails;
-- Fixed: social icon margins;
-- Fixed: updating an imported subscriber no longer triggers welcome email.
+* Added: 12 fresh new templates;
+* Improved: mouse over highlights entire text block instead of partially;
+* Fixed: post titles with single and double quotes break email rendering in ALC and Post blocks;
+* Fixed: "import again" subscriber import errors fixed;
+* Fixed: Twig conflicts with third party plugins.
+* Fixed: import subscribers with custom fields no longer fails;
+* Fixed: social icon margins;
+* Fixed: updating an imported subscriber no longer triggers welcome email.
 
 = 3.22.0 - 2019-03-26 =
-
-- Improved: minor tweaks and fixes, special thanks to valdrinkoshi for a very helpful PR;
-- Improved: admin notices for authorizing FROM addresses;
-- Fixed: German umlaut characters no longer break JSON encoding and sending on some hosts. Thanks Oliver and others;
-- Fixed: increased limit for visible custom fields in form editor to 40;
-- Fixed: sending post notifications with "Monthly on the..." setting.
+* Improved: minor tweaks and fixes, special thanks to valdrinkoshi for a very helpful PR;
+* Improved: admin notices for authorizing FROM addresses;
+* Fixed: German umlaut characters no longer break JSON encoding and sending on some hosts. Thanks Oliver and others;
+* Fixed: increased limit for visible custom fields in form editor to 40;
+* Fixed: sending post notifications with "Monthly on the..." setting.
 
 = 3.21.1 - 2019-03-18 =
-
-- Improved: better highlighting when resizing widgets in editor;
-- Improved: sending with consistent FROM address;
-- Fixed: db connection issues for connections via socket. Thanks Nicolas!
-- Fixed: react console warnings when sending is paused.
+* Improved: better highlighting when resizing widgets in editor;
+* Improved: sending with consistent FROM address;
+* Fixed: db connection issues for connections via socket. Thanks Nicolas!
+* Fixed: react console warnings when sending is paused.
 
 = 3.21.0 - 2019-03-11 =
-
-- Added: backwards compatibility method to fix 3rd party integrations;
-- Added: option to position the title of your post above the excerpt;
-- Added: change the default line heights in Styles sidebar;
-- Improved: human readable error message when mail mail function fails;
-- Fixed: incorrect "authorize your address" link in plugin.
+* Added: backwards compatibility method to fix 3rd party integrations;
+* Added: option to position the title of your post above the excerpt;
+* Added: change the default line heights in Styles sidebar;
+* Improved: human readable error message when mail mail function fails;
+* Fixed: incorrect "authorize your address" link in plugin.
 
 = 3.20.0 - 2019-03-05 =
-
-- Added: requirement for all "from" email addresses to be authorized to enable sending;
-- Added: WooCommerce revenues in stats email notifications;
-- Added: new image for WordPress repo;
-- Improved: adjustments for third-party plugins who do not integrate MailPoet correctly;
-- Improved: email type selection CSS improved to prevent issues with some languages;
-- Fixed: double elements in form editor;
-- Fixed: MailPoet Sending Service can be activated with a key that has an 'expiring' status;
-- Fixed: display bug for 1:2 and 2:1 column layouts in editor;
-- Fixed: pagination controls on listings pages.
+* Added: requirement for all "from" email addresses to be authorized to enable sending;
+* Added: WooCommerce revenues in stats email notifications;
+* Added: new image for WordPress repo;
+* Improved: adjustments for third-party plugins who do not integrate MailPoet correctly;
+* Improved: email type selection CSS improved to prevent issues with some languages;
+* Fixed: double elements in form editor;
+* Fixed: MailPoet Sending Service can be activated with a key that has an 'expiring' status;
+* Fixed: display bug for 1:2 and 2:1 column layouts in editor;
+* Fixed: pagination controls on listings pages.
 
 = 3.19.3 - 2019-02-26 =
-
-- Added: new step in import to educate users about good sending practices during subscriber import;
-- Improved: editor controls;
-- Fixed: issue with duplicating ALC posts.
+* Added: new step in import to educate users about good sending practices during subscriber import;
+* Improved: editor controls;
+* Fixed: issue with duplicating ALC posts.
 
 = 3.19.2 - 2019-02-19 =
-
-- Added: 13 brand new templates;
-- Improved: TinyMCE is hidden on mouse drag;
-- Improved: block and widget controls are hidden on mouse drag;
-- Fixed: cursor position does not get lost with long text on Chrome;
-- Fixed: MailPoet icon in the Members plugin looks good again.
+* Added: 13 brand new templates;
+* Improved: TinyMCE is hidden on mouse drag;
+* Improved: block and widget controls are hidden on mouse drag;
+* Fixed: cursor position does not get lost with long text on Chrome;
+* Fixed: MailPoet icon in the Members plugin looks good again.
 
 = 3.19.1 - 2019-02-12 =
-
-- Added: warning against using free email address in "from" fields;
-- Added: updated Instagram icons;
-- Added: new custom font choices;
-- Improved: new design for block controls;
-- Improved: updated width of image setting width input field for better display of 4-digit numbers;
-- Improved: wider vertical drag button for dividers;
-- Improved: align social icons left, center or right;
-- Improved: minor enhancement to controls of elements in editor;
-- Fixed: restored missing X to modal when deleting templates;
-- Fixed: minor adjustments to assist third-party plugins using MailPoet integrations incorrectly;
-- Fixed: when Post Notification send date/time are left as default, we now create a Post Notification with those settings;
-- Fixed: double click on text in TinyMCE keeps formatting.
+* Added: warning against using free email address in "from" fields;
+* Added: updated Instagram icons;
+* Added: new custom font choices;
+* Improved: new design for block controls;
+* Improved: updated width of image setting width input field for better display of 4-digit numbers;
+* Improved: wider vertical drag button for dividers;
+* Improved: align social icons left, center or right;
+* Improved: minor enhancement to controls of elements in editor;
+* Fixed: restored missing X to modal when deleting templates;
+* Fixed: minor adjustments to assist third-party plugins using MailPoet integrations incorrectly;
+* Fixed: when Post Notification send date/time are left as default, we now create a Post Notification with those settings;
+* Fixed: double click on text in TinyMCE keeps formatting.
 
 = 3.19.0 - 2019-02-05 =
-
-- Added: more clarity for image and column block settings. Thanks focus group testers!;
-- Added: further subscription limits to avoid subscription confirmation email abuse;
-- Updated: MailPoet's logo in footer of emails;
-- Fixed: Linux cron fatal error;
-- Fixed: JS error with WP 5.0 when adding new form;
-- Fixed: buttons in bold show as bold in settings;
-- Fixed: handling of small images with a "Full width" option enabled;
-- Fixed: link colors in text blocks are correctly shown in the inbox;
-- Fixed: announcement sidebar stays closed.
+* Added: more clarity for image and column block settings. Thanks focus group testers!;
+* Added: further subscription limits to avoid subscription confirmation email abuse;
+* Updated: MailPoet's logo in footer of emails;
+* Fixed: Linux cron fatal error;
+* Fixed: JS error with WP 5.0 when adding new form;
+* Fixed: buttons in bold show as bold in settings;
+* Fixed: handling of small images with a "Full width" option enabled;
+* Fixed: link colors in text blocks are correctly shown in the inbox;
+* Fixed: announcement sidebar stays closed.
 
 = 3.18.2 - 2019-01-29 =
-
-- Added: by popular demand, new option to receive a summary email of a campaign's open and click rates;
-- Added: loading animation on subscription form submission;
-- Added: new modal design;
-- Added: first steps for a new WooCommerce customer list;
-- Improved: new warning before sending from a free address, like Gmail;
-- Fixed: issue with some Gutenberg blocks causing a 500 error in ALC with full posts.
+* Added: by popular demand, new option to receive a summary email of a campaign's open and click rates;
+* Added: loading animation on subscription form submission;
+* Added: new modal design;
+* Added: first steps for a new WooCommerce customer list;
+* Improved: new warning before sending from a free address, like Gmail;
+* Fixed: issue with some Gutenberg blocks causing a 500 error in ALC with full posts.
 
 = 3.18.1 - 2019-01-22 =
-
-- Added: new assets for WP plugin repo page;
-- Added: nine shiny and new templates for standard, post notification, and WooCommerce emails;
-- Fixed: button's settings font display fits nicely again;
-- Changed: removed the requirement of having the ZIP PHP extension to use MailPoet 3;
+* Added: new assets for WP plugin repo page;
+* Added: nine shiny and new templates for standard, post notification, and WooCommerce emails;
+* Fixed: button's settings font display fits nicely again;
+* Changed: removed the requirement of having the ZIP PHP extension to use MailPoet 3;
 
 = 3.18.0 - 2019-01-15 =
-
-- Fixed: CSS issues in widget settings;
-- Fixed: CSS for Beamer icon on mobile;
-- Fixed: size slider issue for images without defined dimensions;
-- Fixed: images defaulted to centered in ALC blocks displaying full posts;
-- Added: poll to check status of user's first send;
+* Fixed: CSS issues in widget settings;
+* Fixed: CSS for Beamer icon on mobile;
+* Fixed: size slider issue for images without defined dimensions;
+* Fixed: images defaulted to centered in ALC blocks displaying full posts;
+* Added: poll to check status of user's first send;
 
 = 3.17.2 - 2019-01-08 =
-
-- Fixed: possible conflict with other plugins using webpack. Thanks, Julien;
-- Fixed: creating a new WooCommerce email now defaults to the Woo template page tab instead of standard templates tab;
+* Fixed: possible conflict with other plugins using webpack. Thanks, Julien;
+* Fixed: creating a new WooCommerce email now defaults to the Woo template page tab instead of standard templates tab;
 
 = 3.17.1 - 2018-12-19 =
-
-- Fixed: premium plugin crash; Thanks, Sebastian!
+* Fixed: premium plugin crash; Thanks, Sebastian!
 
 = 3.17.0 - 2018-12-18 =
-
-- Added: new in-app announcements sidebar. Click the carrot to see;
-- Added: option to toggle between desktop and mobile in Preview in Browser;
-- Improved: minor changes and fixes;
-- Fixed: images in ALC blocks set to display with padding may not render correctly on mobile.
+* Added: new in-app announcements sidebar. Click the carrot to see;
+* Added: option to toggle between desktop and mobile in Preview in Browser;
+* Improved: minor changes and fixes;
+* Fixed: images in ALC blocks set to display with padding may not render correctly on mobile.
 
 = 3.16.3 - 2018-12-13 =
-
-- Fixed: select all once again selects all;
-- Fixed: Post Notification emails to include post images for posts created with WordPress 5.0;
-- Fixed: restored correct button captions;
-- Fixed: after a brief rebellion, post notification history now displays in an orderly fashion again;
+* Fixed: select all once again selects all;
+* Fixed: Post Notification emails to include post images for posts created with WordPress 5.0;
+* Fixed: restored correct button captions;
+* Fixed: after a brief rebellion, post notification history now displays in an orderly fashion again;
 
 = 3.16.2 - 2018-12-11 =
-
-- Added: new post notification default subject to highlight how to use Subject Line variables;
-- Improved: minor tweaks and fixes;
+* Added: new post notification default subject to highlight how to use Subject Line variables;
+* Improved: minor tweaks and fixes;
 
 = 3.16.1 - 2018-12-05 =
-
-- Added: error message for banned senders;
-- Improved: PHP compatibility warning updated to recommend PHP 7.2 or later;
-- Improved: Error handling and display;
-- Improved: timing of hook actions to avoid conflicts with other plugins;
-- Fixed: mailer errors are displayed if they occur when sending a newsletter preview.
+* Added: error message for banned senders;
+* Improved: PHP compatibility warning updated to recommend PHP 7.2 or later;
+* Improved: Error handling and display;
+* Improved: timing of hook actions to avoid conflicts with other plugins;
+* Fixed: mailer errors are displayed if they occur when sending a newsletter preview.
 
 = 3.15.0 - 2018-11-27 =
-
-- Improved: plugin ZIP file size is considerably reduced;
-- Fixed: sent and scheduled welcome email counts are displayed correctly;
-- Fixed: hidden honeypot field in subscription form now also hidden in editor;
-- Fixed: email listing renders consistently in PHP 7.0.32;
-- Removed: pluggable.php requirement to avoid conflicts with other plugins.
+* Improved: plugin ZIP file size is considerably reduced;
+* Fixed: sent and scheduled welcome email counts are displayed correctly;
+* Fixed: hidden honeypot field in subscription form now also hidden in editor;
+* Fixed: email listing renders consistently in PHP 7.0.32;
+* Removed: pluggable.php requirement to avoid conflicts with other plugins.
 
 = 3.14.1 - 2018-11-20 =
-
-- Added: show number of sent and scheduled welcome emails on Welcome Emails listing page;
-- Improved: naming and organization of template categories;
-- Fixed: limits on number of categories and tags which may be selected for ALC increased to 100. Thanks, Radwan!;
+* Added: show number of sent and scheduled welcome emails on Welcome Emails listing page;
+* Improved: naming and organization of template categories;
+* Fixed: limits on number of categories and tags which may be selected for ALC increased to 100. Thanks, Radwan!;
 
 = 3.14.0 - 2018-11-13 =
-
-- Added: readme clarified to show we do not support multisite;
-- Added: retina-friendly icon;
-- Added: expanded GDPR information in plugin UI;
-- Added: ten new fonts for use in emails;
-- Improved: post notification email logic;
-- Fixed: new post notification templates aren't sent without posts;
-- Fixed: missing space in listings returned after brief hiatus;
-- Fixed: pausing post notification history items to not prevent further post notifications from being sent; Thanks, Mathieu!
-- Fixed: JS errors on emails page.
+* Added: readme clarified to show we do not support multisite;
+* Added: retina-friendly icon;
+* Added: expanded GDPR information in plugin UI;
+* Added: ten new fonts for use in emails;
+* Improved: post notification email logic;
+* Fixed: new post notification templates aren't sent without posts;
+* Fixed: missing space in listings returned after brief hiatus;
+* Fixed: pausing post notification history items to not prevent further post notifications from being sent; Thanks, Mathieu!
+* Fixed: JS errors on emails page.
 
 = 3.13.0 - 2018-11-06 =
-
-- Improved: content of default signup confirmation email;
-- Changed: sites using PHP 5.6 will get an old version warning due to no longer receiving security updates after December. Please consider upgrading to PHP 7.2!
-- Changed: end of support for PHP 5.5. Please upgrade to PHP 7.0 or newer!
+* Improved: content of default signup confirmation email;
+* Changed: sites using PHP 5.6 will get an old version warning due to no longer receiving security updates after December. Please consider upgrading to PHP 7.2!
+* Changed: end of support for PHP 5.5. Please upgrade to PHP 7.0 or newer!
 
 = 3.12.1 - 2018-10-30 =
-
-- Added: 2:1 and 1:2 column blocks for further newsletter customization;
-- Fixed: conflict with JetPack 6.6 Asset CDN module.
+* Added: 2:1 and 1:2 column blocks for further newsletter customization;
+* Fixed: conflict with JetPack 6.6 Asset CDN module.
 
 = 3.12.0 - 2018-10-23 =
-
-- Improved: formatting of "from" address for new subscriber emails;
-- Fixed: bulk resend of confirmation emails works again;
-- Fixed: email deletion error in the sending process. Thanks @jensgoro!
-- Fixed: in-app announcement shows properly;
-- Fixed: discount notice is now displayed in all places it was meant to;
-- Fixed: minor style and text changes to announcements;
-- Fixed: in MailPoet API welcome emails are scheduled only if subscriber is confirmed.
+* Improved: formatting of "from" address for new subscriber emails;
+* Fixed: bulk resend of confirmation emails works again;
+* Fixed: email deletion error in the sending process. Thanks @jensgoro!
+* Fixed: in-app announcement shows properly;
+* Fixed: discount notice is now displayed in all places it was meant to;
+* Fixed: minor style and text changes to announcements;
+* Fixed: in MailPoet API welcome emails are scheduled only if subscriber is confirmed.
 
 = 3.11.5 - 2018-10-17 =
-
-- Fixed: javascript errors resolved;
+* Fixed: javascript errors resolved;
 
 = 3.11.4 - 2018-10-16 =
-
-- Added: email notifications to administrators when new subscribers subscribe
+* Added: email notifications to administrators when new subscribers subscribe
 
 = 3.11.3 - 2018-10-09 =
-
-- Fixed: Linux cron to work again.
+* Fixed: Linux cron to work again.
 
 = 3.11.2 - 2018-10-09 =
-
-- Added: Linux cron option for sending emails;
-- Fixed: fatal error for admins who are not also subscribers;
-- Fixed: minor style fixes;
-- Fixed: added missing translation string;
-- Fixed: orphaned tasks cleared after subscribers deleted;
-- Fixed: minor styling issue on schedule page for Mac Chrome users.
+* Added: Linux cron option for sending emails;
+* Fixed: fatal error for admins who are not also subscribers;
+* Fixed: minor style fixes;
+* Fixed: added missing translation string;
+* Fixed: orphaned tasks cleared after subscribers deleted;
+* Fixed: minor styling issue on schedule page for Mac Chrome users.
 
 = 3.11.1 - 2018-10-02 =
-
-- Fixed: JS assets caching issues;
+* Fixed: JS assets caching issues;
 
 = 3.11.0 - 2018-09-25 =
-
-- Added: notice for users who've migrated from MP2 to MP3;
-- Added: many new templates for newsletters, welcome emails, notifications, and Woo Commerce;
-- Added: improved sending method error handling;
-- Improved: onboarding user experience tweaks and improvements;
-- Fixed: JS warning in the emails section;
-- Fixed: minor translation issues;
-- Fixed: welcome emails removed from Premium page, as they're free now.
+* Added: notice for users who've migrated from MP2 to MP3;
+* Added: many new templates for newsletters, welcome emails, notifications, and Woo Commerce;
+* Added: improved sending method error handling;
+* Improved: onboarding user experience tweaks and improvements;
+* Fixed: JS warning in the emails section;
+* Fixed: minor translation issues;
+* Fixed: welcome emails removed from Premium page, as they're free now.
 
 = 3.10.1 - 2018-09-18 =
-
-- Improved: made some error messages clearer
+* Improved: made some error messages clearer
 
 = 3.10 - 2018-09-11 =
-
-- Changed: welcome emails to new subscribers are now free for everyone!
-- Fixed: newsletter footer warning to be displayed if unsubscribe link is missing.
+* Changed: welcome emails to new subscribers are now free for everyone!
+* Fixed: newsletter footer warning to be displayed if unsubscribe link is missing.
 
 = 3.9.1 - 2018-09-04 =
-
-- Improved: instructions for migrating from MP2 to MP3 clarified;
-- Improved: minor style adjustments for migration tool;
-- Improved: minor fixes to onboarding intro guide;
-- Improved: template page loading times decreased;
-- Fixed: resolved javascript warnings on help page status;
-- Fixed: subscriber status remains persistent after migration from MP2 to MP3 without sign-up confirmation enabled;
+* Improved: instructions for migrating from MP2 to MP3 clarified;
+* Improved: minor style adjustments for migration tool;
+* Improved: minor fixes to onboarding intro guide;
+* Improved: template page loading times decreased;
+* Fixed: resolved javascript warnings on help page status;
+* Fixed: subscriber status remains persistent after migration from MP2 to MP3 without sign-up confirmation enabled;
 
 = 3.9.0 - 2018-08-28 =
-
-- Improved: email processing in sending queues is now more resilient to invalid data. Thanks Tara!
-- Fixed: replaced WooCommerce image in welcome wizard;
-- Fixed: swapped video in welcome wizard with an updated one;
-- Fixed: welcome wizard button displays properly for all users;
-- Fixed: permission error when bypassing data import after new install or reset;
-- Fixed: added indexes to some foreign keys which were missing;
-- Fixed: error displaying number of exported users;
-- Fixed: export search function restored;
-- Fixed: prevent third party APIs from adding data incorrectly via MailPoets API.
+* Improved: email processing in sending queues is now more resilient to invalid data. Thanks Tara!
+* Fixed: replaced WooCommerce image in welcome wizard;
+* Fixed: swapped video in welcome wizard with an updated one;
+* Fixed: welcome wizard button displays properly for all users;
+* Fixed: permission error when bypassing data import after new install or reset;
+* Fixed: added indexes to some foreign keys which were missing;
+* Fixed: error displaying number of exported users;
+* Fixed: export search function restored;
+* Fixed: prevent third party APIs from adding data incorrectly via MailPoets API.
 
 = 3.8.6 - 2018-08-21 =
-
-- Improved: compatibility with caching plugins
+* Improved: compatibility with caching plugins
 
 = 3.8.5 - 2018-08-14 =
-
-- Changed: End of support for PHP 5.3 and 5.4. Please upgrade to PHP 7.0 or newer!
-- Added: improved compatibility with sites cached by server
-- Added: setup wizard for new users;
-- Fixed: plugin activation for new installs to not crash with white screen;
-- Fixed: slow sending on sites with a lot of sent newsletters.
+* Changed: End of support for PHP 5.3 and 5.4. Please upgrade to PHP 7.0 or newer!
+* Added: improved compatibility with sites cached by server
+* Added: setup wizard for new users;
+* Fixed: plugin activation for new installs to not crash with white screen;
+* Fixed: slow sending on sites with a lot of sent newsletters.
 
 = 3.8.4 - 2018-08-07 =
-
-- Added: activation prompt for MailPoet Sending Service when API key is verified;
-- Added: next scheduled tasks now display in sending queue status;
-- Added: new additional save button to the top of editor page;
+* Added: activation prompt for MailPoet Sending Service when API key is verified;
+* Added: next scheduled tasks now display in sending queue status;
+* Added: new additional save button to the top of editor page;
 
 = 3.8.3 - 2018-08-01 =
-
-- Fixed: resolved potential duplicate sending issue.
+* Fixed: resolved potential duplicate sending issue.
 
 = 3.8.2 - 2018-07-31 =
-
-- Added: more useful sending status information in Help page.
+* Added: more useful sending status information in Help page.
 
 = 3.8.1 - 2018-07-24 =
-
-- Added: images can be used as backgrounds for column layout blocks;
-- Added: notification if cron ping does not work correctly during first sending attempt;
-- Added: new, prettier email type icon;
-- Added: TLS 1.2 support to Swiftmailer to prevent SMTP sending issues;
-- Added: updated error messages coming from the sending service;
-- Added: clarified sending tab to encourage using our free sending service;
-- Fixed: "Create New Form" link in subscription widget now creates a new form again;
-- Fixed: removed call to action for MSS service for users already using MSS.
+* Added: images can be used as backgrounds for column layout blocks;
+* Added: notification if cron ping does not work correctly during first sending attempt;
+* Added: new, prettier email type icon;
+* Added: TLS 1.2 support to Swiftmailer to prevent SMTP sending issues;
+* Added: updated error messages coming from the sending service;
+* Added: clarified sending tab to encourage using our free sending service;
+* Fixed: "Create New Form" link in subscription widget now creates a new form again;
+* Fixed: removed call to action for MSS service for users already using MSS.
 
 = 3.8 - 2018-07-17 =
-
-- Fixed: proper spacing between paragraphs in full post is now respected;
-- Fixed: deleting users who have opened one newsletter correctly records data for GDPR;
-- Fixed: sending tasks are paused when welcome email is deactivated. Thanks, Seng;
-- Fixed: can send when default sender is not set;
-- Updated: API validation message updated to reflect incompatibilities with localhost.
+* Fixed: proper spacing between paragraphs in full post is now respected;
+* Fixed: deleting users who have opened one newsletter correctly records data for GDPR;
+* Fixed: sending tasks are paused when welcome email is deactivated. Thanks, Seng;
+* Fixed: can send when default sender is not set;
+* Updated: API validation message updated to reflect incompatibilities with localhost.
 
 = 3.7.8 - 2018-06-26 =
-
-- Added: support for long URLs in newsletter links;
-- Fixed: controls in editor display correctly;
-- Fixed: full post ALC content now displays post images;
+* Added: support for long URLs in newsletter links;
+* Fixed: controls in editor display correctly;
+* Fixed: full post ALC content now displays post images;
 
 = 3.7.7 - 2018-06-20 =
-
-- Changed: MailPoet 3 to no longer work with PHP version 5.3 or older. Please upgrade to PHP 7!
-- Added: exit user survey;
-- Added: retina display optimized images for MailPoet 3 WordPress plugin entry;
-- Fixed: welcome emails are not being sent;
-- Fixed: non-Premium users now see a proper call to action for WooCommerce automatic email events;
-- Fixed: errors when using Title Only and Display as List setting in ALC content block;
-- Fixed: API reports errors when confirmation emails aren't sent. Thanks, Team BrainstormForce;
-- Fixed: in some cases, button fonts in newsletter would display in preview incorrectly;
-- Fixed: using double quotes cause rendering issues;
-- Fixed: MailPoet translation string should not be available on translate.wordpress.org;
-- Fixed: word "beta" is duplicated on WooCommerce automatic email select screen;
+* Changed: MailPoet 3 to no longer work with PHP version 5.3 or older. Please upgrade to PHP 7!
+* Added: exit user survey;
+* Added: retina display optimized images for MailPoet 3 WordPress plugin entry;
+* Fixed: welcome emails are not being sent;
+* Fixed: non-Premium users now see a proper call to action for WooCommerce automatic email events;
+* Fixed: errors when using Title Only and Display as List setting in ALC content block;
+* Fixed: API reports errors when confirmation emails aren't sent. Thanks, Team BrainstormForce;
+* Fixed: in some cases, button fonts in newsletter would display in preview incorrectly;
+* Fixed: using double quotes cause rendering issues;
+* Fixed: MailPoet translation string should not be available on translate.wordpress.org;
+* Fixed: word "beta" is duplicated on WooCommerce automatic email select screen;
 
 = 3.7.6 - 2018-06-12 =
-
-- Fixed: Woocommerce email template thumbnail overflowing over content.
-- Fixed: Newsletters created before 3.7.4 now follow featured image display rules implemented in latest release;
-- Fixed: form subscription success message is now displayed only upon form submission. Thanks, Mariener;
-- Fixed: it is now possible to delete smaller content rows;
-- Improved: welcome emails to unconfirmed subscribers not to block sending. Thanks, Donald!
-- Improved: layout for welcome and update pages.
+* Fixed: Woocommerce email template thumbnail overflowing over content.
+* Fixed: Newsletters created before 3.7.4 now follow featured image display rules implemented in latest release;
+* Fixed: form subscription success message is now displayed only upon form submission. Thanks, Mariener;
+* Fixed: it is now possible to delete smaller content rows;
+* Improved: welcome emails to unconfirmed subscribers not to block sending. Thanks, Donald!
+* Improved: layout for welcome and update pages.
 
 = 3.7.5 - 2018-06-05 =
-
-- Added: align images left or right of posts excerpts;
-- Fixed: post content block image alignment issues.
+* Added: align images left or right of posts excerpts;
+* Fixed: post content block image alignment issues.
 
 = 3.7.4 - 2018-05-30 =
-
-- Added: What's New page no longer shows after every update;
-- Improved: template selection page thumbnails are larger;
-- Improved: updating post notification emails no longer triggers duplicate emails;
-- Improved: translation enhancements.
+* Added: What's New page no longer shows after every update;
+* Improved: template selection page thumbnails are larger;
+* Improved: updating post notification emails no longer triggers duplicate emails;
+* Improved: translation enhancements.
 
 = 3.7.3 - 2018-05-22 =
-
-- Improved: updated dependency libraries to latest versions;
-- Improved: performance of scheduling new welcome emails on sites with many of new subscribers. Thanks Donald;
-- Fixed: subscriber import tool no longer complains about filenames with multiple periods;
-- Fixed: scheduled send tasks are properly rescheduled when updating their parent newsletter's options;
-- Fixed: paused post notification emails to not block sending of other emails;
-- Fixed: newsletter subject line with shortcodes does not break sending when using our sending service. Thanks, James;
-- Fixed: subscription forms to return less information about the subscriber.
+* Improved: updated dependency libraries to latest versions;
+* Improved: performance of scheduling new welcome emails on sites with many of new subscribers. Thanks Donald;
+* Fixed: subscriber import tool no longer complains about filenames with multiple periods;
+* Fixed: scheduled send tasks are properly rescheduled when updating their parent newsletter's options;
+* Fixed: paused post notification emails to not block sending of other emails;
+* Fixed: newsletter subject line with shortcodes does not break sending when using our sending service. Thanks, James;
+* Fixed: subscription forms to return less information about the subscriber.
 
 = 3.7.2 - 2018-05-15 =
-
-- Added: list of emails a subscriber viewed to GDPR data export;
-- Added: list of links a subscriber clicked to GDPR data export;
-- Added: a tool to forget subscriber's information for GDPR related data erasure;
-- Added: Privacy policy which can be used by WordPress's privacy tool in compliance with GDPR;
-- Improved: performance for sites using many post notification emails. Thanks Jose!
-- Fixed: Javascript warnings on segments page are removed.
-- Fixed: custom field values longer than 255 characters can be stored. Thanks Scott!
+* Added: list of emails a subscriber viewed to GDPR data export;
+* Added: list of links a subscriber clicked to GDPR data export;
+* Added: a tool to forget subscriber's information for GDPR related data erasure;
+* Added: Privacy policy which can be used by WordPress's privacy tool in compliance with GDPR;
+* Improved: performance for sites using many post notification emails. Thanks Jose!
+* Fixed: Javascript warnings on segments page are removed.
+* Fixed: custom field values longer than 255 characters can be stored. Thanks Scott!
 
 = 3.7.1 - 2018-05-08 =
-
-- Added: export of subscriber information (email, personal data and subscription lists) to WordPress 4.9.6 and newer versions in compliance with GDPR requirements;
-- Added: notice for those who use legacy PHP versions (<5.6) - MailPoet recommends upgrading to PHP 7.0 or newer!
-- Improved: sending resource usage has been optimized for large sites. Thanks, Jose;
-- Improved: it is now easier to navigate away from the welcome/changelog page;
-- Fixed: functionality to pause and resume sending is restored;
-- Fixed: proper sent count is now displayed for welcome notifications. Merci Sébastien!
+* Added: export of subscriber information (email, personal data and subscription lists) to WordPress 4.9.6 and newer versions in compliance with GDPR requirements;
+* Added: notice for those who use legacy PHP versions (<5.6) - MailPoet recommends upgrading to PHP 7.0 or newer!
+* Improved: sending resource usage has been optimized for large sites. Thanks, Jose;
+* Improved: it is now easier to navigate away from the welcome/changelog page;
+* Fixed: functionality to pause and resume sending is restored;
+* Fixed: proper sent count is now displayed for welcome notifications. Merci Sébastien!
 
 = 3.7.0 - 2018-04-25 =
-
-- Fixed: subscriber search functionality fixed.
+* Fixed: subscriber search functionality fixed.
 
 = 3.6.7 - 2018-04-24 =
-
-- Fixed: duplicates in the database will not stop scheduled newsletters anymore.
+* Fixed: duplicates in the database will not stop scheduled newsletters anymore.
 
 = 3.6.6 - 2018-04-17 =
-
-- Fixed: missing database records no longer break the sending process. Thanks, Catalin;
+* Fixed: missing database records no longer break the sending process. Thanks, Catalin;
 
 = 3.6.5 - 2018-04-10 =
-
-- Premium: subscriber export tool now supports dynamic segments;
-- Improved: sending was optimized for large newsletters and slow hosts. Thanks, Alison;
-- Fixed: help icon functionality was restored for all users.
+* Premium: subscriber export tool now supports dynamic segments;
+* Improved: sending was optimized for large newsletters and slow hosts. Thanks, Alison;
+* Fixed: help icon functionality was restored for all users.
 
 = 3.6.4 - 2018-04-03 =
-
-- Fixed: editing sent emails will not remove them from email archive. Thanks David!
+* Fixed: editing sent emails will not remove them from email archive. Thanks David!
 
 = 3.6.3 - 2018-03-28 =
-
-- Fixed: scheduled emails can now be sent normally again. Thanks Neil;
-- Fixed: sending to dynamic segments (Premium feature). Thanks to Jilfar;
-- Fixed: changing the background colour of column layouts no longer corrupts their display. Thanks Neil!
+* Fixed: scheduled emails can now be sent normally again. Thanks Neil;
+* Fixed: sending to dynamic segments (Premium feature). Thanks to Jilfar;
+* Fixed: changing the background colour of column layouts no longer corrupts their display. Thanks Neil!
 
 = 3.6.2 - 2018-03-21 =
-
-- Fixed: sending is faster and uses less resources on sites with large number of emails. Thanks Donald and Hostek support team!
-- Fixed: scheduled newsletter task no longer runs non-stop when "site visitor" option is enabled. Thanks to @amedic, @conorsboyd and @aspasa for reporting the issue on the forum!
+* Fixed: sending is faster and uses less resources on sites with large number of emails. Thanks Donald and Hostek support team!
+* Fixed: scheduled newsletter task no longer runs non-stop when "site visitor" option is enabled. Thanks to @amedic, @conorsboyd and @aspasa for reporting the issue on the forum!
 
 = 3.6.1 - 2018-03-20 =
-
-- Fixed: prevents sending from being paused for long time during plugin update. Big thanks to Deborah, Kelley, Ciro and Justin!
+* Fixed: prevents sending from being paused for long time during plugin update. Big thanks to Deborah, Kelley, Ciro and Justin!
 
 = 3.6.0 - 2018-03-20 =
-
-- Improved: previously used widgets settings in the designer are automatically saved to save you time;
-- Improved: welcome emails are now sent with our API's subscribeToList method, and not just addSubscriber. Thanks to Sandra and Donald;
-- Improved: less server resources are required to send to very large number of subscribers;
-- Improved: shortcodes can be used inside URLs when click tracking is enabled. Thanks to Bob;
-- Fixed: more reliable screenshots of your email templates;
+* Improved: previously used widgets settings in the designer are automatically saved to save you time;
+* Improved: welcome emails are now sent with our API's subscribeToList method, and not just addSubscriber. Thanks to Sandra and Donald;
+* Improved: less server resources are required to send to very large number of subscribers;
+* Improved: shortcodes can be used inside URLs when click tracking is enabled. Thanks to Bob;
+* Fixed: more reliable screenshots of your email templates;
 
 = 3.5.1 - 2018-03-13 =
-
-- Improved: email validation for WordPress user synchronization;
-- Fixed: import no longer discards e-mails with dashes. A big thank-you to everyone who reported the issue;
-- Fixed: sending does not get stuck on the last step of the newsletter creation process. Thanks, Rene!
+* Improved: email validation for WordPress user synchronization;
+* Fixed: import no longer discards e-mails with dashes. A big thank-you to everyone who reported the issue;
+* Fixed: sending does not get stuck on the last step of the newsletter creation process. Thanks, Rene!
 
 = 3.5.0 - 2018-03-06 =
-
-- Premium: bulk actions can now be executed on subscribers belonging to a selected segment;
-- Improved: a proper error page is displayed if user credentials can't be verified when clicking a tracked newsletter link. Thanks, Bernhard;
-- Fixed: MailPoet polyfills missing mbstring function for WordPress core. Thanks Dioni!
+* Premium: bulk actions can now be executed on subscribers belonging to a selected segment;
+* Improved: a proper error page is displayed if user credentials can't be verified when clicking a tracked newsletter link. Thanks, Bernhard;
+* Fixed: MailPoet polyfills missing mbstring function for WordPress core. Thanks Dioni!
 
 = 3.4.4 - 2018-02-27 =
-
-- Premium: send emails to WooCommerce customers who purchased a specific product or in a specific product category;
-- Improved: the template import form is now in its own tab;
-- Fixed: subscriber-to-list mappings are now migrated correctly on some installations; Thanks Kevin!
-- Fixed: newsletter editor ignores taxonomies without labels when searching for categories or tags. Thanks Jose!
+* Premium: send emails to WooCommerce customers who purchased a specific product or in a specific product category;
+* Improved: the template import form is now in its own tab;
+* Fixed: subscriber-to-list mappings are now migrated correctly on some installations; Thanks Kevin!
+* Fixed: newsletter editor ignores taxonomies without labels when searching for categories or tags. Thanks Jose!
 
 = 3.4.3 - 2018-02-20 =
-
-- Improved: export includes IP address column and differentiates between global and list subscription status;
-- Improved: email designer checks if "Automatic Latest Content" widget is present in Post Notification emails.
+* Improved: export includes IP address column and differentiates between global and list subscription status;
+* Improved: email designer checks if "Automatic Latest Content" widget is present in Post Notification emails.
 
 = 3.4.2 - 2018-02-13 =
-
-- Premium: you can now segment your subscribers by opened/clicked/unopened events;
-- Improved: default post search parameters inside newsletter editor can be manually changed using a custom WordPress filter. Thanks Jose Salazar;
-- Fixed: saving email templates when website uses both HTTP and HTTPS protocols.
+* Premium: you can now segment your subscribers by opened/clicked/unopened events;
+* Improved: default post search parameters inside newsletter editor can be manually changed using a custom WordPress filter. Thanks Jose Salazar;
+* Fixed: saving email templates when website uses both HTTP and HTTPS protocols.
 
 = 3.4.1 - 2018-02-06 =
-
-- Fixed: previously saved templates are now under "Your saved templates";
-- Improved: imported templates with no matching category are now added to "Your saved templates".
+* Fixed: previously saved templates are now under "Your saved templates";
+* Improved: imported templates with no matching category are now added to "Your saved templates".
 
 = 3.4.0 - 2018-01-30 =
-
-- Added: choices of templates are now categorized for clarity;
-- Fixed: plugin activation to be able to create all plugin tables with MySQL strict mode enabled. Thank you @deltafactory!
-- Fixed: importing subscribers with custom fields. Thanks again @deltafactory!
+* Added: choices of templates are now categorized for clarity;
+* Fixed: plugin activation to be able to create all plugin tables with MySQL strict mode enabled. Thank you @deltafactory!
+* Fixed: importing subscribers with custom fields. Thanks again @deltafactory!
 
 = 3.3.6 - 2018-01-23 =
-
-- Added: optional reCAPTCHA to protect subscription forms from fake signups.
+* Added: optional reCAPTCHA to protect subscription forms from fake signups.
 
 = 3.3.5 - 2018-01-16 =
-
-- Added: additional tools for our support team to mitigate sending issues;
+* Added: additional tools for our support team to mitigate sending issues;
 
 = 3.3.4 - 2018-01-09 =
-
-- Fixed: the plugin no longer spams the same post notification email to subscribers. Thank you Mark, Bruno, Peter, Aaron, PJ, Silowe, Eytan, Beverly and others for your help!
-- Fixed: public assets are loaded for shortcode/PHP form placement methods. Thanks Ehsan!
+* Fixed: the plugin no longer spams the same post notification email to subscribers. Thank you Mark, Bruno, Peter, Aaron, PJ, Silowe, Eytan, Beverly and others for your help!
+* Fixed: public assets are loaded for shortcode/PHP form placement methods. Thanks Ehsan!
 
 = 3.3.3 - 2018-01-02 =
-
-- Improved: Welcome emails are now sent for subscribers manually created by administrators;
-- Improved: content deletion in email designer to more clearly warn about what is being deleted;
-- Improved: HelpScout beacon no longer obstructs pagination in listings.
+* Improved: Welcome emails are now sent for subscribers manually created by administrators;
+* Improved: content deletion in email designer to more clearly warn about what is being deleted;
+* Improved: HelpScout beacon no longer obstructs pagination in listings.
 
 = 3.0.0 - 2017-09-20 =
-
-- Official launch of the new MailPoet. :)
-- Improved: MailPoet 3 now works with other plugins that use a supported version of Twig templating engine. Thanks @supsysticcom;
-- Added: we now offer a free sending plan for "2000" subscribers or less. Thx MailPoet!
+* Official launch of the new MailPoet. :)
+* Improved: MailPoet 3 now works with other plugins that use a supported version of Twig templating engine. Thanks @supsysticcom;
+* Added: we now offer a free sending plan for "2000" subscribers or less. Thx MailPoet!
 
 = 3.0.0-rc.1.0.0 - 2017-08-01 =
-
-- Improved: MailPoet 3 is no longer in Beta!
-- Improved: blockquotes in posts are now displayed in emails; Thanks @newslines!
-- Improved: a bottom padding is added to every last element of a column, except if it's full width image;
-- Fixed: recommended sending limit values are properly updated when the sending method is modified;
-- Fixed: welcome newsletter listings page now loads faster; Thanks Luc!
-- Fixed: [newsletter:post_title] properly displays titles of custom post types; Thanks Adrian!
-- Fixed: post images are displayed in expected positions; Thanks Gary!
+* Improved: MailPoet 3 is no longer in Beta!
+* Improved: blockquotes in posts are now displayed in emails; Thanks @newslines!
+* Improved: a bottom padding is added to every last element of a column, except if it's full width image;
+* Fixed: recommended sending limit values are properly updated when the sending method is modified;
+* Fixed: welcome newsletter listings page now loads faster; Thanks Luc!
+* Fixed: [newsletter:post_title] properly displays titles of custom post types; Thanks Adrian!
+* Fixed: post images are displayed in expected positions; Thanks Gary!
 
 = 3.0.0-beta.1 - 2016-10 =
-
-- Initial public beta release.
+* Initial public beta release.

--- a/mailpoet/tasks/release/ChangelogController.php
+++ b/mailpoet/tasks/release/ChangelogController.php
@@ -84,11 +84,6 @@ class ChangelogController {
     $headingPrefix = explode(self::HEADING_GLUE, $heading)[0];
     $headersDelimiter = "\n";
 
-    if (strpos($fileName, '.md') !== false) {
-      $headersDelimiter .= "\n";
-      $changesList = preg_replace("/^\*/m", "-", $changesList);
-    }
-
     $fileContents = file_get_contents($fileName);
     $changelog = "$heading$headersDelimiter$changesList";
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6446]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6446]: https://mailpoet.atlassian.net/browse/MAILPOET-6446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:changelog-fix)

_The latest successful build from `changelog-fix` will be used. If none is available, the link won't work._