### PR TITLE
Add type parameter to unsubscribe URL and update confirmation template - STOMAIL-7432

### DIFF
--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -506,7 +506,7 @@ class Pages {
   }
 
   private function addTypeParamToUnsubscribeUrl(string $unsubscribeUrl): string {
-    if (!$unsubscribeUrl) {
+    if (empty($unsubscribeUrl)) {
         return $unsubscribeUrl;
     }
     // using the same value as mailpoet/views/subscription/confirm_unsubscribe.html#4

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -463,7 +463,7 @@ class Pages {
     return $this->wp->applyFilters(
       'mailpoet_unsubscribe_confirmation_page',
       $this->templateRenderer->render('subscription/confirm_unsubscribe.html', $templateData),
-      $unsubscribeUrl
+      $this->addTypeParamToUnsubscribeUrl($unsubscribeUrl)
     );
   }
 
@@ -503,5 +503,13 @@ class Pages {
       );
       $this->statisticsClicksRepository->flush();
     }
+  }
+
+  private function addTypeParamToUnsubscribeUrl(string $unsubscribeUrl): string {
+    if (!$unsubscribeUrl) {
+        return $unsubscribeUrl;
+    }
+    // using the same value as mailpoet/views/subscription/confirm_unsubscribe.html#4
+    return $this->wp->addQueryArg('type', 'confirmation', $unsubscribeUrl);
   }
 }

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -229,5 +229,6 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Fixed: PHP Warning: Undefined array key “blocks”.
+* Fixed: Filter `mailpoet_unsubscribe_confirmation_page` not redirecting to success page.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -229,6 +229,6 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Fixed: PHP Warning: Undefined array key “blocks”.
-* Fixed: Filter `mailpoet_unsubscribe_confirmation_page` not redirecting to success page.
+* Fixed: Filter `mailpoet_unsubscribe_confirmation_page` not redirecting to the success page.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/views/subscription/confirm_unsubscribe.html
+++ b/mailpoet/views/subscription/confirm_unsubscribe.html
@@ -1,5 +1,6 @@
 <% block content %>
 <form action="<%= unsubscribeUrl %>" method="post">
+<!--  if updating this hidden field form value, remember to update here as well mailpoet/lib/Router/Endpoints/Subscription.php#L514 -->
   <input type="hidden" name="type" value="confirmation">
   <p class="mailpoet_confirm_unsubscribe">
     <%= __('Simply click on this link to stop receiving emails from us.') %>

--- a/mailpoet/views/subscription/confirm_unsubscribe.html
+++ b/mailpoet/views/subscription/confirm_unsubscribe.html
@@ -1,6 +1,6 @@
 <% block content %>
 <form action="<%= unsubscribeUrl %>" method="post">
-<!--  if updating this hidden field form value, remember to update here as well mailpoet/lib/Router/Endpoints/Subscription.php#L514 -->
+<!--  if updating this hidden field form value, remember to update the corresponding logic in mailpoet/lib/Router/Endpoints/Subscription.php::addTypeParamToUnsubscribeUrl -->
   <input type="hidden" name="type" value="confirmation">
   <p class="mailpoet_confirm_unsubscribe">
     <%= __('Simply click on this link to stop receiving emails from us.') %>


### PR DESCRIPTION
## Description

This PR fixes an issue where users of the filter `mailpoet_unsubscribe_confirmation_page` are not getting redirected to the success page.

Why?
Processing stops due to the exit on this line https://github.com/mailpoet/mailpoet/blob/97091f76816e6b139548e4b63a7409e4d9b270f8/mailpoet/lib/Router/Endpoints/Subscription.php#L81, which is used for one-click unsubscribe POST requests.

We just need to ensure that we process the link in the same way as we do for regular unsubscribe requests going through the unsubscribe confirmation page.

## Code review notes

_N/A_

## QA notes

* Use the code snippet below
* Click on an unsubscribe link from a newsletter
* Click on the link on the page
* Confirm you see the success page.

```php
add_filter( 'mailpoet_unsubscribe_confirmation_page', 'mp_modify_unsubscribe_confirmation_page', 10, 2);
function mp_modify_unsubscribe_confirmation_page( $HTML, $unsubscribeUrl ) {
	$HTML = '<hr>';
	$HTML .= '<h3> Hello there </h3>';
	$HTML .= '<center>You can <a href="'.$unsubscribeUrl.'">click here</a> to unsubscribe.</center>';
	$HTML .= '<hr>';
	return $HTML;
}
```

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7432

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7432-snippet-for-custom-text-on-unsubscribe-page-breaks-success)

_The latest successful build from `stomail-7432-snippet-for-custom-text-on-unsubscribe-page-breaks-success` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the unsubscribe confirmation process to ensure correct redirection to the success page.

* **Documentation**
  * Updated the changelog to reflect the fix for the unsubscribe confirmation filter.
  * Added an inline comment in the unsubscribe confirmation form for developer reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->