### PR TITLE
Fix Uncaught TypeError due to a type hint which affects some platforms

### DIFF
--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -279,7 +279,7 @@ class Email_Editor {
 	 * @param string $template post template.
 	 * @return string
 	 */
-	public function load_email_preview_template( string $template ): string {
+	public function load_email_preview_template( $template ): string {
 		$post = $this->get_current_post();
 
 		if ( ! $post instanceof \WP_Post ) {

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -279,7 +279,7 @@ class Email_Editor {
 	 * @param string $template post template.
 	 * @return string
 	 */
-	public function load_email_preview_template( $template ): string {
+	public function load_email_preview_template( $template ) {
 		$post = $this->get_current_post();
 
 		if ( ! $post instanceof \WP_Post ) {


### PR DESCRIPTION
## Description

According to the [docs](https://developer.wordpress.org/reference/hooks/type_template/), this should be a string, but using NULL here as an input leads to a TypeError.

See p1738738617227929-slack-C01H71ZLBGQ for more information.

## Code review notes

_N/A_

## QA notes

We can skip QA.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-error-notice)

_The latest successful build from `fix-error-notice` will be used. If none is available, the link won't work._