### PR TITLE
Adds `polylang` to the list of permitted scripts.

### DIFF
--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -39,6 +39,7 @@ class ConflictResolver {
       // third-party
       'query-monitor',
       'wpt-tx-updater-network',
+      'polylang',
       // WP.com
       'full-site-editing',
       'wpcomsh',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,7 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.7 - 2025-06-16 =
-* Updated: minimum required WooCommerce version to 9.8 and tested up to version to 9.9.
+= x.x.x - YYYY-MM-DD = =
+* Improved: Adds `polylang` to the list of permitted scripts.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

In Polylang, we have a script that adds a parameter to AJAX requests in order to filter content by language.

Previously, we loaded this script directly in a PHP method using a `<script>` tag, hooked to `admin_print_footer_scripts`, so our script was always loaded.

Recently, in a new version, we improved this by moving the script into a JS file, which is now loaded via `admin_enqueue_scripts`.

Our script is therefore properly enqueued by WordPress, but it is being dequeued by your `resolveScriptsConflict()` method and thus is no longer loaded.

**I therefore suggest adding `polylang` to the list of allowed scripts so that our script is properly loaded and there is no regression in functionality for our mutual clients.**
## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
