### PR TITLE
Initial PHP 8.4 support

### DIFF
--- a/dev/php84/Dockerfile
+++ b/dev/php84/Dockerfile
@@ -1,0 +1,46 @@
+FROM wordpress:php8.4-apache
+
+ARG UID=1000
+ARG GID=1000
+
+# additinal extensions
+RUN apt-get update \
+	&& apt-get install -y git zlib1g-dev libzip-dev zip wget gnupg msmtp libpng-dev gettext subversion \
+	&& \
+    # Install NodeJS, enable Corepack
+    curl -sL https://deb.nodesource.com/setup_19.x | bash - && \
+    apt-get install -y nodejs build-essential && \
+    corepack enable && \
+	\
+	# Install WP-CLI
+	curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+	chmod +x /usr/local/bin/wp && \
+	\
+  # Clean up
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY dev/php.ini /usr/local/etc/php/conf.d/php_user.ini
+
+# msmtp config
+RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
+
+# xdebug build an config
+ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
+RUN git clone -b "3.4.5" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-install xdebug \
+    && mkdir /tmp/debug
+COPY dev/xdebug.ini /tmp/xdebug.ini
+RUN cat /tmp/xdebug.ini >> $XDEBUGINI_PATH
+
+# php extensions
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install mysqli
+
+# allow .htaccess files (between <Directory /var/www/> and </Directory>, which is WordPress installation)
+RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
+# ensure existing content in /var/www/html respects UID and GID, give Node permissions for Corepack
+RUN chown -R ${UID}:${GID} /var/www/html && \
+  mkdir -p /.node && chown -R ${UID}:${GID} /.node

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -78,14 +78,16 @@
       "./tools/vendor/composer.phar --working-dir=tasks/phpstan install",
       "./tools/vendor/composer.phar --working-dir=../tests_env install",
       "php ./tasks/fix-guzzle.php",
-      "php ./tasks/fix-php82-deprecations.php"
+      "php ./tasks/fix-php82-deprecations.php",
+      "php ./tasks/FixPhp84Deprecations.php"
     ],
     "post-install-cmd": [
       "./tools/vendor/composer.phar --working-dir=tasks/code_sniffer install",
       "./tools/vendor/composer.phar --working-dir=tasks/phpstan install",
       "./tools/vendor/composer.phar --working-dir=../tests_env install",
       "php ./tasks/fix-guzzle.php",
-      "php ./tasks/fix-php82-deprecations.php"
+      "php ./tasks/fix-php82-deprecations.php",
+      "php ./tasks/FixPhp84Deprecations.php"
     ],
     "pre-autoload-dump": [
       "php ./tasks/fix-codeception-stub.php",

--- a/mailpoet/prefixer/fix-carbon.php
+++ b/mailpoet/prefixer/fix-carbon.php
@@ -48,6 +48,15 @@ $replacements = [
       '',
     ],
   ],
