### PR TITLE
Flip order status filter logic to support custom statuses [STOMAIL-7384]

### DIFF
--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -63,8 +63,8 @@ class WooCommerceNumberOfOrders implements Filter {
     $date = Carbon::now()->subDays($days);
 
     $joinCondition = $isAllTime
-      ? 'customer.customer_id = orderStats.customer_id AND orderStats.status IN (:allowedStatuses' . $parameterSuffix . ')'
-      : 'customer.customer_id = orderStats.customer_id AND orderStats.date_created >= :date' . $parameterSuffix . ' AND orderStats.status IN (:allowedStatuses' . $parameterSuffix . ')';
+      ? 'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN (:excludedStatuses' . $parameterSuffix . ')'
+      : 'customer.customer_id = orderStats.customer_id AND orderStats.date_created >= :date' . $parameterSuffix . ' AND orderStats.status NOT IN (:excludedStatuses' . $parameterSuffix . ')';
 
     $subQuery = $this->entityManager->getConnection()
       ->createQueryBuilder()
@@ -98,7 +98,7 @@ class WooCommerceNumberOfOrders implements Filter {
       ],
     ], \true)
       ->setParameter('date' . $parameterSuffix, $date->toDateTimeString())
-      ->setParameter('allowedStatuses' . $parameterSuffix, $this->wooFilterHelper->defaultIncludedStatuses(), ArrayParameterType::STRING)
+      ->setParameter('excludedStatuses' . $parameterSuffix, $this->wooFilterHelper->defaultExcludedStatuses(), ArrayParameterType::STRING)
       ->groupBy('inner_subscriber_id');
 
     if ($type === '=') {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -57,23 +57,19 @@ class WooCommerceUsedPaymentMethod implements Filter {
     $data = $filterData->getData();
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
-    $includedStatuses = array_keys($this->wooHelper->getOrderStatuses());
-    $failedKey = array_search('wc-failed', $includedStatuses, true);
-    if ($failedKey !== false) {
-      unset($includedStatuses[$failedKey]);
-    }
+    $excludedStatuses = $this->wooFilterHelper->defaultExcludedStatuses();
     $date = is_int($days) ? Carbon::now()->subDays($days) : Carbon::now();
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:
-        $this->applyForAnyOperator($queryBuilder, $includedStatuses, $paymentMethods, $date, $isAllTime);
+        $this->applyForAnyOperator($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
         break;
       case DynamicSegmentFilterData::OPERATOR_ALL:
-        $this->applyForAllOperator($queryBuilder, $includedStatuses, $paymentMethods, $date, $isAllTime);
+        $this->applyForAllOperator($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
         break;
       case DynamicSegmentFilterData::OPERATOR_NONE:
         $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-        $this->applyForAnyOperator($subQuery, $includedStatuses, $paymentMethods, $date, $isAllTime);
+        $this->applyForAnyOperator($subQuery, $excludedStatuses, $paymentMethods, $date, $isAllTime);
         $subscribersTable = $this->filterHelper->getSubscribersTable();
         $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
         break;
@@ -82,31 +78,31 @@ class WooCommerceUsedPaymentMethod implements Filter {
     return $queryBuilder;
   }
 
-  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime): void {
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime): void {
     if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
-      $this->applyCustomOrderTableJoin($queryBuilder, $includedStatuses, $paymentMethods, $date, $isAllTime);
+      $this->applyCustomOrderTableJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
     } else {
-      $this->applyPostmetaOrderJoin($queryBuilder, $includedStatuses, $paymentMethods, $date, $isAllTime);
+      $this->applyPostmetaOrderJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
     }
   }
 
-  private function applyForAllOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime): void {
+  private function applyForAllOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime): void {
     if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
-      $ordersAlias = $this->applyCustomOrderTableJoin($queryBuilder, $includedStatuses, $paymentMethods, $date, $isAllTime);
+      $ordersAlias = $this->applyCustomOrderTableJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
       $queryBuilder->groupBy('inner_subscriber_id')
         ->having("COUNT(DISTINCT $ordersAlias.payment_method) = " . count($paymentMethods));
     } else {
-      $postmetaAlias = $this->applyPostmetaOrderJoin($queryBuilder, $includedStatuses, $paymentMethods, $date, $isAllTime);
+      $postmetaAlias = $this->applyPostmetaOrderJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
       $queryBuilder->groupBy('inner_subscriber_id')->having("COUNT(DISTINCT $postmetaAlias.meta_value) = " . count($paymentMethods));
     }
   }
 
