### PR TITLE
Apply get_the_excerpt for MailPoet excerpts [MAILPOET-6468]

### DIFF
--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -39,7 +39,13 @@ class PostContentManager {
       if ($this->wp->hasExcerpt($post)) {
         return self::stripShortCodes($this->wp->getTheExcerpt($post));
       }
-      return $this->generateExcerpt($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return self::stripShortCodes(
+        $this->wp->applyFilters(
+          'get_the_excerpt',
+          $this->generateExcerpt($post->post_content), // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          $post
+        )
+      );
     }
     return self::stripShortCodes($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }


### PR DESCRIPTION
## Description
When no manual excerpt is present, MailPoet generates one, if the "excerpt" option is active. But it does not execute the filter. This PR ensures that the filter is executed.

## Code review notes

_N/A_

## QA notes
1. Add a code snippet to your installation like `<?php add_filter('get_the_excerpt', function() { return 'text from the filter. ';});`
2. See how 'text from the filter' is now used as excerpt for your posts in the installation
3. Ensure that when sending post notifications this excerpt is used when the post block display option "excerpt" is used.

## Linked PRs


## Linked tickets
[MAILPOET-6468]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6468]: https://mailpoet.atlassian.net/browse/MAILPOET-6468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6468-apply-excerpt-filter)

_The latest successful build from `MAILPOET-6468-apply-excerpt-filter` will be used. If none is available, the link won't work._