### PR TITLE
Fix listing action items overlaying with row border when on two lines on smaller screens

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing.scss
@@ -195,8 +195,8 @@ div.mailpoet-listing-bulk-actions-container {
     border-bottom: 1px solid $color-tertiary-light;
     box-shadow: none;
     max-width: 30vw;
-    padding: $grid-gap-medium $grid-gap-half;
-    vertical-align: middle;
+    padding: 12px $grid-gap-half;
+    vertical-align: top;
 
     @include respond-to(small-screen) {
       max-width: none;
@@ -310,13 +310,10 @@ a.mailpoet-listing-title {
 
 .mailpoet-listing-actions {
   align-items: center;
-  display: none;
+  display: flex;
   flex-wrap: wrap;
-  left: 0;
   line-height: 15px;
-  position: absolute;
-  top: 0;
-  width: 100%;
+  visibility: hidden;
 
   a {
     color: $color-text-light;
@@ -340,7 +337,7 @@ a.mailpoet-listing-title {
   }
 
   tr:hover & {
-    display: flex;
+    visibility: visible;
   }
 
   @include respond-to(small-screen) {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -222,12 +222,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.0 - 2025-04-29 =
-* Improved: more consistent look and feel of MailPoet pages with WordPress;
-* Improved: optimized email template images to decrease their file size;
-* Improved: better handling of unsubscribes via the link provided in the List-Unsubscribe header;
-* Fixed: unreadable customer name in automation analytics when Gravatar fails to load;
-* Fixed: failing migration when updating from an old plugin version;
-* Fixed: "Custom HTML" block in form editor doesn't preserve "Automatically add paragraphs" setting.
+= x.x.x - YYYY-MM-DD =
+* Fixed: listing action items overlaying with row border when on two lines on smaller screens.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

The reason that the listing action items can overlay with the table row border is that they are absolutely positioned, and when they are rendered on two lines on smaller screens, the row is not automatically enlarged to accommodate it. 

I've made two changes to fix this:

1. Remove the absolute positioning, so the action items also determine the row's height.
2. Vertically align listing rows to the top, otherwise they would look weird on hover. 

| Before | After | 
| ------ | ------ | 
| <img width="1160" alt="Screenshot 2025-05-05 at 21 22 26" src="https://github.com/user-attachments/assets/31c1cf19-cd2f-45a2-ad4e-bd34df9ae291" /> |  <img width="1171" alt="Screenshot 2025-05-05 at 21 13 46" src="https://github.com/user-attachments/assets/85e04165-fcb9-4df9-b611-02dce3691c2e" />   |
| <img width="1160" alt="Screenshot 2025-05-05 at 21 22 38" src="https://github.com/user-attachments/assets/ed6632ab-5639-4456-a629-e0bfd07807b4" /> | <img width="1162" alt="Screenshot 2025-05-05 at 21 13 53" src="https://github.com/user-attachments/assets/3c0a8778-82ae-465a-a09b-05a97ef6dfdb" />    |
| <img width="1165" alt="Screenshot 2025-05-05 at 21 22 59" src="https://github.com/user-attachments/assets/179f256c-cb9c-4dbc-b2d4-0902a1bc146b" /> |  <img width="1164" alt="Screenshot 2025-05-05 at 21 14 01" src="https://github.com/user-attachments/assets/e868e6cf-514e-45fc-80f1-0a3a0b32d8f2" />   |
| <img width="1111" alt="Screenshot 2025-05-05 at 21 23 11" src="https://github.com/user-attachments/assets/7b33d2c0-651b-47c0-b5d9-015620955033" /> |  <img width="1111" alt="Screenshot 2025-05-05 at 21 14 18" src="https://github.com/user-attachments/assets/180a4606-eeb8-47fb-adc9-f23c8782944b" />    |



## Code review notes

Skipping code review.

## QA notes

Skipping QA review.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7401

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7401-links-shown-when-hovering-over-unconfirmed-subscribers-are)

_The latest successful build from `stomail-7401-links-shown-when-hovering-over-unconfirmed-subscribers-are` will be used. If none is available, the link won't work._