### PR TITLE
Hide bulk checkbox on listing page when loading

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing.scss
@@ -71,6 +71,12 @@ input.mailpoet-listing-current-page {
   width: 37px;
 }
 
+.mailpoet-listing-loading {
+  [data-automation-id='select_all'] {
+    display: none;
+  }
+}
+
 .mailpoet-listing-loading tbody tr,
 .mailpoet_form_loading div.mailpoet-form-grid {
   opacity: 0.2;

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -271,6 +271,12 @@ class AcceptanceTester extends \Codeception\Actor {
     $i->seeNoJSErrors();
   }
 
+  public function selectAllListingItems() {
+    $i = $this;
+    $i->waitForElementVisible('[data-automation-id="select_all"]');
+    $i->click('[data-automation-id="select_all"]');
+  }
+
   public function waitForListingItemsToLoad() {
     $i = $this;
     $i->waitForElementNotVisible('.mailpoet-listing-loading');

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
@@ -18,9 +18,8 @@ class DeleteNewsletterCest {
     $i->clickItemRowActionByItemName($newsletterName, 'Move to trash');
     $i->waitForNoticeAndClose('1 email was moved to the trash.');
     $i->waitForListingItemsToLoad();
-    // click to select all newsletters
-    $i->click('[data-automation-id="select_all"]');
-    $i->waitForText('Move to trash');
+    $i->selectAllListingItems();
+    $i->waitForText('Move to trash', 10, '.mailpoet-listing-bulk-actions');
     $i->waitForElementClickable('[data-automation-id="action-trash"]');
     $i->click('[data-automation-id="action-trash"]');
     $i->waitForNoticeAndClose('2 emails were moved to the trash.', 20);
@@ -42,8 +41,7 @@ class DeleteNewsletterCest {
     $i->clickItemRowActionByItemName($newsletterName, 'Restore');
     $i->waitForText('1 email has been restored from the Trash.');
     $i->waitForListingItemsToLoad();
-    // click to select all newsletters
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->waitForText('Restore');
     $i->waitForElementClickable('[data-automation-id="action-restore"]');
     $i->click('[data-automation-id="action-restore"]');
@@ -70,8 +68,7 @@ class DeleteNewsletterCest {
     $i->waitForElementNotVisible($newsletterName);
     $i->waitForText($newsletterName . '2');
     $i->waitForText($newsletterName . '3');
-    // click to select all newsletters
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->click('Delete permanently');
     $i->waitForText('2 emails were permanently deleted.');
     $i->waitForElement('[data-automation-id="filters_all"]');
@@ -107,8 +104,7 @@ class DeleteNewsletterCest {
     $i->login();
     $i->amOnMailpoetPage('Emails');
     $i->waitForText($newsletterName);
-    // click to select all newsletters
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->waitForText('All items on this page are selected.');
     $i->click('Select all items on all pages');
     $i->waitForText('All 22 items are selected.');
@@ -117,8 +113,7 @@ class DeleteNewsletterCest {
     $i->waitForText('22 emails were moved to the trash.');
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
-    // click to select all newsletters
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->waitForText('All items on this page are selected.');
     $i->click('Select all items on all pages');
     $i->waitForText('All 22 items are selected.');

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -275,7 +275,7 @@ class ManageSegmentsCest {
     $i->waitForText($segment2Name);
 
     $i->wantTo('Select all segments and move them back to trash');
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->selectOption('Bulk actions', 'Trash');
     $i->waitForText('Are you sure you want to trash the selected segments');
     $i->click(['xpath' => '//button[text()="Trash"]']); // confirmation modal, xpath to avoid clicking the Trash tab
@@ -284,7 +284,7 @@ class ManageSegmentsCest {
     $i->wantTo('Select all segments in trash and bulk delete them permanently');
     $i->changeWooTableTab('trash');
     $i->waitForText($segment1Name);
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->selectOption('Bulk actions', 'Delete permanently');
     $i->click('Delete permanently'); // modal confirmation
     $i->waitForText('No data to display');

--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -62,7 +62,7 @@ class SubscriberCountShortcodeCest {
     $i->waitForElement('[data-automation-id="listing_filter_segment"]');
     $i->selectOption('[data-automation-id="listing_filter_segment"]', self::SUBSCRIBERS_LIST_NAME_TWO);
     $i->waitForElementVisible('[data-automation-id="listing_filter_segment"]');
-    $i->click('[data-automation-id="select_all"]');
+    $i->selectAllListingItems();
     $i->click('[data-automation-id="action-trash"]');
     $i->waitForListingItemsToLoad();
     $i->waitForNoticeAndClose('11 subscribers were moved to the trash.');


### PR DESCRIPTION
## Description

This aims to improve robustness of tests, where clicking this checkbox before the loading is finished would not select anything

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7404

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7404-fix-acceptance-test-flakiness-when-waiting-on-listing-to)

_The latest successful build from `stomail-7404-fix-acceptance-test-flakiness-when-waiting-on-listing-to` will be used. If none is available, the link won't work._