### PR TITLE
Allow skipping WooMemberships test

### DIFF
--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -26,6 +26,8 @@ class CheckSkippedTestsExtension extends Extension {
       'createAndSendStandardNewsletter',
       'displayNewsletterPreview',
       'selectEditSwapAndResetEmailTemplate',
+      // WooCommerce Memberships tests are not compatible with WordPress 6.8+
+      'createSegmentForMembershipPlan',
     ];
 
     if (in_array($branch, ['trunk', 'release']) && !in_array($testName, $allowedToSkipList)) {


### PR DESCRIPTION
## Description

Allow skipping WooMemberships-related test because the plugin causes errors on WP 6.8

## Code review notes

Here is a test run where I disallowed skipped tests also on the current branch https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20660/workflows/0088dfeb-af98-4697-b16c-a6a2ee4e4f70

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:allow-skip-woo-memberships)

_The latest successful build from `allow-skip-woo-memberships` will be used. If none is available, the link won't work._