### PR TITLE
Order and format changelog entries by importance

### DIFF
--- a/mailpoet/tasks/release/Changelogger.php
+++ b/mailpoet/tasks/release/Changelogger.php
@@ -4,7 +4,7 @@ namespace MailPoetTasks\Release;
 
 class Changelogger {
   const CHANGELOG_DIR = __DIR__ . '/../../changelog/';
-  const VALID_TYPES = ['Added', 'Improved', 'Fixed', 'Changed', 'Updated', 'Removed'];
+  const VALID_TYPES = ['Added', 'Updated', 'Improved', 'Changed', 'Fixed', 'Removed'];
 
   /** @var string */
   private $changelogDir;
@@ -27,12 +27,36 @@ class Changelogger {
     $date = date('Y-m-d');
     $heading = "= $version - $date =\n";
 
+    // Group entries by type and order by importance
+    $groupedEntries = $this->groupEntriesByType($entries);
+
     $compiledEntries = [];
-    foreach ($entries as $entry) {
-      $compiledEntries[] = "* {$entry['type']}: {$entry['description']}";
+    foreach (self::VALID_TYPES as $type) {
+      if (isset($groupedEntries[$type])) {
+        foreach ($groupedEntries[$type] as $entry) {
+          $compiledEntries[] = "* {$entry['type']}: {$entry['description']}";
+        }
+      }
     }
 
-    return $heading . implode("\n", $compiledEntries);
+    $changelogContent = implode(";\n", $compiledEntries) . ".";
+
+    return $heading . $changelogContent;
+  }
+
+  /**
+   * Groups entries by their type
+   */
+  private function groupEntriesByType(array $entries): array {
+    $grouped = [];
+    foreach ($entries as $entry) {
+      $type = $entry['type'];
+      if (!isset($grouped[$type])) {
+        $grouped[$type] = [];
+      }
+      $grouped[$type][] = $entry;
+    }
+    return $grouped;
   }
 
   /**


### PR DESCRIPTION
## Description

Changelog entries are now grouped by type (Added, Updated, Improved, Changed, Fixed, Removed) and joined with semicolons, ending with a period. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:improve-changelog2)

_The latest successful build from `improve-changelog2` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * Changelog entries are now grouped and ordered by type for clearer release notes, with improved formatting for easier reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->