### PR TITLE
Add migration to re-subscribe subscribers unsubscribed by bots

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20250501_114655_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20250501_114655_App.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\App;
+
+use MailPoet\Entities\StatisticsClickEntity;
+use MailPoet\Entities\StatisticsUnsubscribeEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\AppMigration;
+
+class Migration_20250501_114655_App extends AppMigration {
+  public function run(): void {
+    $clicksStatsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
+    $unsubscribeStatsTable = $this->entityManager->getClassMetadata(StatisticsUnsubscribeEntity::class)->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeQuery(
+      "UPDATE {$subscribersTable} SET status = :subscribedStatus WHERE id IN (
+        SELECT
+          mp_unsub.subscriber_id
+        FROM
+          {$unsubscribeStatsTable} AS mp_unsub
+        LEFT JOIN
+          {$clicksStatsTable} AS mp_click
+          ON mp_unsub.newsletter_id = mp_click.newsletter_id
+          AND mp_unsub.subscriber_id = mp_click.subscriber_id
+          AND ABS(TIMESTAMPDIFF(SECOND, mp_click.created_at, mp_unsub.created_at)) <= 4
+        WHERE
+          mp_unsub.created_at > '2025-03-01'
+        GROUP BY
+          mp_unsub.subscriber_id
+        HAVING COUNT(mp_click.id) >= 3
+      ) AND status = :unsubscribedStatus",
+      [
+        'subscribedStatus' => SubscriberEntity::STATUS_SUBSCRIBED,
+        'unsubscribedStatus' => SubscriberEntity::STATUS_UNSUBSCRIBED,
+      ]
+    );
+  }
+}

