### PR TITLE
Clarify activation key logs [MAILPOET-5846]

### DIFF
--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -97,6 +97,10 @@ class LoggerFactory {
     return self::$instance;
   }
 
+  public function clearLoggerInstances() {
+    $this->loggerInstances = [];
+  }
+
   private function getDefaultLogLevel() {
     $logLevel = $this->settings->get('logging', 'errors');
     switch ($logLevel) {

--- a/mailpoet/lib/Logging/LoggerFactory.php
+++ b/mailpoet/lib/Logging/LoggerFactory.php
@@ -27,6 +27,7 @@ class LoggerFactory {
   const TOPIC_NEWSLETTERS = 'newsletters';
   const TOPIC_POST_NOTIFICATIONS = 'post-notifications';
   const TOPIC_MSS = 'mss';
+  const TOPIC_PREMIUM = 'premium';
   const TOPIC_BRIDGE = 'bridge-api';
   const TOPIC_SENDING = 'sending';
   const TOPIC_CRON = 'cron';

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -422,12 +422,17 @@ class API {
   }
 
   private function logKeyCheckError(int $code, string $keyType): void {
+    $topic = LoggerFactory::TOPIC_MSS;
+    if ($keyType === self::KEY_CHECK_TYPE_PREMIUM) {
+      $topic = LoggerFactory::TOPIC_PREMIUM;
+    }
+
     $logData = [
       'http_code' => $code,
       'home_url' => $this->wp->homeUrl(),
       'key_type' => $keyType,
     ];
-    $this->loggerFactory->getLogger(LoggerFactory::TOPIC_MSS)->error('key-validation.failed', $logData);
+    $this->loggerFactory->getLogger($topic)->error('key-validation.failed', $logData);
   }
 
   private function logInvalidDataFormat(string $method, ?string $response = null): void {

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -432,7 +432,7 @@ class API {
       'home_url' => $this->wp->homeUrl(),
       'key_type' => $keyType,
     ];
-    $this->loggerFactory->getLogger($topic)->error('key-validation.failed', $logData);
+    $this->loggerFactory->getLogger($topic)->info('key-validation.failed', $logData);
   }
 
   private function logInvalidDataFormat(string $method, ?string $response = null): void {


### PR DESCRIPTION
## Description

Change the severity of the activation key logs from `error` to `info` so they are not logged automatically. Also correctly group premium key check fails in `premium` instead of `mss`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7303

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-5846]: https://mailpoet.atlassian.net/browse/MAILPOET-5846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:premium-key-check-logger)

_The latest successful build from `premium-key-check-logger` will be used. If none is available, the link won't work._