### PR TITLE
Fix rendering submit button when font size is changed

### DIFF
--- a/mailpoet/assets/js/src/form-editor/store/form-data-types.ts
+++ b/mailpoet/assets/js/src/form-editor/store/form-data-types.ts
@@ -33,7 +33,7 @@ export type FormSettingsType = {
   fixedBarStyles: PlacementStyles;
   fontColor?: string;
   fontFamily?: string;
-  fontSize?: number;
+  fontSize?: string | number;
   formPadding: number;
   formPlacement: {
     popup: FormPlacementBase & {
@@ -105,7 +105,7 @@ export type InputBlockStyles = {
   backgroundColor?: string;
   gradient?: string;
   borderSize?: number;
-  fontSize?: number;
+  fontSize?: string | number;
   fontColor?: string;
   borderRadius?: number;
   borderColor?: string;

--- a/mailpoet/assets/js/src/form-editor/store/mapping/to-blocks/styles-mapper.ts
+++ b/mailpoet/assets/js/src/form-editor/store/mapping/to-blocks/styles-mapper.ts
@@ -39,7 +39,9 @@ export const mapInputBlockStyles = (styles: InputBlockStylesServerData) => {
     mappedStyles.borderSize = Number(styles.border_size);
   }
   if (has(styles, 'font_size') && styles.font_size !== undefined) {
-    mappedStyles.fontSize = Number(styles.font_size);
+    mappedStyles.fontSize = !Number.isNaN(Number(styles.font_size))
+      ? Number(styles.font_size)
+      : styles.font_size;
   }
   if (has(styles, 'font_color') && styles.font_color) {
     mappedStyles.fontColor = styles.font_color;

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -230,6 +230,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 = x.x.x - YYYY-MM-DD =
 * Improved: add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off;
 * Changed: replaced DocsBot with WordPress.com chatbot when searching MailPoet Knowledge Base;
+* Fixed: rendering submit button when font size is changed;
 * Fixed: fatal error in ACF and SCF when working with post templates in location rules.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

When a font size is changed on the submit button, it doesn't reflect in the preview and crashes the block when trying to change it after reloading the page. 

<img width="587" alt="Screenshot 2025-06-26 at 15 40 22" src="https://github.com/user-attachments/assets/b34b630a-8727-44df-a859-9c20b58e10ec" />

The issue is, that font size accepts different units (`px`, `rem`...) so the font size value is saved as string in the database (e.g., `20px`). But the form editor expected a number, which caused the crash. 

## Code review notes

_N/A_

## QA notes

Steps to reproduce:
1. Press on the Start with a blank form
2. Turn off the toggle Inherit style from theme in the button styles
3. Change the size to custom and insert 20 px
4. Save the form
5. Try to preview, check that the button size is smaller
6. Go to the forms list and try to edit the same form
7. Press on the styles of the button
8. Observe an issue

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7316

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7316-subscription-form-button-breaking-when-a-pixel-size-is)

_The latest successful build from `stomail-7316-subscription-form-button-breaking-when-a-pixel-size-is` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rendering of the submit button when font size settings include string values, allowing for more flexible font size specifications.

* **Documentation**
  * Updated the changelog to reflect the fix related to submit button font size rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->