### PR TITLE
Moving fetching iframed assets into get_settings method

### DIFF
--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -42,13 +42,6 @@ class Email_Editor {
 	 */
 	private Patterns $patterns;
 	/**
-	 * Property for the settings controller.
-	 *
-	 * @var Settings_Controller Settings controller.
-	 */
-	private Settings_Controller $settings_controller;
-
-	/**
 	 * Property for the send preview email controller.
 	 *
 	 * @var Send_Preview_Email Send Preview controller.
@@ -68,7 +61,6 @@ class Email_Editor {
 	 * @param Email_Api_Controller          $email_api_controller Email API controller.
 	 * @param Templates                     $templates Templates.
 	 * @param Patterns                      $patterns Patterns.
-	 * @param Settings_Controller           $settings_controller Settings controller.
 	 * @param Send_Preview_Email            $send_preview_email Preview email controller.
 	 * @param Personalization_Tags_Registry $personalization_tags_controller Personalization tags registry that allows initializing personalization tags.
 	 */
@@ -76,14 +68,12 @@ class Email_Editor {
 		Email_Api_Controller $email_api_controller,
 		Templates $templates,
 		Patterns $patterns,
-		Settings_Controller $settings_controller,
 		Send_Preview_Email $send_preview_email,
 		Personalization_Tags_Registry $personalization_tags_controller
 	) {
 		$this->email_api_controller          = $email_api_controller;
 		$this->templates                     = $templates;
 		$this->patterns                      = $patterns;
-		$this->settings_controller           = $settings_controller;
 		$this->send_preview_email            = $send_preview_email;
 		$this->personalization_tags_registry = $personalization_tags_controller;
 	}
@@ -104,7 +94,6 @@ class Email_Editor {
 		$is_editor_page = apply_filters( 'mailpoet_is_email_editor_page', false );
 		if ( $is_editor_page ) {
 			$this->extend_email_post_api();
-			$this->settings_controller->init();
 		}
 		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
 		add_filter( 'mailpoet_email_editor_send_preview_email', array( $this->send_preview_email, 'send_preview_email' ), 11, 1 ); // allow for other filter methods to take precedent.

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -57,39 +57,13 @@ class Settings_Controller {
 	}
 
 	/**
-	 * Method to initialize the settings controller.
-	 *
-	 * @return void
-	 */
-	public function init(): void {
-		/*
-		 * We need to initialize these assets early because they are read from global variables $wp_styles and $wp_scripts
-		 * and in later WordPress page load pages they contain stuff we don't want (e.g. html for admin login popup)
-		 * in the post editor this is called directly in post.php.
-		 */
-		$this->iframe_assets = _wp_get_iframed_editor_assets();
-
-		// Remove layout styles and block library for classic themes. They are added only when a classic theme is active
-		// and they add unwanted margins and paddings in the editor content.
-		$cleaned_styles = array();
-		foreach ( explode( "\n", (string) $this->iframe_assets['styles'] ) as $asset ) {
-			if ( strpos( $asset, 'wp-editor-classic-layout-styles-css' ) !== false ) {
-				continue;
-			}
-			if ( strpos( $asset, 'wp-block-library-theme-css' ) !== false ) {
-				continue;
-			}
-			$cleaned_styles[] = $asset;
-		}
-		$this->iframe_assets['styles'] = implode( "\n", $cleaned_styles );
-	}
-
-	/**
 	 * Get the settings for the email editor.
 	 *
 	 * @return array
 	 */
 	public function get_settings(): array {
+		$this->init_iframe_assets();
+
 		$core_default_settings = \get_default_block_editor_settings();
 		$theme_settings        = $this->theme_controller->get_settings();
 
@@ -214,5 +188,32 @@ class Settings_Controller {
 	 */
 	public function translate_slug_to_color( string $color_slug ): string {
 		return $this->theme_controller->translate_slug_to_color( $color_slug );
+	}
+
+	/**
+	 * Method to initialize iframe assets.
+	 *
+	 * @return void
+	 */
+	private function init_iframe_assets(): void {
+		if ( ! empty( $this->iframe_assets ) ) {
+			return;
+		}
+
+		$this->iframe_assets = _wp_get_iframed_editor_assets();
+
+		// Remove layout styles and block library for classic themes. They are added only when a classic theme is active
+		// and they add unwanted margins and paddings in the editor content.
+		$cleaned_styles = array();
+		foreach ( explode( "\n", (string) $this->iframe_assets['styles'] ) as $asset ) {
+			if ( strpos( $asset, 'wp-editor-classic-layout-styles-css' ) !== false ) {
+				continue;
+			}
+			if ( strpos( $asset, 'wp-block-library-theme-css' ) !== false ) {
+				continue;
+			}
+			$cleaned_styles[] = $asset;
+		}
+		$this->iframe_assets['styles'] = implode( "\n", $cleaned_styles );
 	}
 }

--- a/packages/php/email-editor/tests/integration/_bootstrap.php
+++ b/packages/php/email-editor/tests/integration/_bootstrap.php
@@ -317,7 +317,6 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 					$container->get( Email_Api_Controller::class ),
 					$container->get( Templates::class ),
 					$container->get( Patterns::class ),
-					$container->get( Settings_Controller::class ),
 					$container->get( Send_Preview_Email::class ),
 					$container->get( Personalization_Tags_Registry::class ),
 				);


### PR DESCRIPTION
## Description

Because we called the function for getting editor iframe assets in the nit hook, it could cause some properties to not be set yet. This PR moves to get assets into the `get_settings` method to avoid getting a property on null.


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:iframe-assets-fix)

_The latest successful build from `iframe-assets-fix` will be used. If none is available, the link won't work._