### PR TITLE
Release 5.13.0

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 5.13.0 - 2025-08-12 =
+* Added: Add duplication of an automation step;
+* Added: "Active WooCommerce subscriptions count" field in automation filters;
+* Updated: Bump the minimum required WooCommerce version to 10.0 and tested up to version to 10.1;
+* Improved: Ensure that logging of WooCommerce First Purchase is done only when necessary.
+
 = 5.12.13 - 2025-08-04 =
 * Added: The dynamic products block can filter out out-of-stock products;
 * Fixed: Prevent automatic "Subscribed" status for guest order subscribers when Sign-up Confirmation is disabled.

--- a/mailpoet/changelog/2025-07-23-08-17-13-added-add-duplication-of-an-automation-step.md
+++ b/mailpoet/changelog/2025-07-23-08-17-13-added-add-duplication-of-an-automation-step.md
@@ -1,5 +1,0 @@
-# Type: Added
-
-# Description
-
-Add duplication of an automation step

--- a/mailpoet/changelog/2025-08-05-19-26-58-added-active-woocommerce-subscriptions-count-field-in-au.md
+++ b/mailpoet/changelog/2025-08-05-19-26-58-added-active-woocommerce-subscriptions-count-field-in-au.md
@@ -1,5 +1,0 @@
-# Type: Added
-
-# Description
-
-"Active WooCommerce subscriptions count" field in automation filters

--- a/mailpoet/changelog/2025-08-08-13-12-07-improved-ensure-logging-of-woocommerce-firstpurchase-is-don.md
+++ b/mailpoet/changelog/2025-08-08-13-12-07-improved-ensure-logging-of-woocommerce-firstpurchase-is-don.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Ensure that logging of WooCommerce First Purchase is done only when necessary

--- a/mailpoet/changelog/2025-08-11-07-02-20-updated-bump-the-minimum-required-woocommerce-version-to-1.md
+++ b/mailpoet/changelog/2025-08-11-07-02-20-updated-bump-the-minimum-required-woocommerce-version-to-1.md
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Bump the minimum required WooCommerce version to 10.0 and tested up to version to 10.1

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.12.13
+ * Version: 5.13.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.12.13',
+  'version' => '5.13.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 5.12.13
+Stable tag: 5.13.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,8 +227,10 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.12.13 - 2025-08-04 =
-* Added: The dynamic products block can filter out out-of-stock products;
-* Fixed: Prevent automatic "Subscribed" status for guest order subscribers when Sign-up Confirmation is disabled.
+= 5.13.0 - 2025-08-12 =
+* Added: Add duplication of an automation step;
+* Added: "Active WooCommerce subscriptions count" field in automation filters;
+* Updated: Bump the minimum required WooCommerce version to 10.0 and tested up to version to 10.1;
+* Improved: Ensure that logging of WooCommerce First Purchase is done only when necessary.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Duplicate an automation step.
  - New automation filter: “Active WooCommerce subscriptions count.”
- Improvements
  - WooCommerce First Purchase is logged only when necessary, reducing noise.
- Chores
  - Bumped plugin version to 5.13.0.
  - Increased minimum required WooCommerce to 10.0; tested up to 10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->