### PR TITLE
Allow saving email template image with allow_url_fopen disabled

### DIFF
--- a/mailpoet/changelog/2025-08-11-20-07-01-improved-allow-saving-email-template-image-with-allowurlfop.md
+++ b/mailpoet/changelog/2025-08-11-20-07-01-improved-allow-saving-email-template-image-with-allowurlfop.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Allow saving email template image with allow_url_fopen disabled

--- a/mailpoet/lib/NewsletterTemplates/ThumbnailSaver.php
+++ b/mailpoet/lib/NewsletterTemplates/ThumbnailSaver.php
@@ -116,10 +116,28 @@ class ThumbnailSaver {
   }
 
   /**
-   * Simply saves base64 to a file without any compression
+   * Saves base64 to a file without any compression. We decode the base64 data, because encoded data
+   * is considered URL, and file_put_contents() would fail when allow_url_fopen is disabled in PHP.
+   *
+   * @param string $file The path to the file to save the base64 data to.
+   * @param string $data The base64 data to save to the file.
+   *
    * @return bool
    */
   private function saveBase64AsImageFile(string $file, string $data): bool {
-    return file_put_contents($file, file_get_contents($data)) !== false;
+    // Extract the base64 data from the data URI
+    if (preg_match('/^data:.*;base64,(.+)$/', $data, $matches)) {
+      $base64Data = $matches[1];
+    } else {
+      // If it's not a proper data URI, assume it's already base64 encoded
+      $base64Data = $data;
+    }
+
+    $decodedData = base64_decode($base64Data, true);
+    if ($decodedData === false) {
+      return false;
+    }
+
+    return file_put_contents($file, $decodedData) !== false;
   }
 }


### PR DESCRIPTION
## Description

When `allow_url_fopen` is disabled in PHP, saving email template image will fail with following in logs:
```
[11-Aug-2025 19:48:20 UTC] PHP Warning:  file_get_contents(): data:// wrapper is disabled in the server configuration by allow_url_fopen=0 in /Users/neosinner/Projects/web/wordpress.local/wp-content/plugins/mailpoet/lib/NewsletterTemplates/ThumbnailSaver.php on line 126
[11-Aug-2025 19:48:20 UTC] PHP Warning:  file_get_contents(data:image/jpeg;base64,...
```

However, MailPoet works only locally, so we don't really need to open external URL. The issue was, that using base64 encoded images (`data:image/jpeg;base64,...`) is considered a URL. The fix is to decode the image and only then save it locally.

<img width="656" height="412" alt="Screenshot 2025-08-11 at 21 51 15" src="https://github.com/user-attachments/assets/31008d56-7022-4aa8-9cd6-8a9dc1b42c24" />

## Code review notes

_N/A_

## QA notes

Check that the when an email is saved as template, the image of the template is properly saved. Ideally both with `allow_url_fopen` enabled and disabled.

Steps to reproduce:
1. Create new newsletter and select any template.
2. When in legacy email editor, click `Save as new template`.
3. Go to **MailPoet > Email > Add new email > Create (Newsletter) > Your saved templates** and observe, that the saved template has preview.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7519

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7519-template-image-cant-be-saved-when-allow_url_fopen-is)

_The latest successful build from `stomail-7519-template-image-cant-be-saved-when-allow_url_fopen-is` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Saving images in email templates now works on servers with allow_url_fopen disabled.
  * Improved handling of base64 and data URI images to ensure reliable thumbnail and image saving.
* **Documentation**
  * Updated changelog to reflect the improved image saving compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->