### PR TITLE
Remove alternative text from the avatar image

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/orders/cells/customer.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/orders/cells/customer.tsx
@@ -29,7 +29,7 @@ export function CustomerCell({
       }}
       href={isSample ? '' : `?page=mailpoet-subscribers#/edit/${customer.id}`}
     >
-      <img src={customer.avatar} alt={label} width="20" />
+      <img src={customer.avatar} alt="" width="20" />
       {label}
     </a>
   );

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -223,6 +223,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
-* Improved: optimized email templates images to decrease their file size.
+* Improved: optimized email templates images to decrease their file size;
+* Fixed: unreadable customer name in automation analytics when Gravatar fails to load.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

It adds no additional context, as the same content is written immediately afterward, and screen readers can skip this image entirely.

|  Before   |  After   |
| ------ | ----- |
|  <img width="577" alt="Screenshot 2025-04-28 at 14 59 13" src="https://github.com/user-attachments/assets/4fde8e2c-cce9-4467-9935-693b65746c55" />  | <img width="569" alt="Screenshot 2025-04-28 at 14 59 19" src="https://github.com/user-attachments/assets/31270838-70ef-4777-ab9c-2cccf2643665" />    |

## Code review notes

_N/A_

## QA notes

The issue is present in Firefox.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7341

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7341-email-addresses-become-unreadable-on-the-automation)

_The latest successful build from `stomail-7341-email-addresses-become-unreadable-on-the-automation` will be used. If none is available, the link won't work._