### PR TITLE
Fix compiling haw.js file

### DIFF
--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -201,7 +201,6 @@ const adminConfig = {
   name: 'admin',
   entry: {
     vendor: 'webpack-vendor-index.jsx',
-    haw: 'vendor/happiness-assistant-widget.js',
     mailpoet: 'webpack-mailpoet-index.jsx',
     admin_vendor: ['prop-types', 'lodash', 'webpack-admin-expose.js'], // libraries shared between free and premium plugin
     admin: 'webpack-admin-index.tsx',
@@ -222,6 +221,10 @@ const adminConfig = {
         {
           from: 'node_modules/tinymce/skins/ui/oxide',
           to: 'skins/ui/oxide',
+        },
+        {
+          from: 'assets/js/src/vendor/happiness-assistant-widget.js',
+          to: 'haw.js',
         },
       ],
     }),


### PR DESCRIPTION
## Description

While using `haw` entry point works locally and also when building the branch, it did fail consistently in `trunk`. My guess is, that because it was marked as an entry point, the 434KB `happiness-assistant-widget.js` was too big as webpack needed to read it in full. But now it just copies it, which is a quick operation. 

## Code review notes

I'm not sure if this is verifiable elsewhere than `trunk`, but I did SSH to `trunk` build, make this exact changes there and tried to compile JS and it worked.

Before:
<img width="1128" alt="Screenshot 2025-05-20 at 14 16 34" src="https://github.com/user-attachments/assets/3dbbf71b-43c3-43fa-8303-481884b5ae0c" />

After: 
<img width="567" alt="Screenshot 2025-05-20 at 14 17 55" src="https://github.com/user-attachments/assets/08c38719-d07f-4317-9977-fbc83c94b7b9" />

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-failing-build)

_The latest successful build from `fix-failing-build` will be used. If none is available, the link won't work._