-  private function applyPostmetaOrderJoin(QueryBuilder $queryBuilder, array $includedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime, string $postmetaAlias = 'postmeta'): string {
+  private function applyPostmetaOrderJoin(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime, string $postmetaAlias = 'postmeta'): string {
     $paymentMethodParam = $this->filterHelper->getUniqueParameterName('paymentMethod');
     $paymentMethodMetaKeyParam = $this->filterHelper->getUniqueParameterName('paymentMethod');
 
     $postMetaTable = $this->filterHelper->getPrefixedTable('postmeta');
-    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $excludedStatuses);
     $queryBuilder
       ->innerJoin($orderStatsAlias, $postMetaTable, $postmetaAlias, "$orderStatsAlias.order_id = $postmetaAlias.post_id")
       ->andWhere("postmeta.meta_key = :$paymentMethodMetaKeyParam")
@@ -122,10 +118,10 @@ class WooCommerceUsedPaymentMethod implements Filter {
     return $postmetaAlias;
   }
 
-  private function applyCustomOrderTableJoin(QueryBuilder $queryBuilder, array $includedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime, string $ordersAlias = 'orders'): string {
+  private function applyCustomOrderTableJoin(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime, string $ordersAlias = 'orders'): string {
     $paymentMethodParam = $this->filterHelper->getUniqueParameterName('paymentMethod');
     $ordersTable = $this->wooHelper->getOrdersTableName();
-    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $excludedStatuses);
     $queryBuilder
       ->innerJoin($orderStatsAlias, $ordersTable, 'orders', "$orderStatsAlias.order_id = orders.id")
       ->andWhere("$ordersAlias.payment_method IN (:$paymentMethodParam)")

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -57,22 +57,18 @@ class WooCommerceUsedShippingMethod implements Filter {
     $data = $filterData->getData();
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
-    $includedStatuses = array_keys($this->wooHelper->getOrderStatuses());
-    $failedKey = array_search('wc-failed', $includedStatuses, true);
-    if ($failedKey !== false) {
-      unset($includedStatuses[$failedKey]);
-    }
+    $excludedStatuses = $this->wooFilterHelper->defaultExcludedStatuses();
     $date = is_int($days) ? Carbon::now()->subDays($days) : Carbon::now();
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:
-        $this->applyForAnyOperator($queryBuilder, $includedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+        $this->applyForAnyOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
         break;
       case DynamicSegmentFilterData::OPERATOR_ALL:
-        $this->applyForAllOperator($queryBuilder, $includedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+        $this->applyForAllOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
         break;
       case DynamicSegmentFilterData::OPERATOR_NONE:
-        $this->applyForNoneOperator($queryBuilder, $includedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+        $this->applyForNoneOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
         break;
     }
 
@@ -97,14 +93,14 @@ class WooCommerceUsedShippingMethod implements Filter {
     return $lookupData;
   }
 
-  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
     $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 
     $orderItemsTable = $this->filterHelper->getPrefixedTable('woocommerce_order_items');
     $orderItemsTableAlias = 'orderItems';
     $orderItemMetaTable = $this->filterHelper->getPrefixedTable('woocommerce_order_itemmeta');
     $orderItemMetaTableAlias = 'orderItemMeta';
-    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $excludedStatuses);
     $queryBuilder
       ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsTableAlias, "$orderStatsAlias.order_id = $orderItemsTableAlias.order_id")
       ->innerJoin($orderItemsTableAlias, $orderItemMetaTable, $orderItemMetaTableAlias, "$orderItemsTableAlias.order_item_id = $orderItemMetaTableAlias.order_item_id")
@@ -120,7 +116,7 @@ class WooCommerceUsedShippingMethod implements Filter {
     }
   }
 
-  private function applyForAllOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
+  private function applyForAllOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
     $orderItemTypeParam = $this->filterHelper->getUniqueParameterName('orderItemType');
     $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 
@@ -128,7 +124,7 @@ class WooCommerceUsedShippingMethod implements Filter {
     $orderItemsTableAlias = 'orderItems';
     $orderItemMetaTable = $this->filterHelper->getPrefixedTable('woocommerce_order_itemmeta');
     $orderItemMetaTableAlias = 'orderItemMeta';
-    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $includedStatuses);
+    $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $excludedStatuses);
 
     $queryBuilder
       ->innerJoin($orderStatsAlias, $orderItemsTable, $orderItemsTableAlias, "$orderStatsAlias.order_id = $orderItemsTableAlias.order_id")
@@ -149,9 +145,9 @@ class WooCommerceUsedShippingMethod implements Filter {
     }
   }
 
