### PR TITLE
Adds polylang to the list of permitted scripts.

### DIFF
--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -39,6 +39,7 @@ class ConflictResolver {
       // third-party
       'query-monitor',
       'wpt-tx-updater-network',
+      'polylang',
       // WP.com
       'full-site-editing',
       'wpcomsh',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,7 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.7 - 2025-06-16 =
-* Updated: minimum required WooCommerce version to 9.8 and tested up to version to 9.9.
+= x.x.x - YYYY-MM-DD = =
+* Improved: Adds `polylang` to the list of permitted scripts.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

In Polylang I have a post and a translated post. Before Polylang 3.7 both posts would show up in the Postblock. After Polylang, only one post shows up. This is because Polylang changed their script enqueuing and gets now catched in our script suppression. As it worked before, this PR (kudos @Marianne380) allows polylang to load on MailPoet pages.

Behavior with MailPoet and Polylang 3.7 when I am in the English translation:
![image](https://github.com/user-attachments/assets/c3d41017-1c22-4aa9-b17f-1c61bc018f5e)

After we allow the `polylang`script:
![image](https://github.com/user-attachments/assets/e2b2f22b-45ec-4d39-82ec-23b10fc2c10c)


I checked quickly and there are no obvious conflicts between polylang and MailPoet. Thank you @stkjj for reporting the issue and sorry for the inconvenience. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Fixes https://github.com/polylang/polylang/issues/1680

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-script-perm)

_The latest successful build from `add-script-perm` will be used. If none is available, the link won't work._