### PR TITLE
Add debuging info to satismeter poll [MAILPOET-6457]

### DIFF
--- a/mailpoet/assets/js/src/nps-poll.jsx
+++ b/mailpoet/assets/js/src/nps-poll.jsx
@@ -41,24 +41,36 @@ export const initializeSatismeterSurvey = (writeId = null) => {
     } else {
       writeKey = oldUsersPollId;
     }
+    const traits = {
+      name: window.mailpoet_current_wp_user.user_nicename,
+      email: window.mailpoet_current_wp_user.user_email,
+      mailpoetVersion: window.mailpoet_version,
+      mailpoetPremiumIsActive: window.mailpoet_premium_active,
+      createdAt: trackingData.installedAtIso,
+      newslettersSent: trackingData.newslettersSent,
+      welcomeEmails: trackingData.welcomeEmails,
+      postnotificationEmails: trackingData.postnotificationEmails,
+      woocommerceEmails: trackingData.woocommerceEmails,
+      subscribers: trackingData.subscribers,
+      lists: trackingData.lists,
+      sendingMethod: trackingData.sendingMethod,
+      woocommerceIsInstalled: trackingData.woocommerceIsInstalled,
+      woocommerceVersion: trackingData.woocommerceVersion,
+      WordPressVersion: trackingData.WordPressVersion,
+      blockTheme: trackingData.blockTheme,
+      themeVersion: trackingData.themeVersion,
+      theme: trackingData.theme,
+    };
+    if (trackingData.gutenbergVersion) {
+      traits.gutenbergVersion = trackingData.gutenbergVersion;
+    }
+    if (trackingData.wooCommerceVersion) {
+      traits.wooCommerceVersion = trackingData.wooCommerceVersion;
+    }
     satismeter({
       writeKey,
       userId: window.mailpoet_current_wp_user.ID + window.mailpoet_site_url,
-      traits: {
-        name: window.mailpoet_current_wp_user.user_nicename,
-        email: window.mailpoet_current_wp_user.user_email,
-        mailpoetVersion: window.mailpoet_version,
-        mailpoetPremiumIsActive: window.mailpoet_premium_active,
-        createdAt: trackingData.installedAtIso,
-        newslettersSent: trackingData.newslettersSent,
-        welcomeEmails: trackingData.welcomeEmails,
-        postnotificationEmails: trackingData.postnotificationEmails,
-        woocommerceEmails: trackingData.woocommerceEmails,
-        subscribers: trackingData.subscribers,
-        lists: trackingData.lists,
-        sendingMethod: trackingData.sendingMethod,
-        woocommerceIsInstalled: trackingData.woocommerceIsInstalled,
-      },
+      traits,
       events: {
         submit: (response) => {
           if (response.rating >= 9 && response.completed) {

--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -417,11 +417,15 @@ class Reporter {
   }
 
   public function getTrackingData() {
+    global $wp_version, $woocommerce; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $newsletters = $this->newslettersRepository->getAnalytics();
     $segments = $this->segmentsRepository->getCountsPerType();
     $mta = $this->settings->get('mta', []);
     $installedAt = new Carbon($this->settings->get('installed_at'));
-    return [
+    $theme = $this->wp->wpGetTheme();
+    $result = [
+      'WordPressVersion' => $wp_version, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      'pluginGutenberg' => $this->wp->isPluginActive('gutenberg/gutenberg.php'),
       'installedAtIso' => $installedAt->format(Carbon::ISO8601),
       'newslettersSent' => $newsletters['sent_newsletters_count'],
       'welcomeEmails' => $newsletters['welcome_newsletters_count'],
@@ -429,9 +433,19 @@ class Reporter {
       'woocommerceEmails' => $newsletters['automatic_emails_count'],
       'subscribers' => $this->subscribersFeature->getSubscribersCount(),
       'lists' => isset($segments['default']) ? (int)$segments['default'] : 0,
-      'sendingMethod' => isset($mta['method']) ? $mta['method'] : null,
+      'sendingMethod' => $mta['method'] ?? null,
       'woocommerceIsInstalled' => $this->woocommerceHelper->isWooCommerceActive(),
+      'blockTheme' => $this->wp->wpIsBlockTheme(),
+      'theme' => $theme->Name, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      'themeVersion' => $theme->Version, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     ];
+    if (defined('GUTENBERG_VERSION')) {
+      $result['gutenbergVersion'] = GUTENBERG_VERSION;
+    }
+    if ($this->woocommerceHelper->isWooCommerceActive()) {
+      $result['wooCommerceVersion'] = $woocommerce->version;
+    }
+    return $result;
   }
 
   private function isFilterTypeActive(string $filterType, string $action): bool {


### PR DESCRIPTION
## Description

In order to learn more about the customers, I added some debugging info. If they report something is broken we could spot some patterns.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6457]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6457]: https://mailpoet.atlassian.net/browse/MAILPOET-6457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:improve-satismeter-data)

_The latest successful build from `improve-satismeter-data` will be used. If none is available, the link won't work._