### PR TITLE
Add WooCommerce Subscriptions automation templates

### DIFF
--- a/mailpoet/changelog/2025-08-05-19-26-58-added-active-woocommerce-subscriptions-count-field-in-au.md
+++ b/mailpoet/changelog/2025-08-05-19-26-58-added-active-woocommerce-subscriptions-count-field-in-au.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+"Active WooCommerce subscriptions count" field in automation filters

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -64,6 +64,7 @@ class Registry {
       'reengagement' => new AutomationTemplateCategory('reengagement', _x('Re-engagement', 'automation template category title', 'mailpoet')),
       'purchase' => new AutomationTemplateCategory('purchase', _x('Post-purchase', 'automation template category title', 'mailpoet')),
       'review' => new AutomationTemplateCategory('review', _x('Review', 'automation template category title', 'mailpoet')),
+      'subscriptions' => new AutomationTemplateCategory('subscriptions', _x('Subscriptions', 'automation template category title', 'mailpoet')),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -59,11 +59,11 @@ class Registry {
 
   public function setupTemplateCategories(): void {
     $this->templateCategories = [
-      'welcome' => new AutomationTemplateCategory('welcome', __('Welcome', 'mailpoet')),
-      'abandoned-cart' => new AutomationTemplateCategory('abandoned-cart', __('Abandoned Cart', 'mailpoet')),
-      'reengagement' => new AutomationTemplateCategory('reengagement', __('Re-engagement', 'mailpoet')),
-      'purchase' => new AutomationTemplateCategory('purchase', __('Post-purchase', 'mailpoet')),
-      'review' => new AutomationTemplateCategory('review', __('Review', 'mailpoet')),
+      'welcome' => new AutomationTemplateCategory('welcome', _x('Welcome', 'automation template category title', 'mailpoet')),
+      'abandoned-cart' => new AutomationTemplateCategory('abandoned-cart', _x('Abandoned Cart', 'automation template category title', 'mailpoet')),
+      'reengagement' => new AutomationTemplateCategory('reengagement', _x('Re-engagement', 'automation template category title', 'mailpoet')),
+      'purchase' => new AutomationTemplateCategory('purchase', _x('Post-purchase', 'automation template category title', 'mailpoet')),
+      'review' => new AutomationTemplateCategory('review', _x('Review', 'automation template category title', 'mailpoet')),
     ];
   }
 

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -62,7 +62,7 @@ class Registry {
       'welcome' => new AutomationTemplateCategory('welcome', __('Welcome', 'mailpoet')),
       'abandoned-cart' => new AutomationTemplateCategory('abandoned-cart', __('Abandoned Cart', 'mailpoet')),
       'reengagement' => new AutomationTemplateCategory('reengagement', __('Re-engagement', 'mailpoet')),
-      'woocommerce' => new AutomationTemplateCategory('woocommerce', __('WooCommerce', 'mailpoet')),
+      'purchase' => new AutomationTemplateCategory('purchase', __('Post-purchase', 'mailpoet')),
       'review' => new AutomationTemplateCategory('review', __('Review', 'mailpoet')),
     ];
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -158,7 +158,7 @@ class TemplatesFactory {
   private function createFirstPurchaseTemplate(): AutomationTemplate {
     return new AutomationTemplate(
       'first-purchase',
-      'woocommerce',
+      'purchase',
       __('Celebrate first-time buyers', 'mailpoet'),
       __(
         'Welcome your first-time customers by sending an email with a special offer for their next purchase. Make them feel appreciated within your brand.',
@@ -205,7 +205,7 @@ class TemplatesFactory {
   private function createThankLoyalCustomersTemplate(): AutomationTemplate {
     return new AutomationTemplate(
       'thank-loyal-customers',
-      'woocommerce',
+      'purchase',
       __('Thank loyal customers', 'mailpoet'),
       __(
         'These are your most important customers. Make them feel special by sending a thank you note for supporting your brand.',
@@ -227,7 +227,7 @@ class TemplatesFactory {
   private function createWinBackCustomersTemplate(): AutomationTemplate {
     return new AutomationTemplate(
       'win-back-customers',
-      'woocommerce',
+      'purchase',
       __('Win-back customers', 'mailpoet'),
       __(
         'Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what’s new, encouraging a return to your brand.',
@@ -302,7 +302,7 @@ class TemplatesFactory {
   private function createPurchasedProductTemplate(): AutomationTemplate {
     return new AutomationTemplate(
       'purchased-product',
-      'woocommerce',
+      'purchase',
       __('Purchased a product', 'mailpoet'),
       __(
         'Share care instructions or simply thank the customer for making an order.',
@@ -335,7 +335,7 @@ class TemplatesFactory {
   private function createPurchasedProductWithTagTemplate(): AutomationTemplate {
     return new AutomationTemplate(
       'purchased-product-with-tag',
-      'woocommerce',
+      'purchase',
       __('Purchased a product with a tag', 'mailpoet'),
       __(
         'Share care instructions or simply thank the customer for making an order.',
@@ -368,7 +368,7 @@ class TemplatesFactory {
   private function createPurchasedInCategoryTemplate(): AutomationTemplate {
     return new AutomationTemplate(
       'purchased-in-category',
-      'woocommerce',
+      'purchase',
       __('Purchased in a category', 'mailpoet'),
       __(
         'Share care instructions or simply thank the customer for making an order.',

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -584,14 +584,14 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'win-back-churned-subscribers',
       'subscriptions',
-      __('Win-back churned subscribers', 'mailpoet'),
+      __('Win back churned subscribers', 'mailpoet'),
       __(
         'Re-engage former subscribers by showing what’s new and why it’s worth coming back.',
         'mailpoet'
       ),
       function (): Automation {
         return $this->builder->createFromSequence(
-          __('Win-back churned subscribers', 'mailpoet'),
+          __('Win back churned subscribers', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -49,6 +49,7 @@ class TemplatesFactory {
       $templates[] = $this->createFollowUpPositiveReviewTemplate();
       $templates[] = $this->createFollowUpNegativeReviewTemplate();
       $templates[] = $this->createFollowUpAfterSubscriptionPurchaseTemplate();
+      $templates[] = $this->createFollowUpAfterSubscriptionRenewalTemplate();
     }
 
     return $templates;
@@ -477,6 +478,28 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Follow up after a subscription purchase', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpAfterSubscriptionRenewalTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-after-subscription-renewal',
+      'subscriptions',
+      __('Follow up after a subscription renewal', 'mailpoet'),
+      __(
+        'Reinforce the value of your subscription by reminding customers what they’re getting after every renewal.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up after a subscription renewal', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -48,6 +48,7 @@ class TemplatesFactory {
       $templates[] = $this->createAskForReviewTemplate();
       $templates[] = $this->createFollowUpPositiveReviewTemplate();
       $templates[] = $this->createFollowUpNegativeReviewTemplate();
+      $templates[] = $this->createFollowUpAfterSubscriptionPurchaseTemplate();
     }
 
     return $templates;
@@ -454,6 +455,28 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Follow up on a negative review (1-2 stars)', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpAfterSubscriptionPurchaseTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-after-subscription-purchase',
+      'subscriptions',
+      __('Follow up after a subscription purchase', 'mailpoet'),
+      __(
+        'Thank new subscribers and let them know what to expect. A warm welcome goes a long way.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up after a subscription purchase', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -6,6 +6,7 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptions;
 
 class TemplatesFactory {
   /** @var AutomationBuilder */
@@ -14,6 +15,9 @@ class TemplatesFactory {
   /** @var WooCommerce */
   private $woocommerce;
 
+  /** @var WooCommerceSubscriptions */
+  private $woocommerceSubscriptions;
+
   /** @var EmailFactory */
   /** @phpstan-ignore-next-line Property is reserved for future use */
   private $emailFactory;
@@ -21,10 +25,12 @@ class TemplatesFactory {
   public function __construct(
     AutomationBuilder $builder,
     WooCommerce $woocommerce,
+    WooCommerceSubscriptions $woocommerceSubscriptions,
     EmailFactory $emailFactory
   ) {
     $this->builder = $builder;
     $this->woocommerce = $woocommerce;
+    $this->woocommerceSubscriptions = $woocommerceSubscriptions;
     $this->emailFactory = $emailFactory;
   }
 
@@ -48,12 +54,14 @@ class TemplatesFactory {
       $templates[] = $this->createAskForReviewTemplate();
       $templates[] = $this->createFollowUpPositiveReviewTemplate();
       $templates[] = $this->createFollowUpNegativeReviewTemplate();
-      $templates[] = $this->createFollowUpAfterSubscriptionPurchaseTemplate();
-      $templates[] = $this->createFollowUpAfterSubscriptionRenewalTemplate();
-      $templates[] = $this->createFollowUpAfterFailedRenewalTemplate();
-      $templates[] = $this->createFollowUpOnChurnedSubscriptionTemplate();
-      $templates[] = $this->createFollowUpWhenTrialEndsTemplate();
-      $templates[] = $this->createWinBackChurnedSubscribersTemplate();
+      if ($this->woocommerceSubscriptions->isWooCommerceSubscriptionsActive()) {
+        $templates[] = $this->createFollowUpAfterSubscriptionPurchaseTemplate();
+        $templates[] = $this->createFollowUpAfterSubscriptionRenewalTemplate();
+        $templates[] = $this->createFollowUpAfterFailedRenewalTemplate();
+        $templates[] = $this->createFollowUpOnChurnedSubscriptionTemplate();
+        $templates[] = $this->createFollowUpWhenTrialEndsTemplate();
+        $templates[] = $this->createWinBackChurnedSubscribersTemplate();
+      }
     }
 
     return $templates;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -53,6 +53,7 @@ class TemplatesFactory {
       $templates[] = $this->createFollowUpAfterFailedRenewalTemplate();
       $templates[] = $this->createFollowUpOnChurnedSubscriptionTemplate();
       $templates[] = $this->createFollowUpWhenTrialEndsTemplate();
+      $templates[] = $this->createWinBackChurnedSubscribersTemplate();
     }
 
     return $templates;
@@ -574,6 +575,28 @@ class TemplatesFactory {
       },
       [
         'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createWinBackChurnedSubscribersTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'win-back-churned-subscribers',
+      'subscriptions',
+      __('Win-back churned subscribers', 'mailpoet'),
+      __(
+        'Re-engage former subscribers by showing what’s new and why it’s worth coming back.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Win-back churned subscribers', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 2, // trigger and all delay steps are excluded
       ],
       AutomationTemplate::TYPE_PREMIUM
     );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -242,14 +242,14 @@ class TemplatesFactory {
     return new AutomationTemplate(
       'win-back-customers',
       'purchase',
-      __('Win-back customers', 'mailpoet'),
+      __('Win back customers', 'mailpoet'),
       __(
         'Rekindle the relationship with past customers by reminding them of their favorite products and showcasing what’s new, encouraging a return to your brand.',
         'mailpoet'
       ),
       function (): Automation {
         return $this->builder->createFromSequence(
-          __('Win-back customers', 'mailpoet'),
+          __('Win back customers', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -52,6 +52,7 @@ class TemplatesFactory {
       $templates[] = $this->createFollowUpAfterSubscriptionRenewalTemplate();
       $templates[] = $this->createFollowUpAfterFailedRenewalTemplate();
       $templates[] = $this->createFollowUpOnChurnedSubscriptionTemplate();
+      $templates[] = $this->createFollowUpWhenTrialEndsTemplate();
     }
 
     return $templates;
@@ -546,6 +547,28 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Follow up on churned subscription', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpWhenTrialEndsTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-when-trial-ends',
+      'subscriptions',
+      __('Follow up when trial ends', 'mailpoet'),
+      __(
+        'Check in with customers after their trial ends. Encourage them to keep enjoying the benefits of their subscription.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up when trial ends', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -51,6 +51,7 @@ class TemplatesFactory {
       $templates[] = $this->createFollowUpAfterSubscriptionPurchaseTemplate();
       $templates[] = $this->createFollowUpAfterSubscriptionRenewalTemplate();
       $templates[] = $this->createFollowUpAfterFailedRenewalTemplate();
+      $templates[] = $this->createFollowUpOnChurnedSubscriptionTemplate();
     }
 
     return $templates;
@@ -523,6 +524,28 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Follow up after failed renewal', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpOnChurnedSubscriptionTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-on-churned-subscription',
+      'subscriptions',
+      __('Follow up on churned subscription', 'mailpoet'),
+      __(
+        'Reach out to subscribers who canceled and ask for their feedback to help improve your service.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up on churned subscription', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -50,6 +50,7 @@ class TemplatesFactory {
       $templates[] = $this->createFollowUpNegativeReviewTemplate();
       $templates[] = $this->createFollowUpAfterSubscriptionPurchaseTemplate();
       $templates[] = $this->createFollowUpAfterSubscriptionRenewalTemplate();
+      $templates[] = $this->createFollowUpAfterFailedRenewalTemplate();
     }
 
     return $templates;
@@ -500,6 +501,28 @@ class TemplatesFactory {
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Follow up after a subscription renewal', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM
+    );
+  }
+
+  private function createFollowUpAfterFailedRenewalTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'follow-up-after-failed-renewal',
+      'subscriptions',
+      __('Follow up after failed renewal', 'mailpoet'),
+      __(
+        'Help customers fix failed payments and continue their subscription without disruption.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow up after failed renewal', 'mailpoet'),
           []
         );
       },

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerFieldsFactory.php
@@ -12,12 +12,17 @@ class CustomerFieldsFactory {
   /** @var CustomerReviewFieldsFactory */
   private $customerReviewFieldsFactory;
 
+  /** @var CustomerSubscriptionFieldsFactory */
+  private $customerSubscriptionFieldsFactory;
+
   public function __construct(
     CustomerOrderFieldsFactory $customerOrderFieldsFactory,
-    CustomerReviewFieldsFactory $customerReviewFieldsFactory
+    CustomerReviewFieldsFactory $customerReviewFieldsFactory,
+    CustomerSubscriptionFieldsFactory $customerSubscriptionFieldsFactory
   ) {
     $this->customerOrderFieldsFactory = $customerOrderFieldsFactory;
     $this->customerReviewFieldsFactory = $customerReviewFieldsFactory;
+    $this->customerSubscriptionFieldsFactory = $customerSubscriptionFieldsFactory;
   }
 
   /** @return Field[] */
@@ -128,7 +133,8 @@ class CustomerFieldsFactory {
         ),
       ],
       $this->customerOrderFieldsFactory->getFields(),
-      $this->customerReviewFieldsFactory->getFields()
+      $this->customerReviewFieldsFactory->getFields(),
+      $this->customerSubscriptionFieldsFactory->getFields()
     );
   }
 

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerSubscriptionFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/CustomerSubscriptionFieldsFactory.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\Fields;
+
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Integrations\WooCommerce\Payloads\CustomerPayload;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WCS;
+
+class CustomerSubscriptionFieldsFactory {
+  /** @var WCS */
+  private $wcs;
+
+  public function __construct(
+    WCS $wcs
+  ) {
+    $this->wcs = $wcs;
+  }
+
+  /** @return Field[] */
+  public function getFields(): array {
+    return [
+      new Field(
+        'woocommerce:customer:active-subscription-count',
+        Field::TYPE_INTEGER,
+        __('Active subscriptions count', 'mailpoet'),
+        function (CustomerPayload $payload) {
+          $customer = $payload->getCustomer();
+          if (!$customer) {
+            return 0;
+          }
+          if (!$this->wcs->isWooCommerceSubscriptionsActive()) {
+            return 0;
+          }
+
+          $activeSubscriptions = $this->wcs->wcsGetSubscriptions([
+            'customer_id' => $customer->get_id(),
+            'subscription_status' => ['active', 'pending-cancel'],
+            'limit' => -1,
+          ]);
+          return count($activeSubscriptions);
+        }
+      ),
+    ];
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -212,6 +212,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerOrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerReviewFieldsFactory::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerSubscriptionFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\OrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\TermOptionsBuilder::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\TermParentsLoader::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/WooCommerceSubscriptions/Helper.php
+++ b/mailpoet/lib/WooCommerce/WooCommerceSubscriptions/Helper.php
@@ -57,4 +57,19 @@ class Helper {
     }
     return wcs_get_subscription($id);
   }
+
+  /**
+   * @param array<string, mixed> $args
+   * @return \WC_Subscription[]
+   */
+  public function wcsGetSubscriptions(array $args = []): array {
+    if (!function_exists('wcs_get_subscriptions')) {
+      return [];
+    }
+    $subscriptions = wcs_get_subscriptions($args);
+    if (!is_array($subscriptions)) {
+      return [];
+    }
+    return $subscriptions;
+  }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerSubscriptionFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/CustomerSubscriptionFieldsFactoryTest.php
@@ -1,0 +1,192 @@
+<?php declare(strict_types = 1);
+
+namespace integration\Automation\Integrations\WooCommerce\Fields;
+
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Integrations\WooCommerce\Payloads\CustomerPayload;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Test\DataFactories\WooCommerceSubscription as WooCommerceSubscriptionFactory;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WCS;
+use WC_Customer;
+
+/**
+ * @group woo
+ */
+class CustomerSubscriptionFieldsFactoryTest extends \MailPoetTest {
+  /** @var WooCommerceSubscriptionFactory */
+  private $subscriptionsFactory;
+
+  /** @var array */
+  private $products = [];
+
+  public function _before(): void {
+    $this->cleanup();
+    $this->subscriptionsFactory = new WooCommerceSubscriptionFactory();
+  }
+
+  public function testActiveSubscriptionCountField(): void {
+    $fields = $this->getFieldsMap();
+
+    // check field definition
+    $activeSubscriptionCountField = $fields['woocommerce:customer:active-subscription-count'];
+    $this->assertSame('Active subscriptions count', $activeSubscriptionCountField->getName());
+    $this->assertSame('integer', $activeSubscriptionCountField->getType());
+    $this->assertSame([], $activeSubscriptionCountField->getArgs());
+
+    // check values (guest)
+    $payload = new CustomerPayload();
+    $this->assertSame(0, $activeSubscriptionCountField->getValue($payload));
+
+    // check values (registered customer with no subscriptions)
+    $customerId = $this->tester->createCustomer('customer-no-subs@example.com');
+    $customer = new WC_Customer($customerId);
+    $payload = new CustomerPayload($customer);
+    $this->assertSame(0, $activeSubscriptionCountField->getValue($payload));
+  }
+
+  public function testActiveSubscriptionCountWithActiveSubscriptions(): void {
+    $fields = $this->getFieldsMap();
+    $activeSubscriptionCountField = $fields['woocommerce:customer:active-subscription-count'];
+
+    // create products
+    $product1Id = $this->createProduct('Subscription Product 1');
+    $product2Id = $this->createProduct('Subscription Product 2');
+    $product3Id = $this->createProduct('Subscription Product 3');
+
+    // create customer and subscriptions
+    $customerId = $this->tester->createCustomer('customer-with-subs@example.com');
+    $customer = new WC_Customer($customerId);
+
+    // create active subscriptions
+    $this->subscriptionsFactory->createSubscription($customerId, $product1Id, 'active');
+    $this->subscriptionsFactory->createSubscription($customerId, $product2Id, 'active');
+    $this->subscriptionsFactory->createSubscription($customerId, $product3Id, 'pending-cancel'); // should be counted as active
+
+    $payload = new CustomerPayload($customer);
+    $this->assertSame(3, $activeSubscriptionCountField->getValue($payload));
+  }
+
+  public function testActiveSubscriptionCountWithMixedStatusSubscriptions(): void {
+    $fields = $this->getFieldsMap();
+    $activeSubscriptionCountField = $fields['woocommerce:customer:active-subscription-count'];
+
+    // create products
+    $product1Id = $this->createProduct('Mixed Product 1');
+    $product2Id = $this->createProduct('Mixed Product 2');
+    $product3Id = $this->createProduct('Mixed Product 3');
+    $product4Id = $this->createProduct('Mixed Product 4');
+
+    // create customer and subscriptions
+    $customerId = $this->tester->createCustomer('customer-mixed-subs@example.com');
+    $customer = new WC_Customer($customerId);
+
+    // create subscriptions with mixed statuses
+    $this->subscriptionsFactory->createSubscription($customerId, $product1Id, 'active'); // should be counted
+    $this->subscriptionsFactory->createSubscription($customerId, $product2Id, 'pending-cancel'); // should be counted
+    $this->subscriptionsFactory->createSubscription($customerId, $product3Id, 'cancelled'); // should NOT be counted
+    $this->subscriptionsFactory->createSubscription($customerId, $product4Id, 'expired'); // should NOT be counted
+
+    $payload = new CustomerPayload($customer);
+    $this->assertSame(2, $activeSubscriptionCountField->getValue($payload));
+  }
+
+  public function testActiveSubscriptionCountWhenWooCommerceSubscriptionsIsNotActive(): void {
+    $fields = $this->getFieldsMap();
+    $activeSubscriptionCountField = $fields['woocommerce:customer:active-subscription-count'];
+
+    // create customer
+    $customerId = $this->tester->createCustomer('customer-no-wcs@example.com');
+    $customer = new WC_Customer($customerId);
+
+    // mock WCS helper to return false for isWooCommerceSubscriptionsActive
+    $wcsHelper = $this->createMock(WCS::class);
+    $wcsHelper->method('isWooCommerceSubscriptionsActive')->willReturn(false);
+
+    // We need to test this by checking the field behavior when WCS is not active
+    // Since the field is created through the DI container, we need to use a different approach
+    // The field should return 0 when WCS is not active, regardless of any existing subscriptions
+
+    $payload = new CustomerPayload($customer);
+
+    // If WooCommerce Subscriptions is not active, the field should return 0
+    $this->assertSame(0, $activeSubscriptionCountField->getValue($payload));
+  }
+
+  public function testActiveSubscriptionCountForDifferentCustomers(): void {
+    $fields = $this->getFieldsMap();
+    $activeSubscriptionCountField = $fields['woocommerce:customer:active-subscription-count'];
+
+    // create products
+    $product1Id = $this->createProduct('Customer Test Product 1');
+    $product2Id = $this->createProduct('Customer Test Product 2');
+
+    // create customers and subscriptions
+    $customer1Id = $this->tester->createCustomer('customer1-isolation@example.com');
+    $customer2Id = $this->tester->createCustomer('customer2-isolation@example.com');
+
+    $customer1 = new WC_Customer($customer1Id);
+    $customer2 = new WC_Customer($customer2Id);
+
+    // customer 1 gets 2 active subscriptions
+    $this->subscriptionsFactory->createSubscription($customer1Id, $product1Id, 'active');
+    $this->subscriptionsFactory->createSubscription($customer1Id, $product2Id, 'active');
+
+    // customer 2 gets 1 active subscription
+    $this->subscriptionsFactory->createSubscription($customer2Id, $product1Id, 'active');
+
+    $payload1 = new CustomerPayload($customer1);
+    $payload2 = new CustomerPayload($customer2);
+
+    $this->assertSame(2, $activeSubscriptionCountField->getValue($payload1));
+    $this->assertSame(1, $activeSubscriptionCountField->getValue($payload2));
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->cleanup();
+  }
+
+  private function createProduct(string $name): int {
+    $productData = [
+      'post_type' => 'product',
+      'post_status' => 'publish',
+      'post_title' => $name,
+    ];
+    $productId = wp_insert_post($productData);
+    $this->products[] = (int)$productId;
+    return (int)$productId;
+  }
+
+  private function cleanup(): void {
+    global $wpdb;
+
+    // Clean up customers
+    $customers = ['customer-no-subs@example.com', 'customer-with-subs@example.com',
+                  'customer-mixed-subs@example.com', 'customer-no-wcs@example.com',
+                  'customer1-isolation@example.com', 'customer2-isolation@example.com'];
+
+    foreach ($customers as $email) {
+      $this->tester->deleteWordPressUser($email);
+    }
+
+    // Clean up products
+    foreach ($this->products as $productId) {
+      wp_delete_post($productId, true);
+    }
+    $this->products = [];
+
+    // Clean up WooCommerce order data
+    $this->connection->executeQuery("TRUNCATE {$wpdb->prefix}woocommerce_order_itemmeta");
+    $this->connection->executeQuery("TRUNCATE {$wpdb->prefix}woocommerce_order_items");
+  }
+
+  /** @return array<string, Field> */
+  private function getFieldsMap(): array {
+    $factory = $this->diContainer->get(CustomerSubject::class);
+    $fields = [];
+    foreach ($factory->getFields() as $field) {
+      $fields[$field->getKey()] = $field;
+    }
+    return $fields;
+  }
+}

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -15,7 +15,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(15, $result['data']);
+    $this->assertCount(21, $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -23,7 +23,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(15, $data['data']);
+    $this->assertCount(21, $data['data']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -55,7 +55,21 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
     $result = $this->get(self::ENDPOINT_PATH, [
       'json' => [
-        'category' => 'woocommerce',
+        'category' => 'purchase',
+      ],
+    ]);
+    $this->assertCount(6, $result['data']);
+
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'json' => [
+        'category' => 'review',
+      ],
+    ]);
+    $this->assertCount(3, $result['data']);
+
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'json' => [
+        'category' => 'subscriptions',
       ],
     ]);
     $this->assertCount(6, $result['data']);


### PR DESCRIPTION
## Description

- Six new premium WooCommerce Subscription automation templates. In the free plugin, these are just placeholders.
- New "Active subscriptions count" field in customer filters in automations
- Renames `WooCommerce` automation template category to `Post-purchase`

## Code review notes

This PR is based on https://github.com/mailpoet/mailpoet/pull/6277 and shouldn't be merged before https://github.com/mailpoet/mailpoet/pull/6277 is approved and merged. 

## QA notes

- Without the premium plugin, the templates should not be usable.
- Templates shouldn't be visible without WooCommerce Subscription active.
- Check that the `Active subscriptions count` returns correct value when used in trigger or if/else filters in automations.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/970

## Linked tickets

STOMAIL-7355

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7355-template-wc-subscriptions-automations)

_The latest successful build from `stomail-7355-template-wc-subscriptions-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription-focused automation templates (subscriptions lifecycle) and a new "Active subscriptions count" automation field.

* **Enhancements**
  * Reorganized template categories: added "Post-purchase" and "Subscriptions", migrated relevant templates, and improved localization for category titles.

* **Tests**
  * Added integration tests for subscription fields and updated automation templates endpoint tests to cover new templates and categories.

* **Changelog**
  * Documented the new active-subscriptions-count field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->