### PR TITLE
Skip SendGrid email send test if API key is not set

### DIFF
--- a/mailpoet/tests/_support/CheckSkippedTestsExtension.php
+++ b/mailpoet/tests/_support/CheckSkippedTestsExtension.php
@@ -22,6 +22,7 @@ class CheckSkippedTestsExtension extends Extension {
       'testAllSubscribersFoundWithOperatorAllOf',
       'automationTriggeredByRegistrationWitConfirmationNeeded',
       'automationTriggeredByRegistrationWithoutConfirmationNeeded',
+      'testItCanSendWithSendGrid',
       // Email editor works with the latest WP version only
       'createAndSendStandardNewsletter',
       'displayNewsletterPreview',

--- a/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SendGridTest.php
@@ -115,8 +115,8 @@ class SendGridTest extends \MailPoetTest {
     verify($result['error']->getMessage())->stringContainsString('SendGrid has returned an unknown error.');
   }
 
-  public function testItCanSend() {
-    if (getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true') $this->markTestSkipped();
+  public function testItCanSendWithSendGrid() {
+    if (getenv('WP_TEST_MAILER_ENABLE_SENDING') !== 'true' || empty(getenv('WP_TEST_MAILER_SENDGRID_API'))) $this->markTestSkipped();
     $result = $this->mailer->send(
       $this->newsletter,
       $this->subscriber


### PR DESCRIPTION
## Description

This PR updates the SendGrid email send test to be marked as skipped when `WP_TEST_MAILER_SENDGRID_API` env variable is not provided and adds the tests name to the list of tests allowed to be skipped.

These changes are needed as we've decided to no longer run the test in the CircleCI builds.

Context: p1753693991826479-slack-C01H71ZLBGQ

## Code review notes

Confirm integration tests pass in CircleCI.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/allow-skipping-sendgrid-send-test)

_The latest successful build from `fix/allow-skipping-sendgrid-send-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Renamed a SendGrid-related test for clarity.
  * Updated test skip conditions to require both specific environment variables to be set.
  * Allowed the updated test to be skipped on certain branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->