### PR TITLE
Exclude out-of-stock products in dynamic products block

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/blocks/dynamic-products.ts
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/dynamic-products.ts
@@ -95,7 +95,7 @@ Module.DynamicProductsBlockModel = base.BlockModel.extend({
     base.BlockView.prototype.initialize.apply(this, args);
 
     this.on(
-      'change:amount change:contentType change:terms change:inclusionType change:displayType change:titleFormat change:featuredImagePosition change:titleAlignment change:titleIsLink change:imageFullWidth change:pricePosition change:readMoreType change:readMoreText change:sortBy change:showDivider change:dynamicProductsType change:titlePosition',
+      'change:amount change:contentType change:terms change:inclusionType change:displayType change:titleFormat change:featuredImagePosition change:titleAlignment change:titleIsLink change:imageFullWidth change:pricePosition change:readMoreType change:readMoreText change:sortBy change:showDivider change:dynamicProductsType change:titlePosition change:excludeOutOfStock',
       this._handleChanges,
       this,
     );
@@ -219,6 +219,10 @@ Module.DynamicProductsBlockSettingsView = base.BlockSettingsView.extend({
       'change .mailpoet_dynamic_products_include_or_exclude': _.partial(
         this.changeField,
         'inclusionType',
+      ),
+      'change .mailpoet_dynamic_products_exclude_out_of_stock': _.partial(
+        this.changeBoolCheckboxField,
+        'excludeOutOfStock',
       ),
       'change .mailpoet_dynamic_products_title_alignment': _.partial(
         this.changeField,

--- a/mailpoet/changelog/2025-07-28-14-51-50-added-the-dynamic-products-block-can-filter-out-out-of-s.md
+++ b/mailpoet/changelog/2025-07-28-14-51-50-added-the-dynamic-products-block-can-filter-out-out-of-s.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+The dynamic products block can filter out out-of-stock products

--- a/mailpoet/lib/Newsletter/BlockPostQuery.php
+++ b/mailpoet/lib/Newsletter/BlockPostQuery.php
@@ -17,7 +17,8 @@ class BlockPostQuery {
    *     search?: string,
    *     sortBy?: 'newest' | 'DESC' | 'ASC',
    *     terms?: array{'taxonomy': string, 'id': int}[],
-   *     inclusionType?: 'include'|'exclude'
+   *     inclusionType?: 'include'|'exclude',
+   *     excludeOutOfStock?: bool,
    * } $args
    */
   public $args = [];
@@ -57,7 +58,8 @@ class BlockPostQuery {
    *     search?: string,
    *     sortBy?: 'newest' | 'DESC' | 'ASC',
    *     terms?: array{'taxonomy': string, 'id': int}[],
-   *     inclusionType?: 'include'|'exclude'
+   *     inclusionType?: 'include'|'exclude',
+   *     excludeOutOfStock?: bool,
    *    },
    *    postsToExclude?: int[],
    *    newsletterId?: int|false|null,

--- a/mailpoet/lib/Newsletter/DynamicProducts.php
+++ b/mailpoet/lib/Newsletter/DynamicProducts.php
@@ -96,7 +96,7 @@ class DynamicProducts {
     // Exclude out-of-stock and products that are not on backorder
     $excludeOutOfStock = $query->args['excludeOutOfStock'] ?? false;
     if ($excludeOutOfStock === true || $excludeOutOfStock === 'true') {
-      $wcArgs['stock_status'] = ['instock', 'lowstock', 'onbackorder'];
+      $wcArgs['stock_status'] = $this->wp->applyFilters('mailpoet_products_exclude_out_of_stock_stock_status', ['instock', 'lowstock', 'onbackorder']);
     }
 
     // If we have specific product IDs to include, use them

--- a/mailpoet/lib/Newsletter/DynamicProducts.php
+++ b/mailpoet/lib/Newsletter/DynamicProducts.php
@@ -93,6 +93,12 @@ class DynamicProducts {
       'exclude' => $query->postsToExclude, // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
     ];
 
+    // Exclude out-of-stock and products that are not on backorder
+    $excludeOutOfStock = $query->args['excludeOutOfStock'] ?? false;
+    if ($excludeOutOfStock === true || $excludeOutOfStock === 'true') {
+      $wcArgs['stock_status'] = ['instock', 'lowstock', 'onbackorder'];
+    }
+
     // If we have specific product IDs to include, use them
     if (!empty($parameters['post__in'])) {
       $wcArgs['include'] = $parameters['post__in'];

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/DynamicProductsBlock.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/DynamicProductsBlock.php
@@ -96,7 +96,7 @@ class DynamicProductsBlock {
       // Don't show any products if we don't have specific product IDs
       // and the user didn't choose "selected" in the dynamic products type dropdown
       if ($sendingQueue) {
-        if (!empty($args['dynamicProductsType']) || $args['dynamicProductsType'] !== 'selected') {
+        if (($args['dynamicProductsType'] ?? null) !== 'selected') {
           $queryArgs['includeProductIds'] = [0];
         }
       }

--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -1567,6 +1567,7 @@
           terms: [], // List of category and tag objects
           inclusionType: 'include', // 'include'|'exclude'
           displayType: 'excerpt', // 'excerpt'|'full'|'titleOnly'
+          excludeOutOfStock: true, // true|false
           titleFormat: 'h1', // 'h1'|'h2'|'h3'
           titleAlignment: 'left', // 'left'|'center'|'right'
           titleIsLink: false, // false|true

--- a/mailpoet/views/newsletter/templates/blocks/dynamicProducts/settings.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/dynamicProducts/settings.hbs
@@ -62,6 +62,15 @@
     </div>
 </div>
 
+<div class="mailpoet_form_field">
+    <div class="mailpoet_form_field_checkbox_option">
+        <label>
+            <input type="checkbox" name="mailpoet_dynamic_products_exclude_out_of_stock" class="mailpoet_dynamic_products_exclude_out_of_stock" value="true" {{#if model.excludeOutOfStock}}CHECKED{{/if}}/>
+            <%= __('Exclude out-of-stock products') %>
+        </label>
+    </div>
+</div>
+
 <hr class="mailpoet_separator" />
 
 


### PR DESCRIPTION
## Description

Sending products that are out of stock in emails has a negative effect.

This PR adds an option to exclude out-of-stock products for the dynamic products block.

- When the checkbox is active, the dynamic product block includes only products that have `stock_status` `instock`, `lowstock`, or `onbackorder`. 
- Products that don't manage stock are always included.
- There is also a filter `mailpoet_products_exclude_out_of_stock_stock_status` that allows modifying the statuses.
- The PR also fixes an issue with the Dynamic product block that was not fetching products properly during sending.

<img width="335" height="539" alt="Screenshot 2025-07-28 at 16 49 29" src="https://github.com/user-attachments/assets/03fb9dc6-8fb2-4d2e-a73d-cb10959cd497" />

## Code review notes

_N/A_

## QA notes

1) Create a couple of products, including variable products
2) Setup the products to have managed stock
3) Verify that products that when the option "Exclude out-of-stock products" is checked, are out of stock and don't allow backorder, are excluded from the list.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7484

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7484-hide-out-of-stock-products)

_The latest successful build from `stomail-7484-hide-out-of-stock-products` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an "Exclude out-of-stock products" checkbox to the dynamic products block settings in the newsletter editor.
  * Dynamic products block now supports excluding out-of-stock and unavailable products from display.

* **Bug Fixes**
  * Improved logic to prevent unintended product inclusion when the dynamic product type is not set to "selected".

* **Tests**
  * Added comprehensive tests to verify correct handling of out-of-stock and variable products in dynamic product listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->