### PR TITLE
Potentially fix flaky addCouponAndSelectPredefinedCoupon

### DIFF
--- a/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorCouponCest.php
@@ -103,6 +103,7 @@ class EditorCouponCest {
     $i->click($couponInEditor);
     $i->waitForElement($couponSettingsHeading);
     $i->wantTo('Select predefined coupon');
+    $i->wait(0.5); // animation to open coupon settings panel
     $i->click(Locator::contains('button', 'All coupons'));
     $i->waitForElementClickable(Locator::contains('label', $couponCode));
     $i->click(Locator::contains('label', $couponCode));


### PR DESCRIPTION
## Description

Couldn't replicate it locally, but the sliding sidebar seems like could be the culprit (i.e., the headless browser is clicking on the place where the button will be, but isn't yet due to animation). 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:flaky-addCouponAndSelectPredefinedCoupon-test)

_The latest successful build from `flaky-addCouponAndSelectPredefinedCoupon-test` will be used. If none is available, the link won't work._