### PR TITLE
Add changelog checkbox in PR template [STOMAIL-7371]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,7 @@ _N/A_
 
 ## Tasks
 
+- [ ] I have added a changelog entry
 - [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
 - [ ] I added sufficient test coverage
 - [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


### PR DESCRIPTION
## Description
Adds the changelog checkbox to our PR template

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets
STOMAIL-7371

## After-merge notes

_N/A_

## Tasks

- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:STOMAIL-7371-update-pr-template)

_The latest successful build from `STOMAIL-7371-update-pr-template` will be used. If none is available, the link won't work._