### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 9.8.3
+            ./do download:woo-commerce-zip 9.8.4
             ./do download:woo-commerce-subscriptions-zip 7.4.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.11


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._