### PR TITLE
[WIP] Time based triggers experiment

### DIFF
--- a/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/ActionScheduler.php
@@ -17,6 +17,11 @@ class ActionScheduler {
     return is_int($result) ? $result : 0;
   }
 
+  public function scheduleRecurring(int $timestamp, int $interval, string $hook, array $args = []): int {
+    $result = as_schedule_recurring_action($timestamp, $interval, $hook, $args, self::GROUP_ID);
+    return is_int($result) ? $result : 0;
+  }
+
   public function hasScheduledAction(string $hook, array $args = []): bool {
     return as_has_scheduled_action($hook, $args, self::GROUP_ID);
   }

--- a/mailpoet/lib/Automation/Engine/Control/TimeBasedTriggerHandler.php
+++ b/mailpoet/lib/Automation/Engine/Control/TimeBasedTriggerHandler.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Control;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Integration\TimeBasedTrigger;
+use MailPoet\Automation\Engine\Integration\Trigger;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Engine\WordPress;
+
+class TimeBasedTriggerHandler {
+
+
+  public const KICK_OFF_HOOK = 'mailpoet_automation_time_based_run';
+
+  public const SINGLE_AUTOMATION_HOOK = 'mailpoet_automation_time_based_trigger';
+
+  /** @var ActionScheduler */
+  private $actionScheduler;
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var Registry */
+  private $registry;
+
+  /** @var WordPress */
+  private $wp;
+
+  public function __construct(
+    ActionScheduler $actionScheduler,
+    AutomationStorage $automationStorage,
+    Registry $registry,
+    WordPress $wp
+  ) {
+    $this->actionScheduler = $actionScheduler;
+    $this->automationStorage = $automationStorage;
+    $this->registry = $registry;
+    $this->wp = $wp;
+
+  }
+
+  public function initialize(): void {
+    $this->wp->addAction(self::KICK_OFF_HOOK, [$this, 'run']);
+    $this->wp->addAction(self::SINGLE_AUTOMATION_HOOK, [$this, 'runSingleAutomation']);
+    if ($this->actionScheduler->hasScheduledAction(self::KICK_OFF_HOOK)) {
+      return;
+    }
+
+    $this->actionScheduler->scheduleRecurring(
+      time(),
+      DAY_IN_SECONDS,
+      self::KICK_OFF_HOOK
+    );
+  }
+
+  public function run(): void {
+
+    $triggers = array_filter(
+      $this->registry->getTriggers(),
+      function (Trigger $trigger): bool {
+        return $trigger instanceof TimeBasedTrigger;
+      }
+    );
+
+    $activeTimeBasedAutomations = array_filter(
+      array_map(
+        function (TimeBasedTrigger $trigger) {
+          return [
+            'automations' => $this->automationStorage->getActiveAutomationsByTrigger($trigger),
+            'trigger' => $trigger,
+          ];
+        },
+        $triggers
+      ),
+      function ($automations) {
+        return !empty($automations['automations']);
+      }
+    );
+
+    foreach ($activeTimeBasedAutomations as $automations) {
+      foreach ($automations['automations'] as $automation) {
+        $this->actionScheduler->schedule(
+          time() - 1,
+          self::SINGLE_AUTOMATION_HOOK,
+          [
+            'automation_id' => $automation->getId(),
+            'offset' => 0,
+            'trigger' => $automations['trigger']->getKey(),
+          ]
+        );
+      }
+    }
+  }
+
+  /** @param mixed $args */
+  public function runSingleAutomation($args): void {
+    if (!is_array($args)) {
+      return;
+    }
+    if (!isset($args['automation_id'])) {
+      return;
+    }
+
+    $automationId = (int)$args['automation_id'];
+    $triggerKey = isset($args['trigger']) ? $args['trigger'] : null;
+    $offset = isset($args['offset']) ? (int)$args['offset'] : 0;
+
+    $automation = $this->automationStorage->getAutomation($automationId);
+    $trigger = $this->registry->getTrigger($triggerKey);
+
+    if (!$automation || $automation->getStatus() !== Automation::STATUS_ACTIVE || !$trigger instanceof TimeBasedTrigger) {
+      return;
+    }
+    $triggerData = $automation->getTrigger($triggerKey);
+    if (!$triggerData) {
+      return;
+    }
+
+    $items = $trigger->findItemsToTrigger($automation, $triggerData, $offset);
+    if ($items < $trigger->getLimit()) {
+      return;
+    }
+    $this->actionScheduler->schedule(
+      time() - 1,
+      self::SINGLE_AUTOMATION_HOOK,
+      [
+        'automation_id' => $automationId,
+        'offset' => $offset + $trigger->getLimit(),
+        'trigger' => $triggerKey,
+      ]
+    );
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -4,6 +4,7 @@ namespace MailPoet\Automation\Engine;
 
 use MailPoet\Automation\Engine\API\API;
 use MailPoet\Automation\Engine\Control\StepHandler;
+use MailPoet\Automation\Engine\Control\TimeBasedTriggerHandler;
 use MailPoet\Automation\Engine\Control\TriggerHandler;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsCreateFromTemplateEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsDeleteEndpoint;
@@ -37,6 +38,9 @@ class Engine {
   /** @var TriggerHandler */
   private $triggerHandler;
 
+  /** @var TimeBasedTriggerHandler */
+  private $timeBasedTriggerHandler;
+
   /** @var WordPress */
   private $wordPress;
 
@@ -50,6 +54,7 @@ class Engine {
     Registry $registry,
     StepHandler $stepHandler,
     TriggerHandler $triggerHandler,
+    TimeBasedTriggerHandler $timeBasedTriggerHandler,
     WordPress $wordPress,
     AutomationStorage $automationStorage
   ) {
@@ -59,6 +64,7 @@ class Engine {
     $this->registry = $registry;
     $this->stepHandler = $stepHandler;
     $this->triggerHandler = $triggerHandler;
+    $this->timeBasedTriggerHandler = $timeBasedTriggerHandler;
     $this->wordPress = $wordPress;
     $this->automationStorage = $automationStorage;
   }
@@ -69,6 +75,7 @@ class Engine {
     $this->api->initialize();
     $this->stepHandler->initialize();
     $this->triggerHandler->initialize();
+    $this->timeBasedTriggerHandler->initialize();
 
     $this->coreIntegration->register($this->registry);
     $this->wordPressIntegration->register($this->registry);

--- a/mailpoet/lib/Automation/Engine/Integration/TimeBasedTrigger.php
+++ b/mailpoet/lib/Automation/Engine/Integration/TimeBasedTrigger.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Integration;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Step as StepData;
+
+interface TimeBasedTrigger extends Trigger {
+  public function findItemsToTrigger(Automation $automation, StepData $triggerData, int $offset): int;
+
+  public function getLimit(): int;
+}


### PR DESCRIPTION
## Description

Working on a solution for the time based triggers. This code is not tested at all. This PR atm is more for discussion and alignment.

## Code review notes

The general idea:
The new TimeBasedTriggerHandler registers a daily cron
In this cron, it searches for active automations that have a TimeBasedTrigger
For each of those a new action gets scheduled, which should execute immediately. It contains the trigger-key, the automation-id and an offset

When this fires, the automation gets pulled and now we ask the TimeBasedTrigger to create (or at least find, I think there is some architecture decision to make) the AutomationRuns.

It returns the number of runs created. If that is less than the max limit, we reschedule the same action but with a higher offset. This way, heavy automation run creations are executed in batches.

## QA notes

_N/A_

## Linked PRs

Implementation: https://github.com/mailpoet/mailpoet-premium/pull/935

## Linked tickets

[MAILPOET-6500](https://mailpoet.atlassian.net/browse/MAILPOET-6500)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:time-based-triggers-experiment)

_The latest successful build from `time-based-triggers-experiment` will be used. If none is available, the link won't work._

[MAILPOET-6500]: https://mailpoet.atlassian.net/browse/MAILPOET-6500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