### PR TITLE
Fix font color for lists int rendered emails [STOMAIL-7386]

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
@@ -110,9 +110,19 @@ class StylesHelper {
       $block['styles']['block']['textAlign'] = 'left';
       return $block;
     }
-    return (preg_match('/text-align.*?[center|justify|right]/i', (string)$block)) ?
-      $block :
-      $block . 'text-align:left;';
+
+    // Check if text-align is already set to center, right, or justify
+    if (preg_match('/text-align\s*:\s*(center|justify|right)/i', (string)$block)) {
+      return $block;
+    }
+
+    // Ensure semicolon at the end before appending
+    $block = rtrim((string)$block);
+    if (strlen($block) > 0 && substr($block, -1) !== ';') {
+      $block .= ';';
+    }
+
+    return $block . 'text-align:left;';
   }
 
   /**

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -225,5 +225,6 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 = x.x.x - YYYY-MM-DD =
 * Added: ability to set subscriber status when creating new users in WordPress admin;
 * Improved: plugin release process.
+* Fixed: possible invalid styles in HTML list elements
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
@@ -86,4 +86,18 @@ class StylesHelperTest extends \MailPoetUnitTest {
     verify($styles)->stringContainsString('line-height:18.7px;');
     verify($styles)->stringContainsString('mso-line-height-alt:20px;');
   }
+
+  public function testItAppendsTextAlignmentWithSemicolon(): void {
+    $blockWithoutSemicolon = "color: #000000";
+    verify(StylesHelper::applyTextAlignment($blockWithoutSemicolon))
+      ->equals("color: #000000;text-align:left;");
+
+    $blockWithSemicolon = "color: #000000; ";
+    verify(StylesHelper::applyTextAlignment($blockWithSemicolon))
+      ->equals("color: #000000;text-align:left;");
+
+    $blockWithExtraSpaces = "color: #000000; font-size: 16px;  ";
+    verify(StylesHelper::applyTextAlignment($blockWithExtraSpaces))
+      ->equals("color: #000000; font-size: 16px;text-align:left;");
+  }
 }


### PR DESCRIPTION
## Description

This PR fixes invalid rendering affecting web-based email clients such as G Suite or Outlook.com. The list content in a paragraph was not visible due to invalid styles for the list item:
```
<li class="mailpoet_paragraph" style="mso-ansi-font-size:16px;color:#fffffftext-align:left;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:22.4px;mso-line-height-alt:22px;margin-bottom:10px">
```
Note: See the color value.
## Code review notes

_N/A_

## QA notes

Steps to Reproduce on trunk

1. Create a new email.
2. Insert a paragraph and use a list for the content.
3. Set some color for the paragraph.
4. Open the email preview in a new tab.
5. Check the styles for the HTML element <li> and observe the invalid styles.

When you check out this branch, the styles for li elements should be okay.

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7386

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-list-color-in-emails)

_The latest successful build from `fix-list-color-in-emails` will be used. If none is available, the link won't work._