### PR TITLE
"Your License Key for MailPoet is expiring" shows only on Plugins page [STOMAIL-7281]

### DIFF
--- a/mailpoet/changelog/2025-08-15-13-38-56-fixed-fix-license-expiration-notice-only-showing-on-plug.md
+++ b/mailpoet/changelog/2025-08-15-13-38-56-fixed-fix-license-expiration-notice-only-showing-on-plug.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix: license expiration notice was displayed only on the Plugins page; it now appears on all MailPoet admin pages

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -761,8 +761,8 @@ class Menu {
   }
 
   public function checkPremiumKey(?ServicesChecker $checker = null) {
-    $showNotices = isset($_SERVER['SCRIPT_NAME'])
-      && stripos(sanitize_text_field(wp_unslash($_SERVER['SCRIPT_NAME'])), 'plugins.php') !== false;
+    $showNotices = self::isOnMailPoetAdminPage() || (isset($_SERVER['SCRIPT_NAME'])
+      && stripos(sanitize_text_field(wp_unslash($_SERVER['SCRIPT_NAME'])), 'plugins.php') !== false);
     $checker = $checker ?: $this->servicesChecker;
     $this->premiumKeyValid = $checker->isPremiumKeyValid($showNotices);
   }


### PR DESCRIPTION
## Description

The “Your License Key for MailPoet is expiring!” notice was showing only on the WP Plugins page, and not on any of the MailPoet pages. This pull request changes that and now the notice should be displayed on all MailPoet pages.

### Before:

<img width="2630" height="326" alt="Screenshot 2025-08-15 at 15 28 39" src="https://github.com/user-attachments/assets/99586376-0113-4300-aea1-82815160320f" />

### After

<img width="2612" height="1142" alt="Screenshot 2025-08-15 at 15 32 13" src="https://github.com/user-attachments/assets/285327b8-f176-4122-bb0f-04a85895934d" />




## Code review notes

_N/A_

## QA notes

### Enabling/mocking the expiring state
1) Install a DB manager plugin e.g. Adminer
2) Make sure premium plugin is active
3) Go to `wp_mailpoet_settings` and look for a setting with name `premium`
4) Backup the value and replace it with. This will simulate the key was detected as expiring
```
a:2:{s:17:"premium_key_state";a:4:{s:5:"state";s:8:"expiring";s:18:"access_restriction";N;s:4:"data";a:7:{s:9:"expire_at";s:10:"2025-08-30";s:18:"email_volume_limit";i:0;s:11:"emails_sent";i:0;s:28:"site_active_subscriber_limit";i:10000;s:9:"public_id";s:4:"4321";s:12:"support_tier";s:7:"premium";s:17:"subscription_type";s:6:"STRIPE";}s:4:"code";i:200;}s:11:"premium_key";s:4:"1234";}'
```
5) Verify the change and restore the data from the backup.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7281]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * License expiration notice now displays consistently across all MailPoet admin pages, not just the Plugins page.

* **Documentation**
  * Added changelog entry documenting the fix for license expiration notice visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7281-your-license-key-for-mailpoet-is-expiring-shows-only-on)

_The latest successful build from `stomail-7281-your-license-key-for-mailpoet-is-expiring-shows-only-on` will be used. If none is available, the link won't work._