### PR TITLE
refactor: switch from MailHog to MailPit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -838,8 +838,8 @@ jobs:
           path: tests/_output
           destination: codeception
       - store_artifacts:
-          path: /mailhog-data
-          destination: mailhog-data
+          path: /mailpit-data
+          destination: mailpit-data
   build_release_zip:
     executor: wpcli_php_mysql_latest
     resource_class: large

--- a/dev/dashboard/index.html
+++ b/dev/dashboard/index.html
@@ -83,7 +83,7 @@
         </tr>
         <tr>
           <td>📪</td>
-          <td><a href="http://localhost:8082">MailHog</a></td>
+          <td><a href="http://localhost:8082">MailPit</a></td>
           <td>Email catcher</td>
           <td><a href="http://localhost:8082">http://localhost:8082</a></td>
         </tr>

--- a/dev/initial-setup.sh
+++ b/dev/initial-setup.sh
@@ -18,7 +18,7 @@ cp -n mailpoet/.env.sample mailpoet/.env
 # create Docker mount endpoints beforehand with current user (Docker would create them as root)
 mkdir -p wordpress/wp-content/plugins/mailpoet
 mkdir -p wordpress/wp-content/plugins/mailpoet-premium
-mkdir -p dev/data/mailhog
+mkdir -p dev/data/mailpit
 
 for plugin in "mailpoet" "mailpoet-premium"; do
   docker compose run --rm wordpress /bin/sh -c "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,14 +86,13 @@ services:
       - './packages:/var/www/html/wp-content/plugins/packages'
 
   smtp:
-    container_name: mp-mailhog
-    image: mailhog/mailhog:v1.0.0
+    container_name: mp-mailpit
+    image: axllent/mailpit:v1.22
     user: ${UID:-1000}:${GID:-1000}
     environment:
-      MH_STORAGE: maildir
-      MH_MAILDIR_PATH: /output
+      MP_DATABASE: '/data/mailpit.db'
     volumes:
-      - './dev/data/mailhog:/output'
+      - './dev/data/mailpit:/data'
     ports:
       - '8082:8025'
 

