### PR TITLE
Refactor and remove the dependency on the mailpoet_email post-type - MAILPOET-6430

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -75,7 +75,9 @@ class EditorPageRenderer {
   public function render() {
     $postId = isset($_GET['post']) ? intval($_GET['post']) : 0;
     $post = $this->wp->getPost($postId);
-    if (!$post instanceof \WP_Post || $post->post_type !== EditorInitController::MAILPOET_EMAIL_POST_TYPE) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $currentPostType = $post->post_type; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    if (!$post instanceof \WP_Post || $currentPostType !== EditorInitController::MAILPOET_EMAIL_POST_TYPE) {
       return;
     }
     $newsletter = $this->newslettersRepository->findOneBy(['wpPost' => $postId]);
@@ -142,6 +144,8 @@ class EditorPageRenderer {
       'mailpoet_email_editor',
       'MailPoetEmailEditor',
       [
+        'current_post_type' => esc_js($currentPostType),
+        'current_post_id' => $post->ID,
         'json_api_root' => esc_js($jsonAPIRoot),
         'api_token' => esc_js($token),
         'api_version' => esc_js($apiVersion),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -3,7 +3,6 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\Analytics\Analytics;
-use MailPoet\API\JSON\API;
 use MailPoet\Config\Env;
 use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
@@ -136,9 +135,6 @@ class EditorPageRenderer {
       $assetsParams['version']
     );
 
-    $jsonAPIRoot = rtrim($this->wp->escUrlRaw(admin_url('admin-ajax.php')), '/');
-    $token = $this->wp->wpCreateNonce('mailpoet_token');
-    $apiVersion = API::CURRENT_VERSION;
     $currentUserEmail = $this->wp->wpGetCurrentUser()->user_email;
     $this->wp->wpLocalizeScript(
       'mailpoet_email_editor',
@@ -146,11 +142,6 @@ class EditorPageRenderer {
       [
         'current_post_type' => esc_js($currentPostType),
         'current_post_id' => $post->ID,
-        'json_api_root' => esc_js($jsonAPIRoot),
-        'api_token' => esc_js($token),
-        'api_version' => esc_js($apiVersion),
-        'cdn_url' => esc_js($this->cdnAssetUrl->generateCdnUrl("")),
-        'is_premium_plugin_active' => (bool)$this->servicesChecker->isPremiumPluginActive(),
         'current_wp_user_email' => esc_js($currentUserEmail),
         'editor_settings' => $this->settingsController->get_settings(),
         'editor_theme' => $this->themeController->get_base_theme()->get_raw_data(),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -67,7 +67,6 @@ class EmailEditor {
           'singular_name' => __('Email', 'mailpoet'),
         ],
         'rewrite' => ['slug' => self::MAILPOET_EMAIL_POST_TYPE],
-        'publicly_queryable' => true,
       ],
     ];
     return $postTypes;

--- a/packages/js/email-editor/src/components/header/campaign-name.tsx
+++ b/packages/js/email-editor/src/components/header/campaign-name.tsx
@@ -17,7 +17,7 @@ import {
 /**
  * Internal dependencies
  */
-import { storeName } from '../../store';
+import { storeName, editorCurrentPostType } from '../../store';
 import { recordEvent, recordEventOnce } from '../../events';
 
 // @see https://github.com/WordPress/gutenberg/blob/5e0ffdbc36cb2e967dfa6a6b812a10a2e56a598f/packages/edit-post/src/components/header/document-actions/index.js
@@ -34,7 +34,7 @@ export function CampaignName() {
 
 	const [ emailTitle = '', setTitle ] = useEntityProp(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		'title'
 	);
 

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -27,7 +27,7 @@ import {
  * Internal dependencies
  */
 
-import { storeName } from '../../store';
+import { storeName, editorCurrentPostType } from '../../store';
 import { MoreMenu } from './more-menu';
 import { PreviewDropdown } from '../preview';
 import { SaveEmailButton } from './save-email-button';
@@ -94,8 +94,8 @@ export function Header() {
 	const { validateContent, isInvalid } = useContentValidation();
 
 	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
-	const hasTemplatesEdits = dirtyEntityRecords.some(
-		( entity ) => entity.name === 'wp_template'
+	const hasNonEmailEdits = dirtyEntityRecords.some(
+		( entity ) => entity.name !== editorCurrentPostType
 	);
 
 	const preventDefault = ( event ) => {
@@ -238,7 +238,7 @@ export function Header() {
 			<div className="editor-header__settings edit-post-header__settings">
 				<SaveEmailButton />
 				<PreviewDropdown />
-				{ hasTemplatesEdits ? (
+				{ hasNonEmailEdits ? (
 					<SaveAllButton />
 				) : (
 					<SendButton

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -94,8 +94,8 @@ export function Header() {
 	const { validateContent, isInvalid } = useContentValidation();
 
 	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
-	const hasNonEmailEdits = dirtyEntityRecords.some(
-		( entity ) => entity.name !== 'mailpoet_email'
+	const hasTemplatesEdits = dirtyEntityRecords.some(
+		( entity ) => entity.name === 'wp_template'
 	);
 
 	const preventDefault = ( event ) => {
@@ -238,7 +238,7 @@ export function Header() {
 			<div className="editor-header__settings edit-post-header__settings">
 				<SaveEmailButton />
 				<PreviewDropdown />
-				{ hasNonEmailEdits ? (
+				{ hasTemplatesEdits ? (
 					<SaveAllButton />
 				) : (
 					<SendButton

--- a/packages/js/email-editor/src/components/header/more-menu.tsx
+++ b/packages/js/email-editor/src/components/header/more-menu.tsx
@@ -13,7 +13,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { storeName } from '../../store';
+import { storeName, editorCurrentPostType } from '../../store';
 import { TrashModal } from './trash-modal';
 import { recordEvent } from '../../events';
 
@@ -32,7 +32,7 @@ export function MoreMenu(): JSX.Element {
 	);
 	const [ status, setStatus ] = useEntityProp(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		'status'
 	);
 	const { saveEditedEmail, updateEmailMailPoetProperty } =

--- a/packages/js/email-editor/src/components/header/trash-modal.tsx
+++ b/packages/js/email-editor/src/components/header/trash-modal.tsx
@@ -10,6 +10,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
+import { editorCurrentPostType } from '../../store';
 import { recordEvent } from '../../events';
 
 export function TrashModal( {
@@ -31,7 +32,7 @@ export function TrashModal( {
 		recordEvent( 'trash_modal_move_to_trash_button_clicked' );
 		const success = await deleteEntityRecord(
 			'postType',
-			'mailpoet_email',
+			editorCurrentPostType,
 			postId as unknown as string,
 			{},
 			{ throwOnError: false }
@@ -41,7 +42,7 @@ export function TrashModal( {
 		} else {
 			const lastError = getLastEntityDeleteError(
 				'postType',
-				'mailpoet_email',
+				editorCurrentPostType,
 				postId
 			);
 			// Already deleted.

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -17,7 +17,7 @@ import {
 	getCursorPosition,
 	replacePersonalizationTagsWithHTMLComments,
 } from './rich-text-utils';
-import { storeName } from '../../store';
+import { storeName, editorCurrentPostType } from '../../store';
 import { PersonalizationTagsPopover } from './personalization-tags-popover';
 import { recordEvent, recordEventOnce } from '../../events';
 
@@ -30,7 +30,7 @@ export function RichTextWithButton( {
 } ) {
 	const [ mailpoetEmailData ] = useEntityProp(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		'mailpoet_data'
 	);
 

--- a/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
+++ b/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
@@ -10,9 +10,9 @@ import { PostPreviewButton } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import { SendPreviewEmail } from './send-preview-email';
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
+import { SendPreviewEmail } from './send-preview-email';
 
 export function PreviewDropdown() {
 	const previewDeviceType = useSelect(

--- a/packages/js/email-editor/src/components/preview/send-preview-email.tsx
+++ b/packages/js/email-editor/src/components/preview/send-preview-email.tsx
@@ -22,6 +22,7 @@ import {
 	MailPoetEmailData,
 	SendingPreviewStatus,
 	storeName,
+	editorCurrentPostType,
 } from '../../store';
 import { recordEvent, recordEventOnce } from '../../events';
 
@@ -43,7 +44,7 @@ function RawSendPreviewEmail() {
 
 	const [ mailpoetEmailData ] = useEntityProp(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		'mailpoet_data'
 	) as [ MailPoetEmailData, unknown, unknown ];
 

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -10,8 +10,9 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
+import { editorCurrentPostType } from '../../store';
 import { recordEvent } from '../../events';
+import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
 
 const previewTextMaxLength = 150;
 const previewTextRecommendedLength = 80;
@@ -19,7 +20,7 @@ const previewTextRecommendedLength = 80;
 export function DetailsPanel() {
 	const [ mailpoetEmailData ] = useEntityProp(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		'mailpoet_data'
 	);
 

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -16,6 +16,7 @@ import {
 	storeName,
 	TemplateCategory,
 	TemplatePreview,
+	editorCurrentPostType,
 } from '../../store';
 import { TemplateList } from './template-list';
 import { TemplateCategoriesListSidebar } from './template-categories-list-sidebar';
@@ -94,7 +95,7 @@ export function SelectTemplateModal( {
 	const hasTemplates = templates?.length > 0;
 
 	const handleTemplateSelection = ( template: TemplatePreview ) => {
-		const templateIsPostContent = template.type === 'mailpoet_email';
+		const templateIsPostContent = template.type === editorCurrentPostType;
 
 		const postContent = template.template as unknown as EmailEditorPostType;
 

--- a/packages/js/email-editor/src/components/template-select/select-modal.tsx
+++ b/packages/js/email-editor/src/components/template-select/select-modal.tsx
@@ -59,7 +59,7 @@ function SelectTemplateBody( {
 				setSelectedCategory( TemplateCategories[ 0 ].name );
 			}
 		}, 1000 ); // using setTimeout to ensure the template styles are available before block preview
-	}, [ hasEmailPosts ] );
+	}, [ hasEmailPosts, hideRecentCategory ] );
 
 	return (
 		<div className="block-editor-block-patterns-explorer">

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -12,7 +12,7 @@ import '@wordpress/format-library'; // Enables text formatting capabilities
 import { initBlocks } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { InnerEditor } from './components/block-editor';
-import { createStore, storeName } from './store';
+import { createStore, storeName, editorCurrentPostType } from './store';
 import { initHooks } from './editor-hooks';
 import { KeyboardShortcuts } from './components/keybord-shortcuts';
 import { initEventCollector } from './events';
@@ -33,7 +33,7 @@ function Editor() {
 			<InnerEditor
 				initialEdits={ [] }
 				postId={ postId }
-				postType="mailpoet_email"
+				postType={ editorCurrentPostType }
 				settings={ settings }
 			/>
 		</StrictMode>

--- a/packages/js/email-editor/src/global.d.ts
+++ b/packages/js/email-editor/src/global.d.ts
@@ -1,18 +1,12 @@
 interface Window {
 	MailPoetEmailEditor: {
-		json_api_root: string;
-		api_token: string;
-		api_version: string;
-		cdn_url: string;
-		is_premium_plugin_active: boolean;
 		current_wp_user_email: string;
 		user_theme_post_id: number;
 		urls: {
 			listings: string;
+			send: string;
 		};
 		editor_settings: unknown; // Can't import type in global.d.ts. Typed in getEditorSettings() in store/settings.ts
-		email_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailStyles() in store/settings.ts
-		editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts
 		editor_theme: unknown; // Can't import type in global.d.ts. Typed in getEditorTheme() in store/settings.ts
 		current_post_type: string;
 		current_post_id: string;

--- a/packages/js/email-editor/src/global.d.ts
+++ b/packages/js/email-editor/src/global.d.ts
@@ -16,4 +16,5 @@ interface Window {
 		editor_theme: unknown; // Can't import type in global.d.ts. Typed in getEditorTheme() in store/settings.ts
 	};
 	mailpoet_email_editor_current_post_type: string;
+	mailpoet_email_editor_current_post_id: number;
 }

--- a/packages/js/email-editor/src/global.d.ts
+++ b/packages/js/email-editor/src/global.d.ts
@@ -15,4 +15,5 @@ interface Window {
 		editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts
 		editor_theme: unknown; // Can't import type in global.d.ts. Typed in getEditorTheme() in store/settings.ts
 	};
+	mailpoet_email_editor_current_post_type: string;
 }

--- a/packages/js/email-editor/src/global.d.ts
+++ b/packages/js/email-editor/src/global.d.ts
@@ -14,7 +14,7 @@ interface Window {
 		email_styles: unknown; // Can't import type in global.d.ts. Typed in getEmailStyles() in store/settings.ts
 		editor_layout: unknown; // Can't import type in global.d.ts. Typed in getEmailLayout() in store/settings.ts
 		editor_theme: unknown; // Can't import type in global.d.ts. Typed in getEditorTheme() in store/settings.ts
+		current_post_type: string;
+		current_post_id: string;
 	};
-	mailpoet_email_editor_current_post_type: string;
-	mailpoet_email_editor_current_post_id: number;
 }

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -24,7 +24,11 @@ import {
 /**
  * Internal dependencies
  */
-import { storeName, mainSidebarDocumentTab } from './constants';
+import {
+	storeName,
+	mainSidebarDocumentTab,
+	editorCurrentPostType,
+} from './constants';
 import {
 	SendingPreviewStatus,
 	State,
@@ -99,7 +103,7 @@ export function* saveEditedEmail() {
 
 	const result = yield dispatch( coreDataStore ).saveEditedEntityRecord(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		postId,
 		{ throwOnError: true }
 	);
@@ -135,14 +139,14 @@ export function* updateEmailMailPoetProperty( name: string, value: string ) {
 	// There can be a better way how to get the edited post data
 	const editedPost = select( coreDataStore ).getEditedEntityRecord(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		postId
 	);
 	// @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
 	const mailpoetData = editedPost?.mailpoet_data || {};
 	yield dispatch( coreDataStore ).editEntityRecord(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		postId,
 		{
 			mailpoet_data: {
@@ -159,7 +163,7 @@ export const setTemplateToPost =
 		const postId = registry.select( storeName ).getEmailPostId();
 		registry
 			.dispatch( coreDataStore )
-			.editEntityRecord( 'postType', 'mailpoet_email', postId, {
+			.editEntityRecord( 'postType', editorCurrentPostType, postId, {
 				template: templateSlug,
 			} );
 	};

--- a/packages/js/email-editor/src/store/constants.ts
+++ b/packages/js/email-editor/src/store/constants.ts
@@ -4,3 +4,6 @@ export const mainSidebarId = 'email-editor/editor/main';
 export const mainSidebarDocumentTab = 'document';
 export const mainSidebarBlockTab = 'block';
 export const stylesSidebarId = 'email-editor/editor/styles';
+
+export const editorCurrentPostType =
+	window.mailpoet_email_editor_current_post_type;

--- a/packages/js/email-editor/src/store/constants.ts
+++ b/packages/js/email-editor/src/store/constants.ts
@@ -7,3 +7,4 @@ export const stylesSidebarId = 'email-editor/editor/styles';
 
 export const editorCurrentPostType =
 	window.mailpoet_email_editor_current_post_type;
+export const editorCurrentPostId = window.mailpoet_email_editor_current_post_id;

--- a/packages/js/email-editor/src/store/constants.ts
+++ b/packages/js/email-editor/src/store/constants.ts
@@ -5,6 +5,10 @@ export const mainSidebarDocumentTab = 'document';
 export const mainSidebarBlockTab = 'block';
 export const stylesSidebarId = 'email-editor/editor/styles';
 
+// these values are set once on a page load, so it's fine to keep them here.
 export const editorCurrentPostType =
-	window.mailpoet_email_editor_current_post_type;
-export const editorCurrentPostId = window.mailpoet_email_editor_current_post_id;
+	window.MailPoetEmailEditor.current_post_type;
+export const editorCurrentPostId = parseInt(
+	window.MailPoetEmailEditor.current_post_id,
+	10
+);

--- a/packages/js/email-editor/src/store/initial-state.ts
+++ b/packages/js/email-editor/src/store/initial-state.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mainSidebarDocumentTab } from './constants';
+import { mainSidebarDocumentTab, editorCurrentPostId } from './constants';
 import { State } from './types';
 import {
 	getEditorSettings,
@@ -12,8 +12,7 @@ import {
 } from './settings';
 
 export function getInitialState(): State {
-	const searchParams = new URLSearchParams( window.location.search );
-	const postId = parseInt( searchParams.get( 'post' ), 10 );
+	const postId = editorCurrentPostId;
 	return {
 		inserterSidebar: {
 			isOpened: false,

--- a/packages/js/email-editor/src/store/initial-state.ts
+++ b/packages/js/email-editor/src/store/initial-state.ts
@@ -3,13 +3,7 @@
  */
 import { mainSidebarDocumentTab, editorCurrentPostId } from './constants';
 import { State } from './types';
-import {
-	getEditorSettings,
-	getCdnUrl,
-	isPremiumPluginActive,
-	getEditorTheme,
-	getUrls,
-} from './settings';
+import { getEditorSettings, getEditorTheme, getUrls } from './settings';
 
 export function getInitialState(): State {
 	const postId = editorCurrentPostId;
@@ -30,8 +24,6 @@ export function getInitialState(): State {
 			globalStylesPostId: window.MailPoetEmailEditor.user_theme_post_id,
 		},
 		autosaveInterval: 60,
-		cdnUrl: getCdnUrl(),
-		isPremiumPluginActive: isPremiumPluginActive(),
 		urls: getUrls(),
 		preview: {
 			deviceType: 'Desktop',

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -353,14 +353,6 @@ export function getAutosaveInterval(
 	return state.autosaveInterval;
 }
 
-export function getCdnUrl( state: State ): State[ 'cdnUrl' ] {
-	return state.cdnUrl;
-}
-
-export function isPremiumPluginActive( state: State ): boolean {
-	return state.isPremiumPluginActive;
-}
-
 export function getTheme( state: State ): State[ 'theme' ] {
 	return state.theme;
 }

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -13,7 +13,7 @@ import { Post } from '@wordpress/core-data/build-types/entity-types/post';
 /**
  * Internal dependencies
  */
-import { storeName } from './constants';
+import { storeName, editorCurrentPostType } from './constants';
 import { State, Feature, EmailTemplate, EmailEditorPostType } from './types';
 
 function getContentFromEntity( entity ): string {
@@ -59,7 +59,7 @@ export const hasEdits = createRegistrySelector( ( select ) => (): boolean => {
 	const postId = select( storeName ).getEmailPostId();
 	return !! select( coreDataStore ).hasEditsForEntityRecord(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		postId
 	);
 } );
@@ -69,7 +69,7 @@ export const isEmailLoaded = createRegistrySelector(
 		const postId = select( storeName ).getEmailPostId();
 		return !! select( coreDataStore ).getEntityRecord(
 			'postType',
-			'mailpoet_email',
+			editorCurrentPostType,
 			postId
 		);
 	}
@@ -79,7 +79,7 @@ export const isSaving = createRegistrySelector( ( select ) => (): boolean => {
 	const postId = select( storeName ).getEmailPostId();
 	return !! select( coreDataStore ).isSavingEntityRecord(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		postId
 	);
 } );
@@ -89,7 +89,7 @@ export const isEmpty = createRegistrySelector( ( select ) => (): boolean => {
 
 	const post: EmailEditorPostType = select( coreDataStore ).getEntityRecord(
 		'postType',
-		'mailpoet_email',
+		editorCurrentPostType,
 		postId
 	);
 	if ( ! post ) {
@@ -111,7 +111,7 @@ export const hasEmptyContent = createRegistrySelector(
 
 		const post = select( coreDataStore ).getEntityRecord(
 			'postType',
-			'mailpoet_email',
+			editorCurrentPostType,
 			postId
 		);
 		if ( ! post ) {
@@ -130,7 +130,7 @@ export const isEmailSent = createRegistrySelector(
 
 		const post = select( coreDataStore ).getEntityRecord(
 			'postType',
-			'mailpoet_email',
+			editorCurrentPostType,
 			postId
 		);
 		if ( ! post ) {
@@ -154,7 +154,7 @@ export const getEditedEmailContent = createRegistrySelector(
 		const postId = select( storeName ).getEmailPostId();
 		const record = select( coreDataStore ).getEditedEntityRecord(
 			'postType',
-			'mailpoet_email',
+			editorCurrentPostType,
 			postId
 		) as unknown as
 			| { content: string | unknown; blocks: BlockInstance[] }
@@ -170,7 +170,7 @@ export const getEditedEmailContent = createRegistrySelector(
 export const getSentEmailEditorPosts = createRegistrySelector(
 	( select ) => () =>
 		select( coreDataStore )
-			.getEntityRecords( 'postType', 'mailpoet_email', {
+			.getEntityRecords( 'postType', editorCurrentPostType, {
 				per_page: 30, // show a maximum of 30 for now
 				status: 'publish,sent', // show only sent emails
 			} )
@@ -290,13 +290,13 @@ export const getEmailTemplates = createRegistrySelector(
 		select( coreDataStore )
 			.getEntityRecords( 'postType', 'wp_template', {
 				per_page: -1,
-				post_type: 'mailpoet_email',
+				post_type: editorCurrentPostType,
 			} )
 			// We still need to filter the templates because, in some cases, the API also returns custom templates
 			// ignoring the post_type filter in the query
 			?.filter( ( template ) =>
 				// @ts-expect-error Missing property in type
-				template.post_types.includes( 'mailpoet_email' )
+				template.post_types.includes( editorCurrentPostType )
 			)
 );
 

--- a/packages/js/email-editor/src/store/settings.ts
+++ b/packages/js/email-editor/src/store/settings.ts
@@ -7,14 +7,6 @@ export function getEditorSettings(): EmailEditorSettings {
 	return window.MailPoetEmailEditor.editor_settings as EmailEditorSettings;
 }
 
-export function getCdnUrl(): string {
-	return window.MailPoetEmailEditor.cdn_url;
-}
-
-export function isPremiumPluginActive(): boolean {
-	return window.MailPoetEmailEditor.is_premium_plugin_active;
-}
-
 export function getEditorTheme(): EmailTheme {
 	return window.MailPoetEmailEditor.editor_theme as EmailTheme;
 }

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -195,9 +195,7 @@ export type State = {
 		globalStylesPostId: number | null;
 	};
 	autosaveInterval: number;
-	cdnUrl: string;
 	urls: EmailEditorUrls;
-	isPremiumPluginActive: boolean;
 	preview: {
 		deviceType: string;
 		toEmail: string;

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -268,6 +268,6 @@ export type MailPoetEmailPostContentExtended = {
 };
 
 export type EmailEditorPostType = Omit< Post, 'type' > & {
-	type: 'mailpoet_email';
+	type: string;
 	mailpoet_data?: MailPoetEmailPostContentExtended;
 };

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -76,5 +76,4 @@ We may add, update and delete any of them.
 
 ## TODO
 - We use `mailpoet_data` in some section of the codebase. This will be updated.
-- Native email editor implementation for the `preview_url`.
 - The content validation in the editor looks for the unsubscribe link tag, which is registered in the MailPoet plugin. We need either introduce generic unsubscribe link tag or move the validation to the MailPoet plugin.

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -77,5 +77,4 @@ We may add, update and delete any of them.
 ## TODO
 - We use `mailpoet_data` in some section of the codebase. This will be updated.
 - Native email editor implementation for the `preview_url`.
-- We currently support post editing context (a post has to be created before we can use the editor). We need to add support for creation context.
 - The content validation in the editor looks for the unsubscribe link tag, which is registered in the MailPoet plugin. We need either introduce generic unsubscribe link tag or move the validation to the MailPoet plugin.

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -75,8 +75,6 @@ We may add, update and delete any of them.
 | `mailpoet_email_editor_send_preview_email` | `Array` $postData                         | `boolean` Result of processing. Was email sent successfully? | Allows override of the send preview mail function. Folks may choose to use custom implementation                                                                    |
 
 ## TODO
-- The editor may not start if the URL starts with just `wp-admin/post-new.php?post_type=mailpoet_email` without the post id.
-- Most of the email editor logic heavily depends on the `mailpoet_email` post-type. This is a known issue and we are working to fix it.
 - We use `mailpoet_data` in some section of the codebase. This will be updated.
 - Native email editor implementation for the `preview_url`.
 - We currently support post editing context (a post has to be created before we can use the editor). We need to add support for creation context.

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -185,6 +185,7 @@ class Email_Editor {
 			'has_archive'            => true,
 			'show_in_rest'           => true, // Important to enable Gutenberg editor.
 			'default_rendering_mode' => 'template-locked',
+			'publicly_queryable'     => true,  // required by the preview in new tab feature.
 		);
 	}
 

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -317,7 +317,8 @@ class Email_Editor {
 
 		?>
 		<script type="text/javascript"> <?php // phpcs:ignore ?>
-			window.mailpoet_email_editor_current_post_type = <?php echo wp_json_encode( $email_editor_current_post_type ); ?>;
+			window.mailpoet_email_editor_current_post_type = '<?php echo esc_js( $email_editor_current_post_type ); ?>';
+			window.mailpoet_email_editor_current_post_id = <?php echo esc_js( $post->ID ); ?>;
 		</script>
 		<?php
 	}

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -105,6 +105,7 @@ class Email_Editor {
 		if ( $is_editor_page ) {
 			$this->extend_email_post_api();
 			$this->settings_controller->init();
+			add_filter( 'admin_footer', array( $this, 'load_js_vars' ), 24 ); // @phpstan-ignore-line -- Filter callback return statement is missing.
 		}
 		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
 		add_filter( 'mailpoet_email_editor_send_preview_email', array( $this->send_preview_email, 'send_preview_email' ), 11, 1 ); // allow for other filter methods to take precedent.
@@ -295,5 +296,29 @@ class Email_Editor {
 		);
 
 		return __DIR__ . '/Templates/single-email-post-template.php';
+	}
+
+	/**
+	 * Load JS vars
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException If the post-type is invalid.
+	 */
+	public function load_js_vars() {
+		global $post;
+
+		$email_editor_post_type_names      = array_column( $this->get_post_types(), 'name' );
+		$email_editor_current_post_type    = $post->post_type;
+		$current_post_is_email_editor_type = in_array( $email_editor_current_post_type, $email_editor_post_type_names, true );
+
+		if ( ! $current_post_is_email_editor_type ) {
+			throw new \InvalidArgumentException( esc_html__( 'Invalid email post type', 'mailpoet' ) );
+		}
+
+		?>
+		<script type="text/javascript"> <?php // phpcs:ignore ?>
+			window.mailpoet_email_editor_current_post_type = <?php echo wp_json_encode( $email_editor_current_post_type ); ?>;
+		</script>
+		<?php
 	}
 }


### PR DESCRIPTION
## Description

Refactor and remove the dependency on the mailpoet_email post-type

## Code review notes


Please try switching the [MAILPOET_EMAIL_POST_TYPE](https://github.com/mailpoet/mailpoet/blob/94115d0ef2a532bbbb7747e8a9cd6f8b71181cfa/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php#L10) from `mailpoet_email` to another string variable and confirm the editor works.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6430](https://mailpoet.atlassian.net/browse/MAILPOET-6430)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6430]: https://mailpoet.atlassian.net/browse/MAILPOET-6430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:refactor-and-remove-the-dependency-on-the-mailpoet_email-post-type)

_The latest successful build from `refactor-and-remove-the-dependency-on-the-mailpoet_email-post-type` will be used. If none is available, the link won't work._