### PR TITLE
Add "Contact support" link in Odie chatbot

### DIFF
--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -184,11 +184,30 @@
       <% set support_form_url = has_premium_support ? 'https://www.mailpoet.com/support/support-form/' : 'https://wordpress.org/support/plugin/mailpoet/' %>
       <a slot="support-link"
           href="<%= support_form_url %>"
+          id="mailpoet-support-link"
+          style="display:none"
           target="_blank"
       >
         <%= __('Contact support', 'mailpoet') %>
       </a>
     </chat-widget>
+    <script>
+      const getChatId = () => localStorage.getItem('ai-widget-mailpoet-chat-support-chat-id');
+
+      document.addEventListener('DOMContentLoaded', function() {
+        const supportLink = document.getElementById('mailpoet-support-link');
+        if (supportLink) {
+          // Only show the support link once the chat has begun
+          const checkChatId = setInterval(function() {
+            const chatId = getChatId();
+            if (chatId) {
+              supportLink.style.display = 'block';
+              clearInterval(checkChatId);
+            }
+          }, 2000);
+        }
+      });
+    </script>
   <% else %>
     <script type="text/javascript">window.DocsBotAI=window.DocsBotAI||{},DocsBotAI.init=function(c){return new Promise(function(e,o){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://widget.docsbot.ai/chat.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n),t.addEventListener("load",function(){window.DocsBotAI.mount({id:c.id,supportCallback:c.supportCallback,identify:c.identify,options:c.options});var t;t=function(n){return new Promise(function(e){if(document.querySelector(n))return e(document.querySelector(n));var o=new MutationObserver(function(t){document.querySelector(n)&&(e(document.querySelector(n)),o.disconnect())});o.observe(document.body,{childList:!0,subtree:!0})})},t&&t("#docsbotai-root").then(e).catch(o)}),t.addEventListener("error",function(t){o(t.message)})})};</script>
     <script type="text/javascript">

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -179,7 +179,7 @@
       avatar="<%= cdn_url('chat-avatar.png') %>"
       title="<%= __('MailPoet support', 'mailpoet') %>"
       subtitle="<%= __('Chat with our AI assistant', 'mailpoet') %>"
-      firstMessage="<%= __('How can I help you today?', 'mailpoet') %>"
+      first-message="<%= __('How can I help you today?', 'mailpoet') %>"
     ></chat-widget>
   <% else %>
     <script type="text/javascript">window.DocsBotAI=window.DocsBotAI||{},DocsBotAI.init=function(c){return new Promise(function(e,o){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://widget.docsbot.ai/chat.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n),t.addEventListener("load",function(){window.DocsBotAI.mount({id:c.id,supportCallback:c.supportCallback,identify:c.identify,options:c.options});var t;t=function(n){return new Promise(function(e){if(document.querySelector(n))return e(document.querySelector(n));var o=new MutationObserver(function(t){document.querySelector(n)&&(e(document.querySelector(n)),o.disconnect())});o.observe(document.body,{childList:!0,subtree:!0})})},t&&t("#docsbotai-root").then(e).catch(o)}),t.addEventListener("error",function(t){o(t.message)})})};</script>

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -180,7 +180,15 @@
       title="<%= __('MailPoet support', 'mailpoet') %>"
       subtitle="<%= __('Chat with our AI assistant', 'mailpoet') %>"
       first-message="<%= __('How can I help you today?', 'mailpoet') %>"
-    ></chat-widget>
+    >
+      <% set support_form_url = has_premium_support ? 'https://www.mailpoet.com/support/support-form/' : 'https://wordpress.org/support/plugin/mailpoet/' %>
+      <a slot="support-link"
+          href="<%= support_form_url %>"
+          target="_blank"
+      >
+        <%= __('Contact support', 'mailpoet') %>
+      </a>
+    </chat-widget>
   <% else %>
     <script type="text/javascript">window.DocsBotAI=window.DocsBotAI||{},DocsBotAI.init=function(c){return new Promise(function(e,o){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://widget.docsbot.ai/chat.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n),t.addEventListener("load",function(){window.DocsBotAI.mount({id:c.id,supportCallback:c.supportCallback,identify:c.identify,options:c.options});var t;t=function(n){return new Promise(function(e){if(document.querySelector(n))return e(document.querySelector(n));var o=new MutationObserver(function(t){document.querySelector(n)&&(e(document.querySelector(n)),o.disconnect())});o.observe(document.body,{childList:!0,subtree:!0})})},t&&t("#docsbotai-root").then(e).catch(o)}),t.addEventListener("error",function(t){o(t.message)})})};</script>
     <script type="text/javascript">

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -197,6 +197,16 @@
       document.addEventListener('DOMContentLoaded', function() {
         const supportLink = document.getElementById('mailpoet-support-link');
         if (supportLink) {
+          <% if has_premium_support %>
+            supportLink.addEventListener('click', function(e) {
+              const chatId = getChatId();
+              if (chatId) {
+                e.preventDefault();
+                window.open(`<%= support_form_url %>?chatId=${chatId}`, '_blank');
+              }
+            });
+          <% endif %>
+
           // Only show the support link once the chat has begun
           const checkChatId = setInterval(function() {
             const chatId = getChatId();


### PR DESCRIPTION
## Description

Shows a `Contact support` link after the first reply from Odie, and links either to support form for paying customers or public forum for free users.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7415

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7415-add-contact-support-link-in-odie-chatbot)

_The latest successful build from `stomail-7415-add-contact-support-link-in-odie-chatbot` will be used. If none is available, the link won't work._