### PR TITLE
Fix preview dropdown menu staying open after link click

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -113,7 +113,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->waitForText('Email saved!');
     // there is weird issue in the acceptance env where preview popup goes beyond sidebar
     // this issue is not confirmed to be real issue but only on the acceptance test site
-    $i->click('div.interface-pinned-items > button'); // close sidebar
+    $i->click('[aria-label="Close sidebar"]'); // close sidebar
     $i->click('.mailpoet-preview-dropdown button[aria-label="Preview"]');
     $i->waitForElementVisible('//a[text()="Preview in new tab"]');
     $i->waitForElementClickable('//a[text()="Preview in new tab"]');
@@ -124,6 +124,8 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->closeTab();
 
     $i->wantTo('Send preview email and verify it was delivered');
+    $i->click('.mailpoet-preview-dropdown button[aria-label="Preview"]');
+    $i->waitForElementVisible('//span[text()="Send a test email"]');
     $i->click('//span[text()="Send a test email"]'); // MenuItem component renders a button containing span
     $i->waitForElementClickable('//button[text()="Send test email"]');
     $i->click('//button[text()="Send test email"]');

--- a/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
+++ b/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
@@ -106,11 +106,12 @@ export function PreviewDropdown() {
 											<Icon icon={ external } />
 										</>
 									}
-									onPreview={ () =>
+									onPreview={ () => {
 										recordEvent(
 											'header_preview_dropdown_preview_in_new_tab_selected'
-										)
-									}
+										);
+										onClose();
+									} }
 								/>
 							</div>
 						</MenuGroup>


### PR DESCRIPTION
## Description

Source: p1738942608449169-slack-C0316THTWTX

![Screenshot 2025-02-07 at 5 07 13 PM](https://github.com/user-attachments/assets/1174f686-27fd-4362-adf7-691d4b4daf88)

Fix the preview dropdown menu staying open after the menu item click

## Code review notes

_N/A_

## QA notes

* Click on the Preview icon
* Click on "Preview in new tab"
* Notice the Preview menu is closed automatically.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-preview-toggle)

_The latest successful build from `fix-preview-toggle` will be used. If none is available, the link won't work._