--- a/mailpoet/lib/Migrations/App/Migration_20250501_114655_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20250501_114655_App.php
@@ -6,32 +6,44 @@ use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Migrator\AppMigration;
+use MailPoetVendor\Doctrine\DBAL\Connection;
 
 class Migration_20250501_114655_App extends AppMigration {
   public function run(): void {
     $clicksStatsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
     $unsubscribeStatsTable = $this->entityManager->getClassMetadata(StatisticsUnsubscribeEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+
+    // First get all subscriber IDs that match our criteria
+    $subscriberIds = $this->entityManager->getConnection()->executeQuery(
+      "SELECT DISTINCT mp_unsub.subscriber_id
+       FROM {$unsubscribeStatsTable} AS mp_unsub
+       LEFT JOIN {$clicksStatsTable} AS mp_click
+         ON mp_unsub.newsletter_id = mp_click.newsletter_id
+         AND mp_unsub.subscriber_id = mp_click.subscriber_id
+         AND ABS(TIMESTAMPDIFF(SECOND, mp_click.created_at, mp_unsub.created_at)) <= 4
+       WHERE mp_unsub.created_at > '2025-03-01'
+       GROUP BY mp_unsub.subscriber_id
+       HAVING COUNT(mp_click.id) >= 3"
+    )->fetchFirstColumn();
+
+    if (empty($subscriberIds)) {
+      return;
+    }
+
+    // Then update the subscribers using the collected IDs
     $this->entityManager->getConnection()->executeQuery(
-      "UPDATE {$subscribersTable} SET status = :subscribedStatus WHERE id IN (
-        SELECT
-          mp_unsub.subscriber_id
-        FROM
-          {$unsubscribeStatsTable} AS mp_unsub
-        LEFT JOIN
-          {$clicksStatsTable} AS mp_click
-          ON mp_unsub.newsletter_id = mp_click.newsletter_id
-          AND mp_unsub.subscriber_id = mp_click.subscriber_id
-          AND ABS(TIMESTAMPDIFF(SECOND, mp_click.created_at, mp_unsub.created_at)) <= 4
-        WHERE
-          mp_unsub.created_at > '2025-03-01'
-        GROUP BY
-          mp_unsub.subscriber_id
-        HAVING COUNT(mp_click.id) >= 3
-      ) AND status = :unsubscribedStatus",
+      "UPDATE {$subscribersTable}
+       SET status = :subscribedStatus
+       WHERE id IN (:subscriberIds)
+       AND status = :unsubscribedStatus",
       [
         'subscribedStatus' => SubscriberEntity::STATUS_SUBSCRIBED,
         'unsubscribedStatus' => SubscriberEntity::STATUS_UNSUBSCRIBED,
+        'subscriberIds' => $subscriberIds,
+      ],
+      [
+        'subscriberIds' => Connection::PARAM_INT_ARRAY,
       ]
     );
   }

--- a/mailpoet/tests/DataFactories/StatisticsUnsubscribes.php
+++ b/mailpoet/tests/DataFactories/StatisticsUnsubscribes.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\StatisticsUnsubscribeEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\Assert;
+
+class StatisticsUnsubscribes {
+  protected $data;
+
+  /** @var NewsletterEntity */
+  private $newsletter;
+
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  public function __construct(
+    NewsletterEntity $newsletter,
+    SubscriberEntity $subscriber
+  ) {
+    $this->newsletter = $newsletter;
+    $this->subscriber = $subscriber;
+  }
+
+  public function withCreatedAt(\DateTimeInterface $createdAt): self {
+    $this->data['createdAt'] = $createdAt;
+    return $this;
+  }
+
+  public function create(): StatisticsUnsubscribeEntity {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+    $queue = $this->newsletter->getLatestQueue();
+    Assert::assertInstanceOf(SendingQueueEntity::class, $queue);
+    $entity = new StatisticsUnsubscribeEntity(
+      $this->newsletter,
+      $queue,
+      $this->subscriber
+    );
+    if (($this->data['createdAt'] ?? null) instanceof \DateTimeInterface) {
+      $entity->setCreatedAt($this->data['createdAt']);
+    }
+    $entityManager->persist($entity);
+    $entityManager->flush();
+    return $entity;
+  }
+}

--- a/mailpoet/tests/DataFactories/SubscriberSegment.php
+++ b/mailpoet/tests/DataFactories/SubscriberSegment.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\DataFactories;
+
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class SubscriberSegment {
+  protected $data;
+
+  /** @var SubscriberEntity */
+  private $subscriber;
+
+  /** @var SegmentEntity */
+  private $segment;
+
+  public function __construct(
+    SubscriberEntity $subscriber,
+    SegmentEntity $segment,
+    string $status = SubscriberEntity::STATUS_SUBSCRIBED
+  ) {
+    $this->subscriber = $subscriber;
+    $this->segment = $segment;
+    $this->data['status'] = $status;
+  }
+
+  public function withStatus(string $status): self {
+    $this->data['status'] = $status;
+    return $this;
+  }
+
+  public function withUpdatedAt(\DateTimeInterface $updatedAt): self {
+    $this->data['updatedAt'] = $updatedAt;
+    return $this;
+  }
+
+  public function create(): SubscriberSegmentEntity {
+    $entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
+    $entity = new SubscriberSegmentEntity($this->segment, $this->subscriber, $this->data['status']);
+
+    if (isset($this->data['status'])) {
+      $entity->setStatus($this->data['status']);
+    }
+
+    $entityManager->persist($entity);
+    $entityManager->flush();
+    $entityManager->refresh($entity);
+    if (($this->data['updatedAt'] ?? null) instanceof \DateTimeInterface) {
+      $subscribersSegmentsTable = $entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+      $entityManager->getConnection()->executeQuery("UPDATE {$subscribersSegmentsTable} SET updated_at = :updatedAt WHERE id = :id", [
+        'updatedAt' => $this->data['updatedAt']->format('Y-m-d H:i:s'),
+        'id' => $entity->getId(),
+      ]);
+    };
+    $entityManager->refresh($entity);
+    return $entity;
+  }
+}

--- a/mailpoet/tests/integration/Migrations/App/Migration_20250501_114655_App_Test.php
+++ b/mailpoet/tests/integration/Migrations/App/Migration_20250501_114655_App_Test.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Migrations\App;
+
+use DateTimeImmutable;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrations\App\Migration_20250501_114655_App;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\NewsletterLink as NewsletterLinkFactory;
+use MailPoet\Test\DataFactories\StatisticsClicks;
+use MailPoet\Test\DataFactories\StatisticsUnsubscribes;
+use MailPoet\Test\DataFactories\Subscriber;
+
+// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20250501_114655_App_Test extends \MailPoetTest {
+  /** @var Migration_20250501_114655_App */
+  private $migration;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20250501_114655_App($this->diContainer);
+  }
+
+  public function testItPausesInvalidTasksWithUnprocessedSubscribers(): void {
+    $subscriberFactory = new Subscriber();
+    $subscriberUnsubscribedBefore = $subscriberFactory->withEmail('subscriber1@example.com')
+      ->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->create();
+    $subscriberUnsubscribedByBot = $subscriberFactory->withEmail('subscriber2@example.com')
+      ->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->create();
+    $subscriberUnsubscribedByUserManyClicks = $subscriberFactory->withEmail('subscriber3@example.com')
+      ->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->create();
+    $subscriberUnsubscribedByUserSingleClick = $subscriberFactory->withEmail('subscriber4@example.com')
+      ->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))
+      ->withStatus(SubscriberEntity::STATUS_UNSUBSCRIBED)
+      ->create();
+
+    $newsletterFactory = new NewsletterFactory();
+    $newsletter = $newsletterFactory->withType(NewsletterEntity::TYPE_STANDARD)
+      ->withSubject('Test Newsletter')
+      ->withSendingQueue()
+      ->withStatus(NewsletterEntity::STATUS_SENT)
+      ->create();
+
+    $newsletterLinkFactory = new NewsletterLinkFactory($newsletter);
+    $newsletterLink = $newsletterLinkFactory
+      ->withUrl('https://example.com/test')
+      ->create();
+
+    $newsletterLink2 = $newsletterLinkFactory
+      ->withUrl('https://example.com/test2')
+      ->create();
+
+    $newsletterLink3 = $newsletterLinkFactory
+      ->withUrl('https://example.com/test3')
+      ->create();
+
+    // $subscriberUnsubscribedBefore Has many suspicious clicks but unsubscribed before the issue
+    $subscriber1ClickFactory = new StatisticsClicks($newsletterLink, $subscriberUnsubscribedBefore);
+    $subscriber1ClickFactory->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))->create();
+    $subscriber1ClickFactory = new StatisticsClicks($newsletterLink2, $subscriberUnsubscribedBefore);
+    $subscriber1ClickFactory->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))->create();
+    $subscriber1ClickFactory = new StatisticsClicks($newsletterLink3, $subscriberUnsubscribedBefore);
+    $subscriber1ClickFactory->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))->create();
+    $subscriber1UnsubscribeFactory = new StatisticsUnsubscribes($newsletter, $subscriberUnsubscribedBefore);
+    $subscriber1UnsubscribeFactory->withCreatedAt(new DateTimeImmutable('2024-12-01 10:00:00'))->create();
+
+    // $subscriberUnsubscribedByBot Has many suspicious clicks but and unsubscribed after the issue
+    $subscriber2ClickFactory = new StatisticsClicks($newsletterLink, $subscriberUnsubscribedByBot);
+    $subscriber2ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:00'))->create();
+    $subscriber2ClickFactory = new StatisticsClicks($newsletterLink2, $subscriberUnsubscribedByBot);
+    $subscriber2ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:02'))->create();
+    $subscriber2ClickFactory = new StatisticsClicks($newsletterLink3, $subscriberUnsubscribedByBot);
+    $subscriber2ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:05'))->create();
+    $subscriber2UnsubscribeFactory = new StatisticsUnsubscribes($newsletter, $subscriberUnsubscribedByBot);
+    $subscriber2UnsubscribeFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:03'))->create();
+
+    // $subscriberUnsubscribedByUserManyClicks Has many clicks but they are spread in time so it's not suspicious
+    $subscriber3ClickFactory = new StatisticsClicks($newsletterLink, $subscriberUnsubscribedByUserManyClicks);
+    $subscriber3ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:00'))->create();
+    $subscriber3ClickFactory = new StatisticsClicks($newsletterLink2, $subscriberUnsubscribedByUserManyClicks);
+    $subscriber3ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:30'))->create();
+    $subscriber3ClickFactory = new StatisticsClicks($newsletterLink3, $subscriberUnsubscribedByUserManyClicks);
+    $subscriber3ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:50'))->create();
+    $subscriber3UnsubscribeFactory = new StatisticsUnsubscribes($newsletter, $subscriberUnsubscribedByUserManyClicks);
+    $subscriber3UnsubscribeFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:55'))->create();
+
+    // $subscriberUnsubscribedByUserSingleClick Has one click and unsubscribed after the issue
+    $subscriber4ClickFactory = new StatisticsClicks($newsletterLink, $subscriberUnsubscribedByUserSingleClick);
+    $subscriber4ClickFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:00'))->create();
+    $subscriber4UnsubscribeFactory = new StatisticsUnsubscribes($newsletter, $subscriberUnsubscribedByUserSingleClick);
+    $subscriber4UnsubscribeFactory->withCreatedAt(new DateTimeImmutable('2025-04-01 10:00:00'))->create();
+
+    $this->migration->run();
+
+    $this->entityManager->refresh($subscriberUnsubscribedBefore);
+    $this->entityManager->refresh($subscriberUnsubscribedByBot);
+    $this->entityManager->refresh($subscriberUnsubscribedByUserManyClicks);
+    $this->entityManager->refresh($subscriberUnsubscribedByUserSingleClick);
+
+    $this->assertEquals(SubscriberEntity::STATUS_UNSUBSCRIBED, $subscriberUnsubscribedBefore->getStatus());
+    $this->assertEquals(SubscriberEntity::STATUS_SUBSCRIBED, $subscriberUnsubscribedByBot->getStatus());
+    $this->assertEquals(SubscriberEntity::STATUS_UNSUBSCRIBED, $subscriberUnsubscribedByUserManyClicks->getStatus());
+    $this->assertEquals(SubscriberEntity::STATUS_UNSUBSCRIBED, $subscriberUnsubscribedByUserSingleClick->getStatus());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a migration that attempts to detect unsubscribes done by bots due to an issue fixed in https://github.com/mailpoet/mailpoet/pull/6183

