### PR TITLE
Update save state only when activation does not fail [MAILPOET-6463]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -143,6 +143,7 @@ export function* activate() {
   return {
     type: 'ACTIVATE',
     automation: data?.data ?? automation,
+    saved: !!data?.data,
   } as const;
 }
 

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -41,11 +41,15 @@ export function reducer(state: State, action): State {
         savedState: 'saved',
       };
     case 'ACTIVATE':
-      return {
-        ...state,
-        automationData: action.automation,
-        savedState: 'saved',
-      };
+      return action.saved
+        ? {
+            ...state,
+            automationData: action.automation,
+            savedState: 'saved',
+          }
+        : {
+            ...state,
+          };
     case 'DEACTIVATE':
       return {
         ...state,


### PR DESCRIPTION
## Description
When I create an automation and try to activate it, this can fail. If I haven't saved the state before, a failed activation will not update the state. E.g. I add a wait-step and do not set the time to wait - the activation will fail. The wait step wont be stored in the database. Yet, the UI shows "Saved!" and did not show the "Save draft" button. This PR ensures that the `savedState` in the React application is only moved to `saved` when the activation succeeds.

![image](https://github.com/user-attachments/assets/df05f3ea-32df-40a2-af40-a3b8d1d5a97b)


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

 [MAILPOET-6463]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6463]: https://mailpoet.atlassian.net/browse/MAILPOET-6463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6463-fix-saved-state-when-activation-failed)

_The latest successful build from `MAILPOET-6463-fix-saved-state-when-activation-failed` will be used. If none is available, the link won't work._