### PR TITLE
Update KB links

### DIFF
--- a/mailpoet/assets/js/src/help/knowledge-base.tsx
+++ b/mailpoet/assets/js/src/help/knowledge-base.tsx
@@ -19,7 +19,7 @@ export function KnowledgeBase() {
           <a
             target="_blank"
             rel="noreferrer noopener"
-            href="https://kb.mailpoet.com/category/165-newsletters"
+            href="https://kb.mailpoet.com/category/165-guides-tips"
           >
             Newsletters
           </a>
@@ -37,7 +37,7 @@ export function KnowledgeBase() {
           <a
             target="_blank"
             rel="noreferrer noopener"
-            href="https://kb.mailpoet.com/category/149-sending-methods"
+            href="https://kb.mailpoet.com/category/149-other-sending-methods"
           >
             Sending Methods
           </a>
@@ -64,7 +64,7 @@ export function KnowledgeBase() {
           <a
             target="_blank"
             rel="noreferrer noopener"
-            href="https://kb.mailpoet.com/category/123-newsletter-designer"
+            href="https://kb.mailpoet.com/category/123-newsletter-editor-designer"
           >
             Newsletter Designer
           </a>

--- a/mailpoet/assets/js/src/homepage/components/resources.tsx
+++ b/mailpoet/assets/js/src/homepage/components/resources.tsx
@@ -10,14 +10,14 @@ export function Resources(): JSX.Element {
   const posts = [
     <ResourcePost
       key="createAnEmail"
-      link="https://kb.mailpoet.com/article/141-create-an-email-types-of-campaigns?utm_source=plugin&utm_medium=homepage&utm_campaign=resources"
+      link="https://kb.mailpoet.com/article/141-create-an-email-types-of-campaigns"
       abstract={MailPoet.I18n.t('createAnEmailAbstract')}
       title={MailPoet.I18n.t('createAnEmailTitle')}
       imgSrc={`${MailPoet.cdnUrl}homepage/resources/add_email.20241219.png`}
     />,
     <ResourcePost
       key="createAForm"
-      link="https://kb.mailpoet.com/article/297-create-a-form-with-our-new-editor?utm_source=plugin&utm_medium=homepage&utm_campaign=resources"
+      link="https://kb.mailpoet.com/article/297-create-a-subscription-form-with-our-editor"
       abstract={MailPoet.I18n.t('createAFormAbstract')}
       title={MailPoet.I18n.t('createAFormTitle')}
       imgSrc={`${MailPoet.cdnUrl}homepage/resources/add_form.png`}

--- a/mailpoet/assets/js/src/landingpage/faq.tsx
+++ b/mailpoet/assets/js/src/landingpage/faq.tsx
@@ -44,7 +44,7 @@ function Faq() {
       ),
       readMoreText: __('Read More', 'mailpoet'),
       readMoreLink:
-        'https://kb.mailpoet.com/article/349-choosing-your-mailpoet-plan',
+        'https://kb.mailpoet.com/article/349-mailpoet-plans-and-limits-explained',
     },
     {
       slug: 'item-4',

--- a/mailpoet/assets/js/src/newsletters/send/ga-tracking.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/ga-tracking.tsx
@@ -9,7 +9,7 @@ const trackCampaignNameTyped = _.once(() =>
   MailPoet.trackEvent('User has typed a GA campaign name'),
 );
 const tipLink =
-  'https://kb.mailpoet.com/article/187-track-your-newsletters-subscribers-in-google-analytics';
+  'https://kb.mailpoet.com/article/187-track-newsletters-subscribers-in-google-analytics';
 const tip = ReactStringReplace(
   __('For example, “Spring email”. [link]Read the guide.[/link]', 'mailpoet'),
   /\[link\](.*?)\[\/link\]/g,

--- a/mailpoet/assets/js/src/segments/dynamic/subscribers-counter.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/subscribers-counter.tsx
@@ -95,7 +95,7 @@ function SubscribersCounter(): JSX.Element {
         <span className="mailpoet-form-error-message">
           {MailPoet.I18n.t('dynamicSegmentSizeCalculatingTimeout')}{' '}
           <a
-            href="https://kb.mailpoet.com/article/237-guide-to-subscriber-segmentation?utm_source=plugin&utm_medium=segments"
+            href="https://kb.mailpoet.com/article/237-guide-to-subscriber-segmentation"
             target="_blank"
             className="mailpoet-form-error-message"
             rel="noopener noreferrer"

--- a/mailpoet/assets/js/src/settings/pages/advanced/bounce-address.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/bounce-address.tsx
@@ -15,7 +15,7 @@ export function BounceAddress() {
             {t('yourBouncedEmails')}{' '}
             <a
               className="mailpoet-link"
-              href="https://kb.mailpoet.com/article/180-how-bounce-management-works-in-mailpoet-3"
+              href="https://kb.mailpoet.com/article/180-bounce-management-in-mailpoet-3"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/mailpoet/assets/js/src/settings/pages/advanced/libs-3rd-party.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/libs-3rd-party.tsx
@@ -29,7 +29,7 @@ export function Libs3rdParty() {
             )}{' '}
             <a
               className="mailpoet-link"
-              href="https://kb.mailpoet.com/article/338-what-3rd-party-libraries-we-use"
+              href="https://kb.mailpoet.com/article/338-enabledisable-3rd-party-libraries"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/mailpoet/assets/js/src/settings/pages/advanced/task-scheduler.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/task-scheduler.tsx
@@ -17,7 +17,7 @@ export function TaskScheduler() {
             {__('Select what will activate your newsletter queue.', 'mailpoet')}{' '}
             <a
               className="mailpoet-link"
-              href="https://kb.mailpoet.com/article/129-what-is-the-newsletter-task-scheduler"
+              href="https://kb.mailpoet.com/article/129-newsletter-task-scheduler-cron"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/mailpoet/assets/js/src/settings/pages/send-with/other/test-sending.tsx
+++ b/mailpoet/assets/js/src/settings/pages/send-with/other/test-sending.tsx
@@ -73,7 +73,7 @@ export function TestSending() {
                     key={i}
                     target="_blank"
                     rel="noopener noreferrer"
-                    href="https://kb.mailpoet.com/article/146-my-newsletters-are-not-being-received"
+                    href="https://kb.mailpoet.com/article/146-the-newsletters-are-not-being-received"
                   >
                     {match}
                   </a>

--- a/mailpoet/assets/js/src/settings/pages/signup-confirmation/enable-signup-confirmation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/signup-confirmation/enable-signup-confirmation.tsx
@@ -26,7 +26,7 @@ export function EnableSignupConfirmation() {
             {t('enableSignupConfDescription')}{' '}
             <a
               className="mailpoet-link"
-              href="https://kb.mailpoet.com/article/128-why-you-should-use-signup-confirmation-double-opt-in"
+              href="https://kb.mailpoet.com/article/128-signup-confirmation-double-opt-in-feature"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/warnings.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/warnings.jsx
@@ -67,7 +67,7 @@ function Warnings({
         if (match === '%2$s') return role.join(', ');
         return (
           <a
-            href="https://kb.mailpoet.com/article/270-role-based-email-addresses-are-not-allowed"
+            href="https://kb.mailpoet.com/article/270-sending-to-role-based-email-addresses-is-not-allowed"
             target="_blank"
             rel="noopener noreferrer"
             key={match}

--- a/mailpoet/assets/js/src/wizard/steps/usage-tracking-step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/usage-tracking-step.tsx
@@ -73,7 +73,7 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
                   (match, i) => (
                     <a
                       key={i}
-                      href="https://kb.mailpoet.com/article/338-what-3rd-party-libraries-we-use"
+                      href="https://kb.mailpoet.com/article/338-enabledisable-3rd-party-libraries"
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -22,7 +22,7 @@
     "phpunit/phpunit": "9.6.19",
     "totten/lurkerlite": "^1.3",
     "vlucas/phpdotenv": "v5.6.0",
-    "woocommerce/qit-cli": "^0.5.4",
+    "woocommerce/qit-cli": "^0.9.1",
     "wp-cli/wp-cli-bundle": "2.10.0",
     "symfony/process": "5.4.46"
   },

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a95263a51332277e75d7147e3dc4551e",
+    "content-hash": "f7a009b490822fcf55b4281ad09a773d",
     "packages": [
         {
             "name": "dragonmantank/cron-expression",
@@ -6177,16 +6177,16 @@
         },
         {
             "name": "woocommerce/qit-cli",
-            "version": "0.5.4",
+            "version": "0.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/qit-cli.git",
-                "reference": "6309fa5e8732bad6f64ed7396ea90f31d297cad7"
+                "reference": "71a295b2208a84f375cb907715347db71d244f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/qit-cli/zipball/6309fa5e8732bad6f64ed7396ea90f31d297cad7",
-                "reference": "6309fa5e8732bad6f64ed7396ea90f31d297cad7",
+                "url": "https://api.github.com/repos/woocommerce/qit-cli/zipball/71a295b2208a84f375cb907715347db71d244f7f",
+                "reference": "71a295b2208a84f375cb907715347db71d244f7f",
                 "shasum": ""
             },
             "require": {
@@ -6204,9 +6204,9 @@
             "description": "A command line interface for WooCommerce Quality Insights Toolkit (QIT).",
             "support": {
                 "issues": "https://github.com/woocommerce/qit-cli/issues",
-                "source": "https://github.com/woocommerce/qit-cli/tree/0.5.4"
+                "source": "https://github.com/woocommerce/qit-cli/tree/0.9.1"
             },
-            "time": "2024-08-13T17:19:55+00:00"
+            "time": "2025-04-30T15:46:46+00:00"
         },
         {
             "name": "wp-cli/cache-command",

--- a/mailpoet/views/forms.html
+++ b/mailpoet/views/forms.html
@@ -7,7 +7,7 @@
     <p class="mailpoet_sending_methods_help help">
       <% set allowedHtml = {'a': {'href': [], 'target': [], 'id': []}, 'strong': {}} %>
       <%= __('<strong>Tip:</strong> check out [link]this list[/link] of form plugins that integrate with MailPoet.')
-      |replaceLinkTags('https://kb.mailpoet.com/article/198-list-of-forms-plugins-that-work-with-mailpoet?utm_source=plugin&utm_medium=settings&utm_campaign=helpdocs', {'target': '_blank', id: 'mailpoet_helper_link'})
+      |replaceLinkTags('https://kb.mailpoet.com/article/198-forms-themes-plugins-that-work-with-mailpoet', {'target': '_blank', id: 'mailpoet_helper_link'})
       |wpKses(allowedHtml)
       %>
     </p>

--- a/mailpoet/views/newsletter/templates/components/newsletterPreview.hbs
+++ b/mailpoet/views/newsletter/templates/components/newsletterPreview.hbs
@@ -50,7 +50,7 @@
           <%= __('Your test email has been sent!') %>
         </p>
         <p class="{{#unless previewSendingSuccess}}mailpoet_hidden{{/unless}}">
-          <%= __('Didn’t receive the test email? Read our [link]quick guide[/link] to sending issues.')|replaceLinkTags('https://kb.mailpoet.com/article/146-my-newsletters-are-not-being-received', {'target': '_blank', 'rel': 'noopener noreferrer'})|raw %>
+          <%= __('Didn’t receive the test email? Read our [link]quick guide[/link] to sending issues.')|replaceLinkTags('https://kb.mailpoet.com/article/146-the-newsletters-are-not-being-received', {'target': '_blank', 'rel': 'noopener noreferrer'})|raw %>
         </p>
         <div class="{{#unless previewSendingError}}mailpoet_hidden{{/unless}} mailpoet_error" id="mailpoet_preview_sending_error"></div>
       </div>

--- a/mailpoet/views/subscribers/importExport/export.html
+++ b/mailpoet/views/subscribers/importExport/export.html
@@ -52,7 +52,7 @@
       <label for="export_columns">
         <%= __('List of fields to export') %>
         <p class="description">
-          <a href="https://kb.mailpoet.com/article/245-what-is-global-status" target="_blank">
+          <a href="https://kb.mailpoet.com/article/245-what-is-the-subscriber-global-status" target="_blank">
             <%= _x('Read about the Global status.', 'Link to a documentation page in the knowledge base about what is the subscriber global status') %>
           </a>
         </p>


### PR DESCRIPTION
## Description

I also removed some UTM parameters, as they were used inconsistently and I don't remember us checking them anyway. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7402

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7402-kb-links-lead-to-404)

_The latest successful build from `stomail-7402-kb-links-lead-to-404` will be used. If none is available, the link won't work._