### PR TITLE
Update SwitchingLanguage test

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -92,7 +92,7 @@ class SwitchingLanguagesCest {
     $i->waitForText('Listen');
     $i->waitForText('Einstellungen');
     $i->waitForText('Hilfe');
-    // $i->waitForText('Neue E-Mail'); Temporary disabled because the string changed and is not yet translated
+    $i->waitForText('Add new email'); // This will fail in the future when the string is translated
 
     $i->wantTo('Check Emails filter strings');
     $i->waitForText('Alle');
@@ -120,8 +120,8 @@ class SwitchingLanguagesCest {
     $i->amOnMailpoetPage('forms');
     $i->waitForText('Add new form'); // This will fail in the future when the string is translated
     $i->waitForText('Below pages'); // This will fail in the future when the string is translated
-    $i->waitForText('Sign-ups'); // This will fail in the future when the string is translated
-    $i->waitForText('Modified date'); // This will fail in the future when the string is translated
+    $i->waitForText('Registrierungen');
+    $i->waitForText('Änderungsdatum');
 
     $i->wantTo('Check Subscribers filter strings and button');
     $i->amOnMailpoetPage('subscribers');
@@ -144,7 +144,7 @@ class SwitchingLanguagesCest {
     $i->amOnMailpoetPage('lists');
     $i->waitForText('Abonnenten');
     $i->waitForText('Listen-Bewertung');
-    $i->waitForText('Add new list'); // This will fail in the future when the string is translated
+    $i->waitForText('Neue Liste hinzufügen');
     $i->waitForText('Ausgetragen');
 
     $i->wantTo('Check Settings tabs strings');


### PR DESCRIPTION
## Description

A couple of new strings have been updated to German, and this PR updates the language acceptance test. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7403

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7403-failing-switchinglanguagescest-acceptance-test)

_The latest successful build from `stomail-7403-failing-switchinglanguagescest-acceptance-test` will be used. If none is available, the link won't work._