### PR TITLE
Fix nightly tests [MAILPOET-6493]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1222,7 +1222,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 9.5.2
+          woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
@@ -1263,7 +1263,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 9.5.2
+          woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
@@ -1326,7 +1326,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
-          woo_core_version: 9.5.2
+          woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
@@ -1338,7 +1338,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
-          woo_core_version: 9.5.2
+          woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
           woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -34,7 +34,10 @@ class ListingComponent extends Component {
 
     if (autoRefresh) {
       jQuery(document).on('heartbeat-tick.mailpoet', () => {
-        this.getItems();
+        // Skip auto-refresh if any items are selected for bulk editing
+        if (this.state.selected_ids.length === 0) {
+          this.getItems();
+        }
       });
     }
 


### PR DESCRIPTION
## Description

Fixes nightly tests by updating the oldest supported WC version (caused by https://github.com/mailpoet/mailpoet/pull/6116) and fixing flaky DeleteNewsletter test.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6493]

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6493]: https://mailpoet.atlassian.net/browse/MAILPOET-6493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:nightly-tests)

_The latest successful build from `nightly-tests` will be used. If none is available, the link won't work._