### PR TITLE
Fix page title replacement broken on non-English sites

### DIFF
--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -61,7 +61,7 @@ class PageRenderer {
   }
 
   public function setPageTitle($title = '') {
-    if ($title === Pages::PAGE_TITLE) {
+    if ($title === Pages::PAGE_TITLE || $title === __('MailPoet Page', 'mailpoet')) {
       return $this->getPageTitle();
     }
     return $title;

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -278,7 +278,7 @@ class Pages {
     if (
       (!isset($post))
       ||
-      ($post->post_title !== SettingsPages::PAGE_TITLE) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      ($post->post_title !== SettingsPages::PAGE_TITLE && $post->post_title !== __('MailPoet Page', 'mailpoet')) // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       ||
       ($pageTitle !== $this->wp->singlePostTitle('', false))
     ) {

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -228,6 +228,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
-* Improved: JavaScript and CSS compatibility with other plugins and themes.
+* Improved: JavaScript and CSS compatibility with other plugins and themes;
+* Fixed: page title replacement broken on non-English sites.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

Introduced in https://github.com/mailpoet/mailpoet/pull/6236, I forgot to implement a fallback for existing translated websites. This PR fixes it, so all new websites will use English version, but when replacing the title, we'll still compare to the English and the translated version. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7470

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7470-page-title-replacement-broken-on-french-sites)

_The latest successful build from `stomail-7470-page-title-replacement-broken-on-french-sites` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced page title replacement to correctly handle localized titles on non-English sites.

* **Documentation**
  * Updated the changelog to separately highlight improvements in compatibility and the fix for page title replacement on non-English sites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->