### PR TITLE
Clarify limitations of "Subscribe in comments" option [STOMAIL-7518]

### DIFF
--- a/mailpoet/changelog/2025-08-18-08-41-18-added-explanation-to-subscribe-in-comments-that-only-nat.md
+++ b/mailpoet/changelog/2025-08-18-08-41-18-added-explanation-to-subscribe-in-comments-that-only-nat.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Explanation to Subscribe In Comments that only native WP comments are supported

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -17,7 +17,7 @@
   'replyTo': __('Reply-to'),
 
   'subscribeInCommentsTitle': __('Subscribe in comments'),
-  'subscribeInCommentsDescription': __('Visitors that comment on a post can subscribe to your list via a checkbox.'),
+  'subscribeInCommentsDescription': __('Visitors that comment on a post can subscribe to your list via a checkbox. Note: Only works with the native WordPress comment form. Third-party commenting systems like Jetpack are not supported.'),
   'subscribeInRegistrationTitle': __('Subscribe in registration form'),
   'subscribeInRegistrationDescription': __('Allow users who register as a WordPress user on your website to subscribe to a MailPoet list (in addition to the "WordPress Users" list). This also enables WordPress users to receive confirmation emails (if sign-up confirmation is enabled).'),
   'usersWillBeSubscribedTo': __('Users will be subscribed to these lists:'),


### PR DESCRIPTION
## Description

Add wording to MailPoet "Subscribe in comments" settings area so it's clear only the native WordPress comment form is supported.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7518]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7518-clarify-limitations-of-subscribe-in-comments-option)

_The latest successful build from `stomail-7518-clarify-limitations-of-subscribe-in-comments-option` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified “Subscribe in Comments” support: added a changelog entry and updated the in‑app description to state it only works with the native WordPress comment form.
  - The description now explicitly notes that third‑party commenting systems (e.g., Jetpack) are not supported.
  - No functional changes; this update improves user understanding and prevents misconfiguration by setting clear expectations within the settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->