### PR TITLE
Refactor downloading WooCommerce Memberships in tests [MAILPOET-6502]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           command: |
             ./do download:woo-commerce-zip 9.7.1
             ./do download:woo-commerce-subscriptions-zip 7.2.1
-            ./do download:woo-commerce-memberships-zip 1.26.5
+            ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.7
       - run:
           name: Dump tests ENV variables for acceptance tests
@@ -378,9 +378,6 @@ jobs:
       woo_subscriptions_version:
         type: string
         default: ''
-      woo_memberships_version:
-        type: string
-        default: ''
       automate_woo_version:
         type: string
         default: ''
@@ -480,14 +477,6 @@ jobs:
                 command: |
                   cd ../tests_env/docker
                   docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
-      - when:
-          condition: << parameters.woo_memberships_version >>
-          steps:
-            - run:
-                name: Download WooCommerce Memberships
-                command: |
-                  cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -695,9 +684,6 @@ jobs:
       woo_subscriptions_version:
         type: string
         default: ''
-      woo_memberships_version:
-        type: string
-        default: ''
       automate_woo_version:
         type: string
         default: ''
@@ -776,14 +762,6 @@ jobs:
                 command: |
                   cd ../tests_env/docker
                   docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
-      - when:
-          condition: << parameters.woo_memberships_version >>
-          steps:
-            - run:
-                name: Download WooCommerce Memberships
-                command: |
-                  cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-memberships-zip << parameters.woo_memberships_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -1206,7 +1184,6 @@ workflows:
           name: acceptance_oldest
           woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
-          woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.5
@@ -1247,7 +1224,6 @@ workflows:
           name: integration_oldest
           woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
-          woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1310,7 +1286,6 @@ workflows:
           name: acceptance_with_premium_oldest
           woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
-          woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1322,7 +1297,6 @@ workflows:
           name: integration_with_premium_oldest
           woo_core_version: 9.6.2
           woo_subscriptions_version: 7.1.0
-          woo_memberships_version: 1.25.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1395,13 +1395,13 @@ class RoboFile extends \Robo\Tasks {
     }
   }
 
-  public function downloadWooCommerceMembershipsZip($tag = null) {
+  public function downloadWooCommerceMembershipsZip(): void {
     if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
       $this->yell("Skipping download of WooCommerce Memberships", 40, 'red');
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
-    $this->createGithubClient('woocommerce/woocommerce-memberships')
-      ->downloadReleaseZip('woocommerce-memberships.zip', __DIR__ . '/tests/plugins/', $tag);
+    $this->createGithubClient('woocommerce/all-plugins')
+      ->downloadRawFile('https://api.github.com/repos/woocommerce/all-plugins/contents/product-packages/woocommerce-memberships/woocommerce-memberships.zip?ref=master', 'woocommerce-memberships.zip', __DIR__ . '/tests/plugins/');
   }
 
   public function downloadWooCommerceSubscriptionsZip($tag = null) {

--- a/mailpoet/tasks/GithubClient.php
+++ b/mailpoet/tasks/GithubClient.php
@@ -67,6 +67,14 @@ class GithubClient {
     file_put_contents($downloadDir . '/' . $zip . '-info', $assetDownloadInfo);
   }
 
+  public function downloadRawFile(string $rawUrl, $zip, $downloadDir): void {
+    if (!is_dir($downloadDir)) {
+      mkdir($downloadDir, 0777, true);
+    }
+    $response = $this->get($rawUrl, ['headers' => ['Accept' => 'application/vnd.github.v3.raw']]);
+    file_put_contents($downloadDir . $zip, $response->getBody()->getContents());
+  }
+
   private function getRelease($tag = null) {
     $path = 'releases/' . ($tag && $tag !== 'latest' ? "tags/$tag" : 'latest');
     $response = $this->get($path);

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -103,7 +103,7 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     if [ ! -f "$WOOCOMMERCE_MEMBERSHIPS_ZIP" ]; then
       echo "WooCommerce Memberships plugin zip not found. Downloading WooCommerce Memberships plugin latest zip"
       cd /project
-      ./do download:woo-commerce-memberships-zip latest
+      ./do download:woo-commerce-memberships-zip
       cd /wp-core/wp-content/plugins
     fi
     echo "Unzip Woocommerce Memberships plugin from $WOOCOMMERCE_MEMBERSHIPS_ZIP"


### PR DESCRIPTION
## Description

This PR changes how we download the WooCommerce Memberships plugin for the integration and acceptance tests. From now on, we will test always with the latest version.

## Code review notes

Here is a testing build where I verified that the current latest version works with the acceptance and integration tests for old versions. https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20434/workflows/4ad86597-05a4-410e-9521-0d70f2086d25

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6502]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6502]: https://mailpoet.atlassian.net/browse/MAILPOET-6502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:download-latest-woo-memberships)

_The latest successful build from `download-latest-woo-memberships` will be used. If none is available, the link won't work._