### PR TITLE
Fix fatal error in SCF or ACF when working with post templates in location rules

### DIFF
--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,9 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.8 - 2025-06-24 =
-* Updated: support custom order statuses in WooCommerce segments;
-* Improved: adds `polylang` to the list of permitted scripts;
-* Fixed: warning `Undefined array key "blocks"`.
+= x.x.x - YYYY-MM-DD =
+* Fixed: fatal error in ACF and SCF when working with post templates in location rules.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/packages/php/email-editor/src/Engine/Templates/class-templates.php
+++ b/packages/php/email-editor/src/Engine/Templates/class-templates.php
@@ -162,7 +162,7 @@ class Templates {
 			if ( $block_template->plugin !== $this->template_prefix ) {
 				continue;
 			}
-			$templates[ $block_template->slug ] = $block_template;
+			$templates[ $block_template->slug ] = $block_template->title;  // Requires only the template title, not the full template object.
 		}
 		return $templates;
 	}


### PR DESCRIPTION
## Description

Fixes `Fatal error: Uncaught Error: Object of class WP_Block_Template could not be converted to string in /wp-includes/formatting.php:1096`.

This fix comes from the [WooCommerce monorepo](https://github.com/woocommerce/woocommerce/blob/1ba0fd38935d4af6c093c2f98aada87fdda5d6bc/packages/php/email-editor/src/Engine/Templates/class-templates.php#L172), where the block email editor continues to be developed.

## Code review notes

_N/A_

## QA notes

Steps to reproduce the bug:
1. Install and activate SCF or ACF
2. Create a Field Group
3. Attempt to set the Location Rules to `Show this field group if [Post Template]`

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7433

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7433-fatal-error-in-secure-custom-fields-when-mailpoet-is-active)

_The latest successful build from `stomail-7433-fatal-error-in-secure-custom-fields-when-mailpoet-is-active` will be used. If none is available, the link won't work._