### PR TITLE
Add “Created via” Field to Track WooCommerce Order Sources [MAILPOET-6483]

### DIFF
--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -153,6 +153,17 @@ class OrderFieldsFactory {
           }
         ),
         new Field(
+          'woocommerce:order:created-via',
+          Field::TYPE_ENUM,
+          __('Created via', 'mailpoet'),
+          function (OrderPayload $payload) {
+            return $payload->getOrder()->get_created_via();
+          },
+          [
+            'options' => $this->getOrderCreatedViaOptions(),
+          ]
+        ),
+        new Field(
           'woocommerce:order:paid-date',
           Field::TYPE_DATETIME,
           __('Paid date', 'mailpoet'),
@@ -396,5 +407,26 @@ class OrderFieldsFactory {
       $title = $product['post_title'];
       return ['id' => (int)$id, 'name' => "$title (#$id)"];
     }, (array)$products);
+  }
+
+  private function getOrderCreatedViaOptions(): array {
+    // Common sources for WooCommerce orders
+    // https://github.com/search?q=repo%3Awoocommerce%2Fwoocommerce+order-%3Eset_created_via&type=code
+    $sources = [
+      'checkout' => __('Checkout', 'mailpoet'),
+      'admin' => __('Admin', 'mailpoet'),
+      'rest-api' => __('REST API', 'mailpoet'),
+      'webhook' => __('Webhook', 'mailpoet'),
+      'subscription' => __('Subscription', 'mailpoet'),
+      'pos' => __('POS', 'mailpoet'),
+      'checkout-draft' => __('Checkout Draft', 'mailpoet'),
+    ];
+    
+    $options = [];
+    foreach ($sources as $id => $name) {
+      $options[] = ['id' => $id, 'name' => $name];
+    }
+    
+    return $options;
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -243,6 +243,40 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertSame('processing', $statusField->getValue($payload));
   }
 
+  public function testCreatedViaField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check definitions
+    $createdViaField = $fields['woocommerce:order:created-via'];
+    $this->assertSame('Created via', $createdViaField->getName());
+    $this->assertSame('enum', $createdViaField->getType());
+    $this->assertSame([
+      'options' => [
+        ['id' => 'checkout', 'name' => 'Checkout'],
+        ['id' => 'admin', 'name' => 'Admin'],
+        ['id' => 'rest-api', 'name' => 'REST API'],
+        ['id' => 'webhook', 'name' => 'Webhook'],
+        ['id' => 'subscription', 'name' => 'Subscription'],
+        ['id' => 'pos', 'name' => 'POS'],
+        ['id' => 'checkout-draft', 'name' => 'Checkout Draft'],
+      ],
+    ], $createdViaField->getArgs());
+
+    // check values
+    $order = new WC_Order();
+    $order->set_created_via('checkout');
+    $payload = new OrderPayload($order);
+    $this->assertSame('checkout', $createdViaField->getValue($payload));
+
+    $order->set_created_via('admin');
+    $payload = new OrderPayload($order);
+    $this->assertSame('admin', $createdViaField->getValue($payload));
+
+    $order->set_created_via('rest-api');
+    $payload = new OrderPayload($order);
+    $this->assertSame('rest-api', $createdViaField->getValue($payload));
+  }
+
   public function testTotalField(): void {
     $fields = $this->getFieldsMap();
 


### PR DESCRIPTION
## Description

**Add “Created via” Enum Field for WooCommerce Orders**

This PR introduces a new woocommerce:order:created-via field to track how a WooCommerce order was created. The field is implemented as an enum with predefined options such as “Checkout,” “Admin,” “REST API,” “Webhook,” and others.

**Changes**:
	•	Added a new Field definition for woocommerce:order:created-via in the payload.
	•	Implemented getOrderCreatedViaOptions() to provide a list of possible sources for order creation.
	•	Included unit tests to validate the field’s behavior

## Code review notes

N/A

## QA notes

N/A

## Linked PRs

N/A

## Linked tickets

https://mailpoet.atlassian.net/browse/MAILPOET-6483

## After-merge notes

N/A

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6483)

_The latest successful build from `MAILPOET-6483` will be used. If none is available, the link won't work._