### PR TITLE
Add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off

### DIFF
--- a/mailpoet/assets/js/src/newsletters/types/re-engagement/re-engagement.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/re-engagement/re-engagement.tsx
@@ -12,7 +12,7 @@ import { Scheduling } from './scheduling';
 import { ListingHeadingStepsRoute } from '../../listings/heading-steps-route';
 
 export function NewsletterTypeReEngagement(): JSX.Element {
-  let defaultAfterTime = '';
+  let defaultAfterTime = '11';
   if (MailPoet.deactivateSubscriberAfterInactiveDays) {
     defaultAfterTime = (
       Math.floor(Number(MailPoet.deactivateSubscriberAfterInactiveDays) / 30) -

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -228,6 +228,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
+* Improved: add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off;
 * Fixed: fatal error in ACF and SCF when working with post templates in location rules.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

Normally, this value is taken from the "Inactive subscribers" setting. E.g. when the subscribers become inactive after 6 month, the value in re-engagement emails is 5 months. But when the "Inactive subscribers" feature is turned off, there is no default value.

This PR changes it to 11 months, which would be used when the default "Inactive subscribers" value of 12 months is used.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7285

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7285-no-pre-selected-count-for-the-re-engagement-emails)

_The latest successful build from `stomail-7285-no-pre-selected-count-for-the-re-engagement-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A default trigger value is now set for re-engagement emails when the "Inactive subscribers" feature is disabled.

* **Documentation**
  * Updated changelog to reflect the addition of a default trigger value for re-engagement emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->