### PR TITLE
Fix failing nightly integration test.

### DIFF
--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -864,12 +864,12 @@ class RendererTest extends \MailPoetTest {
       'featuredImagePosition' => 'left',
       'readMoreType' => 'button',
       'readMoreText' => 'Read more',
-      'readMoreButton' => array(
+      'readMoreButton' => [
         'type' => 'button',
         'text' => 'Read the post',
         'url' => '[postLink]',
-        'styles' => array(
-          'block' => array(
+        'styles' => [
+          'block' => [
             'backgroundColor' => '#2ea1cd',
             'borderColor' => '#0074a2',
             'borderWidth' => '1px',
@@ -882,22 +882,22 @@ class RendererTest extends \MailPoetTest {
             'fontSize' => '16px',
             'fontWeight' => 'normal',
             'textAlign' => 'center',
-          ),
-        ),
-      ),
+          ],
+        ],
+      ],
       'showDivider' => true,
-      'divider' => array(
+      'divider' => [
         'type' => 'divider',
-        'styles' => array(
-          'block' => array(
+        'styles' => [
+          'block' => [
             'backgroundColor' => 'transparent',
             'padding' => '13px',
             'borderStyle' => 'solid',
             'borderWidth' => '3px',
             'borderColor' => '#aaaaaa',
-          ),
-        ),
-      ),
+          ],
+        ],
+      ],
     ];
 
     $newsletter->setBody([

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -828,16 +828,18 @@ class RendererTest extends \MailPoetTest {
 
     // Create test products
     $wp = $this->diContainer->get(\MailPoet\WP\Functions::class);
-    $productIds = [];
-    $productIds[] = $wp->wpInsertPost([
-      'post_title' => 'Test Product 1',
-      'post_status' => 'publish',
-      'post_type' => 'product',
+
+    // Create a published product using the tester
+    $this->tester->createWooCommerceProduct([
+      'name' => 'Test Product 1',
+      'status' => 'publish',
+      'price' => '10.00',
     ]);
-    $productIds[] = $wp->wpInsertPost([
-      'post_title' => 'Test Product 2',
-      'post_status' => 'publish',
-      'post_type' => 'product',
+
+    $this->tester->createWooCommerceProduct([
+      'name' => 'Test Product 2',
+      'status' => 'publish',
+      'price' => '10.00',
     ]);
 
     // Create a newsletter with a dynamic products block
@@ -860,6 +862,42 @@ class RendererTest extends \MailPoetTest {
       'imageFullWidth' => true,
       'titlePosition' => 'abovePost',
       'featuredImagePosition' => 'left',
+      'readMoreType' => 'button',
+      'readMoreText' => 'Read more',
+      'readMoreButton' => array(
+        'type' => 'button',
+        'text' => 'Read the post',
+        'url' => '[postLink]',
+        'styles' => array(
+          'block' => array(
+            'backgroundColor' => '#2ea1cd',
+            'borderColor' => '#0074a2',
+            'borderWidth' => '1px',
+            'borderRadius' => '5px',
+            'borderStyle' => 'solid',
+            'width' => '160px',
+            'lineHeight' => '30px',
+            'fontColor' => '#ffffff',
+            'fontFamily' => 'Verdana',
+            'fontSize' => '16px',
+            'fontWeight' => 'normal',
+            'textAlign' => 'center',
+          ),
+        ),
+      ),
+      'showDivider' => true,
+      'divider' => array(
+        'type' => 'divider',
+        'styles' => array(
+          'block' => array(
+            'backgroundColor' => 'transparent',
+            'padding' => '13px',
+            'borderStyle' => 'solid',
+            'borderWidth' => '3px',
+            'borderColor' => '#aaaaaa',
+          ),
+        ),
+      ),
     ];
 
     $newsletter->setBody([
@@ -901,11 +939,6 @@ class RendererTest extends \MailPoetTest {
 
     // Render the newsletter
     $template = $this->renderer->render($newsletter);
-
-    // Clean up test products
-    foreach ($productIds as $productId) {
-      $wp->wpDeletePost($productId, true);
-    }
 
     // Verify the products are rendered
     verify(isset($template['html']))->true();


### PR DESCRIPTION

## Description

Fix the failing nightly integration test.

The tests were failing for the following reasons
* DynamicProducts::getPosts was not fetching WC products because they were not defined correctly.
* The renderer requires some arguments like showDivider, etc, that were not included in the object definition.

Related to https://github.com/mailpoet/mailpoet/pull/6151

## Code review notes

_N/A_

## QA notes

We can skip QA.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-nightly-test)

_The latest successful build from `fix-nightly-test` will be used. If none is available, the link won't work._