### PR TITLE
Weekly MailPoet QIT tests workflow [MAILPOET-6487]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,6 +888,146 @@ jobs:
       - store_artifacts:
           path: tests/_output
 
+  qit_malware_scan:
+    executor: wpcli_php_latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Set up environment'
+          command: |
+            # Copy built ZIP to local directory for easier access from QIT
+            cp /home/circleci/mailpoet/mailpoet.zip .
+            # Authenticate in QIT
+            ./vendor/bin/qit partner:add --user="${QIT_PARTNER_USER}" --application_password="${QIT_PARTNER_SECRET}"
+      - run:
+          name: 'QIT Malware Scan'
+          command: ./do qa:qit-malware | tee tests/_output/qit-malware
+      - run:
+          name: 'Retrieve test results'
+          command: |
+            grep "Result Url" tests/_output/qit-malware | awk '{ print $3 }' | xargs curl -o tests/_output/report.html
+          when: always
+      - store_artifacts:
+          path: tests/_output
+
+  qit_php_compatibility:
+    executor: wpcli_php_latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Set up environment'
+          command: |
+            # Copy built ZIP to local directory for easier access from QIT
+            cp /home/circleci/mailpoet/mailpoet.zip .
+            # Authenticate in QIT
+            ./vendor/bin/qit partner:add --user="${QIT_PARTNER_USER}" --application_password="${QIT_PARTNER_SECRET}"
+      - run:
+          name: 'QIT PHP Compatibility Check'
+          command: ./do qa:qit-php-compatibility | tee tests/_output/qit-php-compatibility
+      - run:
+          name: 'Retrieve test results'
+          command: |
+            grep "Result Url" tests/_output/qit-php-compatibility | awk '{ print $3 }' | xargs curl -o tests/_output/report.html
+          when: always
+      - store_artifacts:
+          path: tests/_output
+
+  qit_activation_tests:
+    executor: wpcli_php_latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Set up environment'
+          command: |
+            # Copy built ZIP to local directory for easier access from QIT
+            cp /home/circleci/mailpoet/mailpoet.zip .
+            # Authenticate in QIT
+            ./vendor/bin/qit partner:add --user="${QIT_PARTNER_USER}" --application_password="${QIT_PARTNER_SECRET}"
+      - run:
+          name: 'QIT Activation Tests'
+          command: |
+            LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+            if [ -z "$LATEST_WC_BETA" ]; then
+              echo "No WooCommerce Beta version found. Using stable."
+              ./do qa:qit-activation | tee tests/_output/qit-activation
+            else
+              echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
+              ./do qa:qit-activation --wc=$LATEST_WC_BETA | tee tests/_output/qit-activation
+            fi
+      - run:
+          name: 'Retrieve test results'
+          command: |
+            grep "Result Url" tests/_output/qit-activation | awk '{ print $3 }' | xargs curl -o tests/_output/report.html
+          when: always
+      - store_artifacts:
+          path: tests/_output
+
+  qit_woo_api_tests:
+    executor: wpcli_php_latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Set up environment'
+          command: |
+            # Copy built ZIP to local directory for easier access from QIT
+            cp /home/circleci/mailpoet/mailpoet.zip .
+            # Authenticate in QIT
+            ./vendor/bin/qit partner:add --user="${QIT_PARTNER_USER}" --application_password="${QIT_PARTNER_SECRET}"
+      - run:
+          name: 'QIT Woo API Tests'
+          command: |
+            LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+            if [ -z "$LATEST_WC_BETA" ]; then
+              echo "No WooCommerce Beta version found. Using stable."
+              ./do qa:qit-woo-api | tee tests/_output/qit-woo-api
+            else
+              echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
+              ./do qa:qit-woo-api --wc=$LATEST_WC_BETA | tee tests/_output/qit-woo-api
+            fi
+      - run:
+          name: 'Retrieve test results'
+          command: |
+            grep "Result Url" tests/_output/qit-woo-api | awk '{ print $3 }' | xargs curl -o tests/_output/report.html
+          when: always
+      - store_artifacts:
+          path: tests/_output
+
+  qit_woo_e2e_tests:
+    executor: wpcli_php_latest
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Set up environment'
+          command: |
+            # Copy built ZIP to local directory for easier access from QIT
+            cp /home/circleci/mailpoet/mailpoet.zip .
+            # Authenticate in QIT
+            ./vendor/bin/qit partner:add --user="${QIT_PARTNER_USER}" --application_password="${QIT_PARTNER_SECRET}"
+      - run:
+          name: 'QIT Woo E2E Tests'
+          no_output_timeout: 1h # Woo E2E tests usually takes ~45m
+          command: |
+            LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
+            if [ -z "$LATEST_WC_BETA" ]; then
+              echo "No WooCommerce Beta version found. Using stable."
+              ./do qa:qit-woo-e2e | tee tests/_output/qit-woo-e2e
+            else
+              echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
+              ./do qa:qit-woo-e2e --wc=$LATEST_WC_BETA | tee tests/_output/qit-woo-e2e
+            fi
+      - run:
+          name: 'Retrieve test results'
+          command: |
+            grep "Result Url" tests/_output/qit-woo-e2e | awk '{ print $3 }' | xargs curl -o tests/_output/report.html
+          when: always
+      - store_artifacts:
+          path: tests/_output
+
 workflows:
   build_and_test:
     jobs:
