### PR TITLE
When choosing an email type, show loading animation only on the selected one

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -62,31 +62,6 @@
   background: $color-badge-green;
 }
 
-.mailpoet_badge_video {
-  background: $color-badge-video-guide;
-  display: inline-block;
-  line-height: 20px;
-  padding: 3px 6px;
-  text-decoration: none;
-  vertical-align: top;
-
-  &:hover,
-  &:active,
-  &:focus {
-    background: $color-badge-green;
-    color: #fff;
-  }
-
-  .dashicons {
-    font-size: 14px;
-    line-height: 20px;
-  }
-}
-
-.mailpoet_badge_video_grey {
-  background: #c3c3c3;
-}
-
 // h1.title needed to override WP styles specificity
 h1.title.mailpoet-newsletter-listing-heading {
   margin-bottom: $grid-gap;

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -128,6 +128,8 @@ export function NewsletterTypes({
             variant="secondary"
             className="mailpoet-button-with-wordpress-icon"
             onClick={onToggle}
+            isBusy={isCreating === 'standard'}
+            disabled={isCreating !== null}
             aria-expanded={isOpen}
             data-automation-id="create_standard_email_dropdown"
           >

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -47,25 +47,23 @@ export function NewsletterTypes({
     }
   };
 
-  const renderType = (type): JSX.Element => {
-    return (
-      <div
-        key={type.slug}
-        data-type={type.slug}
-        className="mailpoet-newsletter-type"
-      >
-        <div className="mailpoet-newsletter-type-image" />
-        <div className="mailpoet-newsletter-type-content">
-          <Heading level={4}>
-            {type.title} {type.beta ? `(${__('Beta', 'mailpoet')})` : ''}
-          </Heading>
-          <p>{type.description}</p>
-          <div className="mailpoet-flex-grow" />
-          <div className="mailpoet-newsletter-type-action">{type.action}</div>
-        </div>
+  const renderType = (type): JSX.Element => (
+    <div
+      key={type.slug}
+      data-type={type.slug}
+      className="mailpoet-newsletter-type"
+    >
+      <div className="mailpoet-newsletter-type-image" />
+      <div className="mailpoet-newsletter-type-content">
+        <Heading level={4}>
+          {type.title} {type.beta ? `(${__('Beta', 'mailpoet')})` : ''}
+        </Heading>
+        <p>{type.description}</p>
+        <div className="mailpoet-flex-grow" />
+        <div className="mailpoet-newsletter-type-action">{type.action}</div>
       </div>
-    );
-  };
+    </div>
+  );
 
   const createNewsletter = (type): void => {
     setIsCreating(type);

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -48,11 +48,6 @@ export function NewsletterTypes({
   };
 
   const renderType = (type): JSX.Element => {
-    const badgeClassName =
-      window.mailpoet_is_new_user === true
-        ? 'mailpoet_badge mailpoet_badge_video'
-        : 'mailpoet_badge mailpoet_badge_video mailpoet_badge_video_grey';
-
     return (
       <div
         key={type.slug}
@@ -65,22 +60,6 @@ export function NewsletterTypes({
             {type.title} {type.beta ? `(${__('Beta', 'mailpoet')})` : ''}
           </Heading>
           <p>{type.description}</p>
-          {type.videoGuide && (
-            <a
-              className={badgeClassName}
-              href={type.videoGuide}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span className="dashicons dashicons-format-video" />
-              {__('See video guide', 'mailpoet')}
-            </a>
-          )}
-          {type.kbLink && (
-            <a href={type.kbLink} target="_blank" rel="noopener noreferrer">
-              {__('Read more.', 'mailpoet')}
-            </a>
-          )}
           <div className="mailpoet-flex-grow" />
           <div className="mailpoet-newsletter-type-action">{type.action}</div>
         </div>

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -33,7 +33,7 @@ export function NewsletterTypes({
 }: Props): JSX.Element {
   const navigate = useNavigate();
 
-  const [isCreating, setIsCreating] = useState(false);
+  const [isCreating, setIsCreating] = useState(null);
 
   const [isSelectEditorModalOpen, setIsSelectEditorModalOpen] = useState(false);
   const isNewEmailEditorEnabled = window.mailpoet_block_email_editor_enabled;
@@ -68,7 +68,7 @@ export function NewsletterTypes({
   };
 
   const createNewsletter = (type): void => {
-    setIsCreating(true);
+    setIsCreating(type);
     MailPoet.trackEvent('Emails > Type selected', {
       'Email type': type,
     });
@@ -85,7 +85,7 @@ export function NewsletterTypes({
         navigate(`/template/${response.data.id}`);
       })
       .fail((response) => {
-        setIsCreating(false);
+        setIsCreating(null);
         if (response.errors.length > 0) {
           return <APIErrorsNotice errors={response.errors} />;
         }
@@ -103,7 +103,7 @@ export function NewsletterTypes({
     're-engagement',
   );
   const createAutomation = () => {
-    setIsCreating(true);
+    setIsCreating('automation');
     window.location.href = 'admin.php?page=mailpoet-automation-templates';
   };
 
@@ -112,7 +112,8 @@ export function NewsletterTypes({
       <Button
         variant="secondary"
         onClick={createStandardNewsletter}
-        isBusy={isCreating}
+        isBusy={isCreating === 'standard'}
+        disabled={isCreating !== null}
         data-automation-id="create_standard"
       >
         {__('Create', 'mailpoet')}
@@ -193,7 +194,8 @@ export function NewsletterTypes({
         <Button
           variant="secondary"
           onClick={createAutomation}
-          isBusy={isCreating}
+          isBusy={isCreating === 'automation'}
+          disabled={isCreating !== null}
           data-automation-id="create_automation"
         >
           {__('Create', 'mailpoet')}
@@ -213,7 +215,8 @@ export function NewsletterTypes({
         <Button
           variant="secondary"
           onClick={createNotificationNewsletter}
-          isBusy={isCreating}
+          isBusy={isCreating === 'notification'}
+          disabled={isCreating !== null}
           data-automation-id="create_notification"
         >
           {__('Create', 'mailpoet')}
@@ -231,7 +234,8 @@ export function NewsletterTypes({
         <Button
           variant="secondary"
           onClick={createReEngagementNewsletter}
-          isBusy={isCreating}
+          isBusy={isCreating === 're_engagement'}
+          disabled={isCreating !== null}
           data-automation-id="create_notification"
         >
           {__('Create', 'mailpoet')}

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -229,6 +229,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Improved: add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off;
+* Improved: when choosing an email type, show loading animation only on the selected one;
 * Changed: replaced DocsBot with WordPress.com chatbot when searching MailPoet Knowledge Base;
 * Fixed: fatal error in ACF and SCF when working with post templates in location rules.
 


### PR DESCRIPTION
## Description

| Before | After |
|--------|--------|
| <img width="1099" alt="Screenshot 2025-06-26 at 21 32 38" src="https://github.com/user-attachments/assets/5ae4d807-e30a-4fe2-89a4-7e6b2b26cc5d" /> | <img width="1105" alt="Screenshot 2025-06-26 at 21 31 41" src="https://github.com/user-attachments/assets/1d92d43b-cd53-49d8-b7bb-9d1057f7cab3" />  |

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7297

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7297-new-email-page-all-buttons-show-loading-animations-if-any-of)

_The latest successful build from `stomail-7297-new-email-page-all-buttons-show-loading-animations-if-any-of` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved newsletter creation experience: the loading animation now appears only on the selected email type, providing clearer feedback during the creation process.

* **Style**
  * Removed video badge styling from the newsletter listing interface.

* **Documentation**
  * Updated the changelog to reflect improvements in the newsletter creation loading animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->