### PR TITLE
Consider `mailpoet_woocommerce_checkout_optin` option when creating new subscriber from guest customer order

### DIFF
--- a/mailpoet/changelog/2025-07-29-12-45-46-fixed-prevent-automatic-subscribed-status-for-guest-orde.md
+++ b/mailpoet/changelog/2025-07-29-12-45-46-fixed-prevent-automatic-subscribed-status-for-guest-orde.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent automatic "Subscribed" status for guest order subscribers when Sign-up Confirmation is disabled

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -170,7 +170,7 @@ class WooCommerce {
     if (!$wcOrder instanceof \WC_Order) return;
     $signupConfirmation = $this->settings->get('signup_confirmation');
     $status = SubscriberEntity::STATUS_UNSUBSCRIBED;
-    if ((bool)$signupConfirmation['enabled'] === false) {
+    if ((bool)$signupConfirmation['enabled'] === false && $this->shouldSubscribeToWooSegment()) {
       $status = SubscriberEntity::STATUS_SUBSCRIBED;
     }
 


### PR DESCRIPTION
## Description

When **Sign-up Confirmation** is disabled and the **Opt-in on Checkout** option is enabled, subscribers created from guest customer orders are always assigned the `Subscribed` status - regardless of whether the customer actually checked the opt-in checkbox during checkout.

This PR addresses that issue by properly respecting the opt-in checkbox value. Now, a new subscriber created during guest checkout will only be marked as `Subscribed` if the customer explicitly checked the subscription box. Otherwise, the subscriber will be created with the `Unsubscribed` status.

## Code review notes

1. In **MailPoet → Settings → Send With...**, set the sending service to **Other**.
2. Disable **Sign-up Confirmation** (i.e., disable double opt-in).
3. Enable **WooCommerce → Opt-in on checkout**.
4. As a guest customer, place an order **without** checking the opt-in checkbox. You can also place an order with logged-in user, but you need to set the billing address to an email address that is not in the Subscribers list.
5. Navigate to **MailPoet → Subscribers**.
6. Confirm that the new subscriber is created with **Subscribed** status.
7. Checkout the changes from this PR and repeat the testing steps.
8. The new subscriber should now be created with **Unsubscribed** when the opt-in checkbox is not checked, and with **Subscribed** otherwise.


## QA notes

_N/A_

## Linked PRs

[STOMAIL-7502: Unexpected status for no opt in on checkout when using third-party sending methods](https://linear.app/a8c/issue/STOMAIL-7502/unexpected-status-for-no-opt-in-on-checkout-when-using-third-party)

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7502-unexpected-status-for-no-opt-in-on-checkout-when-using-third)

_The latest successful build from `stomail-7502-unexpected-status-for-no-opt-in-on-checkout-when-using-third` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Guest order subscribers will no longer be automatically assigned the "Subscribed" status when the Sign-up Confirmation feature is disabled, ensuring more accurate subscription handling.

* **Tests**
  * Added new tests to verify guest customer subscription status under various WooCommerce and sign-up confirmation settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->