### PR TITLE
Fix changelog and premium version release issues

### DIFF
--- a/mailpoet/tasks/release/ChangelogController.php
+++ b/mailpoet/tasks/release/ChangelogController.php
@@ -32,7 +32,7 @@ class ChangelogController {
       throw new \Exception('Version is required');
     }
     $changelog = $this->getChangelogFromReadme();
-    if (!$this->containsNewChangelog($changelog)) {
+    if (!$this->containsNewChangelogOrVersionExists($changelog, $version)) {
       $changelog = self::NEW_CHANGELOG_TEMPLATE . "\n" . self::FALLBACK_RECORD;
     }
     $changelog = $this->updateHeading($changelog, $version);
@@ -48,8 +48,11 @@ class ChangelogController {
     return '';
   }
 
-  private function containsNewChangelog(string $changelog) {
-    return strpos($changelog, self::NEW_CHANGELOG_TEMPLATE) !== false;
+  private function containsNewChangelogOrVersionExists(string $changelog, string $version) {
+    return (
+      strpos($changelog, self::NEW_CHANGELOG_TEMPLATE) !== false ||
+      strpos($changelog, "= $version") !== false
+    );
   }
 
   private function updateHeading(string $changelog, string $version) {
@@ -73,7 +76,7 @@ class ChangelogController {
   private function updateReadmeTxt($changelog, $version) {
     $fileContents = file_get_contents($this->readmeFile);
 
-    if (!$this->containsNewChangelog($fileContents)) {
+    if (!$this->containsNewChangelogOrVersionExists($fileContents, $version)) {
       // In the free plugin, remove the previous changelog before adding a new one.
       // Premium plugin doesn't contain link to full changelog.
       $pattern = '/== Changelog ==(.*)\[See the changelog for all versions.\]/s';

--- a/mailpoet/tasks/release/GitHubController.php
+++ b/mailpoet/tasks/release/GitHubController.php
@@ -25,9 +25,6 @@ class GitHubController {
   /** @var Client */
   private $httpClient;
 
-  /** @var Client */
-  private $freePluginHttpClient;
-
   public function __construct(
     $username,
     $token,
@@ -40,13 +37,6 @@ class GitHubController {
         'Accept' => 'application/vnd.github.v3+json',
       ],
       'base_uri' => self::API_BASE_URI . "/{$this->getGithubPathByProject($project)}/",
-    ]);
-    $this->freePluginHttpClient = new Client([
-      'auth' => [$username, $token],
-      'headers' => [
-        'Accept' => 'application/vnd.github.v3+json',
-      ],
-      'base_uri' => self::API_BASE_URI . "/{$this->getGithubPathByProject(self::PROJECT_MAILPOET)}/",
     ]);
   }
 
@@ -287,7 +277,7 @@ class GitHubController {
    * @return string|null The latest version number or null if no releases exist
    */
   public function getLastReleasedVersion(): ?string {
-    $response = $this->freePluginHttpClient->get('releases', [
+    $response = $this->httpClient->get('releases', [
       'query' => [
         'per_page' => 1,
       ],


### PR DESCRIPTION
## Description

This PR fixes two issues with the release.

### 1. When the version already exist in changelog, use it instead of using fallback

When the release is done, the script publishes the GitHub release and notifies on Slack. It uses the same Changelog controller as when generating it during release preparation. However, the Changelog controller was looking for the `x.x.x` template, and when it didn't find it (because it had already been replaced with the release version), it used a fallback changelog template.

For example, instead of

```
= 5.11.0 – 2025-04-22 =
* Added: Dynamic Products block in email editor. Useful in automations to render order products, cross-sells, abandoned cart content, or selected categories or tags;
* Updated: minimum required WordPress version to 6.7 and tested up to version to 6.8;
* Updated: minimum required WooCommerce version to 9.7.1 and tested up to version to 9.8.1.
```

it would output 

```
= 5.11.0 - 2025-04-23 =
* Improved: minor changes and fixes.
```

Now, it also accepts `$version`, and looks either for `x.x.x` or the specified version, in which case it uses the existing changelog.

### 2. Fixing the incorrect premium version when publishing the release 

Each plugin now uses its own GitHub client when fetching the latest release.

When only the free plugin client was used, after the free plugin was released, the release script for the premium plugin used the just-released version of the free plugin and bumped the minor version **again**, but that version didn't exist in the premium repository.

Now, each plugin checks its own releases, so even when 5.12.0 is released in the free, the latest premium release is still only 5.11.0, so it will correctly determine that it should release 5.12.0. This shouldn't affect determining whether a patch or minor version should be bumped, because the premium release always updates the minor version, and the free release checks for the presence of the `release` branch in the premium repository.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7398

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
