### PR TITLE
Add summarized form usage stats

### DIFF
--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -283,6 +283,12 @@ class Reporter {
       'Forms > Number of active Pop-up forms' => $activeFormCounts[FormEntity::DISPLAY_TYPE_POPUP],
       'Forms > Number of active Slide–in forms' => $activeFormCounts[FormEntity::DISPLAY_TYPE_SLIDE_IN],
       'Forms > Number of active Others (widget) forms' => $activeFormCounts[FormEntity::DISPLAY_TYPE_OTHERS],
+      'Forms > Number of active forms with first name' => $activeFormCounts['with_first_name'],
+      'Forms > Number of active forms with last name' => $activeFormCounts['with_last_name'],
+      'Forms > Number of active forms with custom fields' => $activeFormCounts['with_custom_fields'],
+      'Forms > Min custom fields' => $activeFormCounts['min_custom_fields'],
+      'Forms > Max custom fields' => $activeFormCounts['max_custom_fields'],
+      'Forms > Average custom fields' => $activeFormCounts['average_custom_fields'],
     ];
 
     $result = array_merge(

--- a/mailpoet/lib/Entities/FormEntity.php
+++ b/mailpoet/lib/Entities/FormEntity.php
@@ -43,6 +43,14 @@ class FormEntity {
   const COLUMNS_BLOCK_TYPE = 'columns';
   const COLUMN_BLOCK_TYPE = 'column';
 
+  public const FORM_DISPLAY_TYPES = [
+    self::DISPLAY_TYPE_BELOW_POST,
+    self::DISPLAY_TYPE_FIXED_BAR,
+    self::DISPLAY_TYPE_POPUP,
+    self::DISPLAY_TYPE_SLIDE_IN,
+    self::DISPLAY_TYPE_OTHERS,
+  ];
+
   public const FORM_FIELD_TYPES = [
     self::CHECKBOX_BLOCK_TYPE,
     self::RADIO_BLOCK_TYPE,

--- a/mailpoet/lib/Form/FormsRepository.php
+++ b/mailpoet/lib/Form/FormsRepository.php
@@ -72,6 +72,7 @@ class FormsRepository extends Repository {
 
   public function getActiveFormsCountByType(): array {
     $forms = $this->findAllActive();
+    $formBlocks = $this->getActiveFormsBlocks();
 
     $counts = [
       'all' => count($forms),
@@ -80,6 +81,13 @@ class FormsRepository extends Repository {
       FormEntity::DISPLAY_TYPE_POPUP => 0,
       FormEntity::DISPLAY_TYPE_SLIDE_IN => 0,
       FormEntity::DISPLAY_TYPE_OTHERS => 0,
+      'with_first_name' => 0,
+      'with_last_name' => 0,
+      'with_custom_fields' => 0,
+      'min_custom_fields' => 0,
+      'max_custom_fields' => 0,
+      'average_custom_fields' => 0,
+      'median_custom_fields' => 0,
     ];
 
     foreach ($forms as $form) {
@@ -101,7 +109,79 @@ class FormsRepository extends Repository {
       }
     }
 
+    $customFieldsCounts = [];
+    foreach ($formBlocks as $blocks) {
+      if (in_array('first_name', $blocks)) {
+        $counts['with_first_name']++;
+      }
+      if (in_array('last_name', $blocks)) {
+        $counts['with_last_name']++;
+      }
+
+      $customFieldsInForm = array_filter($blocks, function($block) {
+        return strpos($block, 'custom_') === 0;
+      });
+
+      if (!empty($customFieldsInForm)) {
+        $counts['with_custom_fields']++;
+        $customFieldsCounts[] = count($customFieldsInForm);
+      }
+    }
+
+    if (!empty($customFieldsCounts)) {
+      $counts['min_custom_fields'] = min($customFieldsCounts);
+      $counts['max_custom_fields'] = max($customFieldsCounts);
+      $counts['average_custom_fields'] = round(array_sum($customFieldsCounts) / count($customFieldsCounts), 1);
+    }
+
     return $counts;
+  }
+
+  /**
+   * Get active forms with their placements and blocks for analytics tracking
+   * @return array
+   */
+  private function getActiveFormsBlocks(): array {
+    $forms = $this->findAllActive();
+    $formBlocks = [];
+
+    foreach ($forms as $form) {
+      $settings = $form->getSettings();
+      if (!is_array($settings)) continue;
+
+      $body = $form->getBody();
+      if (!is_array($body)) continue;
+
+      $formBlocks[] = $this->extractBlockTypes($body);
+    }
+
+    return $formBlocks;
+  }
+
+  /**
+   * Extract block types from form body recursively
+   * @param array $blocks
+   * @return array
+   */
+  private function extractBlockTypes(array $blocks): array {
+    $ignored_blocks = ['columns', 'column', 'paragraph', 'heading', 'image', 'divider', 'submit', 'html'];
+    $field_block_ids = ['email', 'first_name', 'last_name', 'segments'];
+    $blockTypes = [];
+
+    foreach ($blocks as $block) {
+      if (in_array($block['id'], $field_block_ids)) {
+        $blockTypes[] = $block['id'];
+      } elseif (!in_array($block['type'], $ignored_blocks)) {
+        $blockTypes[] = 'custom_' . $block['type'];
+      }
+
+      // Recursively check nested blocks (like in columns)
+      if (isset($block['body']) && is_array($block['body'])) {
+        $blockTypes = array_merge($blockTypes, $this->extractBlockTypes($block['body']));
+      }
+    }
+
+    return $blockTypes;
   }
 
   public function delete(FormEntity $form) {

--- a/mailpoet/lib/Form/FormsRepository.php
+++ b/mailpoet/lib/Form/FormsRepository.php
@@ -105,7 +105,7 @@ class FormsRepository extends Repository {
       }
 
       if (!$hasAnyEnabled) {
-        $counts['others']++;
+        $counts[FormEntity::DISPLAY_TYPE_OTHERS]++;
       }
     }
 
@@ -164,14 +164,14 @@ class FormsRepository extends Repository {
    * @return array
    */
   private function extractBlockTypes(array $blocks): array {
-    $ignored_blocks = ['columns', 'column', 'paragraph', 'heading', 'image', 'divider', 'submit', 'html'];
-    $field_block_ids = ['email', 'first_name', 'last_name', 'segments'];
+    $ignoredBlocks = ['columns', 'column', 'paragraph', 'heading', 'image', 'divider', 'submit', 'html'];
+    $fieldBlockIds = ['email', 'first_name', 'last_name', 'segments'];
     $blockTypes = [];
 
     foreach ($blocks as $block) {
-      if (in_array($block['id'], $field_block_ids)) {
+      if (in_array($block['id'], $fieldBlockIds)) {
         $blockTypes[] = $block['id'];
-      } elseif (!in_array($block['type'], $ignored_blocks)) {
+      } elseif (!in_array($block['type'], $ignoredBlocks)) {
         $blockTypes[] = 'custom_' . $block['type'];
       }
 

--- a/mailpoet/tests/integration/Analytics/ReporterTest.php
+++ b/mailpoet/tests/integration/Analytics/ReporterTest.php
@@ -2,14 +2,14 @@
 
 namespace MailPoet\Analytics;
 
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SegmentEntity;
-use MailPoet\Entities\FormEntity;
-use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Test\DataFactories\CustomField;
+use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Segment;
-use MailPoet\Test\DataFactories\Form;
-use MailPoet\Test\DataFactories\CustomField;
 use MailPoetVendor\Carbon\Carbon;
 
 class ReporterTest extends \MailPoetTest {


### PR DESCRIPTION
## Description

Adds form usage stats to better evaluate which features are used. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7473

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7473-add-forms-usage-tracking)

_The latest successful build from `stomail-7473-add-forms-usage-tracking` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics to include detailed statistics on active forms, such as counts by display type (Below pages, Fixed bar, Pop-up, Slide-in, Others), presence of specific fields (first name, last name, custom fields), and custom field statistics (minimum, maximum, average).
  * Added new methods to retrieve and analyze active forms data for reporting.
* **Other**
  * Added a new collection of form display types for improved categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->