### PR TITLE
Support creation of emails from templates in automations [MAILPOET-6478]

### DIFF
--- a/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
+++ b/mailpoet/assets/js/src/automation/templates/components/template-preview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import { Spinner } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -77,8 +78,11 @@ export function TemplatePreview({ template }: Props): JSX.Element {
       initializeIntegrations();
 
       try {
+        const path = addQueryArgs(`/automation-templates/${template.slug}`, {
+          preview: true,
+        });
         const data = await apiFetch<{ data: { automation: unknown } }>({
-          path: `/automation-templates/${template.slug}`,
+          path,
           method: 'GET',
           signal: controller.signal,
         });

--- a/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationTemplate.php
@@ -19,7 +19,7 @@ class AutomationTemplate {
   /** @var string */
   private $description;
 
-  /** @var callable(): Automation */
+  /** @var callable(bool $preview=): Automation */
   private $automationFactory;
 
   /** @var array<string, int|bool> */
@@ -29,7 +29,7 @@ class AutomationTemplate {
   private $type;
 
   /**
-   * @param callable(): Automation $automationFactory
+   * @param callable(bool $preview=): Automation $automationFactory
    * @param array<string, int|bool> $requiredCapabilities
    */
   public function __construct(
@@ -75,8 +75,8 @@ class AutomationTemplate {
     return $this->requiredCapabilities;
   }
 
-  public function createAutomation(): Automation {
-    return ($this->automationFactory)();
+  public function createAutomation(bool $preview = false): Automation {
+    return ($this->automationFactory)($preview);
   }
 
   public function toArray(): array {

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationTemplateGetEndpoint.php
@@ -40,7 +40,7 @@ class AutomationTemplateGetEndpoint extends Endpoint {
       throw Exceptions::automationTemplateNotFound($slug);
     }
 
-    $automation = $template->createAutomation();
+    $automation = $template->createAutomation((bool)$request->getParam('preview'));
     $automation->setId(0);
     $this->automationValidator->validate($automation);
 
@@ -53,6 +53,7 @@ class AutomationTemplateGetEndpoint extends Endpoint {
   public static function getRequestSchema(): array {
     return [
       'slug' => Builder::string()->required(),
+      'preview' => Builder::boolean(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -209,4 +209,8 @@ class WordPress {
   public function humanTimeDiff(int $from, int $to = 0): string {
     return human_time_diff($from, $to);
   }
+
+  public function sanitizeFileName(string $filename): string {
+    return sanitize_file_name($filename);
+  }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -7,6 +7,8 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Newsletter\NewsletterDeleteController;
 use MailPoet\Newsletter\NewslettersRepository;
 
@@ -45,6 +47,12 @@ class AutomationEditorLoadingHooks {
       return;
     }
     $this->disconnectEmptyEmailsFromSendEmailStep($automation);
+    $this->setAutomationIdForEmails($automation);
+  }
+
+  private function setAutomationIdForEmails(Automation $automation): void {
+    $emailFactory = ContainerWrapper::getInstance()->get(EmailFactory::class);
+    $emailFactory->setAutomationIdForEmails($automation);
   }
 
   private function disconnectEmptyEmailsFromSendEmailStep(Automation $automation): void {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Automation\Integrations\MailPoet\Templates;
 
+use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
@@ -42,6 +43,7 @@ class EmailFactory {
     // Create a new newsletter entity
     $newsletter = new NewsletterEntity();
     $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
     $newsletter->setSubject($data['subject'] ?? '');
     $newsletter->setPreheader($data['preheader'] ?? '');
     $newsletter->setSenderName($data['sender_name'] ?? $this->getDefaultSenderName());
@@ -89,9 +91,8 @@ class EmailFactory {
     $templatePath = $this->getTemplatePath($templateName);
 
     if (!file_exists($templatePath)) {
-      return null;
+      throw new NotFoundException('Template not found: ' . $templateName);
     }
-
     return $this->fetchEmailTemplate($templatePath);
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Security;
 
 class EmailFactory {
   /** @var NewslettersRepository */
@@ -62,6 +63,7 @@ class EmailFactory {
     $newsletter->setPreheader($data['preheader'] ?? '');
     $newsletter->setSenderName($data['sender_name'] ?? $this->getDefaultSenderName());
     $newsletter->setSenderAddress($data['sender_address'] ?? $this->getDefaultSenderAddress());
+    $newsletter->setHash(Security::generateHash());
 
     // Set content if provided
     if (isset($data['content'])) {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -16,8 +16,8 @@ class EmailFactory {
   /** @var SettingsController */
   private $settings;
 
-  /** @var string */
-  private $templatesDirectory;
+  /** @var string|null */
+  protected $templatesDirectory;
 
   /** @var WordPress */
   private $wp;
@@ -30,7 +30,6 @@ class EmailFactory {
     $this->newslettersRepository = $newslettersRepository;
     $this->settings = $settings;
     $this->wp = $wp;
-    $this->templatesDirectory = Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates';
   }
 
   /**
@@ -104,7 +103,7 @@ class EmailFactory {
    */
   protected function getTemplatePath(string $templateName): string {
     $sanitizedTemplateName = $this->wp->sanitizeFileName($templateName);
-    return $this->templatesDirectory . '/' . $sanitizedTemplateName . '.json';
+    return $this->getTemplatesDirectory() . '/' . $sanitizedTemplateName . '.json';
   }
 
   /**
@@ -130,10 +129,10 @@ class EmailFactory {
   /**
    * Set the templates directory
    *
-   * @param string $directory The directory where templates are stored
+   * @param string|null $directory The directory where templates are stored
    * @return self
    */
-  public function setTemplatesDirectory(string $directory): self {
+  public function setTemplatesDirectory(?string $directory): self {
     $this->templatesDirectory = $directory;
     return $this;
   }
@@ -144,6 +143,7 @@ class EmailFactory {
    * @return string The directory where templates are stored
    */
   public function getTemplatesDirectory(): string {
-    return $this->templatesDirectory;
+    return $this->templatesDirectory
+      ?: Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates';
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Templates;
+
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Settings\SettingsController;
+
+class EmailFactory {
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var string */
+  private $templatesDirectory;
+
+  /** @var WordPress */
+  private $wp;
+
+  public function __construct(
+    NewslettersRepository $newslettersRepository,
+    SettingsController $settings,
+    WordPress $wp
+  ) {
+    $this->newslettersRepository = $newslettersRepository;
+    $this->settings = $settings;
+    $this->wp = $wp;
+    $this->templatesDirectory = Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates';
+  }
+
+  /**
+   * Create an email from a template and store it in the database
+   *
+   * @param array $data Email data including subject, preheader, etc.
+   * @return int|null The ID of the created email or null if the email couldn't be created
+   */
+  public function createEmail(array $data = []): ?int {
+    // Create a new newsletter entity
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setSubject($data['subject'] ?? '');
+    $newsletter->setPreheader($data['preheader'] ?? '');
+    $newsletter->setSenderName($data['sender_name'] ?? $this->getDefaultSenderName());
+    $newsletter->setSenderAddress($data['sender_address'] ?? $this->getDefaultSenderAddress());
+
+    // Set content if provided
+    if (isset($data['content'])) {
+      $newsletter->setBody($data['content']);
+    } elseif (isset($data['template'])) {
+      $template = $this->loadTemplate($data['template']);
+      if ($template) {
+        $newsletter->setBody($template);
+      }
+    }
+
+    // Save the newsletter to the database
+    $this->newslettersRepository->persist($newsletter);
+    $this->newslettersRepository->flush();
+
+    // Return the newsletter ID
+    return $newsletter->getId();
+  }
+
+  /**
+   * Get the default sender name from settings
+   */
+  private function getDefaultSenderName(): string {
+    return $this->settings->get('sender.name', '');
+  }
+
+  /**
+   * Get the default sender address from settings
+   */
+  private function getDefaultSenderAddress(): string {
+    return $this->settings->get('sender.address', '');
+  }
+
+  /**
+   * Load a template from a file
+   *
+   * @param string $templateName The name of the template file (without .json extension)
+   * @return array|null The template body or null if the template doesn't exist
+   */
+  public function loadTemplate(string $templateName): ?array {
+    $templatePath = $this->getTemplatePath($templateName);
+
+    if (!file_exists($templatePath)) {
+      return null;
+    }
+
+    return $this->fetchEmailTemplate($templatePath);
+  }
+
+  /**
+   * Get the path to a template file
+   *
+   * @param string $templateName The name of the template file (without .json extension)
+   * @return string The full path to the template file
+   */
+  protected function getTemplatePath(string $templateName): string {
+    $sanitizedTemplateName = $this->wp->sanitizeFileName($templateName);
+    return $this->templatesDirectory . '/' . $sanitizedTemplateName . '.json';
+  }
+
+  /**
+   * Fetch email template from a file
+   *
+   * @param string $templatePath The path to the template file
+   * @return array|null The template body or null if the template couldn't be loaded
+   */
+  private function fetchEmailTemplate(string $templatePath): ?array {
+    $templateString = file_get_contents($templatePath);
+    if ($templateString === false) {
+      return null;
+    }
+
+    $templateArr = json_decode((string)$templateString, true);
+    if (!is_array($templateArr) || !isset($templateArr['body'])) {
+      return null;
+    }
+
+    return $templateArr['body'];
+  }
+
+  /**
+   * Set the templates directory
+   *
+   * @param string $directory The directory where templates are stored
+   * @return self
+   */
+  public function setTemplatesDirectory(string $directory): self {
+    $this->templatesDirectory = $directory;
+    return $this;
+  }
+
+  /**
+   * Get the templates directory
+   *
+   * @return string The directory where templates are stored
+   */
+  public function getTemplatesDirectory(): string {
+    return $this->templatesDirectory;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -15,6 +15,7 @@ class TemplatesFactory {
   private $woocommerce;
 
   /** @var EmailFactory */
+  /** @phpstan-ignore-next-line Property is reserved for future use */
   private $emailFactory;
 
   public function __construct(

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -14,12 +14,17 @@ class TemplatesFactory {
   /** @var WooCommerce */
   private $woocommerce;
 
+  /** @var EmailFactory */
+  private $emailFactory;
+
   public function __construct(
     AutomationBuilder $builder,
-    WooCommerce $woocommerce
+    WooCommerce $woocommerce,
+    EmailFactory $emailFactory
   ) {
     $this->builder = $builder;
     $this->woocommerce = $woocommerce;
+    $this->emailFactory = $emailFactory;
   }
 
   public function createTemplates(): array {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -199,7 +199,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\SubscriberSubjectToWordPressUserSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\CommentSubjectToSubscriberSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\TemplatesFactory::class)->setPublic(true)->setShared(false);
-
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory::class)->setPublic(true);
+    
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartHandler::class)->setPublic(true);
 

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Templates;
+
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoetTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class EmailFactoryTest extends MailPoetTest {
+  /** @var EmailFactory */
+  private $emailFactory;
+
+  /** @var WordPress */
+  private $wp;
+
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var SettingsController|MockObject */
+  private $settings;
+
+  /** @var string */
+  private $tempDir;
+
+  public function _before(): void {
+    parent::_before();
+    $this->newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    $this->settings = $this->getMockBuilder(SettingsController::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $this->wp = new WordPress();
+    $this->emailFactory = new EmailFactory($this->newslettersRepository, $this->settings, $this->wp);
+
+    // Create a temporary directory for test templates
+    $this->tempDir = Env::$tempPath . '/mailpoet_test_templates_' . uniqid();
+    mkdir($this->tempDir);
+    $this->emailFactory->setTemplatesDirectory($this->tempDir);
+  }
+
+  public function _after(): void {
+    parent::_after();
+    // Clean up temporary directory
+    if (is_dir($this->tempDir)) {
+      $files = glob("$this->tempDir/*.*");
+      if ($files !== false) {
+        array_map('unlink', $files);
+      }
+      rmdir($this->tempDir);
+    }
+  }
+
+  public function testItCreatesEmailWithCustomSettings(): void {
+    $customData = [
+      'subject' => 'Custom Subject',
+      'preheader' => 'Custom Preheader',
+      'sender_name' => 'Custom Sender',
+      'sender_address' => 'custom@example.com',
+      'content' => ['html' => '<p>Custom content</p>'],
+    ];
+
+    $emailId = $this->emailFactory->createEmail($customData);
+
+    $this->assertIsInt($emailId);
+    $this->assertGreaterThan(0, $emailId);
+
+    // Verify the created newsletter
+    $newsletter = $this->newslettersRepository->findOneById($emailId);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $this->assertEquals(NewsletterEntity::TYPE_AUTOMATION, $newsletter->getType());
+    $this->assertEquals('Custom Subject', $newsletter->getSubject());
+    $this->assertEquals('Custom Preheader', $newsletter->getPreheader());
+    $this->assertEquals('Custom Sender', $newsletter->getSenderName());
+    $this->assertEquals('custom@example.com', $newsletter->getSenderAddress());
+    $this->assertEquals(['html' => '<p>Custom content</p>'], $newsletter->getBody());
+  }
+
+  public function testItCreatesEmailWithTemplate(): void {
+    $templateName = 'test-template';
+    $templateContent = ['html' => '<p>Template content</p>'];
+    $templateFile = $this->tempDir . '/' . $templateName . '.json';
+    file_put_contents($templateFile, json_encode(['body' => $templateContent]));
+
+    // Set up default sender settings
+    $this->settings->expects($this->exactly(2))
+      ->method('get')
+      ->withConsecutive(
+        ['sender.name', ''],
+        ['sender.address', '']
+      )
+      ->willReturnOnConsecutiveCalls(
+        'Default Sender',
+        'default@example.com'
+      );
+
+    $emailId = $this->emailFactory->createEmail(['template' => $templateName]);
+
+    $this->assertIsInt($emailId);
+    $this->assertGreaterThan(0, $emailId);
+
+    // Verify the created newsletter
+    $newsletter = $this->newslettersRepository->findOneById($emailId);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $this->assertEquals(NewsletterEntity::TYPE_AUTOMATION, $newsletter->getType());
+    $this->assertEquals('', $newsletter->getSubject());
+    $this->assertEquals('', $newsletter->getPreheader());
+    $this->assertEquals('Default Sender', $newsletter->getSenderName());
+    $this->assertEquals('default@example.com', $newsletter->getSenderAddress());
+    $this->assertEquals($templateContent, $newsletter->getBody());
+  }
+
+  public function testItHandlesTemplateLoading(): void {
+    $unsafePath = Env::$file; // Main plugin file
+    $this->assertNull($this->emailFactory->loadTemplate($unsafePath));
+
+    $nonExistentPath = 'non-existent-template';
+    $this->assertNull($this->emailFactory->loadTemplate($nonExistentPath));
+
+    $templateName = 'valid-template';
+    $templateContent = ['html' => '<p>Valid template content</p>'];
+    $templateFile = $this->tempDir . '/' . $templateName . '.json';
+    file_put_contents($templateFile, json_encode(['body' => $templateContent]));
+
+    $loadedContent = $this->emailFactory->loadTemplate($templateName);
+    $this->assertEquals($templateContent, $loadedContent);
+  }
+
+  public function testItManagesTemplateDirectory(): void {
+    $customDir = '/custom/templates/dir';
+
+    $this->emailFactory->setTemplatesDirectory($customDir);
+    $this->assertEquals($customDir, $this->emailFactory->getTemplatesDirectory());
+
+    $this->emailFactory->setTemplatesDirectory(Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates');
+    $this->assertEquals(Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates', $this->emailFactory->getTemplatesDirectory());
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
@@ -2,11 +2,17 @@
 
 namespace MailPoet\Test\Automation\Integrations\MailPoet\Templates;
 
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Automation\Integrations\MailPoet\Templates\EmailFactory;
 use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
+use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoetTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,6 +30,12 @@ class EmailFactoryTest extends MailPoetTest {
   /** @var SettingsController|MockObject */
   private $settings;
 
+  /** @var NewsletterOptionsRepository */
+  private $newsletterOptionsRepository;
+
+  /** @var NewsletterOptionFieldsRepository */
+  private $newsletterOptionFieldsRepository;
+
   /** @var string */
   private $tempDir;
 
@@ -33,8 +45,24 @@ class EmailFactoryTest extends MailPoetTest {
     $this->settings = $this->getMockBuilder(SettingsController::class)
       ->disableOriginalConstructor()
       ->getMock();
+
+    // Set up default sender settings
+    $this->settings->method('get')
+      ->will($this->returnValueMap([
+        ['sender.name', '', 'Default Sender'],
+        ['sender.address', '', 'default@example.com'],
+      ]));
+
+    $this->newsletterOptionsRepository = $this->diContainer->get(NewsletterOptionsRepository::class);
+    $this->newsletterOptionFieldsRepository = $this->diContainer->get(NewsletterOptionFieldsRepository::class);
     $this->wp = new WordPress();
-    $this->emailFactory = new EmailFactory($this->newslettersRepository, $this->settings, $this->wp);
+    $this->emailFactory = new EmailFactory(
+      $this->newslettersRepository,
+      $this->settings,
+      $this->wp,
+      $this->newsletterOptionsRepository,
+      $this->newsletterOptionFieldsRepository
+    );
 
     // Create a temporary directory for test templates
     $this->tempDir = Env::$tempPath . '/mailpoet_test_templates_' . uniqid();
@@ -85,18 +113,6 @@ class EmailFactoryTest extends MailPoetTest {
     $templateFile = $this->tempDir . '/' . $templateName . '.json';
     file_put_contents($templateFile, json_encode(['body' => $templateContent]));
 
-    // Set up default sender settings
-    $this->settings->expects($this->exactly(2))
-      ->method('get')
-      ->withConsecutive(
-        ['sender.name', ''],
-        ['sender.address', '']
-      )
-      ->willReturnOnConsecutiveCalls(
-        'Default Sender',
-        'default@example.com'
-      );
-
     $emailId = $this->emailFactory->createEmail(['template' => $templateName]);
 
     $this->assertIsInt($emailId);
@@ -143,5 +159,329 @@ class EmailFactoryTest extends MailPoetTest {
 
     $this->emailFactory->setTemplatesDirectory(null);
     $this->assertEquals(Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates', $this->emailFactory->getTemplatesDirectory());
+  }
+
+  public function testItSetsAutomationIdForEmails(): void {
+    $emailId1 = $this->emailFactory->createEmail([
+      'subject' => 'Test Email 1',
+      'content' => ['html' => '<p>Test content 1</p>'],
+    ]);
+
+    $emailId2 = $this->emailFactory->createEmail([
+      'subject' => 'Test Email 2',
+      'content' => ['html' => '<p>Test content 2</p>'],
+    ]);
+
+    $step1 = new Step(
+      'step-1',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      ['email_id' => $emailId1],
+      [],
+      null
+    );
+
+    $step2 = new Step(
+      'step-2',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      ['email_id' => $emailId2],
+      [],
+      null
+    );
+
+    $step3 = new Step(
+      'step-3',
+      Step::TYPE_ACTION,
+      'some-other-action',
+      [],
+      [],
+      null
+    );
+
+    $rootStep = new Step(
+      'root',
+      Step::TYPE_ROOT,
+      'root',
+      [],
+      [
+        new NextStep('step-1'),
+        new NextStep('step-2'),
+        new NextStep('step-3'),
+      ],
+      null
+    );
+
+    $steps = [
+      'root' => $rootStep,
+      'step-1' => $step1,
+      'step-2' => $step2,
+      'step-3' => $step3,
+    ];
+
+    $automation = new Automation(
+      'Test Automation',
+      $steps,
+      wp_get_current_user(),
+      123
+    );
+
+    $this->emailFactory->setAutomationIdForEmails($automation);
+
+    $this->entityManager->clear();
+
+    // Email 1
+    $newsletter1 = $this->newslettersRepository->findOneById($emailId1);
+    $this->assertNotNull($newsletter1, 'Newsletter 1 not found');
+    $options1 = $newsletter1->getOptions();
+
+    $foundAutomationId = false;
+    $foundStepId = false;
+
+    foreach ($options1 as $option) {
+      $optionField = $option->getOptionField();
+      $this->assertNotNull($optionField, 'Option field is null');
+      $fieldName = $optionField->getName();
+
+      if ($fieldName === NewsletterOptionFieldEntity::NAME_AUTOMATION_ID) {
+        $foundAutomationId = true;
+        $this->assertEquals('123', $option->getValue());
+      }
+
+      if ($fieldName === NewsletterOptionFieldEntity::NAME_AUTOMATION_STEP_ID) {
+        $foundStepId = true;
+        $this->assertEquals('step-1', $option->getValue());
+      }
+    }
+
+    $this->assertTrue($foundAutomationId);
+    $this->assertTrue($foundStepId);
+
+    // Email 2
+    $newsletter2 = $this->newslettersRepository->findOneById($emailId2);
+    $this->assertNotNull($newsletter2, 'Newsletter 2 not found');
+    $options2 = $newsletter2->getOptions();
+
+    $foundAutomationId = false;
+    $foundStepId = false;
+
+    foreach ($options2 as $option) {
+      $optionField = $option->getOptionField();
+      $this->assertNotNull($optionField, 'Option field is null');
+      $fieldName = $optionField->getName();
+
+      if ($fieldName === NewsletterOptionFieldEntity::NAME_AUTOMATION_ID) {
+        $foundAutomationId = true;
+        $this->assertEquals('123', $option->getValue());
+      }
+
+      if ($fieldName === NewsletterOptionFieldEntity::NAME_AUTOMATION_STEP_ID) {
+        $foundStepId = true;
+        $this->assertEquals('step-2', $option->getValue());
+      }
+    }
+
+    $this->assertTrue($foundAutomationId);
+    $this->assertTrue($foundStepId);
+  }
+
+  public function testItHandlesMissingNewsletterWhenSettingAutomationIdForEmails(): void {
+    $step = new Step(
+      'step-1',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      ['email_id' => 99999], // Non-existent email ID
+      [],
+      null
+    );
+
+    $rootStep = new Step(
+      'root',
+      Step::TYPE_ROOT,
+      'root',
+      [],
+      [new NextStep('step-1')],
+      null
+    );
+
+    $steps = [
+      'root' => $rootStep,
+      'step-1' => $step,
+    ];
+
+    $automation = new Automation(
+      'Test Automation',
+      $steps,
+      wp_get_current_user(),
+      123
+    );
+
+    // This should not throw an exception
+    $this->emailFactory->setAutomationIdForEmails($automation);
+  }
+
+  public function testItHandlesAutomationWithNoId(): void {
+    // Create an automation with no ID
+    $step = new Step(
+      'step-1',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      ['email_id' => 1], // Any email ID
+      [],
+      null
+    );
+
+    $rootStep = new Step(
+      'root',
+      Step::TYPE_ROOT,
+      'root',
+      [],
+      [new NextStep('step-1')],
+      null
+    );
+
+    $steps = [
+      'root' => $rootStep,
+      'step-1' => $step,
+    ];
+
+    $automation = new Automation(
+      'Test Automation',
+      $steps,
+      wp_get_current_user(),
+      null // No ID
+    );
+
+    // This should not throw an exception
+    $this->emailFactory->setAutomationIdForEmails($automation);
+  }
+
+  public function testItSkipsEmailsWithCorrectAutomationId(): void {
+    $emailId = $this->emailFactory->createEmail([
+      'subject' => 'Test Email',
+      'content' => ['html' => '<p>Test content</p>'],
+    ]);
+
+    $step = new Step(
+      'step-1',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      ['email_id' => $emailId],
+      [],
+      null
+    );
+
+    $rootStep = new Step(
+      'root',
+      Step::TYPE_ROOT,
+      'root',
+      [],
+      [new NextStep('step-1')],
+      null
+    );
+
+    $steps = [
+      'root' => $rootStep,
+      'step-1' => $step,
+    ];
+
+    $automation = new Automation(
+      'Test Automation',
+      $steps,
+      wp_get_current_user(),
+      123
+    );
+
+    // Set automation ID for the first time
+    $this->emailFactory->setAutomationIdForEmails($automation);
+
+    // Get the newsletter and verify options are set
+    $newsletter = $this->newslettersRepository->findOneById($emailId);
+    $this->assertNotNull($newsletter);
+
+    $automationIdOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_AUTOMATION_ID);
+    $stepIdOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_AUTOMATION_STEP_ID);
+
+    $this->assertNotNull($automationIdOption);
+    $this->assertNotNull($stepIdOption);
+    $this->assertEquals('123', $automationIdOption->getValue());
+    $this->assertEquals('step-1', $stepIdOption->getValue());
+
+    // Mock the repository to track if flush is called
+    $repositoryMock = $this->createMock(NewslettersRepository::class);
+    $repositoryMock->expects($this->never())
+      ->method('flush');
+
+    // Replace the repository in the email factory with our mock
+    $reflectionProperty = new \ReflectionProperty(EmailFactory::class, 'newslettersRepository');
+    $reflectionProperty->setAccessible(true);
+    $originalRepository = $reflectionProperty->getValue($this->emailFactory);
+    $reflectionProperty->setValue($this->emailFactory, $repositoryMock);
+
+    // Call setAutomationIdForEmails again - should skip the email
+    $this->emailFactory->setAutomationIdForEmails($automation);
+
+    // Restore the original repository
+    $reflectionProperty->setValue($this->emailFactory, $originalRepository);
+  }
+
+  public function testItUpdatesEmailsWithDifferentAutomationId(): void {
+    $emailId = $this->emailFactory->createEmail([
+      'subject' => 'Test Email',
+      'content' => ['html' => '<p>Test content</p>'],
+    ]);
+
+    $step = new Step(
+      'step-1',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      ['email_id' => $emailId],
+      [],
+      null
+    );
+
+    $rootStep = new Step(
+      'root',
+      Step::TYPE_ROOT,
+      'root',
+      [],
+      [new NextStep('step-1')],
+      null
+    );
+
+    $steps = [
+      'root' => $rootStep,
+      'step-1' => $step,
+    ];
+
+    // Create first automation with ID 123
+    $automation1 = new Automation(
+      'Test Automation 1',
+      $steps,
+      wp_get_current_user(),
+      123
+    );
+
+    // Set automation ID for the first time
+    $this->emailFactory->setAutomationIdForEmails($automation1);
+
+    // Create second automation with ID 456
+    $automation2 = new Automation(
+      'Test Automation 2',
+      $steps,
+      wp_get_current_user(),
+      456
+    );
+
+    // Set automation ID again with different automation
+    $this->emailFactory->setAutomationIdForEmails($automation2);
+
+    // Get the newsletter and verify options are updated
+    $newsletter = $this->newslettersRepository->findOneById($emailId);
+    $this->assertNotNull($newsletter);
+
+    $automationIdOption = $newsletter->getOption(NewsletterOptionFieldEntity::NAME_AUTOMATION_ID);
+    $this->assertNotNull($automationIdOption);
+    $this->assertEquals('456', $automationIdOption->getValue());
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
@@ -113,13 +113,19 @@ class EmailFactoryTest extends MailPoetTest {
     $this->assertEquals($templateContent, $newsletter->getBody());
   }
 
-  public function testItHandlesTemplateLoading(): void {
+  public function testItHandlesTemplateLoadingForWrongPath(): void {
     $unsafePath = Env::$file; // Main plugin file
-    $this->assertNull($this->emailFactory->loadTemplate($unsafePath));
+    $this->expectException(\MailPoet\Automation\Engine\Exceptions\NotFoundException::class);
+    $this->emailFactory->loadTemplate($unsafePath);
+  }
 
+  public function testItHandlesTemplateLoadingForNonExistentTemplate(): void {
     $nonExistentPath = 'non-existent-template';
-    $this->assertNull($this->emailFactory->loadTemplate($nonExistentPath));
+    $this->expectException(\MailPoet\Automation\Engine\Exceptions\NotFoundException::class);
+    $this->emailFactory->loadTemplate($nonExistentPath);
+  }
 
+  public function testItHandlesTemplateLoadingForValidTemplate(): void {
     $templateName = 'valid-template';
     $templateContent = ['html' => '<p>Valid template content</p>'];
     $templateFile = $this->tempDir . '/' . $templateName . '.json';
@@ -135,7 +141,7 @@ class EmailFactoryTest extends MailPoetTest {
     $this->emailFactory->setTemplatesDirectory($customDir);
     $this->assertEquals($customDir, $this->emailFactory->getTemplatesDirectory());
 
-    $this->emailFactory->setTemplatesDirectory(Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates');
+    $this->emailFactory->setTemplatesDirectory(null);
     $this->assertEquals(Env::$libPath . '/Automation/Integrations/MailPoet/Templates/EmailTemplates', $this->emailFactory->getTemplatesDirectory());
   }
 }


### PR DESCRIPTION
## Description

This PR adds a factory for creating emails from templates when initializing a new automation. An example of usage is in the [linked PR](https://github.com/mailpoet/mailpoet-premium/pull/943).

## Code review notes

_N/A_

## QA notes

No QA needed.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/943

## Linked tickets

[MAILPOET-6478]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6478]: https://mailpoet.atlassian.net/browse/MAILPOET-6478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6478-create-email-from-template-in-automation)

_The latest successful build from `MAILPOET-6478-create-email-from-template-in-automation` will be used. If none is available, the link won't work._