### PR TITLE
Fix "Custom HTML" block in form editor doesn't preserve "Automatically add paragraphs" setting

### DIFF
--- a/mailpoet/assets/js/src/form-editor/store/form-body-to-blocks.jsx
+++ b/mailpoet/assets/js/src/form-editor/store/form-body-to-blocks.jsx
@@ -427,7 +427,7 @@ export const formBodyToBlocksFactory = (
                   item.params && item.params.text ? item.params.text : '',
                 nl2br:
                   item.params && item.params.nl2br
-                    ? !!item.params.nl2br
+                    ? parseInt(item.params.nl2br, 10) > 0
                     : false,
               },
             };

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -224,6 +224,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Improved: optimized email templates images to decrease their file size;
-* Fixed: unreadable customer name in automation analytics when Gravatar fails to load.
+* Fixed: unreadable customer name in automation analytics when Gravatar fails to load;
+* Fixed: "Custom HTML" block in form editor doesn't preserve "Automatically add paragraphs" setting.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

The settings value is saved as `"0"` or `"1"`, both of which will return `true` in JS when using `!!value`. The fix is to first parse the value as a number and compare that. 

Note that this is a visual issue in the form editor. When rendering the form on the website, it correctly parses and interprets the setting. 

## Code review notes

I decided to skip converting the file to TypeScript, as it's 400+ lines long and it's far from a straightforward one to convert. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7249

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7249-custom-html-block-in-form-editor-doesnt-preserve)

_The latest successful build from `stomail-7249-custom-html-block-in-form-editor-doesnt-preserve` will be used. If none is available, the link won't work._