### PR TITLE
Fix content validation search for unsubscribe link in the editor - MAILPOET-6432

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -6,9 +6,16 @@ import { addFilter, addAction } from '@wordpress/hooks';
 import { MailPoet } from 'mailpoet';
 import { withSatismeterSurvey } from './satismeter-survey';
 import './index.scss';
+import { ValidateEmailContent } from './validate-email-content';
 
 addFilter('mailpoet_email_editor_wrap_editor_component', 'mailpoet', (editor) =>
   withSatismeterSurvey(editor),
+);
+
+addFilter(
+  'mailpoet_email_editor_content_validation_rules',
+  'mailpoet',
+  (validationRules: []) => [...validationRules, ...ValidateEmailContent()],
 );
 
 const EVENTS_TO_TRACK = [

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -6,7 +6,7 @@ import { addFilter, addAction } from '@wordpress/hooks';
 import { MailPoet } from 'mailpoet';
 import { withSatismeterSurvey } from './satismeter-survey';
 import './index.scss';
-import { ValidateEmailContent } from './validate-email-content';
+import { useValidationRules } from './validate-email-content';
 
 addFilter('mailpoet_email_editor_wrap_editor_component', 'mailpoet', (editor) =>
   withSatismeterSurvey(editor),
@@ -15,7 +15,7 @@ addFilter('mailpoet_email_editor_wrap_editor_component', 'mailpoet', (editor) =>
 addFilter(
   'mailpoet_email_editor_content_validation_rules',
   'mailpoet',
-  (validationRules: []) => [...validationRules, ...ValidateEmailContent()],
+  (validationRules: []) => [...validationRules, ...useValidationRules()],
 );
 
 const EVENTS_TO_TRACK = [

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
@@ -1,0 +1,93 @@
+import { useMemo } from '@wordpress/element';
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { dispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+const emailEditorStore = 'email-editor/editor';
+
+const contentLink = `<a data-link-href='[mailpoet/subscription-unsubscribe-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${__(
+  'Unsubscribe',
+  'mailpoet',
+)}</a> | <a data-link-href='[mailpoet/subscription-manage-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${__(
+  'Manage subscription',
+  'mailpoet',
+)}</a>`;
+
+export function ValidateEmailContent() {
+  const { contentBlockId, hasFooter } = useSelect((select) => {
+    const allBlocks = select(blockEditorStore).getBlocks();
+    const noBodyBlocks = allBlocks.filter(
+      (block) =>
+        block.name !== 'mailpoet/powered-by-mailpoet' &&
+        block.name !== 'core/post-content',
+    );
+    // @ts-expect-error getBlocksByName is not defined in types
+    const blocks = select(blockEditorStore).getBlocksByName(
+      'core/post-content',
+    ) as string[] | undefined;
+    return {
+      contentBlockId: blocks?.[0],
+      hasFooter: noBodyBlocks.length > 0,
+    };
+  });
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  const { editedTemplateContent, postTemplateId } = useSelect((mapSelect) => ({
+    editedTemplateContent:
+      // @ts-ignore
+      mapSelect(emailEditorStore).getCurrentTemplateContent() as string,
+    postTemplateId:
+      // @ts-ignore
+      mapSelect(emailEditorStore).getCurrentTemplate()?.id as string,
+  }));
+
+  return useMemo(() => {
+    const linksParagraphBlock = createBlock('core/paragraph', {
+      align: 'center',
+      fontSize: 'small',
+      content: contentLink,
+    });
+
+    return [
+      {
+        id: 'missing-unsubscribe-link',
+        test: (emailContent: string) =>
+          !emailContent.includes('[mailpoet/subscription-unsubscribe-url]'),
+        message: __(
+          'All emails must include an "Unsubscribe" link.',
+          'mailpoet',
+        ),
+        actions: [
+          {
+            label: __('Insert link', 'mailpoet'),
+            onClick: () => {
+              if (!hasFooter) {
+                void dispatch(blockEditorStore).insertBlock(
+                  linksParagraphBlock,
+                  undefined,
+                  contentBlockId,
+                );
+              } else {
+                void dispatch(coreDataStore).editEntityRecord(
+                  'postType',
+                  'wp_template',
+                  postTemplateId,
+                  {
+                    content: `
+                      ${editedTemplateContent}
+                      <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+                      ${contentLink}
+                      <!-- /wp:paragraph -->
+                    `,
+                  },
+                );
+              }
+            },
+          },
+        ],
+      },
+    ];
+  }, [contentBlockId, postTemplateId, hasFooter, editedTemplateContent]);
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
@@ -15,7 +15,7 @@ const contentLink = `<a data-link-href='[mailpoet/subscription-unsubscribe-url]'
   'mailpoet',
 )}</a>`;
 
-export function ValidateEmailContent() {
+export function useValidationRules() {
   const { contentBlockId, hasFooter } = useSelect((select) => {
     const allBlocks = select(blockEditorStore).getBlocks();
     const noBodyBlocks = allBlocks.filter(

--- a/packages/js/email-editor/README.md
+++ b/packages/js/email-editor/README.md
@@ -80,3 +80,27 @@ If your WordPress installation does not use the Gutenberg plugin or does not inc
 | Orange.fr      | iOS/Android           | Latest               | ?                | -/0.07              | No                    |                                                                                                                                                                                                          |
 | Thunderbird    | Windows, macOS, Linux | Latest               | Gecko            | -/0.61              | Yes                   | It uses bundled rendering engine so it should be enough to test on one platform                                                                                                                          |
 | Windows Mail   | Windows               | 10, 11               | Word             | -/-                 | Yes                   | Default Client in Windows. Market share should be over 6% in desktop clients                                                                                                                             |
+
+## Actions and Filters
+
+These actions and filters are currently **Work-in-progress**.
+We may add, update and delete any of them.
+
+**Please use with caution**.
+
+### Actions
+
+| Name                           | Argument           | Description         |
+|--------------------------------|--------------------|---------------------|
+| `mailpoet_email_editor_events` | `EventData.detail` | Email editor events |
+
+### Filters
+
+| Name                                             | Argument                  | Return                               | Description                                                                                                         |
+|--------------------------------------------------|---------------------------|--------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `mailpoet_email_editor_events_tracking_enabled`  | `boolean` (false-default) | `boolean`                            | Used to enable the email editor events tracking and collection                                                      |
+| `mailpoet_email_editor_wrap_editor_component`    | `JSX.Element` Editor      | `JSX.Element` Editor                 | The main editor component. Custom component can wrap the editor and provide additional functionality                |
+| `mailpoet_email_editor_send_button_label`        | `string` 'Send'           | `string`  'Send' (default)           | Email editor send button label. The `Send` text can be updated using this filter                                    |
+| `mailpoet_email_editor_send_action_callback`     | `function` sendAction     | `function` sendAction                | Action to perform when the Send button is clicked                                                                   |
+| `mailpoet_email_editor_content_validation_rules` | `array` rules             | `EmailContentValidationRule[]` rules | Email editor content validation rules. The validation is done on `send btton` click and revalidated on `save draft` |
+

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -1,19 +1,23 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from '@wordpress/element';
-import { dispatch, useSelect, subscribe } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
-import { store as coreDataStore } from '@wordpress/core-data';
+import { useCallback } from '@wordpress/element';
+import { useSelect, subscribe } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { storeName as emailEditorStore } from '../store';
+import {
+	EmailContentValidationRule,
+	storeName as emailEditorStore,
+} from '../store';
 import { useShallowEqual } from './use-shallow-equal';
 import { useValidationNotices } from './use-validation-notices';
+
+// Shared reference to an empty array for cases where it is important to avoid
+// returning a new array reference on every invocation
+const EMPTY_ARRAY = [];
 
 export type ContentValidationData = {
 	isInvalid: boolean;
@@ -21,102 +25,25 @@ export type ContentValidationData = {
 };
 
 export const useContentValidation = (): ContentValidationData => {
-	const { contentBlockId, hasFooter } = useSelect( ( select ) => {
-		const allBlocks = select( blockEditorStore ).getBlocks();
-		const noBodyBlocks = allBlocks.filter(
-			( block ) =>
-				block.name !== 'mailpoet/powered-by-mailpoet' &&
-				block.name !== 'core/post-content'
-		);
-		// @ts-expect-error getBlocksByName is not defined in types
-		const blocks = select( blockEditorStore ).getBlocksByName(
-			'core/post-content'
-		) as string[] | undefined;
-		return {
-			contentBlockId: blocks?.[ 0 ],
-			hasFooter: noBodyBlocks.length > 0,
-		};
-	} );
-
 	const { addValidationNotice, hasValidationNotice, removeValidationNotice } =
 		useValidationNotices();
-	const { editedContent, editedTemplateContent, postTemplateId } = useSelect(
+
+	const { editedContent, editedTemplateContent } = useSelect(
 		( mapSelect ) => ( {
 			editedContent:
 				mapSelect( emailEditorStore ).getEditedEmailContent(),
 			editedTemplateContent:
 				mapSelect( emailEditorStore ).getCurrentTemplateContent(),
-			postTemplateId:
-				mapSelect( emailEditorStore ).getCurrentTemplate()?.id,
 		} )
 	);
 
+	const rules: EmailContentValidationRule[] = applyFilters(
+		'mailpoet_email_editor_content_validation_rules',
+		EMPTY_ARRAY
+	) as EmailContentValidationRule[];
+
 	const content = useShallowEqual( editedContent );
 	const templateContent = useShallowEqual( editedTemplateContent );
-
-	const contentLink = `<a data-link-href='[mailpoet/subscription-unsubscribe-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${ __(
-		'Unsubscribe',
-		'mailpoet'
-	) }</a> | <a data-link-href='[mailpoet/subscription-manage-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${ __(
-		'Manage subscription',
-		'mailpoet'
-	) }</a>`;
-
-	const rules = useMemo( () => {
-		const linksParagraphBlock = createBlock( 'core/paragraph', {
-			align: 'center',
-			fontSize: 'small',
-			content: contentLink,
-		} );
-
-		return [
-			{
-				id: 'missing-unsubscribe-link',
-				test: ( emailContent ) =>
-					! emailContent.includes(
-						'[mailpoet/subscription-unsubscribe-url]'
-					),
-				message: __(
-					'All emails must include an "Unsubscribe" link.',
-					'mailpoet'
-				),
-				actions: [
-					{
-						label: __( 'Insert link', 'mailpoet' ),
-						onClick: () => {
-							if ( ! hasFooter ) {
-								void dispatch( blockEditorStore ).insertBlock(
-									linksParagraphBlock,
-									undefined,
-									contentBlockId
-								);
-							} else {
-								void dispatch( coreDataStore ).editEntityRecord(
-									'postType',
-									'wp_template',
-									postTemplateId,
-									{
-										content: `
-                      ${ editedTemplateContent }
-                      <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-                      ${ contentLink }
-                      <!-- /wp:paragraph -->
-                    `,
-									}
-								);
-							}
-						},
-					},
-				],
-			},
-		];
-	}, [
-		contentBlockId,
-		hasFooter,
-		contentLink,
-		postTemplateId,
-		editedTemplateContent,
-	] );
 
 	const validateContent = useCallback( (): boolean => {
 		let isValid = true;

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -3,6 +3,7 @@
  */
 import { useCallback } from '@wordpress/element';
 import { useSelect, subscribe } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -72,7 +73,7 @@ export const useContentValidation = (): ContentValidationData => {
 			return;
 		}
 		validateContent();
-	}, emailEditorStore );
+	}, coreDataStore );
 
 	return {
 		isInvalid: hasValidationNotice(),

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -269,3 +269,15 @@ export type EmailEditorPostType = Omit< Post, 'type' > & {
 	type: string;
 	mailpoet_data?: MailPoetEmailPostContentExtended;
 };
+
+export type EmailContentValidationAction = {
+	label: string;
+	onClick: () => void;
+};
+
+export type EmailContentValidationRule = {
+	id: string;
+	test: ( emailContent: string ) => boolean;
+	message: string;
+	actions: EmailContentValidationAction[];
+};

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -77,4 +77,3 @@ We may add, update and delete any of them.
 
 ## TODO
 - We use `mailpoet_data` in some section of the codebase. This will be updated.
-- The content validation in the editor looks for the unsubscribe link tag, which is registered in the MailPoet plugin. We need either introduce generic unsubscribe link tag or move the validation to the MailPoet plugin.


### PR DESCRIPTION
## Description

This PR extracts the validation rules from the editor core to the MailPoet plugin.

## Code review notes

Please test by removing the `[mailpoet/subscription-unsubscribe-url]` tag from the email content and adding it back.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6432](https://mailpoet.atlassian.net/browse/MAILPOET-6432)

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6432]: https://mailpoet.atlassian.net/browse/MAILPOET-6432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-content-validation-search-for-unsubscribe-link-in-the-editor)

_The latest successful build from `fix-content-validation-search-for-unsubscribe-link-in-the-editor` will be used. If none is available, the link won't work._