### PR TITLE
Test fixes for WordPress 6.8 [MAILPOET-6501]

### DIFF
--- a/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceMembershipsSegmentCest.php
@@ -14,6 +14,13 @@ class WooCommerceMembershipsSegmentCest {
     if (!$i->canTestWithPlugin(\AcceptanceTester::WOO_COMMERCE_MEMBERSHIPS_PLUGIN)) {
       $scenario->skip('Can‘t test without woocommerce-memberships');
     }
+    /**
+     * Skip the test on WordPress 6.8+ because WooCommerce Memberships (Version 1.26.11) is not compatible with WordPress 6.8+.
+     * We can remove this check when we start testing with a newer version of WooCommerce Memberships.
+     */
+    if (version_compare($i->getWordPressVersion(), '6.8', '>=')) {
+      $scenario->skip('Skipping woocommerce-memberships tests on WordPress 6.8+');
+    }
     (new Settings())->withWooCommerceListImportPageDisplayed(true);
     (new Settings())->withCookieRevenueTrackingDisabled();
     $i->activateWooCommerce();

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -36,6 +36,12 @@ wp config set WP_AUTO_UPDATE_CORE false --raw
 mysqladmin --host=mysql --user=root --password=wordpress drop wordpress --force
 mysqladmin --host=mysql --user=root --password=wordpress create wordpress --force
 
+
+if [[ $WORDPRESS_VERSION != "" ]]; then
+  echo "Downloading WordPress version: $WORDPRESS_VERSION"
+  wp core download --version=$WORDPRESS_VERSION --force
+fi
+
 # install WordPress
 WP_CORE_INSTALL_PARAMS="--url=$HTTP_HOST --title=tests --admin_user=admin --admin_email=test@test.com --admin_password=password --skip-email"
 if [[ -z "$MULTISITE" || "$MULTISITE" -eq "0" ]]; then
@@ -47,11 +53,6 @@ else
   wp site create --slug=$WP_TEST_MULTISITE_SLUG
 fi
 
-if [[ $WORDPRESS_VERSION != "" ]]; then
-  echo "Installing WordPress version: $WORDPRESS_VERSION"
-  wp core update --version=$WORDPRESS_VERSION
-  wp core update-db
-fi
 echo "WORDPRESS VERSION:"
 wp core version
 


### PR DESCRIPTION
## Description

This PR fixes two issues causing failures in the nightly [acceptance_tests_wordpress_beta](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20424/workflows/c57bd668-2a2d-4c1e-a747-77c3c81672df/jobs/350234) job.

**1) Issue with restoring login session** - Fixed by downloading the beta upfront instead of installing an older version and updating to beta after. I didn't find the code which was causing the issue. I assume it may have something to do with some additional tasks needed after the update. I think it is better to start the tests from the clean install as we do when we use the version distributed with the image.

**2) Notice from WooCommerce Memberships plugin** - I reported the issue to the developers and temporarily disabled the plugin.

The notice:
```
PHP User Notice: Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>woocommerce-memberships</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /wp-core/wp-includes/functions.php on line 6121
```

## Code review notes

Here is the run with the WP Beta where these failures are no longer present  https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20420/workflows/9703ce7e-a3e1-4ad1-8453-9595793b052d/jobs/350157

There are still many other issues we need to investigate and fix. But this PR will help to reveal them.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6501]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6501]: https://mailpoet.atlassian.net/browse/MAILPOET-6501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