### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             ./do download:woo-commerce-zip 9.9.5
             ./do download:woo-commerce-subscriptions-zip 7.6.0
             ./do download:woo-commerce-memberships-zip
-            ./do download:automate-woo-zip 6.1.14
+            ./do download:automate-woo-zip 6.1.15
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to use AutomateWoo plugin version 6.1.15 during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->