### PR TITLE
Fix failing nightly tests

### DIFF
--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -635,10 +635,14 @@ class Functions {
   }
 
   public function wpRemoteGet($url, array $args = []) {
+    // We only use wp_remote_get with safe hardcoded URLs
+    // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.ssrf
     return wp_remote_get($url, $args);
   }
 
   public function wpRemotePost($url, array $args = []) {
+    // We only use wp_remote_post with safe hardcoded URLs
+    // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.ssrf
     return wp_remote_post($url, $args);
   }
 

--- a/mailpoet/prefixer/fix-doctrine.php
+++ b/mailpoet/prefixer/fix-doctrine.php
@@ -13,8 +13,10 @@ foreach ($files as $file) {
     $data = file_get_contents($file);
     $data = str_replace('\'Doctrine\\\\', '\'MailPoetVendor\\\\Doctrine\\\\', $data);
     $data = str_replace('"Doctrine\\\\', '"MailPoetVendor\\\\Doctrine\\\\', $data);
-    $data = str_replace('\'Doctrine\\', '\'MailPoetVendor\\Doctrine\\', $data);
-    $data = str_replace('"Doctrine\\', '"MailPoetVendor\\Doctrine\\', $data);
+    if (version_compare(PHP_VERSION, '8.4.0', '>=')) {
+      $data = str_replace('\'Doctrine\\', '\'MailPoetVendor\\Doctrine\\', $data);
+      $data = str_replace('"Doctrine\\', '"MailPoetVendor\\Doctrine\\', $data);
+    }
     $data = str_replace(' \\Doctrine\\', ' \\MailPoetVendor\\Doctrine\\', $data);
     $data = str_replace('* @var array<\\Doctrine\\', '* @var array<\\MailPoetVendor\\Doctrine\\', $data);
     file_put_contents($file, $data);

--- a/mailpoet/tasks/FixPhp84Deprecations.php
+++ b/mailpoet/tasks/FixPhp84Deprecations.php
@@ -20,6 +20,11 @@ class FixPhp84Deprecations {
   ];
 
   public function run(): void {
+    // Only run on PHP 8.4
+    if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+      return;
+    }
+
     foreach ($this->vendorDirectories as $vendorDir) {
       if (is_dir($vendorDir)) {
         $this->processDirectory($vendorDir);

--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -1,15 +1,21 @@
 <?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 
-$composerVersion = '2.8.10';
-$phpScoperVersion = '0.18.17';
-$tracyVersion = '2.10.9'; // 2.10.10 causes SyntaxError in JS
 
-// The newer versions drop support for PHP 7.4 and PHP-Scoper also drops 8.1 which we still
-// support in tests and also in development environment.
-if (PHP_VERSION_ID < 80200) {
-  $composerVersion = '2.7.7';
-  $phpScoperVersion = '0.17.2';
-  $tracyVersion = '2.9.4';
+// Tools versions for PHP 7.4+
+$composerVersion = '2.7.7';
+$phpScoperVersion = '0.17.2';
+$tracyVersion = '2.9.4';
+
+// Tools versions for PHP 8.0+
+if (PHP_VERSION_ID >= 80000) {
+  $tracyVersion = '2.9.7'; // Tracy 2.9.4 doesn't support PHP 7.4
+}
+
+// Tools versions for PHP 8.4+
+if (PHP_VERSION_ID >= 80400) {
+  $composerVersion = '2.8.10';
+  $phpScoperVersion = '0.18.17';
+  $tracyVersion = '2.10.9'; // 2.10.10 causes SyntaxError in JS
 }
 
 $tools = [


### PR DESCRIPTION
## Description

Caused by https://github.com/mailpoet/mailpoet/pull/6275. Changes in this PR:
- Load Tracy 2.9.4 only in PHP 7.4 and Tracy 2.9.7 in PHP 8.0-8.3
- Load the latest Composer and PHP-Scoper only in PHP 8.4+
- Run PHP 8.4 fixes only in PHP 8.4+
- Fix security analysis issue

## Code review notes

_N/A_

## QA notes

[Successful nightly run](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21176/workflows/90d67c9e-f675-408e-bf37-9afea418b0d3).

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7516

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7516-failing-nightly-tests-due-to-php-84-changes)

_The latest successful build from `stomail-7516-failing-nightly-tests-due-to-php-84-changes` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal comments and security annotations for improved clarity and suppressed unnecessary security warnings.
  * Refined version checks and conditional logic to better support PHP 8.4+ across various scripts.
  * Adjusted tool version assignments to incrementally match PHP version requirements for improved compatibility.
* **Bug Fixes**
  * Ensured deprecation fixes and namespace replacements only run on supported PHP versions, preventing issues on older versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->