### PR TITLE
Update Migration_20230831_143755_Db to work properly with multi query

### DIFF
--- a/mailpoet/lib/Migrations/Db/Migration_20230831_143755_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20230831_143755_Db.php
@@ -115,7 +115,7 @@ class Migration_20230831_143755_Db extends DbMigration {
         $stepId = strval($item['step_id']);
         $stepKey = strval($steps[$stepId]['key'] ?? 'unknown');
         $triggerId = $steps['root']['next_steps'][0]['id'];
-        $triggerKey = $steps['root']['next_steps'][0]['key'];
+        $triggerKey = $steps['root']['next_steps'][0]['key'] ?? 'unknown';
 
         $queries[] = "UPDATE {$logsTable} SET step_key = '{$stepKey}' WHERE id = {$id}";
 
@@ -132,7 +132,16 @@ class Migration_20230831_143755_Db extends DbMigration {
         }
       }
 
-      $this->connection->executeStatement(implode(';', $queries));
+      $nativeConnection = $this->connection->getNativeConnection();
+      // If the connection is a mysqli object, we can use the multi_query method
+      if (is_object($nativeConnection) && get_class($nativeConnection) === 'mysqli') {
+        $query = implode(';', $queries);
+        $nativeConnection->multi_query($query);
+      } else { // Otherwise, we need to execute each query individually (e.g. PDO or SQLite)
+        foreach ($queries as $query) {
+          $this->connection->executeStatement($query);
+        }
+      }
     }
   }
 }

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -226,6 +226,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 * Improved: more consistent look and feel of MailPoet pages with WordPress;
 * Improved: optimized email templates images to decrease their file size;
 * Fixed: unreadable customer name in automation analytics when Gravatar fails to load;
+* Fixed: failing migration when updating from an old plugin version;
 * Fixed: "Custom HTML" block in form editor doesn't preserve "Automatically add paragraphs" setting.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

After migration to WPDP, we can't execute multiple statements the way we did before in the migration.

Closes  STOMAIL-7397

## Code review notes
WPDB doesn't support multi-queries, but we can access the underlying `mysqli` connection and execute the multi-queries on that. 
I added the second code branch for other connections, mostly because of the playground.

## QA notes

1) Install MailPoet
2) Import testing data to DB (ask @costasovo to provide a zip)
3) Delete Migration_20230831_143755_Db from wp_mailpoet_migrations
4) Deactivate and activate plugin to trigger migration run

Without the fix, the migration fails. After the fix, it is properly executed.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7397-sql-error-in-migration_20230831_143755_db)

_The latest successful build from `stomail-7397-sql-error-in-migration_20230831_143755_db` will be used. If none is available, the link won't work._