### PR TITLE
Add link to changelog entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ _N/A_
 
 ## Tasks
 
-- [ ] I have added a changelog entry
+- [ ] I have added a [changelog entry](https://wp.me/pcNwfB-4Ov/#how-to-write-a-changelog)
 - [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
 - [ ] I added sufficient test coverage
 - [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:changelog-entry)

_The latest successful build from `changelog-entry` will be used. If none is available, the link won't work._