### PR TITLE
Remove changelog examples

### DIFF
--- a/mailpoet/changelog/2024-01-15-14-30-00-fix-undefined-array-key.md
+++ b/mailpoet/changelog/2024-01-15-14-30-00-fix-undefined-array-key.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fixed warning `Undefined array key "blocks"`

--- a/mailpoet/changelog/2024-01-15-14-35-00-improve-polylang-support.md
+++ b/mailpoet/changelog/2024-01-15-14-35-00-improve-polylang-support.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Adds `polylang` to the list of permitted scripts

--- a/mailpoet/changelog/2024-01-15-14-40-00-update-woocommerce-segments.md
+++ b/mailpoet/changelog/2024-01-15-14-40-00-update-woocommerce-segments.md
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Support custom order statuses in WooCommerce segments

--- a/mailpoet/changelog/2025-07-17-12-10-04-update-woocommerce-version.md
+++ b/mailpoet/changelog/2025-07-17-12-10-04-update-woocommerce-version.md
@@ -1,0 +1,4 @@
+---
+type: Updated
+description: minimum required WooCommerce version to 9.9 and tested up to version to 10.0
+---

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -227,7 +227,4 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= x.x.x - YYYY-MM-DD =
-* Updated: minimum required WooCommerce version to 9.9 and tested up to version to 10.0.
-
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:clean-changelog2)

_The latest successful build from `clean-changelog2` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to reflect new WooCommerce version requirements (minimum 9.9, tested up to 10.0).
  * Simplified the changelog section in the readme, now linking directly to the full changelog.
  * Removed older changelog entries related to previous bug fixes and improvements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->