### PR TITLE
Email Editor - POC Migration to the Block Editor [MAILPOET-6439]

### DIFF
--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -359,6 +359,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\EmailEditor\Integrations\Core\Initializer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditorLoader::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EditorPageRenderer::class)->setPublic(true);
     $container->register(\MailPoet\EmailEditor\Engine\Renderer\Css_Inliner::class)
       ->setPublic(true)

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -26,6 +26,8 @@ class EmailEditor {
 
   private TemplatesController $templatesController;
 
+  private EmailEditorLoader $emailEditorLoader;
+
   private FeaturesController $featuresController;
 
   public function __construct(
@@ -36,6 +38,7 @@ class EmailEditor {
     EmailEditorPreviewEmail $emailEditorPreviewEmail,
     PatternsController $patternsController,
     TemplatesController $templatesController,
+    EmailEditorLoader $emailEditorLoader,
     Cli $cli,
     PersonalizationTagManager $personalizationTagManager
   ) {
@@ -45,6 +48,7 @@ class EmailEditor {
     $this->editorPageRenderer = $editorPageRenderer;
     $this->patternsController = $patternsController;
     $this->templatesController = $templatesController;
+    $this->emailEditorLoader = $emailEditorLoader;
     $this->cli = $cli;
     $this->emailEditorPreviewEmail = $emailEditorPreviewEmail;
     $this->personalizationTagManager = $personalizationTagManager;
@@ -55,7 +59,9 @@ class EmailEditor {
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
     $this->wp->addAction('rest_delete_mailpoet_email', [$this->emailApiController, 'trashEmail'], 10, 1);
     $this->wp->addFilter('mailpoet_is_email_editor_page', [$this, 'isEditorPage'], 10, 1);
-    if (!$this->featuresController->isSupported(FeaturesController::FEATURE_UNIFIED_WP_EDITOR)) {
+    if ($this->featuresController->isSupported(FeaturesController::FEATURE_UNIFIED_WP_EDITOR)) {
+      $this->emailEditorLoader->initialize();
+    } else {
       $this->wp->addFilter('replace_editor', [$this, 'replaceEditor'], 10, 2);
     }
     $this->wp->addFilter('mailpoet_email_editor_send_preview_email', [$this->emailEditorPreviewEmail, 'sendPreviewEmail'], 10, 1);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -4,6 +4,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
 use MailPoet\EmailEditor\Integrations\MailPoet\Templates\TemplatesController;
+use MailPoet\Features\FeaturesController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditor {
@@ -25,8 +26,11 @@ class EmailEditor {
 
   private TemplatesController $templatesController;
 
+  private FeaturesController $featuresController;
+
   public function __construct(
     WPFunctions $wp,
+    FeaturesController $featuresController,
     EmailApiController $emailApiController,
     EditorPageRenderer $editorPageRenderer,
     EmailEditorPreviewEmail $emailEditorPreviewEmail,
@@ -36,6 +40,7 @@ class EmailEditor {
     PersonalizationTagManager $personalizationTagManager
   ) {
     $this->wp = $wp;
+    $this->featuresController = $featuresController;
     $this->emailApiController = $emailApiController;
     $this->editorPageRenderer = $editorPageRenderer;
     $this->patternsController = $patternsController;
@@ -50,7 +55,9 @@ class EmailEditor {
     $this->wp->addFilter('mailpoet_email_editor_post_types', [$this, 'addEmailPostType']);
     $this->wp->addAction('rest_delete_mailpoet_email', [$this->emailApiController, 'trashEmail'], 10, 1);
     $this->wp->addFilter('mailpoet_is_email_editor_page', [$this, 'isEditorPage'], 10, 1);
-    $this->wp->addFilter('replace_editor', [$this, 'replaceEditor'], 10, 2);
+    if (!$this->featuresController->isSupported(FeaturesController::FEATURE_UNIFIED_WP_EDITOR)) {
+      $this->wp->addFilter('replace_editor', [$this, 'replaceEditor'], 10, 2);
+    }
     $this->wp->addFilter('mailpoet_email_editor_send_preview_email', [$this->emailEditorPreviewEmail, 'sendPreviewEmail'], 10, 1);
     $this->patternsController->registerPatterns();
     $this->templatesController->initialize();

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet;
+
+use MailPoet\Config\Env;
+use MailPoet\WP\Functions as WPFunctions;
+
+class EmailEditorLoader {
+
+  private WPFunctions $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function initialize() {
+    $this->wp->addAction('enqueue_block_editor_assets', [$this, 'enqueueBlockEditorAssets']);
+  }
+
+  public function enqueueBlockEditorAssets() {
+    $assetsParams = require Env::$assetsPath . '/dist/js/email-editor-unified/email_editor.asset.php';
+    $this->wp->wpEnqueueScript(
+      'mailpoet_email_editor',
+      Env::$assetsUrl . '/dist/js/email-editor-unified/email_editor.js',
+      $assetsParams['dependencies'],
+      $assetsParams['version'],
+      true
+    );
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -64,6 +64,7 @@ class EmailEditorLoader {
         'editor_settings' => $this->settingsController->get_settings(),
         'editor_theme' => $this->themeController->get_base_theme()->get_raw_data(),
         'user_theme_post_id' => $this->userTheme->get_user_theme_post()->ID,
+        'current_post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
       ]
     );
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -3,20 +3,25 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\Config\Env;
+use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditorLoader {
 
   private WPFunctions $wp;
+  private Settings_Controller $settingsController;
 
   public function __construct(
-    WPFunctions $wp
+    WPFunctions $wp,
+    Settings_Controller $settingsController
   ) {
     $this->wp = $wp;
+    $this->settingsController = $settingsController;
   }
 
   public function initialize(): void {
     $this->wp->addAction('mailpoet_email_editor_admin_initialized', [$this, 'initializeAdmin']);
+    $this->wp->addFilter('block_editor_settings_all', [$this, 'blockEditorSettings'], 10, 2);
   }
 
   public function initializeAdmin(): void {
@@ -44,5 +49,13 @@ class EmailEditorLoader {
       $assetsParams['version'],
       true
     );
+  }
+
+  public function blockEditorSettings($settings, $editorContext) {
+    if (!$this->isEmailEditorPage()) {
+      return $settings;
+    }
+    $controllerSettings = $this->settingsController->get_settings();
+    return $controllerSettings;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -6,6 +6,8 @@ use MailPoet\Config\Env;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoet\EmailEditor\Engine\User_Theme;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -16,19 +18,22 @@ class EmailEditorLoader {
   private Theme_Controller $themeController;
   private User_Theme $userTheme;
   private CdnAssetUrl $cdnAssetUrl;
+  private NewslettersRepository $newslettersRepository;
 
   public function __construct(
     WPFunctions $wp,
     Settings_Controller $settingsController,
     Theme_Controller $themeController,
     User_Theme $userTheme,
-    CdnAssetUrl $cdnAssetUrl
+    CdnAssetUrl $cdnAssetUrl,
+    NewslettersRepository $newslettersRepository
   ) {
     $this->wp = $wp;
     $this->settingsController = $settingsController;
     $this->themeController = $themeController;
     $this->userTheme = $userTheme;
     $this->cdnAssetUrl = $cdnAssetUrl;
+    $this->newslettersRepository = $newslettersRepository;
   }
 
   public function initialize(): void {
@@ -56,6 +61,10 @@ class EmailEditorLoader {
   public function enqueueBlockEditorAssets() {
     $postId = isset($_GET['post']) ? intval($_GET['post']) : 0;
     $post = $this->wp->getPost($postId);
+    $newsletter = $this->newslettersRepository->findOneBy(['wpPost' => $postId]);
+    if (!$newsletter instanceof NewsletterEntity) {
+      return;
+    }
     $assetsParams = require Env::$assetsPath . '/dist/js/email-editor-unified/email_editor.asset.php';
     $this->wp->wpEnqueueScript(
       'mailpoet_email_editor',
@@ -74,7 +83,18 @@ class EmailEditorLoader {
         'current_post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
         'current_post_id' => $post->ID,
         'mailpoet_cdn_url' => $this->cdnAssetUrl->generateCdnUrl(""),
+        'urls' => [
+          'listings' => admin_url('admin.php?page=mailpoet-newsletters'),
+          'send' => admin_url('admin.php?page=mailpoet-newsletters#/send/' . $newsletter->getId()),
+        ],
       ]
+    );
+
+    $this->wp->wpEnqueueStyle(
+      'email_editor_unified',
+      Env::$assetsUrl . '/dist/js/email-editor-unified/email_editor.css',
+      [],
+      $assetsParams['version']
     );
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -104,8 +104,22 @@ class EmailEditorLoader {
     );
 
     $this->wp->wpEnqueueStyle(
-      'email_editor_unified',
+      'email_editor_unified_0',
       Env::$assetsUrl . '/dist/js/email-editor-unified/email_editor.css',
+      [],
+      $assetsParams['version']
+    );
+
+    $this->wp->wpEnqueueStyle(
+      'email_editor_unified_2',
+      Env::$assetsUrl . '/dist/js/email-editor/email_editor.css',
+      [],
+      $assetsParams['version']
+    );
+
+    $this->wp->wpEnqueueStyle(
+      'email_editor_unified_3',
+      Env::$assetsUrl . '/dist/js/email_editor_integration/email_editor_integration.css',
       [],
       $assetsParams['version']
     );

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -2,12 +2,14 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\Analytics\Analytics;
 use MailPoet\Config\Env;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoet\EmailEditor\Engine\User_Theme;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Settings\SettingsController;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -19,6 +21,8 @@ class EmailEditorLoader {
   private User_Theme $userTheme;
   private CdnAssetUrl $cdnAssetUrl;
   private NewslettersRepository $newslettersRepository;
+  private Analytics $analytics;
+  private SettingsController $mailpoetSettings;
 
   public function __construct(
     WPFunctions $wp,
@@ -26,7 +30,9 @@ class EmailEditorLoader {
     Theme_Controller $themeController,
     User_Theme $userTheme,
     CdnAssetUrl $cdnAssetUrl,
-    NewslettersRepository $newslettersRepository
+    NewslettersRepository $newslettersRepository,
+    Analytics $analytics,
+    SettingsController $mailpoetSettings
   ) {
     $this->wp = $wp;
     $this->settingsController = $settingsController;
@@ -34,12 +40,13 @@ class EmailEditorLoader {
     $this->userTheme = $userTheme;
     $this->cdnAssetUrl = $cdnAssetUrl;
     $this->newslettersRepository = $newslettersRepository;
+    $this->analytics = $analytics;
+    $this->mailpoetSettings = $mailpoetSettings;
   }
 
   public function initialize(): void {
     $this->wp->addAction('mailpoet_email_editor_admin_initialized', [$this, 'initializeAdmin']);
     $this->wp->addFilter('block_editor_settings_all', [$this, 'blockEditorSettings'], 10, 2);
-    $this->wp->addFilter('rest_request_after_callbacks', [$this, 'modifyThemeResponse'], 10, 3);
   }
 
   public function initializeAdmin(): void {
@@ -73,6 +80,15 @@ class EmailEditorLoader {
     $this->wp->wpEnqueueScript(
       'wp-rich-text',
       Env::$assetsUrl . '/dist/js/email-editor/rich-text.js',
+      $assetsParams['dependencies'],
+      $assetsParams['version'],
+      true
+    );
+
+    $assetsParams = require Env::$assetsPath . '/dist/js/email_editor_integration/email_editor_integration.asset.php';
+    $this->wp->wpEnqueueScript(
+      'mailpoet_email_editor_integration',
+      Env::$assetsUrl . '/dist/js/email_editor_integration/email_editor_integration.js',
       $assetsParams['dependencies'],
       $assetsParams['version'],
       true
@@ -123,6 +139,8 @@ class EmailEditorLoader {
       [],
       $assetsParams['version']
     );
+
+    add_filter('admin_footer', [$this, 'loadAnalyticsModule'], 24);
   }
 
   public function blockEditorSettings($settings, $editorContext) {
@@ -133,17 +151,24 @@ class EmailEditorLoader {
     return $controllerSettings;
   }
 
-  public function modifyThemeResponse($response, $handler, $request) {
-//    ///wp/v2/global-styles/themes/twentytwentyfive
-//    if (strpos($request->get_route(), '/wp/v2/global-styles/themes/') === 0) {
-//      $response->data = $this->themeController->get_base_theme()->get_raw_data();
-//      return $response;
-//    }
-//    ///wp/v2/global-styles/id
-//    if (strpos($request->get_route(), '/wp/v2/global-styles/') === 0) {
-//      $response->data = $this->userTheme->get_theme()->get_raw_data();
-//      return $response;
-//    }
-    return $response;
+  public function loadAnalyticsModule() {  // phpcs:ignore -- MissingReturnStatement not required
+    $publicId = $this->analytics->getPublicId();
+    $isPublicIdNew = $this->analytics->isPublicIdNew();
+    // this is required here because of `analytics-event.js` and order of script load and use in `mailpoet-email-editor-integration/index.ts`
+    $libs3rdPartyEnabled = $this->mailpoetSettings->get('3rd_party_libs.enabled') === '1';
+
+    // we need to set this values because they are used in the analytics.html file
+    ?>
+    <script type="text/javascript"> <?php // phpcs:ignore ?>
+        window.mailpoet_analytics_enabled = true;
+        window.mailpoet_analytics_public_id = '<?php echo esc_js($publicId); ?>';
+        window.mailpoet_analytics_new_public_id = <?php echo wp_json_encode($isPublicIdNew); ?>;
+        window.mailpoet_3rd_party_libs_enabled = <?php echo wp_json_encode($libs3rdPartyEnabled); ?>;
+        window.mailpoet_version = '<?php echo esc_js(MAILPOET_VERSION); ?>';
+        window.mailpoet_premium_version = '<?php echo esc_js((defined('MAILPOET_PREMIUM_VERSION')) ? MAILPOET_PREMIUM_VERSION : ''); ?>';
+    </script>
+    <?php
+
+    include_once Env::$viewsPath . '/analytics.html';
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -15,8 +15,24 @@ class EmailEditorLoader {
     $this->wp = $wp;
   }
 
-  public function initialize() {
-    $this->wp->addAction('enqueue_block_editor_assets', [$this, 'enqueueBlockEditorAssets']);
+  public function initialize(): void {
+    $this->wp->addAction('mailpoet_email_editor_admin_initialized', [$this, 'initializeAdmin']);
+  }
+
+  public function initializeAdmin(): void {
+    if (!$this->isEmailEditorPage()) {
+      return;
+    }
+    $this->wp->addAction('mailpoet_is_email_editor_page', [$this, 'isEmailEditorPage']);
+    $this->enqueueBlockEditorAssets();
+  }
+
+  public function isEmailEditorPage($isEditorPage = false): bool {
+    if ($isEditorPage) {
+      return true;
+    }
+    $current_screen = get_current_screen();
+    return $current_screen && $current_screen->post_type === EmailEditor::MAILPOET_EMAIL_POST_TYPE && $current_screen->base === 'post'; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function enqueueBlockEditorAssets() {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -30,6 +30,7 @@ class EmailEditorLoader {
   public function initialize(): void {
     $this->wp->addAction('mailpoet_email_editor_admin_initialized', [$this, 'initializeAdmin']);
     $this->wp->addFilter('block_editor_settings_all', [$this, 'blockEditorSettings'], 10, 2);
+    $this->wp->addFilter('rest_request_after_callbacks', [$this, 'modifyThemeResponse'], 10, 3);
   }
 
   public function initializeAdmin(): void {
@@ -49,6 +50,8 @@ class EmailEditorLoader {
   }
 
   public function enqueueBlockEditorAssets() {
+    $postId = isset($_GET['post']) ? intval($_GET['post']) : 0;
+    $post = $this->wp->getPost($postId);
     $assetsParams = require Env::$assetsPath . '/dist/js/email-editor-unified/email_editor.asset.php';
     $this->wp->wpEnqueueScript(
       'mailpoet_email_editor',
@@ -65,6 +68,7 @@ class EmailEditorLoader {
         'editor_theme' => $this->themeController->get_base_theme()->get_raw_data(),
         'user_theme_post_id' => $this->userTheme->get_user_theme_post()->ID,
         'current_post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
+        'current_post_id' => $post->ID,
       ]
     );
   }
@@ -75,5 +79,19 @@ class EmailEditorLoader {
     }
     $controllerSettings = $this->settingsController->get_settings();
     return $controllerSettings;
+  }
+
+  public function modifyThemeResponse($response, $handler, $request) {
+//    ///wp/v2/global-styles/themes/twentytwentyfive
+//    if (strpos($request->get_route(), '/wp/v2/global-styles/themes/') === 0) {
+//      $response->data = $this->themeController->get_base_theme()->get_raw_data();
+//      return $response;
+//    }
+//    ///wp/v2/global-styles/id
+//    if (strpos($request->get_route(), '/wp/v2/global-styles/') === 0) {
+//      $response->data = $this->userTheme->get_theme()->get_raw_data();
+//      return $response;
+//    }
+    return $response;
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -4,19 +4,27 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\Config\Env;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
+use MailPoet\EmailEditor\Engine\Theme_Controller;
+use MailPoet\EmailEditor\Engine\User_Theme;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditorLoader {
 
   private WPFunctions $wp;
   private Settings_Controller $settingsController;
+  private Theme_Controller $themeController;
+  private User_Theme $userTheme;
 
   public function __construct(
     WPFunctions $wp,
-    Settings_Controller $settingsController
+    Settings_Controller $settingsController,
+    Theme_Controller $themeController,
+    User_Theme $userTheme
   ) {
     $this->wp = $wp;
     $this->settingsController = $settingsController;
+    $this->themeController = $themeController;
+    $this->userTheme = $userTheme;
   }
 
   public function initialize(): void {
@@ -48,6 +56,15 @@ class EmailEditorLoader {
       $assetsParams['dependencies'],
       $assetsParams['version'],
       true
+    );
+    $this->wp->wpLocalizeScript(
+      'mailpoet_email_editor',
+      'MailPoetEmailEditor',
+      [
+        'editor_settings' => $this->settingsController->get_settings(),
+        'editor_theme' => $this->themeController->get_base_theme()->get_raw_data(),
+        'user_theme_post_id' => $this->userTheme->get_user_theme_post()->ID,
+      ]
     );
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -65,6 +65,19 @@ class EmailEditorLoader {
     if (!$newsletter instanceof NewsletterEntity) {
       return;
     }
+
+    // Email editor rich text JS - Because we Personalization Tags depend on Gutenberg 19.8.0 and higher
+    // the following code replaces used Rich Text for the version containing the necessary changes.
+    $assetsParams = require Env::$assetsPath . '/dist/js/email-editor/rich-text.asset.php';
+    $this->wp->wpDeregisterScript('wp-rich-text');
+    $this->wp->wpEnqueueScript(
+      'wp-rich-text',
+      Env::$assetsUrl . '/dist/js/email-editor/rich-text.js',
+      $assetsParams['dependencies'],
+      $assetsParams['version'],
+      true
+    );
+
     $assetsParams = require Env::$assetsPath . '/dist/js/email-editor-unified/email_editor.asset.php';
     $this->wp->wpEnqueueScript(
       'mailpoet_email_editor',

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorLoader.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Env;
 use MailPoet\EmailEditor\Engine\Settings_Controller;
 use MailPoet\EmailEditor\Engine\Theme_Controller;
 use MailPoet\EmailEditor\Engine\User_Theme;
+use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
 class EmailEditorLoader {
@@ -14,17 +15,20 @@ class EmailEditorLoader {
   private Settings_Controller $settingsController;
   private Theme_Controller $themeController;
   private User_Theme $userTheme;
+  private CdnAssetUrl $cdnAssetUrl;
 
   public function __construct(
     WPFunctions $wp,
     Settings_Controller $settingsController,
     Theme_Controller $themeController,
-    User_Theme $userTheme
+    User_Theme $userTheme,
+    CdnAssetUrl $cdnAssetUrl
   ) {
     $this->wp = $wp;
     $this->settingsController = $settingsController;
     $this->themeController = $themeController;
     $this->userTheme = $userTheme;
+    $this->cdnAssetUrl = $cdnAssetUrl;
   }
 
   public function initialize(): void {
@@ -69,6 +73,7 @@ class EmailEditorLoader {
         'user_theme_post_id' => $this->userTheme->get_user_theme_post()->ID,
         'current_post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
         'current_post_id' => $post->ID,
+        'mailpoet_cdn_url' => $this->cdnAssetUrl->generateCdnUrl(""),
       ]
     );
   }

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -6,11 +6,13 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
+  const FEATURE_UNIFIED_WP_EDITOR = 'email_editor_in_unified_wordpress_editor';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
+    self::FEATURE_UNIFIED_WP_EDITOR => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -542,6 +542,39 @@ const emailEditorCustom = Object.assign({}, wpScriptConfig, {
     : [...wpScriptConfig.plugins, new ForkTsCheckerWebpackPlugin()],
 });
 
+const emailEditorUnified = Object.assign({}, wpScriptConfig, {
+  name: 'email_editor',
+  entry: {
+    email_editor: '../packages/js/email-editor/src/unified-editor.tsx',
+  },
+  output: {
+    filename: '[name].js',
+    path: path.join(__dirname, 'assets/dist/js/email-editor-unified'),
+  },
+  resolve: {
+    ...wpScriptConfig.resolve,
+    modules: ['node_modules', '../packages/js/email-editor'],
+  },
+  module: Object.assign({}, wpScriptConfig.module, {
+    rules: [
+      ...wpScriptConfig.module.rules,
+      {
+        test: /\.(t|j)sx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader?cacheDirectory',
+          options: {
+            presets: ['@wordpress/babel-preset-default'],
+          },
+        },
+      },
+    ],
+  }),
+  plugins: PRODUCTION_ENV
+    ? wpScriptConfig.plugins
+    : [...wpScriptConfig.plugins, new ForkTsCheckerWebpackPlugin()],
+});
+
 // Temporary solution to build rich-text package for email editor
 const emailEditorRichText = Object.assign({}, wpScriptConfig, {
   name: 'email-editor-rich-text',
@@ -599,6 +632,7 @@ const configs = [
   publicConfig,
   adminConfig,
   emailEditorCustom,
+  emailEditorUnified,
   formPreviewConfig,
   postEditorBlock,
   marketingOptinBlock,

--- a/packages/js/email-editor/package.json
+++ b/packages/js/email-editor/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/keycodes": "^4.0.0",
 		"@wordpress/media-utils": "^5.0.0",
 		"@wordpress/notices": "^5.0.0",
+		"@wordpress/plugins": "^7.16.0",
 		"@wordpress/preferences": "^4.0.0",
 		"@wordpress/private-apis": "^1.0.0",
 		"@wordpress/rich-text": "^7.14.0",

--- a/packages/js/email-editor/package.json
+++ b/packages/js/email-editor/package.json
@@ -53,6 +53,7 @@
 		"@wordpress/url": "^4.0.0",
 		"classnames": "^2.5.1",
 		"deepmerge": "^4.3.1",
+		"fast-deep-equal": "^3.1.3",
 		"lodash": "^4.17.21",
 		"react": "18.3.1",
 		"react-dom": "18.3.1"

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -42,6 +42,7 @@ export function initBlocks() {
 	registerCoreBlocks();
 }
 
+// In unified editor we don't need to call registerCoreBlocks
 export function initBlocksUnified() {
 	deactivateStackOnMobile();
 	hideExpandOnClick();
@@ -54,5 +55,7 @@ export function initBlocksUnified() {
 	enhanceColumnBlock();
 	enhanceColumnsBlock();
 	enhancePostContentBlock();
+	extendRichTextFormats();
+	activatePersonalizationTagsReplacing();
 	alterSupportConfiguration();
 }

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -41,3 +41,19 @@ export function initBlocks() {
 	alterSupportConfiguration();
 	registerCoreBlocks();
 }
+
+
+export function initBlocksUnified() {
+	deactivateStackOnMobile();
+	hideExpandOnClick();
+	disableImageFilter();
+	disableCertainRichTextFormats();
+	disableColumnsLayout();
+	disableGroupVariations();
+	enhanceButtonBlock();
+	enhanceButtonsBlock();
+	enhanceColumnBlock();
+	enhanceColumnsBlock();
+	enhancePostContentBlock();
+	alterSupportConfiguration();
+}

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -42,7 +42,6 @@ export function initBlocks() {
 	registerCoreBlocks();
 }
 
-
 export function initBlocksUnified() {
 	deactivateStackOnMobile();
 	hideExpandOnClick();

--- a/packages/js/email-editor/src/components/block-editor/visual-editor/visual-editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/visual-editor/visual-editor.tsx
@@ -130,15 +130,8 @@ export function VisualEditor( {
 
 	const shouldIframe =
 		! disableIframe || [ 'Tablet', 'Mobile' ].includes( deviceType );
-	const containerWidth =
-		deviceType === 'Desktop' ? ( layout.contentSize as string ) : '100%';
 
-	const iframeStyles = [
-		...( ( styles as string[] ) ?? [] ),
-		{
-			css: `.is-root-container{display:flow-root; width:${ containerWidth }; margin: 0 auto;box-sizing: border-box;}`,
-		},
-	];
+	const iframeStyles = [ ...( ( styles as string[] ) ?? [] ) ];
 
 	return (
 		<div

--- a/packages/js/email-editor/src/components/header/index.scss
+++ b/packages/js/email-editor/src/components/header/index.scss
@@ -41,9 +41,9 @@
 }
 
 // We currently don't support command palette so we hide the shortcut
-.editor-document-bar__shortcut {
-	display: none !important;
-}
+//.editor-document-bar__shortcut {
+//	display: none !important;
+//}
 
 // Temporarily hide text about amount of changes to save. The wording is not great for email context.
 .entities-saved-states__text-prompt {

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -52,6 +52,7 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 	return (
 		<Button
 			variant="primary"
+			size="compact"
 			onClick={ () => {
 				recordEvent( 'header_send_button_clicked' );
 				if ( validateContent() ) {

--- a/packages/js/email-editor/src/components/sidebar/details-panel-content.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel-content.tsx
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { ExternalLink } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { editorCurrentPostType } from '../../store';
+import { recordEvent } from '../../events';
+import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
+
+const previewTextMaxLength = 150;
+const previewTextRecommendedLength = 80;
+
+export function DetailsPanelContent() {
+	const [ mailpoetEmailData ] = useEntityProp(
+		'postType',
+		editorCurrentPostType,
+		'mailpoet_data'
+	);
+
+	const subjectHelp = createInterpolateElement(
+		__(
+			'Use personalization tags to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
+			'mailpoet'
+		),
+		{
+			bestPracticeLink: (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+				<a
+					href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ () =>
+						recordEvent(
+							'details_panel_subject_help_best_practice_link_clicked'
+						)
+					}
+				/>
+			),
+			emojiLink: (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+				<a
+					href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ () =>
+						recordEvent(
+							'details_panel_subject_help_emoji_in_subject_lines_link_clicked'
+						)
+					}
+				/>
+			),
+		}
+	);
+
+	const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
+
+	const preheaderHelp = createInterpolateElement(
+		__(
+			'<link>This text</link> will appear in the inbox, underneath the subject line.',
+			'mailpoet'
+		),
+		{
+			link: (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+				<a
+					href={ new URL(
+						'article/418-preview-text',
+						'https://kb.mailpoet.com/'
+					).toString() }
+					key="preview-text-kb"
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ () =>
+						recordEvent(
+							'details_panel_preheader_help_text_link_clicked'
+						)
+					}
+				/>
+			),
+		}
+	);
+
+	return (
+		<>
+			<RichTextWithButton
+				attributeName="subject"
+				label={ __( 'Subject', 'mailpoet' ) }
+				labelSuffix={
+					<ExternalLink
+						href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list"
+						onClick={ () =>
+							recordEvent(
+								'details_panel_personalisation_tags_guide_link_clicked'
+							)
+						}
+					>
+						{ __( 'Guide', 'mailpoet' ) }
+					</ExternalLink>
+				}
+				help={ subjectHelp }
+				placeholder={ __( 'Eg. The summer sale is here!', 'mailpoet' ) }
+			/>
+
+			<RichTextWithButton
+				attributeName="preheader"
+				label={ __( 'Preview text', 'mailpoet' ) }
+				labelSuffix={
+					<span
+						className={ classnames(
+							'mailpoet-settings-panel__preview-text-length',
+							{
+								'mailpoet-settings-panel__preview-text-length-warning':
+									previewTextLength >
+									previewTextRecommendedLength,
+								'mailpoet-settings-panel__preview-text-length-error':
+									previewTextLength > previewTextMaxLength,
+							}
+						) }
+					>
+						{ previewTextLength }/{ previewTextMaxLength }
+					</span>
+				}
+				help={ preheaderHelp }
+				placeholder={ __(
+					"Add a preview text to capture subscribers' attention and increase open rates.",
+					'mailpoet'
+				) }
+			/>
+		</>
+	);
+}

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -1,91 +1,17 @@
 /**
  * External dependencies
  */
-import { ExternalLink, PanelBody } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
+import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { editorCurrentPostType } from '../../store';
 import { recordEvent } from '../../events';
-import { RichTextWithButton } from '../personalization-tags/rich-text-with-button';
-
-const previewTextMaxLength = 150;
-const previewTextRecommendedLength = 80;
+import { DetailsPanelContent } from './details-panel-content';
 
 export function DetailsPanel() {
-	const [ mailpoetEmailData ] = useEntityProp(
-		'postType',
-		editorCurrentPostType,
-		'mailpoet_data'
-	);
 
-	const subjectHelp = createInterpolateElement(
-		__(
-			'Use personalization tags to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
-			'mailpoet'
-		),
-		{
-			bestPracticeLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-				<a
-					href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ () =>
-						recordEvent(
-							'details_panel_subject_help_best_practice_link_clicked'
-						)
-					}
-				/>
-			),
-			emojiLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-				<a
-					href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ () =>
-						recordEvent(
-							'details_panel_subject_help_emoji_in_subject_lines_link_clicked'
-						)
-					}
-				/>
-			),
-		}
-	);
-
-	const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
-
-	const preheaderHelp = createInterpolateElement(
-		__(
-			'<link>This text</link> will appear in the inbox, underneath the subject line.',
-			'mailpoet'
-		),
-		{
-			link: (
-				// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-				<a
-					href={ new URL(
-						'article/418-preview-text',
-						'https://kb.mailpoet.com/'
-					).toString() }
-					key="preview-text-kb"
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ () =>
-						recordEvent(
-							'details_panel_preheader_help_text_link_clicked'
-						)
-					}
-				/>
-			),
-		}
-	);
 
 	return (
 		<PanelBody
@@ -95,50 +21,7 @@ export function DetailsPanel() {
 				recordEvent( 'details_panel_body_toggle', { opened: data } )
 			}
 		>
-			<RichTextWithButton
-				attributeName="subject"
-				label={ __( 'Subject', 'mailpoet' ) }
-				labelSuffix={
-					<ExternalLink
-						href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list"
-						onClick={ () =>
-							recordEvent(
-								'details_panel_personalisation_tags_guide_link_clicked'
-							)
-						}
-					>
-						{ __( 'Guide', 'mailpoet' ) }
-					</ExternalLink>
-				}
-				help={ subjectHelp }
-				placeholder={ __( 'Eg. The summer sale is here!', 'mailpoet' ) }
-			/>
-
-			<RichTextWithButton
-				attributeName="preheader"
-				label={ __( 'Preview text', 'mailpoet' ) }
-				labelSuffix={
-					<span
-						className={ classnames(
-							'mailpoet-settings-panel__preview-text-length',
-							{
-								'mailpoet-settings-panel__preview-text-length-warning':
-									previewTextLength >
-									previewTextRecommendedLength,
-								'mailpoet-settings-panel__preview-text-length-error':
-									previewTextLength > previewTextMaxLength,
-							}
-						) }
-					>
-						{ previewTextLength }/{ previewTextMaxLength }
-					</span>
-				}
-				help={ preheaderHelp }
-				placeholder={ __(
-					"Add a preview text to capture subscribers' attention and increase open rates.",
-					'mailpoet'
-				) }
-			/>
+			<DetailsPanelContent />
 		</PanelBody>
 	);
 }

--- a/packages/js/email-editor/src/components/sidebar/details-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/details-panel.tsx
@@ -11,8 +11,6 @@ import { recordEvent } from '../../events';
 import { DetailsPanelContent } from './details-panel-content';
 
 export function DetailsPanel() {
-
-
 	return (
 		<PanelBody
 			title={ __( 'Details', 'mailpoet' ) }

--- a/packages/js/email-editor/src/components/sidebar/email-type-info.tsx
+++ b/packages/js/email-editor/src/components/sidebar/email-type-info.tsx
@@ -5,37 +5,16 @@ import {
 	Panel,
 	PanelBody,
 	PanelRow,
-	Flex,
-	FlexItem,
-	DropdownMenu,
-	MenuItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, megaphone } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { storeName } from '../../store';
-import { EditTemplateModal } from './edit-template-modal';
-import { SelectTemplateModal } from '../template-select';
-import { recordEvent } from '../../events';
+import { PostStatusPanel } from "./post-status-panel";
 
 export function EmailTypeInfo() {
-	const { template, currentEmailContent } = useSelect(
-		( select ) => ( {
-			template: select( storeName ).getCurrentTemplate(),
-			currentEmailContent: select( storeName ).getEditedEmailContent(),
-		} ),
-		[]
-	);
-	const [ isEditTemplateModalOpen, setEditTemplateModalOpen ] =
-		useState( false );
-	const [ isSelectTemplateModalOpen, setSelectTemplateModalOpen ] =
-		useState( false );
-
 	return (
 		<>
 			<Panel className="mailpoet-email-sidebar__email-type-info">
@@ -54,92 +33,9 @@ export function EmailTypeInfo() {
 							</span>
 						</div>
 					</PanelRow>
-					{ template && (
-						<PanelRow>
-							<Flex justify={ 'start' }>
-								<FlexItem className="editor-post-panel__row-label">
-									{ __( 'Template', 'mailpoet' ) }
-								</FlexItem>
-								<FlexItem>
-									<DropdownMenu
-										icon={ null }
-										text={ template?.title }
-										toggleProps={ { variant: 'tertiary' } }
-										label={ __(
-											'Template actions',
-											'mailpoet'
-										) }
-										onToggle={ ( isOpen ) =>
-											recordEvent(
-												'sidebar_template_actions_clicked',
-												{
-													currentTemplate:
-														template?.title,
-													isOpen,
-												}
-											)
-										}
-									>
-										{ ( { onClose } ) => (
-											<>
-												<MenuItem
-													onClick={ () => {
-														recordEvent(
-															'sidebar_template_actions_edit_template_clicked'
-														);
-														setEditTemplateModalOpen(
-															true
-														);
-														onClose();
-													} }
-												>
-													{ __(
-														'Edit template',
-														'mailpoet'
-													) }
-												</MenuItem>
-												<MenuItem
-													onClick={ () => {
-														recordEvent(
-															'sidebar_template_actions_swap_template_clicked'
-														);
-														setSelectTemplateModalOpen(
-															true
-														);
-														onClose();
-													} }
-												>
-													{ __(
-														'Swap template',
-														'mailpoet'
-													) }
-												</MenuItem>
-											</>
-										) }
-									</DropdownMenu>
-								</FlexItem>
-							</Flex>
-						</PanelRow>
-					) }
+					<PostStatusPanel />
 				</PanelBody>
 			</Panel>
-			{ isEditTemplateModalOpen && (
-				<EditTemplateModal
-					close={ () => {
-						recordEvent( 'edit_template_modal_closed' );
-						return setEditTemplateModalOpen( false );
-					} }
-				/>
-			) }
-			{ isSelectTemplateModalOpen && (
-				<SelectTemplateModal
-					onSelectCallback={ () =>
-						setSelectTemplateModalOpen( false )
-					}
-					closeCallback={ () => setSelectTemplateModalOpen( false ) }
-					previewContent={ currentEmailContent }
-				/>
-			) }
 		</>
 	);
 }

--- a/packages/js/email-editor/src/components/sidebar/email-type-info.tsx
+++ b/packages/js/email-editor/src/components/sidebar/email-type-info.tsx
@@ -1,18 +1,14 @@
 /**
  * External dependencies
  */
-import {
-	Panel,
-	PanelBody,
-	PanelRow,
-} from '@wordpress/components';
+import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, megaphone } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { PostStatusPanel } from "./post-status-panel";
+import { PostStatusPanel } from './post-status-panel';
 
 export function EmailTypeInfo() {
 	return (

--- a/packages/js/email-editor/src/components/sidebar/post-status-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/post-status-panel.tsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import {
+	PanelRow,
+	Flex,
+	FlexItem,
+	DropdownMenu,
+	MenuItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { storeName } from '../../store';
+import { EditTemplateModal } from './edit-template-modal';
+import { SelectTemplateModal } from '../template-select';
+import { recordEvent } from '../../events';
+
+export function PostStatusPanel() {
+	const { template, currentEmailContent } = useSelect(
+		( select ) => ( {
+			template: select( storeName ).getCurrentTemplate(),
+			currentEmailContent: select( storeName ).getEditedEmailContent(),
+		} ),
+		[]
+	);
+	const [ isEditTemplateModalOpen, setEditTemplateModalOpen ] =
+		useState( false );
+	const [ isSelectTemplateModalOpen, setSelectTemplateModalOpen ] =
+		useState( false );
+
+	return (
+		<>
+
+					{ template && (
+						<PanelRow>
+							<Flex justify={ 'start' }>
+								<FlexItem className="editor-post-panel__row-label">
+									{ __( 'Template', 'mailpoet' ) }
+								</FlexItem>
+								<FlexItem>
+									<DropdownMenu
+										icon={ null }
+										text={ template?.title }
+										toggleProps={ { variant: 'tertiary' } }
+										label={ __(
+											'Template actions',
+											'mailpoet'
+										) }
+										onToggle={ ( isOpen ) =>
+											recordEvent(
+												'sidebar_template_actions_clicked',
+												{
+													currentTemplate:
+													template?.title,
+													isOpen,
+												}
+											)
+										}
+									>
+										{ ( { onClose } ) => (
+											<>
+												<MenuItem
+													onClick={ () => {
+														recordEvent(
+															'sidebar_template_actions_edit_template_clicked'
+														);
+														setEditTemplateModalOpen(
+															true
+														);
+														onClose();
+													} }
+												>
+													{ __(
+														'Edit template',
+														'mailpoet'
+													) }
+												</MenuItem>
+												<MenuItem
+													onClick={ () => {
+														recordEvent(
+															'sidebar_template_actions_swap_template_clicked'
+														);
+														setSelectTemplateModalOpen(
+															true
+														);
+														onClose();
+													} }
+												>
+													{ __(
+														'Swap template',
+														'mailpoet'
+													) }
+												</MenuItem>
+											</>
+										) }
+									</DropdownMenu>
+								</FlexItem>
+							</Flex>
+						</PanelRow>
+					) }
+			{ isEditTemplateModalOpen && (
+				<EditTemplateModal
+					close={ () => {
+						recordEvent( 'edit_template_modal_closed' );
+						return setEditTemplateModalOpen( false );
+					} }
+				/>
+			) }
+			{ isSelectTemplateModalOpen && (
+				<SelectTemplateModal
+					onSelectCallback={ () =>
+						setSelectTemplateModalOpen( false )
+					}
+					closeCallback={ () => setSelectTemplateModalOpen( false ) }
+					previewContent={ currentEmailContent }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/js/email-editor/src/components/sidebar/post-status-panel.tsx
+++ b/packages/js/email-editor/src/components/sidebar/post-status-panel.tsx
@@ -35,74 +35,69 @@ export function PostStatusPanel() {
 
 	return (
 		<>
-
-					{ template && (
-						<PanelRow>
-							<Flex justify={ 'start' }>
-								<FlexItem className="editor-post-panel__row-label">
-									{ __( 'Template', 'mailpoet' ) }
-								</FlexItem>
-								<FlexItem>
-									<DropdownMenu
-										icon={ null }
-										text={ template?.title }
-										toggleProps={ { variant: 'tertiary' } }
-										label={ __(
-											'Template actions',
-											'mailpoet'
-										) }
-										onToggle={ ( isOpen ) =>
-											recordEvent(
-												'sidebar_template_actions_clicked',
-												{
-													currentTemplate:
-													template?.title,
-													isOpen,
-												}
-											)
+			{ template && (
+				<PanelRow>
+					<Flex justify={ 'start' }>
+						<FlexItem className="editor-post-panel__row-label">
+							{ __( 'Template', 'mailpoet' ) }
+						</FlexItem>
+						<FlexItem>
+							<DropdownMenu
+								icon={ null }
+								text={ template?.title }
+								toggleProps={ { variant: 'tertiary' } }
+								label={ __( 'Template actions', 'mailpoet' ) }
+								onToggle={ ( isOpen ) =>
+									recordEvent(
+										'sidebar_template_actions_clicked',
+										{
+											currentTemplate: template?.title,
+											isOpen,
 										}
-									>
-										{ ( { onClose } ) => (
-											<>
-												<MenuItem
-													onClick={ () => {
-														recordEvent(
-															'sidebar_template_actions_edit_template_clicked'
-														);
-														setEditTemplateModalOpen(
-															true
-														);
-														onClose();
-													} }
-												>
-													{ __(
-														'Edit template',
-														'mailpoet'
-													) }
-												</MenuItem>
-												<MenuItem
-													onClick={ () => {
-														recordEvent(
-															'sidebar_template_actions_swap_template_clicked'
-														);
-														setSelectTemplateModalOpen(
-															true
-														);
-														onClose();
-													} }
-												>
-													{ __(
-														'Swap template',
-														'mailpoet'
-													) }
-												</MenuItem>
-											</>
-										) }
-									</DropdownMenu>
-								</FlexItem>
-							</Flex>
-						</PanelRow>
-					) }
+									)
+								}
+							>
+								{ ( { onClose } ) => (
+									<>
+										<MenuItem
+											onClick={ () => {
+												recordEvent(
+													'sidebar_template_actions_edit_template_clicked'
+												);
+												setEditTemplateModalOpen(
+													true
+												);
+												onClose();
+											} }
+										>
+											{ __(
+												'Edit template',
+												'mailpoet'
+											) }
+										</MenuItem>
+										<MenuItem
+											onClick={ () => {
+												recordEvent(
+													'sidebar_template_actions_swap_template_clicked'
+												);
+												setSelectTemplateModalOpen(
+													true
+												);
+												onClose();
+											} }
+										>
+											{ __(
+												'Swap template',
+												'mailpoet'
+											) }
+										</MenuItem>
+									</>
+								) }
+							</DropdownMenu>
+						</FlexItem>
+					</Flex>
+				</PanelRow>
+			) }
 			{ isEditTemplateModalOpen && (
 				<EditTemplateModal
 					close={ () => {

--- a/packages/js/email-editor/src/components/styles-sidebar/index.ts
+++ b/packages/js/email-editor/src/components/styles-sidebar/index.ts
@@ -1,1 +1,2 @@
 export * from './styles-sidebar';
+export * from './sidebar-content';

--- a/packages/js/email-editor/src/components/styles-sidebar/sidebar-content.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/sidebar-content.tsx
@@ -1,12 +1,21 @@
 /**
  * External dependencies
  */
-import {__experimentalNavigatorProvider as NavigatorProvider, __experimentalNavigatorScreen as NavigatorScreen} from "@wordpress/components";
+import {
+	__experimentalNavigatorProvider as NavigatorProvider,
+	__experimentalNavigatorScreen as NavigatorScreen,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import {ScreenColors, ScreenLayout, ScreenRoot, ScreenTypography, ScreenTypographyElement} from './screens';
+import {
+	ScreenColors,
+	ScreenLayout,
+	ScreenRoot,
+	ScreenTypography,
+	ScreenTypographyElement,
+} from './screens';
 
 export function StylesSidebarContent() {
 	return (

--- a/packages/js/email-editor/src/components/styles-sidebar/sidebar-content.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/sidebar-content.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import {__experimentalNavigatorProvider as NavigatorProvider, __experimentalNavigatorScreen as NavigatorScreen} from "@wordpress/components";
+
+/**
+ * Internal dependencies
+ */
+import {ScreenColors, ScreenLayout, ScreenRoot, ScreenTypography, ScreenTypographyElement} from './screens';
+
+export function StylesSidebarContent() {
+	return (
+		<NavigatorProvider initialPath="/">
+			<NavigatorScreen path="/">
+				<ScreenRoot />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/typography">
+				<ScreenTypography />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/typography/text">
+				<ScreenTypographyElement element="text" />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/typography/link">
+				<ScreenTypographyElement element="link" />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/typography/heading">
+				<ScreenTypographyElement element="heading" />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/typography/button">
+				<ScreenTypographyElement element="button" />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/colors">
+				<ScreenColors />
+			</NavigatorScreen>
+
+			<NavigatorScreen path="/layout">
+				<ScreenLayout />
+			</NavigatorScreen>
+		</NavigatorProvider>
+	);
+}

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -7,12 +7,11 @@ import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
 
-
 /**
  * Internal dependencies
  */
 import { storeName, stylesSidebarId } from '../../store';
-import { StylesSidebarContent} from "./sidebar-content";
+import { StylesSidebarContent } from './sidebar-content';
 
 type Props = ComponentProps< typeof ComplementaryArea >;
 

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -6,22 +6,13 @@ import { __ } from '@wordpress/i18n';
 import { ComplementaryArea } from '@wordpress/interface';
 import { ComponentProps } from 'react';
 import { styles } from '@wordpress/icons';
-import {
-	__experimentalNavigatorProvider as NavigatorProvider,
-	__experimentalNavigatorScreen as NavigatorScreen,
-} from '@wordpress/components';
+
 
 /**
  * Internal dependencies
  */
 import { storeName, stylesSidebarId } from '../../store';
-import {
-	ScreenTypography,
-	ScreenTypographyElement,
-	ScreenLayout,
-	ScreenRoot,
-	ScreenColors,
-} from './screens';
+import { StylesSidebarContent} from "./sidebar-content";
 
 type Props = ComponentProps< typeof ComplementaryArea >;
 
@@ -37,39 +28,7 @@ export function RawStylesSidebar( props: Props ): JSX.Element {
 			smallScreenTitle={ __( 'No title', 'mailpoet' ) }
 			{ ...props }
 		>
-			<NavigatorProvider initialPath="/">
-				<NavigatorScreen path="/">
-					<ScreenRoot />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/typography">
-					<ScreenTypography />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/typography/text">
-					<ScreenTypographyElement element="text" />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/typography/link">
-					<ScreenTypographyElement element="link" />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/typography/heading">
-					<ScreenTypographyElement element="heading" />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/typography/button">
-					<ScreenTypographyElement element="button" />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/colors">
-					<ScreenColors />
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/layout">
-					<ScreenLayout />
-				</NavigatorScreen>
-			</NavigatorProvider>
+			<StylesSidebarContent />
 		</ComplementaryArea>
 	);
 }

--- a/packages/js/email-editor/src/components/template-select/template-selection.tsx
+++ b/packages/js/email-editor/src/components/template-select/template-selection.tsx
@@ -3,23 +3,34 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { storeName } from '../../store';
 import { SelectTemplateModal } from './select-modal';
+import { useEditorMode } from '../../hooks';
 
 export function TemplateSelection() {
+	const [ editorMode ] = useEditorMode();
 	const [ templateSelected, setTemplateSelected ] = useState( false );
-	const { emailContentIsEmpty, emailHasEdits } = useSelect(
+	const { emailTemplateSlug, emailHasEdits } = useSelect(
 		( select ) => ( {
 			emailContentIsEmpty: select( storeName ).hasEmptyContent(),
 			emailHasEdits: select( storeName ).hasEdits(),
+			emailTemplateSlug:
+				// @ts-expect-error getEditedPostAttribute accepts one argument TS thinks it accepts zero
+				select( editorStore ).getEditedPostAttribute( 'template' ),
 		} ),
 		[]
 	);
-	if ( ! emailContentIsEmpty || emailHasEdits || templateSelected ) {
+	if (
+		editorMode === 'template' ||
+		emailHasEdits ||
+		templateSelected ||
+		emailTemplateSlug
+	) {
 		return null;
 	}
 

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -37,7 +37,7 @@ export function useEmailCss() {
 	);
 
 	const [ styles ] = useGlobalStylesOutputWithConfig( mergedConfig );
-	const finalStyles = [ ...baseStyles, ...(styles ? styles : []) ] ;
+	const finalStyles = [ ...baseStyles, ...( styles ? styles : [] ) ];
 	if ( ! fastDeepEqual( stylesRef.current, finalStyles ) ) {
 		stylesRef.current = finalStyles;
 	}

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import deepmerge from 'deepmerge';
+import fastDeepEqual from 'fast-deep-equal/es6';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { useUserTheme } from './use-user-theme';
 import { useGlobalStylesOutputWithConfig } from '../private-apis';
 
 export function useEmailCss() {
+	const stylesRef = useRef( [] );
 	const { userTheme } = useUserTheme();
 	const { editorTheme } = useSelect(
 		( select ) => ( {
@@ -20,6 +22,9 @@ export function useEmailCss() {
 		} ),
 		[]
 	);
+
+	// @ts-expect-error Todo add styles for editor settings
+	const baseStyles = window.MailPoetEmailEditor.editor_settings.styles;
 
 	const mergedConfig = useMemo(
 		() =>
@@ -32,7 +37,11 @@ export function useEmailCss() {
 	);
 
 	const [ styles ] = useGlobalStylesOutputWithConfig( mergedConfig );
+	const finalStyles = [ ...baseStyles, ...(styles ? styles : []) ] ;
+	if ( ! fastDeepEqual( stylesRef.current, finalStyles ) ) {
+		stylesRef.current = finalStyles;
+	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return [ styles || [] ];
+	return [ stylesRef.current ];
 }

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -16,7 +16,7 @@ import { createStore } from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { SendPreview } from './unified-editor/preview';
-import { DocumentSettings } from './unified-editor/document-setting';
+import { DocumentSettings, TemplatePanel } from './unified-editor/document-setting';
 import { PublishSave } from './unified-editor/publish-save';
 import { useEmailCss } from './hooks';
 
@@ -26,7 +26,7 @@ import './unified-editor/styles.scss';
 window.mailpoet_cdn_url = window.MailPoetEmailEditor.mailpoet_cdn_url;
 
 const EmailEditor = () => {
-	const { setRenderingMode, updateEditorSettings } =
+	const { setRenderingMode, updateEditorSettings, removeEditorPanel } =
 		useDispatch( editorStore );
 	// const { __experimentalReceiveCurrentGlobalStylesId } = useDispatch( coreStore );
 	const { globalStylesId, editorSettings, editedPostId } = useSelect( ( select ) => {
@@ -41,8 +41,8 @@ const EmailEditor = () => {
 
 	// Enforce template-locked mode on start
 	useEffect( () => {
-		console.log( 'Email Editor set template-locked mode' );
 		void setRenderingMode( 'template-locked' );
+		void removeEditorPanel('post-status'); // Hide default post status panel
 		// void __experimentalReceiveCurrentGlobalStylesId( window.MailPoetEmailEditor.user_theme_post_id );
 	}, [ globalStylesId ] );
 
@@ -64,6 +64,7 @@ const EmailEditor = () => {
 			<StylesSidebar />
 			<SendPreview />
 			<DocumentSettings />
+			<TemplatePanel />
 			<PublishSave />
 		</>
 	);

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -1,1 +1,17 @@
-console.log( 'Email editor scripts loaded' ); // eslint-disable-line no-console
+import { registerPlugin } from '@wordpress/plugins';
+import { store as editorStore } from '@wordpress/editor';
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+const EmailEditor = () => {
+	const { setRenderingMode } = useDispatch( editorStore );
+
+	// Enforce template-locked mode on start
+	useEffect( () => {
+		console.log( 'Email Editor set template-locked mode' );
+		void setRenderingMode( 'template-locked' );
+	}, [] );
+	return null;
+};
+
+registerPlugin( 'email-editor-plugin', { render: EmailEditor } );

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -12,6 +12,7 @@ import { useDispatch } from '@wordpress/data';
 import { initBlocksUnified } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { createStore } from './store';
+import { TemplateSelection } from './components/template-select';
 
 const EmailEditor = () => {
 	const { setRenderingMode } = useDispatch( editorStore );
@@ -21,7 +22,9 @@ const EmailEditor = () => {
 		console.log( 'Email Editor set template-locked mode' );
 		void setRenderingMode( 'template-locked' );
 	}, [] );
-	return null;
+	return <>
+		<TemplateSelection />
+	</>;
 };
 
 registerPlugin( 'email-editor-plugin', { render: EmailEditor } );

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -4,18 +4,21 @@
 import { registerPlugin } from '@wordpress/plugins';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { initBlocksUnified } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
-import {createStore, storeName} from './store';
+import { createStore, storeName } from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { SendPreview } from './unified-editor/preview';
-import { DocumentSettings, TemplatePanel } from './unified-editor/document-setting';
+import {
+	DocumentSettings,
+	TemplatePanel,
+} from './unified-editor/document-setting';
 import { PublishSave } from './unified-editor/publish-save';
 import { useEmailCss } from './hooks';
 import { initEventCollector } from './events';
@@ -26,25 +29,25 @@ import './unified-editor/styles.scss';
 window.mailpoet_cdn_url = window.MailPoetEmailEditor.mailpoet_cdn_url;
 
 const EmailEditor = () => {
+	// @ts-expect-error Missing types for setRenderingMode and removeEditorPanel
 	const { setRenderingMode, updateEditorSettings, removeEditorPanel } =
 		useDispatch( editorStore );
-	const { editorSettings, editedPostId, emailContentIsEmpty } = useSelect( ( select ) => {
+	const { editedPostId, emailContentIsEmpty } = useSelect( ( sel ) => {
 		return {
-			editorSettings: select( editorStore ).getEditorSettings(),
-			editedPostId: select( editorStore ).getCurrentPost().id,
-			emailContentIsEmpty: select( storeName ).hasEmptyContent(),
-			emailHasEdits: select( storeName ).hasEdits(),
+			editedPostId: sel( editorStore ).getCurrentPost().id,
+			emailContentIsEmpty: sel( storeName ).hasEmptyContent(),
+			emailHasEdits: sel( storeName ).hasEdits(),
 		};
 	} );
 	const [ styles ] = useEmailCss();
 
 	// Enforce template-locked mode on start
 	useEffect( () => {
-		if (!emailContentIsEmpty) {
+		if ( ! emailContentIsEmpty ) {
 			void setRenderingMode( 'template-locked' );
 		}
-		void removeEditorPanel('post-status'); // Hide default post status panel
-	}, [ emailContentIsEmpty ] );
+		void removeEditorPanel( 'post-status' ); // Hide default post status panel
+	}, [ emailContentIsEmpty, removeEditorPanel, setRenderingMode ] );
 
 	// Push email styles to editor settings.
 	// Set styles directly to settings overwriting the automatically loaded theme styles
@@ -52,11 +55,12 @@ const EmailEditor = () => {
 		if ( ! styles ) {
 			return;
 		}
+		const editorSettings = select( editorStore ).getEditorSettings();
 		updateEditorSettings( {
 			...editorSettings,
 			styles,
 		} );
-	}, [ styles, editedPostId ] );
+	}, [ styles, editedPostId, updateEditorSettings ] );
 
 	return (
 		<>

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -1,0 +1,1 @@
+console.log( 'Email editor scripts loaded' ); // eslint-disable-line no-console

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -17,7 +17,10 @@ import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { SendPreview } from './unified-editor/preview';
 import { DocumentSettings } from './unified-editor/document-setting';
+import { PublishSave } from './unified-editor/publish-save';
 import { useEmailCss } from './hooks';
+
+import './unified-editor/styles.scss';
 
 // @ts-expect-error Hotfix for the Powered by MailPoet block @todo load the variable properly
 window.mailpoet_cdn_url = window.MailPoetEmailEditor.mailpoet_cdn_url;
@@ -61,6 +64,7 @@ const EmailEditor = () => {
 			<StylesSidebar />
 			<SendPreview />
 			<DocumentSettings />
+			<PublishSave />
 		</>
 	);
 };

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -15,10 +15,12 @@ import { initializeLayout } from './layouts/flex-email';
 import { createStore } from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
+import { SendPreview } from './unified-editor/preview';
 import { useEmailCss } from './hooks';
 
 // @ts-expect-error Hotfix for the Powered by MailPoet block @todo load the variable properly
 window.mailpoet_cdn_url = window.MailPoetEmailEditor.mailpoet_cdn_url;
+
 const EmailEditor = () => {
 	const { setRenderingMode, updateEditorSettings } =
 		useDispatch( editorStore );
@@ -56,6 +58,7 @@ const EmailEditor = () => {
 		<>
 			<TemplateSelection />
 			<StylesSidebar />
+			<SendPreview />
 		</>
 	);
 };

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -3,8 +3,9 @@
  */
 import { registerPlugin } from '@wordpress/plugins';
 import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,18 +14,26 @@ import { initBlocksUnified } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { createStore } from './store';
 import { TemplateSelection } from './components/template-select';
+import { StylesSidebar } from './unified-editor/styles-sidebar';
 
 const EmailEditor = () => {
 	const { setRenderingMode } = useDispatch( editorStore );
+	const { __experimentalReceiveCurrentGlobalStylesId } = useDispatch( coreStore );
+	const globalStylesId= useSelect( (select) => select( coreStore ).__experimentalGetCurrentGlobalStylesId() );
 
 	// Enforce template-locked mode on start
 	useEffect( () => {
 		console.log( 'Email Editor set template-locked mode' );
 		void setRenderingMode( 'template-locked' );
-	}, [] );
-	return <>
-		<TemplateSelection />
-	</>;
+		void __experimentalReceiveCurrentGlobalStylesId( window.MailPoetEmailEditor.user_theme_post_id );
+	}, [globalStylesId] );
+	console.log(globalStylesId, 'ee');
+	return (
+		<>
+			<TemplateSelection />
+			<StylesSidebar />
+		</>
+	);
 };
 
 registerPlugin( 'email-editor-plugin', { render: EmailEditor } );

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -3,7 +3,6 @@
  */
 import { registerPlugin } from '@wordpress/plugins';
 import { store as editorStore } from '@wordpress/editor';
-import { store as coreStore } from '@wordpress/core-data';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -12,7 +11,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { initBlocksUnified } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
-import { createStore } from './store';
+import {createStore, storeName} from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { SendPreview } from './unified-editor/preview';
@@ -28,23 +27,23 @@ window.mailpoet_cdn_url = window.MailPoetEmailEditor.mailpoet_cdn_url;
 const EmailEditor = () => {
 	const { setRenderingMode, updateEditorSettings, removeEditorPanel } =
 		useDispatch( editorStore );
-	// const { __experimentalReceiveCurrentGlobalStylesId } = useDispatch( coreStore );
-	const { globalStylesId, editorSettings, editedPostId } = useSelect( ( select ) => {
+	const { editorSettings, editedPostId, emailContentIsEmpty } = useSelect( ( select ) => {
 		return {
-			globalStylesId:
-				select( coreStore ).__experimentalGetCurrentGlobalStylesId(),
 			editorSettings: select( editorStore ).getEditorSettings(),
 			editedPostId: select( editorStore ).getCurrentPost().id,
+			emailContentIsEmpty: select( storeName ).hasEmptyContent(),
+			emailHasEdits: select( storeName ).hasEdits(),
 		};
 	} );
 	const [ styles ] = useEmailCss();
 
 	// Enforce template-locked mode on start
 	useEffect( () => {
-		void setRenderingMode( 'template-locked' );
+		if (!emailContentIsEmpty) {
+			void setRenderingMode( 'template-locked' );
+		}
 		void removeEditorPanel('post-status'); // Hide default post status panel
-		// void __experimentalReceiveCurrentGlobalStylesId( window.MailPoetEmailEditor.user_theme_post_id );
-	}, [ globalStylesId ] );
+	}, [ emailContentIsEmpty ] );
 
 	// Push email styles to editor settings.
 	// Set styles directly to settings overwriting the automatically loaded theme styles

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -1,7 +1,17 @@
+/**
+ * External dependencies
+ */
 import { registerPlugin } from '@wordpress/plugins';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { initBlocksUnified } from './blocks';
+import { initializeLayout } from './layouts/flex-email';
+import { createStore } from './store';
 
 const EmailEditor = () => {
 	const { setRenderingMode } = useDispatch( editorStore );
@@ -15,3 +25,6 @@ const EmailEditor = () => {
 };
 
 registerPlugin( 'email-editor-plugin', { render: EmailEditor } );
+initBlocksUnified();
+initializeLayout();
+createStore();

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -18,6 +18,7 @@ import { SendPreview } from './unified-editor/preview';
 import { DocumentSettings, TemplatePanel } from './unified-editor/document-setting';
 import { PublishSave } from './unified-editor/publish-save';
 import { useEmailCss } from './hooks';
+import { initEventCollector } from './events';
 
 import './unified-editor/styles.scss';
 
@@ -73,3 +74,4 @@ registerPlugin( 'email-editor-plugin', { render: EmailEditor } );
 initBlocksUnified();
 initializeLayout();
 createStore();
+initEventCollector();

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -15,19 +15,41 @@ import { initializeLayout } from './layouts/flex-email';
 import { createStore } from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
+import { useEmailCss } from './hooks';
 
 const EmailEditor = () => {
-	const { setRenderingMode } = useDispatch( editorStore );
-	const { __experimentalReceiveCurrentGlobalStylesId } = useDispatch( coreStore );
-	const globalStylesId= useSelect( (select) => select( coreStore ).__experimentalGetCurrentGlobalStylesId() );
+	const { setRenderingMode, updateEditorSettings } =
+		useDispatch( editorStore );
+	// const { __experimentalReceiveCurrentGlobalStylesId } = useDispatch( coreStore );
+	const { globalStylesId, editorSettings, editedPostId } = useSelect( ( select ) => {
+		return {
+			globalStylesId:
+				select( coreStore ).__experimentalGetCurrentGlobalStylesId(),
+			editorSettings: select( editorStore ).getEditorSettings(),
+			editedPostId: select( editorStore ).getCurrentPost().id,
+		};
+	} );
+	const [ styles ] = useEmailCss();
 
 	// Enforce template-locked mode on start
 	useEffect( () => {
 		console.log( 'Email Editor set template-locked mode' );
 		void setRenderingMode( 'template-locked' );
-		void __experimentalReceiveCurrentGlobalStylesId( window.MailPoetEmailEditor.user_theme_post_id );
-	}, [globalStylesId] );
-	console.log(globalStylesId, 'ee');
+		// void __experimentalReceiveCurrentGlobalStylesId( window.MailPoetEmailEditor.user_theme_post_id );
+	}, [ globalStylesId ] );
+
+	// Push email styles to editor settings.
+	// Set styles directly to settings overwriting the automatically loaded theme styles
+	useEffect( () => {
+		if ( ! styles ) {
+			return;
+		}
+		updateEditorSettings( {
+			...editorSettings,
+			styles,
+		} );
+	}, [ styles, editedPostId ] );
+
 	return (
 		<>
 			<TemplateSelection />

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -17,6 +17,8 @@ import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { useEmailCss } from './hooks';
 
+// @ts-expect-error Hotfix for the Powered by MailPoet block @todo load the variable properly
+window.mailpoet_cdn_url = window.MailPoetEmailEditor.mailpoet_cdn_url;
 const EmailEditor = () => {
 	const { setRenderingMode, updateEditorSettings } =
 		useDispatch( editorStore );

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -11,7 +11,7 @@ import { useDispatch, useSelect, select } from '@wordpress/data';
  */
 import { initBlocksUnified } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
-import { createStore, storeName } from './store';
+import { createStore } from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { SendPreview } from './unified-editor/preview';
@@ -32,22 +32,23 @@ const EmailEditor = () => {
 	// @ts-expect-error Missing types for setRenderingMode and removeEditorPanel
 	const { setRenderingMode, updateEditorSettings, removeEditorPanel } =
 		useDispatch( editorStore );
-	const { editedPostId, emailContentIsEmpty } = useSelect( ( sel ) => {
+	const { editedPostId, emailTemplateSlug } = useSelect( ( sel ) => {
 		return {
 			editedPostId: sel( editorStore ).getCurrentPost().id,
-			emailContentIsEmpty: sel( storeName ).hasEmptyContent(),
-			emailHasEdits: sel( storeName ).hasEdits(),
+			emailTemplateSlug:
+				// @ts-expect-error getEditedPostAttribute accepts one argument TS thinks it accepts zero
+				select( editorStore ).getEditedPostAttribute( 'template' ),
 		};
 	} );
 	const [ styles ] = useEmailCss();
 
 	// Enforce template-locked mode on start
 	useEffect( () => {
-		if ( ! emailContentIsEmpty ) {
+		if ( emailTemplateSlug ) {
 			void setRenderingMode( 'template-locked' );
 		}
 		void removeEditorPanel( 'post-status' ); // Hide default post status panel
-	}, [ emailContentIsEmpty, removeEditorPanel, setRenderingMode ] );
+	}, [ emailTemplateSlug, removeEditorPanel, setRenderingMode ] );
 
 	// Push email styles to editor settings.
 	// Set styles directly to settings overwriting the automatically loaded theme styles

--- a/packages/js/email-editor/src/unified-editor.tsx
+++ b/packages/js/email-editor/src/unified-editor.tsx
@@ -16,6 +16,7 @@ import { createStore } from './store';
 import { TemplateSelection } from './components/template-select';
 import { StylesSidebar } from './unified-editor/styles-sidebar';
 import { SendPreview } from './unified-editor/preview';
+import { DocumentSettings } from './unified-editor/document-setting';
 import { useEmailCss } from './hooks';
 
 // @ts-expect-error Hotfix for the Powered by MailPoet block @todo load the variable properly
@@ -59,6 +60,7 @@ const EmailEditor = () => {
 			<TemplateSelection />
 			<StylesSidebar />
 			<SendPreview />
+			<DocumentSettings />
 		</>
 	);
 };

--- a/packages/js/email-editor/src/unified-editor/document-setting.tsx
+++ b/packages/js/email-editor/src/unified-editor/document-setting.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { DetailsPanelContent } from "../components/sidebar/details-panel-content";
+
+export function DocumentSettings() {
+	return (<PluginDocumentSettingPanel
+		name="details-panel"
+		title={__('Details', 'mailpoet')}
+		className="details-panel"
+	>
+		<DetailsPanelContent />
+	</PluginDocumentSettingPanel>);
+};

--- a/packages/js/email-editor/src/unified-editor/document-setting.tsx
+++ b/packages/js/email-editor/src/unified-editor/document-setting.tsx
@@ -1,20 +1,31 @@
 /**
  * External dependencies
  */
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { DetailsPanelContent } from "../components/sidebar/details-panel-content";
+import { PostStatusPanel } from "../components/sidebar/post-status-panel";
 
 export function DocumentSettings() {
 	return (<PluginDocumentSettingPanel
 		name="details-panel"
 		title={__('Details', 'mailpoet')}
-		className="details-panel"
+		className="details-panel mailpoet-email-editor__settings-panel"
 	>
 		<DetailsPanelContent />
 	</PluginDocumentSettingPanel>);
 };
+
+export function TemplatePanel() {
+	return (<PluginDocumentSettingPanel
+		name="template-panel"
+		title={__('Template', 'mailpoet')}
+		className="mailpoet-email-editor__template-panel"
+	>
+		<PostStatusPanel />
+	</PluginDocumentSettingPanel>);
+}

--- a/packages/js/email-editor/src/unified-editor/document-setting.tsx
+++ b/packages/js/email-editor/src/unified-editor/document-setting.tsx
@@ -1,31 +1,36 @@
 /**
  * External dependencies
  */
-import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+// @ts-expect-error Missing types for PluginDocumentSettingPanel
+import { PluginDocumentSettingPanel } from '@wordpress/editor'; // eslint-disable-line @woocommerce/dependency-group
 
 /**
  * Internal dependencies
  */
-import { DetailsPanelContent } from "../components/sidebar/details-panel-content";
-import { PostStatusPanel } from "../components/sidebar/post-status-panel";
+import { DetailsPanelContent } from '../components/sidebar/details-panel-content';
+import { PostStatusPanel } from '../components/sidebar/post-status-panel';
 
 export function DocumentSettings() {
-	return (<PluginDocumentSettingPanel
-		name="details-panel"
-		title={__('Details', 'mailpoet')}
-		className="details-panel mailpoet-email-editor__settings-panel"
-	>
-		<DetailsPanelContent />
-	</PluginDocumentSettingPanel>);
-};
+	return (
+		<PluginDocumentSettingPanel
+			name="details-panel"
+			title={ __( 'Details', 'mailpoet' ) }
+			className="details-panel mailpoet-email-editor__settings-panel"
+		>
+			<DetailsPanelContent />
+		</PluginDocumentSettingPanel>
+	);
+}
 
 export function TemplatePanel() {
-	return (<PluginDocumentSettingPanel
-		name="template-panel"
-		title={__('Template', 'mailpoet')}
-		className="mailpoet-email-editor__template-panel"
-	>
-		<PostStatusPanel />
-	</PluginDocumentSettingPanel>);
+	return (
+		<PluginDocumentSettingPanel
+			name="template-panel"
+			title={ __( 'Template', 'mailpoet' ) }
+			className="mailpoet-email-editor__template-panel"
+		>
+			<PostStatusPanel />
+		</PluginDocumentSettingPanel>
+	);
 }

--- a/packages/js/email-editor/src/unified-editor/preview.tsx
+++ b/packages/js/email-editor/src/unified-editor/preview.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { PluginPreviewMenuItem } from '@wordpress/editor';
+import { useDispatch  } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { storeName } from '../store/constants';
+import { SendPreviewEmail } from '../components/preview/send-preview-email';
+
+export function SendPreview() {
+	const { togglePreviewModal } = useDispatch( storeName );
+
+	return (
+		<>
+		<PluginPreviewMenuItem icon={external} onClick={() => {
+			togglePreviewModal(true);
+		}}>
+			{ __( 'Send preview' ) }
+		</PluginPreviewMenuItem>
+			<SendPreviewEmail />
+			</>
+	);
+}

--- a/packages/js/email-editor/src/unified-editor/preview.tsx
+++ b/packages/js/email-editor/src/unified-editor/preview.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { PluginPreviewMenuItem } from '@wordpress/editor';
-import { useDispatch  } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
+// @ts-expect-error Missing types for PluginPreviewMenuItem
+import { PluginPreviewMenuItem } from '@wordpress/editor'; // eslint-disable-line @woocommerce/dependency-group
 
 /**
  * Internal dependencies
@@ -17,12 +18,15 @@ export function SendPreview() {
 
 	return (
 		<>
-		<PluginPreviewMenuItem icon={external} onClick={() => {
-			togglePreviewModal(true);
-		}}>
-			{ __( 'Send preview' ) }
-		</PluginPreviewMenuItem>
+			<PluginPreviewMenuItem
+				icon={ external }
+				onClick={ () => {
+					togglePreviewModal( true );
+				} }
+			>
+				{ __( 'Send preview', 'mailpoet' ) }
+			</PluginPreviewMenuItem>
 			<SendPreviewEmail />
-			</>
+		</>
 	);
 }

--- a/packages/js/email-editor/src/unified-editor/publish-save.tsx
+++ b/packages/js/email-editor/src/unified-editor/publish-save.tsx
@@ -2,31 +2,36 @@
  * External dependencies
  */
 import { useEffect, useState, createPortal } from '@wordpress/element';
+// @ts-expect-error Missing types for useEntitiesSavedStatesIsDirty
+import { useEntitiesSavedStatesIsDirty } from '@wordpress/editor'; // eslint-disable-line @woocommerce/dependency-group
 
 /**
  * Internal dependencies
  */
 import { SendButton } from '../components/header/send-button';
 import { useContentValidation } from '../hooks';
-import { useEntitiesSavedStatesIsDirty } from '@wordpress/editor';
+
 import { editorCurrentPostType } from '../store';
 
 type NextButtonSlotPropType = {
 	children: React.ReactNode;
 };
 
-function NextPublishSlot({ children }: NextButtonSlotPropType) {
-	const [sendButtonPortalEl] = useState(document.createElement('div'));
+function NextPublishSlot( { children }: NextButtonSlotPropType ) {
+	const [ sendButtonPortalEl ] = useState( document.createElement( 'div' ) );
 
 	// Place element for rendering send button next to publish button
-	useEffect(() => {
+	useEffect( () => {
 		const publishButton = document.getElementsByClassName(
-			'editor-post-publish-button__button',
-		)[0];
-		publishButton.parentNode.insertBefore(sendButtonPortalEl, publishButton.nextSibling);
-	}, [sendButtonPortalEl]);
+			'editor-post-publish-button__button'
+		)[ 0 ];
+		publishButton.parentNode.insertBefore(
+			sendButtonPortalEl,
+			publishButton.nextSibling
+		);
+	}, [ sendButtonPortalEl ] );
 
-	return createPortal(<>{children}</>, sendButtonPortalEl);
+	return createPortal( <>{ children }</>, sendButtonPortalEl );
 }
 
 export function PublishSave() {
@@ -36,31 +41,36 @@ export function PublishSave() {
 	const hasNonEmailEdits = dirtyEntityRecords.some(
 		( entity ) => entity.name !== editorCurrentPostType
 	);
-	useEffect(() => {
+	useEffect( () => {
 		const publishButton = document.getElementsByClassName(
-			'editor-post-publish-button__button',
-		)[0];
-		if (hasNonEmailEdits) {
-			publishButton.classList.remove('force-hidden');
+			'editor-post-publish-button__button'
+		)[ 0 ];
+		if ( hasNonEmailEdits ) {
+			publishButton.classList.remove( 'force-hidden' );
 		} else {
-			publishButton.classList.add('force-hidden');
+			publishButton.classList.add( 'force-hidden' );
 		}
 		// It may get additionally re-rendered by the editor, so we need to check it again
-		setTimeout(() => {
-			const publishButton = document.getElementsByClassName(
-				'editor-post-publish-button__button',
-			)[0];
-			if (hasNonEmailEdits) {
-				publishButton.classList.remove('force-hidden');
+		setTimeout( () => {
+			const publishButtonEl = document.getElementsByClassName(
+				'editor-post-publish-button__button'
+			)[ 0 ];
+			if ( hasNonEmailEdits ) {
+				publishButtonEl.classList.remove( 'force-hidden' );
 			} else {
-				publishButton.classList.add('force-hidden');
+				publishButtonEl.classList.add( 'force-hidden' );
 			}
-		}, 200)
-	});
+		}, 200 );
+	} );
 
 	return (
 		<NextPublishSlot>
-			{!hasNonEmailEdits && <SendButton validateContent={validateContent} isContentInvalid={isInvalid}/>}
+			{ ! hasNonEmailEdits && (
+				<SendButton
+					validateContent={ validateContent }
+					isContentInvalid={ isInvalid }
+				/>
+			) }
 		</NextPublishSlot>
 	);
 }

--- a/packages/js/email-editor/src/unified-editor/publish-save.tsx
+++ b/packages/js/email-editor/src/unified-editor/publish-save.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState, createPortal } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { SendButton } from '../components/header/send-button';
+import { useContentValidation } from '../hooks';
+import { useEntitiesSavedStatesIsDirty } from '@wordpress/editor';
+import { editorCurrentPostType } from '../store';
+
+type NextButtonSlotPropType = {
+	children: React.ReactNode;
+};
+
+function NextPublishSlot({ children }: NextButtonSlotPropType) {
+	const [sendButtonPortalEl] = useState(document.createElement('div'));
+
+	// Place element for rendering send button next to publish button
+	useEffect(() => {
+		const publishButton = document.getElementsByClassName(
+			'editor-post-publish-button__button',
+		)[0];
+		publishButton.parentNode.insertBefore(sendButtonPortalEl, publishButton.nextSibling);
+	}, [sendButtonPortalEl]);
+
+	return createPortal(<>{children}</>, sendButtonPortalEl);
+}
+
+export function PublishSave() {
+	const { validateContent, isInvalid } = useContentValidation();
+
+	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
+	const hasNonEmailEdits = dirtyEntityRecords.some(
+		( entity ) => entity.name !== editorCurrentPostType
+	);
+	useEffect(() => {
+		const publishButton = document.getElementsByClassName(
+			'editor-post-publish-button__button',
+		)[0];
+		if (hasNonEmailEdits) {
+			publishButton.classList.remove('force-hidden');
+		} else {
+			publishButton.classList.add('force-hidden');
+		}
+		// It may get additionally re-rendered by the editor, so we need to check it again
+		setTimeout(() => {
+			const publishButton = document.getElementsByClassName(
+				'editor-post-publish-button__button',
+			)[0];
+			if (hasNonEmailEdits) {
+				publishButton.classList.remove('force-hidden');
+			} else {
+				publishButton.classList.add('force-hidden');
+			}
+		}, 200)
+	});
+
+	return (
+		<NextPublishSlot>
+			{!hasNonEmailEdits && <SendButton validateContent={validateContent} isContentInvalid={isInvalid}/>}
+		</NextPublishSlot>
+	);
+}

--- a/packages/js/email-editor/src/unified-editor/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/unified-editor/styles-sidebar.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
+import { styles } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { StylesSidebarContent } from '../components/styles-sidebar';
+
+export function StylesSidebar() {
+	return (
+		<>
+			<PluginSidebarMoreMenuItem target="sidebar-name" icon={ styles }>
+				{ __( 'Email styles' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar name="sidebar-name" icon={ styles } title="Styles">
+				<StylesSidebarContent />
+			</PluginSidebar>
+		</>
+	);
+}

--- a/packages/js/email-editor/src/unified-editor/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/unified-editor/styles-sidebar.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
 import { styles } from '@wordpress/icons';
+// @ts-expect-error Missing types for PluginSidebar, PluginSidebarMoreMenuItem
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor'; // eslint-disable-line @woocommerce/dependency-group
 
 /**
  * Internal dependencies
@@ -14,9 +15,14 @@ export function StylesSidebar() {
 	return (
 		<>
 			<PluginSidebarMoreMenuItem target="sidebar-name" icon={ styles }>
-				{ __( 'Email styles' ) }
+				{ __( 'Email styles', 'mailpoet' ) }
 			</PluginSidebarMoreMenuItem>
-			<PluginSidebar name="sidebar-name" icon={ styles } title="Styles" className="mailpoet-email-editor__styles-panel">
+			<PluginSidebar
+				name="sidebar-name"
+				icon={ styles }
+				title={ __( 'Styles', 'mailpoet' ) }
+				className="mailpoet-email-editor__styles-panel"
+			>
 				<StylesSidebarContent />
 			</PluginSidebar>
 		</>

--- a/packages/js/email-editor/src/unified-editor/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/unified-editor/styles-sidebar.tsx
@@ -16,7 +16,7 @@ export function StylesSidebar() {
 			<PluginSidebarMoreMenuItem target="sidebar-name" icon={ styles }>
 				{ __( 'Email styles' ) }
 			</PluginSidebarMoreMenuItem>
-			<PluginSidebar name="sidebar-name" icon={ styles } title="Styles">
+			<PluginSidebar name="sidebar-name" icon={ styles } title="Styles" className="mailpoet-email-editor__styles-panel">
 				<StylesSidebarContent />
 			</PluginSidebar>
 		</>

--- a/packages/js/email-editor/src/unified-editor/styles.scss
+++ b/packages/js/email-editor/src/unified-editor/styles.scss
@@ -1,0 +1,3 @@
+.force-hidden {
+	display: none !important;
+}

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -91,10 +91,14 @@ class Email_Editor {
 		$this->register_block_templates();
 		$this->register_email_post_sent_status();
 		$this->register_personalization_tags();
-		$this->extend_email_post_api();
 		add_action( 'enqueue_block_editor_assets', array( $this, 'initialize_admin' ) );
 		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
 		add_filter( 'single_template', array( $this, 'load_email_preview_template' ) );
+		$is_editor_page = apply_filters( 'mailpoet_is_email_editor_page', false );
+		if ( $is_editor_page ) {
+			// The renderer doesn't support block styles, let's remove them from the editor.
+			remove_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );
+		}
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -91,6 +91,19 @@ class Email_Editor {
 		$this->register_block_templates();
 		$this->register_email_post_sent_status();
 		$this->register_personalization_tags();
+		$this->extend_email_post_api();
+		$is_editor_page = apply_filters( 'mailpoet_is_email_editor_page', false );
+		if ( $is_editor_page ) {
+			$this->settings_controller->init();
+		}
+		add_action( 'enqueue_block_editor_assets', array( $this, 'initialize_admin' ) );
+	}
+
+	/**
+	 * Run editor hooks etc. that are related to WP Admin area.
+	 */
+	public function initialize_admin(): void {
+		do_action( 'mailpoet_email_editor_admin_initialized' );
 		$is_editor_page = apply_filters( 'mailpoet_is_email_editor_page', false );
 		if ( $is_editor_page ) {
 			$this->extend_email_post_api();

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -92,12 +92,9 @@ class Email_Editor {
 		$this->register_email_post_sent_status();
 		$this->register_personalization_tags();
 		$this->extend_email_post_api();
-		$is_editor_page = apply_filters( 'mailpoet_is_email_editor_page', false );
-		if ( $is_editor_page ) {
-			$this->settings_controller->init();
-		}
 		add_action( 'enqueue_block_editor_assets', array( $this, 'initialize_admin' ) );
 		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
+		add_filter( 'single_template', array( $this, 'load_email_preview_template' ) );
 	}
 
 	/**
@@ -110,7 +107,6 @@ class Email_Editor {
 			$this->extend_email_post_api();
 		}
 		add_filter( 'mailpoet_email_editor_send_preview_email', array( $this->send_preview_email, 'send_preview_email' ), 11, 1 ); // allow for other filter methods to take precedent.
-		add_filter( 'single_template', array( $this, 'load_email_preview_template' ) );
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -97,6 +97,7 @@ class Email_Editor {
 			$this->settings_controller->init();
 		}
 		add_action( 'enqueue_block_editor_assets', array( $this, 'initialize_admin' ) );
+		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
 	}
 
 	/**
@@ -108,7 +109,6 @@ class Email_Editor {
 		if ( $is_editor_page ) {
 			$this->extend_email_post_api();
 		}
-		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
 		add_filter( 'mailpoet_email_editor_send_preview_email', array( $this->send_preview_email, 'send_preview_email' ), 11, 1 ); // allow for other filter methods to take precedent.
 		add_filter( 'single_template', array( $this, 'load_email_preview_template' ) );
 	}

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -80,9 +80,10 @@ class Settings_Controller {
 
 		$settings['__experimentalFeatures'] = $theme_settings;
 		// Controls which alignment options are available for blocks.
-		$settings['supportsLayout']              = true; // Allow using default layouts.
-		$settings['supportsTemplateMode']        = true; // Allow template mode.
-		$settings['__unstableIsBlockBasedTheme'] = true; // For default setting this to true disables wide and full alignments.
+		$settings['supportsLayout']              = true;  // Allow using default layouts.
+		$settings['supportsTemplateMode']        = true;  // Allow template mode.
+		$settings['__unstableIsBlockBasedTheme'] = true;  // For default setting this to true disables wide and full alignments.
+		$settings['codeEditingEnabled']          = false; // We heavily transform the code in renderer so it makes no sense to allow editing it.
 		return $settings;
 	}
 

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -81,6 +81,7 @@ class Settings_Controller {
 		$settings['__experimentalFeatures'] = $theme_settings;
 		// Controls which alignment options are available for blocks.
 		$settings['supportsLayout']              = true; // Allow using default layouts.
+		$settings['supportsTemplateMode']        = true; // Allow template mode.
 		$settings['__unstableIsBlockBasedTheme'] = true; // For default setting this to true disables wide and full alignments.
 		return $settings;
 	}

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -71,11 +71,13 @@ class Settings_Controller {
 		$settings['allowedBlockTypes'] = self::ALLOWED_BLOCK_TYPES;
 		// Assets for iframe editor (component styles, scripts, etc.).
 		$settings['__unstableResolvedAssets'] = $this->iframe_assets;
+		$layout_settings                      = $this->get_layout();
 		$editor_content_styles                = file_get_contents( __DIR__ . '/content-editor.css' );
 		$shares_content_styles                = file_get_contents( __DIR__ . '/content-shared.css' );
 		$settings['styles']                   = array(
 			array( 'css' => $editor_content_styles ),
 			array( 'css' => $shares_content_styles ),
+			array( 'css' => "\n.is-root-container{display:flow-root; width:" . esc_attr( $layout_settings['contentSize'] ) . "; margin: 0 auto;box-sizing: border-box;max-width: 100%;}\n" ),
 		);
 
 		$settings['__experimentalFeatures'] = $theme_settings;

--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -63,7 +63,7 @@
  * For the WYSIWYG experience we don't want to display any margins between blocks in the editor
  */
 .wp-block {
-	clear: both; // for ensuring that floated elements (images) are cleared
+	clear: both;
 }
 
 /*

--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -26,16 +26,6 @@
 }
 
 /*
- * Set the max-width for the editor content to 660px.
- * @todo Temporary hack. This should be set at block level in a template or from layout configuration in email theme.
- */
-.editor-styles-wrapper > .is-root-container {
-	width: 660px;
-	margin: 0 auto;
-	max-width: 100%;
-}
-
-/*
  * Email Editor specific styles for vertical gap between blocks in column and group.
  * This is needed because we disable layout for core/group, core/column and core/columns blocks, and .is-layout-flex is not applied.
  */

--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -25,9 +25,14 @@
 	width: 100%;
 }
 
+/*
+ * Set the max-width for the editor content to 660px.
+ * @todo Temporary hack. This should be set at block level in a template or from layout configuration in email theme.
+ */
 .editor-styles-wrapper > .is-root-container {
 	width: 660px;
 	margin: 0 auto;
+	max-width: 100%;
 }
 
 /*

--- a/packages/php/email-editor/src/Engine/content-editor.css
+++ b/packages/php/email-editor/src/Engine/content-editor.css
@@ -25,6 +25,11 @@
 	width: 100%;
 }
 
+.editor-styles-wrapper > .is-root-container {
+	width: 660px;
+	margin: 0 auto;
+}
+
 /*
  * Email Editor specific styles for vertical gap between blocks in column and group.
  * This is needed because we disable layout for core/group, core/column and core/columns blocks, and .is-layout-flex is not applied.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,6 +652,9 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       lodash:
         specifier: ^4.17.21
         version: 4.17.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
       '@wordpress/notices':
         specifier: ^5.0.0
         version: 5.0.0(react@18.3.1)
+      '@wordpress/plugins':
+        specifier: ^7.16.0
+        version: 7.16.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences':
         specifier: ^4.0.0
         version: 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -5459,6 +5462,15 @@ packages:
       '@wordpress/i18n': 5.0.0
     dev: false
 
+  /@wordpress/a11y@4.16.0:
+    resolution: {integrity: sha512-i3zrNFx+N+dNivQxUeQXWKGT1ccWePXcqPkVTqjdO+lACv+MtJoyE9PXZCmaxHWq00g1RTvIpLtrzV5L4gzZkA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/dom-ready': 4.16.0
+      '@wordpress/i18n': 5.16.0
+    dev: false
+
   /@wordpress/api-fetch@6.55.0:
     resolution: {integrity: sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==}
     engines: {node: '>=12'}
@@ -6160,6 +6172,66 @@ packages:
       - supports-color
     dev: false
 
+  /@wordpress/components@29.2.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-a7vUL4oUGu4Jicqf0cFSdQvGtZVw9h4Gvxr53o8yJYmXY8YRVrbeEsZjA/twaqRa8WxGzzWnWNQ/XwtMEXNG0w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+    dependencies:
+      '@ariakit/react': 0.4.15(react-dom@18.3.1)(react@18.3.1)
+      '@babel/runtime': 7.25.7
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
+      '@types/gradient-parser': 0.1.3
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.16.0
+      '@wordpress/compose': 7.16.0(react@18.3.1)
+      '@wordpress/date': 5.16.0
+      '@wordpress/deprecated': 4.16.0
+      '@wordpress/dom': 4.16.0
+      '@wordpress/element': 6.16.0
+      '@wordpress/escape-html': 3.16.0
+      '@wordpress/hooks': 4.16.0
+      '@wordpress/html-entities': 4.16.0
+      '@wordpress/i18n': 5.16.0
+      '@wordpress/icons': 10.16.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.16.0
+      '@wordpress/keycodes': 4.16.0
+      '@wordpress/primitives': 4.16.0(react@18.3.1)
+      '@wordpress/private-apis': 1.16.0
+      '@wordpress/rich-text': 7.16.0(react@18.3.1)
+      '@wordpress/warning': 3.16.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 3.6.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.13.1(react-dom@18.3.1)(react@18.3.1)
+      gradient-parser: 0.1.5
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.0
+      path-to-regexp: 6.3.0
+      re-resizable: 6.10.3(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - supports-color
+    dev: false
+
   /@wordpress/compose@3.25.3(react@18.3.1):
     resolution: {integrity: sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==}
     dependencies:
@@ -6257,6 +6329,28 @@ packages:
       '@wordpress/keycodes': 4.0.0
       '@wordpress/priority-queue': 3.13.0
       '@wordpress/undo-manager': 1.13.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+    dev: false
+
+  /@wordpress/compose@7.16.0(react@18.3.1):
+    resolution: {integrity: sha512-FTpfEUeEyH3LnVRlNZxRwce3sEUPDAVI1P+AaF7ZrbzcV2ita4WamCoEHFDS4OMOnvISnSbVh2Rz3gF9oLvomQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.16.0
+      '@wordpress/dom': 4.16.0
+      '@wordpress/element': 6.16.0
+      '@wordpress/is-shallow-equal': 5.16.0
+      '@wordpress/keycodes': 4.16.0
+      '@wordpress/priority-queue': 3.16.0
+      '@wordpress/undo-manager': 1.16.0
       change-case: 4.1.2
       clipboard: 2.0.11
       mousetrap: 1.6.5
@@ -6468,6 +6562,30 @@ packages:
       use-memo-one: 1.1.3(react@18.3.1)
     dev: false
 
+  /@wordpress/data@10.16.0(react@18.3.1):
+    resolution: {integrity: sha512-5Gx0Hb1VsnvACQJBJhgaFf0xn6cf1s0Wqv3q2DRnRShuSQTNxkUxA41+eZsPxC1JrnVXg0vPRCu5GpqwPO4O9g==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/compose': 7.16.0(react@18.3.1)
+      '@wordpress/deprecated': 4.16.0
+      '@wordpress/element': 6.16.0
+      '@wordpress/is-shallow-equal': 5.16.0
+      '@wordpress/priority-queue': 3.16.0
+      '@wordpress/private-apis': 1.16.0
+      '@wordpress/redux-routine': 5.16.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+    dev: false
+
   /@wordpress/data@7.6.0(react@18.3.1):
     resolution: {integrity: sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==}
     engines: {node: '>=12'}
@@ -6581,6 +6699,16 @@ packages:
       moment-timezone: 0.5.45
     dev: false
 
+  /@wordpress/date@5.16.0:
+    resolution: {integrity: sha512-Sb2eJ7S7bn7ODfe0WVgNEqLpilgwpKIoJjVxMxT8wtJpx4rEs25+BAyQ6Bpj6lxX9P99ZmPsdrq5YavxP9NKHg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/deprecated': 4.16.0
+      moment: 2.30.1
+      moment-timezone: 0.5.45
+    dev: false
+
   /@wordpress/dependency-extraction-webpack-plugin@5.9.0(webpack@5.94.0):
     resolution: {integrity: sha512-hXbCkbG1XES47t7hFSETRrLfaRSPyQPlCnhlCx7FfhYFD0wh1jVArApXX5dD+A6wTrayXX/a16MpfaNqE662XA==}
     engines: {node: '>=18'}
@@ -6620,6 +6748,14 @@ packages:
       '@wordpress/hooks': 4.0.0
     dev: false
 
+  /@wordpress/deprecated@4.16.0:
+    resolution: {integrity: sha512-apv94cskjvWqkanqNn3vP7lugJODkSkPlLqjKPY5iBXI0RATaKuxcTNxuO9/Gn5QcuM89fjhsGTcZ4X/SZTGNQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/hooks': 4.16.0
+    dev: false
+
   /@wordpress/dom-ready@3.58.0:
     resolution: {integrity: sha512-sDgRPjNBToRKgYrpwvMRv2Yc7/17+sp8hm/rRnbubwb+d/DbGkK4Tc/r4sNLSZCqUAtcBXq9uk1lzvhge3QUSg==}
     engines: {node: '>=12'}
@@ -6634,6 +6770,13 @@ packages:
 
   /@wordpress/dom-ready@4.13.0:
     resolution: {integrity: sha512-ajR4BeHaUERWC7M3JyEVrhtahWYaj/r78k1bUoP80HRzAhIFEGsicPc9+j/KaLHFJoHyPllMiRZfTgjwYJ7zqQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+    dev: false
+
+  /@wordpress/dom-ready@4.16.0:
+    resolution: {integrity: sha512-rlp7gZRRPsob8z+//tS8bHHRTlkRiOfbKA1SJmyfakU/p4fcEXskLfdq/0wGPZtoHnia6kLKUyFMWhIBe8SuYQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.25.7
@@ -6659,6 +6802,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/deprecated': 4.0.0
+
+  /@wordpress/dom@4.16.0:
+    resolution: {integrity: sha512-iT9D8BnoSgD9w+viDCKtO7lfMmzku3tC7oLEakH6LNZRas0jQuTC46cfokMAz6HTchxiAnuXoPYHsCPhGzWy8Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/deprecated': 4.16.0
+    dev: false
 
   /@wordpress/e2e-test-utils-playwright@0.26.0(typescript@5.0.2):
     resolution: {integrity: sha512-4KFyQ3IsYIJaIvOQ1qhAHhRISs9abNToF/bktfMNxQiEJsmbNn7lq/IbaY+shqwdBWVg8TQtLcL4MpSl0ISaxQ==}
@@ -6712,7 +6863,7 @@ packages:
       '@wordpress/keyboard-shortcuts': 5.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.0.0
       '@wordpress/notices': 5.0.0(react@18.3.1)
-      '@wordpress/plugins': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.16.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/private-apis': 1.0.0
       '@wordpress/url': 4.0.0
@@ -6769,7 +6920,7 @@ packages:
       '@wordpress/keycodes': 4.0.0
       '@wordpress/notices': 5.0.0(react@18.3.1)
       '@wordpress/patterns': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/plugins': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/primitives': 4.0.0
       '@wordpress/priority-queue': 3.0.0
@@ -6831,7 +6982,7 @@ packages:
       '@wordpress/media-utils': 5.0.0
       '@wordpress/notices': 5.0.0(react@18.3.1)
       '@wordpress/patterns': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/plugins': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.16.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/private-apis': 1.0.0
       '@wordpress/reusable-blocks': 5.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -6925,6 +7076,20 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@wordpress/element@6.16.0:
+    resolution: {integrity: sha512-1Db9jeu7dxil/fJqAiLN5dA6gwoHWcgMSqZJ4dmZ0kMDMs40rtm6o60GFmAQGlrj+mmUvhOHTTwrBdpyfuv4bA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+      '@wordpress/escape-html': 3.16.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@wordpress/escape-html@1.12.2:
     resolution: {integrity: sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==}
     dependencies:
@@ -6945,6 +7110,13 @@ packages:
 
   /@wordpress/escape-html@3.13.0:
     resolution: {integrity: sha512-wKPFlXD2d3K6ies4+btGcPB+p8lvgiMOVS3L0b1O+1s+cKUkgtq1aD0Q1pxQ2sLHXFIQjYWjVfTUvZrKE+6xPA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+    dev: false
+
+  /@wordpress/escape-html@3.16.0:
+    resolution: {integrity: sha512-Rb3nUsqK2tzLpKhSRO5IID5O+gvNlyHRkKVmTszTB+0vjK+yh0Mc4UPzdHksPo8K7KnlAFt3SgjcfWYo3LYyUA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.25.7
@@ -7080,6 +7252,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.7
 
+  /@wordpress/hooks@4.16.0:
+    resolution: {integrity: sha512-W82L1PdIhJPNpEb2F+0NWzrDoUqZo6NnYID7qHCexBiagq4+QS4uydM6anyFvUNrpL51CmkCNu31Xi8HjpSTGg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+    dev: false
+
   /@wordpress/html-entities@3.58.0:
     resolution: {integrity: sha512-FU7b6QZdwTCuLKq6wCl0IZqqOMcMRxMcekVVytzTse7hYk9dvL1qQL/U4eQ/CNyKqiT9u7fb5NKTQILOzoolVQ==}
     engines: {node: '>=12'}
@@ -7091,6 +7270,13 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.24.7
+    dev: false
+
+  /@wordpress/html-entities@4.16.0:
+    resolution: {integrity: sha512-wnCtif4GsQ3gZgINN2GK6+yLH+vIsW3ASvUfdUlxYMcvMagNhJsqaE6dqsnKkezD8q/WNL7zv82BDyGSLKeHNQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
     dev: false
 
   /@wordpress/i18n@3.20.0:
@@ -7143,6 +7329,19 @@ packages:
       tannin: 1.2.0
     dev: false
 
+  /@wordpress/i18n@5.16.0:
+    resolution: {integrity: sha512-O4ZUvjS8AlYzTxvw7fmp3xk51rpKv1h2/dGFc/L+IB97UrCBAiC9HBv6FIHRF1gci4Vdu/QnCDw3qpC+N/2gCw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/hooks': 4.16.0
+      gettext-parser: 1.4.0
+      memize: 2.1.0
+      sprintf-js: 1.1.3
+      tannin: 1.2.0
+    dev: false
+
   /@wordpress/icons@10.0.0:
     resolution: {integrity: sha512-BL1LtPgfFZdMLd2EUmckX8EXo10LDGDlQZx4CyyL0Vnx/6HcR/H3Z5EN6yeJl57fbjPg7noyOZVCdvG1EiiZnA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7159,6 +7358,17 @@ packages:
       '@babel/runtime': 7.25.7
       '@wordpress/element': 6.0.0
       '@wordpress/primitives': 4.13.0(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+    dev: false
+
+  /@wordpress/icons@10.16.0(react@18.3.1):
+    resolution: {integrity: sha512-fHZujKpOkYD3JnPGCYqB1VafUiqsUOnpdVGdBd7En5ELwRg189a0NcI4EmM8OkeItNDml4LU/4nCCkypSy29eA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/element': 6.16.0
+      '@wordpress/primitives': 4.16.0(react@18.3.1)
     transitivePeerDependencies:
       - react
     dev: false
@@ -7209,7 +7419,7 @@ packages:
       '@wordpress/element': 6.0.0
       '@wordpress/i18n': 5.0.0
       '@wordpress/icons': 10.0.0
-      '@wordpress/plugins': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/private-apis': 1.0.0
       '@wordpress/viewport': 6.0.0(react@18.3.1)
@@ -7238,7 +7448,7 @@ packages:
       '@wordpress/element': 6.13.0
       '@wordpress/i18n': 5.13.0
       '@wordpress/icons': 10.13.0(react@18.3.1)
-      '@wordpress/plugins': 7.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.16.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/private-apis': 1.13.0
       '@wordpress/viewport': 6.13.0(react@18.3.1)
@@ -7267,7 +7477,7 @@ packages:
       '@wordpress/element': 6.0.0
       '@wordpress/i18n': 5.0.0
       '@wordpress/icons': 10.0.0
-      '@wordpress/plugins': 7.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.16.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/viewport': 6.13.0(react@18.3.1)
       clsx: 2.1.1
@@ -7296,6 +7506,13 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.24.7
+
+  /@wordpress/is-shallow-equal@5.16.0:
+    resolution: {integrity: sha512-9JI0bz7bQ9PdXPtXSnZXtbkyh0h7ZtojeG0lFtf9xtFkA56JUuMALa623v1YeuHKYbYmCc03/pqtpDKc/8QfVQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+    dev: false
 
   /@wordpress/jest-console@7.29.0(jest@29.7.0):
     resolution: {integrity: sha512-/9PZJhyszdRX4mka7t1WzoooM+Q/DwC4jkNVtJxqci5lbL3Lrhy1cCJGCgMr1n/9w+zs7eLmExFBvV4v44iyNw==}
@@ -7370,6 +7587,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.7
       '@wordpress/i18n': 5.0.0
+
+  /@wordpress/keycodes@4.16.0:
+    resolution: {integrity: sha512-T4kaFkw6R1VkcBk+F7B4gmzEhSPRJwpMdkP7roNvENzKGtXs49K4xO0koOZhWUlGpZvhPJ1WWERyoub8S7rX2A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/i18n': 5.16.0
+    dev: false
 
   /@wordpress/media-utils@5.0.0:
     resolution: {integrity: sha512-qDbL+lMdi9VrDZf/k3Z2IXy1IkkcWSPZHBKkr9DmxeyRTiur+lLfmn9tts+XeybAMDsCzbuJpuB4dIa2xZkaEw==}
@@ -7485,6 +7710,30 @@ packages:
       '@wordpress/hooks': 4.0.0
       '@wordpress/icons': 10.0.0
       '@wordpress/is-shallow-equal': 5.0.0
+      memize: 2.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - supports-color
+    dev: false
+
+  /@wordpress/plugins@7.16.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-uyqJcuB2up8/tJ4qabjYO1ZHD5hEuhNRp2z6nDROnKWKpegFnO2lXbxzhEZkBLDRox2ds+3sOBkEHquwxVFsBA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/components': 29.2.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/compose': 7.16.0(react@18.3.1)
+      '@wordpress/deprecated': 4.16.0
+      '@wordpress/element': 6.16.0
+      '@wordpress/hooks': 4.16.0
+      '@wordpress/icons': 10.16.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.16.0
       memize: 2.1.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7639,6 +7888,18 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@wordpress/primitives@4.16.0(react@18.3.1):
+    resolution: {integrity: sha512-mf5LPcA500KOo/UPiwNanNlH6Satwf4xBB1DPzw4InE67eACvAlde3oSYsoE6Uce6+7URRIefg9j47yXP2jkxw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/element': 6.16.0
+      clsx: 2.1.1
+      react: 18.3.1
+    dev: false
+
   /@wordpress/priority-queue@1.11.2:
     resolution: {integrity: sha512-ulwmUOklY3orn1xXpcPnTyGWV5B/oycxI+cHZ6EevBVgM5sq+BW3xo0PKLR/MMm6UNBtFTu/71QAJrNZcD6V1g==}
     dependencies:
@@ -7667,6 +7928,14 @@ packages:
       requestidlecallback: 0.3.0
     dev: false
 
+  /@wordpress/priority-queue@3.16.0:
+    resolution: {integrity: sha512-YmVPE/kHmAIEYiSnnfxQI7JBAvXxlCyVoGlfWxCJ/IH8W7gbZtl1R+iuRvT8L4Cdr+sUybT68Ry+o4o39OqURg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      requestidlecallback: 0.3.0
+    dev: false
+
   /@wordpress/private-apis@0.11.0:
     resolution: {integrity: sha512-GpAZ34Ou9YkYi9fuJCb9oDIZhsLqj41stuHflxpTNih6vV/Qw7ApBkLZDhDCyWjOybnjtHQH1LWw3K3RCN4miw==}
     engines: {node: '>=12'}
@@ -7688,6 +7957,13 @@ packages:
 
   /@wordpress/private-apis@1.13.0:
     resolution: {integrity: sha512-HGGWMFWIobfkhJdS+WYmmkSJ0m5beQ9x/2DUoQxxd/zISLMD7qQyRn016s/spapoT2fBLjtoQBWyfX2v0q+odA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+    dev: false
+
+  /@wordpress/private-apis@1.16.0:
+    resolution: {integrity: sha512-k/AQ11+vlbpSWhyOU5t8huoGdN+PursA8bUxVfhEnqcKRWTK+LKSmSEpdyL1sv6XJqznWYjgaNSdIxTkadsPpg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.25.7
@@ -7729,6 +8005,19 @@ packages:
 
   /@wordpress/redux-routine@5.13.0(redux@5.0.1):
     resolution: {integrity: sha512-yXl6XhFec9jxIZ/ogIJFntpzMX0uKrk2MnQfjfKCNnQJulZP6renTag/ysxsjpFw4+xy4isdHiL8v4PMf8mg1A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      redux: '>=4'
+    dependencies:
+      '@babel/runtime': 7.25.7
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      redux: 5.0.1
+      rungen: 0.3.2
+    dev: false
+
+  /@wordpress/redux-routine@5.16.0(redux@5.0.1):
+    resolution: {integrity: sha512-piLnJnV+tzWOEPJPdp431TcaKRoCpgGJ309W+UxM7fRHrYH/XZcXD8a+0pq56Dh/1QFO1elXXhPzhZQknwtyYw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       redux: '>=4'
@@ -7840,6 +8129,25 @@ packages:
       '@wordpress/escape-html': 3.13.0
       '@wordpress/i18n': 5.13.0
       '@wordpress/keycodes': 4.0.0
+      memize: 2.1.0
+      react: 18.3.1
+    dev: false
+
+  /@wordpress/rich-text@7.16.0(react@18.3.1):
+    resolution: {integrity: sha512-p+9WPzVo5pXLr1Xt04gQ1kdYQYmw05r2Kp42tgIfFNjgCBH1plpSrzjCyV/dyHrZ7APpJFg8sNjlOJmyLQiCFg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/a11y': 4.16.0
+      '@wordpress/compose': 7.16.0(react@18.3.1)
+      '@wordpress/data': 10.16.0(react@18.3.1)
+      '@wordpress/deprecated': 4.16.0
+      '@wordpress/element': 6.16.0
+      '@wordpress/escape-html': 3.16.0
+      '@wordpress/i18n': 5.16.0
+      '@wordpress/keycodes': 4.16.0
       memize: 2.1.0
       react: 18.3.1
     dev: false
@@ -8105,6 +8413,14 @@ packages:
       '@wordpress/is-shallow-equal': 5.0.0
     dev: false
 
+  /@wordpress/undo-manager@1.16.0:
+    resolution: {integrity: sha512-IE3u5Yk8QzUhiLAiGmYostsygxQExs9mVWlZ1BAXniEGCAcVdvDv7IB16dIgQxCYG3/idvmFdNbN8aQGX+nEIg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/is-shallow-equal': 5.16.0
+    dev: false
+
   /@wordpress/url@3.59.0:
     resolution: {integrity: sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==}
     engines: {node: '>=12'}
@@ -8153,6 +8469,11 @@ packages:
   /@wordpress/warning@3.0.0:
     resolution: {integrity: sha512-vZ7SH4lwnwglsZC+5dmrMJS/9lZXn7BvADC+ZHzrRM0s6Ufumi1RdG0QJr/HJuTRY9fX5bbPNdUQVyrv+weSEg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  /@wordpress/warning@3.16.0:
+    resolution: {integrity: sha512-XsgqRPvB+VSecXnD3VfvJJxhcdTTX4EkgdzvWspmQnw0rNCV636KByZVgolzYhvr3La9EgqO+MqXzwvPHg/xfQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dev: false
 
   /@wordpress/widgets@4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-OBvDhEJ/+dxKj+vgvSMQxHoc+ASY/ZuiLmr4XdlaVnHBzHfpmnVSIDWVvlCcTftWxMx80WCK5Cfy/4cb7KUYiw==}


### PR DESCRIPTION
## Description

This PR introduces the POC of the email editor built on top of WordPress's Block Editor.
To access the POC editor, you need to switch a feature switch on `/wp-admin/admin.php?page=mailpoet-experimental`

![Screenshot 2025-02-07 at 16 00 10](https://github.com/user-attachments/assets/3692ec93-7f6a-454a-8079-54c327b81082)


## Code review notes

I'm aware that we are migrating the code to another repo, and it may take some time to decide. So, it is probable that we won't be able to merge the PR before the move, and **it should not block the move to Woo**. 
We can reintroduce the PR after we move the code. I want to ask you to review the code to get feedback on the changes. Perhaps there could be better solutions for some of the issues.

It might be worth testing the editor with the demo plugin.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:email-editor/unified-wp-editor)

_The latest successful build from `email-editor/unified-wp-editor` will be used. If none is available, the link won't work._