### PR TITLE
Fix inconsistent spacing when adding tags to subscribers

### DIFF
--- a/mailpoet/assets/css/src/generic/_forms-token-field.scss
+++ b/mailpoet/assets/css/src/generic/_forms-token-field.scss
@@ -3,14 +3,16 @@
   border: 1px solid $color-input-border !important;
   border-radius: $form-control-border-radius !important;
   box-sizing: border-box;
+  display: flex;
   max-width: 100%;
   min-height: $form-control-height;
   min-width: 0;
   width: $grid-column;
   // To align the left padding with the other inputs
   input[type='text'].components-form-token-field__input {
+    line-height: 16px;
     margin-left: 0;
-    min-height: 30px;
+    min-height: 24px;
     padding-left: 8px;
   }
   // For better fit when the last item is active

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -229,6 +229,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 = x.x.x - YYYY-MM-DD =
 * Improved: JavaScript and CSS compatibility with other plugins and themes;
+* Fixed: inconsistent spacing when adding tags to subscribers;
 * Fixed: page title replacement broken on non-English sites.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

| Before | After |
| --- | ---- | 
| <img width="390" height="120" alt="Screenshot 2025-07-11 at 10 52 40" src="https://github.com/user-attachments/assets/11570568-ddcc-4f4b-9621-690e816d819e" />  |  <img width="383" height="115" alt="Screenshot 2025-07-11 at 10 52 53" src="https://github.com/user-attachments/assets/cfa9ce6f-760b-4c3c-bd9d-1bd71710526b" />  |

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7267

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7267-spacing-between-tags-is-not-consistent)

_The latest successful build from `stomail-7267-spacing-between-tags-is-not-consistent` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing and alignment when adding tags to subscribers for a more consistent appearance.

* **Documentation**
  * Updated changelog to reflect the fix for inconsistent spacing when adding tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->