### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.0.4
+            ./do download:woo-commerce-zip 10.1.0
             ./do download:woo-commerce-subscriptions-zip 7.7.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.15
@@ -1182,7 +1182,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 9.9.5
+          woo_core_version: 10.0.4
           woo_subscriptions_version: 7.6.0
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
@@ -1222,7 +1222,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 9.9.5
+          woo_core_version: 10.0.4
           woo_subscriptions_version: 7.6.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
@@ -1284,7 +1284,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
-          woo_core_version: 9.9.5
+          woo_core_version: 10.0.4
           woo_subscriptions_version: 7.6.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
@@ -1295,7 +1295,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
-          woo_core_version: 9.9.5
+          woo_core_version: 10.0.4
           woo_subscriptions_version: 7.6.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated CI test matrix to use WooCommerce Core 10.0.4 across acceptance and integration scenarios, including nightly and workflow pipelines.
  - Updated WooCommerce plugin used in tests to 10.1.0 to validate against the latest stable release.
  - Ensures broader compatibility coverage across supported environments.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->