### PR TITLE
Ensure anchor link in a post in email contain full post URL

### DIFF
--- a/mailpoet/changelog/2025-08-15-13-03-08-fixed-anchor-links-in-posts-added-to-emails-were-not-wor.md
+++ b/mailpoet/changelog/2025-08-15-13-03-08-fixed-anchor-links-in-posts-added-to-emails-were-not-wor.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+anchor links in posts added to emails were not working

--- a/mailpoet/lib/Newsletter/Editor/PostContentManager.php
+++ b/mailpoet/lib/Newsletter/Editor/PostContentManager.php
@@ -18,9 +18,10 @@ class PostContentManager {
   private $wp;
 
   public function __construct(
-    ?WooCommerceHelper $woocommerceHelper = null
+    ?WooCommerceHelper $woocommerceHelper = null,
+    ?WPFunctions $wp = null
   ) {
-    $this->wp = new WPFunctions;
+    $this->wp = $wp ?: new WPFunctions;
     $this->maxExcerptLength = $this->wp->applyFilters('mailpoet_newsletter_post_excerpt_length', $this->maxExcerptLength);
     $this->woocommerceHelper = $woocommerceHelper ?: new WooCommerceHelper($this->wp);
   }
@@ -46,17 +47,20 @@ class PostContentManager {
 
     if ($displayType === 'excerpt') {
       if ($this->wp->hasExcerpt($post)) {
-        return self::stripShortCodes($this->wp->getTheExcerpt($post));
+        $content = self::stripShortCodes($this->wp->getTheExcerpt($post));
+        return $this->fixAnchorLinks($content, $post);
       }
-      return self::stripShortCodes(
+      $content = self::stripShortCodes(
         $this->wp->applyFilters(
           'get_the_excerpt',
           $this->generateExcerpt($post->post_content), // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
           $post
         )
       );
+      return $this->fixAnchorLinks($content, $post);
     }
-    return self::stripShortCodes($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $content = self::stripShortCodes($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    return $this->fixAnchorLinks($content, $post);
   }
 
   public function filterContent($content, $displayType, $withPostClass = true) {
@@ -172,5 +176,28 @@ class PostContentManager {
 
   private function isWcProduct($post) {
     return class_exists('\WC_Product') && $post instanceof \WC_Product;
+  }
+
+  private function fixAnchorLinks($content, $post) {
+    if (empty($content) || !$post) {
+      return $content;
+    }
+
+    // Get the post's permalink to use as base URL
+    $postUrl = $this->wp->getPermalink($post);
+    if (!$postUrl) {
+      return $content;
+    }
+
+    // Find and replace anchor-only links (href="#...") with full URLs
+    $content = preg_replace_callback(
+      '/(<a[^>]+href=["\'])#([^"\']*)(["\'])/i',
+      function($matches) use ($postUrl) {
+        return $matches[1] . $postUrl . '#' . $matches[2] . $matches[3];
+      },
+      $content
+    );
+
+    return $content;
   }
 }


### PR DESCRIPTION
## Description

This PR fixes issues that anchor links, like footnotes, were not working in emails. 
With disabled tracking, they simply didn't work with enabled tracking; they were causing `ERR_TOO_MANY_REDIRECTS`.

## Code review notes

I fixed the issue by adding the full post URLs to anchor links when generating the post content.
I didn't attempt to fix existing links for sent newsletters because we have no data.

## QA notes

#### Testing instructions
1) Create a post and add some anchor links. For example, footnotes: https://wordpress.com/support/how-to-add-footnotes/
2) Add the post to an email. You can use the Posts block and select the 'Full Post' display type in the display settings.
3) Sent the email and observe the issue

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7337

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7337-issues-with-post-notifications-and-footnotes)

_The latest successful build from `stomail-7337-issues-with-post-notifications-and-footnotes` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anchor links in posts added to emails now work correctly. Anchor-only links are converted to full URLs pointing to the correct sections of the original post, for both excerpts and full content.

* **Documentation**
  * Added a changelog entry describing the fix for non-functioning anchor links in email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->