### PR TITLE
Improve handling of MailPoet Page title when switching website languages

### DIFF
--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Captcha;
 
 use MailPoet\Form\AssetsController;
+use MailPoet\Settings\Pages;
 use MailPoet\WP\Functions as WPFunction;
 
 class PageRenderer {
@@ -60,7 +61,7 @@ class PageRenderer {
   }
 
   public function setPageTitle($title = '') {
-    if ($title === __('MailPoet Page', 'mailpoet')) {
+    if ($title === Pages::PAGE_TITLE) {
       return $this->getPageTitle();
     }
     return $title;

--- a/mailpoet/lib/Settings/Pages.php
+++ b/mailpoet/lib/Settings/Pages.php
@@ -8,6 +8,7 @@ use MailPoet\WP\Functions as WPFunctions;
 class Pages {
   const PAGE_SUBSCRIPTIONS = 'subscriptions';
   const PAGE_CAPTCHA = 'captcha';
+  const PAGE_TITLE = 'MailPoet Page';
 
   public function __construct() {
   }
@@ -15,8 +16,8 @@ class Pages {
   public function init() {
     WPFunctions::get()->registerPostType('mailpoet_page', [
       'labels' => [
-        'name' => __('MailPoet Page', 'mailpoet'),
-        'singular_name' => __('MailPoet Page', 'mailpoet'),
+        'name' => self::PAGE_TITLE,
+        'singular_name' => self::PAGE_TITLE,
       ],
       'public' => true,
       'has_archive' => false,
@@ -51,7 +52,7 @@ class Pages {
       'post_type' => 'mailpoet_page',
       'post_author' => 1,
       'post_content' => '[mailpoet_page]',
-      'post_title' => __('MailPoet Page', 'mailpoet'),
+      'post_title' => self::PAGE_TITLE,
       'post_name' => $postName,
     ]);
 

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -11,6 +11,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\AssetsController;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Settings\Pages as SettingsPages;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsClicksRepository;
 use MailPoet\Statistics\Track\SubscriberHandler;
@@ -277,7 +278,7 @@ class Pages {
     if (
       (!isset($post))
       ||
-      ($post->post_title !== __('MailPoet Page', 'mailpoet')) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      ($post->post_title !== SettingsPages::PAGE_TITLE) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       ||
       ($pageTitle !== $this->wp->singlePostTitle('', false))
     ) {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -228,6 +228,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
+* Improved: handling of MailPoet Page title when switching website languages;
 * Improved: add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off;
 * Fixed: fatal error in ACF and SCF when working with post templates in location rules.
 

--- a/mailpoet/tests/_support/DefaultsExtension.php
+++ b/mailpoet/tests/_support/DefaultsExtension.php
@@ -3,6 +3,7 @@
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Extension;
+use MailPoet\Settings\Pages;
 use MailPoet\Test\DataFactories\ScheduledTask;
 use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\UserFlags;
@@ -40,7 +41,7 @@ class DefaultsExtension extends Extension {
 
     // posts & pages
     $this->createPost('post', 'hello-world', 'Hello world!', 'Hello from WordPress.');
-    $this->createPost('mailpoet_page', '', 'MailPoet Page', '[mailpoet_page]');
+    $this->createPost('mailpoet_page', '', Pages::PAGE_TITLE, '[mailpoet_page]');
 
     // get rid of 'blog/' prefix that is added automatically to rewrite rules on multisite by default
     // (init() loads 'permalink_structure' option from DB, flush_rules() regenerates 'rewrite_rules')

--- a/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
+++ b/mailpoet/tests/acceptance/Settings/ConfirmConfirmationPageCest.php
@@ -4,6 +4,7 @@
 
  use Codeception\Util\Locator;
  use MailPoet\Captcha\CaptchaConstants;
+ use MailPoet\Settings\Pages;
  use MailPoet\Test\DataFactories\Form;
  use MailPoet\Test\DataFactories\Settings;
 
@@ -62,7 +63,7 @@ class ConfirmConfirmationPageCest {
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="signup_settings_tab"]');
     $i->waitForText('Enable sign-up confirmation');
-    $i->waitForText('MailPoet Page');
+    $i->waitForText(Pages::PAGE_TITLE);
     $i->click('[data-automation-id="preview_page_link"]');
     $i->switchToNextTab();
     $i->see("You have subscribed to $siteTitle");
@@ -73,7 +74,7 @@ class ConfirmConfirmationPageCest {
     $i->amOnMailPoetPage('Settings');
     $i->click('[data-automation-id="signup_settings_tab"]');
     $i->waitForText('Enable sign-up confirmation');
-    $i->waitForText('MailPoet Page');
+    $i->waitForText(Pages::PAGE_TITLE);
     $i->selectOption('[data-automation-id="page_selection"]', $pageTitle);
     $i->click('Save settings');
     $i->waitForText('Settings saved');


### PR DESCRIPTION
## Description

Remove translating `MailPoet Page` title which is not meant to be shown but replaced depending on which MailPoet page is rendered. This should prevent issue when the page is created in language X and when the website language is switched to language Y, this condition is no longer true and a wrong page title is showed.
https://github.com/mailpoet/mailpoet/blob/435f638011d51d2c6d50429f836089be45c1cac3/mailpoet/lib/Subscription/Pages.php#L286

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7274

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7274-non-english-translations-return-mailpoet-page-on-default)

_The latest successful build from `stomail-7274-non-english-translations-return-mailpoet-page-on-default` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the MailPoet Page title into a single constant, improving consistency across the application.
* **Documentation**
  * Updated the changelog to note improved handling of the MailPoet Page title when switching website languages.
* **Tests**
  * Updated test cases to use the new page title constant for greater reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->