### PR TITLE
[STOMAIL-7385] Fix tests for WooCommerce 9.8 and WP 6.8

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -522,6 +522,12 @@ class AcceptanceTester extends \Codeception\Actor {
    */
   public function orderProduct(array $product, $userEmail, $doRegister = true, $doSubscribe = true) {
     $i = $this;
+    // Reset WooCommerce session cookies to avoid conflicts with previous tests
+    $wcSessionCookies = $i->grabCookiesWithPattern('/^wp_woocommerce_session_[a-z0-9]+$/') ?: [];
+    foreach ($wcSessionCookies as $cookie) {
+      $i->resetCookie($cookie->getName());
+    }
+
     $i->amOnPage('checkout/?add-to-cart=' . $product['id']);
     $i->fillCustomerInfo($userEmail);
 

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -505,7 +505,9 @@ class AcceptanceTester extends \Codeception\Actor {
 
   public function getWordPressVersion(): string {
     $i = $this;
-    return $i->cliToString(['core', 'version']);
+    $version = $i->cliToString(['core', 'version']);
+    // Clean version from beta and RC strings
+    return preg_replace('/[- ]?(beta|RC|alpha)[0-9]*/i', '', $version);
   }
 
   public function orderProductWithoutRegistration(array $product, $userEmail, $doSubscribe = true) {

--- a/packages/js/email-editor/src/components/sidebar/sidebar.tsx
+++ b/packages/js/email-editor/src/components/sidebar/sidebar.tsx
@@ -51,7 +51,6 @@ function SidebarContent( props: Props ) {
 			}
 			icon={ drawerRight }
 			scope={ storeName }
-			smallScreenTitle={ __( 'No title', 'mailpoet' ) }
 			isActiveByDefault
 			{ ...props }
 		>

--- a/packages/js/email-editor/src/components/styles-sidebar/index.scss
+++ b/packages/js/email-editor/src/components/styles-sidebar/index.scss
@@ -4,6 +4,7 @@
 	height: 100%;
 
 	.components-panel,
+	.components-navigator,
 	.components-navigator-provider,
 	.components-navigator-screen {
 		height: 100%;

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -34,7 +34,6 @@ export function RawStylesSidebar( props: Props ): JSX.Element {
 			closeLabel={ __( 'Close styles sidebar', 'mailpoet' ) }
 			icon={ styles }
 			scope={ storeName }
-			smallScreenTitle={ __( 'No title', 'mailpoet' ) }
 			{ ...props }
 		>
 			<NavigatorProvider initialPath="/">

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -170,7 +170,13 @@ class Email_Editor {
 			'show_ui'                => true,
 			'show_in_menu'           => false,
 			'show_in_nav_menus'      => false,
-			'supports'               => array( 'editor', 'title', 'custom-fields' ), // 'custom-fields' is required for loading meta fields via API.
+			'supports'               => array(
+				'editor' => array(
+					'default-mode' => 'template-locked',
+				),
+				'title',
+				'custom-fields', // 'custom-fields' is required for loading meta fields via API.
+			),
 			'has_archive'            => true,
 			'show_in_rest'           => true, // Important to enable Gutenberg editor.
 			'default_rendering_mode' => 'template-locked',


### PR DESCRIPTION
## Description

This PR fixes tests related to WooCommerce and the compatibility of the new email editor with WP 6.8.
- In some cases, the WooCommerce cart was empty, and after long testing, I found that this was caused by the cookie `wp_woocommerce_session_*`. Resetting this cookie solved this issue.
- I fixed compatibility of the new email editor with WP 6.8 because some tests were also failing.
- Because we use RC and Beta versions of WP, I added code removing the `beta` and `RC` strings from the version string to avoid test failures when we use them in comparison.

## Code review notes

_N/A_

## QA notes

[Here](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20561/workflows/ff27590e-8f33-488b-bed3-5ff97f74459e) is a testing job which passed.

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7385

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-woocomerce-9-8-tests)

_The latest successful build from `fix-woocomerce-9-8-tests` will be used. If none is available, the link won't work._