### PR TITLE
Apply the latest changes in the form editor in the preview

### DIFF
--- a/mailpoet/assets/js/src/form-editor/store/actions.ts
+++ b/mailpoet/assets/js/src/form-editor/store/actions.ts
@@ -233,7 +233,9 @@ export function* showPreview() {
   yield changeActiveSidebar('default');
   const customFields = select(storeName).getAllAvailableCustomFields();
   const formData = select(storeName).getFormData();
-  const formBlocks = select(storeName).getFormBlocks();
+  // Get blocks directly from block editor store to ensure we have the latest state
+  const formBlocks = select(blockEditorStore).getBlocks();
+
   const blocksToFormBody = blocksToFormBodyFactory(
     FONT_SIZES,
     SETTINGS_DEFAULTS.colors,

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -232,6 +232,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 * Improved: when choosing an email type, show loading animation only on the selected one;
 * Changed: replaced DocsBot with WordPress.com chatbot when searching MailPoet Knowledge Base;
 * Fixed: rendering submit button when font size is changed;
-* Fixed: fatal error in ACF and SCF when working with post templates in location rules.
+* Fixed: fatal error in ACF and SCF when working with post templates in location rules;
+* Fixed: apply the latest changes in the form editor in the preview.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

Fixes loading the changes in the block settings done in the current session when opening the preview. 

## Code review notes

_N/A_

## QA notes

Steps to reproduce:
1. Create a new form, select one of the templates
2. On the bottom styles switch the toggle Inherit style from theme on and then off
3. Make some changes like border size or border radius
4. Save the form
5. Press on the preview, check that there are no changes after switching the toggle off
6. Check the form on the site, the changes were applied
7. Changes in the preview mode will be visible after reloading the form page
## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7317

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7317-no-changes-on-the-preview-mode-after-switching-the-toggle)

_The latest successful build from `stomail-7317-no-changes-on-the-preview-mode-after-switching-the-toggle` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the latest changes in the form editor are accurately reflected in the form preview.
  * Fixed a fatal error in ACF and SCF when working with post templates in location rules.

* **Documentation**
  * Updated the changelog to include recent fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->