### PR TITLE
Add placeholder for premium "WordPress user role changes" trigger

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
@@ -16,11 +16,13 @@ import { registerAutomationSidebar } from './automation-sidebar';
 import { step as TagAddedTrigger } from './steps/tag-added';
 import { step as TagRemovedTrigger } from './steps/tag-removed';
 import { step as ClicksEmailLinkTrigger } from './steps/clicks-email-link';
+import { step as WpUserRoleChangedTrigger } from './steps/wp-user-role-changed';
 // Insert new imports here
 
 export const initialize = (): void => {
   registerStepType(SendEmailStep);
   registerStepType(WpUserRegisteredTrigger);
+  registerStepType(WpUserRoleChangedTrigger);
   registerStepType(SomeoneSubscribesTrigger);
   registerStepType(CustomTriggerStep);
   registerStepType(CustomActionStep);

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-role-changed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-role-changed/index.tsx
@@ -1,0 +1,42 @@
+import { __ } from '@wordpress/i18n';
+import { wordpress } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+
+const keywords = [
+  // translators: used as a search keyword for "WordPress user role changes" automation trigger
+  __('wordpress', 'mailpoet'),
+  // translators: used as a search keyword for "WordPress user role changes" automation trigger
+  __('user', 'mailpoet'),
+  // translators: used as a search keyword for "WordPress user role changes" automation trigger
+  __('role', 'mailpoet'),
+  // translators: used as a search keyword for "WordPress user role changes" automation trigger
+  __('change', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'mailpoet:user-role-changed',
+  group: 'triggers',
+  title: () => __('WordPress user role changes', 'mailpoet'),
+  description: () =>
+    __('Start the automation when a WordPress user role changes.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={__('Premium', 'mailpoet')} />,
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => wordpress,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_user_role_changed',
+      }}
+    >
+      {__(
+        'Triggering an automation when a WordPress user role changes is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;


### PR DESCRIPTION
## Description

This is just a placeholder trigger for a premium one.

<img width="1099" height="636" alt="Screenshot 2025-08-13 at 08 34 21" src="https://github.com/user-attachments/assets/e739c34e-ba50-4220-8b04-f4ce57167285" />

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/975

## Linked tickets

STOMAIL-7478

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7478-automations-and-user-role-changes)

_The latest successful build from `stomail-7478-automations-and-user-role-changes` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “WordPress user role changes” automation trigger to start workflows when a user’s role is updated.
  * Includes WordPress icon, title/description, four discoverable keywords, and distinct styling.
  * Marked as Premium; non‑Premium users are shown an upgrade modal when attempting to edit (with tracking/utm info).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->