### PR TITLE
Update Gutenberg blocks to API v3 to fix QIT E2E tests

### DIFF
--- a/mailpoet/assets/js/src/marketing-optin-block/block.json
+++ b/mailpoet/assets/js/src/marketing-optin-block/block.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": 2,
+  "apiVersion": 3,
   "name": "mailpoet/marketing-optin-block",
   "version": "0.1.0",
   "title": "MailPoet Marketing Opt-in",

--- a/mailpoet/assets/js/src/marketing-optin-block/edit.tsx
+++ b/mailpoet/assets/js/src/marketing-optin-block/edit.tsx
@@ -18,6 +18,7 @@ const adminUrl = getSetting('adminUrl');
 const { optinEnabled, defaultText } = getSetting('mailpoet_data');
 
 function EmptyState(): JSX.Element {
+  const adminUrlToEnableOptIn = `${adminUrl}admin.php?page=mailpoet-settings#/woocommerce`;
   return (
     <Placeholder
       icon={<Icon icon={megaphone} />}
@@ -32,10 +33,10 @@ function EmptyState(): JSX.Element {
       </span>
       <Button
         variant="primary"
-        href={`${adminUrl}admin.php?page=mailpoet-settings#/woocommerce`}
-        target="_blank"
-        rel="noopener noreferrer"
         className="wp-block-mailpoet-newsletter-block-placeholder__button"
+        onClick={() => {
+          window.open(adminUrlToEnableOptIn, '_blank', 'noopener noreferrer');
+        }}
       >
         {__('Enable opt-in for Checkout', 'mailpoet')}
       </Button>

--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
@@ -4,12 +4,13 @@ import { Icon } from './icon.jsx';
 
 const wp = window.wp;
 const { Placeholder, PanelBody } = wp.components;
-const { BlockIcon, InspectorControls } = wp.blockEditor;
+const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const ServerSideRender = wp.serverSideRender;
 
 const allForms = window.mailpoet_forms;
 
 function Edit({ attributes, setAttributes }) {
+  const blockProps = useBlockProps();
   function displayFormsSelect() {
     if (!Array.isArray(allForms)) return null;
     if (allForms.length === 0) return null;
@@ -27,7 +28,7 @@ function Edit({ attributes, setAttributes }) {
           {window.locale.selectForm}
         </option>
         {allForms.map((form) => (
-          <option value={form.id}>
+          <option value={form.id} key={`form-${form.id}`}>
             {form.name +
               (form.status === 'disabled'
                 ? ` (${window.locale.inactive})`
@@ -63,7 +64,7 @@ function Edit({ attributes, setAttributes }) {
   }
 
   return (
-    <>
+    <div {...blockProps}>
       <InspectorControls>
         <PanelBody title="MailPoet Subscription Form" initialOpen>
           {selectFormSettings()}
@@ -81,7 +82,7 @@ function Edit({ attributes, setAttributes }) {
         )}
         {attributes.formId !== null && renderForm()}
       </div>
-    </>
+    </div>
   );
 }
 

--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/form-block.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/form-block.jsx
@@ -6,6 +6,7 @@ const { registerBlockType } = wp.blocks;
 
 registerBlockType('mailpoet/subscription-form-block-render', {
   title: window.locale.subscriptionForm,
+  apiVersion: 3,
   attributes: {
     formId: {
       type: 'number',
@@ -19,6 +20,7 @@ registerBlockType('mailpoet/subscription-form-block-render', {
 
 registerBlockType('mailpoet/subscription-form-block', {
   title: window.locale.subscriptionForm,
+  apiVersion: 3,
   icon: Icon,
   category: 'widgets',
   example: {},

--- a/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
+++ b/mailpoet/tests/acceptance/Forms/GutenbergFormBlockCest.php
@@ -122,22 +122,22 @@ class GutenbergFormBlockCest {
     $i->amEditingPostWithId($postId);
     $this->closeDialog($i);
     $i->waitForText('My Gutenberg form');
+    $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->click('[aria-label="Add title"]');
     $i->click('[aria-label="Add block"]');
+    $i->switchToIFrame();
     $i->fillField('[placeholder="Search"]', 'MailPoet Subscription Form');
     $i->waitForElement(Locator::contains('button', 'MailPoet Subscription Form'));
     $i->click(Locator::contains('button', 'MailPoet Subscription Form'));
+    $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->waitForElement('[aria-label="Block: MailPoet Subscription Form"]');
     $i->selectOption('.mailpoet-block-create-forms-list', 'Acceptance Test Block Form');
     $i->waitForElementVisible('[data-automation-id="form_email"]');
     $i->waitForElementVisible('[data-automation-id="form_first_name"]');
     $i->waitForElementVisible('[data-automation-id="form_last_name"]');
-    // From WP 6.6 the button label is Save
-    if (version_compare($i->getWordPressVersion(), '6.6', '<')) {
-      $i->click('Update');
-    } else {
-      $i->click('Save');
-    }
+    $i->switchToIFrame();
+    $i->click('Save');
+
     $i->waitForText('Post updated.');
 
     $i->wantTo('Verify the added form on the front-end');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -63,7 +63,9 @@ class WooCheckoutBlocksCest {
     $i->wantTo('Check a message when opt-in is disabled');
     $i->login();
     $i->amOnAdminPage("post.php?post={$this->checkoutPostId}&action=edit");
+    $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->canSee('MailPoet marketing opt-in would be shown here if enabled. You can enable from the settings page.');
+    $i->switchToIframe();
     $i->logOut();
     $this->orderProduct($i, $customerEmail, true, false);
     $i->login();
@@ -223,25 +225,27 @@ class WooCheckoutBlocksCest {
       $i->wantTo('Choose a pattern was not present, skipping action.');
     }
     $this->closeDialog($i);
+    $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->click('[aria-label="Add title"]'); // For block inserter to show up
     $i->click('[aria-label="Add block"]');
+    $i->switchToIframe();
     $i->fillField('[placeholder="Search"]', 'Checkout');
     $i->waitForElement(Locator::contains('button > span > span', 'Checkout'));
     $i->click(Locator::contains('button > span > span', 'Checkout')); // Select Checkout block
+    $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->waitForElement('[aria-label="Block: Checkout"]');
+
     // Close dialog with Compatibility notice
+    $i->switchToIframe();
     $this->closeDialog($i);
 
     // Enable registration during the checkout
+    $i->switchToIframe('iframe[name="editor-canvas"]');
     $i->click('[aria-label="Block: Contact Information"]');
 
-    // From WP 6.6 the button label is Save
-    $version = (string)preg_replace('/-(RC|beta)\d*/', '', $i->getWordPressVersion());
-    if (version_compare($version, '6.6', '<')) {
-      $i->click('Update');
-    } else {
-      $i->click('Save');
-    }
+    $i->switchToIframe();
+    $i->click('Save');
+
     $i->waitForText('Page updated.');
     $i->logOut();
     return $postId;


### PR DESCRIPTION
## Description

The QIT E2E tests were failing because they expected that the WP's post editor runs in iframe mode. They failed to locate the post title in an iframe. The editor runs in an iframe mode only if all blocks declare compatibility with the iframe mode.
To declare the compatibility a block needs to declare it is compatible with API v3. Our two blocks, the form block and the marketing opt-in block, were not configured as compatible with API v3.

This PR fixes the issue by updating the form and marketing opt-in blocks to API v3.

## Code review notes

Here is a test run with QIT E2E tests https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20666/workflows/741c677a-d689-4302-aa37-813b945130d2

## QA notes

Please test the functionality of the MailPoet Subscription form block.
You need to create a form and then go to the post editor and insert the MailPoet Subscription Form block and test it works.

Please also test the checkout opt-in block. You need to install Woo and try to edit the checkout page and enable/disable the optin etc.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-qit-e2e)

_The latest successful build from `fix-qit-e2e` will be used. If none is available, the link won't work._