### PR TITLE
Ensure that email content patterns are not use as page starter patterns [MAILPOET-6458]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/OneColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/OneColumn.php
@@ -6,7 +6,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
 
 class OneColumn extends Pattern {
   protected $name = '1-column-content';
-  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $block_types = []; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $categories = ['email-contents'];
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ThreeColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ThreeColumn.php
@@ -6,7 +6,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
 
 class ThreeColumn extends Pattern {
   protected $name = '3-column-content';
-  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $block_types = []; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $categories = ['email-contents'];
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TwoColumn.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/TwoColumn.php
@@ -6,7 +6,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
 
 class TwoColumn extends Pattern {
   protected $name = '2-column-content';
-  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $block_types = []; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $categories = ['email-contents'];
 


### PR DESCRIPTION
## Description

This PR fixes the issue of email content patterns (1 Column, 2 Columns, etc.) being displayed among starter patterns for pages and posts in the site editor. 

## Code review notes
I removed "core/post-content" from block_types from the email content patterns. The configuration was causing the patterns to be presented in the site editor as starter patterns for pages and posts. We have [recently changed](https://github.com/mailpoet/mailpoet/pull/6066) how we fetch the patterns, and we no longer use block_types for that.


## QA notes

#### Replication 

1) Go to the site editor
2) Create a new page
3) Observe that email patterns are present. 

Please also check that the email editor's email preset selection works as expected.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6458]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6458]: https://mailpoet.atlassian.net/browse/MAILPOET-6458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-email-patterns-as-page-starter-patterns)

_The latest successful build from `fix-email-patterns-as-page-starter-patterns` will be used. If none is available, the link won't work._