### PR TITLE
Add review-based automation templates

### DIFF
--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -63,6 +63,7 @@ class Registry {
       'abandoned-cart' => new AutomationTemplateCategory('abandoned-cart', __('Abandoned Cart', 'mailpoet')),
       'reengagement' => new AutomationTemplateCategory('reengagement', __('Re-engagement', 'mailpoet')),
       'woocommerce' => new AutomationTemplateCategory('woocommerce', __('WooCommerce', 'mailpoet')),
+      'review' => new AutomationTemplateCategory('review', __('Review', 'mailpoet')),
     ];
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -73,7 +73,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );
@@ -102,7 +102,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );
@@ -124,7 +124,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 2,
+        'automationSteps' => 2, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );
@@ -146,7 +146,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 2,
+        'automationSteps' => 2, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );
@@ -193,7 +193,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );
@@ -215,7 +215,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );
@@ -237,7 +237,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 4,
+        'automationSteps' => 4, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );
@@ -268,7 +268,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );
@@ -290,7 +290,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 5,
+        'automationSteps' => 5, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );
@@ -323,7 +323,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );
@@ -356,7 +356,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );
@@ -389,7 +389,7 @@ class TemplatesFactory {
         );
       },
       [
-        'automationSteps' => 1,
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
     );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -45,6 +45,7 @@ class TemplatesFactory {
       $templates[] = $this->createPurchasedProductTemplate();
       $templates[] = $this->createPurchasedProductWithTagTemplate();
       $templates[] = $this->createPurchasedInCategoryTemplate();
+      $templates[] = $this->createAskForReviewTemplate();
     }
 
     return $templates;
@@ -392,6 +393,28 @@ class TemplatesFactory {
         'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_DEFAULT
+    );
+  }
+
+  private function createAskForReviewTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'ask-for-review',
+      'review',
+      __('Ask to leave a review post-purchase', 'mailpoet'),
+      __(
+        'Encourage your customers to leave a review a few days after their purchase. Show them their opinion matters.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Ask to leave a review post-purchase', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 2, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
     );
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -46,6 +46,7 @@ class TemplatesFactory {
       $templates[] = $this->createPurchasedProductWithTagTemplate();
       $templates[] = $this->createPurchasedInCategoryTemplate();
       $templates[] = $this->createAskForReviewTemplate();
+      $templates[] = $this->createFollowUpPositiveReviewTemplate();
     }
 
     return $templates;
@@ -413,6 +414,28 @@ class TemplatesFactory {
       },
       [
         'automationSteps' => 2, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpPositiveReviewTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-positive-review',
+      'review',
+      __('Follow up on a positive review (4-5 stars)', 'mailpoet'),
+      __(
+        'Thank your happy customers for their feedback and let them know you appreciate their support.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up on a positive review (4-5 stars)', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -47,6 +47,7 @@ class TemplatesFactory {
       $templates[] = $this->createPurchasedInCategoryTemplate();
       $templates[] = $this->createAskForReviewTemplate();
       $templates[] = $this->createFollowUpPositiveReviewTemplate();
+      $templates[] = $this->createFollowUpNegativeReviewTemplate();
     }
 
     return $templates;
@@ -431,6 +432,28 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Follow up on a positive review (4-5 stars)', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpNegativeReviewTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-negative-review',
+      'review',
+      __('Follow up on a negative review (1-2 stars)', 'mailpoet'),
+      __(
+        'Reach out to unhappy customers and show you care. Offer help or gather more feedback to improve.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up on a negative review (1-2 stars)', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -15,7 +15,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(12, $result['data']);
+    $this->assertCount(15, $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -23,7 +23,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(12, $data['data']);
+    $this->assertCount(15, $data['data']);
   }
 
   public function testGuestNotAllowed(): void {


### PR DESCRIPTION
## Description

Three new premium templates to ask for a review and follow up on positive or negative ones. In the free plugin, these are just placeholders.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/969

## Linked tickets

STOMAIL-7352

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7352-template-reviews-automations)

_The latest successful build from `stomail-7352-template-reviews-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Review" category for automation templates.
  * Added three new automation templates for customer reviews: request a review, follow up on positive reviews, and follow up on negative reviews.

* **Other**
  * Updated template step descriptions for improved clarity (no functional changes).
  * Increased the number of available automation templates visible in the system from 12 to 15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->