### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           name: Download additional WP Plugins for tests
           command: |
             ./do download:woo-commerce-zip 9.8.1
-            ./do download:woo-commerce-subscriptions-zip 7.3.1
+            ./do download:woo-commerce-subscriptions-zip 7.4.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.10
       - run:
@@ -1183,7 +1183,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_oldest
           woo_core_version: 9.7.1
-          woo_subscriptions_version: 7.2.1
+          woo_subscriptions_version: 7.3.1
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.5
@@ -1223,7 +1223,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           woo_core_version: 9.7.1
-          woo_subscriptions_version: 7.2.1
+          woo_subscriptions_version: 7.3.1
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1285,7 +1285,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
           woo_core_version: 9.7.1
-          woo_subscriptions_version: 7.2.1
+          woo_subscriptions_version: 7.3.1
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1296,7 +1296,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
           woo_core_version: 9.7.1
-          woo_subscriptions_version: 7.2.1
+          woo_subscriptions_version: 7.3.1
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1189,7 +1189,7 @@ workflows:
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           requires:
             - build
       - performance_tests:
@@ -1227,7 +1227,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.5
           requires:
@@ -1289,7 +1289,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           requires:
             - build_premium
       - integration_tests:
@@ -1300,7 +1300,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.5
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             ./do download:woo-commerce-zip 9.8.1
             ./do download:woo-commerce-subscriptions-zip 7.3.1
             ./do download:woo-commerce-memberships-zip
-            ./do download:automate-woo-zip 6.1.9
+            ./do download:automate-woo-zip 6.1.10
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |

--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -9,7 +9,6 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\Subscriber;
-use Throwable;
 
 class SwitchingLanguagesCest {
   public function _before(\AcceptanceTester $i) {
@@ -159,14 +158,5 @@ class SwitchingLanguagesCest {
     $i->wantTo('Check some Settings strings');
     $i->waitForText('Standardabsender');
     $i->waitForText('Einstellungen speichern');
-  }
-
-  public function _after(AcceptanceTester $i) {
-    try {
-      $i->cli(['language', 'core', 'uninstall', 'de_DE']);
-      $i->cli(['language', 'plugin', 'uninstall', 'mailpoet', 'de_DE']);
-    } catch (Throwable $e) {
-      // language already uninstalled
-    }
   }
 }

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -104,7 +104,11 @@ class AdminUserSubscriptionCest {
 
     // Verify the Unconfirmed option is not available when confirmation is disabled
     $i->amOnAdminPage('user-new.php');
-    $i->waitForText('Add New User');
+    try {
+      $i->waitForText('Add User'); // WP 6.8+
+    } catch (\Exception $e) {
+      $i->waitForText('Add New User'); // WP 6.7 and below;
+    }
     $i->waitForText('MailPoet Subscriber Status');
     $i->dontSee('Unconfirmed (will receive a confirmation email)');
   }
@@ -219,7 +223,11 @@ class AdminUserSubscriptionCest {
    */
   private function createUserWithStatus(\AcceptanceTester $i, $username, $email, $status = null) {
     $i->amOnAdminPage('user-new.php');
-    $i->waitForText('Add New User');
+    try {
+      $i->waitForText('Add User'); // WP 6.8+
+    } catch (\Exception $e) {
+      $i->waitForText('Add New User'); // WP 6.7 and below;
+    }
     $i->fillField('#user_login', $username);
     $i->fillField('#email', $email);
 

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -144,6 +144,11 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
   wp plugin activate woocommerce-memberships --url=$ACTIVATION_CONTEXT
   wp plugin activate automatewoo --url=$ACTIVATION_CONTEXT
 
+  # patch WooCommerce CLI issue https://github.com/woocommerce/woocommerce/pull/57291
+  # This can be removed once WooCommerce 9.9.0 is released
+  WOO_CLI_FILE="/wp-core/wp-content/plugins/woocommerce/includes/class-wc-cli.php"
+  sed -i "s/FeaturesUtil::feature_is_enabled( 'blueprint' )/false/g" "$WOO_CLI_FILE"
+
   # print info about activated plugins
   wp plugin get woocommerce --url=$ACTIVATION_CONTEXT
   wp plugin get woocommerce-subscriptions --url=$ACTIVATION_CONTEXT

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -192,6 +192,9 @@ if [[ $BLOCKBASED_THEME == "1" ]]; then
   wp theme install twentytwentyfour --activate
 fi
 
+# Install German language for testing in foreign languages
+wp language core install de_DE
+
 # Remove Doctrine Annotations (they are not needed since generated metadata are packed)
 # We want to remove them for tests to make sure they are really not needed
 if [[ $TEST_TYPE == "acceptance" ]] && [[ $CIRCLE_JOB ]]; then

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.7.2-php8.3}
+    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.8.0-php8.3}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Note for code reviewer

I had to add a couple of fixes to make the tests pass on WordPress 6.8.
Please see the explanation in the commit messages.

The issue with failing mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php was also fixable by making the wait time longer, and WordPress eventually installed translations in like 30 seconds, but I chose the solution with preinstalling the DE language during bootstrapping.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._