### PR TITLE
Improve robustness of acceptance tests when editing a list, a segment, or a subscriber

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -22,7 +22,7 @@
     "phpunit/phpunit": "9.6.19",
     "totten/lurkerlite": "^1.3",
     "vlucas/phpdotenv": "v5.6.0",
-    "woocommerce/qit-cli": "^0.9.1",
+    "woocommerce/qit-cli": "^0.5.4",
     "wp-cli/wp-cli-bundle": "2.10.0",
     "symfony/process": "5.4.46"
   },

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7a009b490822fcf55b4281ad09a773d",
+    "content-hash": "a95263a51332277e75d7147e3dc4551e",
     "packages": [
         {
             "name": "dragonmantank/cron-expression",
@@ -6177,16 +6177,16 @@
         },
         {
             "name": "woocommerce/qit-cli",
-            "version": "0.9.1",
+            "version": "0.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/qit-cli.git",
-                "reference": "71a295b2208a84f375cb907715347db71d244f7f"
+                "reference": "6309fa5e8732bad6f64ed7396ea90f31d297cad7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/qit-cli/zipball/71a295b2208a84f375cb907715347db71d244f7f",
-                "reference": "71a295b2208a84f375cb907715347db71d244f7f",
+                "url": "https://api.github.com/repos/woocommerce/qit-cli/zipball/6309fa5e8732bad6f64ed7396ea90f31d297cad7",
+                "reference": "6309fa5e8732bad6f64ed7396ea90f31d297cad7",
                 "shasum": ""
             },
             "require": {
@@ -6204,9 +6204,9 @@
             "description": "A command line interface for WooCommerce Quality Insights Toolkit (QIT).",
             "support": {
                 "issues": "https://github.com/woocommerce/qit-cli/issues",
-                "source": "https://github.com/woocommerce/qit-cli/tree/0.9.1"
+                "source": "https://github.com/woocommerce/qit-cli/tree/0.5.4"
             },
-            "time": "2025-04-30T15:46:46+00:00"
+            "time": "2024-08-13T17:19:55+00:00"
         },
         {
             "name": "wp-cli/cache-command",

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -60,6 +60,8 @@ class ManageListsCest {
     $i->wantTo('Edit existing list');
     $i->waitForText('Lists');
     $i->clickItemRowActionByItemName($newListTitle, 'Edit');
+    $i->waitForText('Edit list');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->waitForText($newListTitle);
     $i->clearFormField('#field_name');
     $i->fillField('Public list name', $editedListTitle);

--- a/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSegmentEmailAbsoluteCountCest.php
@@ -69,6 +69,8 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->wantTo('Edit the segment');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElementVisible('[data-automation-id="segment-number-of-opens"]');
     $i->seeInField('[data-automation-id="segment-number-of-opens"]', '2');
     $i->seeInField('[data-automation-id="segment-number-of-days"]', '3');
@@ -105,6 +107,8 @@ class CreateSegmentEmailAbsoluteCountCest {
     $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElementVisible('[data-automation-id="segment-email"]');
     $i->waitForText('This segment has 1 subscribers');
     $i->selectOptionInReactSelect('number of opens', '[data-automation-id="select-segment-action"]');

--- a/mailpoet/tests/acceptance/Segments/CreateSubscriberScoreSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/CreateSubscriberScoreSegmentCest.php
@@ -42,6 +42,8 @@ class CreateSubscriberScoreSegmentCest {
     $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElementVisible('[data-automation-id="segment-subscriber-score-operator"]');
     $i->seeInField('[data-automation-id="segment-subscriber-score-value"]', '20.51');
     $i->waitForText('This segment has');
@@ -80,6 +82,8 @@ class CreateSubscriberScoreSegmentCest {
     $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElementVisible('[data-automation-id="segment-subscriber-score-operator"]');
     $i->dontSeeElement('[data-automation-id="segment-subscriber-score-value"]');
     $i->waitForText('This segment has');

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -97,6 +97,8 @@ class ManageSegmentsCest {
 
     $i->wantTo('Edit existing segment');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForText('This segment has 3 subscribers');
     $i->clearFormField($nameElement);
     $i->clearField($descriptionElement, '');
@@ -363,7 +365,8 @@ class ManageSegmentsCest {
     $listingAutomationSelector = '[data-automation-id="mailpoet_dynamic_segment_name_' . $segment->getId() . '"]';
     $i->waitForText($segmentTitle, 10, $listingAutomationSelector);
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
-    $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForText('This segment has 2 subscribers.');
     $i->seeNoJSErrors();
     $i->selectOptionInReactSelect('Subscriber', '[data-automation-id="segment-wordpress-role"]');

--- a/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageWooCommerceSegmentsCest.php
@@ -50,6 +50,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($categorySelectElement);
     $i->seeInField($segmentNameField, $segmentTitle);
     $i->seeInField($segmentDescriptionField, $segmentDesc);
@@ -75,6 +77,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($editedTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($categorySelectElement);
     $i->seeInField($segmentNameField, $editedTitle);
     $i->seeInField($segmentDescriptionField, $editedDesc);
@@ -116,6 +120,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($productSelectElement);
     $i->seeInField($segmentNameField, $segmentTitle);
     $i->seeInField($segmentDescriptionField, $segmentDesc);
@@ -142,6 +148,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($editedTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($productSelectElement);
     $i->seeInField($segmentNameField, $editedTitle);
     $i->seeInField($segmentDescriptionField, $editedDesc);
@@ -182,6 +190,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($numberOfOrdersTypeElement);
     $i->seeInField($segmentNameField, $segmentTitle);
     $i->seeInField($segmentDescriptionField, $segmentDesc);
@@ -212,6 +222,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($editedTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($numberOfOrdersTypeElement);
     $i->seeInField($segmentNameField, $editedTitle);
     $i->seeInField($segmentDescriptionField, $editedDesc);
@@ -252,6 +264,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($totalSpentTypeElement);
     $i->seeInField($segmentNameField, $segmentTitle);
     $i->seeInField($segmentDescriptionField, $segmentDesc);
@@ -283,6 +297,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($editedTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($totalSpentTypeElement);
     $i->seeInField($segmentNameField, $editedTitle);
     $i->seeInField($segmentDescriptionField, $editedDesc);
@@ -323,6 +339,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($segmentTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($singleOrderValueTypeElement);
     $i->seeInField($segmentNameField, $segmentTitle);
     $i->seeInField($segmentDescriptionField, $segmentDesc);
@@ -354,6 +372,8 @@ class ManageWooCommerceSegmentsCest {
 
     $i->wantTo('Open edit form and check that all values were saved correctly');
     $i->clickWooTableActionByItemName($editedTitle, 'Edit');
+    $i->waitForText('Edit segment');
+    $i->waitForElementNotVisible('#mailpoet_loading');
     $i->waitForElement($singleOrderValueTypeElement);
     $i->seeInField($segmentNameField, $editedTitle);
     $i->seeInField($segmentDescriptionField, $editedDesc);

--- a/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
+++ b/mailpoet/tests/acceptance/Settings/CreateNewWordPressUserCest.php
@@ -59,8 +59,9 @@ class CreateNewWordPressUserCest {
     $i->amOnMailpoetPage('Subscribers');
     $i->waitForText('Subscribers');
     $i->clickItemRowActionByItemName('newuser@test.com', 'Edit');
-    $i->waitForText('Subscribed');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
+    $i->waitForText('Subscribed');
     $i->seeSelectedInSelect2($secondListName);
   }
 }

--- a/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscribeOnRegistrationPageCest.php
@@ -59,6 +59,8 @@ class SubscribeOnRegistrationPageCest {
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForText('registerpagesignup@fake.fake');
     $i->clickItemRowActionByItemName($regpageuseremail, 'Edit');
+    $i->waitForText('Edit subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->waitForText($regseg);
   }
 

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -192,7 +192,7 @@ class ManageSubscribersCest {
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->selectOptionInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
     $i->seeNoJSErrors();
@@ -214,6 +214,7 @@ class ManageSubscribersCest {
     $i->wantTo('Check subscriber edit page and the attached lists');
     $i->waitForText('Subscriber');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
     $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_CAMPING);
@@ -231,7 +232,7 @@ class ManageSubscribersCest {
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->waitForText(self::SINGLE_SEGMENT_NAME);
     $i->click('.select2-selection__choice__remove');
@@ -244,7 +245,7 @@ class ManageSubscribersCest {
 
     $i->wantTo('Remove subscriber from list from the listing page');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->selectOptionInSelect2(self::SINGLE_SEGMENT_NAME);
     $i->click('Save');
@@ -274,11 +275,11 @@ class ManageSubscribersCest {
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForListingItemsToLoad();
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->fillField(['name' => 'first_name'], 'EditedNew');
     $i->fillField(['name' => 'last_name'], 'EditedGlobalUser');
     $i->selectOption('[data-automation-id="subscriber-status"]', 'Unsubscribed');
-    $i->waitForElementNotVisible('.mailpoet_form_loading');
     // we cannot use data-automation attribute because this input is based on guttenberg component
     $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag 1,'); // the comma separates the tag
     $i->fillField('.mailpoet-form-field-tags input[type="text"]', 'My tag 2,');
@@ -292,7 +293,7 @@ class ManageSubscribersCest {
     $i->see('My tag 2');
     $i->see('My tag 3');
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->seeOptionIsSelected('[data-automation-id="subscriber-status"]', 'Unsubscribed');
     $i->see('Unsubscribed at', $unsubscribedMessage);
@@ -312,7 +313,7 @@ class ManageSubscribersCest {
     $i->see(self::MULTIPLE_SEGMENT_NAME_COOKING);
     $i->see(self::MULTIPLE_SEGMENT_NAME_CAMPING);
     $i->clickItemRowActionByItemName($newSubscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
     $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_COOKING);
     $i->seeSelectedInSelect2(self::MULTIPLE_SEGMENT_NAME_CAMPING);

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscriptionLinkCest.php
@@ -106,7 +106,8 @@ class ManageSubscriptionLinkCest {
     $i->amOnMailpoetPage('Subscribers');
     $i->waitForText(\AcceptanceTester::ADMIN_EMAIL);
     $i->clickItemRowActionByItemName(\AcceptanceTester::ADMIN_EMAIL, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->waitForElement('[data-automation-id="subscriber_edit_form"]');
     $i->selectOption('[data-automation-id="subscriber-status"]', 'Subscribed');
     $i->click('Save');

--- a/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/AdminUserSubscriptionCest.php
@@ -148,7 +148,8 @@ class AdminUserSubscriptionCest {
 
     // Verify the first/last name values before WP user creation
     $i->clickItemRowActionByItemName($subscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->waitForElementVisible(['css' => 'input[name="first_name"]']);
     $i->seeInField(['css' => 'input[name="first_name"]'], $uniqueFirstName);
     $i->seeInField(['css' => 'input[name="last_name"]'], $uniqueLastName);
@@ -176,7 +177,8 @@ class AdminUserSubscriptionCest {
 
     // Verify the first/last name were updated to match WordPress user data
     $i->clickItemRowActionByItemName($subscriberEmail, 'Edit');
-    $i->waitForText('Subscriber');
+    $i->waitForText('Edit subscriber');
+    $i->waitForElementNotVisible('.mailpoet_form_loading');
     $i->waitForElementVisible(['css' => 'input[name="first_name"]']);
 
     // Check that the values match WordPress user data


### PR DESCRIPTION
## Description

1. Check for the updated edit page title from https://github.com/mailpoet/mailpoet/pull/6160 (e.g. `Subscriber` => `Edit subscriber`).
2. Wait until the loading animation is not visible.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7406

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7406-flaky-adminusersubscriptioncest-acceptance-test)

_The latest successful build from `stomail-7406-flaky-adminusersubscriptioncest-acceptance-test` will be used. If none is available, the link won't work._