### PR TITLE
Fix composer conflicts after modyfing plugin dependencies [MAILPOET-6469]

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -61,6 +61,9 @@
       "MailPoet\\Test\\DataGenerator\\": "tests/DataGenerator"
     }
   },
+  "replace": {
+    "soundasleep/html2text": "*"
+  },
   "scripts": {
     "pre-install-cmd": [
       "@php tools/install.php",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -73,7 +73,7 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/php/email-editor",
-                "reference": "7bb0a4d32045c61deaca453030ed2b345ee56148"
+                "reference": "53577c5aa3a97e82c58284d48c3aa339cb2a15d4"
             },
             "require": {
                 "php": ">=7.4",
@@ -83,9 +83,6 @@
             "autoload": {
                 "classmap": [
                     "src/"
-                ],
-                "files": [
-                    "src/exceptions.php"
                 ]
             },
             "autoload-dev": {

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9957467448f215809ac9dc8fbcab2b00",
+    "content-hash": "51893b0f5ed38d130932b86b48e55b94",
     "packages": [
         {
             "name": "dragonmantank/cron-expression",
@@ -73,15 +73,19 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/php/email-editor",
-                "reference": "311798cfd57b26bb5df1fc7f97b5732e45603419"
+                "reference": "7bb0a4d32045c61deaca453030ed2b345ee56148"
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=7.4",
+                "soundasleep/html2text": "^2.1"
             },
             "type": "library",
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/exceptions.php"
                 ]
             },
             "autoload-dev": {
@@ -101,6 +105,9 @@
                 ],
                 "code-style-fix": [
                     "../../../mailpoet/tasks/code_sniffer/vendor/bin/phpcbf -p"
+                ],
+                "phpstan": [
+                    "php ./tasks/run-phpstan.php"
                 ]
             },
             "description": "Email editor based on WordPress Gutenberg package.",

--- a/packages/php/email-editor/composer.json
+++ b/packages/php/email-editor/composer.json
@@ -5,10 +5,7 @@
   "autoload": {
     "classmap": [
       "src/"
-    ],
-		"files": [
-			"src/exceptions.php"
-		]
+    ]
   },
   "autoload-dev": {
     "classmap": [
@@ -29,7 +26,7 @@
     "unit-test": "../../../tests_env/vendor/bin/codecept run unit",
     "integration-test": "cd ../../../tests_env/docker && COMPOSE_HTTP_TIMEOUT=200 docker compose run -e SKIP_DEPS=1 -e SKIP_PLUGINS=1 -e PACKAGE_NAME=email-editor codeception_integration",
     "code-style": "../../../mailpoet/tasks/code_sniffer/vendor/bin/phpcs -ps",
-		"code-style-fix": "../../../mailpoet/tasks/code_sniffer/vendor/bin/phpcbf -p",
-		"phpstan": "php ./tasks/run-phpstan.php"
+    "code-style-fix": "../../../mailpoet/tasks/code_sniffer/vendor/bin/phpcbf -p",
+    "phpstan": "php ./tasks/run-phpstan.php"
   }
 }


### PR DESCRIPTION
## Description

Because the email editor package is symlinked on local development, the composer tries to manage the email editor packages in the plugin vendor directory. Configuring the email editor dependency for replacement solves this problem, and it is the easiest solution for now because the package will be moved into another repository.

This PR also removes the file with exceptions from the `composer.json` in the PHP package because it caused issues in tests, and it is not needed anymore.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6469]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6469]: https://mailpoet.atlassian.net/browse/MAILPOET-6469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:composer-conflicts)

_The latest successful build from `composer-conflicts` will be used. If none is available, the link won't work._