### PR TITLE
Use WooCommerce RC versions in nightly_qit job [MAILPOET-6498]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -949,14 +949,8 @@ jobs:
       - run:
           name: 'QIT Activation Tests'
           command: |
-            LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
-            if [ -z "$LATEST_WC_BETA" ]; then
-              echo "No WooCommerce Beta version found. Using stable."
-              ./do qa:qit-activation | tee tests/_output/qit-activation
-            else
-              echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
-              ./do qa:qit-activation --wc=$LATEST_WC_BETA | tee tests/_output/qit-activation
-            fi
+            echo "Using WooCommerce RC Version"
+            ./do qa:qit-activation --wc=rc | tee tests/_output/qit-activation
       - run:
           name: 'Retrieve test results'
           command: |
@@ -980,14 +974,8 @@ jobs:
       - run:
           name: 'QIT Woo API Tests'
           command: |
-            LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
-            if [ -z "$LATEST_WC_BETA" ]; then
-              echo "No WooCommerce Beta version found. Using stable."
-              ./do qa:qit-woo-api | tee tests/_output/qit-woo-api
-            else
-              echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
-              ./do qa:qit-woo-api --wc=$LATEST_WC_BETA | tee tests/_output/qit-woo-api
-            fi
+            echo "Using WooCommerce RC Version"
+            ./do qa:qit-woo-api --wc=rc | tee tests/_output/qit-woo-api
       - run:
           name: 'Retrieve test results'
           command: |
@@ -1012,14 +1000,8 @@ jobs:
           name: 'QIT Woo E2E Tests'
           no_output_timeout: 1h # Woo E2E tests usually takes ~45m
           command: |
-            LATEST_WC_BETA=$(../.circleci/check_woocommerce_beta.sh | grep 'LATEST_BETA' | cut -d'=' -f2)
-            if [ -z "$LATEST_WC_BETA" ]; then
-              echo "No WooCommerce Beta version found. Using stable."
-              ./do qa:qit-woo-e2e | tee tests/_output/qit-woo-e2e
-            else
-              echo "Using WooCommerce Beta Version: $LATEST_WC_BETA"
-              ./do qa:qit-woo-e2e --wc=$LATEST_WC_BETA | tee tests/_output/qit-woo-e2e
-            fi
+            echo "Using WooCommerce RC Version"
+            ./do qa:qit-woo-e2e --wc=rc | tee tests/_output/qit-woo-e2e
       - run:
           name: 'Retrieve test results'
           command: |


### PR DESCRIPTION
## Description

This PR simplifies the logic about using the WC RC version on our nightly QIT job.

## Code review notes

_N/A_

## QA notes

We can skip QA here. The reviewer can check the output of [the CircleCI testing run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20387/workflows/d71b50fa-6d42-45af-a781-a7a362c330b9).

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6498]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6498]: https://mailpoet.atlassian.net/browse/MAILPOET-6498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:use-rc-versions-qit)

_The latest successful build from `use-rc-versions-qit` will be used. If none is available, the link won't work._