### PR TITLE
Add missing translation

### DIFF
--- a/mailpoet/assets/js/src/notices/mailer-error.tsx
+++ b/mailpoet/assets/js/src/notices/mailer-error.tsx
@@ -26,11 +26,19 @@ const resumeMailerSending = () =>
 function PHPMailerCheckSettingsNotice() {
   return (
     <>
-      <p>{MailPoet.I18n.t('mailerSendErrorCheckConfiguration')}</p>
+      <p>
+        {__(
+          'Please check your sending method configuration, you may need to consult with your hosting company.',
+          'mailpoet',
+        )}
+      </p>
       <br />
       <p>
         {ReactStringReplace(
-          MailPoet.I18n.t('mailerSendErrorUseSendingService'),
+          __(
+            'The easy alternative is to <b>send emails with MailPoet Sending Service</b> instead, like thousands of other users do.',
+            'mailpoet',
+          ),
           /<b>(.*?)<\/b>/g,
           (match, key) => (
             <b key={key}>{match}</b>
@@ -45,7 +53,7 @@ function PHPMailerCheckSettingsNotice() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          {MailPoet.I18n.t('mailerSendErrorSignUpForSendingService')}
+          {__('Sign up for free in minutes', 'mailpoet')}
         </a>
       </p>
       <br />
@@ -57,7 +65,7 @@ function MailerCheckSettingsNotice() {
   return (
     <p>
       {ReactStringReplace(
-        MailPoet.I18n.t('mailerCheckSettingsNotice'),
+        __('Check your [link]sending method settings[/link].', 'mailpoet'),
         /\[link\](.*?)\[\/link\]/g,
         (match) => (
           <a href="?page=mailpoet-settings#mta" key="check-sending">

--- a/mailpoet/assets/js/src/notices/transactional-emails-propose-opt-in-notice.tsx
+++ b/mailpoet/assets/js/src/notices/transactional-emails-propose-opt-in-notice.tsx
@@ -1,3 +1,4 @@
+import { __, _x } from '@wordpress/i18n';
 import { useState } from 'react';
 import { Notice } from 'notices/notice';
 import { MailPoet } from 'mailpoet';
@@ -49,20 +50,34 @@ function TransactionalEmailsProposeOptInNotice({
 
   return (
     <Notice type="success" timeout={false} onClose={saveNoticeDismissed}>
-      <h3>{MailPoet.I18n.t('transactionalEmailNoticeTitle')}</h3>
+      <h3>
+        {__(
+          'Good news! MailPoet can now send your website’s emails too',
+          'mailpoet',
+        )}
+      </h3>
       <p>
-        {MailPoet.I18n.t('transactionalEmailNoticeBody')}{' '}
+        {__(
+          'All of your WordPress and WooCommerce emails are sent with your hosting company, unless you have an SMTP plugin. Would you like such emails to be delivered with MailPoet’s active sending method for better deliverability?',
+          'mailpoet',
+        )}{' '}
         <a
           href="https://kb.mailpoet.com/article/292-choose-how-to-send-your-wordpress-websites-emails"
           target="_blank"
           rel="noopener noreferrer"
         >
-          {MailPoet.I18n.t('transactionalEmailNoticeBodyReadMore')}
+          {
+            // translators: This is a link that leads to more information about transactional emails
+            __('Read more.', 'mailpoet')
+          }
         </a>
       </p>
       <p>
         <button type="button" className="button" onClick={enable}>
-          {MailPoet.I18n.t('transactionalEmailNoticeCTA')}
+          {
+            // translators: Button, after clicking it we will enable transactional emails
+            _x('Enable', 'verb', 'mailpoet')
+          }
         </button>
       </p>
     </Notice>

--- a/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
+++ b/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 import { MailPoet } from 'mailpoet';
 import { extractEmailDomain } from 'common/functions';
@@ -47,7 +48,7 @@ const resumeMailerSending = () => {
     action: 'resumeSending',
   })
     .done(() => {
-      MailPoet.Notice.success(MailPoet.I18n.t('mailerSendingResumedNotice'));
+      MailPoet.Notice.success(__('Sending has been resumed.', 'mailpoet'));
     })
     .fail((response: ErrorResponse) => {
       if (response.errors.length > 0) {

--- a/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
+++ b/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
@@ -61,7 +61,10 @@ const resumeSendingIfAuthorized = (fromAddress: string | null) =>
   isValidFromAddress(fromAddress).then((valid) => {
     if (!valid) {
       MailPoet.Notice.error(
-        MailPoet.I18n.t('mailerSendingNotResumedUnauthorized'),
+        __(
+          'Failed to resume sending because the email address is unauthorized. Please authorize it and try again.',
+          'mailpoet',
+        ),
         { scroll: true },
       );
       MailPoet.trackEvent('Unauthorized email used', {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -117,9 +117,6 @@
   'updateMailPoetNotice': __('[link]Update MailPoet[/link] to see the latest changes'),
   'ajaxFailedErrorMessage': __('An error has happened while performing a request, the server has responded with response code %d'),
   'ajaxTimeoutErrorMessage': __('An error has happened while performing a request, the server request has timed out after %d seconds'),
-  'senderEmailAddressWarning1': _x('You might not reach the inbox of your subscribers if you use this email address.', 'In the last step, before sending a newsletter. URL: ?page=mailpoet-newsletters#/send/2'),
-  'senderEmailAddressWarning3': _x('Read more.'),
-  'mailerSendingNotResumedUnauthorized': __('Failed to resume sending because the email address is unauthorized. Please authorize it and try again.'),
   'dismissNotice': __('Dismiss this notice.'),
   'confirmEdit': __('Sending is in progress. Do you want to pause sending and edit the newsletter?'),
   'confirmAutomaticNewsletterEdit': __('To edit this email, it needs to be deactivated. You can activate it again after you make the changes.'),
@@ -162,23 +159,6 @@
 
   'bridgePingErrorHeader': __('There is an issue with the connection to the MailPoet Sending Service'),
   'systemStatusMSSConnectionCanNotConnect': __('Currently, your installation can not reach the sending service. If you want to use our service please consult our [link]knowledge base article[/link] for troubleshooting tips.'),
-
-  'transactionalEmailNoticeTitle': __('Good news! MailPoet can now send your website’s emails too'),
-  'transactionalEmailNoticeBody': __('All of your WordPress and WooCommerce emails are sent with your hosting company, unless you have an SMTP plugin. Would you like such emails to be delivered with MailPoet’s active sending method for better deliverability?'),
-  'transactionalEmailNoticeBodyReadMore': _x('Read more.', 'This is a link that leads to more information about transactional emails'),
-  'transactionalEmailNoticeCTA': _x('Enable', 'Button, after clicking it we will enable transactional emails'),
-
-  'mailerSendErrorNotice': __('Sending has been paused due to a technical issue with %1$s'),
-  'mailerSendErrorCheckConfiguration': __('Please check your sending method configuration, you may need to consult with your hosting company.'),
-  'mailerSendErrorUseSendingService': __('The easy alternative is to <b>send emails with MailPoet Sending Service</b> instead, like thousands of other users do.'),
-  'mailerSendErrorSignUpForSendingService': __('Sign up for free in minutes'),
-  'mailerConnectionErrorNotice': __('Sending is paused because the following connection issue prevents MailPoet from delivering emails'),
-  'mailerErrorCode': __('Error code: %1$s'),
-  'mailerCheckSettingsNotice': __('Check your [link]sending method settings[/link].'),
-  'mailerResumeSendingButton': __('Resume sending'),
-  'mailerResumeSendingAfterUpgradeButton': __('I have upgraded my subscription, resume sending'),
-
-  'topBarLogoTitle': __('Back to section root'),
 
   'close': __('Close'),
   'today': __('Today'),


### PR DESCRIPTION
## Description

Add missing `mailerSendingResumedNotice` and refactor a couple of related strings.

## Code review notes

_N/A_

## QA notes

Please try to trigger all changed notices to ensure they still render correctly. 

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7300

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7300-missing-translation-mailersendingresumednotice)

_The latest successful build from `stomail-7300-missing-translation-mailersendingresumednotice` will be used. If none is available, the link won't work._