### PR TITLE
STOMAIL-7511: Use WooCommerce fine‑grained GitHub token for WooCommerce downloads in CI and tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
                 name: Download WooCommerce Core
                 command: |
                   cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -476,7 +476,7 @@ jobs:
                 name: Download WooCommerce Subscriptions
                 command: |
                   cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -484,7 +484,7 @@ jobs:
                 name: Download AutomateWoo
                 command: |
                   cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_acceptance
+                  docker compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_acceptance
       - run:
           name: Group acceptance tests
           command: |
@@ -753,7 +753,7 @@ jobs:
                 name: Download WooCommerce Core
                 command: |
                   cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_integration
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -761,7 +761,7 @@ jobs:
                 name: Download WooCommerce Subscriptions
                 command: |
                   cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-subscriptions-zip << parameters.woo_subscriptions_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_integration
       - when:
           condition: << parameters.automate_woo_version >>
           steps:
@@ -769,7 +769,7 @@ jobs:
                 name: Download AutomateWoo
                 command: |
                   cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_TOKEN=${WP_GITHUB_TOKEN} codeception_integration
+                  docker compose run --rm -w /project --entrypoint "./do download:automate-woo-zip << parameters.automate_woo_version >>" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_integration
       - run:
           name: 'PHP Integration tests'
           command: |

