### PR TITLE
Add a parameter to `ChangelogController` for specifying the changelog directory of `Changelogger`

### DIFF
--- a/mailpoet/changelog/2025-08-08-13-12-07-improved-ensure-logging-of-woocommerce-firstpurchase-is-don.md
+++ b/mailpoet/changelog/2025-08-08-13-12-07-improved-ensure-logging-of-woocommerce-firstpurchase-is-don.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Ensure that logging of WooCommerce First Purchase is done only when necessary.
+Ensure that logging of WooCommerce First Purchase is done only when necessary

--- a/mailpoet/changelog/2025-08-11-07-02-20-updated-bump-the-minimum-required-woocommerce-version-to-1.md
+++ b/mailpoet/changelog/2025-08-11-07-02-20-updated-bump-the-minimum-required-woocommerce-version-to-1.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Bump the minimum required WooCommerce version to 10.0 and tested up to version to 10.1.
+Bump the minimum required WooCommerce version to 10.0 and tested up to version to 10.1

--- a/mailpoet/tasks/release/ChangelogController.php
+++ b/mailpoet/tasks/release/ChangelogController.php
@@ -15,10 +15,11 @@ class ChangelogController {
   private $changelogger;
 
   public function __construct(
-    $readmeFile
+    $readmeFile,
+    $changelogDir = null
   ) {
     $this->readmeFile = $readmeFile;
-    $this->changelogger = new Changelogger();
+    $this->changelogger = new Changelogger($changelogDir);
   }
 
   public function update(string $version) {


### PR DESCRIPTION
## Description

This PR adds a parameter to `ChangelogController` for specifying the changelog directory of `Changelogger`.

## Code review notes

1. Locally run `./do release:changelog-write 5.13.0`
2. Check if the generated changelog and local changes are expected

<img width="1136" height="450" alt="image" src="https://github.com/user-attachments/assets/baab45d0-e674-46c8-97f0-b68fdc3b10ec" />

## QA notes

There are no user-facing changes, QA can be skipped.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/972

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-changelog-when-releasing-premium)

_The latest successful build from `fix-changelog-when-releasing-premium` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Improved release tooling to support a configurable changelog directory while preserving existing defaults and behavior. No impact on user-facing functionality.

* Chores
  * Standardized punctuation in recent changelog entries for consistency and readability. No semantic or content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->