### PR TITLE
Duplicate automation step [STOMAIL-7459]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -12,6 +12,8 @@ type Props = {
   step: StepData;
 };
 
+// TODO duplicate email
+
 export function StepMoreMenu({ step }: Props): JSX.Element {
   const { context } = useContext(AutomationContext);
   const [showModal, setShowModal] = useState(false);
@@ -20,37 +22,38 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
   const moreControls: StepMoreControlsType = Hooks.applyFilters(
     'mailpoet.automation.step.more-controls',
     {
-      ...(step.key !== 'core:if-else' && {
-        duplicate: {
-          key: 'duplicate',
-          control: {
-            title: __('Duplicate step', 'mailpoet'),
-            icon: copy,
-            onClick: () => setShowDuplicateModal(true),
+      ...(step.key !== 'core:if-else' &&
+        step.type !== 'trigger' && {
+          duplicate: {
+            key: 'duplicate',
+            control: {
+              title: __('Duplicate step', 'mailpoet'),
+              icon: copy,
+              onClick: () => setShowDuplicateModal(true),
+            },
+            slot: () => {
+              if (!showDuplicateModal) {
+                return false;
+              }
+              return (
+                <PremiumModal
+                  onRequestClose={() => {
+                    setShowDuplicateModal(false);
+                  }}
+                  tracking={{
+                    utm_medium: 'upsell_modal',
+                    utm_campaign: 'duplicate_automation_step',
+                  }}
+                >
+                  {__(
+                    'You cannot duplicate a step in the automation.',
+                    'mailpoet',
+                  )}
+                </PremiumModal>
+              );
+            },
           },
-          slot: () => {
-            if (!showDuplicateModal) {
-              return false;
-            }
-            return (
-              <PremiumModal
-                onRequestClose={() => {
-                  setShowDuplicateModal(false);
-                }}
-                tracking={{
-                  utm_medium: 'upsell_modal',
-                  utm_campaign: 'duplicate_automation_step',
-                }}
-              >
-                {__(
-                  'You cannot duplicate a step in the automation.',
-                  'mailpoet',
-                )}
-              </PremiumModal>
-            );
-          },
-        },
-      }),
+        }),
       delete: {
         key: 'delete',
         control: {

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -12,8 +12,6 @@ type Props = {
   step: StepData;
 };
 
-// TODO duplicate email
-
 export function StepMoreMenu({ step }: Props): JSX.Element {
   const { context } = useContext(AutomationContext);
   const [showModal, setShowModal] = useState(false);

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -19,6 +19,21 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
   const moreControls: StepMoreControlsType = Hooks.applyFilters(
     'mailpoet.automation.step.more-controls',
     {
+      ...(step.key !== 'core:if-else' && {
+        duplicate: {
+          key: 'duplicate',
+          control: {
+            title: __('Duplicate step', 'mailpoet'),
+            icon: null,
+            onClick: () => {
+              // Placeholder for duplicate logic
+              // TODO: Implement actual duplication
+              // eslint-disable-next-line no-alert
+              alert(__('Duplicate step clicked', 'mailpoet'));
+            },
+          },
+        },
+      }),
       delete: {
         key: 'delete',
         control: {

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -17,41 +17,41 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
   const [showModal, setShowModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
 
+  const canDuplicate = step.key !== 'core:if-else' && step.type !== 'trigger';
   const moreControls: StepMoreControlsType = Hooks.applyFilters(
     'mailpoet.automation.step.more-controls',
     {
-      ...(step.key !== 'core:if-else' &&
-        step.type !== 'trigger' && {
-          duplicate: {
-            key: 'duplicate',
-            control: {
-              title: __('Duplicate step', 'mailpoet'),
-              icon: copy,
-              onClick: () => setShowDuplicateModal(true),
-            },
-            slot: () => {
-              if (!showDuplicateModal) {
-                return false;
-              }
-              return (
-                <PremiumModal
-                  onRequestClose={() => {
-                    setShowDuplicateModal(false);
-                  }}
-                  tracking={{
-                    utm_medium: 'upsell_modal',
-                    utm_campaign: 'duplicate_automation_step',
-                  }}
-                >
-                  {__(
-                    'You cannot duplicate a step in the automation.',
-                    'mailpoet',
-                  )}
-                </PremiumModal>
-              );
-            },
+      ...(canDuplicate && {
+        duplicate: {
+          key: 'duplicate',
+          control: {
+            title: __('Duplicate step', 'mailpoet'),
+            icon: copy,
+            onClick: () => setShowDuplicateModal(true),
           },
-        }),
+          slot: () => {
+            if (!showDuplicateModal) {
+              return false;
+            }
+            return (
+              <PremiumModal
+                onRequestClose={() => {
+                  setShowDuplicateModal(false);
+                }}
+                tracking={{
+                  utm_medium: 'upsell_modal',
+                  utm_campaign: 'duplicate_automation_step',
+                }}
+              >
+                {__(
+                  'Duplicating automation steps is available in premium plans. Upgrade to unlock this feature.',
+                  'mailpoet',
+                )}
+              </PremiumModal>
+            );
+          },
+        },
+      }),
       delete: {
         key: 'delete',
         control: {

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react';
 import { DropdownMenu } from '@wordpress/components';
-import { moreVertical, trash } from '@wordpress/icons';
+import { moreVertical, trash, copy } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import { PremiumModal } from 'common/premium-modal';
@@ -15,6 +15,7 @@ type Props = {
 export function StepMoreMenu({ step }: Props): JSX.Element {
   const { context } = useContext(AutomationContext);
   const [showModal, setShowModal] = useState(false);
+  const [showDuplicateModal, setShowDuplicateModal] = useState(false);
 
   const moreControls: StepMoreControlsType = Hooks.applyFilters(
     'mailpoet.automation.step.more-controls',
@@ -24,13 +25,29 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
           key: 'duplicate',
           control: {
             title: __('Duplicate step', 'mailpoet'),
-            icon: null,
-            onClick: () => {
-              // Placeholder for duplicate logic
-              // TODO: Implement actual duplication
-              // eslint-disable-next-line no-alert
-              alert(__('Duplicate step clicked', 'mailpoet'));
-            },
+            icon: copy,
+            onClick: () => setShowDuplicateModal(true),
+          },
+          slot: () => {
+            if (!showDuplicateModal) {
+              return false;
+            }
+            return (
+              <PremiumModal
+                onRequestClose={() => {
+                  setShowDuplicateModal(false);
+                }}
+                tracking={{
+                  utm_medium: 'upsell_modal',
+                  utm_campaign: 'duplicate_automation_step',
+                }}
+              >
+                {__(
+                  'You cannot duplicate a step in the automation.',
+                  'mailpoet',
+                )}
+              </PremiumModal>
+            );
           },
         },
       }),

--- a/mailpoet/changelog/2025-07-23-08-17-13-added-add-duplication-of-an-automation-step.md
+++ b/mailpoet/changelog/2025-07-23-08-17-13-added-add-duplication-of-an-automation-step.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add duplication of an automation step

--- a/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
@@ -45,14 +45,16 @@ class DuplicateAutomationController {
     );
     $duplicate->setStatus(Automation::STATUS_DRAFT);
 
-    foreach ($duplicate->getSteps() as $step) {
+    $steps = $duplicate->getSteps();
+    foreach ($steps as $id => $step) {
       if ($step->getType() === 'action') {
         $action = $this->registry->getAction($step->getKey());
         if ($action) {
-          $action->onDuplicate($step);
+          $steps[$id] = $action->onDuplicate($step);
         }
       }
     }
+    $duplicate->setSteps($steps);
 
     $automationId = $this->automationStorage->createAutomation($duplicate);
     $savedAutomation = $this->automationStorage->getAutomation($automationId);

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -10,7 +10,6 @@ use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
-use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
@@ -32,9 +31,6 @@ class UpdateAutomationController {
   /** @var UpdateStepsController */
   private $updateStepsController;
 
-  /** @var Registry */
-  private $registry;
-
   private AutomationRunStorage $automationRunStorage;
 
   private ActionScheduler $actionScheduler;
@@ -46,8 +42,7 @@ class UpdateAutomationController {
     AutomationValidator $automationValidator,
     AutomationRunStorage $automationRunStorage,
     ActionScheduler $actionScheduler,
-    UpdateStepsController $updateStepsController,
-    Registry $registry
+    UpdateStepsController $updateStepsController
   ) {
     $this->hooks = $hooks;
     $this->storage = $storage;
@@ -56,7 +51,6 @@ class UpdateAutomationController {
     $this->updateStepsController = $updateStepsController;
     $this->automationRunStorage = $automationRunStorage;
     $this->actionScheduler = $actionScheduler;
-    $this->registry = $registry;
   }
 
   public function updateAutomation(int $id, array $data): Automation {

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -82,8 +82,6 @@ class UpdateAutomationController {
       foreach ($automation->getSteps() as $step) {
         $this->hooks->doAutomationStepBeforeSave($step, $automation);
         $this->hooks->doAutomationStepByKeyBeforeSave($step, $automation);
-
-        $this->maybeRunOnDuplicate($step, $automation);
       }
     }
 
@@ -183,32 +181,6 @@ class UpdateAutomationController {
       $automationArgs = reset($args);
       if (isset($automationArgs['automation_run_id']) && isset($runIds[$automationArgs['automation_run_id']])) {
         $this->actionScheduler->unscheduleAction(Hooks::AUTOMATION_STEP, $args);
-      }
-    }
-  }
-
-  /**
-   * @param Step $step
-   * @param Automation $automation
-   * @return void
-   */
-  public function maybeRunOnDuplicate(Step $step, Automation $automation): void {
-    if ($step->getType() === 'action') {
-      $args = $step->getArgs();
-      $isStepDuplicated = !empty($args['stepDuplicated']);
-      if ($isStepDuplicated) {
-        $action = $this->registry->getAction($step->getKey());
-        if ($action) {
-
-          $duplicatedStep = $action->onDuplicate($step);
-
-          unset($duplicatedStep->getArgs()['stepDuplicated']);
-          
-          // save the updated step into the automation
-          $allSteps = $automation->getSteps();
-          $allSteps[$step->getId()] = $duplicatedStep;
-          $automation->setSteps($allSteps);
-        }
       }
     }
   }

--- a/mailpoet/lib/Automation/Engine/Integration/Action.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Action.php
@@ -9,5 +9,11 @@ use MailPoet\Automation\Engine\Data\StepRunArgs;
 interface Action extends \MailPoet\Automation\Engine\Integration\Step {
   public function run(StepRunArgs $args, StepRunController $controller): void;
 
+  /**
+   * Called when a step is duplicated to allow custom duplication logic.
+   *
+   * @param Step $step The step being duplicated
+   * @return Step The duplicated step (may be the same instance or a modified copy)
+   */
   public function onDuplicate(Step $step): Step;
 }

--- a/mailpoet/lib/Automation/Engine/Integration/Action.php
+++ b/mailpoet/lib/Automation/Engine/Integration/Action.php
@@ -3,8 +3,11 @@
 namespace MailPoet\Automation\Engine\Integration;
 
 use MailPoet\Automation\Engine\Control\StepRunController;
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 
-interface Action extends Step {
+interface Action extends \MailPoet\Automation\Engine\Integration\Step {
   public function run(StepRunArgs $args, StepRunController $controller): void;
+
+  public function onDuplicate(Step $step): Step;
 }

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
@@ -52,7 +52,7 @@ class DelayAction implements Action {
     }
   }
 
-  public function onDuplicate(\MailPoet\Automation\Engine\Data\Step $step): Step {
+  public function onDuplicate(Step $step): Step {
         // Intentionally left empty for now
         return $step;
   }

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
@@ -53,8 +53,8 @@ class DelayAction implements Action {
   }
 
   public function onDuplicate(Step $step): Step {
-        // Intentionally left empty for now
-        return $step;
+    // Intentionally left empty for now
+    return $step;
   }
 
   public static function calculateSeconds(Step $step): int {

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/DelayAction.php
@@ -52,6 +52,11 @@ class DelayAction implements Action {
     }
   }
 
+  public function onDuplicate(\MailPoet\Automation\Engine\Data\Step $step): Step {
+        // Intentionally left empty for now
+        return $step;
+  }
+
   public static function calculateSeconds(Step $step): int {
     $delay = (int)($step->getArgs()['delay'] ?? null);
     switch ($step->getArgs()['delay_type']) {

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
@@ -73,7 +73,7 @@ class IfElseAction implements Action {
     $controller->scheduleNextStepByIndex($matches ? 0 : 1);
   }
 
-  public function onDuplicate(\MailPoet\Automation\Engine\Data\Step $step): Step {
+  public function onDuplicate(Step $step): Step {
         // Intentionally left empty for now, this cannot be duplicated
         return $step;
   }

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Integrations\Core\Actions;
 use MailPoet\Automation\Engine\Control\FilterHandler;
 use MailPoet\Automation\Engine\Control\StepRunController;
 use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\StepValidationArgs;
 use MailPoet\Automation\Engine\Integration\Action;
@@ -70,5 +71,10 @@ class IfElseAction implements Action {
   public function run(StepRunArgs $args, StepRunController $controller): void {
     $matches = $this->filterHandler->matchesFilters($args);
     $controller->scheduleNextStepByIndex($matches ? 0 : 1);
+  }
+
+  public function onDuplicate(\MailPoet\Automation\Engine\Data\Step $step): Step {
+        // Intentionally left empty for now, this cannot be duplicated
+        return $step;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Actions/IfElseAction.php
@@ -74,7 +74,7 @@ class IfElseAction implements Action {
   }
 
   public function onDuplicate(Step $step): Step {
-        // Intentionally left empty for now, this cannot be duplicated
-        return $step;
+    // Intentionally left empty for now, this cannot be duplicated
+    return $step;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -117,7 +117,7 @@ class SendEmailAction implements Action {
     NewsletterOptionsRepository $newsletterOptionsRepository,
     NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository,
     WordPress $wp,
-    NewsletterSaveController $newsletterSaveController,
+    NewsletterSaveController $newsletterSaveController
   ) {
     $this->automationController = $automationController;
     $this->settings = $settings;
@@ -554,10 +554,14 @@ class SendEmailAction implements Action {
     $email = $this->newslettersRepository->findOneBy([
       'id' => $emailId,
     ]);
-    if (!$emailId) {
-      return $step;
+    if (!$email) {
+      throw new \MailPoet\Automation\Engine\Exceptions\InvalidStateException('Automation email entity not found for duplication.');
     }
-    $duplicatedNewsletter = $this->newsletterSaveController->duplicate($email);
+    try {
+      $duplicatedNewsletter = $this->newsletterSaveController->duplicate($email);
+    } catch (\Throwable $e) {
+      throw new \MailPoet\Automation\Engine\Exceptions\InvalidStateException('Failed to duplicate automation email: ' . $e->getMessage());
+    }
     $duplicatedNewsletter->setStatus($email->getStatus());
     $this->newslettersRepository->flush();
 

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateStepsControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateStepsControllerTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Builder;
+
+use MailPoet\Automation\Engine\Builder\UpdateStepsController;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoetTest;
+
+class UpdateStepsControllerTest extends MailPoetTest {
+  public function testItDuplicatesNewsletterOnStepDuplication(): void {
+    $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    // Create a newsletter to be used by the action
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+    $newsletter->setSubject('Original Subject');
+    $newsletter->setPreheader('Original Preheader');
+    $newsletter->setSenderName('Sender');
+    $newsletter->setSenderAddress('sender@example.com');
+    $newslettersRepository->persist($newsletter);
+    $newslettersRepository->flush();
+    $originalNewsletterId = $newsletter->getId();
+
+    // Prepare a SendEmailAction step with stepDuplicated flag
+    $step = new Step(
+      'a1',
+      Step::TYPE_ACTION,
+      'mailpoet:send-email',
+      [
+        'email_id' => $originalNewsletterId,
+        'stepDuplicated' => true,
+        'subject' => 'Original Subject',
+      ],
+      [new NextStep('end')]
+    );
+    $automation = new Automation('Test automation', [$step], \wp_get_current_user());
+
+    $updateStepsController = $this->diContainer->get(UpdateStepsController::class);
+    $updateStepsController->updateSteps($automation, [
+      $step->getId() => $step->toArray(),
+    ]);
+
+    $updatedStep = $automation->getStep('a1');
+    $this->assertNotNull($updatedStep);
+    $this->assertNotEquals($originalNewsletterId, $updatedStep->getArgs()['email_id']);
+    $duplicatedNewsletter = $newslettersRepository->findOneBy(['id' => $updatedStep->getArgs()['email_id']]);
+    $this->assertNotNull($duplicatedNewsletter);
+    $this->assertEquals('Copy of Original Subject', $duplicatedNewsletter->getSubject());
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateStepsControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateStepsControllerTest.php
@@ -37,7 +37,7 @@ class UpdateStepsControllerTest extends MailPoetTest {
       ],
       [new NextStep('end')]
     );
-    $automation = new Automation('Test automation', [$step], \wp_get_current_user());
+    $automation = new Automation('Test automation', [$step->getId() => $step], \wp_get_current_user());
 
     $updateStepsController = $this->diContainer->get(UpdateStepsController::class);
     $updateStepsController->updateSteps($automation, [

--- a/mailpoet/tests/integration/Automation/Stubs/TestAction.php
+++ b/mailpoet/tests/integration/Automation/Stubs/TestAction.php
@@ -43,8 +43,8 @@ class TestAction implements Action {
   }
 
   public function onDuplicate(Step $step): Step {
-        // Intentionally left empty for now
-        return $step;
+    // Intentionally left empty for now
+    return $step;
   }
 
   public function getKey(): string {

--- a/mailpoet/tests/integration/Automation/Stubs/TestAction.php
+++ b/mailpoet/tests/integration/Automation/Stubs/TestAction.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Automation\Stubs;
 
 use MailPoet\Automation\Engine\Control\StepRunController;
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
 use MailPoet\Automation\Engine\Data\StepValidationArgs;
 use MailPoet\Automation\Engine\Integration\Action;
@@ -39,6 +40,11 @@ class TestAction implements Action {
     if ($this->callback) {
       ($this->callback)($args);
     }
+  }
+
+  public function onDuplicate(Step $step): Step {
+        // Intentionally left empty for now
+        return $step;
   }
 
   public function getKey(): string {

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepOrderRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepOrderRuleTest.php
@@ -231,8 +231,8 @@ class ValidStepOrderRuleTest extends AutomationRuleTest {
       public function validate(StepValidationArgs $args): void {
       }
 
-      public function onDuplicate(\MailPoet\Automation\Engine\Integration\Step $step, \MailPoet\Automation\Engine\Data\Automation $automation): void {
-          // Intentionally left empty for now
+      public function onDuplicate(\MailPoet\Automation\Engine\Data\Step $step): \MailPoet\Automation\Engine\Data\Step {
+          return $step;
       }
     };
   }

--- a/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepOrderRuleTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Validation/AutomationRules/ValidStepOrderRuleTest.php
@@ -230,6 +230,10 @@ class ValidStepOrderRuleTest extends AutomationRuleTest {
 
       public function validate(StepValidationArgs $args): void {
       }
+
+      public function onDuplicate(\MailPoet\Automation\Engine\Integration\Step $step, \MailPoet\Automation\Engine\Data\Automation $automation): void {
+          // Intentionally left empty for now
+      }
     };
   }
 }


### PR DESCRIPTION
## Description

1. Add new Duplicate step item to step menu (behind the three dots)
2. Don't allow duplicating if/else step, or triggers
3. When duplicating Send email step, also duplicate the email assigned. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/966

## Linked tickets

[STOMAIL-7459]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7459-duplicate-automation-step)

_The latest successful build from `stomail-7459-duplicate-automation-step` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Duplicate step" option in the automation editor's step menu for eligible steps, with a modal explaining it is a premium feature.
  * Enabled duplication of automation steps, including proper handling of duplicated newsletter steps to create copies with updated details.
  * Improved the "Edit content" button for duplicated email steps to handle backend duplication and redirect correctly.

* **Bug Fixes**
  * None.

* **Tests**
  * Added integration and unit tests to ensure correct duplication behavior for newsletter steps and step duplication logic.

* **Documentation**
  * Updated the changelog to document the addition of the step duplication feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->