### PR TITLE
Bump minimum WooCommerce to 9.8, tested up to 9.9

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 9.7.1
- * WC tested up to: 9.8.2
+ * WC requires at least: 9.8
+ * WC tested up to: 9.9
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.7'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.7'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.8'; // L-1 version, not the latest
 
 
 // Display WP version error notice

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,9 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.6 - 2025-06-09 =
-* Added: new networks in social icons block (Behance, Bluesky, Discord, GitHub, Gravatar, Mastodon, Medium, Patreon, Reddit, RSS, Spotify, Telegram, Threads, TikTok, Tumblr, Twitch, Viemo, WhatsApp, WordPress);
-* Improved: updated existing social networks with the official icons;
-* Improved: hide 'unsubscribe' bulk action when segmenting unsubscribed subscribers.
+= x.x.x - YYYY-MM-DD =
+* Updated: minimum required WooCommerce version to 9.8 and tested up to version to 9.9.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7426

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7426-declare-woocommerce-99-compatibility)

_The latest successful build from `stomail-7426-declare-woocommerce-99-compatibility` will be used. If none is available, the link won't work._