### PR TITLE
Update the use of mailpoet data in the editor codebase - MAILPOET-6431

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
@@ -1,0 +1,151 @@
+import {
+  ExternalLink,
+  __experimentalText as Text, // eslint-disable-line
+  TextareaControl,
+} from '@wordpress/components';
+import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import classnames from 'classnames';
+
+const previewTextMaxLength = 150;
+const previewTextRecommendedLength = 80;
+
+export function EmailSidebarExtension() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+
+  const updateEmailMailPoetProperty = (name: string, value: string) => {
+    const postId = select(editorStore).getCurrentPostId();
+    const currentPostType = 'mailpoet_email'; // only for mailpoet_email post-type
+
+    const editedPost = select(coreDataStore).getEditedEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+    );
+
+    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+    const mailpoetData = editedPost?.mailpoet_data || {};
+    void dispatch(coreDataStore).editEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+      {
+        mailpoet_data: {
+          ...mailpoetData,
+          [name]: value,
+        },
+      },
+    );
+  };
+
+  const subjectHelp = createInterpolateElement(
+    __(
+      'Use shortcodes to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
+      'mailpoet',
+    ),
+    {
+      bestPracticeLink: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
+          target="_blank"
+          rel="noopener noreferrer"
+        />
+      ),
+      emojiLink: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
+          target="_blank"
+          rel="noopener noreferrer"
+        />
+      ),
+    },
+  );
+
+  const subjectLabel = (
+    <>
+      <span>{__('Subject', 'mailpoet')}</span>
+      <ExternalLink href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes#list">
+        {__('Shortcode guide', 'mailpoet')}
+      </ExternalLink>
+    </>
+  );
+
+  const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
+
+  const preheaderLabel = (
+    <>
+      <span>{__('Preview text', 'mailpoet')}</span>
+      <span
+        className={classnames('mailpoet-settings-panel__preview-text-length', {
+          'mailpoet-settings-panel__preview-text-length-warning':
+            previewTextLength > previewTextRecommendedLength,
+          'mailpoet-settings-panel__preview-text-length-error':
+            previewTextLength > previewTextMaxLength,
+        })}
+      >
+        {previewTextLength}/{previewTextMaxLength}
+      </span>
+    </>
+  );
+
+  return (
+    <>
+      <TextareaControl
+        className="mailpoet-settings-panel__subject"
+        label={subjectLabel}
+        placeholder={__('Eg. The summer sale is here!', 'mailpoet')}
+        value={mailpoetEmailData?.subject ?? ''}
+        onChange={(value) => updateEmailMailPoetProperty('subject', value)}
+        data-automation-id="email_subject"
+      />
+      <div className="mailpoet-settings-panel__help">
+        <Text>{subjectHelp}</Text>
+      </div>
+
+      <TextareaControl
+        className="mailpoet-settings-panel__preview-text"
+        label={preheaderLabel}
+        placeholder={__(
+          "Add a preview text to capture subscribers' attention and increase open rates.",
+          'mailpoet',
+        )}
+        value={mailpoetEmailData?.preheader ?? ''}
+        onChange={(value) => updateEmailMailPoetProperty('preheader', value)}
+        data-automation-id="email_preview_text"
+      />
+      <div className="mailpoet-settings-panel__help">
+        <Text>
+          {createInterpolateElement(
+            __(
+              '<link>This text</link> will appear in the inbox, underneath the subject line.',
+              'mailpoet',
+            ),
+            {
+              link: (
+                // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                <a
+                  href={new URL(
+                    'article/418-preview-text',
+                    'https://kb.mailpoet.com/',
+                  ).toString()}
+                  key="preview-text-kb"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+            },
+          )}
+        </Text>
+      </div>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
@@ -93,7 +93,7 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
     <>
       <RichTextWithButton
         attributeName="subject"
-        attributeValue={mailpoetEmailData?.subject || ' '}
+        attributeValue={mailpoetEmailData?.subject}
         updateProperty={updateEmailMailPoetProperty}
         label={__('Subject', 'mailpoet')}
         labelSuffix={
@@ -109,7 +109,7 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
 
       <RichTextWithButton
         attributeName="preheader"
-        attributeValue={mailpoetEmailData?.preheader || 'preheader'}
+        attributeValue={mailpoetEmailData?.preheader}
         updateProperty={updateEmailMailPoetProperty}
         label={__('Preview text', 'mailpoet')}
         labelSuffix={

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
@@ -1,8 +1,4 @@
-import {
-  ExternalLink,
-  __experimentalText as Text, // eslint-disable-line
-  TextareaControl,
-} from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
@@ -13,7 +9,7 @@ import classnames from 'classnames';
 const previewTextMaxLength = 150;
 const previewTextRecommendedLength = 80;
 
-export function EmailSidebarExtension() {
+export function EmailSidebarExtensionBody({ RichTextWithButton }) {
   const [mailpoetEmailData] = useEntityProp(
     'postType',
     'mailpoet_email',
@@ -47,7 +43,7 @@ export function EmailSidebarExtension() {
 
   const subjectHelp = createInterpolateElement(
     __(
-      'Use shortcodes to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
+      'Use personalization tags to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
       'mailpoet',
     ),
     {
@@ -57,6 +53,7 @@ export function EmailSidebarExtension() {
           href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => {}}
         />
       ),
       emojiLink: (
@@ -65,87 +62,87 @@ export function EmailSidebarExtension() {
           href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => {}}
         />
       ),
     },
   );
 
-  const subjectLabel = (
-    <>
-      <span>{__('Subject', 'mailpoet')}</span>
-      <ExternalLink href="https://kb.mailpoet.com/article/215-personalize-newsletter-with-shortcodes#list">
-        {__('Shortcode guide', 'mailpoet')}
-      </ExternalLink>
-    </>
-  );
-
   const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
 
-  const preheaderLabel = (
-    <>
-      <span>{__('Preview text', 'mailpoet')}</span>
-      <span
-        className={classnames('mailpoet-settings-panel__preview-text-length', {
-          'mailpoet-settings-panel__preview-text-length-warning':
-            previewTextLength > previewTextRecommendedLength,
-          'mailpoet-settings-panel__preview-text-length-error':
-            previewTextLength > previewTextMaxLength,
-        })}
-      >
-        {previewTextLength}/{previewTextMaxLength}
-      </span>
-    </>
+  const preheaderHelp = createInterpolateElement(
+    __(
+      '<link>This text</link> will appear in the inbox, underneath the subject line.',
+      'mailpoet',
+    ),
+    {
+      link: (
+        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+        <a
+          href={new URL(
+            'article/418-preview-text',
+            'https://kb.mailpoet.com/',
+          ).toString()}
+          key="preview-text-kb"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => {}}
+        />
+      ),
+    },
   );
 
   return (
     <>
-      <TextareaControl
-        className="mailpoet-settings-panel__subject"
-        label={subjectLabel}
+      <RichTextWithButton
+        attributeName="subject"
+        attributeValue={mailpoetEmailData?.subject || 'subject'}
+        updateProperty={updateEmailMailPoetProperty}
+        label={__('Subject', 'mailpoet')}
+        labelSuffix={
+          <ExternalLink
+            href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list"
+            onClick={() => {}}
+          >
+            {__('Guide', 'mailpoet')}
+          </ExternalLink>
+        }
+        help={subjectHelp}
         placeholder={__('Eg. The summer sale is here!', 'mailpoet')}
-        value={mailpoetEmailData?.subject ?? ''}
-        onChange={(value) => updateEmailMailPoetProperty('subject', value)}
-        data-automation-id="email_subject"
       />
-      <div className="mailpoet-settings-panel__help">
-        <Text>{subjectHelp}</Text>
-      </div>
 
-      <TextareaControl
-        className="mailpoet-settings-panel__preview-text"
-        label={preheaderLabel}
+      <br />
+
+      <RichTextWithButton
+        attributeName="preheader"
+        attributeValue={mailpoetEmailData?.preheader || 'preheader'}
+        updateProperty={updateEmailMailPoetProperty}
+        label={__('Preview text', 'mailpoet')}
+        labelSuffix={
+          <span
+            className={classnames(
+              'mailpoet-settings-panel__preview-text-length',
+              {
+                'mailpoet-settings-panel__preview-text-length-warning':
+                  previewTextLength > previewTextRecommendedLength,
+                'mailpoet-settings-panel__preview-text-length-error':
+                  previewTextLength > previewTextMaxLength,
+              },
+            )}
+          >
+            {previewTextLength}/{previewTextMaxLength}
+          </span>
+        }
+        help={preheaderHelp}
         placeholder={__(
           "Add a preview text to capture subscribers' attention and increase open rates.",
           'mailpoet',
         )}
-        value={mailpoetEmailData?.preheader ?? ''}
-        onChange={(value) => updateEmailMailPoetProperty('preheader', value)}
-        data-automation-id="email_preview_text"
       />
-      <div className="mailpoet-settings-panel__help">
-        <Text>
-          {createInterpolateElement(
-            __(
-              '<link>This text</link> will appear in the inbox, underneath the subject line.',
-              'mailpoet',
-            ),
-            {
-              link: (
-                // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                <a
-                  href={new URL(
-                    'article/418-preview-text',
-                    'https://kb.mailpoet.com/',
-                  ).toString()}
-                  key="preview-text-kb"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              ),
-            },
-          )}
-        </Text>
-      </div>
     </>
   );
+}
+
+export function EmailSidebarExtension(RichTextWithButton: JSX.Element) {
+  return <EmailSidebarExtensionBody RichTextWithButton={RichTextWithButton} />;
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
@@ -93,7 +93,7 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
     <>
       <RichTextWithButton
         attributeName="subject"
-        attributeValue={mailpoetEmailData?.subject || 'subject'}
+        attributeValue={mailpoetEmailData?.subject || ' '}
         updateProperty={updateEmailMailPoetProperty}
         label={__('Subject', 'mailpoet')}
         labelSuffix={

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
@@ -53,7 +53,6 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
           href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => {}}
         />
       ),
       emojiLink: (
@@ -62,7 +61,6 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
           href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => {}}
         />
       ),
     },
@@ -86,7 +84,6 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
           key="preview-text-kb"
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => {}}
         />
       ),
     },
@@ -100,10 +97,7 @@ export function EmailSidebarExtensionBody({ RichTextWithButton }) {
         updateProperty={updateEmailMailPoetProperty}
         label={__('Subject', 'mailpoet')}
         labelSuffix={
-          <ExternalLink
-            href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list"
-            onClick={() => {}}
-          >
+          <ExternalLink href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list">
             {__('Guide', 'mailpoet')}
           </ExternalLink>
         }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -5,6 +5,7 @@
 import { addFilter, addAction } from '@wordpress/hooks';
 import { MailPoet } from 'mailpoet';
 import { withSatismeterSurvey } from './satismeter-survey';
+import { EmailSidebarExtension } from './email-sidebar-extension';
 import './index.scss';
 import { useValidationRules } from './validate-email-content';
 
@@ -52,4 +53,11 @@ addFilter(
   'mailpoet_email_editor_events_tracking_enabled',
   'mailpoet',
   () => !!window.mailpoet_analytics_enabled,
+);
+
+// integration point for settings sidebar
+addFilter(
+  'mailpoet_email_editor_setting_sidebar_extension_component',
+  'mailpoet',
+  () => EmailSidebarExtension,
 );

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -13,10 +13,12 @@ addFilter('mailpoet_email_editor_wrap_editor_component', 'mailpoet', (editor) =>
   withSatismeterSurvey(editor),
 );
 
+// validate email editor content using the defined validation rules
+// content is first validated when the "Send" button is clicked and revalidated on "Save Draft"
 addFilter(
   'mailpoet_email_editor_content_validation_rules',
   'mailpoet',
-  (validationRules: []) => [...validationRules, ...useValidationRules()],
+  () => useValidationRules(), // returns a memorized set of rules (array of rules)
 );
 
 const EVENTS_TO_TRACK = [

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -62,3 +62,14 @@ addFilter(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   (RichTextWithButton) => EmailSidebarExtension.bind(null, RichTextWithButton),
 );
+
+// use mailpoet data subject if available
+addFilter(
+  'mailpoet_email_editor_preferred_template_title',
+  'mailpoet',
+  (...args) => {
+    const [, post] = args;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return post?.mailpoet_data?.subject || ''; // use MailPoet subject as title
+  },
+);

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -59,5 +59,6 @@ addFilter(
 addFilter(
   'mailpoet_email_editor_setting_sidebar_extension_component',
   'mailpoet',
-  () => EmailSidebarExtension,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  (RichTextWithButton) => EmailSidebarExtension.bind(null, RichTextWithButton),
 );

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
@@ -64,12 +64,14 @@ export function useValidationRules() {
             label: __('Insert link', 'mailpoet'),
             onClick: () => {
               if (!hasFooter) {
+                // update the email content
                 void dispatch(blockEditorStore).insertBlock(
                   linksParagraphBlock,
                   undefined,
                   contentBlockId,
                 );
               } else {
+                // update the template
                 void dispatch(coreDataStore).editEntityRecord(
                   'postType',
                   'wp_template',

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
@@ -35,7 +35,7 @@ class EmailEditorPreviewEmail {
   }
 
   private function validateData($data) {
-    if (empty($data['email']) || empty($data['postId']) || empty($data['newsletterId'])) {
+    if (empty($data['email']) || empty($data['postId'])) {
       throw new \InvalidArgumentException(esc_html__('Missing required data', 'mailpoet'));
     }
 
@@ -50,9 +50,9 @@ class EmailEditorPreviewEmail {
    * @throws \Exception
    */
   private function fetchNewsletter($postData): NewsletterEntity {
-    $newsletter = $this->newslettersRepository->findOneById((int)$postData['newsletterId']);
+    $newsletter = $this->newslettersRepository->findOneBy(['wpPost' => (int)$postData['postId']]);
 
-    if (!$newsletter) {
+    if (!$newsletter instanceof NewsletterEntity) {
       throw new \Exception(esc_html__('This email does not exist.', 'mailpoet'));
     }
 

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -59,7 +59,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('[data-automation-id="email_editor_send_button"]');
     $i->waitForElement('[name="subject"]');
     $subject = $i->grabValueFrom('[name="subject"]');
-    verify($subject)->equals('My New Subject '); // we need extra space here because the subject input-textarea contains some space as default
+    verify($subject)->equals('My New Subject');
     $i->waitForText('My New Preview Text');
     $i->fillField('sender_name', 'John Doe');
     $i->fillField('sender_address', 'john.doe@example.com');

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -59,7 +59,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('[data-automation-id="email_editor_send_button"]');
     $i->waitForElement('[name="subject"]');
     $subject = $i->grabValueFrom('[name="subject"]');
-    verify($subject)->equals('My New Subject ');
+    verify($subject)->equals('My New Subject '); // we need extra space here because the subject input-textarea contains some space as default
     $i->waitForText('My New Preview Text');
     $i->fillField('sender_name', 'John Doe');
     $i->fillField('sender_address', 'john.doe@example.com');

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -55,10 +55,11 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('Save Draft');
     $i->waitForText('Saved');
     $i->waitForText('Email saved!');
-    $i->click('Send');
+    $i->click('[aria-label="Close sidebar"]'); // close the sidebar. It sometimes interferes with the send button click
+    $i->click('[data-automation-id="email_editor_send_button"]');
     $i->waitForElement('[name="subject"]');
     $subject = $i->grabValueFrom('[name="subject"]');
-    verify($subject)->equals('My New Subject');
+    verify($subject)->equals('My New Subject ');
     $i->waitForText('My New Preview Text');
     $i->fillField('sender_name', 'John Doe');
     $i->fillField('sender_address', 'john.doe@example.com');

--- a/packages/js/email-editor/src/components/header/more-menu.tsx
+++ b/packages/js/email-editor/src/components/header/more-menu.tsx
@@ -35,8 +35,7 @@ export function MoreMenu(): JSX.Element {
 		editorCurrentPostType,
 		'status'
 	);
-	const { saveEditedEmail, updateEmailMailPoetProperty } =
-		useDispatch( storeName );
+	const { saveEditedEmail } = useDispatch( storeName );
 	const goToListings = () => {
 		window.location.href = urls.listings;
 	};
@@ -132,10 +131,6 @@ export function MoreMenu(): JSX.Element {
 								<MenuItem
 									onClick={ async () => {
 										await setStatus( 'draft' );
-										await updateEmailMailPoetProperty(
-											'deleted_at',
-											''
-										);
 										await saveEditedEmail();
 										recordEvent(
 											'header_more_menu_restore_from_trash_button_clicked'

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -63,6 +63,7 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 				}
 			} }
 			disabled={ isDisabled }
+			data-automation-id="email_editor_send_button"
 		>
 			{ label }
 		</Button>

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-utils.ts
@@ -18,7 +18,7 @@ type Replacement = {
 function getChildElement( rootElement: HTMLElement ): HTMLElement | null {
 	let currentElement: HTMLElement | null = rootElement;
 
-	while ( currentElement && currentElement.children.length > 0 ) {
+	while ( currentElement && currentElement?.children?.length > 0 ) {
 		// Traverse into the first child element
 		currentElement = currentElement.children[ 0 ] as HTMLElement;
 	}

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import type { ReactNode } from 'react';
 import { BaseControl, Button } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
-import { useEntityProp } from '@wordpress/core-data';
 import { create, insert, toHTMLString } from '@wordpress/rich-text';
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
@@ -17,9 +17,22 @@ import {
 	getCursorPosition,
 	replacePersonalizationTagsWithHTMLComments,
 } from './rich-text-utils';
-import { storeName, editorCurrentPostType } from '../../store';
+import { storeName } from '../../store';
 import { PersonalizationTagsPopover } from './personalization-tags-popover';
 import { recordEvent, recordEventOnce } from '../../events';
+
+type Props = {
+	label: string;
+	labelSuffix?: ReactNode;
+	help?: ReactNode;
+	placeholder: string;
+	attributeName: string;
+	attributeValue?: string;
+	updateProperty: (
+		theAttributeName: string,
+		theUpdatedValue: string
+	) => void;
+};
 
 export function RichTextWithButton( {
 	label,
@@ -27,15 +40,9 @@ export function RichTextWithButton( {
 	help,
 	placeholder,
 	attributeName,
-} ) {
-	const [ mailpoetEmailData ] = useEntityProp(
-		'postType',
-		editorCurrentPostType,
-		'mailpoet_data'
-	);
-
-	const { updateEmailMailPoetProperty } = useDispatch( storeName );
-
+	attributeValue,
+	updateProperty = () => {},
+}: Props ) {
 	const [ selectionRange, setSelectionRange ] = useState( null );
 	const [ isModalOpened, setIsModalOpened ] = useState( false );
 	const list = useSelect(
@@ -61,11 +68,11 @@ export function RichTextWithButton( {
 			const updatedValue = toHTMLString( { value: richTextValue } );
 
 			// Update the corresponding property
-			updateEmailMailPoetProperty( attributeName, updatedValue );
+			updateProperty( attributeName, updatedValue );
 
 			setSelectionRange( null );
 		},
-		[ attributeName, updateEmailMailPoetProperty ]
+		[ attributeName, updateProperty ]
 	);
 
 	const finalLabel = (
@@ -90,7 +97,7 @@ export function RichTextWithButton( {
 		</>
 	);
 
-	if ( ! mailpoetEmailData ) {
+	if ( ! attributeValue ) {
 		return null;
 	}
 
@@ -107,7 +114,7 @@ export function RichTextWithButton( {
 				onInsert={ ( value ) => {
 					handleInsertPersonalizationTag(
 						value,
-						mailpoetEmailData[ attributeName ] ?? '',
+						attributeValue ?? '',
 						selectionRange
 					);
 					setIsModalOpened( false );
@@ -125,17 +132,13 @@ export function RichTextWithButton( {
 			<PersonalizationTagsPopover
 				contentRef={ richTextRef }
 				onUpdate={ ( originalTag, updatedTag ) => {
-					const currentValue =
-						mailpoetEmailData[ attributeName ] ?? '';
+					const currentValue = attributeValue ?? '';
 					// When we update the tag, we need to add brackets to the tag, because the popover removes them
 					const updatedContent = currentValue.replace(
 						`<!--[${ originalTag }]-->`,
 						`<!--[${ updatedTag }]-->`
 					);
-					updateEmailMailPoetProperty(
-						attributeName,
-						updatedContent
-					);
+					updateProperty( attributeName, updatedContent );
 				} }
 			/>
 			<RichText
@@ -144,26 +147,17 @@ export function RichTextWithButton( {
 				placeholder={ placeholder }
 				onFocus={ () => {
 					setSelectionRange(
-						getCursorPosition(
-							richTextRef,
-							mailpoetEmailData[ attributeName ] ?? ''
-						)
+						getCursorPosition( richTextRef, attributeValue ?? '' )
 					);
 				} }
 				onKeyUp={ () => {
 					setSelectionRange(
-						getCursorPosition(
-							richTextRef,
-							mailpoetEmailData[ attributeName ] ?? ''
-						)
+						getCursorPosition( richTextRef, attributeValue ?? '' )
 					);
 				} }
 				onClick={ () => {
 					setSelectionRange(
-						getCursorPosition(
-							richTextRef,
-							mailpoetEmailData[ attributeName ] ?? ''
-						)
+						getCursorPosition( richTextRef, attributeValue ?? '' )
 					);
 				} }
 				onChange={ ( value ) => {
@@ -171,7 +165,7 @@ export function RichTextWithButton( {
 						value ?? '',
 						list
 					);
-					updateEmailMailPoetProperty( attributeName, value );
+					updateProperty( attributeName, value );
 					recordEventOnce(
 						'rich_text_with_button_input_field_updated',
 						{
@@ -179,7 +173,7 @@ export function RichTextWithButton( {
 						}
 					);
 				} }
-				value={ mailpoetEmailData[ attributeName ] ?? '' }
+				value={ attributeValue ?? '' }
 				data-automation-id={ `email_${ attributeName }` }
 			/>
 		</BaseControl>

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -103,7 +103,7 @@ export function RichTextWithButton( {
 
 	return (
 		<BaseControl
-			id={ `mailpoet-settings-panel__${ attributeName }` }
+			id=""
 			label={ finalLabel }
 			className={ `mailpoet-settings-panel__${ attributeName }-text` }
 			help={ help }

--- a/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/rich-text-with-button.tsx
@@ -97,13 +97,13 @@ export function RichTextWithButton( {
 		</>
 	);
 
-	if ( ! attributeValue ) {
+	if ( ! attributeName ) {
 		return null;
 	}
 
 	return (
 		<BaseControl
-			id=""
+			id="" // See https://github.com/mailpoet/mailpoet/pull/6089#discussion_r1952126850 to understand why the ID is empty
 			label={ finalLabel }
 			className={ `mailpoet-settings-panel__${ attributeName }-text` }
 			help={ help }

--- a/packages/js/email-editor/src/components/preview/send-preview-email.tsx
+++ b/packages/js/email-editor/src/components/preview/send-preview-email.tsx
@@ -4,7 +4,7 @@
 import { Button, Modal, TextControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { check, Icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useEffect,
 	useRef,
@@ -13,12 +13,22 @@ import {
 } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { isEmail } from '@wordpress/url';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { SendingPreviewStatus, storeName } from '../../store';
+import {
+	SendingPreviewStatus,
+	storeName,
+	editorCurrentPostType,
+} from '../../store';
 import { recordEvent, recordEventOnce } from '../../events';
+
+const sendingMethodConfigurationLink = applyFilters(
+	'mailpoet_email_editor_check_sending_method_configuration_link',
+	'admin.php?page=mailpoet-settings#mta'
+) as string;
 
 function RawSendPreviewEmail() {
 	const sendToRef = useRef( null );
@@ -34,6 +44,7 @@ function RawSendPreviewEmail() {
 		isSendingPreviewEmail,
 		sendingPreviewStatus,
 		isModalOpened,
+		errorMessage,
 	} = useSelect( ( select ) => select( storeName ).getPreviewState(), [] );
 
 	const handleSendPreviewEmail = () => {
@@ -66,33 +77,48 @@ function RawSendPreviewEmail() {
 		>
 			{ sendingPreviewStatus === SendingPreviewStatus.ERROR ? (
 				<div className="mailpoet-send-preview-modal-notice-error">
-					{ __(
-						'Sorry, we were unable to send this email.',
-						'mailpoet'
-					) }
+					<p>
+						{ __(
+							'Sorry, we were unable to send this email.',
+							'mailpoet'
+						) }
+					</p>
+
+					<strong>
+						{ errorMessage &&
+							sprintf(
+								// translators: %s is an error message.
+								__( 'Error: %s', 'mailpoet' ),
+								errorMessage
+							) }
+					</strong>
+
 					<ul>
 						<li>
-							{ createInterpolateElement(
-								__(
-									'Please check your <link>sending method configuration</link> with your hosting provider.',
-									'mailpoet'
-								),
-								{
-									link: (
-										// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-										<a
-											href="admin.php?page=mailpoet-settings#mta"
-											target="_blank"
-											rel="noopener noreferrer"
-											onClick={ () =>
-												recordEvent(
-													'send_preview_email_modal_check_sending_method_configuration_link_clicked'
-												)
-											}
-										/>
+							{ sendingMethodConfigurationLink &&
+								createInterpolateElement(
+									__(
+										'Please check your <link>sending method configuration</link> with your hosting provider.',
+										'mailpoet'
 									),
-								}
-							) }
+									{
+										link: (
+											// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+											<a
+												href={
+													sendingMethodConfigurationLink
+												}
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ () =>
+													recordEvent(
+														'send_preview_email_modal_check_sending_method_configuration_link_clicked'
+													)
+												}
+											/>
+										),
+									}
+								) }
 						</li>
 						<li>
 							{ createInterpolateElement(
@@ -104,10 +130,7 @@ function RawSendPreviewEmail() {
 									link: (
 										// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
 										<a
-											href={ new URL(
-												'free-plan',
-												'https://www.mailpoet.com/'
-											).toString() }
+											href={ `https://account.mailpoet.com/?s=1&g=1&utm_source=mailpoet_email_editor&utm_medium=plugin&utm_source_platform=${ editorCurrentPostType }` }
 											key="sign-up-for-free"
 											target="_blank"
 											rel="noopener noreferrer"

--- a/packages/js/email-editor/src/components/preview/send-preview-email.tsx
+++ b/packages/js/email-editor/src/components/preview/send-preview-email.tsx
@@ -13,17 +13,11 @@ import {
 } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { isEmail } from '@wordpress/url';
-import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import {
-	MailPoetEmailData,
-	SendingPreviewStatus,
-	storeName,
-	editorCurrentPostType,
-} from '../../store';
+import { SendingPreviewStatus, storeName } from '../../store';
 import { recordEvent, recordEventOnce } from '../../events';
 
 function RawSendPreviewEmail() {
@@ -42,17 +36,8 @@ function RawSendPreviewEmail() {
 		isModalOpened,
 	} = useSelect( ( select ) => select( storeName ).getPreviewState(), [] );
 
-	const [ mailpoetEmailData ] = useEntityProp(
-		'postType',
-		editorCurrentPostType,
-		'mailpoet_data'
-	) as [ MailPoetEmailData, unknown, unknown ];
-
 	const handleSendPreviewEmail = () => {
-		void requestSendingNewsletterPreview(
-			mailpoetEmailData.id,
-			previewToEmail
-		);
+		void requestSendingNewsletterPreview( previewToEmail );
 	};
 
 	const closeCallback = () => {

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -1,92 +1,21 @@
 /**
  * External dependencies
  */
-import { ExternalLink, PanelBody } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
+import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
-import classnames from 'classnames';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { editorCurrentPostType } from '../../store';
 import { recordEvent } from '../../events';
-import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
 
-const previewTextMaxLength = 150;
-const previewTextRecommendedLength = 80;
+const SidebarExtensionComponent = applyFilters(
+	'mailpoet_email_editor_setting_sidebar_extension_component',
+	<br />
+) as JSX.Element;
 
 export function DetailsPanel() {
-	const [ mailpoetEmailData ] = useEntityProp(
-		'postType',
-		editorCurrentPostType,
-		'mailpoet_data'
-	);
-
-	const subjectHelp = createInterpolateElement(
-		__(
-			'Use personalization tags to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
-			'mailpoet'
-		),
-		{
-			bestPracticeLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-				<a
-					href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ () =>
-						recordEvent(
-							'details_panel_subject_help_best_practice_link_clicked'
-						)
-					}
-				/>
-			),
-			emojiLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-				<a
-					href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ () =>
-						recordEvent(
-							'details_panel_subject_help_emoji_in_subject_lines_link_clicked'
-						)
-					}
-				/>
-			),
-		}
-	);
-
-	const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
-
-	const preheaderHelp = createInterpolateElement(
-		__(
-			'<link>This text</link> will appear in the inbox, underneath the subject line.',
-			'mailpoet'
-		),
-		{
-			link: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-				<a
-					href={ new URL(
-						'article/418-preview-text',
-						'https://kb.mailpoet.com/'
-					).toString() }
-					key="preview-text-kb"
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ () =>
-						recordEvent(
-							'details_panel_preheader_help_text_link_clicked'
-						)
-					}
-				/>
-			),
-		}
-	);
-
 	return (
 		<PanelBody
 			title={ __( 'Details', 'mailpoet' ) }
@@ -95,50 +24,13 @@ export function DetailsPanel() {
 				recordEvent( 'details_panel_body_toggle', { opened: data } )
 			}
 		>
-			<RichTextWithButton
-				attributeName="subject"
-				label={ __( 'Subject', 'mailpoet' ) }
-				labelSuffix={
-					<ExternalLink
-						href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list"
-						onClick={ () =>
-							recordEvent(
-								'details_panel_personalisation_tags_guide_link_clicked'
-							)
-						}
-					>
-						{ __( 'Guide', 'mailpoet' ) }
-					</ExternalLink>
+			<>
+				{
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					<SidebarExtensionComponent />
 				}
-				help={ subjectHelp }
-				placeholder={ __( 'Eg. The summer sale is here!', 'mailpoet' ) }
-			/>
-
-			<RichTextWithButton
-				attributeName="preheader"
-				label={ __( 'Preview text', 'mailpoet' ) }
-				labelSuffix={
-					<span
-						className={ classnames(
-							'mailpoet-settings-panel__preview-text-length',
-							{
-								'mailpoet-settings-panel__preview-text-length-warning':
-									previewTextLength >
-									previewTextRecommendedLength,
-								'mailpoet-settings-panel__preview-text-length-error':
-									previewTextLength > previewTextMaxLength,
-							}
-						) }
-					>
-						{ previewTextLength }/{ previewTextMaxLength }
-					</span>
-				}
-				help={ preheaderHelp }
-				placeholder={ __(
-					"Add a preview text to capture subscribers' attention and increase open rates.",
-					'mailpoet'
-				) }
-			/>
+			</>
 		</PanelBody>
 	);
 }

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -9,10 +9,11 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { recordEvent } from '../../events';
+import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
 
 const SidebarExtensionComponent = applyFilters(
 	'mailpoet_email_editor_setting_sidebar_extension_component',
-	<br />
+	RichTextWithButton
 ) as JSX.Element;
 
 export function DetailsPanel() {

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -14,7 +14,7 @@ import { RichTextWithButton } from '../personalization-tags/rich-text-with-butto
 const SidebarExtensionComponent = applyFilters(
 	'mailpoet_email_editor_setting_sidebar_extension_component',
 	RichTextWithButton
-) as JSX.Element;
+) as () => JSX.Element;
 
 export function DetailsPanel() {
 	return (
@@ -25,13 +25,7 @@ export function DetailsPanel() {
 				recordEvent( 'details_panel_body_toggle', { opened: data } )
 			}
 		>
-			<>
-				{
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore
-					<SidebarExtensionComponent />
-				}
-			</>
+			<>{ <SidebarExtensionComponent /> }</>
 		</PanelBody>
 	);
 }

--- a/packages/js/email-editor/src/hooks/use-preview-templates.ts
+++ b/packages/js/email-editor/src/hooks/use-preview-templates.ts
@@ -5,6 +5,7 @@ import { useMemo } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -163,6 +164,11 @@ export function usePreviewTemplates(
 
 	const allEmailPosts = useMemo( () => {
 		return emailPosts?.map( ( post: EmailEditorPostType ) => {
+			const preferredTitle = applyFilters(
+				'mailpoet_email_editor_preferred_template_title',
+				'',
+				post
+			);
 			const { postTemplateContent } = generateTemplateContent(
 				post,
 				allTemplates
@@ -180,9 +186,8 @@ export function usePreviewTemplates(
 			const template = {
 				...post,
 				title: {
-					raw: post?.mailpoet_data?.subject || post.title.raw,
-					rendered:
-						post?.mailpoet_data?.subject || post.title.rendered, // use MailPoet subject as title
+					raw: post.title.raw,
+					rendered: preferredTitle || post.title.rendered,
 				},
 			};
 			return {

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -134,29 +134,6 @@ export function* saveEditedEmail() {
 	} );
 }
 
-export function* updateEmailMailPoetProperty( name: string, value: string ) {
-	const postId = select( storeName ).getEmailPostId();
-	// There can be a better way how to get the edited post data
-	const editedPost = select( coreDataStore ).getEditedEntityRecord(
-		'postType',
-		editorCurrentPostType,
-		postId
-	);
-	// @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
-	const mailpoetData = editedPost?.mailpoet_data || {};
-	yield dispatch( coreDataStore ).editEntityRecord(
-		'postType',
-		editorCurrentPostType,
-		postId,
-		{
-			mailpoet_data: {
-				...mailpoetData,
-				[ name ]: value,
-			},
-		}
-	);
-}
-
 export const setTemplateToPost =
 	( templateSlug ) =>
 	async ( { registry } ) => {

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -168,10 +168,7 @@ export const setTemplateToPost =
 			} );
 	};
 
-export function* requestSendingNewsletterPreview(
-	newsletterId: number,
-	email: string
-) {
+export function* requestSendingNewsletterPreview( email: string ) {
 	// If preview is already sending do nothing
 	const previewState = select( storeName ).getPreviewState();
 	if ( previewState.isSendingPreviewEmail ) {
@@ -192,7 +189,6 @@ export function* requestSendingNewsletterPreview(
 			path: '/mailpoet-email-editor/v1/send_preview_email',
 			method: 'POST',
 			data: {
-				newsletterId,
 				email,
 				postId,
 			},

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -209,6 +209,9 @@ export function* requestSendingNewsletterPreview( email: string ) {
 			state: {
 				sendingPreviewStatus: SendingPreviewStatus.ERROR,
 				isSendingPreviewEmail: false,
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				errorMessage: JSON.stringify( errorResponse?.error ),
 			},
 		};
 	}

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -96,13 +96,8 @@ export const isEmpty = createRegistrySelector( ( select ) => (): boolean => {
 		return true;
 	}
 
-	const { content, mailpoet_data: mailpoetData, title } = post;
-	return (
-		! content.raw &&
-		! mailpoetData.subject &&
-		! mailpoetData.preheader &&
-		! title.raw
-	);
+	const { content, title } = post;
+	return ! content.raw && ! title.raw;
 } );
 
 export const hasEmptyContent = createRegistrySelector(

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -210,13 +210,6 @@ export type State = {
 	};
 };
 
-export type MailPoetEmailData = {
-	id: number;
-	subject: string;
-	preheader: string;
-	preview_url: string;
-};
-
 export type EmailTemplate = {
 	id: string;
 	slug: string;

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -202,6 +202,7 @@ export type State = {
 		isModalOpened: boolean;
 		isSendingPreviewEmail: boolean;
 		sendingPreviewStatus: SendingPreviewStatus | null;
+		errorMessage?: string;
 	};
 	personalizationTags: {
 		list: PersonalizationTag[];

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -261,7 +261,6 @@ export type MailPoetEmailPostContentExtended = {
 
 export type EmailEditorPostType = Omit< Post, 'type' > & {
 	type: string;
-	mailpoet_data?: MailPoetEmailPostContentExtended;
 };
 
 export type EmailContentValidationAction = {

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -75,5 +75,3 @@ We may add, update and delete any of them.
 | `mailpoet_email_editor_send_preview_email`    | `Array` $postData                         | `boolean` Result of processing. Was email sent successfully? | Allows override of the send preview mail function. Folks may choose to use custom implementation                                                                    |
 | `mailpoet_email_editor_post_sent_status_args` | `Array` `sent` post status args           | `Array` register_post_status args                            | Allows update of the argument for the sent post status                                                                                                              |
 
-## TODO
-- We use `mailpoet_data` in some section of the codebase. This will be updated.

--- a/packages/php/email-editor/src/Engine/class-email-api-controller.php
+++ b/packages/php/email-editor/src/Engine/class-email-api-controller.php
@@ -66,7 +66,6 @@ class Email_Api_Controller {
 		 * $data - Post Data
 		 * format
 		 * [_locale] => user
-		 * [newsletterId] => NEWSLETTER_ID
 		 * [email] => Provided email address
 		 * [postId] => POST_ID
 		 */


### PR DESCRIPTION
## Description

This PR removes the use of `mailpoet_data` from the core editor codebase and moves it to the MailPoet part of the codebase.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6431](https://mailpoet.atlassian.net/browse/MAILPOET-6431)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-the-use-of-mailpoet_data-in-the-editor-codebase)

_The latest successful build from `update-the-use-of-mailpoet_data-in-the-editor-codebase` will be used. If none is available, the link won't work._

[MAILPOET-6431]: https://mailpoet.atlassian.net/browse/MAILPOET-6431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