### PR TITLE
Unsubscribe only on POST requests to List-Unsubscribe URL 

### DIFF
--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -443,7 +443,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Captcha::class)->setPublic(true);
     // Statistics
-    $container->autowire(\MailPoet\Statistics\Track\Clicks::class);
+    $container->autowire(\MailPoet\Statistics\Track\Clicks::class)->setPublic(true);
     $container->autowire(\MailPoet\Statistics\Track\Opens::class)->setPublic(true);
     $container->autowire(\MailPoet\Statistics\Track\PageViewCookie::class)->setPublic(true);
     $container->autowire(\MailPoet\Statistics\Track\SubscriberActivityTracker::class)->setPublic(true);

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -72,11 +72,18 @@ class Subscription {
 
   public function unsubscribe($data) {
     if ($this->request->isPost()) {
-      $this->applyOneClickUnsubscribeStrategy($data);
-      exit;
+      if ($this->request->getStringParam('type') === 'confirmation') {
+        // POST from confirmation page
+        $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
+        $subscription->unsubscribe(StatisticsUnsubscribeEntity::METHOD_LINK);
+      } else {
+        // POST from one click unsubscribe
+        $this->applyOneClickUnsubscribeStrategy($data);
+        exit;
+      }
     } else {
-      $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
-      $subscription->unsubscribe(StatisticsUnsubscribeEntity::METHOD_LINK);
+      // For GET requests, we render to the confirmUnsubscribe endpoint
+      $this->confirmUnsubscribe($data);
     }
   }
 

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -81,8 +81,12 @@ class Subscription {
         exit;
       }
     } else {
-      // For GET requests, we render to the confirmUnsubscribe endpoint
-      $this->confirmUnsubscribe($data);
+      // For GET requests, we render the confirmUnsubscribe page, unless it is preview request of successful unsubscribe
+      if (isset($data['preview']) && $data['preview'] && !isset($data['token'])) {
+        $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_LINK);
+      } else {
+        $this->confirmUnsubscribe($data);
+      }
     }
   }
 

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -54,7 +54,7 @@ class Subscription {
 
   public function confirmUnsubscribe($data) {
     $enableUnsubscribeConfirmation = $this->wp->applyFilters('mailpoet_unsubscribe_confirmation_enabled', true);
-    if ($this->request->isPost()) {
+    if ($this->isPostRequest()) {
       $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_ONE_CLICK);
       exit;
     }
@@ -71,7 +71,7 @@ class Subscription {
   }
 
   public function unsubscribe($data) {
-    if ($this->request->isPost()) {
+    if ($this->isPostRequest()) {
       if ($this->request->getStringParam('type') === 'confirmation') {
         // POST from confirmation page
         $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_LINK);
@@ -101,5 +101,17 @@ class Subscription {
   private function performUnsubscribe($data, string $method): void {
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
     $subscription->unsubscribe($method);
+  }
+
+  private function isPostRequest(): bool {
+    if ($this->request->isPost()) {
+      return true;
+    }
+    // For tracking redirects we store original method in the query string
+    $requestMethod = $this->request->getStringParam('request_method');
+    if (!$requestMethod) {
+      return false;
+    }
+    return strtoupper($requestMethod) === 'POST';
   }
 }

--- a/mailpoet/lib/Router/Endpoints/Subscription.php
+++ b/mailpoet/lib/Router/Endpoints/Subscription.php
@@ -55,14 +55,14 @@ class Subscription {
   public function confirmUnsubscribe($data) {
     $enableUnsubscribeConfirmation = $this->wp->applyFilters('mailpoet_unsubscribe_confirmation_enabled', true);
     if ($this->request->isPost()) {
-      $this->applyOneClickUnsubscribeStrategy($data);
+      $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_ONE_CLICK);
       exit;
     }
 
     if ($enableUnsubscribeConfirmation) {
       $this->initSubscriptionPage(UserSubscription\Pages::ACTION_CONFIRM_UNSUBSCRIBE, $data);
     } else {
-      $this->unsubscribe($data);
+      $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_LINK);
     }
   }
 
@@ -74,11 +74,10 @@ class Subscription {
     if ($this->request->isPost()) {
       if ($this->request->getStringParam('type') === 'confirmation') {
         // POST from confirmation page
-        $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
-        $subscription->unsubscribe(StatisticsUnsubscribeEntity::METHOD_LINK);
+        $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_LINK);
       } else {
         // POST from one click unsubscribe
-        $this->applyOneClickUnsubscribeStrategy($data);
+        $this->performUnsubscribe($data, StatisticsUnsubscribeEntity::METHOD_ONE_CLICK);
         exit;
       }
     } else {
@@ -95,8 +94,8 @@ class Subscription {
     return $this->subscriptionPages->init($action, $data, true, true);
   }
 
-  private function applyOneClickUnsubscribeStrategy($data): void {
+  private function performUnsubscribe($data, string $method): void {
     $subscription = $this->initSubscriptionPage(UserSubscription\Pages::ACTION_UNSUBSCRIBE, $data);
-    $subscription->unsubscribe(StatisticsUnsubscribeEntity::METHOD_ONE_CLICK);
+    $subscription->unsubscribe($method);
   }
 }

--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -15,6 +15,7 @@ use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\Cookies;
+use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Clicks {
@@ -49,6 +50,9 @@ class Clicks {
   /** @var TrackingConfig */
   private $trackingConfig;
 
+  /** @var Request */
+  private $request;
+
   public function __construct(
     Cookies $cookies,
     SubscriberCookie $subscriberCookie,
@@ -58,7 +62,8 @@ class Clicks {
     UserAgentsRepository $userAgentsRepository,
     LinkShortcodeCategory $linkShortcodeCategory,
     SubscribersRepository $subscribersRepository,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    Request $request
   ) {
     $this->cookies = $cookies;
     $this->subscriberCookie = $subscriberCookie;
@@ -69,6 +74,7 @@ class Clicks {
     $this->userAgentsRepository = $userAgentsRepository;
     $this->subscribersRepository = $subscribersRepository;
     $this->trackingConfig = $trackingConfig;
+    $this->request = $request;
   }
 
   /**
@@ -156,6 +162,10 @@ class Clicks {
         $queue,
         $wpUserPreview
       );
+      // We need to know the original method for unsubscribe actions
+      if ($this->request->isPost() && $url) {
+        $url = $url . (parse_url($url, PHP_URL_QUERY) ? '&' : '?') . 'request_method=POST';
+      }
     } else {
       $this->shortcodes->setQueue($queue);
       $this->shortcodes->setNewsletter($newsletter);

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -455,6 +455,7 @@ class Pages {
     }
     $queueId = isset($this->data['queueId']) ? (int)$this->data['queueId'] : null;
     $unsubscribeUrl = $this->subscriptionUrlFactory->getUnsubscribeUrl($this->subscriber, $queueId);
+    $unsubscribeUrl = $unsubscribeUrl . (parse_url($unsubscribeUrl, PHP_URL_QUERY) ? '&' : '?') . 'request_method=POST';
     $templateData = [
       'unsubscribeUrl' => $unsubscribeUrl,
     ];

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -434,7 +434,7 @@ class Pages {
   private function getUnsubscribeContent() {
     $content = '';
     if ($this->isPreview() || $this->subscriber !== null) {
-      $content .= '<p>' . __('Accidentally unsubscribed?', 'mailpoet') . ' <strong>';
+      $content .= '<p class="mailpoet_unsubscribed_content">' . __('Accidentally unsubscribed?', 'mailpoet') . ' <strong>';
       $content .= '[mailpoet_manage]';
       $content .= '</strong></p>';
     }

--- a/mailpoet/lib/Util/Request.php
+++ b/mailpoet/lib/Util/Request.php
@@ -6,4 +6,11 @@ class Request {
   public function isPost(): bool {
     return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST' || count($_POST) > 0;
   }
+
+  public function getStringParam(string $key): ?string {
+    if ($this->isPost()) {
+      return isset($_POST[$key]) ? sanitize_text_field($_POST[$key]) : null;
+    }
+    return isset($_GET[$key]) ? sanitize_text_field($_GET[$key]) : null;
+  }
 }

--- a/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/SubscriptionTest.php
@@ -45,11 +45,13 @@ class SubscriptionTest extends \MailPoetTest {
     do_shortcode('[mailpoet_manage_subscription]');
   }
 
-  public function testItDisplaysUnsubscribePage() {
+  public function testItDisplaysConfirmationPageOnGetRequest() {
     $pages = Stub::make(Pages::class, [
       'wp' => new WPFunctions,
-      'unsubscribe' => Expected::exactly(1),
+      'confirmUnsubscribe' => Expected::exactly(1),
     ], $this);
+    $request = $this->createMock(Request::class);
+    $request->method('isPost')->willReturn(false);
     $subscription = new Subscription($pages, $this->wp, $this->request);
     $subscription->unsubscribe($this->data);
   }

--- a/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
+++ b/mailpoet/tests/integration/Statistics/Track/ClicksTest.php
@@ -23,6 +23,7 @@ use MailPoet\Statistics\UserAgentsRepository;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\Cookies;
+use MailPoet\Util\Request;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -101,7 +102,8 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(UserAgentsRepository::class),
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(TrackingConfig::class)
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class)
     );
 
     $this->statisticsClicksRepository = $this->diContainer->get(StatisticsClicksRepository::class);
@@ -120,6 +122,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'abort' => Expected::exactly(2),
     ], $this);
@@ -146,6 +149,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -167,6 +171,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -190,6 +195,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -216,6 +222,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -248,6 +255,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -290,6 +298,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -332,6 +341,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -367,6 +377,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -404,6 +415,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => Expected::exactly(1),
     ], $this);
@@ -421,6 +433,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -442,6 +455,20 @@ class ClicksTest extends \MailPoetTest {
     verify($link)->stringContainsString('&endpoint=view_in_browser');
   }
 
+  public function testItAddsMethodForPostRequestsToShortCodes() {
+    $requestMock = $this->createMock(Request::class);
+    $requestMock->method('isPost')->willReturn(true);
+    $this->clicks = $this->getServiceWithOverrides(Clicks::class, ['request' => $requestMock]);
+    $link = $this->clicks->processUrl(
+      '[link:newsletter_view_in_browser_url]',
+      $this->newsletter,
+      $this->subscriber,
+      $this->queue,
+      $preview = false
+    );
+    verify($link)->stringContainsString('&request_method=POST');
+  }
+
   public function testItFailsToConvertsInvalidShortcodeToUrl() {
     $clicks = Stub::construct($this->clicks, [
       $this->diContainer->get(Cookies::class),
@@ -453,6 +480,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'abort' => Expected::exactly(1),
     ], $this);
@@ -532,6 +560,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $subscribersRepository,
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -576,6 +605,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $subscribersRepository,
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -620,6 +650,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $subscribersRepository,
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);
@@ -648,6 +679,7 @@ class ClicksTest extends \MailPoetTest {
       $this->diContainer->get(LinkShortcodeCategory::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(Request::class),
     ], [
       'redirectToUrl' => null,
     ], $this);

--- a/mailpoet/views/subscription/confirm_unsubscribe.html
+++ b/mailpoet/views/subscription/confirm_unsubscribe.html
@@ -1,7 +1,10 @@
 <% block content %>
-<p class="mailpoet_confirm_unsubscribe">
-  <%= __('Simply click on this link to stop receiving emails from us.') %>
-  <br>
-  <a href="<%= unsubscribeUrl %>" rel="nofollow"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
+<form action="<%= unsubscribeUrl %>" method="post">
+  <input type="hidden" name="type" value="confirmation">
+  <p class="mailpoet_confirm_unsubscribe">
+    <%= __('Simply click on this link to stop receiving emails from us.') %>
+    <br>
+    <a href="#" onclick="this.closest('form').submit(); return false;" rel="nofollow"><%= _x('Yes, unsubscribe me', 'Text in unsubscribe link') %></a>
 </p>
+</form>
 <% endblock %>


### PR DESCRIPTION
## Description

This PR addresses the issue that the URL we provide in the List-Unsubscribe header unsubscribes a recipient without confirmation when requested via both GET and POST HTTP methods. So when an antispam software accesses the URL, the recipient is unsubscribed.

According to the description by Certified Senders Alliance:

![Screenshot 2025-04-29 at 9 13 02](https://github.com/user-attachments/assets/80c9d448-6ce2-4dc5-9ea8-48dead0b61fd)

The List-Unsubscribe header, when accessed via GET, should not immediately unsubscribe the recipient but display a page where they can unsubscribe (in our case, the confirmation page).

This PR fixes the issue described above by showing the confirmation page on GET and performing unsubscribe only on POST. 
I also refactored the confirmation page to use a form instead of a simple link for confirming unsubscribes. This is to further strengthen it against bots following links.

Closes STOMAIL-7396

## Code review notes

- I tried to explain decisions in commit messages.

## QA notes

Please test that unsubscribing from emails links works as expected.
- Check classic unsubscribe link in email body
- Check the link provided in the List-Unsubscribe email header. When opened in a browser, it should display a confirmation page, and when accessed via POST, it should immediately unsubscribe the subscriber.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7396-subscribers-are-unsubscribed-on-get-request-to-url-provided)

_The latest successful build from `stomail-7396-subscribers-are-unsubscribed-on-get-request-to-url-provided` will be used. If none is available, the link won't work._