@@ -1209,3 +1349,36 @@ workflows:
           mysql_image: mysql:5.5
           requires:
             - build_premium
+
+  nightly_qit:
+    jobs:
+      - build:
+          <<: *slack-fail-post-step
+      - build_release_zip:
+          <<: *slack-fail-post-step
+          requires:
+            - build
+      - qit_security_scan:
+          <<: *slack-fail-post-step
+          requires:
+            - build_release_zip
+      - qit_activation_tests:
+          <<: *slack-fail-post-step
+          requires:
+            - build_release_zip
+      - qit_malware_scan:
+          <<: *slack-fail-post-step
+          requires:
+            - build_release_zip
+      - qit_php_compatibility:
+          <<: *slack-fail-post-step
+          requires:
+            - build_release_zip
+      - qit_woo_api_tests:
+          <<: *slack-fail-post-step
+          requires:
+            - build_release_zip
+      - qit_woo_e2e_tests:
+          <<: *slack-fail-post-step
+          requires:
+            - build_release_zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1351,6 +1351,13 @@ workflows:
             - build_premium
 
   nightly_qit:
+    triggers:
+      - schedule:
+          cron: '0 2 * * 3' # Every Wednesday at 2am UTC
+          filters:
+            branches:
+              only:
+                - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -815,6 +815,47 @@ class RoboFile extends \Robo\Tasks {
     return $this->_exec('./vendor/bin/qit run:security mailpoet --zip=mailpoet.zip --wait');
   }
 
+  public function qaQitMalware() {
+    return $this->_exec('./vendor/bin/qit run:malware mailpoet --zip=mailpoet.zip --wait');
+  }
+
+  public function qaQitPhpCompatibility() {
+    return $this->_exec('./vendor/bin/qit run:phpcompatibility mailpoet --zip=mailpoet.zip --wait');
+  }
+
+  public function qaQitActivation($opts = ['wp' => 'stable', 'wc' => 'stable']) {
+    $command = './vendor/bin/qit run:activation mailpoet --zip=mailpoet.zip --wait';
+    if ($opts['wp']) {
+      $command .= ' --wordpress_version=' . $opts['wp'];
+    }
+    if ($opts['wc']) {
+      $command .= ' --woocommerce_version=' . $opts['wc'];
+    }
+    return $this->_exec($command);
+  }
+
+  public function qaQitWooApi($opts = ['wp' => 'stable', 'wc' => 'stable']) {
+    $command = './vendor/bin/qit run:woo-api mailpoet --zip=mailpoet.zip --wait';
+    if ($opts['wp']) {
+      $command .= ' --wordpress_version=' . $opts['wp'];
+    }
+    if ($opts['wc']) {
+      $command .= ' --woocommerce_version=' . $opts['wc'];
+    }
+    return $this->_exec($command);
+  }
+
+  public function qaQitWooE2e($opts = ['wp' => 'stable', 'wc' => 'stable']) {
+    $command = './vendor/bin/qit run:woo-e2e mailpoet --zip=mailpoet.zip --wait';
+    if ($opts['wp']) {
+      $command .= ' --wordpress_version=' . $opts['wp'];
+    }
+    if ($opts['wc']) {
+      $command .= ' --woocommerce_version=' . $opts['wc'];
+    }
+    return $this->_exec($command);
+  }
+
   public function svnCheckout() {
     $svnDir = ".mp_svn";
 


### PR DESCRIPTION
## Description

New weekly (Wednesday at 2 am) workflow in CircleCI to run QIT tests with the latest WooCommerce beta/RC. 

Here is the [workflow run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20310/workflows/0c04ecea-4f8d-46e2-84a3-58c7cf09cf05).

## Code review notes

Note that [PHP Compatibility check](https://qit.woo.com/?qit_results=4750527.6toWYqShPYRriNxjrEq6d3DMF87vmJlh59TkeDDAdLQz3CDBCC6URvwiRjrRsa4G) fails with hundreds of errors and warnings. Some are MailPoet's issues, but some are from libraries and generated folders. I checked with Masamune (p1740173882228569-slack-C03R7A7D1DW), and they'll allow ignoring folders, but we'll still need to fix issues on our side. 

I kept the check in the workflow, even though it will fail, as a reminder to fix this as soon as possible. Otherwise, I think we'd just ignore it. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6487]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

[MAILPOET-6487]: https://mailpoet.atlassian.net/browse/MAILPOET-6487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:qit)

_The latest successful build from `qit` will be used. If none is available, the link won't work._