### PR TITLE
Set maximum PHP version to use with WordPress images

### DIFF
--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check-versions:
     runs-on: ubuntu-latest
+    env:
+      MAX_PHP_VERSION: '8.3' # Maximum PHP version to use for WordPress Docker images
 
     steps:
       - name: Checkout repository
@@ -16,11 +18,11 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3' # Specify the PHP version you want to use
+          php-version: ${{ env.MAX_PHP_VERSION }}
 
       # Updating used WordPress
       - name: Check WordPress Docker Versions
-        run: php .github/workflows/scripts/check_wordpress_versions.php
+        run: php .github/workflows/scripts/check_wordpress_versions.php ${{ env.MAX_PHP_VERSION }}
 
       - name: Check for WordPress changes
         id: check_wp_changes


### PR DESCRIPTION
## Description

Add a check for PHP version, so the GitHub action doesn't bump WordPress image to an [unsupported PHP version](https://github.com/mailpoet/mailpoet/pull/6144/commits/1712a4f32458c4716897f26198f433312a370458). 

## Code review notes

Notice the `Latest version` in these two outputs, based on the provided max PHP version as an argument.

```bash
$ php .github/workflows/scripts/check_wordpress_versions.php 8.4
Using maximum PHP version: 8.4
Fetching WordPress versions...
Fetching page 1...
Fetching page 2...
Fetching page 3...
Fetching page 4...
Latest version: 6.7.2-php8.4
Previous version: 6.6.2-php8.1
Replacing the latest version in the docker file...
Replacing the previous version in the config file...
Nothing to update in /Users/neosinner/Projects/mailpoet/mailpoet/.github/workflows/scripts./../../../.circleci/config.yml


$ php .github/workflows/scripts/check_wordpress_versions.php 8.3
Using maximum PHP version: 8.3
Fetching WordPress versions...
Fetching page 1...
Fetching page 2...
Fetching page 3...
Fetching page 4...
Latest version: 6.7.2-php8.3
Previous version: 6.6.2-php8.1
Replacing the latest version in the docker file...
Replacing the previous version in the config file...
Nothing to update in /Users/neosinner/Projects/mailpoet/mailpoet/.github/workflows/scripts./../../../.circleci/config.yml
```

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7379

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7379-prevent-auto-bumping-tests-docker-images-to-unsupported-php)

_The latest successful build from `stomail-7379-prevent-auto-bumping-tests-docker-images-to-unsupported-php` will be used. If none is available, the link won't work._