### PR TITLE
Fix ServicesTest to properly verify premium status response

### DIFF
--- a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php
@@ -248,7 +248,7 @@ class ServicesTest extends \MailPoetTest {
     $response = $servicesEndpoint->checkPremiumKey($this->data);
     verify($response->status)->equals(APIResponse::STATUS_OK);
     foreach (array_keys(Installer::getPremiumStatus()) as $key) {
-      verify(isset($response->meta[$key]))->true();
+      verify(array_key_exists($key, $response->meta))->true();
     }
   }
 


### PR DESCRIPTION
## Description

The [`testItRespondsWithSuccessIfPremiumKeyIsValid`](https://github.com/mailpoet/mailpoet/blob/8cc70831bef8a385903dc5f67de44b3013e06e3a/mailpoet/tests/integration/API/JSON/v1/ServicesTest.php#L251) test currently uses `isset()` to verify the presence of premium status keys in the status response object. However, `isset()` returns `false` if a key exists but its value is `null`, which leads to the test failing in some cases even though the key is present.

This PR updates the check to use `array_key_exists()`.

The issue with this test occurred during a temporary outage of `release.mailpoet.com`, which caused `Installer::getPremiumStatus()` to return `[..., 'premium_plugin_info' => null]`.

While mocking the method to avoid performing the API call during the test might have been a better approach, the fact that `Installer::getPremiumStatus()` is a static method would require significant refactoring. In this case, such changes don't seem justified, as the purpose of the test is simply to verify the expected shape of the response.

## Code review notes

To simulate the test failure, you can block access to `release.mailpoet.com` and run the tests as follows:

1. Check out the `trunk` branch.
2. Add the following entry to your `/etc/hosts` file to block the domain: `127.0.0.1 release.mailpoet.com`
3. From the `./mailpoet` directory, run the test suite with: `./do test:integration --file=tests/integration/API/JSON/v1/ServicesTest.php`
4. Confirm that the `testItRespondsWithSuccessIfPremiumKeyIsValid` test fails.
5. Check out this branch and run the tests again to verify the fix.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7419](https://linear.app/a8c/issue/STOMAIL-7419/intermittent-failures-in-testitrespondswithsuccessifpremiumkeyisvalid)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7419-intermittent-failures-in)

_The latest successful build from `stomail-7419-intermittent-failures-in` will be used. If none is available, the link won't work._