### PR TITLE
Bump minimum WooCommerce to 9.9, tested up to 10.0

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,7 +11,7 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 9.8
+ * WC requires at least: 9.9
  * WC tested up to: 9.9
  *
  * @package WordPress
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.7'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.8'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '9.9'; // L-1 version, not the latest
 
 
 // Display WP version error notice

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -12,7 +12,7 @@
  * Domain Path: /lang
  *
  * WC requires at least: 9.9
- * WC tested up to: 9.9
+ * WC tested up to: 10.0
  *
  * @package WordPress
  * @author MailPoet

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,10 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.11 - 2025-07-14 =
-* Improved: JavaScript and CSS compatibility with other plugins and themes;
-* Fixed: inconsistent spacing when adding tags to subscribers;
-* Fixed: error message position when creating a list during import;
-* Fixed: page title replacement broken on non-English sites.
+= x.x.x - YYYY-MM-DD =
+* Updated: minimum required WooCommerce version to 9.9 and tested up to version to 10.0.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

pfRkvP-Dz-p2

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-woocommerce-10-0-compatibility)

_The latest successful build from `update-woocommerce-10-0-compatibility` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required and tested WooCommerce versions to 9.9 and 10.0.
  * Replaced the changelog with a placeholder entry reflecting the updated WooCommerce version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->