### PR TITLE
Fix missing changelog in Slack and GitHub notifications during release

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1250,7 +1250,7 @@ class RoboFile extends \Robo\Tasks {
     $changelog = $this->getChangelogController()->get($version);
 
     $githubController = $this->createGitHubController();
-    $githubController->publishRelease($version, $changelog[1], self::ZIP_BUILD_PATH);
+    $githubController->publishRelease($version, $changelog, self::ZIP_BUILD_PATH);
     $this->say("Release '$version' was published to GitHub.");
   }
 
@@ -1259,7 +1259,7 @@ class RoboFile extends \Robo\Tasks {
     $changelog = $this->getChangelogController()->get($version);
 
     $slackNotifier = $this->createSlackNotifier();
-    $slackNotifier->notify($version, $changelog[1]);
+    $slackNotifier->notify($version, $changelog);
     $this->say("Release '$version' info was published on Slack.");
   }
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7393

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7393-missing-changelog-in-slack-and-github-notifications)

_The latest successful build from `stomail-7393-missing-changelog-in-slack-and-github-notifications` will be used. If none is available, the link won't work._