### PR TITLE
Add an option to restrict coupon to current subscriber [MAILPOET-6384]

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/blocks/coupon.tsx
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/coupon.tsx
@@ -19,6 +19,7 @@ Module.CouponBlockModel = base.BlockModel.extend({
     return this._getDefaults(
       {
         isStandardEmail: App.getNewsletter().isStandardEmail(),
+        isAutomationEmail: App.getNewsletter().isAutomationEmail(),
         productIds: [], // selected product ids,
         excludedProductIds: [],
         productCategoryIds: [], // selected categories id
@@ -33,6 +34,10 @@ Module.CouponBlockModel = base.BlockModel.extend({
         minimumAmount: '',
         maximumAmount: '',
         emailRestrictions: '',
+        restrictToSubscriber: false,
+        showRestrictToSubscriber:
+          App.getNewsletter().isAutomationEmail() ||
+          App.getNewsletter().isWelcomeEmail(),
         styles: {
           block: {
             backgroundColor: '#ffffff',

--- a/mailpoet/assets/js/src/newsletter-editor/blocks/coupon/usage-restriction.tsx
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/coupon/usage-restriction.tsx
@@ -31,6 +31,7 @@ type State = {
   productCategoryIds: Post[];
   excludedProductCategoryIds: Post[];
   emailRestrictions: string;
+  restrictToSubscriber: boolean;
 };
 
 class UsageRestriction extends Component<Props, State> {
@@ -62,6 +63,8 @@ class UsageRestriction extends Component<Props, State> {
         'excludedProductCategoryIds',
       ).toJSON() as Post[],
       emailRestrictions: this.getValueCallback('emailRestrictions') as string,
+      restrictToSubscriber:
+        (this.getValueCallback('restrictToSubscriber') as boolean) || false,
     };
   }
 
@@ -262,6 +265,25 @@ class UsageRestriction extends Component<Props, State> {
               )}
             />
           </PanelRow>
+          {this.getValueCallback('showRestrictToSubscriber') && (
+            <PanelRow>
+              <ToggleControl
+                checked={this.state.restrictToSubscriber}
+                label={__('Restrict to subscriber email', 'mailpoet')}
+                onChange={(restrictToSubscriber) => {
+                  this.setValueCallback(
+                    'restrictToSubscriber',
+                    restrictToSubscriber,
+                  );
+                  this.setState({ restrictToSubscriber });
+                }}
+                help={__(
+                  'Restrict coupon usage to the subscriber receiving this email.',
+                  'mailpoet',
+                )}
+              />
+            </PanelRow>
+          )}
         </PanelBody>
       </Panel>
     );

--- a/mailpoet/assets/js/src/newsletter-editor/components/content.js
+++ b/mailpoet/assets/js/src/newsletter-editor/components/content.js
@@ -35,6 +35,9 @@ Module.NewsletterModel = SuperModel.extend({
   isStandardEmail: function isStandardEmail() {
     return this.get('type') === NewsletterType.Standard;
   },
+  isWelcomeEmail: function isWelcomeEmail() {
+    return this.get('type') === NewsletterType.Welcome;
+  },
 });
 
 // Content block view and model handlers for different content types

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -53,7 +53,7 @@ class Preprocessor {
       return $content;
     }
     $contentBlocks = $content['blocks'];
-    $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview);
+    $contentBlocks = $this->couponPreProcessor->processCoupons($newsletter, $contentBlocks, $preview, $sendingQueue);
     $content['blocks'] = $this->processContainer($newsletter, $contentBlocks, $preview, $sendingQueue);
     return $content;
   }

--- a/mailpoet/lib/WooCommerce/CouponPreProcessor.php
+++ b/mailpoet/lib/WooCommerce/CouponPreProcessor.php
@@ -3,6 +3,7 @@
 namespace MailPoet\WooCommerce;
 
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
 use MailPoet\NewsletterProcessingException;
@@ -30,12 +31,12 @@ class CouponPreProcessor {
   /**
    * @throws NewsletterProcessingException
    */
-  public function processCoupons(NewsletterEntity $newsletter, array $blocks, bool $preview = false): array {
+  public function processCoupons(NewsletterEntity $newsletter, array $blocks, bool $preview = false, ?SendingQueueEntity $sendingQueue = null): array {
     if ($preview) {
       return $blocks;
     }
 
-    $generated = $this->ensureCouponForBlocks($blocks, $newsletter);
+    $generated = $this->ensureCouponForBlocks($blocks, $newsletter, $sendingQueue);
     $body = $newsletter->getBody();
 
     if ($generated && $body && $this->shouldPersist($newsletter)) {
@@ -54,11 +55,10 @@ class CouponPreProcessor {
     return $blocks;
   }
 
-  private function ensureCouponForBlocks(array &$blocks, NewsletterEntity $newsletter): bool {
-
+  private function ensureCouponForBlocks(array &$blocks, NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue): bool {
     foreach ($blocks as &$innerBlock) {
       if (isset($innerBlock['blocks']) && !empty($innerBlock['blocks'])) {
-        $this->ensureCouponForBlocks($innerBlock['blocks'], $newsletter);
+        $this->ensureCouponForBlocks($innerBlock['blocks'], $newsletter, $sendingQueue);
       }
       if (isset($innerBlock['type']) && $innerBlock['type'] === Coupon::TYPE) {
         if (!$this->wcHelper->isWooCommerceActive()) {
@@ -66,7 +66,7 @@ class CouponPreProcessor {
         }
         if ($this->shouldGenerateCoupon($innerBlock)) {
           try {
-            $innerBlock['couponId'] = $this->addOrUpdateCoupon($innerBlock, $newsletter);
+            $innerBlock['couponId'] = $this->addOrUpdateCoupon($innerBlock, $newsletter, $sendingQueue);
             $this->generated = true;
           } catch (\Exception $e) {
             throw NewsletterProcessingException::create()->withMessage($e->getMessage())->withCode($e->getCode());
@@ -81,10 +81,11 @@ class CouponPreProcessor {
   /**
    * @param array $couponBlock
    * @param NewsletterEntity $newsletter
+   * @param SendingQueueEntity|null $sendingQueue
    * @return int
    * @throws \WC_Data_Exception|\Exception
    */
-  private function addOrUpdateCoupon(array $couponBlock, NewsletterEntity $newsletter) {
+  private function addOrUpdateCoupon(array $couponBlock, NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue) {
     $coupon = $this->wcHelper->createWcCoupon($couponBlock['couponId'] ?? '');
     if ($this->shouldGenerateCoupon($couponBlock)) {
       $code = isset($couponBlock['code']) && $couponBlock['code'] !== Coupon::CODE_PLACEHOLDER ? $couponBlock['code'] : $this->generateRandomCode();
@@ -128,7 +129,24 @@ class CouponPreProcessor {
     $coupon->set_product_categories($this->getItemIds($couponBlock['productCategoryIds'] ?? []));
     $coupon->set_excluded_product_categories($this->getItemIds($couponBlock['excludedProductCategoryIds'] ?? []));
 
-    $coupon->set_email_restrictions(explode(',', $couponBlock['emailRestrictions'] ?? ''));
+    $emailRestrictions = [];
+    if (!empty($couponBlock['emailRestrictions'])) {
+      $emailRestrictions = explode(',', $couponBlock['emailRestrictions']);
+    }
+
+    if (!empty($couponBlock['restrictToSubscriber']) && $sendingQueue && $sendingQueue->getTask()) {
+      $subscribers = $sendingQueue->getTask()->getSubscribers();
+      if (is_iterable($subscribers) && count($subscribers) === 1) { // Only apply to single-subscriber sending queues
+        foreach ($subscribers as $taskSubscriber) {
+          $subscriber = $taskSubscriber->getSubscriber();
+          if ($subscriber && $subscriber->getEmail()) {
+            $emailRestrictions[] = $subscriber->getEmail();
+          }
+        }
+      }
+    }
+
+    $coupon->set_email_restrictions(array_unique(array_filter($emailRestrictions)));
 
     // usage limit
     $coupon->set_usage_limit($couponBlock['usageLimit'] ?? 0);


### PR DESCRIPTION
## Description

There's a new toggle in the coupon block settings which allows to restrict the coupon to the current subscriber:
![restrict-to-subscriber](https://github.com/user-attachments/assets/5b052d77-2713-4497-9b2b-deae288ca225)
Allowed emails can be specified in addition to the current subscriber. 

I made this feature to work for automation and welcome emails. Do we need it for any other email types?

## Code review notes

_N/A_

## QA notes

Testing instructions:
1. Create a new automation with an email containing a coupon block.
2. Verify that the "Restrict to subscriber email" toggle appears in the coupon block settings under "Usage restriction" below "Allowed emails".
3. Enable the toggle.
4. Trigger the automation so the email is sent to a subscriber.
5. Verify that the generated coupon in WooCommerce > Coupons has email restriction set to the subscriber's email.
6. Check that allowed emails can be specified in addition to the subscriber email, the coupon should work for any of them.
7. Check that the toggle doesn't appear in standard newsletters and post notifications.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6384]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6384]: https://mailpoet.atlassian.net/browse/MAILPOET-6384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:restrict-coupon-to-subscriber)

_The latest successful build from `restrict-coupon-to-subscriber` will be used. If none is available, the link won't work._