-  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $includedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
+  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
     $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-    $this->applyForAnyOperator($subQuery, $includedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+    $this->applyForAnyOperator($subQuery, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
     $subscribersTable = $this->filterHelper->getSubscribersTable();
     $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
   }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooFilterHelper.php
@@ -21,8 +21,8 @@ class WooFilterHelper {
     $this->filterHelper = $filterHelper;
   }
 
-  public function defaultIncludedStatuses(): array {
-    return ['wc-processing', 'wc-completed'];
+  public function defaultExcludedStatuses(): array {
+    return ['wc-pending', 'wc-on-hold', 'wc-cancelled', 'wc-refunded', 'wc-failed'];
   }
 
   /**
@@ -70,18 +70,22 @@ class WooFilterHelper {
 
   /**
    * @param QueryBuilder $queryBuilder
-   * @param array|null $allowedStatuses
+   * @param array|null $excludedStatuses
    * @return string - The alias of the joined order stats table
    */
-  public function applyOrderStatusFilter(QueryBuilder $queryBuilder, ?array $allowedStatuses = null): string {
-    if (is_null($allowedStatuses)) {
-      $allowedStatuses = $this->defaultIncludedStatuses();
+  public function applyOrderStatusFilter(QueryBuilder $queryBuilder, ?array $excludedStatuses = null): string {
+    if (is_null($excludedStatuses)) {
+      $excludedStatuses = $this->defaultExcludedStatuses();
     }
 
-    $statusParam = $this->filterHelper->getUniqueParameterName('status');
     $orderStatsAlias = $this->applyCustomerOrderJoin($queryBuilder);
-    $queryBuilder->andWhere("$orderStatsAlias.status IN (:$statusParam)");
-    $queryBuilder->setParameter($statusParam, $allowedStatuses, ArrayParameterType::STRING);
+
+    if (!empty($excludedStatuses)) {
+      $statusParam = $this->filterHelper->getUniqueParameterName('status');
+      $queryBuilder->andWhere("$orderStatsAlias.status NOT IN (:$statusParam)");
+      $queryBuilder->setParameter($statusParam, $excludedStatuses, ArrayParameterType::STRING);
+    }
+
     return $orderStatsAlias;
   }
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -230,5 +230,6 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 = x.x.x - YYYY-MM-DD =
 * Improved: Adds `polylang` to the list of permitted scripts.
 * Fixed: warning `Undefined array key "blocks"`
+* Updated: Support custom order statuses in WooCommerce segments
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

The previous implementation only included specific order statuses in custom segments, which meant that non-standard statuses from plugins were ignored. This change flips the logic to exclude specific statuses instead.

This ensures that orders with custom status values from third-party plugins will now be properly included in dynamic segments.


1. Install and activate a custom order segment plugin (the MailPoet Master test site has Custom Order Status by Addify) and create a custom order status "Out for Delivery"
2. Create a coupon code (MailPoet10 with a 10 0iscount)
3. With more than one subscriber, make a purchase and use that coupon code
4. Set one of the test orders to the custom status "Out for Delivery"
5. Create a custom dynamic segment under MailPoet > Segments
6. Set it up so that it is pulling in all orders, all time, that used coupon "mailpoet10" 
7. Note that the segment count is 1 where it should be 2; if you look at the list of subscribers, only the default order is picked by the segment, not the one with custom status;

## Screenshots

| Before | After |
| ------ | ----- |
|   ![Screenshot 2025-06-17 at 14 01 03](https://github.com/user-attachments/assets/5e34180a-27be-4e46-b7d4-c932b2af84c4)  |   ![Screenshot 2025-06-17 at 14 21 43](https://github.com/user-attachments/assets/aceb7f7d-cc08-4ab9-826a-923c54af1439) |


## Code review notes

_N/A_

## QA notes

It would be great to check some of the WooCommerce segments, the specific ones that were touched by this code are:
- Number of Orders
- Payment Method
- Shipping Method

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7384]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7384-mailpoet-segments-dont-pick-up-orders-that-have-non-standard)

_The latest successful build from `stomail-7384-mailpoet-segments-dont-pick-up-orders-that-have-non-standard` will be used. If none is available, the link won't work._