### PR TITLE
Bump MySQL to 5.6 in oldest tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1186,7 +1186,7 @@ workflows:
           woo_subscriptions_version: 7.6.0
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
-          mysql_image: mysql:5.5
+          mysql_image: mysql:5.6
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.7.2
@@ -1229,7 +1229,7 @@ workflows:
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.7.2
           mysql_command: --max_allowed_packet=100M
-          mysql_image: mysql:5.5
+          mysql_image: mysql:5.6
           requires:
             - build
       - build_premium:
@@ -1302,7 +1302,7 @@ workflows:
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.7.2
           mysql_command: --max_allowed_packet=100M
-          mysql_image: mysql:5.5
+          mysql_image: mysql:5.6
           requires:
             - build_premium
 


### PR DESCRIPTION
## Description

This is due to WooCommerce 9.9 (oldest supported by MailPoet) adding an [SQL query which is 5.6+](https://github.com/woocommerce/woocommerce/pull/53940/files) and WooCommerce fails to activate on MySQL 5.5. 

| Before | After |
| ------ | ----- |
| [CI run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21041/workflows/5103afb1-e602-4140-99ad-3bb8f311cdd8) | [CI run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21044/workflows/386c8bee-82aa-497e-95cd-e22b58b61faf) |

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] 🚫 I have added a changelog entry (pcNwfB-4Ov-p2#how-to-write-a-changelog)
- [x] 🚫 I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] 🚫 I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:bump-mysql-to-5.6)

_The latest successful build from `bump-mysql-to-5.6` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MySQL version used in nightly test workflows from 5.5 to 5.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->