### PR TITLE
Update the mailpoet page capability type [MAILPOET-6424]

### DIFF
--- a/mailpoet/lib/Settings/Pages.php
+++ b/mailpoet/lib/Settings/Pages.php
@@ -27,6 +27,7 @@ class Pages {
       'can_export' => false,
       'publicly_queryable' => true,
       'exclude_from_search' => true,
+      'capability_type' => 'page',
     ]);
   }
 

--- a/mailpoet/lib/Settings/Pages.php
+++ b/mailpoet/lib/Settings/Pages.php
@@ -29,6 +29,16 @@ class Pages {
       'exclude_from_search' => true,
       'capability_type' => 'page',
     ]);
+
+    WPFunctions::get()->addFilter('next_post_link', [$this, 'disableNavigationLinks']);
+    WPFunctions::get()->addFilter('previous_post_link', [$this, 'disableNavigationLinks']);
+  }
+
+  public function disableNavigationLinks($output) {
+    if (is_singular('mailpoet_page')) {
+      return ''; // Return an empty string to remove navigation links
+    }
+    return $output;
   }
 
   public static function createMailPoetPage($postName) {


### PR DESCRIPTION
## Description

MailPoet default pages were created using the default post capability type.

This means post navigation links (previous and next) are often found on the default pages, such as the unsubscribe and the manage subscription page.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6424]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6424]: https://mailpoet.atlassian.net/browse/MAILPOET-6424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:page-capabilities)

_The latest successful build from `page-capabilities` will be used. If none is available, the link won't work._