### PR TITLE
Bump WooCommerce minimum version to 9.6 [MAILPOET-6490]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 9.6.2
+            ./do download:woo-commerce-zip 9.7.0
             ./do download:woo-commerce-subscriptions-zip 7.2.1
             ./do download:woo-commerce-memberships-zip 1.26.5
             ./do download:automate-woo-zip 6.1.7

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 9.5.1
- * WC tested up to: 9.6.0
+ * WC requires at least: 9.6.2
+ * WC tested up to: 9.7.0
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.6'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.5'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.6'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Skipping code review.

## QA notes

Skipping QA review.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6490]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6470]: https://mailpoet.atlassian.net/browse/MAILPOET-6470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:minimum-wc-96)

_The latest successful build from `minimum-wc-96` will be used. If none is available, the link won't work._

[MAILPOET-6490]: https://mailpoet.atlassian.net/browse/MAILPOET-6490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