In the migration, we consider subscribers who made three and more clicks and unsubscribed within 4 seconds before and 4 seconds after unsubscribe as unsubscribed by a bot.

From research of affected sites, it seems that the issue started in late March or early April. So we restrict the date to the start of March.

Closes STOMAIL-7399

## Code review notes

_N/A_

## QA notes

#### Testing

1. Install a plugin version without this migration e.g. 5.12.0
2. Create bot like unsubscribed subscribers:
 - Send an email
 - Click on multiple links (min 3)
 - Unsubscribe
 - Go to the DB `wp_mailpoet_statistics_unsubsribes` and check the `created_at` datetime of your unsubscribe
 - Update the clicks associated with the same subscriber in `wp_mailpoet_statistics_clicks` to have the `created_at` datetime set max. 4 seconds from the unsubscribe datetime
 3. Install the version with migration and make sure migration ran (e.g., deactivate and activate the plugin)
 4. Verify that the unsubscribed subscriber with multiple clicks at the same time is subscribed.
 5. Verify also that other unsubscribed subscribers (e.g, who clicked only one link) remained unsubscribed.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7399-add-migration-to-resubscribe-subscribers-unsubscribed-by-a)

_The latest successful build from `stomail-7399-add-migration-to-resubscribe-subscribers-unsubscribed-by-a` will be used. If none is available, the link won't work._