### PR TITLE
Hide Amazon SES keys in MailPoet dashboard - STOMAIL-7318

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -245,6 +245,7 @@ progress::-moz-progress-bar {
 }
 
 .mailpoet-password-input-toggle {
-  height: 34px;
+  border-radius: 0 3px 3px 0 !important;
+  height: 100%;
   padding: 0 10px !important;
 }

--- a/mailpoet/assets/css/src/components-plugin/_forms.scss
+++ b/mailpoet/assets/css/src/components-plugin/_forms.scss
@@ -243,3 +243,8 @@ progress::-moz-progress-bar {
 .mailpoet-form-field-disabled {
   cursor: not-allowed;
 }
+
+.mailpoet-password-input-toggle {
+  height: 34px;
+  padding: 0 10px !important;
+}

--- a/mailpoet/assets/css/src/components-plugin/_settings.scss
+++ b/mailpoet/assets/css/src/components-plugin/_settings.scss
@@ -165,8 +165,3 @@ ul.sending-method-benefits {
 .mailpoet-verify-key-button {
   height: 36px;
 }
-
-.mailpoet-premium-key-toggle {
-  height: 34px;
-  padding: 0 10px !important;
-}

--- a/mailpoet/assets/js/src/common/form/index.ts
+++ b/mailpoet/assets/js/src/common/form/index.ts
@@ -2,3 +2,4 @@ export * from './select/select';
 export * from './input/input';
 export * from './toggle/toggle';
 export * from './checkbox/checkbox';
+export * from './input/password-input';

--- a/mailpoet/assets/js/src/common/form/input/input.tsx
+++ b/mailpoet/assets/js/src/common/form/input/input.tsx
@@ -2,7 +2,7 @@ import { InputHTMLAttributes } from 'react';
 import classnames from 'classnames';
 import { Tooltip } from 'common/tooltip/tooltip';
 
-type Props = InputHTMLAttributes<HTMLInputElement> & {
+export type Props = InputHTMLAttributes<HTMLInputElement> & {
   customLabel?: string;
   dimension?: 'small';
   isFullWidth?: boolean;

--- a/mailpoet/assets/js/src/common/form/input/password-input.tsx
+++ b/mailpoet/assets/js/src/common/form/input/password-input.tsx
@@ -1,4 +1,4 @@
-import { _x } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 import { Button } from 'common/button/button';
@@ -9,16 +9,18 @@ type Props = InputProps & {
   forceRevealed?: boolean;
 };
 
-export function PasswordInput({
-  forceRevealed = false,
-  ...attributes
-}: Props) {
+export function PasswordInput({ forceRevealed = false, ...attributes }: Props) {
   const [isRevealed, setIsRevealed] = useState(false);
   const inputType = forceRevealed || isRevealed ? 'text' : 'password';
   const toggleButton = !forceRevealed && (
     <Button
       className="mailpoet-password-input-toggle"
       variant="tertiary"
+      aria-label={
+        isRevealed
+          ? __('Hide input value', 'mailpoet')
+          : __('Show input value', 'mailpoet')
+      }
       onClick={() => setIsRevealed(!isRevealed)}
     >
       {isRevealed
@@ -29,11 +31,5 @@ export function PasswordInput({
     </Button>
   );
 
-  return (
-    <Input
-      type={inputType}
-      iconEnd={toggleButton}
-      {...attributes}
-    />
-  );
+  return <Input type={inputType} iconEnd={toggleButton} {...attributes} />;
 }

--- a/mailpoet/assets/js/src/common/form/input/password-input.tsx
+++ b/mailpoet/assets/js/src/common/form/input/password-input.tsx
@@ -1,0 +1,39 @@
+import { _x } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+import { Button } from 'common/button/button';
+
+import { Props as InputProps, Input } from './input';
+
+type Props = InputProps & {
+  forceRevealed?: boolean;
+};
+
+export function PasswordInput({
+  forceRevealed = false,
+  ...attributes
+}: Props) {
+  const [isRevealed, setIsRevealed] = useState(false);
+  const inputType = forceRevealed || isRevealed ? 'text' : 'password';
+  const toggleButton = !forceRevealed && (
+    <Button
+      className="mailpoet-password-input-toggle"
+      variant="tertiary"
+      onClick={() => setIsRevealed(!isRevealed)}
+    >
+      {isRevealed
+        ? // translators: Used as a button to show or hide the password
+          _x('Hide', 'verb', 'mailpoet')
+        : // translators: Used as a button to show or hide the password
+          _x('Show', 'verb', 'mailpoet')}
+    </Button>
+  );
+
+  return (
+    <Input
+      type={inputType}
+      iconEnd={toggleButton}
+      {...attributes}
+    />
+  );
+}

--- a/mailpoet/assets/js/src/common/premium-key/key-input.tsx
+++ b/mailpoet/assets/js/src/common/premium-key/key-input.tsx
@@ -1,7 +1,5 @@
-import { _x } from '@wordpress/i18n';
-import { Button, Input } from 'common/index';
+import { PasswordInput } from 'common/index';
 import { useAction, useSelector } from 'settings/store/hooks';
-import { useState } from 'react';
 
 type KeyInputPropType = {
   placeholder?: string;
@@ -16,25 +14,9 @@ export function KeyInput({
 }: KeyInputPropType) {
   const state = useSelector('getKeyActivationState')();
   const setState = useAction('updateKeyActivationState');
-  const [isRevealed, setIsRevealed] = useState(false);
-  const inputType = forceRevealed || isRevealed ? 'text' : 'password';
-  const toggleButton = !forceRevealed && (
-    <Button
-      className="mailpoet-premium-key-toggle"
-      variant="tertiary"
-      onClick={() => setIsRevealed(!isRevealed)}
-    >
-      {isRevealed
-        ? // translators: Used as a button to show or hide the premium key
-          _x('Hide', 'verb', 'mailpoet')
-        : // translators: Used as a button to show or hide the premium key
-          _x('Show', 'verb', 'mailpoet')}
-    </Button>
-  );
-
   return (
-    <Input
-      type={inputType}
+    <PasswordInput
+      forceRevealed={forceRevealed}
       id="mailpoet_premium_key"
       name="premium[premium_key]"
       placeholder={placeholder}
@@ -48,7 +30,6 @@ export function KeyInput({
           key: event.target.value.trim() || null,
         })
       }
-      iconEnd={toggleButton}
     />
   );
 }

--- a/mailpoet/assets/js/src/settings/pages/send-with/other/amazon-ses-fields.tsx
+++ b/mailpoet/assets/js/src/settings/pages/send-with/other/amazon-ses-fields.tsx
@@ -1,6 +1,6 @@
 import { Label, Inputs } from 'settings/components';
 import { t, onChange } from 'common/functions';
-import { Input } from 'common/form/input/input';
+import { PasswordInput } from 'common/form';
 import { Select } from 'common/form/select/select';
 import { useSetting, useSelector } from 'settings/store/hooks';
 import { SendingFrequency } from './sending-frequency';
@@ -35,9 +35,8 @@ export function AmazonSesFields() {
       </Inputs>
       <Label title={t('accessKey')} htmlFor="mailpoet_amazon_ses_access_key" />
       <Inputs>
-        <Input
+        <PasswordInput
           dimension="small"
-          type="text"
           value={accessKey}
           className="regular-text"
           onChange={onChange(setAccessKey)}
@@ -46,9 +45,8 @@ export function AmazonSesFields() {
       </Inputs>
       <Label title={t('secretKey')} htmlFor="mailpoet_amazon_ses_secret_key" />
       <Inputs>
-        <Input
+        <PasswordInput
           dimension="small"
-          type="text"
           value={secretKey}
           className="regular-text"
           onChange={onChange(setSecretKey)}

--- a/mailpoet/assets/js/src/settings/pages/send-with/other/sendgrid-fields.tsx
+++ b/mailpoet/assets/js/src/settings/pages/send-with/other/sendgrid-fields.tsx
@@ -1,6 +1,6 @@
 import { Label, Inputs } from 'settings/components';
 import { t, onChange } from 'common/functions';
-import { Input } from 'common/form/input/input';
+import { PasswordInput } from 'common/form';
 import { useSetting, useSelector } from 'settings/store/hooks';
 import { SendingFrequency } from './sending-frequency';
 
@@ -15,9 +15,8 @@ export function SendGridFields() {
       />
       <Label title={t('apiKey')} htmlFor="mailpoet_sendgrid_api_key" />
       <Inputs>
-        <Input
+        <PasswordInput
           dimension="small"
-          type="text"
           value={apiKey}
           onChange={onChange(setApiKey)}
           id="mailpoet_sendgrid_api_key"

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -228,7 +228,8 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
-* Fixed: PHP Warning: Undefined array key “blocks”.
-* Fixed: Filter `mailpoet_unsubscribe_confirmation_page` not redirecting to the success page.
+* Improved: SendGrid API key field and Amazon SES access key and secret key fields now use masked input fields to prevent accidental credential exposure;
+* Fixed: PHP Warning: Undefined array key “blocks”;
+* Fixed: filter `mailpoet_unsubscribe_confirmation_page` not redirecting to the success page.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

This PR enhances security in the MailPoet dashboard by implementing masked input fields for sensitive API credentials. The changes prevent accidental exposure of Amazon SES and SendGrid API keys while still allowing users to view credentials when needed through a show/hide toggle functionality.

**Why this change is needed:**
API keys and secrets displayed in plain text pose a security risk as they can be accidentally exposed during screenshots, screen sharing, or shoulder surfing. This is particularly important for Amazon SES access keys, secret keys, and SendGrid API keys which provide access to external email services.

**What was implemented:**
- Created a new reusable `PasswordInput` component with show/hide toggle functionality
- Applied the `PasswordInput` component to Amazon SES access key and secret key fields
- Applied the `PasswordInput` component to SendGrid API key field
- Refactored the existing premium key input to use the new `PasswordInput` component for consistency
- Added appropriate styling for the password toggle button

## Code review notes

The implementation follows these patterns:
- The `PasswordInput` component extends the existing `Input` component props
- Uses WordPress i18n for translatable "Show"/"Hide" button text
- Maintains the same UI/UX patterns as other form inputs in the settings
- CSS classes follow existing naming conventions (`mailpoet-password-input-toggle`)

Key files changed:
- `assets/js/src/common/form/input/password-input.tsx` - New reusable component
- `assets/js/src/settings/pages/send-with/other/amazon-ses-fields.tsx` - Updated to use PasswordInput
- `assets/js/src/settings/pages/send-with/other/sendgrid-fields.tsx` - Updated to use PasswordInput
- `assets/js/src/common/premium-key/key-input.tsx` - Refactored to use PasswordInput

## QA notes

**Testing scenarios:**
1. Navigate to Settings > Send With > Other and select Amazon SES
   - Verify access key and secret key fields show as masked password inputs
   - Verify clicking "Show" reveals the actual values
   - Verify clicking "Hide" masks the values again
2. Navigate to Settings > Send With > Other and select SendGrid
   - Verify API key field shows as masked password input with toggle functionality
3. Navigate to Settings > Advanced > Premium
   - Verify premium key input maintains show/hide functionality
4. Test form submission and data persistence works correctly with masked inputs
5. Verify existing functionality for saving and loading API keys is not affected

**Visual verification:**
- Password toggle buttons should be consistently styled across all forms
- Toggle state should be maintained per field independently
- Fields should default to masked state on page load


## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7318

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7318-hide-amazon-ses-keys-in-mailpoet-dashboard)

_The latest successful build from `stomail-7318-hide-amazon-ses-keys-in-mailpoet-dashboard` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a password input field with visibility toggle functionality for improved user experience when entering sensitive information.

* **Enhancements**
  * Updated Amazon SES and SendGrid API key fields to use the new password input, ensuring keys are masked by default.
  * Improved styling for password input toggles.

* **Refactor**
  * Simplified premium key input by utilizing the new password input component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->