### PR TITLE
Fix missing space when scheduling an email

### DIFF
--- a/mailpoet/assets/css/src/generic/_grid.scss
+++ b/mailpoet/assets/css/src/generic/_grid.scss
@@ -1,5 +1,6 @@
 .mailpoet-flex {
   display: flex;
+  gap: $grid-gap;
 }
 
 .mailpoet-flex-grow {

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -216,6 +216,11 @@
             }
           }, 2000);
         }
+        // Prevent conflicts with other keydown events on Dotcom
+        function writingFixer (e) {
+            e.stopPropagation();
+        }
+        document.getElementById('chat').addEventListener('keydown', writingFixer);
       });
     </script>
   <% else %>
@@ -234,7 +239,7 @@
           <% endif %>
         },
       }).then(() => {
-          // stopping propagation to avoid conflicts with other keydown events form WP.com
+        // Prevent conflicts with other keydown events on Dotcom
         function writingFixer (e) {
           e.stopPropagation();
         }


### PR DESCRIPTION
## Description

| Before | After |
| ----- | ----- | 
| <img width="404" alt="Screenshot 2025-05-22 at 13 40 53" src="https://github.com/user-attachments/assets/d7e684f8-ec93-4d33-a7a1-ecc843e13de5" />   | <img width="398" alt="Screenshot 2025-05-22 at 13 40 43" src="https://github.com/user-attachments/assets/8f74afb4-181c-4a0e-ae20-22268db21f24" />  |
| <img width="399" alt="Screenshot 2025-05-22 at 13 43 53" src="https://github.com/user-attachments/assets/dcede6e5-6d22-45b9-a638-684c6fa26457" />  | <img width="411" alt="Screenshot 2025-05-22 at 13 44 04" src="https://github.com/user-attachments/assets/30c7e616-ec9a-45ff-9844-d7b925913235" />  |

In addition to adding missing space, this PR also fixes conflict between Odie and Dotcom, where writing inside Odie can still trigger an event in Dotcom, e.g. pressing `n` opens notifications sidebar that covers chatbot. 



## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7287

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7287-different-spaces-between-time-fields-in-the-woo-and-non-woo)

_The latest successful build from `stomail-7287-different-spaces-between-time-fields-in-the-woo-and-non-woo` will be used. If none is available, the link won't work._