### PR TITLE
Use the local test site when testing if the site is reachable

### DIFF
--- a/mailpoet/tests/integration/Cron/CronHelperTest.php
+++ b/mailpoet/tests/integration/Cron/CronHelperTest.php
@@ -226,20 +226,25 @@ class CronHelperTest extends \MailPoetTest {
   }
 
   public function testItGetsSiteUrl() {
+    $siteUrl = getenv('MAILPOET_TEST_SITE_URL');
+    // fallback to public URL local test URL is not set
+    if (!$siteUrl) {
+      $siteUrl = 'http://example.com';
+    }
+
     // 1. do nothing when the url does not contain port
-    $siteUrl = 'http://example.com';
     verify($this->cronHelper->getSiteUrl($siteUrl))->equals($siteUrl);
 
     if (getenv('WP_TEST_ENABLE_NETWORK_TESTS') !== 'true') $this->markTestSkipped();
 
     // 2. when url contains valid port, try connecting to it
-    $siteUrl = 'http://example.com:80';
-    verify($this->cronHelper->getSiteUrl($siteUrl))->equals($siteUrl);
+    $siteTestUrl = $siteUrl . ':80';
+    verify($this->cronHelper->getSiteUrl($siteTestUrl))->equals($siteTestUrl);
 
     // 3. when url contains invalid port, try connecting to it. when connection fails,
     // another attempt will be made to connect to the standard port derived from URL schema
-    $siteUrl = 'http://example.com:8080';
-    verify($this->cronHelper->getSiteUrl($siteUrl))->equals('http://example.com');
+    $siteTestUrl = $siteUrl . ':8080';
+    verify($this->cronHelper->getSiteUrl($siteTestUrl))->equals($siteUrl);
 
     // 4. when connection can't be established, exception should be thrown
     $siteUrl = 'https://invalid:80';

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       WORDPRESS_TABLE_PREFIX: mp_
       TEST_TYPE: integration
       PHP_IDE_CONFIG: 'serverName=MailPoetTest'
+      MAILPOET_TEST_SITE_URL: 'http://test.local'
 
   smtp:
     image: mailhog/mailhog:v1.0.0


### PR DESCRIPTION
## Description

This PR aims to fix the flaky `CronHelperTest: It gets site url` test.

It seems that Circle CI has occasional issues with pinging example.com. This PR updates the ' ItGetsSiteUrl` test to ping the test site running in the Docker environment, so we don't need to make a request over the internet. The site test.local is running inside the Docker environment.
There is a fallback to example.com for cases when a developer doesn't use the test environment.
## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7481

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7481-flaky-getSiteUrl)

_The latest successful build from `stomail-7481-flaky-getSiteUrl` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to use a configurable site URL from an environment variable, improving flexibility for different test environments.
  * Docker test environment now sets a default site URL for integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->