### PR TITLE
Exclude regex from permittedAssetsLocations to fix flaky test in `ConflictResolver

### DIFF
--- a/mailpoet/tests/integration/Util/ConflictResolverTest.php
+++ b/mailpoet/tests/integration/Util/ConflictResolverTest.php
@@ -30,7 +30,12 @@ class ConflictResolverTest extends \MailPoetTest {
   public function testItUnloadsAllStylesFromLocationsNotOnPermittedList() {
     verify(!empty($this->wpFilter['mailpoet_conflict_resolver_styles']))->true();
     // grab a random permitted style location
-    $permittedAssetLocation = $this->conflictResolver->permittedAssetsLocations['styles'][array_rand($this->conflictResolver->permittedAssetsLocations['styles'], 1)];
+    $excluded = ['\bwp\.com\b'];
+    $filteredPermittedLocations = array_values(array_filter(
+      $this->conflictResolver->permittedAssetsLocations['styles'],
+      fn($item) => !in_array($item, $excluded, true)
+    ));
+    $permittedAssetLocation = $filteredPermittedLocations[array_rand($filteredPermittedLocations)];
     // enqueue styles
     wp_enqueue_style('select2', '/wp-content/some/offending/plugin/select2.css');
     wp_enqueue_style('some_random_style', 'https://examplewp.com/some_style.css'); // test domain ending with wp.com
@@ -71,8 +76,13 @@ class ConflictResolverTest extends \MailPoetTest {
 
   public function testItUnloadsAllScriptsFromLocationsNotOnPermittedList() {
     verify(!empty($this->wpFilter['mailpoet_conflict_resolver_scripts']))->true();
-    // grab a random permitted script location
-    $permittedAssetLocation = $this->conflictResolver->permittedAssetsLocations['scripts'][array_rand($this->conflictResolver->permittedAssetsLocations['scripts'], 1)];
+    // grab a random permitted script location, but exclude the value for wp.com because it is regular expression and it causes failing test.
+    $excluded = ['\bwp\.com\b'];
+    $filteredPermittedLocations = array_values(array_filter(
+      $this->conflictResolver->permittedAssetsLocations['scripts'],
+      fn($item) => !in_array($item, $excluded, true)
+    ));
+    $permittedAssetLocation = $filteredPermittedLocations[array_rand($filteredPermittedLocations)];
     // enqueue scripts
     wp_enqueue_script('select2', '/wp-content/some/offending/plugin/select2.js');
     wp_enqueue_script('some_random_script', 'http://example.com/some_script.js', [], null, $inFooter = true); // test inside footer


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-flaky-conflict-resolver-test)

_The latest successful build from `fix-flaky-conflict-resolver-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of asset unloading tests by excluding problematic patterns from random selection, reducing test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->