### PR TITLE
Fix linking duplicated Newsletter with global $post object

### DIFF
--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -195,7 +195,7 @@ class NewsletterSaveController {
     $this->newslettersRepository->flush();
 
     // duplicate wp post data
-    $post = $this->wp->getPost($newsletter->getWpPostId());
+    $post = !is_null($newsletter->getWpPostId()) ? $this->wp->getPost($newsletter->getWpPostId()) : null;
     if ($post instanceof \WP_Post) {
       $newPostId = $this->wp->wpInsertPost([
         'post_status' => NewsletterEntity::STATUS_DRAFT,

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -224,5 +224,6 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Improved: Add "4th" day of week as a monthly frequency option.
+* Fixed an issue where duplicated newsletters could be incorrectly linked to unrelated posts under certain conditions.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

This PR resolves an issue where a duplicated newsletter could be incorrectly linked to an unrelated post.

1. Some plugins or themes may set the global post object using `global $post` or `$GLOBALS['post']`.
2. MailPoet's newsletter duplication functionality [duplicates the associated post from `wp_posts`](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/lib/Newsletter/NewsletterSaveController.php#L198) (for newsletters created using the new block email editor, a related post exists in `wp_posts`).
3. When the duplicated newsletter is created with the default email editor and does not have a related post, `$newsletter->getWpPostId()` returns `null`.
4. If a post exists in `$GLOBALS['post']`, and a call is made to `$this->wp->getPost(null)`, [WordPress returns the global post object](https://github.com/WordPress/WordPress/blob/master/wp-includes/post.php#L1096-L1098). While duplicating a post, having these conditions results in unintentionally duplicating an unrelated post and linking it to the duplicated newsletter.

## Code review notes

To simulate a plugin or theme polluting the global $post object, you can add the following plugin in your test environment - `/wp-content/mu-plugins/set-global-post.php`:

```php
<?php

add_action( 'init', function() {
	global $post;
	$post = get_post(1); // 1 is the ID of the "Hello world!" on a clean install, but could be any post id from wp_posts.
} );
```

1. Create a Newsletter with the default email editor and save it as draft.
2. Duplicate the newsletter from the listing screen `/wp-admin/admin.php?page=mailpoet-newsletters#/standard`.
3. The duplicated newsletter should be named "Copy of Hello world!", where "Hello world!" is the title of the global `$post` object. Editing the duplicate, would open the editor with the duplicated global post.
4. Apply the changes from the PR and duplicate the original newsletter from the listing screen.
5. The duplicated newsletter should now have a title "Copy of [source-newsletter-name]" and editing it should open the duplicated newsletter entry.

## QA notes

* Verify duplicating a newsletter created with the default and the new block email editor works as expected.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7420: Complex duplicate email / block editor issue](https://linear.app/a8c/issue/STOMAIL-7420/complex-duplicate-email-block-editor-issue)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7420-complex-duplicate-email-block-editor-issue)

_The latest successful build from `stomail-7420-complex-duplicate-email-block-editor-issue` will be used. If none is available, the link won't work._