### PR TITLE
Fix locking in the Newsletter template [MAILPOET-6461]

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
@@ -28,7 +28,7 @@ class Newsletter {
   public function getContent(): string {
     // translators: This is a text used in a footer on an email <!--[mailpoet/site-title]--> will be replaced with the site title.
     $footerText = __('You received this email because you are subscribed to the <!--[mailpoet/site-title]-->', 'mailpoet');
-    return '<!-- wp:group {"backgroundColor":"white","layout":{"type":"constrained"},"lock":{"move":false,"remove":false}} -->
+    return '<!-- wp:group {"backgroundColor":"white","layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} -->
       <div class="wp-block-group has-white-background-color has-background">
         <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
         <div
@@ -51,7 +51,7 @@ class Newsletter {
           <!-- /wp:image -->
         </div>
         <!-- /wp:group -->
-        <!-- wp:post-content {"lock":{"move":false,"remove":false},"layout":{"type":"default"}} /-->
+        <!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"default"}} /-->
         <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"var:preset|spacing|20","top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
         <div
           class="wp-block-group"


### PR DESCRIPTION
## Description

This PR fixes the issue of deleting the content block from the "Newsletter" template. With the new setting, users can move the blocks but can't remove them.

## Code review notes

I applied the setting on the parent block because deleting it would also delete the content. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6461]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6461]: https://mailpoet.atlassian.net/browse/MAILPOET-6461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-template-lock)

_The latest successful build from `fix-template-lock` will be used. If none is available, the link won't work._