### PR TITLE
No implicit nullables rule  [MAILPOET-6491]

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1383,7 +1383,7 @@ class RoboFile extends \Robo\Tasks {
     $this->say("Release '$version[name]' info was published on Slack.");
   }
 
-  public function releaseRerunCircleWorkflow(string $project = null) {
+  public function releaseRerunCircleWorkflow(?string $project = null) {
     $circleciController = $this->createCircleCiController();
     $result = $circleciController->rerunLatestWorkflow($project);
     // Sometimes can be useful to know which Circle project workflow was restarted

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -158,7 +158,7 @@ class NewslettersResponseBuilder {
    * @param SendingQueueEntity|null $latestQueue
    * @return array<string, mixed>
    */
-  private function buildListingItem(NewsletterEntity $newsletter, NewsletterStatistics $statistics = null, SendingQueueEntity $latestQueue = null): array {
+  private function buildListingItem(NewsletterEntity $newsletter, ?NewsletterStatistics $statistics = null, ?SendingQueueEntity $latestQueue = null): array {
     $couponBlockLogs = array_map(function ($item) {
       return "Coupon block: $item";
     }, $this->logRepository->getRawMessagesForNewsletter($newsletter, LoggerFactory::TOPIC_COUPONS));

--- a/mailpoet/lib/API/REST/Response.php
+++ b/mailpoet/lib/API/REST/Response.php
@@ -6,7 +6,7 @@ use WP_REST_Response;
 
 class Response extends WP_REST_Response {
   public function __construct(
-    array $data = null,
+    ?array $data = null,
     int $status = 200
   ) {
     parent::__construct(['data' => $data], $status);

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -107,7 +107,7 @@ class Help {
     return $actionSchedulerData;
   }
 
-  private function getLatestActionSchedulerActionDate(string $hook, string $status = null): ?string {
+  private function getLatestActionSchedulerActionDate(string $hook, ?string $status = null): ?string {
     $query = [
       'per_page' => 1,
       'order' => 'DESC',

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -36,7 +36,7 @@ class FirstPurchase {
   private $subscribersRepository;
 
   public function __construct(
-    WCHelper $helper = null
+    ?WCHelper $helper = null
   ) {
     if ($helper === null) {
       $helper = ContainerWrapper::getInstance()->get(WCHelper::class);

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -34,7 +34,7 @@ class PurchasedInCategory {
   private $subscribersRepository;
 
   public function __construct(
-    WCHelper $woocommerceHelper = null
+    ?WCHelper $woocommerceHelper = null
   ) {
     if ($woocommerceHelper === null) {
       $woocommerceHelper = ContainerWrapper::getInstance()->get(WCHelper::class);

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -35,7 +35,7 @@ class PurchasedProduct {
   private $subscribersRepository;
 
   public function __construct(
-    WCHelper $helper = null
+    ?WCHelper $helper = null
   ) {
     if ($helper === null) {
       $helper = ContainerWrapper::getInstance()->get(WCHelper::class);

--- a/mailpoet/lib/Automation/Engine/Control/StepRunController.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunController.php
@@ -25,15 +25,15 @@ class StepRunController {
     $this->stepRunLogger = $stepRunLogger;
   }
 
-  public function scheduleProgress(int $timestamp = null): int {
+  public function scheduleProgress(?int $timestamp = null): int {
     return $this->stepScheduler->scheduleProgress($this->stepRunArgs, $timestamp);
   }
 
-  public function scheduleNextStep(int $timestamp = null): int {
+  public function scheduleNextStep(?int $timestamp = null): int {
     return $this->stepScheduler->scheduleNextStep($this->stepRunArgs, $timestamp);
   }
 
-  public function scheduleNextStepByIndex(int $nextStepIndex, int $timestamp = null): int {
+  public function scheduleNextStepByIndex(int $nextStepIndex, ?int $timestamp = null): int {
     return $this->stepScheduler->scheduleNextStepByIndex($this->stepRunArgs, $nextStepIndex, $timestamp);
   }
 

--- a/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepRunLogger.php
@@ -42,7 +42,7 @@ class StepRunLogger {
     string $stepId,
     string $stepType,
     int $runNumber,
-    bool $isWpDebug = null
+    ?bool $isWpDebug = null
   ) {
     $this->automationRunLogStorage = $automationRunLogStorage;
     $this->hooks = $hooks;

--- a/mailpoet/lib/Automation/Engine/Control/StepScheduler.php
+++ b/mailpoet/lib/Automation/Engine/Control/StepScheduler.php
@@ -23,13 +23,13 @@ class StepScheduler {
     $this->automationRunStorage = $automationRunStorage;
   }
 
-  public function scheduleProgress(StepRunArgs $args, int $timestamp = null): int {
+  public function scheduleProgress(StepRunArgs $args, ?int $timestamp = null): int {
     $runId = $args->getAutomationRun()->getId();
     $data = $this->getActionData($runId, $args->getStep()->getId(), $args->getRunNumber() + 1);
     return $this->scheduleStepAction($data, $timestamp);
   }
 
-  public function scheduleNextStep(StepRunArgs $args, int $timestamp = null): int {
+  public function scheduleNextStep(StepRunArgs $args, ?int $timestamp = null): int {
     $step = $args->getStep();
     $nextSteps = $step->getNextSteps();
 
@@ -46,7 +46,7 @@ class StepScheduler {
     return $this->scheduleNextStepByIndex($args, 0, $timestamp);
   }
 
-  public function scheduleNextStepByIndex(StepRunArgs $args, int $nextStepIndex, int $timestamp = null): int {
+  public function scheduleNextStepByIndex(StepRunArgs $args, int $nextStepIndex, ?int $timestamp = null): int {
     $step = $args->getStep();
     $nextStep = $step->getNextSteps()[$nextStepIndex] ?? null;
     if (!$nextStep) {
@@ -95,7 +95,7 @@ class StepScheduler {
     return $this->hasScheduledNextStep($args) || $this->hasScheduledProgress($args);
   }
 
-  private function scheduleStepAction(array $data, int $timestamp = null): int {
+  private function scheduleStepAction(array $data, ?int $timestamp = null): int {
     return $timestamp === null
       ? $this->actionScheduler->enqueue(Hooks::AUTOMATION_STEP, $data)
       : $this->actionScheduler->schedule($timestamp, Hooks::AUTOMATION_STEP, $data);

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -53,8 +53,8 @@ class Automation {
     string $name,
     array $steps,
     \WP_User $author,
-    int $id = null,
-    int $versionId = null
+    ?int $id = null,
+    ?int $versionId = null
   ) {
     $this->name = $name;
     $this->steps = $steps;

--- a/mailpoet/lib/Automation/Engine/Data/AutomationRun.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationRun.php
@@ -42,7 +42,7 @@ class AutomationRun {
     int $versionId,
     string $triggerKey,
     array $subjects,
-    int $id = null
+    ?int $id = null
   ) {
     $this->automationId = $automationId;
     $this->versionId = $versionId;
@@ -91,7 +91,7 @@ class AutomationRun {
   }
 
   /** @return Subject[] */
-  public function getSubjects(string $key = null): array {
+  public function getSubjects(?string $key = null): array {
     if ($key) {
       return array_values(
         array_filter($this->subjects, function (Subject $subject) use ($key) {

--- a/mailpoet/lib/Automation/Engine/Data/AutomationRunLog.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationRunLog.php
@@ -60,7 +60,7 @@ class AutomationRunLog {
     int $automationRunId,
     string $stepId,
     string $stepType,
-    int $id = null
+    ?int $id = null
   ) {
     $this->automationRunId = $automationRunId;
     $this->stepId = $stepId;

--- a/mailpoet/lib/Automation/Engine/Data/Step.php
+++ b/mailpoet/lib/Automation/Engine/Data/Step.php
@@ -35,7 +35,7 @@ class Step {
     string $key,
     array $args,
     array $nextSteps,
-    Filters $filters = null
+    ?Filters $filters = null
   ) {
     $this->id = $id;
     $this->type = $type;

--- a/mailpoet/lib/Automation/Engine/Exceptions/Exception.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions/Exception.php
@@ -20,16 +20,16 @@ abstract class Exception extends PhpException implements RestException {
   protected $errors = [];
 
   final public function __construct(
-    string $message = null,
-    string $errorCode = null,
-    Throwable $previous = null
+    ?string $message = null,
+    ?string $errorCode = null,
+    ?Throwable $previous = null
   ) {
     parent::__construct($message ?? __('Unknown error.', 'mailpoet'), 0, $previous);
     $this->errorCode = $errorCode ?? 'mailpoet_automation_unknown_error';
   }
 
   /** @return static */
-  public static function create(Throwable $previous = null) {
+  public static function create(?Throwable $previous = null) {
     return new static(null, null, $previous);
   }
 

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -19,7 +19,7 @@ class AutomationMapper {
     $this->statisticsStorage = $statisticsStorage;
   }
 
-  public function buildAutomation(Automation $automation, AutomationStatistics $statistics = null): array {
+  public function buildAutomation(Automation $automation, ?AutomationStatistics $statistics = null): array {
 
     return [
       'id' => $automation->getId(),

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -98,7 +98,7 @@ class Registry {
   }
 
   /** @return array<string, AutomationTemplate> */
-  public function getTemplates(string $category = null): array {
+  public function getTemplates(?string $category = null): array {
     return $category
       ? array_filter(
         $this->templates,
@@ -254,7 +254,7 @@ class Registry {
     $this->wordPress->addAction(Hooks::AUTOMATION_BEFORE_SAVE, $callback, $priority);
   }
 
-  public function onBeforeAutomationStepSave(callable $callback, string $key = null, int $priority = 10): void {
+  public function onBeforeAutomationStepSave(callable $callback, ?string $key = null, int $priority = 10): void {
     $keyPart = $key ? "/key=$key" : '';
     $this->wordPress->addAction(Hooks::AUTOMATION_STEP_BEFORE_SAVE . $keyPart, $callback, $priority, 2);
   }

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunLogStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunLogStorage.php
@@ -32,7 +32,7 @@ class AutomationRunLogStorage {
     }
   }
 
-  public function getAutomationRunStatisticsForAutomationInTimeFrame(int $automationId, string $status, \DateTimeImmutable $after, \DateTimeImmutable $before, int $versionId = null): array {
+  public function getAutomationRunStatisticsForAutomationInTimeFrame(int $automationId, string $status, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
     global $wpdb;
     $andWhere = $versionId ? 'AND run.version_id = %d' : '';
     $results = $wpdb->get_results(

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -218,7 +218,7 @@ class AutomationRunStorage {
     }
   }
 
-  public function getAutomationStepStatisticForTimeFrame(int $automationId, string $status, \DateTimeImmutable $after, \DateTimeImmutable $before, int $versionId = null): array {
+  public function getAutomationStepStatisticForTimeFrame(int $automationId, string $status, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
     global $wpdb;
     $andWhere = $versionId ? 'AND version_id = %d' : '';
     $result = $wpdb->get_results(

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStatisticsStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStatisticsStorage.php
@@ -39,7 +39,7 @@ class AutomationStatisticsStorage {
     return $statistics;
   }
 
-  public function getAutomationStats(int $automationId, int $versionId = null, \DateTimeImmutable $after = null, \DateTimeImmutable $before = null): AutomationStatistics {
+  public function getAutomationStats(int $automationId, ?int $versionId = null, ?\DateTimeImmutable $after = null, ?\DateTimeImmutable $before = null): AutomationStatistics {
     $data = $this->getStatistics([$automationId], $versionId, $after, $before);
     return new AutomationStatistics(
       $automationId,
@@ -53,7 +53,7 @@ class AutomationStatisticsStorage {
    * @param int[] $automationIds
    * @return array<int, array{id: int, total: int, running: int}>
    */
-  private function getStatistics(array $automationIds, int $versionId = null, \DateTimeImmutable $after = null, \DateTimeImmutable $before = null): array {
+  private function getStatistics(array $automationIds, ?int $versionId = null, ?\DateTimeImmutable $after = null, ?\DateTimeImmutable $before = null): array {
     global $wpdb;
     $totalSubquery = $this->getStatsQuery($automationIds, $versionId, $after, $before);
     $runningSubquery = $this->getStatsQuery($automationIds, $versionId, $after, $before, AutomationRun::STATUS_RUNNING);
@@ -71,7 +71,7 @@ class AutomationStatisticsStorage {
     return array_combine(array_column($results, 'id'), $results) ?: [];
   }
 
-  private function getStatsQuery(array $automationIds, int $versionId = null, \DateTimeImmutable $after = null, \DateTimeImmutable $before = null, string $status = null): string {
+  private function getStatsQuery(array $automationIds, ?int $versionId = null, ?\DateTimeImmutable $after = null, ?\DateTimeImmutable $before = null, ?string $status = null): string {
     global $wpdb;
 
     $versionCondition = $versionId ? 'AND version_id = %d' : '';

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
@@ -126,7 +126,7 @@ class AutomationStorage {
     ) : [];
   }
 
-  public function getAutomation(int $automationId, int $versionId = null): ?Automation {
+  public function getAutomation(int $automationId, ?int $versionId = null): ?Automation {
     global $wpdb;
 
     if ($versionId) {
@@ -153,7 +153,7 @@ class AutomationStorage {
   }
 
   /** @return Automation[] */
-  public function getAutomations(array $status = null): array {
+  public function getAutomations(?array $status = null): array {
     global $wpdb;
 
     $statusFilter = $status ? 'AND a.status IN (' . implode(',', array_fill(0, count($status), '%s')) . ')' : '';
@@ -184,7 +184,7 @@ class AutomationStorage {
   }
 
   /** @return int[] */
-  public function getAutomationIdsBySubject(Subject $subject, array $runStatus = null, int $inTheLastSeconds = null): array {
+  public function getAutomationIdsBySubject(Subject $subject, ?array $runStatus = null, ?int $inTheLastSeconds = null): array {
     global $wpdb;
 
     $statusFilter = $runStatus ? 'AND r.status IN (' . implode(',', array_fill(0, count($runStatus), '%s')) . ')' : '';

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -68,7 +68,7 @@ class WordPress {
   }
 
   /** @return WP_Post[]|int[] */
-  public function getPosts(array $args = null): array {
+  public function getPosts(?array $args = null): array {
     return get_posts($args);
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -423,7 +423,7 @@ class SendEmailAction implements Action {
     $this->newslettersRepository->flush();
   }
 
-  private function storeNewsletterOption(NewsletterEntity $newsletter, string $optionName, string $optionValue = null): void {
+  private function storeNewsletterOption(NewsletterEntity $newsletter, string $optionName, ?string $optionValue = null): void {
     $options = $newsletter->getOptions()->toArray();
     foreach ($options as $key => $option) {
       if ($option->getName() === $optionName) {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/Query.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/Query.php
@@ -41,7 +41,7 @@ class Query {
     string $orderDirection = 'asc',
     int $page = 1,
     array $filter = [],
-    string $search = null
+    ?string $search = null
   ) {
     $this->primaryAfter = $primaryAfter;
     $this->primaryBefore = $primaryBefore;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/QueryWithCompare.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/QueryWithCompare.php
@@ -25,7 +25,7 @@ class QueryWithCompare extends Query {
     string $orderDirection = 'asc',
     int $page = 0,
     array $filter = [],
-    string $search = null
+    ?string $search = null
   ) {
     parent::__construct($primaryAfter, $primaryBefore, $limit, $orderBy, $orderDirection, $page, $filter, $search);
     $this->secondaryAfter = $secondaryAfter;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactory.php
@@ -66,7 +66,7 @@ class SubscriberAutomationFieldsFactory {
     ];
   }
 
-  private function getAutomationIds(SubscriberPayload $payload, array $status = null, array $params = []): array {
+  private function getAutomationIds(SubscriberPayload $payload, ?array $status = null, array $params = []): array {
     $inTheLastSeconds = isset($params['in_the_last']) ? (int)$params['in_the_last'] : null;
     $subject = new Subject(SubscriberSubject::KEY, ['subscriber_id' => $payload->getId()]);
     return $this->automationStorage->getAutomationIdsBySubject($subject, $status, $inTheLastSeconds);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberCustomFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberCustomFieldsFactory.php
@@ -141,7 +141,7 @@ class SubscriberCustomFieldsFactory {
 
   private function getCustomFieldValue(SubscriberPayload $payload, CustomFieldEntity $customField): ?string {
     $subscriberCustomField = $payload->getSubscriber()->getSubscriberCustomFields()->filter(
-      function (SubscriberCustomFieldEntity $subscriberCustomField = null) use ($customField) {
+      function (?SubscriberCustomFieldEntity $subscriberCustomField = null) use ($customField) {
         return $subscriberCustomField && $subscriberCustomField->getCustomField() === $customField;
       }
     )->first() ?: null;

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerOrderFieldsFactory.php
@@ -332,7 +332,7 @@ class CustomerOrderFieldsFactory {
     return $date ? new DateTimeImmutable($date, new DateTimeZone('GMT')) : null;
   }
 
-  private function getOrderProductTermIds(WC_Customer $customer, string $taxonomy, int $inTheLastSeconds = null): array {
+  private function getOrderProductTermIds(WC_Customer $customer, string $taxonomy, ?int $inTheLastSeconds = null): array {
     global $wpdb;
 
     $statuses = array_map(function (string $status) {

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerReviewFieldsFactory.php
@@ -53,7 +53,7 @@ class CustomerReviewFieldsFactory {
    * Calculate the customer's review count excluding multiple reviews on the same product.
    * Inspired by AutomateWoo implementation.
    */
-  private function getUniqueProductReviewCount(WC_Customer $customer, int $inTheLastSeconds = null): int {
+  private function getUniqueProductReviewCount(WC_Customer $customer, ?int $inTheLastSeconds = null): int {
     global $wpdb;
 
     $inTheLastFilter = isset($inTheLastSeconds) ? 'AND c.comment_date_gmt >= DATE_SUB(current_timestamp, INTERVAL %d SECOND)' : '';

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Payloads/CustomerPayload.php
@@ -11,8 +11,8 @@ class CustomerPayload implements Payload {
   private ?WC_Order $order;
 
   public function __construct(
-    WC_Customer $customer = null,
-    WC_Order $order = null
+    ?WC_Customer $customer = null,
+    ?WC_Order $order = null
   ) {
     $this->customer = $customer;
     $this->order = $order;

--- a/mailpoet/lib/Captcha/CaptchaPhrase.php
+++ b/mailpoet/lib/Captcha/CaptchaPhrase.php
@@ -10,7 +10,7 @@ class CaptchaPhrase {
 
   public function __construct(
     CaptchaSession $session,
-    PhraseBuilder $phraseBuilder = null
+    ?PhraseBuilder $phraseBuilder = null
   ) {
     $this->session = $session;
     $this->phraseBuilder = $phraseBuilder ?? new PhraseBuilder();

--- a/mailpoet/lib/Captcha/Validator/ValidationError.php
+++ b/mailpoet/lib/Captcha/Validator/ValidationError.php
@@ -10,7 +10,7 @@ class ValidationError extends \RuntimeException {
     $message = "",
     array $meta = [],
     $code = 0,
-    \Throwable $previous = null
+    ?\Throwable $previous = null
   ) {
     $this->meta = $meta;
     $this->meta['error'] = $message;

--- a/mailpoet/lib/Config/Capabilities.php
+++ b/mailpoet/lib/Config/Capabilities.php
@@ -16,7 +16,7 @@ class Capabilities {
 
   public function __construct(
     $renderer = null,
-    WPFunctions $wp = null
+    ?WPFunctions $wp = null
   ) {
     if ($renderer !== null) {
       $this->renderer = $renderer;

--- a/mailpoet/lib/Config/HooksWooCommerce.php
+++ b/mailpoet/lib/Config/HooksWooCommerce.php
@@ -145,7 +145,7 @@ class HooksWooCommerce {
     }
   }
 
-  public function onRegister($errors, string $userLogin, string $userEmail = null) {
+  public function onRegister($errors, string $userLogin, ?string $userEmail = null) {
     try {
       if (empty($errors->errors)) {
         $this->subscriberRegistration->onRegister($errors, $userLogin, $userEmail);

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -711,7 +711,7 @@ class Menu {
     );
   }
 
-  public static function isOnMailPoetAdminPage(array $exclude = null, $screenId = null) {
+  public static function isOnMailPoetAdminPage(?array $exclude = null, $screenId = null) {
     if (is_null($screenId)) {
       if (empty($_REQUEST['page'])) {
         return false;
@@ -762,7 +762,7 @@ class Menu {
     // Used for displaying admin notices only
   }
 
-  public function checkPremiumKey(ServicesChecker $checker = null) {
+  public function checkPremiumKey(?ServicesChecker $checker = null) {
     $showNotices = isset($_SERVER['SCRIPT_NAME'])
       && stripos(sanitize_text_field(wp_unslash($_SERVER['SCRIPT_NAME'])), 'plugins.php') !== false;
     $checker = $checker ?: $this->servicesChecker;

--- a/mailpoet/lib/Config/TwigEnvironment.php
+++ b/mailpoet/lib/Config/TwigEnvironment.php
@@ -14,7 +14,7 @@ class TwigEnvironment extends Environment {
    * We need to produce the same class regardless of PHP_VERSION. Therefore, we
    * overwrite this method.
    **/
-  public function getTemplateClass(string $name, int $index = null): string {
+  public function getTemplateClass(string $name, ?int $index = null): string {
     return $this->templateClassPrefix . \hash('sha256', $name) . (null === $index ? '' : '___' . $index);
   }
 }

--- a/mailpoet/lib/Cron/DaemonHttpRunner.php
+++ b/mailpoet/lib/Cron/DaemonHttpRunner.php
@@ -27,7 +27,7 @@ class DaemonHttpRunner {
   private $wordpressTrigger;
 
   public function __construct(
-    ?Daemon $daemon = null,
+    ?Daemon $daemon,
     CronHelper $cronHelper,
     SettingsController $settings,
     WordPress $wordpressTrigger

--- a/mailpoet/lib/Cron/DaemonHttpRunner.php
+++ b/mailpoet/lib/Cron/DaemonHttpRunner.php
@@ -27,7 +27,7 @@ class DaemonHttpRunner {
   private $wordpressTrigger;
 
   public function __construct(
-    Daemon $daemon = null,
+    ?Daemon $daemon = null,
     CronHelper $cronHelper,
     SettingsController $settings,
     WordPress $wordpressTrigger
@@ -140,7 +140,7 @@ class DaemonHttpRunner {
    *
    * @return bool
    */
-  private function shouldTerminateExecution(array $settingsDaemonData = null) {
+  private function shouldTerminateExecution(?array $settingsDaemonData = null) {
     return !$settingsDaemonData ||
        $settingsDaemonData['token'] !== $this->token ||
        (isset($settingsDaemonData['status']) && $settingsDaemonData['status'] !== CronHelper::DAEMON_STATUS_ACTIVE);

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Links.php
@@ -64,7 +64,7 @@ class Links {
     return $this->newsletterLinks->save($links, $newsletter->getId(), $queue->getId());
   }
 
-  public function getUnsubscribeUrl($queueId, SubscriberEntity $subscriber = null) {
+  public function getUnsubscribeUrl($queueId, ?SubscriberEntity $subscriber = null) {
     if ($this->trackingConfig->isEmailTrackingEnabled() && $subscriber) {
       $linkHash = $this->newsletterLinkRepository->findOneBy(
         [

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Mailer.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Mailer.php
@@ -23,7 +23,7 @@ class Mailer {
     $this->mailer = $this->configureMailer();
   }
 
-  public function configureMailer(NewsletterEntity $newsletter = null) {
+  public function configureMailer(?NewsletterEntity $newsletter = null) {
     $sender['address'] = ($newsletter && !empty($newsletter->getSenderAddress())) ?
       $newsletter->getSenderAddress() :
       null;

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -79,10 +79,10 @@ class Newsletter {
   private $personalizer;
 
   public function __construct(
-    WPFunctions $wp = null,
-    PostsTask $postsTask = null,
-    GATracking $gaTracking = null,
-    Emoji $emoji = null
+    ?WPFunctions $wp = null,
+    ?PostsTask $postsTask = null,
+    ?GATracking $gaTracking = null,
+    ?Emoji $emoji = null
   ) {
     $trackingConfig = ContainerWrapper::getInstance()->get(TrackingConfig::class);
     $this->trackingEnabled = $trackingConfig->isEmailTrackingEnabled();

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Shortcodes.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Shortcodes.php
@@ -16,7 +16,7 @@ class Shortcodes {
    * @param SubscriberEntity|null $subscriber
    * @param SendingQueueEntity|null $queue
    */
-  public static function process($content, $contentSource = null, NewsletterEntity $newsletter = null, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
+  public static function process($content, $contentSource = null, ?NewsletterEntity $newsletter = null, ?SubscriberEntity $subscriber = null, ?SendingQueueEntity $queue = null) {
     /** @var NewsletterShortcodes $shortcodes */
     $shortcodes = ContainerWrapper::getInstance()->get(NewsletterShortcodes::class);
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -138,7 +138,7 @@ class Worker {
     ];
   }
 
-  private function prepareContext(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue, NewsletterLinkEntity $link = null) {
+  private function prepareContext(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue, ?NewsletterLinkEntity $link = null) {
     $statistics = $this->newsletterStatisticsRepository->getStatistics($newsletter);
     $clicked = ($statistics->getClickCount() * 100) / $statistics->getTotalSentCount();
     $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -699,7 +699,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     return $container;
   }
 
-  public static function getPremiumService($id, ContainerInterface $container = null) {
+  public static function getPremiumService($id, ?ContainerInterface $container = null) {
     if ($container === null) {
       return null;
     }

--- a/mailpoet/lib/DI/ContainerWrapper.php
+++ b/mailpoet/lib/DI/ContainerWrapper.php
@@ -20,7 +20,7 @@ class ContainerWrapper implements ContainerInterface {
 
   public function __construct(
     Container $freeContainer,
-    Container $premiumContainer = null
+    ?Container $premiumContainer = null
   ) {
     $this->freeContainer = $freeContainer;
     $this->premiumContainer = $premiumContainer;

--- a/mailpoet/lib/Doctrine/Repository.php
+++ b/mailpoet/lib/Doctrine/Repository.php
@@ -41,7 +41,7 @@ abstract class Repository {
    * @param int|null $offset
    * @return T[]
    */
-  public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null) {
+  public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null) {
     return $this->doctrineRepository->findBy($criteria, $orderBy, $limit, $offset);
   }
 
@@ -62,7 +62,7 @@ abstract class Repository {
    * @param array|null $orderBy
    * @return T|null
    */
-  public function findOneBy(array $criteria, array $orderBy = null) {
+  public function findOneBy(array $criteria, ?array $orderBy = null) {
     return $this->doctrineRepository->findOneBy($criteria, $orderBy);
   }
 
@@ -114,7 +114,7 @@ abstract class Repository {
   /**
    * @param callable(T): bool|null $filter
    */
-  public function refreshAll(callable $filter = null): void {
+  public function refreshAll(?callable $filter = null): void {
     $entities = $this->getAllFromIdentityMap();
     foreach ($entities as $entity) {
       if ($filter && !$filter($entity)) {
@@ -142,7 +142,7 @@ abstract class Repository {
   /**
    * @param callable(T): bool|null $filter
    */
-  public function detachAll(callable $filter = null): void {
+  public function detachAll(?callable $filter = null): void {
     $entities = $this->getAllFromIdentityMap();
     foreach ($entities as $entity) {
       if ($filter && !$filter($entity)) {

--- a/mailpoet/lib/Entities/FormEntity.php
+++ b/mailpoet/lib/Entities/FormEntity.php
@@ -174,7 +174,7 @@ class FormEntity {
     ];
   }
 
-  public function getBlocksByTypes(array $types, array $blocks = null): array {
+  public function getBlocksByTypes(array $types, ?array $blocks = null): array {
     $found = [];
     if ($blocks === null) {
       $blocks = $this->getBody() ?? [];

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -474,7 +474,7 @@ class NewsletterEntity {
    * @return int[]
    */
   public function getSegmentIds() {
-    return array_filter($this->newsletterSegments->map(function(NewsletterSegmentEntity $newsletterSegment = null) {
+    return array_filter($this->newsletterSegments->map(function(?NewsletterSegmentEntity $newsletterSegment = null) {
       if (!$newsletterSegment) return null;
       $segment = $newsletterSegment->getSegment();
       return $segment ? (int)$segment->getId() : null;
@@ -489,7 +489,7 @@ class NewsletterEntity {
   }
 
   public function getOption(string $name): ?NewsletterOptionEntity {
-    $option = $this->options->filter(function (NewsletterOptionEntity $option = null) use ($name): bool {
+    $option = $this->options->filter(function (?NewsletterOptionEntity $option = null) use ($name): bool {
       if (!$option) return false;
       return ($field = $option->getOptionField()) ? $field->getName() === $name : false;
     })->first();

--- a/mailpoet/lib/Entities/ScheduledTaskEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskEntity.php
@@ -243,7 +243,7 @@ class ScheduledTaskEntity {
   public function getSubscribersByProcessed(int $processed): array {
     $criteria = Criteria::create()
       ->where(Criteria::expr()->eq('processed', $processed));
-    $subscribers = $this->subscribers->matching($criteria)->map(function (ScheduledTaskSubscriberEntity $taskSubscriber = null): ?SubscriberEntity {
+    $subscribers = $this->subscribers->matching($criteria)->map(function (?ScheduledTaskSubscriberEntity $taskSubscriber = null): ?SubscriberEntity {
       if (!$taskSubscriber) return null;
       return $taskSubscriber->getSubscriber();
     });

--- a/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
+++ b/mailpoet/lib/Entities/ScheduledTaskSubscriberEntity.php
@@ -61,7 +61,7 @@ class ScheduledTaskSubscriberEntity {
     SubscriberEntity $subscriber,
     int $processed = 0,
     int $failed = 0,
-    string $error = null
+    ?string $error = null
   ) {
     $this->task = $task;
     $this->subscriber = $subscriber;

--- a/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
+++ b/mailpoet/lib/Entities/StatisticsNewsletterEntity.php
@@ -45,7 +45,7 @@ class StatisticsNewsletterEntity {
     NewsletterEntity $newsletter,
     SendingQueueEntity $queue,
     SubscriberEntity $subscriber,
-    \DateTimeInterface $sentAt = null
+    ?\DateTimeInterface $sentAt = null
   ) {
     $this->newsletter = $newsletter;
     $this->queue = $queue;

--- a/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
+++ b/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
@@ -67,8 +67,8 @@ class StatisticsUnsubscribeEntity {
   private $method = self::METHOD_UNKNOWN;
 
   public function __construct(
-    ?NewsletterEntity $newsletter = null,
-    ?SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter,
+    ?SendingQueueEntity $queue,
     SubscriberEntity $subscriber
   ) {
     $this->newsletter = $newsletter;

--- a/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
+++ b/mailpoet/lib/Entities/StatisticsUnsubscribeEntity.php
@@ -67,8 +67,8 @@ class StatisticsUnsubscribeEntity {
   private $method = self::METHOD_UNKNOWN;
 
   public function __construct(
-    NewsletterEntity $newsletter = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SendingQueueEntity $queue = null,
     SubscriberEntity $subscriber
   ) {
     $this->newsletter = $newsletter;

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -504,7 +504,7 @@ class SubscriberEntity {
 
   /** * @return Collection<int, SegmentEntity> */
   public function getSegments() {
-    return $this->subscriberSegments->map(function (SubscriberSegmentEntity $subscriberSegment = null) {
+    return $this->subscriberSegments->map(function (?SubscriberSegmentEntity $subscriberSegment = null) {
       if (!$subscriberSegment) return null;
       return $subscriberSegment->getSegment();
     })->filter(function (?SegmentEntity $segment = null) {
@@ -635,7 +635,7 @@ class SubscriberEntity {
   /** @ORM\PreFlush */
   public function cleanupSubscriberSegments(): void {
     // Delete old orphan SubscriberSegments to avoid errors on update
-    $this->subscriberSegments->map(function (SubscriberSegmentEntity $subscriberSegment = null) {
+    $this->subscriberSegments->map(function (?SubscriberSegmentEntity $subscriberSegment = null) {
       if (!$subscriberSegment) return null;
       if ($subscriberSegment->getSegment() === null) {
         $this->subscriberSegments->removeElement($subscriberSegment);

--- a/mailpoet/lib/Form/Renderer.php
+++ b/mailpoet/lib/Form/Renderer.php
@@ -41,14 +41,14 @@ class Renderer {
     return $html;
   }
 
-  public function renderHTML(FormEntity $form = null): string {
+  public function renderHTML(?FormEntity $form = null): string {
     if (($form instanceof FormEntity) && !empty($form->getBody()) && is_array($form->getSettings())) {
       return $this->renderBlocks($form->getBody(), $form->getSettings() ?? [], $form->getId());
     }
     return '';
   }
 
-  public function getCustomStyles(FormEntity $form = null): string {
+  public function getCustomStyles(?FormEntity $form = null): string {
     if (($form instanceof FormEntity) && (strlen(trim($form->getStyles() ?? '')) > 0)) {
       return strip_tags($form->getStyles() ?? '');
     } else {

--- a/mailpoet/lib/Listing/ListingDefinition.php
+++ b/mailpoet/lib/Listing/ListingDefinition.php
@@ -31,9 +31,9 @@ class ListingDefinition {
   private $selection;
 
   public function __construct(
-    string $group = null,
+    ?string $group = null,
     array $filters = [],
-    string $search = null,
+    ?string $search = null,
     array $parameters = [],
     string $sortBy = 'created_at',
     string $sortOrder = 'desc',

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -50,11 +50,11 @@ class LogRepository extends Repository {
    * @return LogEntity[]
    */
   public function getLogs(
-    \DateTimeInterface $dateFrom = null,
-    \DateTimeInterface $dateTo = null,
-    string $search = null,
-    string $offset = null,
-    string $limit = null
+    ?\DateTimeInterface $dateFrom = null,
+    ?\DateTimeInterface $dateTo = null,
+    ?string $search = null,
+    ?string $offset = null,
+    ?string $limit = null
   ): array {
     $query = $this->doctrineRepository->createQueryBuilder('l')
       ->select('l');

--- a/mailpoet/lib/Mailer/MailerFactory.php
+++ b/mailpoet/lib/Mailer/MailerFactory.php
@@ -45,7 +45,7 @@ class MailerFactory {
     return $this->defaultMailer;
   }
 
-  public function buildMailer(array $mailerConfig = null, array $sender = null, array $replyTo = null, string $returnPath = null): Mailer {
+  public function buildMailer(?array $mailerConfig = null, ?array $sender = null, ?array $replyTo = null, ?string $returnPath = null): Mailer {
     $sender = $this->getSenderNameAndAddress($sender);
     $replyTo = $this->getReplyToNameAndAddress($sender, $replyTo);
     $mailerConfig = $mailerConfig ?? $this->getMailerConfig();
@@ -120,7 +120,7 @@ class MailerFactory {
     return $config;
   }
 
-  private function getSenderNameAndAddress(array $sender = null): array {
+  private function getSenderNameAndAddress(?array $sender = null): array {
     if (empty($sender)) {
       $sender = $this->settings->get('sender', []);
       if (empty($sender['address'])) throw new InvalidStateException(__('Sender name and email are not configured.', 'mailpoet'));
@@ -133,7 +133,7 @@ class MailerFactory {
     ];
   }
 
-  private function getReplyToNameAndAddress(array $sender, array $replyTo = null): array {
+  private function getReplyToNameAndAddress(array $sender, ?array $replyTo = null): array {
     if (!$replyTo) {
       $replyTo = $this->settings->get('reply_to');
       $replyTo['name'] = (!empty($replyTo['name'])) ?

--- a/mailpoet/lib/Mailer/MailerLog.php
+++ b/mailpoet/lib/Mailer/MailerLog.php
@@ -33,7 +33,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return MailerLogData
    */
-  public static function getMailerLog(array $mailerLog = null): array {
+  public static function getMailerLog(?array $mailerLog = null): array {
     if ($mailerLog) return $mailerLog;
     $settings = SettingsController::getInstance();
     $mailerLog = $settings->get(self::SETTING_NAME);
@@ -90,7 +90,7 @@ class MailerLog {
    * @return null
    * @throws \Exception
    */
-  public static function enforceExecutionRequirements(array $mailerLog = null) {
+  public static function enforceExecutionRequirements(?array $mailerLog = null) {
     $mailerLog = self::getMailerLog($mailerLog);
     if ($mailerLog['retry_attempt'] === self::RETRY_ATTEMPTS_LIMIT) {
       $mailerLog = self::pauseSending($mailerLog);
@@ -162,9 +162,9 @@ class MailerLog {
   public static function processError(
     string $operation,
     string $errorMessage,
-    string $errorCode = null,
+    ?string $errorCode = null,
     bool $pauseSending = false,
-    int $throttledBatchSize = null
+    ?int $throttledBatchSize = null
   ) {
     $mailerLog = self::getMailerLog();
     if (!isset($throttledBatchSize) || $throttledBatchSize === 1) {
@@ -232,7 +232,7 @@ class MailerLog {
     array $mailerLog,
     string $operation,
     string $errorMessage,
-    string $errorCode = null
+    ?string $errorCode = null
   ): array {
     $mailerLog['error'] = [
       'operation' => $operation,
@@ -248,7 +248,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return MailerLogError|null
    */
-  public static function getError(array $mailerLog = null): ?array {
+  public static function getError(?array $mailerLog = null): ?array {
     $mailerLog = self::getMailerLog($mailerLog);
     return isset($mailerLog['error']) ? $mailerLog['error'] : null;
   }
@@ -300,7 +300,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return bool
    */
-  public static function isSendingLimitReached(array $mailerLog = null): bool {
+  public static function isSendingLimitReached(?array $mailerLog = null): bool {
     $settings = SettingsController::getInstance();
     $mailerConfig = $settings->get(Mailer::MAILER_CONFIG_SETTING_NAME);
     // do not enforce sending limit for MailPoet's sending method
@@ -322,7 +322,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return int
    */
-  public static function sentSince(int $sinceSeconds = null, array $mailerLog = null): int {
+  public static function sentSince(?int $sinceSeconds = null, ?array $mailerLog = null): int {
 
     if ($sinceSeconds === null) {
       $settings = SettingsController::getInstance();
@@ -353,7 +353,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return MailerLogData
    */
-  private static function removeOutdatedSentInformationFromMailerlog(array $mailerLog = null): array {
+  private static function removeOutdatedSentInformationFromMailerlog(?array $mailerLog = null): array {
 
     $settings = SettingsController::getInstance();
     $mailerConfig = $settings->get(Mailer::MAILER_CONFIG_SETTING_NAME);
@@ -375,7 +375,7 @@ class MailerLog {
    * @param int|null $timestamp
    * @return string
    */
-  private static function sentEntriesDate(int $timestamp = null): string {
+  private static function sentEntriesDate(?int $timestamp = null): string {
 
     return date('Y-m-d H:i:s', $timestamp ?? time());
   }
@@ -384,7 +384,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return bool
    */
-  public static function isSendingPaused(array $mailerLog = null): bool {
+  public static function isSendingPaused(?array $mailerLog = null): bool {
     $mailerLog = self::getMailerLog($mailerLog);
     return $mailerLog['status'] === self::STATUS_PAUSED;
   }
@@ -393,7 +393,7 @@ class MailerLog {
    * @param MailerLogData|null $mailerLog
    * @return bool
    */
-  public static function isSendingWaitingForRetry(array $mailerLog = null): bool {
+  public static function isSendingWaitingForRetry(?array $mailerLog = null): bool {
     $mailerLog = self::getMailerLog($mailerLog);
     $retryAt = $mailerLog['retry_at'] ?? null;
     return $retryAt && (time() <= $retryAt);

--- a/mailpoet/lib/Mailer/MetaInfo.php
+++ b/mailpoet/lib/Mailer/MetaInfo.php
@@ -18,7 +18,7 @@ class MetaInfo {
     return $this->makeMetaInfo('email_stats_notification', 'unknown', 'administrator');
   }
 
-  public function getWordPressTransactionalMetaInfo(SubscriberEntity $subscriber = null) {
+  public function getWordPressTransactionalMetaInfo(?SubscriberEntity $subscriber = null) {
     return $this->makeMetaInfo(
       'transactional',
       $subscriber ? $subscriber->getStatus() : 'unknown',

--- a/mailpoet/lib/Mailer/Methods/Common/BlacklistCheck.php
+++ b/mailpoet/lib/Mailer/Methods/Common/BlacklistCheck.php
@@ -9,7 +9,7 @@ class BlacklistCheck {
   private $blacklist;
 
   public function __construct(
-    Blacklist $blacklist = null
+    ?Blacklist $blacklist = null
   ) {
     if (is_null($blacklist)) {
       $blacklist = new Blacklist();

--- a/mailpoet/lib/Migrator/Migrator.php
+++ b/mailpoet/lib/Migrator/Migrator.php
@@ -30,7 +30,7 @@ class Migrator {
     $this->store = $store;
   }
 
-  public function run(Logger $logger = null): void {
+  public function run(?Logger $logger = null): void {
     $this->store->ensureMigrationsTable();
     $migrations = $this->getStatus();
 

--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -18,7 +18,7 @@ class PostContentManager {
   private $wp;
 
   public function __construct(
-    WooCommerceHelper $woocommerceHelper = null
+    ?WooCommerceHelper $woocommerceHelper = null
   ) {
     $this->wp = new WPFunctions;
     $this->maxExcerptLength = $this->wp->applyFilters('mailpoet_newsletter_post_excerpt_length', $this->maxExcerptLength);

--- a/mailpoet/lib/Newsletter/Editor/PostTransformer.php
+++ b/mailpoet/lib/Newsletter/Editor/PostTransformer.php
@@ -15,7 +15,7 @@ class PostTransformer {
 
   public function __construct(
     $args,
-    PostTransformerContentsExtractor $extractor = null
+    ?PostTransformerContentsExtractor $extractor = null
   ) {
     $this->args = $args;
     $this->withLayout = isset($args['withLayout']) ? (bool)filter_var($args['withLayout'], FILTER_VALIDATE_BOOLEAN) : false;

--- a/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
+++ b/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
@@ -260,7 +260,7 @@ class NewsletterListingRepository extends ListingRepository {
     $queryBuilder->addOrderBy("n.$sortBy", $sortOrder);
   }
 
-  private function applyType(QueryBuilder $queryBuilder, string $type, string $group = null) {
+  private function applyType(QueryBuilder $queryBuilder, string $type, ?string $group = null) {
     if (!in_array($type, self::$supportedTypes)) {
       return;
     }

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/AbandonedCartContent.php
@@ -22,7 +22,7 @@ class AbandonedCartContent {
     NewsletterEntity $newsletter,
     array $args,
     bool $preview = false,
-    SendingQueueEntity $sendingQueue = null
+    ?SendingQueueEntity $sendingQueue = null
   ): array {
     if (
       !in_array(
@@ -38,12 +38,12 @@ class AbandonedCartContent {
       // Do not display the block if not an automatic email
       return [];
     }
-    $groupOption = $newsletter->getOptions()->filter(function (NewsletterOptionEntity $newsletterOption = null) {
+    $groupOption = $newsletter->getOptions()->filter(function (?NewsletterOptionEntity $newsletterOption = null) {
       if (!$newsletterOption) return false;
       $optionField = $newsletterOption->getOptionField();
       return $optionField && $optionField->getName() === 'group';
     })->first();
-    $eventOption = $newsletter->getOptions()->filter(function (NewsletterOptionEntity $newsletterOption = null) {
+    $eventOption = $newsletter->getOptions()->filter(function (?NewsletterOptionEntity $newsletterOption = null) {
       if (!$newsletterOption) return false;
       $optionField = $newsletterOption->getOptionField();
       return $optionField && $optionField->getName() === 'event';

--- a/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
+++ b/mailpoet/lib/Newsletter/Renderer/Preprocessor.php
@@ -48,7 +48,7 @@ class Preprocessor {
    * @param NewsletterEntity $newsletter
    * @return array
    */
-  public function process(NewsletterEntity $newsletter, $content, bool $preview = false, SendingQueueEntity $sendingQueue = null) {
+  public function process(NewsletterEntity $newsletter, $content, bool $preview = false, ?SendingQueueEntity $sendingQueue = null) {
     if (!array_key_exists('blocks', $content)) {
       return $content;
     }
@@ -74,7 +74,7 @@ class Preprocessor {
     return $containerBlocks;
   }
 
-  public function processBlock(NewsletterEntity $newsletter, array $block, bool $preview = false, SendingQueueEntity $sendingQueue = null): array {
+  public function processBlock(NewsletterEntity $newsletter, array $block, bool $preview = false, ?SendingQueueEntity $sendingQueue = null): array {
     switch ($block['type']) {
       case 'abandonedCartContent':
         return $this->abandonedCartContent->render($newsletter, $block, $preview, $sendingQueue);

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -68,7 +68,7 @@ class Renderer {
     $this->capabilitiesManager = $capabilitiesManager;
   }
 
-  public function render(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue = null, $type = false) {
+  public function render(NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue = null, $type = false) {
     return $this->_render($newsletter, $sendingQueue, $type);
   }
 
@@ -76,7 +76,7 @@ class Renderer {
     return $this->_render($newsletter, null, $type, true, $subject);
   }
 
-  private function _render(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue = null, $type = false, $preview = false, $subject = null) {
+  private function _render(NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue = null, $type = false, $preview = false, $subject = null) {
     $language = $this->wp->getBloginfo('language');
     $metaRobots = $preview ? '<meta name="robots" content="noindex, nofollow" />' : '';
     $subject = $subject ?: $newsletter->getSubject();

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/CategoryInterface.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/CategoryInterface.php
@@ -9,9 +9,9 @@ use MailPoet\Entities\SubscriberEntity;
 interface CategoryInterface {
   public function process(
     array $shortcodeDetails,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     string $content = '',
     bool $wpUserPreview = false
   ): ?string;

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Date.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Date.php
@@ -10,9 +10,9 @@ use MailPoet\WP\Functions as WPFunctions;
 class Date implements CategoryInterface {
   public function process(
     array $shortcodeDetails,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     string $content = '',
     bool $wpUserPreview = false
   ): ?string {

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Link.php
@@ -40,9 +40,9 @@ class Link implements CategoryInterface {
 
   public function process(
     array $shortcodeDetails,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     string $content = '',
     bool $wpUserPreview = false
   ): ?string {
@@ -119,9 +119,9 @@ class Link implements CategoryInterface {
 
   public function processShortcodeAction(
     $shortcodeAction,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     $wpUserPreview = false
   ): ?string {
     $subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Newsletter.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Newsletter.php
@@ -25,9 +25,9 @@ class Newsletter implements CategoryInterface {
 
   public function process(
     array $shortcodeDetails,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     string $content = '',
     bool $wpUserPreview = false
   ): ?string {

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -19,9 +19,9 @@ class Site implements CategoryInterface {
 
   public function process(
     array $shortcodeDetails,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     string $content = '',
     bool $wpUserPreview = false
   ): ?string {

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -28,9 +28,9 @@ class Subscriber implements CategoryInterface {
 
   public function process(
     array $shortcodeDetails,
-    NewsletterEntity $newsletter = null,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null,
+    ?NewsletterEntity $newsletter = null,
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null,
     string $content = '',
     bool $wpUserPreview = false
   ): ?string {

--- a/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -60,15 +60,15 @@ class Shortcodes {
     $this->wp = $wp;
   }
 
-  public function setNewsletter(NewsletterEntity $newsletter = null): void {
+  public function setNewsletter(?NewsletterEntity $newsletter = null): void {
     $this->newsletter = $newsletter;
   }
 
-  public function setSubscriber(SubscriberEntity $subscriber = null): void {
+  public function setSubscriber(?SubscriberEntity $subscriber = null): void {
     $this->subscriber = $subscriber;
   }
 
-  public function setQueue(SendingQueueEntity $queue = null): void {
+  public function setQueue(?SendingQueueEntity $queue = null): void {
     $this->queue = $queue;
   }
 

--- a/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
+++ b/mailpoet/lib/Newsletter/Statistics/NewsletterStatisticsRepository.php
@@ -65,8 +65,8 @@ class NewsletterStatisticsRepository extends Repository {
    */
   public function getBatchStatistics(
     array $newsletters,
-    \DateTimeImmutable $from = null,
-    \DateTimeImmutable $to = null,
+    ?\DateTimeImmutable $from = null,
+    ?\DateTimeImmutable $to = null,
     array $include = [
       'totals',
       StatisticsClickEntity::class,
@@ -133,8 +133,8 @@ class NewsletterStatisticsRepository extends Repository {
    */
   public function getAllForSubscriber(
     SubscriberEntity $subscriber,
-    int $limit = null,
-    int $offset = null
+    ?int $limit = null,
+    ?int $offset = null
   ): array {
     return $this->entityManager->createQueryBuilder()
       ->select('IDENTITY(statistics.newsletter) AS newsletter_id')
@@ -192,7 +192,7 @@ class NewsletterStatisticsRepository extends Repository {
     }
   }
 
-  private function getTotalSentCounts(array $newsletters, \DateTimeImmutable $from = null, \DateTimeImmutable $to = null): array {
+  private function getTotalSentCounts(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
     $query = $this->doctrineRepository
       ->createQueryBuilder('n')
       ->select('n.id, SUM(q.countProcessed) AS cnt')
@@ -226,7 +226,7 @@ class NewsletterStatisticsRepository extends Repository {
     return $counts;
   }
 
-  private function getStatisticCounts(string $statisticsEntityName, array $newsletters, \DateTimeImmutable $from = null, \DateTimeImmutable $to = null): array {
+  private function getStatisticCounts(string $statisticsEntityName, array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null): array {
     $qb = $this->getStatisticsQuery($statisticsEntityName, $newsletters);
     if (
       $statisticsEntityName === StatisticsClickEntity::class
@@ -267,7 +267,7 @@ class NewsletterStatisticsRepository extends Repository {
       ->setParameter('newsletters', $newsletters);
   }
 
-  private function getWooCommerceRevenues(array $newsletters, \DateTimeImmutable $from = null, \DateTimeImmutable $to = null) {
+  private function getWooCommerceRevenues(array $newsletters, ?\DateTimeImmutable $from = null, ?\DateTimeImmutable $to = null) {
     if (!$this->wcHelper->isWooCommerceActive()) {
       return null;
     }

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -49,8 +49,8 @@ class ViewInBrowserRenderer {
   public function render(
     bool $isPreview,
     NewsletterEntity $newsletter,
-    SubscriberEntity $subscriber = null,
-    SendingQueueEntity $queue = null
+    ?SubscriberEntity $subscriber = null,
+    ?SendingQueueEntity $queue = null
   ) {
     $wpUserPreview = $isPreview;
     $isTrackingEnabled = $this->trackingConfig->isEmailTrackingEnabled();

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -191,7 +191,7 @@ class EmailAction implements Filter {
     return $queryBuilder;
   }
 
-  private function createNotStatsJoinCondition(string $parameterSuffix, array $linkIds = null): string {
+  private function createNotStatsJoinCondition(string $parameterSuffix, ?array $linkIds = null): string {
     $clause = "statssent.subscriber_id = stats.subscriber_id AND stats.newsletter_id = :newsletter" . $parameterSuffix;
     if ($linkIds) {
       $clause .= ' AND stats.link_id IN (:links' . $parameterSuffix . ')';

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
@@ -73,7 +73,7 @@ class WooFilterHelper {
    * @param array|null $allowedStatuses
    * @return string - The alias of the joined order stats table
    */
-  public function applyOrderStatusFilter(QueryBuilder $queryBuilder, array $allowedStatuses = null): string {
+  public function applyOrderStatusFilter(QueryBuilder $queryBuilder, ?array $allowedStatuses = null): string {
     if (is_null($allowedStatuses)) {
       $allowedStatuses = $this->defaultIncludedStatuses();
     }

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -38,7 +38,7 @@ class SegmentSubscribersRepository {
     $this->segmentsRepository = $segmentsRepository;
   }
 
-  public function findSubscribersIdsInSegment(int $segmentId, array $candidateIds = null): array {
+  public function findSubscribersIdsInSegment(int $segmentId, ?array $candidateIds = null): array {
     return $this->loadSubscriberIdsInSegment($segmentId, $candidateIds);
   }
 
@@ -46,13 +46,13 @@ class SegmentSubscribersRepository {
     return $this->loadSubscriberIdsInSegment($segmentId);
   }
 
-  public function getSubscribersCount(int $segmentId, string $status = null): int {
+  public function getSubscribersCount(int $segmentId, ?string $status = null): int {
     $segment = $this->getSegment($segmentId);
     $result = $this->getSubscribersStatisticsCount($segment);
     return (int)$result[$status ?: 'all'];
   }
 
-  public function getSubscribersCountBySegmentIds(array $segmentIds, string $status = null, ?int $filterSegmentId = null): int {
+  public function getSubscribersCountBySegmentIds(array $segmentIds, ?string $status = null, ?int $filterSegmentId = null): int {
     $segmentRepository = $this->entityManager->getRepository(SegmentEntity::class);
     $segments = $segmentRepository->findBy(['id' => $segmentIds]);
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
@@ -369,7 +369,7 @@ class SegmentSubscribersRepository {
       ->setParameter('statusSubscribed', SubscriberEntity::STATUS_SUBSCRIBED);
   }
 
-  private function loadSubscriberIdsInSegment(int $segmentId, array $candidateIds = null): array {
+  private function loadSubscriberIdsInSegment(int $segmentId, ?array $candidateIds = null): array {
     $segment = $this->getSegment($segmentId);
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $queryBuilder = $this->entityManager
@@ -397,7 +397,7 @@ class SegmentSubscribersRepository {
   private function filterSubscribersInStaticSegment(
     QueryBuilder $queryBuilder,
     SegmentEntity $segment,
-    string $status = null
+    ?string $status = null
   ): QueryBuilder {
     $subscribersSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
@@ -420,7 +420,7 @@ class SegmentSubscribersRepository {
   private function filterSubscribersInDynamicSegment(
     QueryBuilder $queryBuilder,
     SegmentEntity $segment,
-    string $status = null
+    ?string $status = null
   ): QueryBuilder {
     $filters = [];
     $dynamicFilters = $segment->getDynamicFilters();

--- a/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
+++ b/mailpoet/lib/Segments/SegmentsSimpleListRepository.php
@@ -65,7 +65,7 @@ class SegmentsSimpleListRepository {
    */
   private function getList(
     array $segmentTypes = [],
-    string $subscriberGlobalStatus = null
+    ?string $subscriberGlobalStatus = null
   ): array {
     $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -161,7 +161,7 @@ class AuthorizedEmailsController {
     return null;
   }
 
-  public function onNewsletterSenderAddressUpdate(NewsletterEntity $newsletter, string $oldSenderAddress = null) {
+  public function onNewsletterSenderAddressUpdate(NewsletterEntity $newsletter, ?string $oldSenderAddress = null) {
     if ($newsletter->getSenderAddress() === $oldSenderAddress) {
       return;
     }
@@ -243,7 +243,7 @@ class AuthorizedEmailsController {
   /**
    * @param array|null $error
    */
-  private function updateMailerLog(array $error = null) {
+  private function updateMailerLog(?array $error = null) {
     if ($error) {
       return;
     }

--- a/mailpoet/lib/Services/Bridge.php
+++ b/mailpoet/lib/Services/Bridge.php
@@ -52,7 +52,7 @@ class Bridge {
   private $settings;
 
   public function __construct(
-    SettingsController $settingsController = null
+    ?SettingsController $settingsController = null
   ) {
     if ($settingsController === null) {
       $settingsController = SettingsController::getInstance();

--- a/mailpoet/lib/Settings/TrackingConfig.php
+++ b/mailpoet/lib/Settings/TrackingConfig.php
@@ -19,22 +19,22 @@ class TrackingConfig {
     $this->settings = $settings;
   }
 
-  public function isEmailTrackingEnabled(string $level = null): bool {
+  public function isEmailTrackingEnabled(?string $level = null): bool {
     $level = $level ?? $this->settings->get('tracking.level', self::LEVEL_FULL);
     return in_array($level, [self::LEVEL_PARTIAL, self::LEVEL_FULL], true);
   }
 
-  public function isCookieTrackingEnabled(string $level = null): bool {
+  public function isCookieTrackingEnabled(?string $level = null): bool {
     $level = $level ?? $this->settings->get('tracking.level', self::LEVEL_FULL);
     return $level === self::LEVEL_FULL;
   }
 
-  public function areOpensMerged(string $opens = null): bool {
+  public function areOpensMerged(?string $opens = null): bool {
     $opens = $opens ?? $this->settings->get('tracking.opens', self::OPENS_MERGED);
     return $opens !== self::OPENS_SEPARATED;
   }
 
-  public function areOpensSeparated(string $opens = null): bool {
+  public function areOpensSeparated(?string $opens = null): bool {
     return !$this->areOpensMerged($opens);
   }
 

--- a/mailpoet/lib/Statistics/Track/Unsubscribes.php
+++ b/mailpoet/lib/Statistics/Track/Unsubscribes.php
@@ -35,8 +35,8 @@ class Unsubscribes {
   public function track(
     int $subscriberId,
     string $source,
-    int $queueId = null,
-    string $meta = null,
+    ?int $queueId = null,
+    ?string $meta = null,
     string $method = StatisticsUnsubscribeEntity::METHOD_UNKNOWN
   ) {
     $queue = null;

--- a/mailpoet/lib/Subscribers/RequiredCustomFieldValidator.php
+++ b/mailpoet/lib/Subscribers/RequiredCustomFieldValidator.php
@@ -22,7 +22,7 @@ class RequiredCustomFieldValidator {
    *
    * @throws Exception
    */
-  public function validate(array $data, FormEntity $form = null) {
+  public function validate(array $data, ?FormEntity $form = null) {
     $allCustomFields = $this->getCustomFields($form);
     foreach ($allCustomFields as $customFieldId => $customFieldName) {
       if ($this->isCustomFieldMissing($customFieldId, $data)) {
@@ -47,7 +47,7 @@ class RequiredCustomFieldValidator {
     return false;
   }
 
-  private function getCustomFields(FormEntity $form = null): array {
+  private function getCustomFields(?FormEntity $form = null): array {
     $result = [];
 
     if ($form) {

--- a/mailpoet/lib/Subscription/Blacklist.php
+++ b/mailpoet/lib/Subscription/Blacklist.php
@@ -20,8 +20,8 @@ class Blacklist {
   ];
 
   public function __construct(
-    array $blacklistedEmails = null,
-    array $blacklistedDomains = null
+    ?array $blacklistedEmails = null,
+    ?array $blacklistedDomains = null
   ) {
     if ($blacklistedEmails) {
       $this->blacklistedEmails = array_fill_keys(array_map([$this, 'hash'], $blacklistedEmails), 1);

--- a/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
+++ b/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
@@ -35,29 +35,29 @@ class SubscriptionUrlFactory {
     $this->linkTokens = $linkTokens;
   }
 
-  public function getConfirmationUrl(SubscriberEntity $subscriber = null) {
+  public function getConfirmationUrl(?SubscriberEntity $subscriber = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.confirmation'));
     return $this->getSubscriptionUrl($post, 'confirm', $subscriber);
   }
 
-  public function getConfirmUnsubscribeUrl(SubscriberEntity $subscriber = null, int $queueId = null) {
+  public function getConfirmUnsubscribeUrl(?SubscriberEntity $subscriber = null, ?int $queueId = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.confirm_unsubscribe'));
     $data = $queueId && $subscriber ? ['queueId' => $queueId] : null;
     return $this->getSubscriptionUrl($post, 'confirm_unsubscribe', $subscriber, $data);
   }
 
-  public function getManageUrl(SubscriberEntity $subscriber = null) {
+  public function getManageUrl(?SubscriberEntity $subscriber = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.manage'));
     return $this->getSubscriptionUrl($post, 'manage', $subscriber);
   }
 
-  public function getUnsubscribeUrl(SubscriberEntity $subscriber = null, int $queueId = null) {
+  public function getUnsubscribeUrl(?SubscriberEntity $subscriber = null, ?int $queueId = null) {
     $post = $this->getPost($this->settings->get('subscription.pages.unsubscribe'));
     $data = $queueId && $subscriber ? ['queueId' => $queueId] : null;
     return $this->getSubscriptionUrl($post, 'unsubscribe', $subscriber, $data);
   }
 
-  public function getReEngagementUrl(SubscriberEntity $subscriber = null) {
+  public function getReEngagementUrl(?SubscriberEntity $subscriber = null) {
     $reEngagementSetting = $this->settings->get('reEngagement');
     $postId = $reEngagementSetting['page'] ?? null;
 
@@ -68,7 +68,7 @@ class SubscriptionUrlFactory {
   public function getSubscriptionUrl(
     $post = null,
     $action = null,
-    SubscriberEntity $subscriber = null,
+    ?SubscriberEntity $subscriber = null,
     $data = null
   ) {
     if ($post === null || $action === null) return;

--- a/mailpoet/lib/Twig/Assets.php
+++ b/mailpoet/lib/Twig/Assets.php
@@ -21,7 +21,7 @@ class Assets extends AbstractExtension {
   public function __construct(
     array $globals,
     WPFunctions $wp,
-    CdnAssetUrl $cdnAssetsUrl = null
+    ?CdnAssetUrl $cdnAssetsUrl = null
   ) {
     $this->globals = $globals;
     $this->wp = $wp;

--- a/mailpoet/lib/Util/License/Features/Subscribers.php
+++ b/mailpoet/lib/Util/License/Features/Subscribers.php
@@ -85,7 +85,7 @@ class Subscribers {
     return $count;
   }
 
-  public function isSubscribersCountEnoughForCache(int $count = null): bool {
+  public function isSubscribersCountEnoughForCache(?int $count = null): bool {
     if (is_null($count) && func_num_args() === 0) {
       $count = $this->getSubscribersCount();
     }

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
@@ -20,7 +20,7 @@ class UnauthorizedEmailNotice {
 
   public function __construct(
     WPFunctions $wp,
-    SettingsController $settings = null
+    ?SettingsController $settings = null
   ) {
     $this->settings = $settings;
     $this->wp = $wp;

--- a/mailpoet/lib/Validator/Builder.php
+++ b/mailpoet/lib/Validator/Builder.php
@@ -34,13 +34,13 @@ class Builder {
     return new NullSchema();
   }
 
-  public static function array(Schema $items = null): ArraySchema {
+  public static function array(?Schema $items = null): ArraySchema {
     $array = new ArraySchema();
     return $items ? $array->items($items) : $array;
   }
 
   /** @param array<string, Schema>|null $properties */
-  public static function object(array $properties = null): ObjectSchema {
+  public static function object(?array $properties = null): ObjectSchema {
     $object = new ObjectSchema();
     return $properties === null ? $object : $object->properties($properties);
   }

--- a/mailpoet/lib/WP/DateTime.php
+++ b/mailpoet/lib/WP/DateTime.php
@@ -14,7 +14,7 @@ class DateTime {
   private $wp;
 
   public function __construct(
-    WPFunctions $wp = null
+    ?WPFunctions $wp = null
   ) {
     if ($wp === null) {
       $wp = new WPFunctions();

--- a/mailpoet/lib/WP/Emoji.php
+++ b/mailpoet/lib/WP/Emoji.php
@@ -12,7 +12,7 @@ class Emoji {
   private $wp;
 
   public function __construct(
-    WPFunctions $wp = null
+    ?WPFunctions $wp = null
   ) {
     if ($wp === null) {
       $wp = new WPFunctions();

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -296,7 +296,7 @@ class Functions {
     return get_post_type($post);
   }
 
-  public function getPosts(array $args = null) {
+  public function getPosts(?array $args = null) {
     return get_posts($args);
   }
 
@@ -861,7 +861,7 @@ class Functions {
   }
 
   /** @param string[]|null $protocols */
-  public function escUrlRaw(string $url, array $protocols = null): string {
+  public function escUrlRaw(string $url, ?array $protocols = null): string {
     return esc_url_raw($url, $protocols);
   }
 

--- a/mailpoet/tasks/code_sniffer/MailPoet/shared-ruleset.xml
+++ b/mailpoet/tasks/code_sniffer/MailPoet/shared-ruleset.xml
@@ -382,6 +382,8 @@
   <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
   <!-- Disallows use of continue without integer operand in switch because it emits a warning in PHP 7.3 and higher. -->
   <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
+  <!-- Do not allow implicit nullables -->
+  <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
   <!-- Control structures must have at least one statement in the body -->
   <!--<rule ref="Generic.CodeAnalysis.EmptyStatement"/>-->
   <!-- For loops with only second expression should be while loops -->

--- a/mailpoet/tasks/release/JiraController.php
+++ b/mailpoet/tasks/release/JiraController.php
@@ -166,7 +166,7 @@ class JiraController {
   /**
    * @see https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-search-get
    */
-  public function search($jql, array $fields = null) {
+  public function search($jql, ?array $fields = null) {
     $params = ['jql' => $jql];
     if ($fields) {
       $params['fields'] = join(',', $fields);

--- a/mailpoet/tests/DataFactories/Automation.php
+++ b/mailpoet/tests/DataFactories/Automation.php
@@ -87,7 +87,7 @@ class Automation {
     return $this->withStep($step);
   }
 
-  public function withIfElseStep(Step $elseStep = null): self {
+  public function withIfElseStep(?Step $elseStep = null): self {
     $subscribedFilter = new Filter(
       'f1',
       'enum',

--- a/mailpoet/tests/DataFactories/AutomationRun.php
+++ b/mailpoet/tests/DataFactories/AutomationRun.php
@@ -78,7 +78,7 @@ class AutomationRun {
     return $this;
   }
 
-  public function withNextStep(string $nextStep = null): self {
+  public function withNextStep(?string $nextStep = null): self {
     $this->nextStep = $nextStep;
     return $this;
   }

--- a/mailpoet/tests/DataFactories/ScheduledTask.php
+++ b/mailpoet/tests/DataFactories/ScheduledTask.php
@@ -35,8 +35,8 @@ class ScheduledTask {
     string $type,
     ?string $status,
     ?\DateTimeInterface $scheduledAt = null,
-    \DateTimeInterface $deletedAt = null,
-    \DateTimeInterface $updatedAt = null
+    ?\DateTimeInterface $deletedAt = null,
+    ?\DateTimeInterface $updatedAt = null
   ) {
     $task = new ScheduledTaskEntity();
     $task->setType($type);

--- a/mailpoet/tests/DataFactories/ScheduledTaskSubscriber.php
+++ b/mailpoet/tests/DataFactories/ScheduledTaskSubscriber.php
@@ -31,7 +31,7 @@ class ScheduledTaskSubscriber {
     return $taskSubscriber;
   }
 
-  public function createFailed(ScheduledTaskEntity $task, SubscriberEntity $subscriberEntity, string $error = null): ScheduledTaskSubscriberEntity {
+  public function createFailed(ScheduledTaskEntity $task, SubscriberEntity $subscriberEntity, ?string $error = null): ScheduledTaskSubscriberEntity {
     $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriberEntity, 1, 1, $error);
     $this->entityManager->persist($taskSubscriber);
     $this->entityManager->flush();

--- a/mailpoet/tests/DataFactories/SendingQueue.php
+++ b/mailpoet/tests/DataFactories/SendingQueue.php
@@ -19,7 +19,7 @@ class SendingQueue {
     $this->entityManager = $diContainer->get(EntityManager::class);
   }
 
-  public function create(ScheduledTaskEntity $task, ?NewsletterEntity $newsletter = null, \DateTimeInterface $deletedAt = null): SendingQueueEntity {
+  public function create(ScheduledTaskEntity $task, ?NewsletterEntity $newsletter = null, ?\DateTimeInterface $deletedAt = null): SendingQueueEntity {
     $queue = new SendingQueueEntity();
     $queue->setTask($task);
     $task->setSendingQueue($queue);

--- a/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
+++ b/mailpoet/tests/DataGenerator/Generators/WooCommercePastRevenues.php
@@ -510,7 +510,7 @@ class WooCommercePastRevenues implements Generator {
   /**
    * @return \WC_Order|\WP_Error
    */
-  private function createCompletedWooCommerceOrder($subscriberId, $email, $customerId = null, $products = [], Carbon $completedAt = null): \WC_Order {
+  private function createCompletedWooCommerceOrder($subscriberId, $email, $customerId = null, $products = [], ?Carbon $completedAt = null): \WC_Order {
     $random = $this->getRandomString();
     $countries = ['FR', 'GB', 'US', 'IE', 'IT'];
     $address = [

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -168,7 +168,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->click($xpath);
   }
 
-  public function clickWooTableActionInsideMoreButton(string $itemName, string $moreButtonAction, string $confirmAction = null) {
+  public function clickWooTableActionInsideMoreButton(string $itemName, string $moreButtonAction, ?string $confirmAction = null) {
     $i = $this;
     $i->clickWooTableMoreButtonByItemName($itemName);
     $i->waitForText($itemName);

--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -278,7 +278,7 @@ class IntegrationTester extends \Codeception\Actor {
     return $order;
   }
 
-  public function createWooProductReview(int $customerId, string $customerEmail, int $productId, int $rating, Carbon $date = null): int {
+  public function createWooProductReview(int $customerId, string $customerEmail, int $productId, int $rating, ?Carbon $date = null): int {
     if ($date === null) {
       $date = Carbon::now()->subDay();
     }

--- a/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
+++ b/mailpoet/tests/acceptance/Automation/AnalyticsCest.php
@@ -244,7 +244,7 @@ class AnalyticsCest {
     return $subscriber;
   }
 
-  private function createRunForSubscriber(SubscriberEntity $subscriber, string $nextStep = null, string $status = AutomationRun::STATUS_COMPLETE) {
+  private function createRunForSubscriber(SubscriberEntity $subscriber, ?string $nextStep = null, string $status = AutomationRun::STATUS_COMPLETE) {
     $run = (new DataFactories\AutomationRun())
       ->withAutomation($this->automation)
       ->withStatus($nextStep ? $status : AutomationRun::STATUS_COMPLETE)

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -314,7 +314,7 @@ class SubscribersTest extends \MailPoetTest {
     verify($response->data)->equals(
       $this->responseBuilder->build($this->subscriber2)
     );
-    verify($this->subscriber2->getSubscriberSegments()->filter(function (SubscriberSegmentEntity $subscriberSegment = null) {
+    verify($this->subscriber2->getSubscriberSegments()->filter(function (?SubscriberSegmentEntity $subscriberSegment = null) {
       if (!$subscriberSegment) return false;
       return $subscriberSegment->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED;
     })->count())->equals(0);

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -37,7 +37,7 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
   /**
    * @dataProvider dataForTestItCalculatesTotalsCorrectly
    */
-  public function testItCalculatesTotalsCorrectlyForSingleAutomation(int $automationIndex, int $expectedTotal, int $expectedInProgress, int $expectedExited, int $versionId = null) {
+  public function testItCalculatesTotalsCorrectlyForSingleAutomation(int $automationIndex, int $expectedTotal, int $expectedInProgress, int $expectedExited, ?int $versionId = null) {
     $automation = $this->automationStorage->getAutomation($this->automations[$automationIndex], $versionId);
     $this->assertInstanceOf(Automation::class, $automation);
     $i = 0;

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/NewsletterLinkFieldsTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/NewsletterLinkFieldsTest.php
@@ -50,7 +50,7 @@ class NewsletterLinkFieldsTest extends \MailPoetTest {
     $this->assertEquals($expectedId, $field->getValue($payload));
   }
 
-  private function getPayload(int $id = 1, string $url = 'https://example.com', \DateTimeImmutable $created = null): NewsletterLinkPayload {
+  private function getPayload(int $id = 1, string $url = 'https://example.com', ?\DateTimeImmutable $created = null): NewsletterLinkPayload {
     $newsletter = new NewsletterEntity();
     $queue = new SendingQueueEntity();
     $newsletterLink = new NewsletterLinkEntity($newsletter, $queue, $url, 'hash');

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Fields/SubscriberAutomationFieldsFactoryTest.php
@@ -169,7 +169,7 @@ class SubscriberAutomationFieldsFactoryTest extends MailPoetTest {
     Automation $automation,
     string $status,
     array $subjects,
-    DateTimeInterface $createdAt = null
+    ?DateTimeInterface $createdAt = null
   ): AutomationRun {
     $runStorage = $this->diContainer->get(AutomationRunStorage::class);
     $run = $this->tester->createAutomationRun($automation, $subjects);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/BuysAProductTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/BuysAProductTriggerTest.php
@@ -120,7 +120,7 @@ class BuysAProductTriggerTest extends \MailPoetTest {
    * @return \WC_Order
    * @throws \WC_Data_Exception
    */
-  private function createOrder(array $productIds, string $billingEmail = null): \WC_Order {
+  private function createOrder(array $productIds, ?string $billingEmail = null): \WC_Order {
 
     $order = new \WC_Order();
     $order->set_billing_email($billingEmail ?? uniqid() . '@example.com');

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/BuysFromACategoryTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/BuysFromACategoryTriggerTest.php
@@ -136,7 +136,7 @@ class BuysFromACategoryTriggerTest extends \MailPoetTest {
    * @return \WC_Order
    * @throws \WC_Data_Exception
    */
-  private function createOrder(array $productIds, string $billingEmail = null): \WC_Order {
+  private function createOrder(array $productIds, ?string $billingEmail = null): \WC_Order {
 
     $order = new \WC_Order();
     $order->set_billing_email($billingEmail ?? uniqid() . '@example.com');

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/BuysFromATagTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/BuysFromATagTriggerTest.php
@@ -135,7 +135,7 @@ class BuysFromATagTriggerTest extends \MailPoetTest {
    * @return \WC_Order
    * @throws \WC_Data_Exception
    */
-  private function createOrder(array $productIds, string $billingEmail = null): \WC_Order {
+  private function createOrder(array $productIds, ?string $billingEmail = null): \WC_Order {
 
     $order = new \WC_Order();
     $order->set_billing_email($billingEmail ?? uniqid() . '@example.com');

--- a/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
+++ b/mailpoet/tests/integration/Cron/Triggers/WordPressTest.php
@@ -294,7 +294,7 @@ class WordPressTest extends \MailPoetTest {
     verify($this->wordpressTrigger->checkExecutionRequirements())->false();
   }
 
-  private function addMTAConfigAndLog($sent, $status = null, int $retryAt = null) {
+  private function addMTAConfigAndLog($sent, $status = null, ?int $retryAt = null) {
     $mtaConfig = [
       'frequency' => [
         'emails' => 1,

--- a/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/KeyCheck/KeyCheckWorkerTest.php
@@ -106,7 +106,7 @@ class KeyCheckWorkerTest extends \MailPoetTest {
     verify($nextRunDate->diffInSeconds($dateTime))->lessThanOrEqual(21600 + $secondsToMidnight);
   }
 
-  private function createRunningTask(Carbon $scheduledAt = null) {
+  private function createRunningTask(?Carbon $scheduledAt = null) {
     if (!$scheduledAt) {
       $scheduledAt = Carbon::now()->millisecond(0);
     }

--- a/mailpoet/tests/integration/Newsletter/Editor/PostContentTransformerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Editor/PostContentTransformerTest.php
@@ -313,7 +313,7 @@ class PostContentTransformerTest extends \MailPoetTest {
   /**
    * @return PostTransformer
    */
-  private function getTransformer(array $args, array $content, array $title, array $image = null, bool $isProduct = false) {
+  private function getTransformer(array $args, array $content, array $title, ?array $image = null, bool $isProduct = false) {
     $extractor = $this->make(
       PostTransformerContentsExtractor::class,
       [

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -127,7 +127,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
       ],
     ];
     $newsletter = $this->saveController->save($newsletterData);
-    $scheduleOption = $newsletter->getOptions()->filter(function (NewsletterOptionEntity $newsletterOption = null) {
+    $scheduleOption = $newsletter->getOptions()->filter(function (?NewsletterOptionEntity $newsletterOption = null) {
       if ($newsletterOption === null) return false; // PHPStan
       $optionField = $newsletterOption->getOptionField();
       return $optionField && $optionField->getName() === 'schedule';
@@ -140,7 +140,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     $newsletterData['options']['intervalType'] = PostNotificationScheduler::INTERVAL_IMMEDIATELY;
     $savedNewsletter = $this->saveController->save($newsletterData);
 
-    $scheduleOption = $savedNewsletter->getOptions()->filter(function (NewsletterOptionEntity $newsletterOption = null) {
+    $scheduleOption = $savedNewsletter->getOptions()->filter(function (?NewsletterOptionEntity $newsletterOption = null) {
       if ($newsletterOption === null) return false; // PHPStan
       $optionField = $newsletterOption->getOptionField();
       return $optionField && $optionField->getName() === 'schedule';
@@ -184,7 +184,7 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     ];
 
     $newsletter = $this->saveController->save($newsletterData);
-    $scheduleOption = $newsletter->getOptions()->filter(function (NewsletterOptionEntity $newsletterOption = null) {
+    $scheduleOption = $newsletter->getOptions()->filter(function (?NewsletterOptionEntity $newsletterOption = null) {
       if ($newsletterOption === null) return false; // PHPStan
       $optionField = $newsletterOption->getOptionField();
       return $optionField && $optionField->getName() === 'schedule';

--- a/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Scheduler/ReEngagementSchedulerTest.php
@@ -193,7 +193,7 @@ class ReEngagementSchedulerTest extends \MailPoetTest {
     $this->entityManager->flush();
   }
 
-  private function createSubscriber($email, $lastEngagement, SegmentEntity $segment = null) {
+  private function createSubscriber($email, $lastEngagement, ?SegmentEntity $segment = null) {
     $factory = new Subscriber();
     if ($segment) {
       $factory = $factory->withSegments([$segment]);

--- a/mailpoet/tests/integration/Newsletter/Sending/SendingQueuesRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/SendingQueuesRepositoryTest.php
@@ -148,7 +148,7 @@ class SendingQueuesRepositoryTest extends \MailPoetTest {
     return $task;
   }
 
-  private function createQueue(ScheduledTaskEntity $task, NewsletterEntity $newsletter = null): SendingQueueEntity {
+  private function createQueue(ScheduledTaskEntity $task, ?NewsletterEntity $newsletter = null): SendingQueueEntity {
     if (!$newsletter) {
       $newsletter = new NewsletterEntity();
       $newsletter->setType('type');

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -481,7 +481,7 @@ class ShortcodesTest extends \MailPoetTest {
     return $subscriber;
   }
 
-  public function _createNewsletter(NewsletterEntity $parent = null, $type = NewsletterEntity::TYPE_NOTIFICATION): NewsletterEntity {
+  public function _createNewsletter(?NewsletterEntity $parent = null, $type = NewsletterEntity::TYPE_NOTIFICATION): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setSubject('some subject');
     $newsletter->setType($type);

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -138,7 +138,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
   public function testUsesEmptySubscriberWhenNotLoggedIn() {
 
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
+      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, ?SubscriberEntity $subscriber = null, ?SendingQueueEntity $queue = null) {
         $this->assertNotNull($subscriber); // PHPStan
         verify($subscriber)->notNull();
         verify($subscriber->getId())->equals(0);
@@ -155,7 +155,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
   public function testItSetsSubscriberToLoggedInWPUserWhenPreviewIsEnabled() {
     $subscriberId = $this->subscriber->getId();
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) use ($subscriberId) {
+      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, ?SubscriberEntity $subscriber = null, ?SendingQueueEntity $queue = null) use ($subscriberId) {
         $this->assertNotNull($subscriber); // PHPStan
         verify($subscriber)->notNull();
         verify($subscriber->getId())->equals($subscriberId);
@@ -176,7 +176,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
 
   public function testItGetsQueueByQueueId() {
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
+      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, ?SubscriberEntity $subscriber = null, ?SendingQueueEntity $queue = null) {
         $this->assertNotNull($queue); // PHPStan
         verify($queue)->notNull();
         verify($queue->getId())->equals($this->sendingQueue->getId());
@@ -192,7 +192,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
 
   public function testItGetsQueueByNewsletter() {
     $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
-      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, SubscriberEntity $subscriber = null, SendingQueueEntity $queue = null) {
+      'render' => Expected::once(function (bool $isPreview, NewsletterEntity $newsletter, ?SubscriberEntity $subscriber = null, ?SendingQueueEntity $queue = null) {
         $this->assertNotNull($queue); // PHPStan
         verify($queue)->notNull();
         verify($queue->getId())->equals($this->sendingQueue->getId());

--- a/mailpoet/tests/integration/REST/API/Endpoint.php
+++ b/mailpoet/tests/integration/REST/API/Endpoint.php
@@ -12,7 +12,7 @@ class Endpoint extends APIEndpoint {
   private $requestCallback;
 
   public function __construct(
-    callable $requestCallback = null
+    ?callable $requestCallback = null
   ) {
     $this->requestCallback = $requestCallback;
   }

--- a/mailpoet/tests/integration/REST/API/EndpointTest.php
+++ b/mailpoet/tests/integration/REST/API/EndpointTest.php
@@ -107,17 +107,17 @@ class EndpointTest extends Test {
     $this->assertSame($request->getParams(), ['required' => 'required']);
   }
 
-  private function registerTestingGetRoute(string $path, callable $requestCallback = null): void {
+  private function registerTestingGetRoute(string $path, ?callable $requestCallback = null): void {
     $api = $this->createApi($requestCallback);
     $api->registerGetRoute("mailpoet-api-testing-route/$path", Endpoint::class);
   }
 
-  private function registerTestingPostRoute(string $path, callable $requestCallback = null): void {
+  private function registerTestingPostRoute(string $path, ?callable $requestCallback = null): void {
     $api = $this->createApi($requestCallback);
     $api->registerPostRoute("mailpoet-api-testing-route/$path", Endpoint::class);
   }
 
-  private function createApi(callable $requestCallback = null): API {
+  private function createApi(?callable $requestCallback = null): API {
     // ensure REST server is initialized for endpoint registration
     rest_get_server();
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionClickAnyTest.php
@@ -73,7 +73,7 @@ class EmailActionClickAnyTest extends \MailPoetTest {
     verify($emails[0])->equals('opened_clicked@example.com');
   }
 
-  private function getSegmentFilterData(string $action, int $newsletterId = null, int $linkId = null): DynamicSegmentFilterData {
+  private function getSegmentFilterData(string $action, ?int $newsletterId = null, ?int $linkId = null): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'newsletter_id' => $newsletterId,
       'link_id' => $linkId,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/NumberOfClicksTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/NumberOfClicksTest.php
@@ -89,7 +89,7 @@ class NumberOfClicksTest extends \MailPoetTest {
     ]);
   }
 
-  private function createClicks(SubscriberEntity $subscriber, int $count, DateTimeInterface $date = null): void {
+  private function createClicks(SubscriberEntity $subscriber, int $count, ?DateTimeInterface $date = null): void {
     if ($date === null) {
       $date = CarbonImmutable::now();
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/UserRoleTest.php
@@ -82,7 +82,7 @@ class UserRoleTest extends \MailPoetTest {
    * @param string|null $operator
    * @return DynamicSegmentFilterData
    */
-  private function getSegmentFilterData($role, string $operator = null): DynamicSegmentFilterData {
+  private function getSegmentFilterData($role, ?string $operator = null): DynamicSegmentFilterData {
     $filterData = [
       'wordpressRole' => $role,
     ];

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCountryTest.php
@@ -60,7 +60,7 @@ class WooCommerceCountryTest extends \MailPoetTest {
    * @param string|null $operator
    * @return DynamicSegmentFilterData
    */
-  private function getSegmentFilterData($country, string $operator = null): DynamicSegmentFilterData {
+  private function getSegmentFilterData($country, ?string $operator = null): DynamicSegmentFilterData {
     $filterData = [
       'country_code' => $country,
     ];

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSubscriptionTest.php
@@ -104,7 +104,7 @@ class WooCommerceSubscriptionTest extends \MailPoetTest {
     return (int)$productId;
   }
 
-  private function getSegmentFilterData(string $operator, array $productIds = null): DynamicSegmentFilterData {
+  private function getSegmentFilterData(string $operator, ?array $productIds = null): DynamicSegmentFilterData {
     $filterData = [
       'operator' => $operator,
       'product_ids' => $productIds ?: $this->products,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCodeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCodeTest.php
@@ -313,7 +313,7 @@ class WooCommerceUsedCouponCodeTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  private function createOrder(int $customerId, array $couponCodes = [], Carbon $createdAt = null): int {
+  private function createOrder(int $customerId, array $couponCodes = [], ?Carbon $createdAt = null): int {
     if (is_null($createdAt)) {
       $createdAt = Carbon::now()->millisecond(0)->subDay();
     }

--- a/mailpoet/tests/integration/Segments/SegmentsFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentsFinderTest.php
@@ -94,7 +94,7 @@ class SegmentsFinderTest extends MailPoetTest {
       ->create();
   }
 
-  private function createSegment(string $type, string $name = null): SegmentEntity {
+  private function createSegment(string $type, ?string $name = null): SegmentEntity {
     $name = $name ?? "Segment $type";
     $segmentFactory = new SegmentFactory();
     return $segmentFactory

--- a/mailpoet/tests/integration/Segments/WooCommerceTest.php
+++ b/mailpoet/tests/integration/Segments/WooCommerceTest.php
@@ -743,7 +743,7 @@ class WooCommerceTest extends \MailPoetTest {
     return $guest;
   }
 
-  private function insertRegisteredCustomerWithOrder(?int $number = null, array $data = null): WPTestUser {
+  private function insertRegisteredCustomerWithOrder(?int $number = null, ?array $data = null): WPTestUser {
     $number = !is_null($number) ? (int)$number : mt_rand();
     $data = is_array($data) ? $data : [];
     $user = $this->insertRegisteredCustomer($number, $data['first_name'] ?? null, $data['last_name'] ?? null);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterClicksExporterTest.php
@@ -74,7 +74,7 @@ class NewsletterClicksExporterTest extends \MailPoetTest {
     $this->assertSame($result['data'][0]['data'][3], ['name' => 'User-agent', 'value' => 'Unknown']);
   }
 
-  protected function prepareDataToBeExported(string $userEmail, string $userAgentName = null) {
+  protected function prepareDataToBeExported(string $userEmail, ?string $userAgentName = null) {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($userEmail);
     $this->entityManager->persist($subscriber);

--- a/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/PersonalDataExporters/NewsletterOpensExporterTest.php
@@ -79,7 +79,7 @@ class NewsletterOpensExporterTest extends \MailPoetTest {
     $this->assertSame($result['data'][0]['data'][2], ['name' => 'User-agent', 'value' => 'Unknown']);
   }
 
-  protected function prepareDataToBeExported(string $userEmail, string $userAgentName = null) {
+  protected function prepareDataToBeExported(string $userEmail, ?string $userAgentName = null) {
     $subscriber = new SubscriberEntity();
     $subscriber->setEmail($userEmail);
     $this->entityManager->persist($subscriber);

--- a/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
+++ b/mailpoet/tests/integration/Subscription/ManageSubscriptionFormRendererTest.php
@@ -63,7 +63,7 @@ class ManageSubscriptionFormRendererTest extends \MailPoetTest {
     return $segment;
   }
 
-  private function getSubscriber(SegmentEntity $segment = null): SubscriberEntity {
+  private function getSubscriber(?SegmentEntity $segment = null): SubscriberEntity {
     $subscriber = new SubscriberEntity();
     $subscriber->setStatus(SubscriberEntity::STATUS_SUBSCRIBED);
     $subscriber->setFirstName('Fname');

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -295,8 +295,8 @@ class PagesTest extends \MailPoetTest {
   }
 
   private function getPages(
-    NewSubscriberNotificationMailer $newSubscriberNotificationsMock = null,
-    Unsubscribes $unsubscribesMock = null
+    ?NewSubscriberNotificationMailer $newSubscriberNotificationsMock = null,
+    ?Unsubscribes $unsubscribesMock = null
   ): Pages {
     $container = ContainerWrapper::getInstance();
     return new Pages(

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/UnknownStepRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/UnknownStepRuleTest.php
@@ -80,7 +80,7 @@ class UnknownStepRuleTest extends AutomationRuleTest {
     (new AutomationWalker())->walk($automation, [$this->getRule($existingAutomation, [new RootStep()])]);
   }
 
-  private function getRule(Automation $existingAutomation = null, array $steps = []): UnknownStepRule {
+  private function getRule(?Automation $existingAutomation = null, array $steps = []): UnknownStepRule {
     $stepMap = [];
     foreach ($steps as $step) {
       $stepMap[$step->getKey()] = $step;

--- a/mailpoet/tests/unit/Cron/CronTriggerTest.php
+++ b/mailpoet/tests/unit/Cron/CronTriggerTest.php
@@ -62,8 +62,8 @@ class CronTriggerTest extends \MailPoetUnitTest {
 
   private function createCronTrigger(
     SettingsController $settings,
-    WordPress $wordpressTrigger = null,
-    DaemonActionSchedulerRunner $actionSchedulerRunner = null
+    ?WordPress $wordpressTrigger = null,
+    ?DaemonActionSchedulerRunner $actionSchedulerRunner = null
   ) {
     $wordpressTrigger = $wordpressTrigger ?: $this->make(WordPress::class, ['run' => true]);
     $actionSchedulerRunner = $actionSchedulerRunner ?: $this->make(DaemonActionSchedulerRunner::class, ['init' => true]);


### PR DESCRIPTION
## Description
Introduces a new code sniffer rule to avoid implicit nullables

🛑 `function text(string $text = null)`
✅ `function text(?string $text = null)`

This change brought our compatibility issues down from 230 to 32 https://qit.woo.com/?qit_results=4753125.5A1sk1Yl9df9kTiHiicb1vKJKTDnesG8pJaCsWytB3wwFFeLXvlR25yE7yYriJkl

## Code review notes

30849a45ae010061c2cbea44ce826b2afcfa17e9 adds a new code sniffer rule which checks that there are no implicit nullables. You can use phpcbf to fix those errors automatically

7f15a54baa2a2b2ccf3b66577700d358875cdaed applies phpcbf

970c4d0dbbfb3352bac1ac34dff167e897e0f252 fixes some deprecation notices which followed from the previous changes

## QA notes

Some smoke testing would be helpful I think.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/941

## Linked tickets

[MAILPOET-6491]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6491]: https://mailpoet.atlassian.net/browse/MAILPOET-6491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6491-no-implicit-nullables-rule)

_The latest successful build from `MAILPOET-6491-no-implicit-nullables-rule` will be used. If none is available, the link won't work._