### PR TITLE
Update notice when editing active automation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ _N/A_
 
 ## Tasks
 
-- [ ] I have added a [changelog entry](https://wp.me/pcNwfB-4Ov/#how-to-write-a-changelog)
+- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
 - [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
 - [ ] I added sufficient test coverage
 - [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -55,7 +55,7 @@ export function ActivateButton({ label }): JSX.Element {
       <Tooltip
         delay={0}
         text={__(
-          'Editing an active automation is temporarily unavailable. We are working on introducing this functionality.',
+          'Editing an active automation is currently unavailable.',
           'mailpoet',
         )}
       >
@@ -106,7 +106,7 @@ export function UpdateButton(): JSX.Element {
     <Tooltip
       delay={0}
       text={__(
-        'Editing an active automation is temporarily unavailable. We are working on introducing this functionality.',
+        'Editing an active automation is currently unavailable.',
         'mailpoet',
       )}
     >

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -59,10 +59,7 @@ function updatingActiveAutomationNotPossible() {
   const { createNotice } = dispatch(noticesStore);
   void createNotice(
     'success',
-    __(
-      'Editing an active automation is temporarily unavailable. We are working on introducing this functionality.',
-      'mailpoet',
-    ),
+    __('Editing an active automation is currently unavailable.', 'mailpoet'),
     {
       type: 'snackbar',
     },


### PR DESCRIPTION
## Description

Update messaging when editing active automation so it doesn't imply this functionality is work-in-progress.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7382

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7382-update-notice-when-editing-active-automation)

_The latest successful build from `stomail-7382-update-notice-when-editing-active-automation` will be used. If none is available, the link won't work._