--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -25,7 +25,7 @@ class Settings {
 
   public function withDefaultSettings() {
     $this->withCronTriggerMethod('Linux Cron');
-    $this->withSendingMethodSmtpMailhog();
+    $this->withSendingMethodSmtpMailpit();
     $this->withSender('admin', 'wp@example.com');
     $this->withSkippedTutorials();
     $this->withCookieRevenueTracking();
@@ -181,15 +181,15 @@ class Settings {
   }
 
   public function withMisconfiguredSendingMethodSmtp() {
-    $this->withSendingMethodSmtpMailhog();
+    $this->withSendingMethodSmtpMailpit();
     $this->settings->set('mta.host', 'unknown_server');
   }
 
-  public function withSendingMethodSmtpMailhog() {
+  public function withSendingMethodSmtpMailpit() {
     $this->settings->set('mta_group', 'smtp');
     $this->settings->set('mta.method', Mailer::METHOD_SMTP);
     $this->settings->set('mta.port', 1025);
-    $this->settings->set('mta.host', 'mailhog');
+    $this->settings->set('mta.host', 'mailpit');
     $this->settings->set('mta.authentication', 0);
     $this->settings->set('mta.login', '');
     $this->settings->set('mta.password', '');

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -47,7 +47,7 @@ class AcceptanceTester extends \Codeception\Actor {
 
   const WP_DOMAIN = 'test.local';
   const WP_URL = 'http://' . self::WP_DOMAIN;
-  const MAIL_URL = 'http://mailhog:8025';
+  const MAIL_URL = 'http://mailpit:8025';
   const AUTHORIZED_SENDING_EMAIL = 'staff@mailpoet.com';
   const LISTING_LOADING_SELECTOR = '.mailpoet-listing-loading';
   const WOO_COMMERCE_PLUGIN = 'woocommerce';
@@ -55,7 +55,7 @@ class AcceptanceTester extends \Codeception\Actor {
   const WOO_COMMERCE_MEMBERSHIPS_PLUGIN = 'woocommerce-memberships';
   const WOO_COMMERCE_SUBSCRIPTIONS_PLUGIN = 'woocommerce-subscriptions';
   const AUTOMATE_WOO_PLUGIN = 'automatewoo';
-  const MAILHOG_DATA_PATH = '/mailhog-data';
+  const MAILPIT_DATA_PATH = '/mailpit-data';
   const ADMIN_EMAIL = 'test@test.com';
   const EMAIL_EDITOR_MINIMAL_WP_VERSION = '6.7';
 
@@ -111,13 +111,13 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   /**
-   * Navigate to Mailhog page and wait for angular to load
+   * Navigate to Mailpit page and wait for angular to load
    */
   public function amOnMailboxAppPage() {
     $i = $this;
     $i->amOnUrl(self::MAIL_URL);
-    // ensure that angular is loaded by checking angular specific class
-    $i->waitForElement('.messages.ng-scope');
+    // ensure that Mailpit has finished loading by looking for message listing element.
+    $i->waitForElement('#message-page');
   }
 
   /**
@@ -132,7 +132,7 @@ class AcceptanceTester extends \Codeception\Actor {
    * Clear the Mailbox so it's empty
    */
   public function emptyMailbox() {
-    exec('rm -rf ' . self::MAILHOG_DATA_PATH . '/*', $output);
+    exec('rm -rf ' . self::MAILPIT_DATA_PATH . '/*', $output);
   }
 
   public function clickItemRowActionByItemName($itemName, $link) {

--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -15,7 +15,7 @@ class CleanupExtension extends Extension {
   const DB_USERNAME = 'root';
   const DB_PASSWORD = 'wordpress';
   const DB_NAME = 'wordpress';
-  const MAILHOG_DATA_PATH = '/mailhog-data';
+  const MAILPIT_DATA_PATH = '/mailpit-data';
 
   public static $events = [
     Events::SUITE_BEFORE => 'backupDatabase',
@@ -82,7 +82,7 @@ class CleanupExtension extends Extension {
     while ($this->rootConnection->next_result()) {
       // flush all multi_query results
     }
-    exec('rm -rf ' . self::MAILHOG_DATA_PATH . '/*', $output);
+    exec('rm -rf ' . self::MAILPIT_DATA_PATH . '/*', $output);
 
     // cleanup EntityManager for data factories that are using it
     ContainerWrapper::getInstance()->get(EntityManager::class)->clear();

--- a/mailpoet/tests/performance/docker-compose.yml
+++ b/mailpoet/tests/performance/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     container_name: performance_wordpress
     depends_on:
       mysql: { condition: service_healthy }
-      mailhog: { condition: service_started }
+      mailpit: { condition: service_started }
     user: 33:33
     volumes:
       - performance-wordpress-data:/var/www/html
@@ -61,19 +61,18 @@ services:
       timeout: 600s
       retries: 200
 
-  mailhog:
-    image: mailhog/mailhog:v1.0.0
-    container_name: performance_mailhog
-    hostname: mailhog
+  mailpit:
+    image: axllent/mailpit:v1.22
+    container_name: performance_mailpit
+    hostname: mailpit
     ports:
       - 9501:8025
     user: ${UID:-1000}:${GID:-1000}
     environment:
-      MH_STORAGE: maildir
-      MH_MAILDIR_PATH: /mailhog-data
+      MP_DATABASE: '/data/mailpit.db'
     volumes:
-      - performance-mailhog-data:/mailhog-data
+      - 'performance-mailpit-data:/data'
 
 volumes:
   performance-wordpress-data:
-  performance-mailhog-data:
+  performance-mailpit-data:

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -18,7 +18,7 @@ chown www-data:www-data wp-content/plugins
 chown www-data:www-data wp-content/uploads
 chmod 755 wp-content/plugins
 chmod -R 777 wp-content/uploads
-chmod -R 777 /mailhog-data
+chmod -R 777 /data
 
 # deleting configs in case are set in previous run
 wp config delete MULTISITE > /dev/null 2>&1

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - chrome
     volumes:
       - wp-core:/wp-core
-      - mailhog-data:/mailhog-data
+      - mailpit-data:/data
       - ../../mailpoet:/project
       - ../../mailpoet:/wp-core/wp-content/plugins/mailpoet
       - ../../mailpoet-premium:/project/mailpoet-premium
@@ -37,7 +37,7 @@ services:
       - wordpress
     volumes:
       - wp-core:/wp-core
-      - mailhog-data:/mailhog-data
+      - mailpit-data:/data
       - ../../mailpoet:/project
       - ../../mailpoet:/wp-core/wp-content/plugins/mailpoet
       - ../../mailpoet-premium:/project/mailpoet-premium
@@ -61,18 +61,17 @@ services:
       PHP_IDE_CONFIG: 'serverName=MailPoetTest'
 
   smtp:
-    image: mailhog/mailhog:v1.0.0
-    container_name: mailhog_${CIRCLE_NODE_INDEX:-default}
-    hostname: mailhog
+    image: axllent/mailpit:v1.22
+    container_name: mailpit_${CIRCLE_NODE_INDEX:-default}
+    hostname: mailpit
     ports:
       - 1025:1025
       - 8025:8025
     user: ${UID:-1000}:${GID:-1000}
     environment:
-      MH_STORAGE: maildir
-      MH_MAILDIR_PATH: /mailhog-data
+      MP_DATABASE: /data/mailpoet.db
     volumes:
-      - mailhog-data:/mailhog-data
+      - mailpit-data:/data
 
   wordpress:
     image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.7.1-php8.3}
@@ -139,7 +138,7 @@ services:
       - 5900:5900
 volumes:
   wp-core:
-  mailhog-data:
+  mailpit-data:
 
 networks:
   default:


### PR DESCRIPTION
## Description

Replace the venerable, but unmaintained [mailhog](https://github.com/mailhog/MailHog), with [mailpit](https://github.com/axllent/mailpit).

> [!NOTE]
> I'm sharing this early. Some tests fail on CI currently (integration), but pass locally (flaky tests?). The yak's not entirely shaved yet. ⏳ 

## Code review notes

_N/A_

## QA notes

This change impacts dev envs and CI, there's no need to check the software.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6472](https://mailpoet.atlassian.net/browse/MAILPOET-6472)

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:mailpit)

_The latest successful build from `mailpit` will be used. If none is available, the link won't work._

[MAILPOET-6472]: https://mailpoet.atlassian.net/browse/MAILPOET-6472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