### PR TITLE
Fix matching script urls in ConflictResolver - STOMAIL-7434

### DIFF
--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -13,7 +13,7 @@ class ConflictResolver {
       '^/wp-includes',
       // CDN
       'googleapis.com/ajax/libs',
-      'wp.com',
+      '\bwp\.com\b',
       // third-party
       'jetpack',
       'query-monitor',

--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -35,7 +35,7 @@ class ConflictResolver {
       '^/wp-includes',
       // CDN
       'googleapis.com/ajax/libs',
-      'wp.com',
+      '\bwp\.com\b',
       // third-party
       'query-monitor',
       'wpt-tx-updater-network',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,9 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.10 - 2025-07-07 =
-* Improved: SendGrid API key field and Amazon SES access key and secret key fields now use masked input fields to prevent accidental credential exposure;
-* Fixed: PHP Warning: Undefined array key “blocks”;
-* Fixed: filter `mailpoet_unsubscribe_confirmation_page` not redirecting to the success page.
+= x.x.x - YYYY-MM-DD =
+* Improved: JavaScript compatibility with other plugins and themes.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -228,6 +228,6 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = x.x.x - YYYY-MM-DD =
-* Improved: JavaScript compatibility with other plugins and themes.
+* Improved: JavaScript and CSS compatibility with other plugins and themes.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -72,7 +72,9 @@ class ConflictResolverTest extends \MailPoetTest {
     // enqueue scripts
     wp_enqueue_script('select2', '/wp-content/some/offending/plugin/select2.js');
     wp_enqueue_script('some_random_script', 'http://example.com/some_script.js', [], null, $inFooter = true); // test inside footer
+    wp_enqueue_script('some_random_script_2', 'https://examplewp.com/some_script.js', [], null, $inFooter = false); // test domain ending with wp.com
     wp_enqueue_script('permitted_script', trim($permittedAssetLocation, '^'));
+    wp_enqueue_script('permitted_script_2', 'https://wp.com/wp-content/some/offending/plugin/script.js');
     $this->conflictResolver->resolveScriptsConflict();
     do_action('wp_print_scripts');
     do_action('admin_print_footer_scripts');
@@ -80,7 +82,9 @@ class ConflictResolverTest extends \MailPoetTest {
     // it should dequeue all scripts except those found on the list of permitted locations
     verify(in_array('select2', $wp_scripts->queue))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify(in_array('some_random_script', $wp_scripts->queue))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('some_random_script_2', $wp_scripts->queue))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify(in_array('permitted_script', $wp_scripts->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('permitted_script_2', $wp_scripts->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function testItWhitelistsScripts() {

--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -33,7 +33,9 @@ class ConflictResolverTest extends \MailPoetTest {
     $permittedAssetLocation = $this->conflictResolver->permittedAssetsLocations['styles'][array_rand($this->conflictResolver->permittedAssetsLocations['styles'], 1)];
     // enqueue styles
     wp_enqueue_style('select2', '/wp-content/some/offending/plugin/select2.css');
+    wp_enqueue_style('some_random_style', 'https://examplewp.com/some_style.css'); // test domain ending with wp.com
     wp_enqueue_style('permitted_style', trim($permittedAssetLocation, '^'));
+    wp_enqueue_style('permitted_style_2', 'https://wp.com/wp-content/some/offending/plugin/styles.css');
     $this->conflictResolver->resolveStylesConflict();
     do_action('wp_print_styles');
     do_action('admin_print_styles');
@@ -42,7 +44,9 @@ class ConflictResolverTest extends \MailPoetTest {
     global $wp_styles; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     // it should dequeue all styles except those found on the list of permitted locations
     verify(in_array('select2', $wp_styles->queue))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('some_random_style', $wp_styles->queue))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify(in_array('permitted_style', $wp_styles->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    verify(in_array('permitted_style_2', $wp_styles->queue))->true(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 
   public function testItWhitelistsStyles() {


### PR DESCRIPTION
## Description

We have a unique user when their URL matches one of the permitted locations. This causes our ConflictResolver not to work correctly. This PR makes the rule stricter.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7434

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7434-fatal-error-when-scheduling-emails)

_The latest successful build from `stomail-7434-fatal-error-when-scheduling-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script and style domain matching to permit assets only from the exact "wp.com" domain, preventing unintended matches.

* **Documentation**
  * Simplified changelog entry to a generic note about improved JavaScript and CSS compatibility.

* **Tests**
  * Enhanced tests to confirm correct handling of assets from domains ending with or exactly matching "wp.com".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->