### PR TITLE
Sort form names and email subjects alphabetically for API error messages

### DIFF
--- a/mailpoet/lib/Form/FormsRepository.php
+++ b/mailpoet/lib/Form/FormsRepository.php
@@ -38,6 +38,11 @@ class FormsRepository extends Repository {
       }
     }
 
+    // Sort form names alphabetically for each segment
+    foreach ($nameMap as &$names) {
+      sort($names);
+    }
+
     return $nameMap;
   }
 

--- a/mailpoet/lib/Newsletter/Segment/NewsletterSegmentRepository.php
+++ b/mailpoet/lib/Newsletter/Segment/NewsletterSegmentRepository.php
@@ -63,6 +63,12 @@ class NewsletterSegmentRepository extends Repository {
       }
       $nameMap[(string)$result['segment_id']][] = $result['subject'];
     }
+
+    // Sort email subjects alphabetically for each segment
+    foreach ($nameMap as &$names) {
+      sort($names);
+    }
+
     return $nameMap;
   }
 


### PR DESCRIPTION
## Description

Fixes [flaky test](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/20885/workflows/ed3ac184-360b-4e8e-a78e-8051ad275c93/jobs/358852) that expects names to be in alphabetical order

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:flaky-SegmentsTest)

_The latest successful build from `flaky-SegmentsTest` will be used. If none is available, the link won't work._