### PR TITLE
Hide 'unsubscribe' bulk action when segmenting unsubscribed subscribers

### DIFF
--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -404,6 +404,15 @@ const getBulkActions = () => {
     },
   ];
 
+  // Filter out 'unsubscribe' action if we're in the unsubscribed group
+  const url = window.location.href;
+  const match = url.match(/group\[(.*?)\]/);
+  const group = match ? match[1] : null;
+
+  if (group === 'unsubscribed') {
+    return bulkActions.filter((action) => action.name !== 'unsubscribe');
+  }
+
   return bulkActions;
 };
 

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -176,232 +176,236 @@ const createModal = (submitModal, closeModal, field, title) => (
   </Modal>
 );
 
-const getBulkActions = () => [
-  {
-    name: 'moveToList',
-    label: __('Move to list...', 'mailpoet'),
-    onSelect: function onSelect(submitModal, closeModal) {
-      const field = {
-        id: 'move_to_segment',
-        name: 'move_to_segment',
-        endpoint: 'segments',
-        filter: function filter(segment) {
-          return !!(!segment.deleted_at && segment.type === 'default');
-        },
-      };
+const getBulkActions = () => {
+  const bulkActions = [
+    {
+      name: 'moveToList',
+      label: __('Move to list...', 'mailpoet'),
+      onSelect: function onSelect(submitModal, closeModal) {
+        const field = {
+          id: 'move_to_segment',
+          name: 'move_to_segment',
+          endpoint: 'segments',
+          filter: function filter(segment) {
+            return !!(!segment.deleted_at && segment.type === 'default');
+          },
+        };
 
-      return createModal(
-        submitModal,
-        closeModal,
-        field,
-        __('Move to list...', 'mailpoet'),
-      );
+        return createModal(
+          submitModal,
+          closeModal,
+          field,
+          __('Move to list...', 'mailpoet'),
+        );
+      },
+      getData: function getData() {
+        return {
+          segment_id: Number(jQuery('#move_to_segment').val()),
+        };
+      },
+      onSuccess: function onSuccess(response: Response) {
+        MailPoet.Notice.success(
+          __(
+            '%1$d subscribers were moved to list <strong>%2$s</strong>.',
+            'mailpoet',
+          )
+            .replace('%1$d', Number(response.meta.count).toLocaleString())
+            .replace('%2$s', response.meta.segment),
+        );
+      },
     },
-    getData: function getData() {
-      return {
-        segment_id: Number(jQuery('#move_to_segment').val()),
-      };
-    },
-    onSuccess: function onSuccess(response: Response) {
-      MailPoet.Notice.success(
-        __(
-          '%1$d subscribers were moved to list <strong>%2$s</strong>.',
-          'mailpoet',
-        )
-          .replace('%1$d', Number(response.meta.count).toLocaleString())
-          .replace('%2$s', response.meta.segment),
-      );
-    },
-  },
-  {
-    name: 'addToList',
-    label: __('Add to list...', 'mailpoet'),
-    onSelect: function onSelect(submitModal, closeModal) {
-      const field = {
-        id: 'add_to_segment',
-        name: 'add_to_segment',
-        endpoint: 'segments',
-        filter: function filter(segment) {
-          return !!(!segment.deleted_at && segment.type === 'default');
-        },
-      };
+    {
+      name: 'addToList',
+      label: __('Add to list...', 'mailpoet'),
+      onSelect: function onSelect(submitModal, closeModal) {
+        const field = {
+          id: 'add_to_segment',
+          name: 'add_to_segment',
+          endpoint: 'segments',
+          filter: function filter(segment) {
+            return !!(!segment.deleted_at && segment.type === 'default');
+          },
+        };
 
-      return createModal(
-        submitModal,
-        closeModal,
-        field,
-        __('Add to list...', 'mailpoet'),
-      );
+        return createModal(
+          submitModal,
+          closeModal,
+          field,
+          __('Add to list...', 'mailpoet'),
+        );
+      },
+      getData: function getData() {
+        return {
+          segment_id: Number(jQuery('#add_to_segment').val()),
+        };
+      },
+      onSuccess: function onSuccess(response: Response) {
+        MailPoet.Notice.success(
+          __(
+            '%1$d subscribers were added to list <strong>%2$s</strong>.',
+            'mailpoet',
+          )
+            .replace('%1$d', Number(response.meta.count).toLocaleString())
+            .replace('%2$s', response.meta.segment),
+        );
+      },
     },
-    getData: function getData() {
-      return {
-        segment_id: Number(jQuery('#add_to_segment').val()),
-      };
-    },
-    onSuccess: function onSuccess(response: Response) {
-      MailPoet.Notice.success(
-        __(
-          '%1$d subscribers were added to list <strong>%2$s</strong>.',
-          'mailpoet',
-        )
-          .replace('%1$d', Number(response.meta.count).toLocaleString())
-          .replace('%2$s', response.meta.segment),
-      );
-    },
-  },
-  {
-    name: 'removeFromList',
-    label: __('Remove from list...', 'mailpoet'),
-    onSelect: function onSelect(submitModal, closeModal) {
-      const field = {
-        id: 'remove_from_segment',
-        name: 'remove_from_segment',
-        endpoint: 'segments',
-        filter: function filter(segment) {
-          return segment.type === 'default';
-        },
-      };
+    {
+      name: 'removeFromList',
+      label: __('Remove from list...', 'mailpoet'),
+      onSelect: function onSelect(submitModal, closeModal) {
+        const field = {
+          id: 'remove_from_segment',
+          name: 'remove_from_segment',
+          endpoint: 'segments',
+          filter: function filter(segment) {
+            return segment.type === 'default';
+          },
+        };
 
-      return createModal(
-        submitModal,
-        closeModal,
-        field,
-        __('Remove from list...', 'mailpoet'),
-      );
+        return createModal(
+          submitModal,
+          closeModal,
+          field,
+          __('Remove from list...', 'mailpoet'),
+        );
+      },
+      getData: function getData() {
+        return {
+          segment_id: Number(jQuery('#remove_from_segment').val()),
+        };
+      },
+      onSuccess: function onSuccess(response: Response) {
+        MailPoet.Notice.success(
+          __(
+            '%1$d subscribers were removed from list <strong>%2$s</strong>.',
+            'mailpoet',
+          )
+            .replace('%1$d', Number(response.meta.count).toLocaleString())
+            .replace('%2$s', response.meta.segment),
+        );
+      },
     },
-    getData: function getData() {
-      return {
-        segment_id: Number(jQuery('#remove_from_segment').val()),
-      };
+    {
+      name: 'removeFromAllLists',
+      label: __('Remove from all lists', 'mailpoet'),
+      onSuccess: function onSuccess(response: Response) {
+        MailPoet.Notice.success(
+          __(
+            '%1$d subscribers were removed from all lists.',
+            'mailpoet',
+          ).replace('%1$d', Number(response.meta.count).toLocaleString()),
+        );
+      },
     },
-    onSuccess: function onSuccess(response: Response) {
-      MailPoet.Notice.success(
-        __(
-          '%1$d subscribers were removed from list <strong>%2$s</strong>.',
-          'mailpoet',
-        )
-          .replace('%1$d', Number(response.meta.count).toLocaleString())
-          .replace('%2$s', response.meta.segment),
-      );
+    {
+      name: 'trash',
+      label: __('Move to trash', 'mailpoet'),
+      onSuccess: getMessages().onTrash,
     },
-  },
-  {
-    name: 'removeFromAllLists',
-    label: __('Remove from all lists', 'mailpoet'),
-    onSuccess: function onSuccess(response: Response) {
-      MailPoet.Notice.success(
-        __('%1$d subscribers were removed from all lists.', 'mailpoet').replace(
-          '%1$d',
-          Number(response.meta.count).toLocaleString(),
-        ),
-      );
-    },
-  },
-  {
-    name: 'trash',
-    label: __('Move to trash', 'mailpoet'),
-    onSuccess: getMessages().onTrash,
-  },
-  {
-    name: 'unsubscribe',
-    label: __('Unsubscribe', 'mailpoet'),
-    onSelect: (submitModal, closeModal, bulkActionProps) => {
-      const count =
-        bulkActionProps.selection !== 'all'
-          ? bulkActionProps.selected_ids.length
-          : bulkActionProps.count;
-      return (
-        <Modal
-          title={__('Unsubscribe', 'mailpoet')}
-          onRequestClose={closeModal}
-          isDismissible
-        >
-          <p>
-            {__(
-              'This action will unsubscribe %s subscribers from all lists. This action cannot be undone. Are you sure, you want to continue?',
-              'mailpoet',
-            ).replace('%s', Number(count).toLocaleString())}
-          </p>
-          <span className="mailpoet-gap-half" />
-          <Button
-            onClick={submitModal}
-            dimension="small"
-            variant="secondary"
-            automationId="bulk-unsubscribe-confirm"
+    {
+      name: 'unsubscribe',
+      label: __('Unsubscribe', 'mailpoet'),
+      onSelect: (submitModal, closeModal, bulkActionProps) => {
+        const count =
+          bulkActionProps.selection !== 'all'
+            ? bulkActionProps.selected_ids.length
+            : bulkActionProps.count;
+        return (
+          <Modal
+            title={__('Unsubscribe', 'mailpoet')}
+            onRequestClose={closeModal}
+            isDismissible
           >
-            {__('Apply', 'mailpoet')}
-          </Button>
-        </Modal>
-      );
+            <p>
+              {__(
+                'This action will unsubscribe %s subscribers from all lists. This action cannot be undone. Are you sure, you want to continue?',
+                'mailpoet',
+              ).replace('%s', Number(count).toLocaleString())}
+            </p>
+            <span className="mailpoet-gap-half" />
+            <Button
+              onClick={submitModal}
+              dimension="small"
+              variant="secondary"
+              automationId="bulk-unsubscribe-confirm"
+            >
+              {__('Apply', 'mailpoet')}
+            </Button>
+          </Modal>
+        );
+      },
     },
-  },
-  {
-    name: 'addTag',
-    label: __('Add tag...', 'mailpoet'),
-    onSelect: function onSelect(submitModal, closeModal) {
-      const field = {
-        id: 'add_tag',
-        name: 'add_tag',
-        endpoint: 'tags',
-      };
+    {
+      name: 'addTag',
+      label: __('Add tag...', 'mailpoet'),
+      onSelect: function onSelect(submitModal, closeModal) {
+        const field = {
+          id: 'add_tag',
+          name: 'add_tag',
+          endpoint: 'tags',
+        };
 
-      return createModal(
-        submitModal,
-        closeModal,
-        field,
-        __('Add tag...', 'mailpoet'),
-      );
+        return createModal(
+          submitModal,
+          closeModal,
+          field,
+          __('Add tag...', 'mailpoet'),
+        );
+      },
+      getData: function getData() {
+        return {
+          tag_id: Number(jQuery('#add_tag').val()),
+        };
+      },
+      onSuccess: function onSuccess(response: Response) {
+        MailPoet.Notice.success(
+          __(
+            'Tag <strong>%1$s</strong> was added to %2$d subscribers.',
+            'mailpoet',
+          )
+            .replace('%1$s', response.meta.tag)
+            .replace('%2$d', Number(response.meta.count).toLocaleString()),
+        );
+      },
     },
-    getData: function getData() {
-      return {
-        tag_id: Number(jQuery('#add_tag').val()),
-      };
-    },
-    onSuccess: function onSuccess(response: Response) {
-      MailPoet.Notice.success(
-        __(
-          'Tag <strong>%1$s</strong> was added to %2$d subscribers.',
-          'mailpoet',
-        )
-          .replace('%1$s', response.meta.tag)
-          .replace('%2$d', Number(response.meta.count).toLocaleString()),
-      );
-    },
-  },
-  {
-    name: 'removeTag',
-    label: __('Remove tag...', 'mailpoet'),
-    onSelect: function onSelect(submitModal, closeModal) {
-      const field = {
-        id: 'remove_tag',
-        name: 'remove_tag',
-        endpoint: 'tags',
-      };
+    {
+      name: 'removeTag',
+      label: __('Remove tag...', 'mailpoet'),
+      onSelect: function onSelect(submitModal, closeModal) {
+        const field = {
+          id: 'remove_tag',
+          name: 'remove_tag',
+          endpoint: 'tags',
+        };
 
-      return createModal(
-        submitModal,
-        closeModal,
-        field,
-        __('Remove tag...', 'mailpoet'),
-      );
+        return createModal(
+          submitModal,
+          closeModal,
+          field,
+          __('Remove tag...', 'mailpoet'),
+        );
+      },
+      getData: function getData() {
+        return {
+          tag_id: Number(jQuery('#remove_tag').val()),
+        };
+      },
+      onSuccess: function onSuccess(response: Response) {
+        MailPoet.Notice.success(
+          __(
+            'Tag <strong>%1$s</strong> was removed from %2$d subscribers.',
+            'mailpoet',
+          )
+            .replace('%1$s', response.meta.tag)
+            .replace('%2$d', Number(response.meta.count).toLocaleString()),
+        );
+      },
     },
-    getData: function getData() {
-      return {
-        tag_id: Number(jQuery('#remove_tag').val()),
-      };
-    },
-    onSuccess: function onSuccess(response: Response) {
-      MailPoet.Notice.success(
-        __(
-          'Tag <strong>%1$s</strong> was removed from %2$d subscribers.',
-          'mailpoet',
-        )
-          .replace('%1$s', response.meta.tag)
-          .replace('%2$d', Number(response.meta.count).toLocaleString()),
-      );
-    },
-  },
-];
+  ];
+
+  return bulkActions;
+};
 
 const getItemActions = () => [
   {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,8 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.5 - 2025-06-02 =
-* Improved: Add "4th" day of week as a monthly frequency option;
-* Fixed: issue where duplicated newsletters could be incorrectly linked to unrelated posts under certain conditions.
+= x.x.x - YYYY-MM-DD =
+* Improved: hide 'unsubscribe' bulk action when segmenting unsubscribed subscribers.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

When on **MailPoet > Subscribers > Unsubscribed** page, don't show `Unsubscribe` bulk action, as these subscribers are already unsubscribed. 

**Before**
<img width="967" alt="Screenshot 2025-06-06 at 16 15 37" src="https://github.com/user-attachments/assets/a9d796ab-20b2-4499-b946-bdda36a6a6a5" />

**After**
<img width="984" alt="Screenshot 2025-06-06 at 16 15 07" src="https://github.com/user-attachments/assets/59400d18-ea8e-47d0-9566-6ad4dce00e5f" />

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7250

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7250-hide-unsubscribe-action-when-viewing-the-unsubscribed-tab)

_The latest successful build from `stomail-7250-hide-unsubscribe-action-when-viewing-the-unsubscribed-tab` will be used. If none is available, the link won't work._