### PR TITLE
Remove DocsBot code, keep Odie

### DIFF
--- a/mailpoet/assets/js/src/features-controller.js
+++ b/mailpoet/assets/js/src/features-controller.js
@@ -1,6 +1,5 @@
 export const FeaturesController = (config) => ({
   FEATURE_BRAND_TEMPLATES: 'brand_templates',
-  FEATURE_ODIE_CHATBOT: 'odie_chatbot',
 
   isSupported: (feature) => {
     return config[feature] || false;

--- a/mailpoet/assets/js/src/wizard/steps/usage-tracking-step.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/usage-tracking-step.tsx
@@ -66,7 +66,7 @@ function WelcomeWizardUsageTrackingStep({ loading, submitForm }) {
               <div className="mailpoet-wizard-note">
                 {ReactStringReplace(
                   __(
-                    'MailPoet may load Google Fonts, DocsBot and other [link]3rd party libraries[/link].',
+                    'MailPoet may load Google Fonts, WordPress.com and other [link]3rd party libraries[/link].',
                     'mailpoet',
                   ),
                   /\[link\](.*?)\[\/link\]/g,

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -204,7 +204,7 @@ class PageRenderer {
         'name' => $tag->getName(),
         ];
       }, $this->tagRepository->findAll()),
-      'display_docsbot_widget' => $this->displayDocsBotWidget(),
+      'display_chatbot_widget' => $this->displayChatBotWidget(),
       'is_woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
       'cron_trigger_method' => $this->settings->get('cron_trigger.method'),
     ];
@@ -252,7 +252,7 @@ class PageRenderer {
     ];
   }
 
-  public function displayDocsBotWidget(): bool {
+  public function displayChatBotWidget(): bool {
     $display = $this->wp->applyFilters('mailpoet_display_docsbot_widget', $this->settings->get('3rd_party_libs.enabled') === '1');
     return (bool)$display;
   }

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -6,13 +6,11 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
-  const FEATURE_ODIE_CHATBOT = 'odie_chatbot';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
-    self::FEATURE_ODIE_CHATBOT => true,
   ];
 
   /** @var array|null */

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -157,7 +157,7 @@ To improve user experience, MailPoet may use the following 3rd party libraries i
 
 * [Google Fonts](https://fonts.google.com/) - used in Form Editor which you can use to customize your forms, and in the Email Editor to style emails. This can be individually [disabled by a filter](https://kb.mailpoet.com/article/332-how-to-disable-google-fonts). [TOS](https://policies.google.com/terms?hl=en) and [Privacy Policy](https://policies.google.com/privacy?hl=en)
 
-* [DocsBot](https://docsbot.ai) - used for searching in Knowledge Base with the help of AI. This functionality may load scripts from [https://widget.docsbot.ai/chat.js](https://widget.docsbot.ai/chat.js). [TOS and Privacy Policy](https://docsbot.ai/legal)
+* [WordPress.com](https://public-api.wordpress.com/) - used for searching in Knowledge Base with the help of AI.
 
 * [Mixpanel](https://mixpanel.com/) - used to send data about the usage of the MailPoet plugin when you [agree with sharing usage data with us](https://kb.mailpoet.com/article/130-sharing-your-data-with-us). [TOS](https://mixpanel.com/legal/terms-of-use/) and [Privacy Policy](https://mixpanel.com/legal/privacy-policy/)
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -229,6 +229,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Improved: add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off;
+* Changed: replaced DocsBot with WordPress.com chatbot when searching MailPoet Knowledge Base;
 * Fixed: fatal error in ACF and SCF when working with post templates in location rules.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -1,6 +1,4 @@
 <!-- pre connect to 3d party to speed up page loading -->
-<link rel="preconnect" href="https://widget.docsbot.ai/">
-<link rel="dns-prefetch" href="https://widget.docsbot.ai/">
 <link rel="preconnect" href="http://cdn.mxpnl.com">
 <link rel="dns-prefetch" href="http://cdn.mxpnl.com">
 
@@ -170,83 +168,58 @@
   <% include 'analytics.html' %>
 <% endif %>
 
-<% if display_docsbot_widget and not is_dotcom_ecommerce_plan() %>
-  <% if feature_flags.odie_chatbot %>
-    <script type="text/javascript" src="<%= getJavascriptScriptUrl('haw.js') %>"></script>
-    <chat-widget
-      id="chat"
-      bot="mailpoet-chat-support"
-      avatar="<%= cdn_url('chat-avatar.png') %>"
-      title="<%= __('MailPoet support', 'mailpoet') %>"
-      subtitle="<%= __('Chat with our AI assistant', 'mailpoet') %>"
-      first-message="<%= __('How can I help you today?', 'mailpoet') %>"
+<% if display_chatbot_widget and not is_dotcom_ecommerce_plan() %>
+  <script type="text/javascript" src="<%= getJavascriptScriptUrl('haw.js') %>"></script>
+  <chat-widget
+    id="chat"
+    bot="mailpoet-chat-support"
+    avatar="<%= cdn_url('chat-avatar.png') %>"
+    title="<%= __('MailPoet support', 'mailpoet') %>"
+    subtitle="<%= __('Chat with our AI assistant', 'mailpoet') %>"
+    first-message="<%= __('How can I help you today?', 'mailpoet') %>"
+  >
+    <% set support_form_url = has_premium_support ? 'https://www.mailpoet.com/support/support-form/' : 'https://wordpress.org/support/plugin/mailpoet/' %>
+    <a slot="support-link"
+        href="<%= support_form_url %>"
+        id="mailpoet-support-link"
+        style="display:none"
+        target="_blank"
     >
-      <% set support_form_url = has_premium_support ? 'https://www.mailpoet.com/support/support-form/' : 'https://wordpress.org/support/plugin/mailpoet/' %>
-      <a slot="support-link"
-          href="<%= support_form_url %>"
-          id="mailpoet-support-link"
-          style="display:none"
-          target="_blank"
-      >
-        <%= __('Contact support', 'mailpoet') %>
-      </a>
-    </chat-widget>
-    <script>
-      const getChatId = () => localStorage.getItem('ai-widget-mailpoet-chat-support-chat-id');
+      <%= __('Contact support', 'mailpoet') %>
+    </a>
+  </chat-widget>
+  <script>
+    const getChatId = () => localStorage.getItem('ai-widget-mailpoet-chat-support-chat-id');
 
-      document.addEventListener('DOMContentLoaded', function() {
-        const supportLink = document.getElementById('mailpoet-support-link');
-        if (supportLink) {
-          <% if has_premium_support %>
-            supportLink.addEventListener('click', function(e) {
-              const chatId = getChatId();
-              if (chatId) {
-                e.preventDefault();
-                window.open(`<%= support_form_url %>?chatId=${chatId}`, '_blank');
-              }
-            });
-          <% endif %>
-
-          // Only show the support link once the chat has begun
-          const checkChatId = setInterval(function() {
+    document.addEventListener('DOMContentLoaded', function() {
+      const supportLink = document.getElementById('mailpoet-support-link');
+      if (supportLink) {
+        <% if has_premium_support %>
+          supportLink.addEventListener('click', function(e) {
             const chatId = getChatId();
             if (chatId) {
-              supportLink.style.display = 'block';
-              clearInterval(checkChatId);
+              e.preventDefault();
+              window.open(`<%= support_form_url %>?chatId=${chatId}`, '_blank');
             }
-          }, 2000);
-        }
-        // Prevent conflicts with other keydown events on Dotcom
-        function writingFixer (e) {
-            e.stopPropagation();
-        }
-        document.getElementById('chat').addEventListener('keydown', writingFixer);
-      });
-    </script>
-  <% else %>
-    <script type="text/javascript">window.DocsBotAI=window.DocsBotAI||{},DocsBotAI.init=function(c){return new Promise(function(e,o){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://widget.docsbot.ai/chat.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n),t.addEventListener("load",function(){window.DocsBotAI.mount({id:c.id,supportCallback:c.supportCallback,identify:c.identify,options:c.options});var t;t=function(n){return new Promise(function(e){if(document.querySelector(n))return e(document.querySelector(n));var o=new MutationObserver(function(t){document.querySelector(n)&&(e(document.querySelector(n)),o.disconnect())});o.observe(document.body,{childList:!0,subtree:!0})})},t&&t("#docsbotai-root").then(e).catch(o)}),t.addEventListener("error",function(t){o(t.message)})})};</script>
-    <script type="text/javascript">
-      DocsBotAI.init({
-        id: "TqTdebbGjJeUjrmBIFjh/kzFE5FBebBJiSJ2Tm0nR",
-        options: {
-          <% if has_premium_support %>
-            supportLink: 'https://www.mailpoet.com/support/premium/',
-          <% else %>
-            supportLink: 'https://wordpress.org/support/plugin/mailpoet/',
-            labels: {
-              getSupport: "<%= __('Get help in the forum', 'mailpoet' )|escape('js') %>"
-            }
-          <% endif %>
-        },
-      }).then(() => {
-        // Prevent conflicts with other keydown events on Dotcom
-        function writingFixer (e) {
+          });
+        <% endif %>
+
+        // Only show the support link once the chat has begun
+        const checkChatId = setInterval(function() {
+          const chatId = getChatId();
+          if (chatId) {
+            supportLink.style.display = 'block';
+            clearInterval(checkChatId);
+          }
+        }, 2000);
+      }
+      // Prevent conflicts with other keydown events on Dotcom
+      function writingFixer (e) {
           e.stopPropagation();
-        }
-        document.getElementById('docsbotai-root').addEventListener("keydown", writingFixer);
-      })
-    </script>
-  <% endif %>
+      }
+      document.getElementById('chat').addEventListener('keydown', writingFixer);
+    });
+  </script>
 <% endif %>
 
 <div id="mailpoet-modal"></div>

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -106,7 +106,7 @@
   'after12months': __('After 12 months (default)'),
   'after18months': __('After 18 months'),
   'libs3rdPartyTitle': __('Load 3rd-party libraries'),
-  'libs3rdPartyDescription': __('E.g. Google Fonts in the Form and Email editor and DocsBot to get help. When disabled, you can still reach support at [link]www.mailpoet.com/support/[/link].'),
+  'libs3rdPartyDescription': __('E.g. Google Fonts in the Form and Email editor and WordPress.com to get help. When disabled, you can still reach support at [link]www.mailpoet.com/support/[/link].'),
   'shareDataTitle': __('Share anonymous data'),
   'shareDataDescription': __('Share anonymous data and help us improve the plugin. We appreciate your help!'),
   'captchaTitle': __('Protect your MailPoet forms against spam signups'),


### PR DESCRIPTION
## Description

Remove Odie feature flag and remaining DocsBot code and keep only Odie. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7390

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7390-remove-docsbot-code-and-only-use-happiness-assistant-widget)

_The latest successful build from `stomail-7390-remove-docsbot-code-and-only-use-happiness-assistant-widget` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new WordPress.com chatbot for Knowledge Base searches, replacing the previous DocsBot integration.

* **Bug Fixes**
  * Updated user-facing text in the welcome wizard and settings to reference WordPress.com instead of DocsBot.

* **Documentation**
  * Revised documentation and changelog to reflect the switch from DocsBot to the WordPress.com chatbot.

* **Refactor**
  * Simplified and consolidated chatbot integration in the interface, removing legacy DocsBot code and related feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->