### PR TITLE
Fix handling of Japanese characters in custom field blocks [STOMAIL-7383]

### DIFF
--- a/mailpoet/assets/js/src/form-editor/blocks/format-custom-field-block-name.jsx
+++ b/mailpoet/assets/js/src/form-editor/blocks/format-custom-field-block-name.jsx
@@ -1,8 +1,15 @@
 import slugify from 'slugify';
 
 export function formatCustomFieldBlockName(blockName, customField) {
-  const name = slugify(customField.name, { lower: true })
+  let name = slugify(customField.name, { lower: true })
     .replace(/[^a-z0-9]+/g, '')
     .replace(/-$/, '');
+
+  // Ensure unique block names by appending ID if the slug is empty or too short
+  // (which can happen with certain character sets)
+  if (!name || name.length < 2) {
+    name = `field${customField.id}`;
+  }
+
   return `${blockName}-${name}`;
 }

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -223,6 +223,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
-* Fixed: listing action items overlaying with row border when on two lines on smaller screens.
+* Fixed: listing action items overlaying with row border when on two lines on smaller screens;
+* Fixed: Handling of Japanese characters in custom field blocks in the form editor.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

When creating a form in MailPoet and trying to add multiple custom fields with Japanese characters, adding more than one field is impossible. 

**Steps to Reproduce**

1. Go to MailPoet > Forms and create a new form
2. Add a custom field to the form, and set the Field Name + Label to "会社名・団体名". See that the field is added without issue
3. Try adding a second custom field, and set the Field Name + Label to "電話番号".  
4. The first time doing this, I saw that it added a field with the first name/label again instead, with a note saying that you can only add the field once
5. Try removing it, and adding again with "電話番号".  The second time, no matter what I tried, hitting the "Create" button just doesn't do anything.
6. Remove the field again, and try adding something in English like "Phone" — this field can be added without issue
7. Try adding "電話番号" again, but see that "Create" button does nothing again…

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7383]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7383-mailpoet-forms-cant-add-multiple-custom-fields-with-japanese)

_The latest successful build from `stomail-7383-mailpoet-forms-cant-add-multiple-custom-fields-with-japanese` will be used. If none is available, the link won't work._