### PR TITLE
Fix failing AdminUserSubscriptionCest in multisite environment

### DIFF
--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -13,10 +13,14 @@ class AdminUserSubscriptionCest {
   /** @var string */
   private $testEmailPrefix;
 
+  /** @var string */
+  private $successMessage;
+
   public function _before() {
     $this->settings = new Settings();
     // Unique email prefix to avoid collisions between test runs
     $this->testEmailPrefix = 'admin_user_test_' . uniqid() . '_';
+    $this->successMessage = getenv('MULTISITE') ? 'User has been added to your site.' : 'New user created';
   }
 
   /**
@@ -233,6 +237,6 @@ class AdminUserSubscriptionCest {
     }
 
     $i->click('#createusersub');
-    $i->waitForText('New user created', 20); // Increase timeout to 20 seconds for user creation
+    $i->waitForText($this->successMessage, 20);
   }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -80,23 +80,7 @@ class AdminUserSubscriptionCest {
     // Test default (unsubscribed) status when confirmation is disabled
     $emailUnsubscribed = $this->testEmailPrefix . 'default_unsub@example.com';
 
-    // Generate a strong password for WordPress user creation
-    $strongPassword = 'V3ryStr0ngP@ssw0rd!' . uniqid();
-
-    $i->amOnAdminPage('user-new.php');
-    $i->waitForText('Add New User');
-    $i->fillField('#user_login', 'default_unsub_user');
-    $i->fillField('#email', $emailUnsubscribed);
-    $i->fillField('#pass1', $strongPassword);
-    // Setting "send user notification" to unchecked to avoid extra emails
-    $i->uncheckOption('#send_user_notification');
-
-    // Wait for the page to be fully loaded before submission
-    $i->wait(1);
-
-    // Submit the form to create user
-    $i->click('#createusersub');
-    $i->waitForText('New user created', 20);
+    $this->createUserWithStatus($i, 'defaultunsubuser', $emailUnsubscribed);
 
     // Verify user was created as an unsubscribed subscriber (default when confirmation disabled)
     $i->amOnMailPoetPage('Subscribers');
@@ -203,23 +187,8 @@ class AdminUserSubscriptionCest {
 
     // Create user with unconfirmed status and send notification enabled
     $emailUnconfirmed = $this->testEmailPrefix . 'notification_test@example.com';
-    $username = 'notification_test_user';
-
-    $i->amOnAdminPage('user-new.php');
-    $i->waitForText('Add New User');
-    $i->fillField('#user_login', $username);
-    $i->fillField('#email', $emailUnconfirmed);
-    $i->fillField('#pass1', 'V3ryStr0ngP@ssw0rd!23456');
-
-    // Select unconfirmed subscriber status
-    $i->selectOption('#mailpoet_subscriber_status', 'Unconfirmed (will receive a confirmation email)');
-
-    // Ensure notification checkbox is checked
-    $i->uncheckOption('#send_user_notification');
-
-    // Submit the form to create user
-    $i->click('#createusersub');
-    $i->waitForText('New user created', 20);
+    $username = 'notificationtestuser';
+    $this->createUserWithStatus($i, $username, $emailUnconfirmed, SubscriberEntity::STATUS_UNCONFIRMED);
 
     // Verify user was created as an unconfirmed subscriber
     $i->amOnMailPoetPage('Subscribers');
@@ -238,7 +207,7 @@ class AdminUserSubscriptionCest {
   /**
    * Helper method to create a user with a specific status
    */
-  private function createUserWithStatus(\AcceptanceTester $i, $username, $email, $status, $firstName = null, $lastName = null) {
+  private function createUserWithStatus(\AcceptanceTester $i, $username, $email, $status = null, $firstName = null, $lastName = null) {
     $i->amOnAdminPage('user-new.php');
     $i->waitForText('Add New User');
     $i->fillField('#user_login', $username);

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -33,7 +33,7 @@ class AdminUserSubscriptionCest {
 
     // Test Unconfirmed status (should be default when confirmation is enabled)
     $emailUnconfirmed = $this->testEmailPrefix . 'unconfirmed@example.com';
-    $this->createUserWithStatus($i, 'unconfirmed_user', $emailUnconfirmed, SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->createUserWithStatus($i, 'unconfirmeduser', $emailUnconfirmed, SubscriberEntity::STATUS_UNCONFIRMED);
 
     // Verify user was created as an unconfirmed subscriber
     $i->amOnMailPoetPage('Subscribers');
@@ -46,7 +46,7 @@ class AdminUserSubscriptionCest {
 
     // Test Subscribed status
     $emailSubscribed = $this->testEmailPrefix . 'subscribed@example.com';
-    $this->createUserWithStatus($i, 'subscribed_user', $emailSubscribed, SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->createUserWithStatus($i, 'subscribeduser', $emailSubscribed, SubscriberEntity::STATUS_SUBSCRIBED);
 
     // Verify user was created as a subscribed subscriber
     $i->amOnMailPoetPage('Subscribers');
@@ -56,7 +56,7 @@ class AdminUserSubscriptionCest {
 
     // Test Unsubscribed status
     $emailUnsubscribed = $this->testEmailPrefix . 'unsubscribed@example.com';
-    $this->createUserWithStatus($i, 'unsubscribed_user', $emailUnsubscribed, SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->createUserWithStatus($i, 'unsubscribeduser', $emailUnsubscribed, SubscriberEntity::STATUS_UNSUBSCRIBED);
 
     // Verify user was created as an unsubscribed subscriber
     $i->amOnMailPoetPage('Subscribers');
@@ -106,7 +106,7 @@ class AdminUserSubscriptionCest {
 
     // Test Subscribed status
     $emailSubscribed = $this->testEmailPrefix . 'sub_noconfirm@example.com';
-    $this->createUserWithStatus($i, 'sub_noconfirm_user', $emailSubscribed, SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->createUserWithStatus($i, 'subnoconfirmuser', $emailSubscribed, SubscriberEntity::STATUS_SUBSCRIBED);
 
     // Verify user was created as a subscribed subscriber
     $i->amOnMailPoetPage('Subscribers');
@@ -168,7 +168,7 @@ class AdminUserSubscriptionCest {
     $wpFirstName = 'WP_First_Name_' . uniqid();
     $wpLastName = 'WP_Last_Name_' . uniqid();
     $i->comment('Creating WordPress user with same email but different name');
-    $this->createUserWithStatus($i, 'wp_user_name', $subscriberEmail, SubscriberEntity::STATUS_SUBSCRIBED, $wpFirstName, $wpLastName);
+    $this->createUserWithStatus($i, 'wpusername', $subscriberEmail, SubscriberEntity::STATUS_SUBSCRIBED, $wpFirstName, $wpLastName);
 
     // Verify the subscriber data was updated to match WordPress user data
     $i->amOnMailPoetPage('Subscribers');

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -236,6 +236,11 @@ class AdminUserSubscriptionCest {
       $i->fillField('#last_name', $lastName);
     }
 
+    // Skip sending confirmation email to create WP user in Multisite
+    if (getenv('MULTISITE')) {
+      $i->checkOption('#noconfirmation');
+    }
+
     $i->click('#createusersub');
     $i->waitForText($this->successMessage, 20);
   }

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -156,7 +156,13 @@ class AdminUserSubscriptionCest {
     $wpFirstName = 'WP_First_Name_' . uniqid();
     $wpLastName = 'WP_Last_Name_' . uniqid();
     $i->comment('Creating WordPress user with same email but different name');
-    $this->createUserWithStatus($i, 'wpusername', $subscriberEmail, SubscriberEntity::STATUS_SUBSCRIBED, $wpFirstName, $wpLastName);
+    $this->createUserWithStatus($i, 'wpusername', $subscriberEmail, SubscriberEntity::STATUS_SUBSCRIBED);
+    $i->click('Edit user');
+
+    $i->fillField('#first_name', $wpFirstName);
+    $i->fillField('#last_name', $wpLastName);
+    $i->click('#submit');
+    $i->waitForText('User updated', 20);
 
     // Verify the subscriber data was updated to match WordPress user data
     $i->amOnMailPoetPage('Subscribers');
@@ -211,7 +217,7 @@ class AdminUserSubscriptionCest {
   /**
    * Helper method to create a user with a specific status
    */
-  private function createUserWithStatus(\AcceptanceTester $i, $username, $email, $status = null, $firstName = null, $lastName = null) {
+  private function createUserWithStatus(\AcceptanceTester $i, $username, $email, $status = null) {
     $i->amOnAdminPage('user-new.php');
     $i->waitForText('Add New User');
     $i->fillField('#user_login', $username);
@@ -226,14 +232,6 @@ class AdminUserSubscriptionCest {
 
     if (isset($statusOptionsMap[$status])) {
       $i->selectOption('#mailpoet_subscriber_status', $statusOptionsMap[$status]);
-    }
-
-    if ($firstName) {
-      $i->fillField('#first_name', $firstName);
-    }
-
-    if ($lastName) {
-      $i->fillField('#last_name', $lastName);
     }
 
     // Skip sending confirmation email to create WP user in Multisite

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -212,9 +212,6 @@ class AdminUserSubscriptionCest {
     $i->waitForText('Add New User');
     $i->fillField('#user_login', $username);
     $i->fillField('#email', $email);
-    $i->fillField('#pass1', 'V3ryStr0ngP@ssw0rd!23456');
-    // Setting "send user notification" to unchecked to avoid extra emails
-    $i->uncheckOption('#send_user_notification');
 
     // Select the requested subscriber status
     $statusOptionsMap = [


### PR DESCRIPTION
## Description

When adding a new user in a multisite environment, there are different fields, and also the success notices differ. This PR updates the test while keeping the same test coverage. [Failing test](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20565/workflows/dd8428c1-b940-415d-b804-ef3f6b58b72b/jobs/352935).

## Code review notes

_N/A_

## QA notes

Here is a [successful CI run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20570/workflows/c2ccf513-e380-4f70-9396-5268fc151707) including multisite tests.  

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7387

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7387-failing-adminusersubscriptioncest-in-multisite-environment)

_The latest successful build from `stomail-7387-failing-adminusersubscriptioncest-in-multisite-environment` will be used. If none is available, the link won't work._