+  [
+    'file' => '../vendor-prefixed/nesbot/carbon/src/Carbon/Traits/Timestamp.php',
+    'find' => [
+      'public static function createFromTimestamp($timestamp, $tz = null)',
+    ],
+    'replace' => [
+      '#[\ReturnTypeWillChange]' . PHP_EOL . 'public static function createFromTimestamp($timestamp, $tz = null)',
+    ],
+  ],
 ];
 
 foreach ($replacements as $singleFile) {

--- a/mailpoet/prefixer/fix-doctrine.php
+++ b/mailpoet/prefixer/fix-doctrine.php
@@ -13,6 +13,8 @@ foreach ($files as $file) {
     $data = file_get_contents($file);
     $data = str_replace('\'Doctrine\\\\', '\'MailPoetVendor\\\\Doctrine\\\\', $data);
     $data = str_replace('"Doctrine\\\\', '"MailPoetVendor\\\\Doctrine\\\\', $data);
+    $data = str_replace('\'Doctrine\\', '\'MailPoetVendor\\Doctrine\\', $data);
+    $data = str_replace('"Doctrine\\', '"MailPoetVendor\\Doctrine\\', $data);
     $data = str_replace(' \\Doctrine\\', ' \\MailPoetVendor\\Doctrine\\', $data);
     $data = str_replace('* @var array<\\Doctrine\\', '* @var array<\\MailPoetVendor\\Doctrine\\', $data);
     file_put_contents($file, $data);

--- a/mailpoet/tasks/FixPhp84Deprecations.php
+++ b/mailpoet/tasks/FixPhp84Deprecations.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tasks;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Fix PHP 8.4 deprecation: "Implicitly marking parameter $x as nullable is deprecated,
+ * the explicit nullable type must be used instead"
+ *
+ * This script finds and fixes function/method parameters that have a default value of null
+ * but are not explicitly marked as nullable with the ? prefix.
+ */
+
+class FixPhp84Deprecations {
+  private array $vendorDirectories = [
+    'vendor',
+    'vendor-prefixed',
+  ];
+
+  public function run(): void {
+    foreach ($this->vendorDirectories as $vendorDir) {
+      if (is_dir($vendorDir)) {
+        $this->processDirectory($vendorDir);
+      }
+    }
+  }
+
+  private function processDirectory(string $directory): void {
+    $iterator = new RecursiveIteratorIterator(
+      new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+      if ($file->getExtension() === 'php') {
+        $this->processFile($file->getPathname());
+      }
+    }
+  }
+
+  private function processFile(string $filePath): void {
+    $content = file_get_contents($filePath);
+    if ($content === false) {
+      return;
+    }
+
+    $originalContent = $content;
+
+    $content = $this->fixImplicitlyNullableParameters($content);
+
+    // Only write if changes were made
+    if ($content !== $originalContent) {
+      file_put_contents($filePath, $content);
+    }
+  }
+
+  private function fixImplicitlyNullableParameters(string $content): string {
+    // Find potential matches
+    $pattern = '/(\s|,|\()\s*([A-Za-z_\\\\][A-Za-z0-9_\\\\]*)(\s+\$\w+\s*=\s*null\b)/';
+
+    $content = preg_replace_callback($pattern, function($matches) {
+      $fullMatch = $matches[0];
+      $prefix = $matches[1];
+      $type = $matches[2];
+      $paramPart = $matches[3];
+
+      // Additional safety checks
+      if (strpos($fullMatch, '|') !== false) {
+        return $fullMatch; // Don't modify union types
+      }
+
+      // Check if already nullable (look for ? before the type in the prefix)
+      if (strpos($prefix, '?') !== false) {
+        return $fullMatch; // Already nullable
+      }
+
+      // Don't modify visibility modifiers or storage class specifiers
+      $excludedKeywords = ['static', 'private', 'protected', 'public', 'const', 'var'];
+      if (in_array(trim($type), $excludedKeywords)) {
+        return $fullMatch;
+      }
+
+      // Don't modify 'mixed' type since it already includes null
+      if (trim($type) === 'mixed') {
+        return $fullMatch;
+      }
+
+      return $prefix . '?' . $type . $paramPart;
+    }, $content);
+
+    return $content;
+  }
+}
+
+$fixer = new FixPhp84Deprecations();
+$fixer->run();

--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -1,14 +1,18 @@
 <?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
+$composerVersion = '2.8.10';
+$phpScoperVersion = '0.18.17';
 $tracyVersion = '2.10.9'; // 2.10.10 causes SyntaxError in JS
 // The newer tracy version doesn't support PHP 7.X which we still support in tests and also in development environment.
 if (PHP_VERSION_ID < 80000) {
+  $composerVersion = '2.7.7';
+  $phpScoperVersion = '0.17.2';
   $tracyVersion = '2.9.4';
 }
 
 $tools = [
-  'https://github.com/composer/composer/releases/download/2.7.7/composer.phar' => 'composer.phar',
-  'https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar' => 'php-scoper.phar',
+  "https://github.com/composer/composer/releases/download/$composerVersion/composer.phar" => 'composer.phar',
+  "https://github.com/humbug/php-scoper/releases/download/$phpScoperVersion/php-scoper.phar" => 'php-scoper.phar',
   "https://github.com/nette/tracy/releases/download/v$tracyVersion/tracy.phar" => 'tracy.phar',
 ];
 // ensure installation in dev-mode only

--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
-$tracyVersion = '2.9.7';
+$tracyVersion = '2.10.9'; // 2.10.10 causes SyntaxError in JS
 // The newer tracy version doesn't support PHP 7.X which we still support in tests and also in development environment.
 if (PHP_VERSION_ID < 80000) {
   $tracyVersion = '2.9.4';

--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -3,8 +3,10 @@
 $composerVersion = '2.8.10';
 $phpScoperVersion = '0.18.17';
 $tracyVersion = '2.10.9'; // 2.10.10 causes SyntaxError in JS
-// The newer tracy version doesn't support PHP 7.X which we still support in tests and also in development environment.
-if (PHP_VERSION_ID < 80000) {
+
+// The newer versions drop support for PHP 7.4 and PHP-Scoper also drops 8.1 which we still
+// support in tests and also in development environment.
+if (PHP_VERSION_ID < 80200) {
   $composerVersion = '2.7.7';
   $phpScoperVersion = '0.17.2';
   $tracyVersion = '2.9.4';


### PR DESCRIPTION
## Description

The first step in adding full support for PHP 8.4. We still can't switch local dev or tests to run on PHP 8.4, but some initial issues are already fixed. 

- Updated Tracy, Composer, and PHP-Scoper to the latest versions with PHP 8.4 support. 
- Added PHP 8.4 Dockerfile for local development.
- Fixed Carbon issue.
- Fixed deprecated implicitly marking params as nullable in vendor files.
    - I considered using https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html but ended up with a somewhat simple script instead of using a whole library. 
- Added `mailpoet/wordpress:8.4_20250729.1` and `mailpoet/wordpress:8.4-cli_20250729.1` Docker images in https://github.com/mailpoet/wordpress-images/pull/53

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7508

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7508-check-compatibility-with-php-84)

_The latest successful build from `stomail-7508-check-compatibility-with-php-84` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for PHP 8.4 in the WordPress development environment, including a new Docker image with updated tools and PHP extensions.
  * Introduced an automated script to fix PHP 8.4 deprecation warnings in vendor code.
* **Bug Fixes**
  * Improved namespace prefixing for Doctrine dependencies to ensure compatibility.
  * Added attribute to suppress return type warnings in the Carbon library.
* **Chores**
  * Updated tool installation script to select Composer, PHP-Scoper, and Tracy versions based on the PHP runtime version.
  * Enhanced Composer scripts to run the new PHP 8.4 deprecation fixer automatically after install and update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->