### PR TITLE
Add sorting to `check_woocommerce_beta.sh` to resolve the correct latest beta/RC version

### DIFF
--- a/.circleci/check_woocommerce_beta.sh
+++ b/.circleci/check_woocommerce_beta.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Fetch the versions of WooCommerce from the WordPress API
-VERSIONS=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | keys_unsorted | .[]' | grep -v 'trunk')
-LATEST_VERSION=""
-
-# Find the latest version
-for version in $VERSIONS; do
-  LATEST_VERSION=$version
-done
+LATEST_VERSION=$(
+  curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
+  jq -r '.versions | keys_unsorted | .[]' | \
+  grep -v 'trunk' | \
+  sort -V | \
+  tail -n 1
+)
 
 # Check if the latest version is a beta/RC version
 if [[ $LATEST_VERSION != *'beta'* && $LATEST_VERSION != *'rc'* ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,12 @@ anchors:
       # Add GitHub to known_hosts (for jobs without a checkout step that need to clone repos)
       echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> ~/.ssh/known_hosts
 
+  only_tmp_test_branch: &only_tmp_test_branch
+    filters:
+      branches:
+        only:
+          - dev-fix-wc-beta-version-sh
+
 executors:
   wpcli_php_oldest:
     <<: *default_job_config
@@ -1152,17 +1158,11 @@ workflows:
           requires:
             - build_release_zip
 
-  nightly:
-    triggers:
-      - schedule:
-          cron: '0 1 * * 1-5'
-          filters:
-            branches:
-              only:
-                - trunk
+  dev_test_nightly:
     jobs:
       - build:
           <<: *slack-fail-post-step
+          <<: *only_tmp_test_branch
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
@@ -1251,6 +1251,7 @@ workflows:
             - build
       - integration_tests:
           <<: *slack-fail-post-step
+          <<: *only_tmp_test_branch
           name: integration_tests_woocommerce_beta
           use_woocommerce_beta: true
           mysql_image: mysql:8.3
@@ -1266,6 +1267,7 @@ workflows:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
+          <<: *only_tmp_test_branch
           name: acceptance_tests_woocommerce_beta
           enable_hpos: 1
           use_woocommerce_beta: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,6 @@ anchors:
       # Add GitHub to known_hosts (for jobs without a checkout step that need to clone repos)
       echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> ~/.ssh/known_hosts
 
-  only_tmp_test_branch: &only_tmp_test_branch
-    filters:
-      branches:
-        only:
-          - dev-fix-wc-beta-version-sh
-
 executors:
   wpcli_php_oldest:
     <<: *default_job_config
@@ -1158,11 +1152,17 @@ workflows:
           requires:
             - build_release_zip
 
-  dev_test_nightly:
+  nightly:
+    triggers:
+      - schedule:
+          cron: '0 1 * * 1-5'
+          filters:
+            branches:
+              only:
+                - trunk
     jobs:
       - build:
           <<: *slack-fail-post-step
-          <<: *only_tmp_test_branch
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_latest
@@ -1251,7 +1251,6 @@ workflows:
             - build
       - integration_tests:
           <<: *slack-fail-post-step
-          <<: *only_tmp_test_branch
           name: integration_tests_woocommerce_beta
           use_woocommerce_beta: true
           mysql_image: mysql:8.3
@@ -1267,7 +1266,6 @@ workflows:
             - build
       - acceptance_tests:
           <<: *slack-fail-post-step
-          <<: *only_tmp_test_branch
           name: acceptance_tests_woocommerce_beta
           enable_hpos: 1
           use_woocommerce_beta: true


### PR DESCRIPTION
## Description

The recent `integration_tests_wordpress_beta` job in `nightly` workflow didn't run in full because the latest beta/RC version couldn't be resolved correctly.

![image](https://github.com/user-attachments/assets/072d432c-00ac-4fb5-bb3e-f734ddd84d5b)

This PR adds sorting to `check_woocommerce_beta.sh` to resolve the correct latest beta/RC version.

When WC comes to version 10.0.0, it needs to correct the sort result from
```sh
VERSIONS=("10.0.0-rc.1" "3.0.0" ... "9.9.4" "9.9.5")
```
to
```sh
VERSIONS=("3.0.0" ... "9.9.4" "9.9.5" "10.0.0-rc.1")
```
to get the target version correctly.

## Code review notes

The latest WooCommerce version in the API response is 10.0.0-rc.1 for now. It should be possible to run the script to verify if this PR can resolve the latest beta/RC version.

```sh
./.circleci/check_woocommerce_beta.sh
```

### 📷 Before

![image](https://github.com/user-attachments/assets/884da08f-f01d-470b-83f9-84a981bbc6dc)

### 📷 After

![image](https://github.com/user-attachments/assets/db064dc0-d731-4201-addc-27357af98b4b)

### 📷 Testing run on CircleCI

![image](https://github.com/user-attachments/assets/e8d29a5d-38a8-49c9-840e-818f05cfd790)

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

💡 I didn't tick any tasks below because this PR only adjusts a CircleCI-related script for development.

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:dev-fix-wc-beta-version-sh)

_The latest successful build from `dev-fix-wc-beta-version-sh` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the process for identifying the latest WooCommerce version, making it more reliable and efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->