### PR TITLE
Fix flaky getSiteUrl test

### DIFF
--- a/mailpoet/lib/Cron/CronHelper.php
+++ b/mailpoet/lib/Cron/CronHelper.php
@@ -204,13 +204,13 @@ class CronHelper {
     if (!isset($parsedUrl['port']) || empty($parsedUrl['port'])) return $siteUrl;
     // 2. if site URL contains valid port, try connecting to it
     $urlHost = $parsedUrl['host'] ?? '';
-    $fp = @fsockopen($callScheme . $urlHost, $parsedUrl['port'], $errno, $errstr, 1);
+    $fp = @fsockopen($callScheme . $urlHost, $parsedUrl['port'], $errno, $errstr, 2);
     if ($fp) return $siteUrl;
     // 3. if connection fails, attempt to connect the standard port derived from URL
     // schema
     $urlScheme = $parsedUrl['scheme'] ?? '';
     $port = (strtolower($urlScheme) === 'http') ? 80 : 443;
-    $fp = @fsockopen($callScheme . $urlHost, $port, $errno, $errstr, 1);
+    $fp = @fsockopen($callScheme . $urlHost, $port, $errno, $errstr, 2);
     if ($fp) return sprintf('%s://%s', $urlScheme, $urlHost);
     // 4. throw an error if all connection attempts failed
     throw new \Exception(__('Site URL is unreachable.', 'mailpoet'));


### PR DESCRIPTION
## Description

Increasing the socket connect timeout when testing site url is reachable seems to fix the issue. 
I think the issue started because of some networking or performance changes on Circle CI.
I think it is ok to increase the timeout. The original 1 second was pretty optimistic. It can be also an improvement for the sites that are configured with a port.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7481

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7481-flaky-testsintegrationcroncronhelpertestphp)

_The latest successful build from `stomail-7481-flaky-testsintegrationcroncronhelpertestphp` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the connection timeout for certain network operations, improving reliability when accessing the site under slower network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->