### PR TITLE
Fix captcha title being applied to menu items in non-block based themes [MAILPOET-6485]

### DIFF
--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -39,18 +39,18 @@ class PageRenderer {
 
     if ($separatorLocation === 'right') {
       // first part
-      $titleParts[0] = $this->setPageTitle();
+      $titleParts[0] = $this->getPageTitle();
     } else {
       // last part
       $lastIndex = count($titleParts) - 1;
-      $titleParts[$lastIndex] = $this->setPageTitle();
+      $titleParts[$lastIndex] = $this->getPageTitle();
     }
 
     return implode(" $separator ", $titleParts);
   }
 
   public function setWindowTitleParts($meta = []) {
-    $meta['title'] = $this->setPageTitle();
+    $meta['title'] = $this->getPageTitle();
     return $meta;
   }
 
@@ -58,8 +58,11 @@ class PageRenderer {
     echo '<meta name="robots" content="noindex,nofollow">';
   }
 
-  public function setPageTitle() {
-    return __("Confirm you’re not a robot", 'mailpoet');
+  public function setPageTitle($title = '') {
+    if ($title === __('MailPoet Page', 'mailpoet')) {
+      return $this->getPageTitle();
+    }
+    return $title;
   }
 
   public function setPageContent($pageContent) {
@@ -71,5 +74,9 @@ class PageRenderer {
     }
 
     return str_replace('[mailpoet_page]', trim($content), $pageContent);
+  }
+
+  private function getPageTitle() {
+    return __('Confirm you’re not a robot', 'mailpoet');
   }
 }

--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -28,6 +28,7 @@ class PageRenderer {
     $this->wp->removeAction('wp_head', 'noindex', 1);
     $this->wp->addAction('wp_head', [$this, 'setMetaRobots'], 1);
     $this->wp->addFilter('the_title', [$this, 'setPageTitle']);
+    $this->wp->addFilter('single_post_title', [$this, 'setPageTitle']);
     $this->wp->addFilter('the_content', [$this, 'setPageContent']);
   }
 


### PR DESCRIPTION
## Description

On non-block-based theme, the Captcha title was applied to all titles on the page (those in the menu, widgets, ...) instead of just the main one (the one "in the loop").

| Before | After |
| ------ | ----- |
| <img width="735" alt="Screenshot 2025-02-19 at 09 12 44" src="https://github.com/user-attachments/assets/a90a5e84-43bb-4184-806b-d6675d8f09b3" /> | <img width="760" alt="Screenshot 2025-02-19 at 09 12 27" src="https://github.com/user-attachments/assets/93b70eb0-a757-48d2-9064-95c040deafd5" /> | 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6485]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6485]: https://mailpoet.atlassian.net/browse/MAILPOET-6485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:captcha-page-title)

_The latest successful build from `captcha-page-title` will be used. If none is available, the link won't work._