### PR TITLE
Fix ENT compat issue [MAILPOET-6492]

### DIFF
--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -245,7 +245,7 @@ class PageRenderer {
       'decimalSeparator' => $this->wooCommerceHelper->wcGetPriceDecimalSeperator(),
       'thousandSeparator' => $this->wooCommerceHelper->wcGetPriceThousandSeparator(),
       'code' => $this->wooCommerceHelper->getWoocommerceCurrency(),
-      'symbol' => html_entity_decode($this->wooCommerceHelper->getWoocommerceCurrencySymbol()),
+      'symbol' => html_entity_decode($this->wooCommerceHelper->getWoocommerceCurrencySymbol(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),
       'symbolPosition' => $this->wp->getOption('woocommerce_currency_pos'),
       'priceFormat' => $this->wooCommerceHelper->getWoocommercePriceFormat(),
 

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -184,7 +184,7 @@ class DynamicSegments {
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE_SUBSCRIPTION
     );
     $wooCurrencySymbol = $this->woocommerceHelper->isWooCommerceActive() ? $this->woocommerceHelper->getWoocommerceCurrencySymbol() : '';
-    $data['woocommerce_currency_symbol'] = html_entity_decode($wooCurrencySymbol);
+    $data['woocommerce_currency_symbol'] = html_entity_decode($wooCurrencySymbol, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
     $data['signup_forms'] = array_map(function(FormEntity $form) {
       return [
         'id' => $form->getId(),

--- a/mailpoet/lib/Captcha/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaFormRenderer.php
@@ -8,6 +8,7 @@ use MailPoet\Form\FormsRepository;
 use MailPoet\Form\Renderer as FormRenderer;
 use MailPoet\Form\Util\Styles;
 use MailPoet\Util\Url as UrlHelper;
+use MailPoet\WP\Functions as WPFunctions;
 
 class CaptchaFormRenderer {
   /** @var UrlHelper */
@@ -31,6 +32,8 @@ class CaptchaFormRenderer {
   /** @var Styles */
   private $styles;
 
+  private $wp;
+
   public function __construct(
     UrlHelper $urlHelper,
     CaptchaSession $captchaSession,
@@ -38,7 +41,8 @@ class CaptchaFormRenderer {
     CaptchaUrlFactory $urlFactory,
     FormsRepository $formsRepository,
     FormRenderer $formRenderer,
-    Styles $styles
+    Styles $styles,
+    WPFunctions $wp
   ) {
     $this->urlHelper = $urlHelper;
     $this->captchaSession = $captchaSession;
@@ -47,6 +51,7 @@ class CaptchaFormRenderer {
     $this->formRenderer = $formRenderer;
     $this->formsRepository = $formsRepository;
     $this->styles = $styles;
+    $this->wp = $wp;
   }
 
   public function render(array $data) {
@@ -91,13 +96,13 @@ class CaptchaFormRenderer {
       return $this->renderFormMessages($formModel, true);
     }
 
-    $redirectUrl = htmlspecialchars($this->urlHelper->getCurrentUrl(), ENT_QUOTES);
-    $hiddenFields = '<input type="hidden" name="data[form_id]" value="' . $formId . '" />';
-    $hiddenFields .= '<input type="hidden" name="data[captcha_session_id]" value="' . htmlspecialchars($sessionId) . '" />';
+    $redirectUrl = $this->urlHelper->getCurrentUrl();
+    $hiddenFields = '<input type="hidden" name="data[form_id]" value="' . $this->wp->escAttr($formId) . '" />';
+    $hiddenFields .= '<input type="hidden" name="data[captcha_session_id]" value="' . $this->wp->escAttr($sessionId) . '" />';
     $hiddenFields .= '<input type="hidden" name="api_version" value="v1" />';
     $hiddenFields .= '<input type="hidden" name="endpoint" value="subscribers" />';
     $hiddenFields .= '<input type="hidden" name="mailpoet_method" value="subscribe" />';
-    $hiddenFields .= '<input type="hidden" name="mailpoet_redirect" value="' . $redirectUrl . '" />';
+    $hiddenFields .= '<input type="hidden" name="mailpoet_redirect" value="' . $this->wp->escAttr($redirectUrl) . '" />';
 
     $actionUrl = admin_url('admin-post.php?action=mailpoet_subscription_form');
 
@@ -119,14 +124,14 @@ class CaptchaFormRenderer {
 
     unset($data['captcha_session_id']);
     // The 'name' attr is required in this format for the refresh button to work
-    $hiddenFields = '<input type="hidden" name="data[captcha_session_id]" value="' . htmlspecialchars($sessionId) . '" />';
+    $hiddenFields = '<input type="hidden" name="data[captcha_session_id]" value="' . $this->wp->escAttr($sessionId) . '" />';
 
     $actionUrl = $data['referrer_form_url'];
     unset($data['referrer_form_url']);
 
     unset($data['referrer_form']);
     foreach ($data as $key => $value) {
-      $hiddenFields .= '<input type="hidden" name="' . $key . '" value="' . htmlspecialchars($value) . '" />';
+      $hiddenFields .= '<input type="hidden" name="' . $key . '" value="' . $this->wp->escAttr($value) . '" />';
     }
 
     $submitLabel = $data[$submitLabelKey] ?? esc_attr_e('Register'); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
@@ -177,7 +182,7 @@ class CaptchaFormRenderer {
       $classes = 'mailpoet_captcha_form';
     }
 
-    $formHtml = '<form method="POST" action="' . $actionUrl . '" class="' . $classes . '" id="mailpoet_captcha_form" novalidate>';
+    $formHtml = '<form method="POST" action="' . $this->wp->escAttr($actionUrl) . '" class="' . $this->wp->escAttr($classes) . '" id="mailpoet_captcha_form" novalidate>';
     $formHtml .= $hiddenFields;
 
     $width = 220;
@@ -189,12 +194,12 @@ class CaptchaFormRenderer {
 
     $formHtml .= '<div class="mailpoet_form_hide_on_success">';
     $formHtml .= '<p class="mailpoet_paragraph">';
-    $formHtml .= '<img class="mailpoet_captcha" src="' . $captchaUrl . '" width="' . $width . '" height="' . $height . '" title="' . esc_attr__('CAPTCHA', 'mailpoet') . '" />';
+    $formHtml .= '<img class="mailpoet_captcha" src="' . $this->wp->escAttr($captchaUrl) . '" width="' . $this->wp->escAttr($width) . '" height="' . $this->wp->escAttr($height) . '" title="' . esc_attr__('CAPTCHA', 'mailpoet') . '" />';
     $formHtml .= '</p>';
-    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_update" title="' . esc_attr(__('Reload CAPTCHA', 'mailpoet')) . '"><img src="' . $reloadIcon . '" alt="" /></button>';
-    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_audio" title="' . esc_attr(__('Play CAPTCHA', 'mailpoet')) . '"><img src="' . $playIcon . '" alt="" /></button>';
+    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_update" title="' . esc_attr(__('Reload CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escAttr($reloadIcon) . '" alt="" /></button>';
+    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_audio" title="' . esc_attr(__('Play CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escAttr($playIcon) . '" alt="" /></button>';
     $formHtml .= '<audio class="mailpoet_captcha_player">';
-    $formHtml .= '<source src="' . $mp3CaptchaUrl . '" type="audio/mpeg">';
+    $formHtml .= '<source src="' . $this->wp->escAttr($mp3CaptchaUrl) . '" type="audio/mpeg">';
     $formHtml .= '</audio>';
 
     $formHtml .= $this->formRenderer->renderBlocks($form, [], null, $honeypot = false);
@@ -222,8 +227,8 @@ class CaptchaFormRenderer {
     $errorMessage = __('The characters you entered did not match the CAPTCHA image. Please try again with this new image.', 'mailpoet');
 
     $formHtml = '<div class="mailpoet_message" role="alert" aria-live="assertive">';
-    $formHtml .= '<p class="mailpoet_validate_success" ' . ($showSuccessMessage ? '' : ' style="display:none;"') . '>' . $settings['success_message'] . '</p>';
-    $formHtml .= '<p class="mailpoet_validate_error" ' . ($showErrorMessage ? '' : ' style="display:none;"') . '>' . $errorMessage . '</p>';
+    $formHtml .= '<p class="mailpoet_validate_success" ' . ($showSuccessMessage ? '' : ' style="display:none;"') . '>' . $this->wp->escHtml($settings['success_message']) . '</p>';
+    $formHtml .= '<p class="mailpoet_validate_error" ' . ($showErrorMessage ? '' : ' style="display:none;"') . '>' . $this->wp->escHtml($errorMessage) . '</p>';
     $formHtml .= '</div>';
 
     return $formHtml;

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Site.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Site.php
@@ -15,7 +15,7 @@ class Site {
   }
 
   public function getTitle(array $context, array $args = []): string {
-    return htmlspecialchars_decode($this->wp->getBloginfo('name'));
+    return htmlspecialchars_decode($this->wp->getBloginfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
   }
 
   public function getHomepageURL(array $context, array $args = []): string {

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -124,7 +124,7 @@ class Renderer {
         [
           $language,
           $metaRobots,
-          htmlspecialchars($subject),
+          htmlspecialchars($subject, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),
           $renderedStyles,
           $customFontsLinks,
           EHelper::escapeHtmlText($newsletter->getPreheader()),

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Newsletter.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Newsletter.php
@@ -47,7 +47,7 @@ class Newsletter implements CategoryInterface {
           // Removing HTML tags from the title because
           $title = $this->wp->wpStripAllTags($latestPost['post_title']);
           // Decoding special characters such as &amp; to &, etc.
-          return htmlspecialchars_decode($title);
+          return htmlspecialchars_decode($title, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
         }
         return null;
 

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Site.php
@@ -28,7 +28,7 @@ class Site implements CategoryInterface {
     switch ($shortcodeDetails['action']) {
       case 'title':
         // Decoding special characters such as &amp; to &, etc.
-        return htmlspecialchars_decode($this->wp->getBloginfo('name'));
+        return htmlspecialchars_decode($this->wp->getBloginfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
 
       case 'homepage_url':
         return $this->wp->getBloginfo('url');

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -42,9 +42,9 @@ class Subscriber implements CategoryInterface {
       '';
     switch ($shortcodeDetails['action']) {
       case 'firstname':
-        return (!empty($subscriber->getFirstName())) ? htmlspecialchars($subscriber->getFirstName()) : $defaultValue;
+        return (!empty($subscriber->getFirstName())) ? htmlspecialchars($subscriber->getFirstName(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
       case 'lastname':
-        return !empty($subscriber->getLastName()) ? htmlspecialchars($subscriber->getLastName()) : $defaultValue;
+        return !empty($subscriber->getLastName()) ? htmlspecialchars($subscriber->getLastName(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
       case 'email':
         return $subscriber->getEmail();
       case 'displayname':
@@ -65,7 +65,7 @@ class Subscriber implements CategoryInterface {
             'customField' => $customField[1],
           ]);
           return ($customField instanceof SubscriberCustomFieldEntity && !empty($customField->getValue()))
-            ? htmlspecialchars($customField->getValue())
+            ? htmlspecialchars($customField->getValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)
             : $defaultValue;
         }
         return null;

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -120,10 +120,10 @@ class WP {
     }
 
     // get first name & last name
-    $firstName = html_entity_decode($wpUser->first_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    $lastName = html_entity_decode($wpUser->last_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $firstName = html_entity_decode($wpUser->first_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $lastName = html_entity_decode($wpUser->last_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     if (empty($wpUser->first_name) && empty($wpUser->last_name)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $firstName = html_entity_decode($wpUser->display_name); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $firstName = html_entity_decode($wpUser->display_name, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
     $signupConfirmationEnabled = SettingsController::getInstance()->get('signup_confirmation.enabled');
     $status = $signupConfirmationEnabled ? SubscriberEntity::STATUS_UNCONFIRMED : SubscriberEntity::STATUS_SUBSCRIBED;

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -474,7 +474,7 @@ class Pages {
 
     // get label or display default label
     $text = isset($params['text'])
-      ? htmlspecialchars($params['text'])
+      ? htmlspecialchars($params['text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)
       : __('Manage your subscription', 'mailpoet');
 
     return '<a href="' . $this->subscriptionUrlFactory->getManageUrl($subscriber) . '">' . $text . '</a>';

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -140,7 +140,7 @@ class Helper {
 
   public function getRawPrice($price, array $args = []) {
     $htmlPrice = $this->wcPrice($price, $args);
-    return html_entity_decode(strip_tags($htmlPrice));
+    return html_entity_decode(strip_tags($htmlPrice), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
   }
 
   public function getAllowedCountries(): array {


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

Outside of some compatibility fixes, there are also changes in how values are escaped in the form Captcha renderer (the built-in captcha), so please do some smoke testing there.

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6492], related to #4947

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6492-ent-compat-issue)

_The latest successful build from `MAILPOET-6492-ent-compat-issue` will be used. If none is available, the link won't work._

[MAILPOET-6492]: https://mailpoet.atlassian.net/browse/MAILPOET-6492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