### PR TITLE
Fix PHP Warning: Undefined array key “blocks”

### DIFF
--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
@@ -72,7 +72,7 @@ class Renderer {
   }
 
   public function render(NewsletterEntity $newsletter, $data) {
-    if (!isset($data['blocks']) || !is_countable($data['blocks'])) {
+    if (!isset($data['blocks']) || !is_countable($data['blocks']) || !is_iterable($data['blocks'])) {
         return null;
     }
     $columnCount = count($data['blocks']);

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
@@ -72,10 +72,7 @@ class Renderer {
   }
 
   public function render(NewsletterEntity $newsletter, $data) {
-    if (
-      (!isset($data['blocks']) || !is_countable($data['blocks']))
-      && isset($data['type'])
-    ) {
+    if (!isset($data['blocks']) || !is_countable($data['blocks'])) {
         return null;
     }
     $columnCount = count($data['blocks']);

--- a/mailpoet/lib/Newsletter/Renderer/Columns/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Columns/Renderer.php
@@ -6,8 +6,11 @@ use MailPoet\Newsletter\Renderer\EscapeHelper as EHelper;
 
 class Renderer {
   public function render($contentBlock, $columnsData) {
-    if (is_null($contentBlock['blocks']) && isset($contentBlock['type'])) {
-      return "<!-- Skipped unsupported block type: {$contentBlock['type']} -->";
+    if (!isset($contentBlock['blocks']) || !is_countable($contentBlock['blocks'])) {
+      if (isset($contentBlock['type'])) {
+        return "<!-- Skipped unsupported block type: {$contentBlock['type']} -->";
+      }
+      return "<!-- Skipped unsupported block -->";
     }
 
     $columnsCount = count($contentBlock['blocks']);

--- a/mailpoet/lib/Newsletter/Renderer/Columns/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Columns/Renderer.php
@@ -6,7 +6,7 @@ use MailPoet\Newsletter\Renderer\EscapeHelper as EHelper;
 
 class Renderer {
   public function render($contentBlock, $columnsData) {
-    if (!isset($contentBlock['blocks']) || !is_countable($contentBlock['blocks'])) {
+    if (!isset($contentBlock['blocks']) || !is_countable($contentBlock['blocks']) || !is_iterable($contentBlock['blocks'])) {
       if (isset($contentBlock['type'])) {
         return "<!-- Skipped unsupported block type: {$contentBlock['type']} -->";
       }

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,13 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.9 - 2025-06-30 =
-* Improved: handling of MailPoet Page title when switching website languages;
-* Improved: add default re-engagement emails trigger value when "Inactive subscribers" feature is turned off;
-* Improved: when choosing an email type, show loading animation only on the selected one;
-* Changed: replaced DocsBot with WordPress.com chatbot when searching MailPoet Knowledge Base;
-* Fixed: rendering submit button when font size is changed;
-* Fixed: fatal error in ACF and SCF when working with post templates in location rules;
-* Fixed: apply the latest changes in the form editor in the preview.
+= x.x.x - YYYY-MM-DD =
+* Fixed: PHP Warning: Undefined array key “blocks”.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/RendererTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/RendererTest.php
@@ -83,9 +83,8 @@ class RendererTest extends \MailPoetUnitTest {
   }
 
   public function testItReturnsNullWhenDataHasTypeButNoCountableBlocks() {
-    // Test case 1: data has type but no blocks property
+    // Test case 1: data has no type but no blocks property
     $dataWithTypeNoBlocks = [
-      'type' => 'container',
       'styles' => ['block' => []],
     ];
 
@@ -102,9 +101,8 @@ class RendererTest extends \MailPoetUnitTest {
     $result = $this->renderer->render($this->newsletter, $dataWithTypeNullBlocks);
     verify($result)->null();
 
-    // Test case 3: data has type and blocks property but blocks is not countable (string)
+    // Test case 3: data has no type and blocks property but blocks is not countable (string)
     $dataWithTypeStringBlocks = [
-      'type' => 'container',
       'blocks' => 'not countable',
       'styles' => ['block' => []],
     ];

--- a/mailpoet/tests/unit/Newsletter/Renderer/Columns/RendererTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Columns/RendererTest.php
@@ -1,0 +1,336 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Renderer\Columns;
+
+class RendererTest extends \MailPoetUnitTest {
+  /** @var Renderer */
+  private $renderer;
+
+  public function _before() {
+    parent::_before();
+    $this->renderer = new Renderer();
+  }
+
+  public function testItReturnsSkippedMessageWhenContentBlockHasNoBlocks() {
+    $contentBlock = [
+      'styles' => ['block' => []],
+    ];
+
+    $result = $this->renderer->render($contentBlock, []);
+    verify($result)->equals('<!-- Skipped unsupported block -->');
+  }
+
+  public function testItReturnsSkippedMessageWhenContentBlockHasTypeButNoBlocks() {
+    $contentBlock = [
+      'type' => 'container',
+      'styles' => ['block' => []],
+    ];
+
+    $result = $this->renderer->render($contentBlock, []);
+    verify($result)->equals('<!-- Skipped unsupported block type: container -->');
+  }
+
+  public function testItReturnsSkippedMessageWhenBlocksIsNotCountable() {
+    $contentBlock = [
+      'type' => 'container',
+      'blocks' => 'not countable',
+      'styles' => ['block' => []],
+    ];
+
+    $result = $this->renderer->render($contentBlock, []);
+    verify($result)->equals('<!-- Skipped unsupported block type: container -->');
+  }
+
+  public function testItRendersOneColumn() {
+    $contentBlock = [
+      'blocks' => [1], // Single block
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#ffffff',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>Test content</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('mailpoet_content');
+    verify($result)->stringContainsString('cols-one');
+    verify($result)->stringContainsString('Test content');
+    verify($result)->stringContainsString('background-color:#ffffff!important;');
+  }
+
+  public function testItRendersOneColumnWithImage() {
+    $contentBlock = [
+      'blocks' => [1], // Single block
+      'image' => [
+        'src' => 'test-image.jpg',
+        'display' => 'scale',
+      ],
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#f0f0f0',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>Test content with image</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('mailpoet_content');
+    verify($result)->stringContainsString('cols-one');
+    verify($result)->stringContainsString('Test content with image');
+    verify($result)->stringContainsString('background-image: url(test-image.jpg)');
+    verify($result)->stringContainsString('background-size: cover');
+  }
+
+  public function testItRendersMultipleColumns() {
+    $contentBlock = [
+      'blocks' => [1, 2], // Two blocks
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#e0e0e0',
+        ],
+      ],
+    ];
+
+    $columnsData = [
+      '<div>First column</div>',
+      '<div>Second column</div>',
+    ];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('mailpoet_content-cols-two');
+    verify($result)->stringContainsString('First column');
+    verify($result)->stringContainsString('Second column');
+    verify($result)->stringContainsString('width="330"');
+    verify($result)->stringContainsString('align="left"');
+  }
+
+  public function testItRendersMultipleColumnsWithCustomLayout() {
+    $contentBlock = [
+      'blocks' => [1, 2], // Two blocks
+      'columnLayout' => '1_2',
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#d0d0d0',
+        ],
+      ],
+    ];
+
+    $columnsData = [
+      '<div>Narrow column</div>',
+      '<div>Wide column</div>',
+    ];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('mailpoet_content-cols-two');
+    verify($result)->stringContainsString('Narrow column');
+    verify($result)->stringContainsString('Wide column');
+    verify($result)->stringContainsString('width="220"');
+    verify($result)->stringContainsString('width="440"');
+  }
+
+  public function testItRendersThreeColumns() {
+    $contentBlock = [
+      'blocks' => [1, 2, 3], // Three blocks
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#c0c0c0',
+        ],
+      ],
+    ];
+
+    $columnsData = [
+      '<div>First column</div>',
+      '<div>Second column</div>',
+      '<div>Third column</div>',
+    ];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('mailpoet_content-cols-three');
+    verify($result)->stringContainsString('First column');
+    verify($result)->stringContainsString('Second column');
+    verify($result)->stringContainsString('Third column');
+    verify($result)->stringContainsString('width="220"');
+    verify($result)->stringContainsString('align="right"');
+  }
+
+  public function testItHandlesTransparentBackground() {
+    $contentBlock = [
+      'blocks' => [1],
+      'styles' => [
+        'block' => [
+          'backgroundColor' => 'transparent',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>Transparent background</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('Transparent background');
+    verify($result)->stringNotContainsString('background-color:transparent!important;');
+    verify($result)->stringNotContainsString('bgcolor=');
+  }
+
+  public function testItHandlesMissingBackgroundColor() {
+    $contentBlock = [
+      'blocks' => [1],
+      'styles' => [
+        'block' => [],
+      ],
+    ];
+
+    $columnsData = ['<div>No background</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('No background');
+    verify($result)->stringNotContainsString('background-color');
+    verify($result)->stringNotContainsString('bgcolor=');
+  }
+
+  public function testItHandlesImageWithTileDisplay() {
+    $contentBlock = [
+      'blocks' => [1],
+      'image' => [
+        'src' => 'tile-image.jpg',
+        'display' => 'tile',
+      ],
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#ffffff',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>Tiled image</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('Tiled image');
+    verify($result)->stringContainsString('background-repeat: repeat');
+    verify($result)->stringContainsString('background-size: contain');
+  }
+
+  public function testItHandlesImageWithContainDisplay() {
+    $contentBlock = [
+      'blocks' => [1],
+      'image' => [
+        'src' => 'contain-image.jpg',
+        'display' => 'contain',
+      ],
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#ffffff',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>Contained image</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('Contained image');
+    verify($result)->stringContainsString('background-repeat: no-repeat');
+    verify($result)->stringContainsString('background-size: contain');
+  }
+
+  public function testItHandlesImageWithNullSrc() {
+    $contentBlock = [
+      'blocks' => [1],
+      'image' => [
+        'src' => null,
+        'display' => 'scale',
+      ],
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#ffffff',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>No image src</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('No image src');
+    verify($result)->stringContainsString('background-color:#ffffff!important;');
+    verify($result)->stringContainsString('bgcolor="#ffffff"');
+  }
+
+  public function testItHandlesNullImage() {
+    $contentBlock = [
+      'blocks' => [1],
+      'image' => null,
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#ffffff',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>No image</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('No image');
+    verify($result)->stringContainsString('background-color:#ffffff!important;');
+    verify($result)->stringContainsString('bgcolor="#ffffff"');
+  }
+
+  public function testGetOneColumnTemplate() {
+    $styles = [
+      'backgroundColor' => '#ff0000',
+    ];
+
+    $template = $this->renderer->getOneColumnTemplate($styles, null);
+    verify($template)->arrayHasKey('content_start');
+    verify($template)->arrayHasKey('content_end');
+    verify($template['content_start'])->stringContainsString('mailpoet_content');
+    verify($template['content_start'])->stringContainsString('cols-one');
+    verify($template['content_start'])->stringContainsString('background-color:#ff0000!important;');
+  }
+
+  public function testGetOneColumnTemplateWithImage() {
+    $styles = [
+      'backgroundColor' => '#00ff00',
+    ];
+
+    $image = [
+      'src' => 'test.jpg',
+      'display' => 'scale',
+    ];
+
+    $template = $this->renderer->getOneColumnTemplate($styles, $image);
+    verify($template)->arrayHasKey('content_start');
+    verify($template)->arrayHasKey('content_end');
+    verify($template['content_start'])->stringContainsString('mailpoet_content');
+    verify($template['content_start'])->stringContainsString('cols-one');
+    verify($template['content_start'])->stringContainsString('background-image: url(test.jpg)');
+  }
+
+  public function testGetMultipleColumnsContentStart() {
+    $width = 330;
+    $alignment = 'left';
+    $class = 'cols-two';
+
+    $result = $this->renderer->getMultipleColumnsContentStart($width, $alignment, $class);
+    verify($result)->stringContainsString('width="330"');
+    verify($result)->stringContainsString('align="left"');
+    verify($result)->stringContainsString('mailpoet_cols-two');
+    verify($result)->stringContainsString('max-width:330px');
+  }
+
+  public function testItEscapesHtmlInBackgroundStyles() {
+    $contentBlock = [
+      'blocks' => [1],
+      'styles' => [
+        'block' => [
+          'backgroundColor' => '#ffffff',
+        ],
+      ],
+    ];
+
+    $columnsData = ['<div>Test</div>'];
+
+    $result = $this->renderer->render($contentBlock, $columnsData);
+    verify($result)->stringContainsString('background-color:#ffffff!important;');
+  }
+}


### PR DESCRIPTION
## Description

A follow up for https://github.com/mailpoet/mailpoet/pull/6228 to remove unnecessary condition that can still result in PHP warning, as well as adding a check also in Columns renderer. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7439

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7439-php-warning-undefined-array-key-blocks)

_The latest successful build from `stomail-7439-php-warning-undefined-array-key-blocks` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a PHP warning caused by an undefined array key "blocks" when rendering newsletter content blocks.
  * Improved handling of unsupported or empty content blocks, ensuring appropriate messages are shown when blocks are missing, not countable, or not iterable.

* **Tests**
  * Added comprehensive tests for rendering column-based newsletter content, covering various layout and styling scenarios.
  * Updated test comments for clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->