### PR TITLE
Fix error message position when creating a list during import

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_import-export.scss
+++ b/mailpoet/assets/css/src/components-plugin/_import-export.scss
@@ -100,7 +100,7 @@ tr {
 .mailpoet-notice-container {
   .mailpoet_notice {
     box-sizing: border-box;
-    margin: 0 0 1em 0;
+    margin: 0 0 1em;
     max-width: $grid-column;
     padding-right: 38px;
   }

--- a/mailpoet/assets/css/src/components-plugin/_import-export.scss
+++ b/mailpoet/assets/css/src/components-plugin/_import-export.scss
@@ -96,3 +96,12 @@ tr {
     font-size: $font-size;
   }
 }
+
+.mailpoet-notice-container {
+  .mailpoet_notice {
+    box-sizing: border-box;
+    margin: 0 0 1em 0;
+    max-width: $grid-column;
+    padding-right: 38px;
+  }
+}

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.jsx
@@ -38,7 +38,7 @@ export const createNewSegment = (onCreateSegment) => {
         if (response.errors.length > 0) {
           MailPoet.Notice.hide();
           MailPoet.Notice.showApiErrorNotice(response, {
-            positionAfter: '#new_segment_name',
+            positionAfter: '#new_segment_error_message',
           });
         }
       });

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.tsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.tsx
@@ -1,19 +1,47 @@
 import jQuery from 'jquery';
 import { MailPoet } from 'mailpoet';
 
-export const createNewSegment = (onCreateSegment) => {
+interface Segment {
+  id: string;
+  name: string;
+  text: string;
+  subscriberCount: number;
+}
+
+interface CreateSegmentResponse {
+  data: {
+    id: string;
+    name: string;
+    description: string;
+  };
+}
+
+interface ApiErrorResponse {
+  errors: Array<{
+    error: string;
+    message: string;
+  }>;
+}
+
+export const createNewSegment = (
+  onCreateSegment: (segment: Segment) => void,
+): void => {
   MailPoet.Modal.popup({
     title: MailPoet.I18n.t('addNewList'),
     template: jQuery('#new_segment_template').html(),
   });
-  jQuery('#new_segment_name').on('keypress', (e) => {
+
+  jQuery('#new_segment_name').on('keypress', (e: JQuery.KeyPressEvent) => {
     if (e.which === 13) {
       jQuery('#new_segment_process').trigger('click');
     }
   });
+
   jQuery('#new_segment_process').on('click', () => {
-    const segmentName = jQuery('#new_segment_name').val().trim();
-    const segmentDescription = jQuery('#new_segment_description').val().trim();
+    const segmentName: string =
+      jQuery('#new_segment_name').val()?.toString().trim() || '';
+    const segmentDescription: string =
+      jQuery('#new_segment_description').val()?.toString().trim() || '';
 
     MailPoet.Ajax.post({
       api_version: window.mailpoet_api_version,
@@ -24,7 +52,7 @@ export const createNewSegment = (onCreateSegment) => {
         description: segmentDescription,
       },
     })
-      .done((response) => {
+      .done((response: CreateSegmentResponse) => {
         onCreateSegment({
           id: response.data.id,
           name: response.data.name,
@@ -34,7 +62,7 @@ export const createNewSegment = (onCreateSegment) => {
 
         MailPoet.Modal.close();
       })
-      .fail((response) => {
+      .fail((response: ApiErrorResponse) => {
         if (response.errors.length > 0) {
           MailPoet.Notice.hide();
           MailPoet.Notice.showApiErrorNotice(response, {
@@ -43,6 +71,7 @@ export const createNewSegment = (onCreateSegment) => {
         }
       });
   });
+
   jQuery('#new_segment_cancel').on('click', () => {
     MailPoet.Modal.close();
   });

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.tsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-new-segment.tsx
@@ -69,7 +69,8 @@ export const createNewSegment = (
             positionAfter: '#new_segment_error_message',
           });
         }
-      });
+      })
+      .catch(() => {});
   });
 
   jQuery('#new_segment_cancel').on('click', () => {

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/select-segment.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/select-segment.jsx
@@ -9,7 +9,7 @@ import {
   createSelection,
   destroySelection,
 } from './generate-segment-selection.jsx';
-import { createNewSegment } from './create-new-segment.jsx';
+import { createNewSegment } from './create-new-segment';
 
 function SelectSegment({ setSelectedSegments }) {
   const { segments: segmentsContext } = useContext(GlobalContext);

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -230,6 +230,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 = x.x.x - YYYY-MM-DD =
 * Improved: JavaScript and CSS compatibility with other plugins and themes;
 * Fixed: inconsistent spacing when adding tags to subscribers;
+* Fixed: error message position when creating a list during import;
 * Fixed: page title replacement broken on non-English sites.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/views/subscribers/importExport/import/step_data_manipulation.html
+++ b/mailpoet/views/subscribers/importExport/import/step_data_manipulation.html
@@ -24,6 +24,10 @@
         </div>
       </p>
 
+      <div class="mailpoet-notice-container">
+        <div id="new_segment_error_message"></div>
+      </div>
+
       <p class="mailpoet_align_right">
         <input type="submit" value="<%= __('Cancel') %>" id="new_segment_cancel" class="mailpoet-button button-secondary"/>
         <input type="submit" value="<%= __('Done') %>" id="new_segment_process" class="mailpoet-button button-primary"/>


### PR DESCRIPTION
## Description

| Before | After | 
| ---- | ---- | 
|  <img width="449" height="394" alt="Screenshot 2025-07-11 at 13 17 20" src="https://github.com/user-attachments/assets/30c86ff6-bd4d-4728-9771-12645f5a845d" />  |  <img width="461" height="479" alt="Screenshot 2025-07-11 at 13 32 24" src="https://github.com/user-attachments/assets/17b935fb-c560-45ae-be85-c9d7e322d774" />   |

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7244

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] 🚫 I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7244-globalstep-the-wrong-error-message-appears-for-trying-to)

_The latest successful build from `stomail-7244-globalstep-the-wrong-error-message-appears-for-trying-to` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of error messages when creating a list during the import process, ensuring clearer visibility to users.

* **Style**
  * Enhanced styling for notice containers and error messages to improve layout and spacing.

* **Documentation**
  * Updated the changelog to reflect the fix for error message positioning during list creation in the import process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->