### PR TITLE
Add "4th" as option for nthWeekDay interval type

### DIFF
--- a/mailpoet/assets/js/src/newsletters/scheduling/common.jsx
+++ b/mailpoet/assets/js/src/newsletters/scheduling/common.jsx
@@ -76,6 +76,7 @@ const nthWeekDayValues = {
   1: __('1st', 'mailpoet'),
   2: __('2nd', 'mailpoet'),
   3: __('3rd', 'mailpoet'),
+  4: __('4th', 'mailpoet'),
   L: _x('last', 'e.g. monthly every last Monday', 'mailpoet'),
 };
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -222,7 +222,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.4 - 2025-05-26 =
-* Improved: minor changes and fixes.
+= x.x.x - YYYY-MM-DD =
+* Improved: Add "4th" day of week as a monthly frequency option.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

| Before | After |
| - | - |
| ![GaS3sqPZYyDhvsUt](https://github.com/user-attachments/assets/aa88cb57-0839-4848-a722-29672251e36d) | ![UNXFxvVoQLl7n6Ah](https://github.com/user-attachments/assets/d976c017-7f9a-4e26-ab10-d921f93ed97d) |

Add "4th" as an option for the nth week day interval type, as the 4th week day of the month does not always overlap with the "last" week day of the month.

## Code review notes

_N/A_

## QA notes

1. Go to **Emails** → **Add new email**.
2. Create a Post Notification.
3. Go to the Settings page.
4. Select a frequency → **Monthly every...**.
5. Set day of week, for example "Monday".
6. Confirm "4th" is in the available options.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7418

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7418-4th-weekday-of-the-month-bug)

_The latest successful build from `stomail-7418-4th-weekday-of-the-month-bug` will be used. If none is available, the link won't work._