### PR TITLE
Change docker container name prefixes + disable onboarding flow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   dashboard:
-    container_name: mp-dashboard
+    container_name: a8cmail-dashboard
     image: nginx:1.21-alpine
     ports:
       - 8888:80
@@ -8,7 +8,7 @@ services:
       - ./dev/dashboard:/usr/share/nginx/html:ro
 
   db:
-    container_name: mp-db
+    container_name: a8cmail-db
     image: mysql:5.7
     volumes:
       - my-datavolume:/var/lib/mysql
@@ -22,7 +22,7 @@ services:
       MYSQL_PASSWORD: wordpress
 
   wordpress:
-    container_name: mp-wp
+    container_name: a8cmail-wp
     build:
       context: .
       dockerfile: dev/php82/Dockerfile
@@ -61,7 +61,7 @@ services:
       - './templates:/var/www/templates'
 
   test_wordpress:
-    container_name: mp-test-wp
+    container_name: a8cmail-test-wp
     build:
       context: .
       dockerfile: dev/php81/Dockerfile
@@ -86,7 +86,7 @@ services:
       - './packages:/var/www/html/wp-content/plugins/packages'
 
   smtp:
-    container_name: mp-mailhog
+    container_name: a8cmail-mailhog
     image: mailhog/mailhog:v1.0.0
     user: ${UID:-1000}:${GID:-1000}
     environment:
@@ -98,7 +98,7 @@ services:
       - '8082:8025'
 
   adminer:
-    container_name: mp-adminer
+    container_name: a8cmail-adminer
     image: adminer:latest
     depends_on:
       - db

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -362,6 +362,13 @@ class Initializer {
       $this->automationEngine->initialize();
       $this->blockTypesController->initialize();
       $this->emailEditor->initialize();
+
+      $this->settings->set('3rd_party_libs.enabled', '1' );
+
+      $this->wpFunctions->addFilter('mailpoet_skip_welcome_wizard', function() {
+        return true;
+      });
+
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {
       return $this->handleRunningMigration($e);

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -31,7 +31,7 @@ use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Menu {
-  const MAIN_PAGE_SLUG = self::HOMEPAGE_PAGE_SLUG;
+  const MAIN_PAGE_SLUG = self::EMAILS_PAGE_SLUG;
   const NO_PARENT_PAGE_SLUG = 'mailpoet-no-parent';
 
   const EMAILS_PAGE_SLUG = 'mailpoet-newsletters';


### PR DESCRIPTION
## Description

- Rename docker containers so they don't clash in case you are also running MP locally on the side.
- Small changes to MailPoet to skip flows we don't need.
