### PR TITLE
Update WordPress version in oldest tests in nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1189,7 +1189,7 @@ workflows:
           mysql_image: mysql:5.5
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           requires:
             - build
       - performance_tests:
@@ -1227,7 +1227,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.5
           requires:
@@ -1289,7 +1289,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           requires:
             - build_premium
       - integration_tests:
@@ -1300,7 +1300,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.6.2
+          wordpress_version: 6.7.2
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.5
           requires:


### PR DESCRIPTION
## Description

After updating the minimal required WP version, the oldest tests started failing because they were configured to use an older WP.
This PR updates the versions.

## Code review notes

Here is a test run with the oldest tests: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20645/workflows/a6cc8836-4dc0-4aa3-8c5d-71a8fbca9847

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-wp-oldest-tests)

_The latest successful build from `update-wp-oldest-tests` will be used. If none is available, the link won't work._