### PR TITLE
Make implicit nullables explicit [MAILPOET-6513]

### DIFF
--- a/mailpoet/lib/exceptions.php
+++ b/mailpoet/lib/exceptions.php
@@ -18,12 +18,12 @@ abstract class Exception extends \Exception {
   /** @var string[] */
   private $errors = [];
 
-  final public function __construct($message = '', $code = 0, \Throwable $previous = null) {
+  final public function __construct($message = '', $code = 0, ?\Throwable $previous = null) {
     parent::__construct($message, $code, $previous);
   }
 
   /** @return static */
-  public static function create(\Throwable $previous = null) {
+  public static function create(?\Throwable $previous = null) {
     return new static('', 0, $previous);
   }
 


### PR DESCRIPTION
## Description
We skip phpcs checks on lib/exceptions.php. This unfortunately meant, we did not see that there were implicit nullables in this file. This PR fixes those.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-6513]

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


[MAILPOET-6513]: https://mailpoet.atlassian.net/browse/MAILPOET-6513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:MAILPOET-6513-implicit-nullable-in-exceptions-php)

_The latest successful build from `MAILPOET-6513-implicit-nullable-in-exceptions-php` will be used. If none is available, the link won't work._