### PR TITLE
Add templates registry to get possibility of registred templates [MAILPOET-6453]

### DIFF
--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -352,6 +352,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Preprocessors\Typography_Preprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\Renderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Templates\Templates::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Engine\Templates\Templates_Registry::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Patterns\Patterns::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Engine\Renderer\ContentRenderer\Blocks_Registry::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Templates;
 
+use MailPoet\EmailEditor\Engine\Templates\Template;
+use MailPoet\EmailEditor\Engine\Templates\Templates_Registry;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Templates\Library\Newsletter;
 use MailPoet\Util\CdnAssetUrl;
@@ -21,26 +23,22 @@ class TemplatesController {
   }
 
   public function initialize() {
-    $this->wp->addAction('mailpoet_email_editor_register_templates', [$this, 'registerTemplates'], 10, 0);
+    $this->wp->addFilter('mailpoet_email_editor_register_templates', [$this, 'registerTemplates'], 10, 1);
   }
 
-  public function registerTemplates() {
+  public function registerTemplates(Templates_Registry $templatesRegistry): Templates_Registry {
     $newsletter = new Newsletter($this->cdnAssetUrl);
-    $templateName = $this->templatePrefix . '//' . $newsletter->getSlug();
 
-    if (\WP_Block_Templates_Registry::get_instance()->is_registered($templateName)) {
-      // skip registration if the template was already registered.
-      return;
-    }
-
-    register_block_template(
-      $templateName,
-      [
-        'title' => $newsletter->getTitle(),
-        'description' => $newsletter->getDescription(),
-        'content' => $newsletter->getContent(),
-        'post_types' => [EmailEditor::MAILPOET_EMAIL_POST_TYPE],
-      ]
+    $template = new Template(
+      $this->templatePrefix,
+      $newsletter->getSlug(),
+      $newsletter->getTitle(),
+      $newsletter->getDescription(),
+      $newsletter->getContent(),
+      [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
     );
+    $templatesRegistry->register($template);
+
+    return $templatesRegistry;
   }
 }

--- a/packages/php/email-editor/src/Engine/Templates/class-template.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-template.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * This file is part of the MailPoet Email Editor package.
+ *
+ * @package MailPoet\EmailEditor
+ */
+
+declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Templates;
+
+/**
+ * The class represents a template
+ */
+class Template {
+	/**
+	 * Plugin uri used in the template name.
+	 *
+	 * @var string $plugin_uri
+	 */
+	private string $plugin_uri;
+	/**
+	 * The template slug used in the template name.
+	 *
+	 * @var string $slug
+	 */
+	private string $slug;
+	/**
+	 * The template name used for block template registration.
+	 *
+	 * @var string $name
+	 */
+	private string $name;
+	/**
+	 * The template title.
+	 *
+	 * @var string $title
+	 */
+	private string $title;
+	/**
+	 * The template description.
+	 *
+	 * @var string $description
+	 */
+	private string $description;
+	/**
+	 * The template content.
+	 *
+	 * @var string $content
+	 */
+	private string $content;
+	/**
+	 * The list of supoorted post types.
+	 *
+	 * @var string[]
+	 */
+	private array $post_types;
+
+	/**
+	 * Constructor of the class.
+	 *
+	 * @param string   $plugin_uri The plugin uri.
+	 * @param string   $slug The template slug.
+	 * @param string   $title The template title.
+	 * @param string   $description The template description.
+	 * @param string   $content The template content.
+	 * @param string[] $post_types The list of post types supported by the template.
+	 */
+	public function __construct(
+		string $plugin_uri,
+		string $slug,
+		string $title,
+		string $description,
+		string $content,
+		array $post_types = array()
+	) {
+		$this->plugin_uri  = $plugin_uri;
+		$this->slug        = $slug;
+		$this->name        = "{$plugin_uri}//{$slug}"; // The template name is composed from the namespace and the slug.
+		$this->title       = $title;
+		$this->description = $description;
+		$this->content     = $content;
+		$this->post_types  = $post_types;
+	}
+	/**
+	 * Get the plugin uri.
+	 *
+	 * @return string
+	 */
+	public function get_pluginuri(): string {
+		return $this->plugin_uri;
+	}
+	/**
+	 * Get the template slug.
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return $this->slug;
+	}
+
+	/**
+	 * Get the template name composed from the plugin_uri and the slug.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return $this->name;
+	}
+	/**
+	 * Get the template title.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return $this->title;
+	}
+	/**
+	 * Get the template description.
+	 *
+	 * @return string
+	 */
+	public function get_description(): string {
+		return $this->description;
+	}
+	/**
+	 * Get the template content.
+	 *
+	 * @return string
+	 */
+	public function get_content(): string {
+		return $this->content;
+	}
+	/**
+	 * Get the list of supported post types.
+	 *
+	 * @return string[]
+	 */
+	public function get_post_types(): array {
+		return $this->post_types;
+	}
+}

--- a/packages/php/email-editor/src/Engine/Templates/class-templates-registry.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates-registry.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of the MailPoet Email Editor package.
+ *
+ * @package MailPoet\EmailEditor
+ */
+
+declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Engine\Templates;
+
+/**
+ * Registry for email templates.
+ */
+class Templates_Registry {
+	/**
+	 * List of registered templates.
+	 *
+	 * @var Template[]
+	 */
+	private $templates = array();
+
+	/**
+	 * Initialize the template registry.
+	 * This method should be called only once.
+	 *
+	 * @return void
+	 */
+	public function initialize(): void {
+		apply_filters( 'mailpoet_email_editor_register_templates', $this );
+	}
+
+	/**
+	 * Register a template instance in the registry.
+	 *
+	 * @param Template $template The template to register.
+	 * @return void
+	 */
+	public function register( Template $template ): void {
+		// The function was added in WordPress 6.7. We can remove this check after we drop support for WordPress 6.6.
+		if ( ! function_exists( 'register_block_template' ) ) {
+			return;
+		}
+
+		if ( ! \WP_Block_Templates_Registry::get_instance()->is_registered( $template->get_name() ) ) {
+			// skip registration if the template was already registered.
+			register_block_template(
+				$template->get_name(),
+				array(
+					'title'       => $template->get_title(),
+					'description' => $template->get_description(),
+					'content'     => $template->get_content(),
+					'post_types'  => $template->get_post_types(),
+				)
+			);
+			$this->templates[ $template->get_name() ] = $template;
+		}
+	}
+
+	/**
+	 * Retrieve a template by its name.
+	 * Example: get_by_name( 'mailpoet//email-general' ) will return the instance of Template with identical name.
+	 *
+	 * @param string $name The name of the template.
+	 * @return Template|null The template object or null if not found.
+	 */
+	public function get_by_name( string $name ): ?Template {
+		return $this->templates[ $name ] ?? null;
+	}
+
+	/**
+	 * Retrieve a template by its slug.
+	 * Example: get_by_slug( 'email-general' ) will return the instance of Template with identical slug.
+	 *
+	 * @param string $slug The slug of the template.
+	 * @return Template|null The template object or null if not found.
+	 */
+	public function get_by_slug( string $slug ): ?Template {
+		foreach ( $this->templates as $template ) {
+			if ( $template->get_slug() === $slug ) {
+				return $template;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Retrieve all registered templates.
+	 *
+	 * @return array List of all registered templates.
+	 */
+	public function get_all() {
+		return $this->templates;
+	}
+}

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -129,9 +129,11 @@ class Templates {
 	 * @return array
 	 */
 	public function get_post_types( $response_object ): array {
-		if ( isset( $response_object['plugin'] ) && $response_object['plugin'] === $this->template_prefix ) {
-			return $this->post_types;
+		$template = $this->templates_registry->get_by_slug( $response_object['slug'] ?? '' );
+		if ( $template ) {
+			return $template->get_post_types();
 		}
+
 		return $response_object['post_types'] ?? array();
 	}
 

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -33,6 +33,21 @@ class Templates {
 	 * @var string $template_directory
 	 */
 	private string $template_directory = __DIR__ . DIRECTORY_SEPARATOR;
+	/**
+	 * The templates registry.
+	 *
+	 * @var Templates_Registry $templates_registry
+	 */
+	private Templates_Registry $templates_registry;
+
+	/**
+	 * Constructor of the class.
+	 *
+	 * @param Templates_Registry $templates_registry The templates registry.
+	 */
+	public function __construct( Templates_Registry $templates_registry ) {
+		$this->templates_registry = $templates_registry;
+	}
 
 	/**
 	 * Initializes the class.
@@ -42,7 +57,8 @@ class Templates {
 	public function initialize( array $post_types ): void {
 		$this->post_types = $post_types;
 		add_filter( 'theme_templates', array( $this, 'add_theme_templates' ), 10, 4 ); // Workaround needed when saving post – template association.
-		$this->register_templates();
+		add_filter( 'mailpoet_email_editor_register_templates', array( $this, 'register_templates' ) );
+		$this->templates_registry->initialize();
 		$this->register_post_types_to_api();
 	}
 
@@ -60,36 +76,26 @@ class Templates {
 
 	/**
 	 * Register the templates via register_block_template
+	 *
+	 * @param Templates_Registry $templates_registry The templates registry.
 	 */
-	private function register_templates(): void {
-		// The function was added in WordPress 6.7. We can remove this check after we drop support for WordPress 6.6.
-		if ( ! function_exists( 'register_block_template' ) ) {
-			return;
-		}
+	public function register_templates( Templates_Registry $templates_registry ): Templates_Registry {
 		// Register basic blank template.
-		$general_email     = array(
-			'title'       => __( 'General Email', 'mailpoet' ),
-			'description' => __( 'A general template for emails.', 'mailpoet' ),
-			'slug'        => 'email-general',
+		$general_email_slug = 'email-general';
+		$template_filename  = $general_email_slug . '.html';
+
+		$general_email = new Template(
+			$this->template_prefix,
+			$general_email_slug,
+			__( 'General Email', 'mailpoet' ),
+			__( 'A general template for emails.', 'mailpoet' ),
+			(string) file_get_contents( $this->template_directory . $template_filename ),
+			$this->post_types
 		);
-		$template_filename = $general_email['slug'] . '.html';
 
-		$template_name = $this->template_prefix . '//' . $general_email['slug'];
+		$templates_registry->register( $general_email );
 
-		if ( ! \WP_Block_Templates_Registry::get_instance()->is_registered( $template_name ) ) {
-			// skip registration if the template was already registered.
-			register_block_template(
-				$template_name,
-				array(
-					'title'       => $general_email['title'],
-					'description' => $general_email['description'],
-					'content'     => (string) file_get_contents( $this->template_directory . $template_filename ),
-					'post_types'  => $this->post_types,
-				)
-			);
-		}
-
-		do_action( 'mailpoet_email_editor_register_templates' );
+		return $templates_registry;
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Engine/Templates/Templates_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Templates/Templates_Test.php
@@ -51,7 +51,7 @@ class Templates_Test extends \MailPoetTest {
 	 */
 	public function testItTriggersActionForRegisteringTemplates(): void {
 		$trigger_check = false;
-		add_action(
+		add_filter(
 			'mailpoet_email_editor_register_templates',
 			function ( $registry ) use ( &$trigger_check ) {
 				$trigger_check = true;

--- a/packages/php/email-editor/tests/integration/Engine/Templates/Templates_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Templates/Templates_Test.php
@@ -53,8 +53,9 @@ class Templates_Test extends \MailPoetTest {
 		$trigger_check = false;
 		add_action(
 			'mailpoet_email_editor_register_templates',
-			function () use ( &$trigger_check ) {
+			function ( $registry ) use ( &$trigger_check ) {
 				$trigger_check = true;
+				return $registry;
 			}
 		);
 		$this->templates->initialize( array( 'mailpoet_email' ) );

--- a/packages/php/email-editor/tests/integration/_bootstrap.php
+++ b/packages/php/email-editor/tests/integration/_bootstrap.php
@@ -28,6 +28,7 @@ use MailPoet\EmailEditor\Engine\Renderer\Renderer;
 use MailPoet\EmailEditor\Engine\Send_Preview_Email;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Templates\Templates;
+use MailPoet\EmailEditor\Engine\Templates\Templates_Registry;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoet\EmailEditor\Engine\User_Theme;
 use MailPoet\EmailEditor\Integrations\Core\Initializer;
@@ -188,9 +189,15 @@ abstract class MailPoetTest extends \Codeception\TestCase\Test { // phpcs:ignore
 			}
 		);
 		$container->set(
-			Templates::class,
+			Templates_Registry::class,
 			function () {
-				return new Templates();
+				return new Templates_Registry();
+			}
+		);
+		$container->set(
+			Templates::class,
+			function ( $container ) {
+				return new Templates( $container->get( Templates_Registry::class ) );
 			}
 		);
 		$container->set(

--- a/packages/php/email-editor/tests/unit/Engine/Templates/Template_Registry_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Templates/Template_Registry_Test.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * This file is part of the MailPoet Email Editor package.
+ *
+ * @package MailPoet\EmailEditor
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use MailPoet\EmailEditor\Engine\Templates\Templates_Registry;
+use MailPoet\EmailEditor\Engine\Templates\Template;
+
+/**
+ * Test cases for the Templates_Registry class.
+ */
+class TemplatesRegistryTest extends TestCase {
+	/**
+	 * Property for the templates registry.
+	 *
+	 * @var Templates_Registry Templates registry instance.
+	 */
+	private Templates_Registry $registry;
+
+	/**
+	 * Set up the test case.
+	 */
+	protected function setUp(): void {
+		$this->registry = new Templates_Registry();
+	}
+
+	/**
+	 * Register a template and retrieve it by name.
+	 */
+	public function testRegisterAndGetTemplateByName(): void {
+		$template = $this->createMock( Template::class );
+		$template->method( 'get_name' )->willReturn( 'mailpoet//email-general' );
+		$template->method( 'get_title' )->willReturn( 'Email General' );
+		$template->method( 'get_description' )->willReturn( 'A general email template.' );
+		$template->method( 'get_content' )->willReturn( '<!-- wp:paragraph --> <p>Hello World</p> <!-- /wp:paragraph -->' );
+		$template->method( 'get_post_types' )->willReturn( array( 'mailpoet_email' ) );
+
+		// Register the template.
+		$this->registry->register( $template );
+
+		// Retrieve the template by name.
+		$retrieved_template = $this->registry->get_by_name( 'mailpoet//email-general' );
+
+		$this->assertNotNull( $retrieved_template );
+		$this->assertSame( 'mailpoet//email-general', $retrieved_template->get_name() );
+		$this->assertSame( 'Email General', $retrieved_template->get_title() );
+		$this->assertSame( 'A general email template.', $retrieved_template->get_description() );
+		$this->assertSame( '<!-- wp:paragraph --> <p>Hello World</p> <!-- /wp:paragraph -->', $retrieved_template->get_content() );
+		$this->assertSame( array( 'mailpoet_email' ), $retrieved_template->get_post_types() );
+	}
+
+	/**
+	 * Register a template and retrieve it by slug.
+	 */
+	public function testRegisterAndGetTemplateBySlug(): void {
+		$template = $this->createMock( Template::class );
+		$template->method( 'get_name' )->willReturn( 'mailpoet//email-general' );
+		$template->method( 'get_slug' )->willReturn( 'email-general' );
+
+		// Register the template.
+		$this->registry->register( $template );
+
+		// Retrieve the template by slug.
+		$retrieved_template = $this->registry->get_by_slug( 'email-general' );
+
+		$this->assertNotNull( $retrieved_template );
+		$this->assertSame( 'email-general', $retrieved_template->get_slug() );
+	}
+
+	/**
+	 * Try to retrieve a template that hasn't been registered.
+	 */
+	public function testRetrieveNonexistentTemplate(): void {
+		$this->assertNull( $this->registry->get_by_name( 'nonexistent-template' ) );
+		$this->assertNull( $this->registry->get_by_slug( 'nonexistent-slug' ) );
+	}
+
+	/**
+	 * Register multiple templates and retrieve them.
+	 */
+	public function testRegisterMultipleTemplates(): void {
+		$template1 = $this->createMock( Template::class );
+		$template1->method( 'get_name' )->willReturn( 'mailpoet//template-1' );
+		$template1->method( 'get_slug' )->willReturn( 'template-1' );
+
+		$template2 = $this->createMock( Template::class );
+		$template2->method( 'get_name' )->willReturn( 'mailpoet//template-2' );
+		$template2->method( 'get_slug' )->willReturn( 'template-2' );
+
+		// Register both templates.
+		$this->registry->register( $template1 );
+		$this->registry->register( $template2 );
+
+		$all_templates = $this->registry->get_all();
+
+		$this->assertCount( 2, $all_templates );
+		$this->assertArrayHasKey( 'mailpoet//template-1', $all_templates );
+		$this->assertArrayHasKey( 'mailpoet//template-2', $all_templates );
+	}
+
+	/**
+	 * Ensure duplicate templates are not registered.
+	 */
+	public function testRegisterDuplicateTemplate(): void {
+		$template = $this->createMock( Template::class );
+		$template->method( 'get_name' )->willReturn( 'mailpoet//email-general' );
+
+		// Register the same template twice.
+		$this->registry->register( $template );
+		$this->registry->register( $template );
+
+		// Registry should contain only one instance.
+		$this->assertCount( 1, $this->registry->get_all() );
+	}
+
+	/**
+	 * Initialize the registry and apply a filter.
+	 */
+	public function testInitializeAppliesFilter(): void {
+		// Mock WordPress's `apply_filters` function.
+		global $wp_filter_applied;
+		$wp_filter_applied = false;
+
+		add_filter(
+			'mailpoet_email_editor_register_templates',
+			function ( $registry ) use ( &$wp_filter_applied ) {
+				$wp_filter_applied = true;
+				return $registry;
+			}
+		);
+
+		// Initialize the registry.
+		$this->registry->initialize();
+
+		// Assert that the filter was applied.
+		$this->assertTrue( $wp_filter_applied );
+	}
+}

--- a/packages/php/email-editor/tests/unit/_bootstrap.php
+++ b/packages/php/email-editor/tests/unit/_bootstrap.php
@@ -11,6 +11,19 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 $console = new \Codeception\Lib\Console\Output( array() );
 
+if ( ! function_exists( 'register_block_template' ) ) {
+	/**
+	 * Mock register_block_template function.
+	 *
+	 * @param string $name Template name.
+	 * @param array  $attr Template attributes.
+	 * @return string
+	 */
+	function register_block_template( $name, $attr ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return $name;
+	}
+}
+
 if ( ! function_exists( 'esc_attr' ) ) {
 	/**
 	 * Mock esc_attr function.

--- a/packages/php/email-editor/tests/unit/_stubs.php
+++ b/packages/php/email-editor/tests/unit/_stubs.php
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 // Dummy WP classes.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 if ( ! class_exists( \WP_Theme_JSON::class ) ) {
 	/**
 	 * Class WP_Theme_JSON
@@ -28,6 +29,49 @@ if ( ! class_exists( \WP_Theme_JSON::class ) ) {
 		 */
 		public function get_settings() {
 			return array();
+		}
+	}
+}
+
+if ( ! class_exists( \WP_Block_Templates_Registry::class ) ) {
+	/**
+	 * Dummy class to replace WP_Block_Templates_Registry in PHPUnit tests.
+	 */
+	class WP_Block_Templates_Registry {
+		/**
+		 * List of registered templates.
+		 *
+		 * @var array Stores registered templates.
+		 */
+		private static array $registered_templates = array();
+
+		/**
+		 * Singleton instance.
+		 *
+		 * @var self|null
+		 */
+		private static ?self $instance = null;
+
+		/**
+		 * Get singleton instance.
+		 *
+		 * @return self
+		 */
+		public static function get_instance(): self {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
+
+		/**
+		 * Checks if a template is registered.
+		 *
+		 * @param string $name Template name.
+		 * @return bool
+		 */
+		public function is_registered( string $name ): bool {
+			return isset( self::$registered_templates[ $name ] );
 		}
 	}
 }


### PR DESCRIPTION
## Description

Creating a new Templates Registry class allows us to modify the method `get_post_types()`, which returns associated post_types with the template. This change removes the limitation with template `plugin_uri` (`namespace`).

## Code review notes

_N/A_

## QA notes

We may skip QA here if the reviewer tests that the email editor templates work correctly.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6453]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:templates-registry)

_The latest successful build from `templates-registry` will be used. If none is available, the link won't work._

[MAILPOET-6453]: https://mailpoet.atlassian.net/browse/MAILPOET-6453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