### PR TITLE
Clarify free support in DocsBot [MAILPOET-6504]

### DIFF
--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -195,15 +195,12 @@
   <script type="text/javascript">
     DocsBotAI.init({
       id: "TqTdebbGjJeUjrmBIFjh/kzFE5FBebBJiSJ2Tm0nR",
-      // We want to redirect users to the proper page depending on their plan
-      supportCallback: function (event, history) {
+      options: {
         <% if has_premium_support %>
-          const mailpoet_redirect_support_link = 'https://www.mailpoet.com/support/premium/';
+          supportLink: 'https://www.mailpoet.com/support/premium/',
         <% else %>
-          const mailpoet_redirect_support_link = 'https://wordpress.org/support/plugin/mailpoet/';
+          supportLink: 'https://wordpress.org/support/plugin/mailpoet/',
         <% endif %>
-        event.preventDefault(); // Prevent default behavior opening the url.
-        window.open(mailpoet_redirect_support_link, '_blank');
       },
     }).then(() => {
         // stopping propagation to avoid conflicts with other keydown events form WP.com

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -200,6 +200,9 @@
           supportLink: 'https://www.mailpoet.com/support/premium/',
         <% else %>
           supportLink: 'https://wordpress.org/support/plugin/mailpoet/',
+          labels: {
+            getSupport: "<%= __('Get help in the forum', 'mailpoet' )|escape('js') %>"
+          }
         <% endif %>
       },
     }).then(() => {


### PR DESCRIPTION
## Description

Changes the link label to support for free users.

## Code review notes

_N/A_

## QA notes

Can be skipped when an engineer verifies the functionality in the UI. 

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6504]

## After-merge notes

_N/A_

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6504]: https://mailpoet.atlassian.net/browse/MAILPOET-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:docsbot-options)

_The latest successful build from `docsbot-options` will be used. If none is available, the link won't work._