### PR TITLE
Fix: WC Transactional Emails acceptance test

### DIFF
--- a/mailpoet/tests/DataFactories/Settings.php
+++ b/mailpoet/tests/DataFactories/Settings.php
@@ -10,16 +10,19 @@ use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
+use MailPoet\WooCommerce\TransactionalEmails;
 
 class Settings {
   const DEFAULT_OPTIN_MESSAGE = 'Yes, I would like to be added to your mailing list';
 
   private SettingsController $settings;
   private AuthorizedEmailsController $authorizedEmailsController;
+  private TransactionalEmails $transactionalEmails;
 
   public function __construct() {
     $this->settings = SettingsController::getInstance();
     $this->authorizedEmailsController = ContainerWrapper::getInstance()->get(AuthorizedEmailsController::class);
+    $this->transactionalEmails = ContainerWrapper::getInstance()->get(TransactionalEmails::class);
     $this->settings->resetCache();
   }
 
@@ -242,6 +245,8 @@ class Settings {
 
   public function withWooCommerceEmailCustomizerEnabled() {
     $this->settings->set('woocommerce.use_mailpoet_editor', true);
+    // When we activate WC email customization directly via settings controller we need to init the transactional email.
+    $this->transactionalEmails->init();
     return $this;
   }
 


### PR DESCRIPTION
## Description

There was a false positive test in our codebase. We change the MailPoet settings for WC email customization via Data Factory, but because we don't use the API Endpoint, the transactional email initialization is not triggered. This PR adds the execution of the transactional emails initialization.

**Before the fix**
<img width="1270" alt="Screenshot 2025-05-13 at 14 49 01" src="https://github.com/user-attachments/assets/9316f43f-c2bc-4257-9a5d-c95a5e4714fb" />

**After the fix**
<img width="1261" alt="Screenshot 2025-05-13 at 14 51 10" src="https://github.com/user-attachments/assets/ae6a629e-0c56-4e42-bbac-e7e879eb8713" />


## Code review notes

The test started failing with WC 9.9.0 beta1

## QA notes

We can skip QA here because the fix is related to tests only.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/wc-transactional-email-test)

_The latest successful build from `fix/wc-transactional-email-test` will be used. If none is available, the link won't work._