### PR TITLE
Trigger: Follow up when order note is added [STOMAIL-7366]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
@@ -3,6 +3,7 @@ import { step as OrderStatusChanged } from './steps/order-status-changed';
 import { step as OrderCompletedTrigger } from './steps/order-completed';
 import { step as OrderCancelledTrigger } from './steps/order-cancelled';
 import { step as OrderCreatedTrigger } from './steps/order-created';
+import { step as OrderNoteAddedTrigger } from './steps/order-note-added';
 import { step as AbandonedCartTrigger } from './steps/abandoned-cart';
 import { MailPoet } from '../../../mailpoet';
 import { step as BuysAProductTrigger } from './steps/buys-a-product';
@@ -19,6 +20,7 @@ export const initialize = (): void => {
   registerStepType(OrderCompletedTrigger);
   registerStepType(OrderCancelledTrigger);
   registerStepType(OrderCreatedTrigger);
+  registerStepType(OrderNoteAddedTrigger);
   registerStepType(AbandonedCartTrigger);
   registerStepType(BuysAProductTrigger);
   registerStepType(BuysFromACategory);

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/edit/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/edit/index.tsx
@@ -1,0 +1,56 @@
+import { __ } from '@wordpress/i18n';
+import { dispatch, useSelect } from '@wordpress/data';
+import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import { PlainBodyTitle } from '../../../../../editor/components';
+import { storeName } from '../../../../../editor/store';
+
+export function Edit(): JSX.Element {
+  const { selectedStep } = useSelect(
+    (select) => ({
+      selectedStep: select(storeName).getSelectedStep(),
+    }),
+    [],
+  );
+
+  const noteType = (selectedStep.args?.note_type as string) ?? 'all';
+  const noteContains = (selectedStep.args?.note_contains as string) ?? '';
+
+  return (
+    <PanelBody opened>
+      <PlainBodyTitle title={__('Trigger settings', 'mailpoet')} />
+
+      <SelectControl
+        label={__('Note type', 'mailpoet')}
+        value={noteType}
+        options={[
+          { label: __('All', 'mailpoet'), value: 'all' },
+          { label: __('Note to customer', 'mailpoet'), value: 'customer' },
+          { label: __('Private note', 'mailpoet'), value: 'private' },
+        ]}
+        onChange={(value) => {
+          void dispatch(storeName).updateStepArgs(
+            selectedStep.id,
+            'note_type',
+            value,
+          );
+        }}
+      />
+
+      <TextControl
+        label={__('Note contains text', 'mailpoet')}
+        help={__(
+          'Only trigger this workflow if the order note contains the certain text. This field is optional.',
+          'mailpoet',
+        )}
+        value={noteContains}
+        onChange={(value) => {
+          void dispatch(storeName).updateStepArgs(
+            selectedStep.id,
+            'note_contains',
+            value,
+          );
+        }}
+      />
+    </PanelBody>
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
@@ -1,0 +1,30 @@
+import { __, _x } from '@wordpress/i18n';
+import { commentContent } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Order Note Added" trigger
+  __('order', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Order Note Added" trigger
+  __('note', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Order Note Added" trigger
+  __('comment', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:order-note-added',
+  group: 'triggers',
+  title: () => __('Order Note Added', 'mailpoet'),
+  description: () =>
+    __(
+      'Fires when any note is added to an order, can include both private notes and notes to the customer. These notes appear on the right of the order edit screen.',
+      'mailpoet',
+    ),
+  subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => commentContent,
+  edit: () => null,
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
@@ -1,6 +1,7 @@
 import { __, _x } from '@wordpress/i18n';
 import { commentContent } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store';
+import { Edit } from './edit';
 
 const keywords = [
   __('woocommerce', 'mailpoet'),
@@ -26,5 +27,5 @@ export const step: StepType = {
   foreground: '#2271b1',
   background: '#f0f6fc',
   icon: () => commentContent,
-  edit: () => null,
+  edit: () => <Edit />,
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
@@ -5,18 +5,18 @@ import { Edit } from './edit';
 
 const keywords = [
   __('woocommerce', 'mailpoet'),
-  // translators: noun, used as a search keyword for "Order Note Added" trigger
+  // translators: noun, used as a search keyword for "Order note added" trigger
   __('order', 'mailpoet'),
-  // translators: noun, used as a search keyword for "Order Note Added" trigger
+  // translators: noun, used as a search keyword for "Order note added" trigger
   __('note', 'mailpoet'),
-  // translators: noun, used as a search keyword for "Order Note Added" trigger
+  // translators: noun, used as a search keyword for "Order note added" trigger
   __('comment', 'mailpoet'),
 ];
 
 export const step: StepType = {
   key: 'woocommerce:order-note-added',
   group: 'triggers',
-  title: () => __('Order Note Added', 'mailpoet'),
+  title: () => __('Order note added', 'mailpoet'),
   description: () =>
     __(
       'Fires when any note is added to an order, can include both private notes and notes to the customer. These notes appear on the right of the order edit screen.',

--- a/mailpoet/changelog/2025-07-18-07-23-22-added-a-new-automation-trigger-when-a-new-woocommerce-or.md
+++ b/mailpoet/changelog/2025-07-18-07-23-22-added-a-new-automation-trigger-when-a-new-woocommerce-or.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+A new Automation Trigger when a new WooCommerce order note is added

--- a/mailpoet/lib/Automation/Engine/Integration/Step.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Step.php
@@ -5,15 +5,66 @@ namespace MailPoet\Automation\Engine\Integration;
 use MailPoet\Automation\Engine\Data\StepValidationArgs;
 use MailPoet\Validator\Schema\ObjectSchema;
 
+/**
+ * Step Interface
+ *
+ * Defines the base contract for all automation steps in the MailPoet automation system.
+ * Can be either triggers, actions, or other step types.
+ */
 interface Step {
+  /**
+   * Get the unique identifier for this step type.
+   *
+   * This key is used to identify the step in the automation system and must be
+   * unique across all registered steps. It's typically in the format 'vendor:step-name'.
+   *
+   * @return string The unique step key
+   */
   public function getKey(): string;
 
+  /**
+   * Get the human-readable name for this step.
+   *
+   * This name is displayed in the automation editor and should be translatable.
+   *
+   * @return string The step name
+   */
   public function getName(): string;
 
+  /**
+   * Get the JSON schema for step configuration arguments.
+   *
+   * This schema defines the structure and validation rules for the step's
+   * configuration. It's used to validate step arguments during automation
+   * creation and to generate the UI for step configuration.
+   *
+   * @return ObjectSchema The JSON schema for step arguments
+   */
   public function getArgsSchema(): ObjectSchema;
 
-  /** @return string[] */
+  /**
+   * Get the subject keys that this step requires.
+   *
+   * Subjects represent data that flows through the automation. Each step
+   * declares which subjects it needs to function properly. The automation
+   * system ensures these subjects are available before the step executes.
+   *
+   * @return string[] Array of subject keys required by this step
+   */
   public function getSubjectKeys(): array;
 
+  /**
+   * Validate the step configuration and context.
+   *
+   * This method is called during automation validation to ensure the step
+   * is properly configured and can execute successfully. It receives the
+   * automation context, step data, and available subjects for validation.
+   *
+   * Implementations should throw ValidationException if validation fails.
+   *
+   * @param StepValidationArgs $args Validation context containing automation, step, and subjects
+   * @return void
+   * @throws \MailPoet\Automation\Engine\Integration\ValidationException When validation fails
+   */
   public function validate(StepValidationArgs $args): void;
 }

--- a/mailpoet/lib/Automation/Engine/Integration/Trigger.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Trigger.php
@@ -4,8 +4,37 @@ namespace MailPoet\Automation\Engine\Integration;
 
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 
+/**
+ * Trigger Interface
+ *
+ * Triggers are the entry points of automations that determine when an automation
+ * should start executing based on specific events or conditions.
+ *
+ */
 interface Trigger extends Step {
+  /**
+   * Register WordPress hooks to listen for trigger events.
+   *
+   * This method is called when automations using this trigger are activated.
+   * Implementations should use WordPress action/filter hooks to listen for
+   * specific events that should trigger the automation.
+   *
+   * @return void
+   */
   public function registerHooks(): void;
 
+  /**
+   * Determine if the trigger should fire based on the current context.
+   *
+   * This method is called when a trigger event occurs to determine if the
+   * automation should actually start. It receives the step run arguments
+   * containing automation data, subjects, and other context information.
+   *
+   * The method should return true if the automation should proceed, false otherwise.
+   * This allows for fine-grained control over when automations execute.
+   *
+   * @param StepRunArgs $args The step run arguments containing automation context
+   * @return bool True if the automation should proceed, false otherwise
+   */
   public function isTriggeredBy(StepRunArgs $args): bool;
 }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
@@ -56,6 +56,7 @@ class OrderNoteAddedTrigger implements Trigger {
   }
 
   public function validate(StepValidationArgs $args): void {
+    // No validation required for this trigger
   }
 
   public function registerHooks(): void {

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders;
+
+use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\StepValidationArgs;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Integration\Trigger;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
+use MailPoet\Automation\Integrations\WordPress\Subjects\CommentSubject;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema\ObjectSchema;
+
+class OrderNoteAddedTrigger implements Trigger {
+
+  /** @var WordPress */
+  protected $wp;
+
+  /** @var WooCommerce */
+  protected $woocommerce;
+
+  public function __construct(
+    WordPress $wp,
+    WooCommerce $woocommerceHelper
+  ) {
+    $this->wp = $wp;
+    $this->woocommerce = $woocommerceHelper;
+  }
+
+  public function getKey(): string {
+    return 'woocommerce:order-note-added';
+  }
+
+  public function getName(): string {
+    // translators: automation trigger title
+    return __('Order note added', 'mailpoet');
+  }
+
+  public function getArgsSchema(): ObjectSchema {
+    return Builder::object([
+      'note_contains' => Builder::string()->default(''),
+      'note_type' => Builder::oneOf([
+        Builder::string()->default('all'),
+        Builder::string()->default('customer'),
+        Builder::string()->default('private'),
+      ])->default('all'),
+    ]);
+  }
+
+  public function getSubjectKeys(): array {
+    return [
+      OrderSubject::KEY,
+      CustomerSubject::KEY,
+      CommentSubject::KEY,
+    ];
+  }
+
+  public function validate(StepValidationArgs $args): void {
+  }
+
+  public function registerHooks(): void {
+    $this->wp->addAction(
+      'woocommerce_order_note_added',
+      [
+        $this,
+        'handle',
+      ],
+      10,
+      2
+    );
+  }
+
+  public function handle(int $commentId, \WC_Order $order): void {
+    $comment = get_comment($commentId);
+    if (!$comment) {
+      return;
+    }
+
+    $isCustomerNote = (bool)get_comment_meta($commentId, 'is_customer_note', true);
+    $noteType = $isCustomerNote ? 'customer' : 'private';
+
+    $this->wp->doAction(Hooks::TRIGGER, $this, [
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+      new Subject(CustomerSubject::KEY, ['customer_id' => $order->get_customer_id(), 'order_id' => $order->get_id()]),
+      new Subject(CommentSubject::KEY, [
+        'comment_id' => $commentId,
+        'comment_content' => $comment->commentContent,
+        'note_type' => $noteType,
+      ]),
+    ]);
+  }
+
+  public function isTriggeredBy(StepRunArgs $args): bool {
+    $triggerArgs = $args->getStep()->getArgs();
+    $configuredNoteContains = $triggerArgs['note_contains'] ?? '';
+    $configuredNoteType = $triggerArgs['note_type'] ?? 'all';
+
+    /** @var \WP_Comment $comment */
+    $comment = $args->getSinglePayloadByClass(\WP_Comment::class);
+    if (!$comment) {
+      return false;
+    }
+
+    // Check note content filter
+    if ($configuredNoteContains !== '' && stripos($comment->commentContent, $configuredNoteContains) === false) {
+      return false;
+    }
+
+    // Check note type filter
+    if ($configuredNoteType !== 'all') {
+      $isCustomerNote = (bool)get_comment_meta($comment->commentId, 'is_customer_note', true);
+      $actualNoteType = $isCustomerNote ? 'customer' : 'private';
+      if ($actualNoteType !== $configuredNoteType) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
@@ -56,7 +56,14 @@ class OrderNoteAddedTrigger implements Trigger {
   }
 
   public function validate(StepValidationArgs $args): void {
-    // No validation required for this trigger
+    $triggerArgs = $args->getStep()->getArgs();
+    $noteType = $triggerArgs['note_type'] ?? 'all';
+
+    if (!in_array($noteType, ['all', 'customer', 'private'], true)) {
+      throw new \InvalidArgumentException(
+        sprintf('Invalid note_type "%s". Allowed values: all, customer, private', $noteType)
+      );
+    }
   }
 
   public function registerHooks(): void {

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTrigger.php
@@ -124,9 +124,9 @@ class OrderNoteAddedTrigger implements Trigger {
 
     // Check note type filter
     if ($configuredNoteType !== 'all') {
-      // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $isCustomerNote = (bool)get_comment_meta((int)$comment->comment_ID, 'is_customer_note', true);
-      $actualNoteType = $isCustomerNote ? 'customer' : 'private';
+      $commentSubjectEntry = $args->getSingleSubjectEntry(CommentSubject::KEY);
+      $subjectArgs = $commentSubjectEntry->getSubjectData()->getArgs();
+      $actualNoteType = $subjectArgs['note_type'] ?? null;
       if ($actualNoteType !== $configuredNoteType) {
         return false;
       }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerceIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerceIntegration.php
@@ -15,6 +15,7 @@ use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromATagTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCancelledTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCompletedTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCreatedTrigger;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderNoteAddedTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderStatusChangedTrigger;
 
 class WooCommerceIntegration {
@@ -29,6 +30,9 @@ class WooCommerceIntegration {
   private $orderCompletedTrigger;
 
   private $orderCancelledTrigger;
+
+  /** @var OrderNoteAddedTrigger */
+  private $orderNoteAddedTrigger;
 
   /** @var AbandonedCartTrigger  */
   private $abandonedCartTrigger;
@@ -68,6 +72,7 @@ class WooCommerceIntegration {
     OrderCreatedTrigger $orderCreatedTrigger,
     OrderCompletedTrigger $orderCompletedTrigger,
     OrderCancelledTrigger $orderCancelledTrigger,
+    OrderNoteAddedTrigger $orderNoteAddedTrigger,
     AbandonedCartTrigger $abandonedCartTrigger,
     BuysAProductTrigger $buysAProductTrigger,
     BuysFromACategoryTrigger $buysFromACategoryTrigger,
@@ -84,6 +89,7 @@ class WooCommerceIntegration {
     $this->orderCreatedTrigger = $orderCreatedTrigger;
     $this->orderCompletedTrigger = $orderCompletedTrigger;
     $this->orderCancelledTrigger = $orderCancelledTrigger;
+    $this->orderNoteAddedTrigger = $orderNoteAddedTrigger;
     $this->abandonedCartTrigger = $abandonedCartTrigger;
     $this->buysAProductTrigger = $buysAProductTrigger;
     $this->buysFromACategoryTrigger = $buysFromACategoryTrigger;
@@ -114,6 +120,7 @@ class WooCommerceIntegration {
     $registry->addTrigger($this->orderCreatedTrigger);
     $registry->addTrigger($this->orderCompletedTrigger);
     $registry->addTrigger($this->orderCancelledTrigger);
+    $registry->addTrigger($this->orderNoteAddedTrigger);
     $registry->addTrigger($this->abandonedCartTrigger);
     $registry->addTrigger($this->buysAProductTrigger);
     $registry->addTrigger($this->buysFromACategoryTrigger);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -219,6 +219,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCreatedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCompletedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderCancelledTrigger::class)->setPublic(true)->setShared(false);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderNoteAddedTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysAProductTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromACategoryTrigger::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysFromATagTrigger::class)->setPublic(true)->setShared(false);

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTriggerTest.php
@@ -1,0 +1,205 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\Triggers\Orders;
+
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderNoteAddedTrigger;
+use MailPoet\Automation\Integrations\WordPress\Subjects\CommentSubject;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+
+/**
+ * @group woo
+ */
+class OrderNoteAddedTriggerTest extends \MailPoetTest {
+
+    /** @var OrderNoteAddedTrigger */
+    private $testee;
+
+    /** @var AutomationRunStorage */
+    private $automationRunStorage;
+
+  public function _before() {
+      $this->testee = $this->diContainer->get(OrderNoteAddedTrigger::class);
+      $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
+  }
+
+  public function testItCreatesRunWhenOrderNoteIsAdded() {
+      $orderNoteAddedTriggerStep = new Step(
+        uniqid(),
+        Step::TYPE_TRIGGER,
+        $this->testee->getKey(),
+        [],
+        []
+      );
+      $automation = ( new AutomationFactory() )
+      ->withStep($orderNoteAddedTriggerStep)
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+      $this->testee->registerHooks();
+
+      $this->assertEmpty($this->automationRunStorage->getAutomationRunsForAutomation($automation));
+
+      $order = wc_create_order(['customer_id' => 1]);
+      $this->assertInstanceOf(\WC_Order::class, $order);
+
+      // Add a note to trigger the automation
+      $commentId = $order->add_order_note('Test order note');
+      $this->assertIsInt($commentId);
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs);
+      /** @var AutomationRun $run */
+      $run = current($runs);
+
+      $orderSubject = $run->getSubjects(OrderSubject::KEY)[0];
+      $this->assertEquals($order->get_id(), $orderSubject->getArgs()['order_id']);
+
+      $commentSubject = $run->getSubjects(CommentSubject::KEY)[0];
+      $this->assertEquals($commentId, $commentSubject->getArgs()['comment_id']);
+      $this->assertEquals('Test order note', $commentSubject->getArgs()['comment_content']);
+      $this->assertEquals('private', $commentSubject->getArgs()['note_type']);
+  }
+
+  public function testItCreatesRunWhenCustomerNoteIsAdded() {
+      $orderNoteAddedTriggerStep = new Step(
+        uniqid(),
+        Step::TYPE_TRIGGER,
+        $this->testee->getKey(),
+        [],
+        []
+      );
+      $automation = ( new AutomationFactory() )
+      ->withStep($orderNoteAddedTriggerStep)
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+      $this->testee->registerHooks();
+
+      $order = wc_create_order(['customer_id' => 1]);
+      $this->assertInstanceOf(\WC_Order::class, $order);
+
+      // Add a customer note to trigger the automation
+      $commentId = $order->add_order_note('Customer note', 1);
+      $this->assertIsInt($commentId);
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs);
+      /** @var AutomationRun $run */
+      $run = current($runs);
+
+      $commentSubject = $run->getSubjects(CommentSubject::KEY)[0];
+      $this->assertEquals($commentId, $commentSubject->getArgs()['comment_id']);
+      $this->assertEquals('Customer note', $commentSubject->getArgs()['comment_content']);
+      $this->assertEquals('customer', $commentSubject->getArgs()['note_type']);
+  }
+
+  public function testItDoesNotRunWhenNoteContentDoesNotMatch() {
+      $orderNoteAddedTriggerStep = new Step(
+        uniqid(),
+        Step::TYPE_TRIGGER,
+        $this->testee->getKey(),
+        [
+              'note_contains' => 'specific text',
+          ],
+        []
+      );
+      $automation = ( new AutomationFactory() )
+      ->withStep($orderNoteAddedTriggerStep)
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+      $this->testee->registerHooks();
+
+      $order = wc_create_order(['customer_id' => 1]);
+      $this->assertInstanceOf(\WC_Order::class, $order);
+
+      // Add a note that doesn't contain the required text
+      $order->add_order_note('Different note content');
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(0, $runs);
+
+      // Add a note that contains the required text
+      $order->add_order_note('This note contains specific text');
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs);
+  }
+
+  public function testItDoesNotRunWhenNoteTypeDoesNotMatch() {
+      $orderNoteAddedTriggerStep = new Step(
+        uniqid(),
+        Step::TYPE_TRIGGER,
+        $this->testee->getKey(),
+        [
+              'note_type' => 'customer',
+          ],
+        []
+      );
+      $automation = ( new AutomationFactory() )
+      ->withStep($orderNoteAddedTriggerStep)
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+      $this->testee->registerHooks();
+
+      $order = wc_create_order(['customer_id' => 1]);
+      $this->assertInstanceOf(\WC_Order::class, $order);
+
+      // Add a private note when customer note is required
+      $order->add_order_note('Private note');
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(0, $runs);
+
+      // Add a customer note
+      $order->add_order_note('Customer note', 1);
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs);
+  }
+
+  public function testItRunsWhenBothFiltersMatch() {
+      $orderNoteAddedTriggerStep = new Step(
+        uniqid(),
+        Step::TYPE_TRIGGER,
+        $this->testee->getKey(),
+        [
+              'note_contains' => 'important',
+              'note_type' => 'customer',
+          ],
+        []
+      );
+      $automation = ( new AutomationFactory() )
+      ->withStep($orderNoteAddedTriggerStep)
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+      $this->testee->registerHooks();
+
+      $order = wc_create_order(['customer_id' => 1]);
+      $this->assertInstanceOf(\WC_Order::class, $order);
+
+      // Add a customer note with the required text
+      $order->add_order_note('This is an important customer note', 1);
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs);
+
+      // Add a private note with the required text (should not trigger)
+      $order->add_order_note('This is an important private note');
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs); // Still only 1 run
+
+      // Add a customer note without the required text (should not trigger)
+      $order->add_order_note('Regular customer note', 1);
+
+      $runs = $this->automationRunStorage->getAutomationRunsForAutomation($automation);
+      $this->assertCount(1, $runs); // Still only 1 run
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTriggerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Triggers/Orders/OrderNoteAddedTriggerTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace MailPoet\Test\Automation\Integrations\MailPoet\Triggers\Orders;
+namespace MailPoet\Test\Automation\Integrations\WooCommerce\Triggers\Orders;
 
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\Step;


### PR DESCRIPTION
## Description

When an order note gets added, the trigger is triggered.

<img width="2262" height="1220" alt="Screenshot 2025-07-16 at 13 59 33" src="https://github.com/user-attachments/assets/3c45e56e-c7ea-41e9-ab1a-6d2bc8e7839e" />


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes:  [STOMAIL-7366]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7366-trigger-follow-up-when-order-note-is-added)

_The latest successful build from `stomail-7366-trigger-follow-up-when-order-note-is-added` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new WooCommerce automation trigger that activates when an order note is added, with filters for note type and content.
  * Added a user-friendly interface to configure the trigger’s settings, including note type selection and content matching.

* **Documentation**
  * Enhanced documentation for automation step and trigger interfaces to clarify their purpose and usage.

* **Tests**
  * Added thorough integration tests validating the new order note trigger’s behavior under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->