--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -118,10 +118,21 @@ function replacePrivatePluginVersion(
   string $configParameterName,
   string $versionsFilename
 ): void {
-// Read the GitHub token from environment variable
-  $token = getenv('GH_TOKEN');
+  // Read the GitHub token from environment variable. Set at https://github.com/mailpoet/mailpoet/settings/secrets/actions.
+
+  // If the repository is woocommerce, use the WooCommerce token, otherwise use the general token.
+  $isWooCommerceRepository = strpos($repository, 'woocommerce/') !== false;
+  if ($isWooCommerceRepository) {
+    $token = getenv('WP_GITHUB_WOOCOMMERCE_TOKEN');
+  } else {
+    $token = getenv('WP_GITHUB_TOKEN');
+  }
   if (!$token) {
-    die("GitHub token not found. Make sure it's set in the environment variable 'GH_TOKEN'.");
+    if ($isWooCommerceRepository) {
+      die("WooCommerce token not found. For WooCommerce repositories requests, make sure to set the token in the environment variable 'WP_GITHUB_WOOCOMMERCE_TOKEN'.");
+    } else {
+      die("GitHub token not found. Make sure it's set in the environment variable 'WP_GITHUB_TOKEN'.");
+    }
   }
 
   $page = 1;

--- a/mailpoet/.env.sample
+++ b/mailpoet/.env.sample
@@ -34,6 +34,9 @@ WP_CIRCLECI_TOKEN=
 WP_GITHUB_USERNAME=
 WP_GITHUB_TOKEN=
 
+# GitHub fine-grained token for the WooCommerce organization. Fetch it from the Secret Store by searching for "MailPoet: GitHub MailPoet CI - WooCommerce token".
+WP_GITHUB_WOOCOMMERCE_TOKEN=
+
 # k6 performance test suite
 # Get following secrets from the Secret Store, look for "MailPoet: plugin .env":
 WP_TEST_PERFORMANCE_DATA_URL=

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1311,29 +1311,33 @@ class RoboFile extends \Robo\Tasks {
   }
 
   public function downloadWooCommerceMembershipsZip(): void {
-    if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
+    $token = getenv('WP_GITHUB_WOOCOMMERCE_TOKEN');
+    if (!getenv('WP_GITHUB_USERNAME') && !$token) {
       $this->yell("Skipping download of WooCommerce Memberships", 40, 'red');
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
-    $this->createGithubClient('woocommerce/all-plugins')
+    $this->createGithubClient('woocommerce/all-plugins', $token)
       ->downloadRawFile('https://api.github.com/repos/woocommerce/all-plugins/contents/product-packages/woocommerce-memberships/woocommerce-memberships.zip?ref=master', 'woocommerce-memberships.zip', __DIR__ . '/tests/plugins/');
   }
 
   public function downloadWooCommerceSubscriptionsZip($tag = null) {
-    if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
+    $token = getenv('WP_GITHUB_WOOCOMMERCE_TOKEN');
+    if (!getenv('WP_GITHUB_USERNAME') && !$token) {
       $this->yell("Skipping download of WooCommerce Subscriptions", 40, 'red');
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
-    $this->createGithubClient('woocommerce/woocommerce-subscriptions')
+
+    $this->createGithubClient('woocommerce/woocommerce-subscriptions', $token)
       ->downloadReleaseZip('woocommerce-subscriptions.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
   public function downloadAutomateWooZip($tag = null) {
-    if (!getenv('WP_GITHUB_USERNAME') && !getenv('WP_GITHUB_TOKEN')) {
+    $token = getenv('WP_GITHUB_WOOCOMMERCE_TOKEN');
+    if (!getenv('WP_GITHUB_USERNAME') && !$token) {
       $this->yell("Skipping download of Automate Woo", 40, 'red');
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
-    $this->createGithubClient('woocommerce/automatewoo')
+    $this->createGithubClient('woocommerce/automatewoo', $token)
       ->downloadReleaseZip('automatewoo.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
@@ -1489,11 +1493,12 @@ class RoboFile extends \Robo\Tasks {
     );
   }
 
-  protected function createGitHubController($project = \MailPoetTasks\Release\GitHubController::PROJECT_MAILPOET) {
+  protected function createGitHubController($project = \MailPoetTasks\Release\GitHubController::PROJECT_MAILPOET, $token = null) {
     $help = "Use your GitHub username and a token from https://github.com/settings/tokens with 'repo' scopes.";
+    $token = $token ?: $this->getEnv('WP_GITHUB_TOKEN', $help);
     return new \MailPoetTasks\Release\GitHubController(
       $this->getEnv('WP_GITHUB_USERNAME', $help),
-      $this->getEnv('WP_GITHUB_TOKEN', $help),
+      $token,
       $project
     );
   }
@@ -1530,12 +1535,13 @@ class RoboFile extends \Robo\Tasks {
     return $exitCode;
   }
 
-  private function createGithubClient($repositoryName) {
+  private function createGithubClient($repositoryName, $token = null) {
     require_once __DIR__ . '/tasks/GithubClient.php';
+    $token = $token ?: $this->getEnv('WP_GITHUB_TOKEN');
     return new \MailPoetTasks\GithubClient(
       $repositoryName,
       getenv('WP_GITHUB_USERNAME') ?: null,
-      getenv('WP_GITHUB_TOKEN') ?: null
+      $token
     );
   }
 


### PR DESCRIPTION
## Description

Why: WooCommerce private repositories now require a fine‑grained token scoped to the woocommerce organization. Using the general token as of September will lead to download failures in CI and local tooling. This change isolates WooCommerce access to a dedicated token, aligning with least-privilege and restoring reliable downloads for tests and local dev.

What:
* `.circleci/config.yml`: Replace `WP_GITHUB_TOKEN` with `WP_GITHUB_WOOCOMMERCE_TOKEN` for steps that download WooCommerce (Core, Subscriptions, AutomateWoo).
* `.github/workflows/scripts/helpers.php`: Use `WP_GITHUB_WOOCOMMERCE_TOKEN` when the repo is under `woocommerce/`; otherwise use `WP_GITHUB_TOKEN`. Improve error messages to reference the correct env var per path.
* `mailpoet/.env.sample`: Add `WP_GITHUB_WOOCOMMERCE_TOKEN` with guidance on where to obtain it.
* `mailpoet/RoboFile.php`: Pass the WooCommerce token to download methods and the underlying GitHub client; keep fallback to the general token for non-WooCommerce repos.

## Code review notes
- Scope: CI configuration, GitHub Actions helper, local tooling (`RoboFile.php`), and `.env.sample`. No production plugin code or runtime behavior is changed.
- Backwards compatibility:
  - Non-WooCommerce downloads continue to use `WP_GITHUB_TOKEN`.
  - WooCommerce downloads now uses `WP_GITHUB_WOOCOMMERCE_TOKEN`;

## QA notes

- Pre-requisites:
  - Ensure `WP_GITHUB_USERNAME` and `WP_GITHUB_WOOCOMMERCE_TOKEN` are set (locally via `.env` or CI secrets).
  - Keep `WP_GITHUB_TOKEN` available for non-WooCommerce repos.
- Validation:
  - Local tooling:
    - `./do download:woo-commerce-zip <version>`
    - `./do download:woo-commerce-subscriptions-zip <tag>`
    - `./do download:automate-woo-zip <tag>`
    - Expect successful downloads using `WP_GITHUB_WOOCOMMERCE_TOKEN`.
    - Unset `WP_GITHUB_WOOCOMMERCE_TOKEN` and verify it falls back to `WP_GITHUB_TOKEN`.
  - CI:
    - Trigger acceptance/integration pipelines with WooCommerce steps enabled; confirm downloads succeed and no token is echoed in logs.
- Regression:
  - Validate non-WooCommerce GitHub downloads still work with `WP_GITHUB_TOKEN`.


## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7511

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7511-create-new-github-token-to-download-woo-extensions)

_The latest successful build from `stomail-7511-create-new-github-token-to-download-woo-extensions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated WooCommerce GitHub token for downloading WooCommerce-related packages.

* **Chores**
  * Replaced generic token usage with the WooCommerce-specific token where applicable.
  * Updated sample environment configuration and documentation to include the new WooCommerce GitHub token variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->