### PR TITLE
Fix failing tests

### DIFF
--- a/mailpoet/prefixer/fix-carbon.php
+++ b/mailpoet/prefixer/fix-carbon.php
@@ -47,8 +47,11 @@ $replacements = [
     'replace' => [
       '',
     ],
-  ],
-  [
+  ]
+];
+
+if (PHP_VERSION_ID >= 80400) {
+  $replacements[] = [
     'file' => '../vendor-prefixed/nesbot/carbon/src/Carbon/Traits/Timestamp.php',
     'find' => [
       'public static function createFromTimestamp($timestamp, $tz = null)',
@@ -56,8 +59,8 @@ $replacements = [
     'replace' => [
       '#[\ReturnTypeWillChange]' . PHP_EOL . 'public static function createFromTimestamp($timestamp, $tz = null)',
     ],
-  ],
-];
+  ];
+}
 
 foreach ($replacements as $singleFile) {
   $data = file_get_contents($singleFile['file']);

--- a/mailpoet/tasks/FixPhp84Deprecations.php
+++ b/mailpoet/tasks/FixPhp84Deprecations.php
@@ -13,6 +13,12 @@ use RecursiveIteratorIterator;
  * but are not explicitly marked as nullable with the ? prefix.
  */
 
+ // exit for php versions less than 8.4
+if (PHP_VERSION_ID < 80400) {
+  echo 'PHP version less than 8.4, exiting...';
+  exit;
+}
+
 class FixPhp84Deprecations {
   private array $vendorDirectories = [
     'vendor',


### PR DESCRIPTION
## Description

Ensure we check for the PHP version before updating files.

Related to https://github.com/mailpoet/mailpoet/pull/6275

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/6275

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with PHP 8.4.0 and above by conditionally applying updates for newer versions.
* **Bug Fixes**
  * Prevented script execution on unsupported PHP versions, displaying a clear message and exiting when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->