### PR TITLE
Custom trigger transactional emails [MAILPOET-6466]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/helper/is-transactional.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/helper/is-transactional.ts
@@ -3,6 +3,7 @@ import { Step } from '../../../../../editor/components/automation/types';
 import { storeName } from '../../../../../editor/store';
 
 const transactionalTriggers = [
+  'mailpoet:custom-trigger',
   'woocommerce:order-status-changed',
   'woocommerce:order-created',
   'woocommerce:order-completed',

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -62,6 +62,7 @@ class SendEmailAction implements Action {
   private const OPTIN_RETRIES = 'optin_retries';
 
   private const TRANSACTIONAL_TRIGGERS = [
+    'mailpoet:custom-trigger',
     'woocommerce:order-status-changed',
     'woocommerce:order-created',
     'woocommerce:order-completed',


### PR DESCRIPTION
## Description
When using a custom trigger we want to mark the email as transactional.

Before:
Subscribers who are not `subscribed` (e.g. unconfirmed, unsubscribed) would not receive the email
![image](https://github.com/user-attachments/assets/4f749d89-1579-4d9b-94f6-8ec2e82b44e9)


After:
All subscribers receive the email (except the ones marked as `bounced`)
![image](https://github.com/user-attachments/assets/82687273-2043-4d52-8f0f-54e03ccf76f0)


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
[MAILPOET-6466]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6466]: https://mailpoet.atlassian.net/browse/MAILPOET-6466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6466-custom-trigger-transactional-emails)

_The latest successful build from `MAILPOET-6466-custom-trigger-transactional-emails` will be used. If none is available, the link won't work._