### PR TITLE
Fix GitHub Workflow for updating plugins in CircleCI 

### DIFF
--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -33,17 +33,23 @@ function filterStableVersions(array $versions): array {
 }
 
 /**
- * Function to get the latest and previous minor/major versions from a list of versions.
+ * Function to get the latest and previous versions from a list of versions.
+ * First tries to find the immediate previous version (patch-level), then falls back to previous minor/major version.
  */
 function getLatestAndPreviousMinorMajorVersions(array $versions): array {
   usort($versions, 'version_compare');
   $currentVersion = end($versions);
 
-  $previousVersion = null;
-  foreach (array_reverse($versions) as $version) {
-    if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
-      $previousVersion = $version;
-      break;
+  // First, try to find the immediate previous version (any version lower than current)
+  $previousVersion = getActualPreviousVersion($versions, $currentVersion);
+  
+  // If no immediate previous version found, fall back to the old logic for major.minor differences
+  if ($previousVersion === null) {
+    foreach (array_reverse($versions) as $version) {
+      if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
+        $previousVersion = $version;
+        break;
+      }
     }
   }
 
@@ -53,6 +59,21 @@ function getLatestAndPreviousMinorMajorVersions(array $versions): array {
 function getMinorMajorVersion(string $version): string {
   $parts = explode('.', $version);
   return $parts[0] . '.' . $parts[1];
+}
+
+/**
+ * Function to find the immediate previous version from a list of versions.
+ * Returns the highest version that is still lower than the current version.
+ */
+function getActualPreviousVersion(array $versions, string $currentVersion): ?string {
+  $previousVersion = null;
+  foreach (array_reverse($versions) as $version) {
+    if (version_compare($version, $currentVersion, '<')) {
+      $previousVersion = $version;
+      break;
+    }
+  }
+  return $previousVersion;
 }
 
 /**

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .idea
 .vscode
+.claude/settings.local.json
 dev/data
 docker-compose.override.yml
 node_modules


### PR DESCRIPTION
## Description

The GitHub [workflow for updating the plugin versions in CircleCI config](https://github.com/mailpoet/mailpoet/blob/1b7596800423f15f304a5909c2234b91b0040189/.github/workflows/update-wordpress-and-plugins.yml) reported an incorrect previous version in the commit message body.

For example:

- https://github.com/mailpoet/mailpoet/commit/1b7596800423f15f304a5909c2234b91b0040189
- https://github.com/mailpoet/mailpoet/commit/82e1c59f0f09a8f7739c9b0c7655f4bead153f17
- https://github.com/mailpoet/mailpoet/commit/de6ec0fd6f3bb15e6a1bd2a8d70a562e68506de7

This workflow assumed that all updates were minor version changes, ignoring any patch level updates.

## Code review notes

_N/A_

## QA notes

No need for QA in this Pull Request

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7506]

## After-merge notes

_N/A_

## Tasks

No need for changelog, there are no user-facing changes

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7506-github-workflow-for-updating-plugins-in-circleci-reports)

_The latest successful build from `stomail-7506-github-workflow-for-updating-plugins-in-circleci-reports` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated version selection to first detect an immediate prior patch release, falling back to prior minor/major logic when none exists.
  * Updated repository ignore rules to specifically exclude a single local settings file rather than an entire hidden folder.
* **Documentation**
  * Clarified internal documentation to describe the new two-step version selection behavior without changing public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->