### PR TITLE
Allow override MAILPOET_TRACY_LOG_DIR in tests [PREMIUM-293]

### DIFF
--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_TABLE_PREFIX: mp_
       MAILPOET_TRACY_PRODUCTION_MODE: 1
-      MAILPOET_TRACY_LOG_DIR: /var/www/html/wp-content/plugins/mailpoet/tests/_output/exceptions
+      MAILPOET_TRACY_LOG_DIR: '${TRACY_LOG_DIR:-/var/www/html/wp-content/plugins/mailpoet/tests/_output/exceptions}'
     command: ['docker-entrypoint.sh', 'apache2-foreground']
     networks:
       default:


### PR DESCRIPTION
## Description

This PR adds ability to override `MAILPOET_TRACY_LOG_DIR` in the tests environment via `TRACY_LOG_DIR` env variable.
This is needed for a premium plugin, which reuses the test env but it is convenient to use a different output directory.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/946

## Linked tickets

[PREMIUM-293]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[PREMIUM-293]: https://mailpoet.atlassian.net/browse/PREMIUM-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-acceptance)

_The latest successful build from `fix-acceptance` will be used. If none is available, the link won't work._