### PR TITLE
Refactor updated_at handling in response builders to ensure null safety for date formatting - STOMAIL-7525

### DIFF
--- a/mailpoet/changelog/2025-08-18-10-24-17-fixed-fix-the-error-call-to-a-member-function-format-on-.md
+++ b/mailpoet/changelog/2025-08-18-10-24-17-fixed-fix-the-error-call-to-a-member-function-format-on-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix the error "Call to a member function format on null".

--- a/mailpoet/lib/API/JSON/ResponseBuilders/CustomFieldsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/CustomFieldsResponseBuilder.php
@@ -24,7 +24,7 @@ class CustomFieldsResponseBuilder {
       'type' => $customField->getType(),
       'params' => $customField->getParams(),
       'created_at' => ($createdAt = $customField->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null,
-      'updated_at' => $customField->getUpdatedAt()->format('Y-m-d H:i:s'),
+      'updated_at' => ($updatedAt = $customField->getUpdatedAt()) ? $updatedAt->format('Y-m-d H:i:s') : null,
     ];
   }
 }

--- a/mailpoet/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/FormsResponseBuilder.php
@@ -26,7 +26,7 @@ class FormsResponseBuilder {
       'settings' => $form->getSettings(),
       'styles' => $form->getStyles(),
       'created_at' => ($createdAt = $form->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $form->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $form->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $form->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
     ];
   }

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewsletterTemplatesResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewsletterTemplatesResponseBuilder.php
@@ -16,7 +16,7 @@ class NewsletterTemplatesResponseBuilder {
       'readonly' => $template->getReadonly(),
       'body' => $template->getBody(),
       'created_at' => ($createdAt = $template->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $template->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $template->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'newsletter_id' => ($newsletter = $template->getNewsletter()) ? $newsletter->getId() : null,
     ];
   }

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -75,7 +75,7 @@ class NewslettersResponseBuilder {
       'body' => $newsletter->getBody(),
       'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format(self::DATE_FORMAT) : null,
       'created_at' => ($createdAt = $newsletter->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $newsletter->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $newsletter->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $newsletter->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'parent_id' => ($parent = $newsletter->getParent()) ? $parent->getId() : null,
       'unsubscribe_token' => $newsletter->getUnsubscribeToken(),
@@ -169,7 +169,7 @@ class NewslettersResponseBuilder {
       'type' => $newsletter->getType(),
       'status' => $newsletter->getStatus(),
       'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $newsletter->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $newsletter->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $newsletter->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'segments' => [],
       'queue' => false,
@@ -258,7 +258,7 @@ class NewslettersResponseBuilder {
       }, $filters),
       'description' => $segment->getDescription(),
       'created_at' => ($createdAt = $segment->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $segment->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $segment->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
     ];
   }
@@ -276,7 +276,7 @@ class NewslettersResponseBuilder {
       'scheduled_at' => ($scheduledAt = $task->getScheduledAt()) ? $scheduledAt->format(self::DATE_FORMAT) : null,
       'processed_at' => ($processedAt = $task->getProcessedAt()) ? $processedAt->format(self::DATE_FORMAT) : null,
       'created_at' => ($createdAt = $queue->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $queue->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $queue->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $queue->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'meta' => $queue->getMeta(),
       'task_id' => (string)$task->getId(), // (string) for BC

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -30,7 +30,7 @@ class SegmentsResponseBuilder {
       'type' => $segment->getType(),
       'description' => $segment->getDescription(),
       'created_at' => ($createdAt = $segment->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $segment->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $segment->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'average_engagement_score' => $segment->getAverageEngagementScore(),
       'filters_connect' => $segment->getFiltersConnectOperator(),

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -105,7 +105,7 @@ class SubscribersResponseBuilder {
           'created_at' => ($createdAt = $subscriberSegment->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
           'segment_id' => (string)$segment->getId(),
           'status' => $subscriberSegment->getStatus(),
-          'updated_at' => $subscriberSegment->getUpdatedAt()->format(self::DATE_FORMAT),
+          'updated_at' => ($updatedAt = $subscriberSegment->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
         ];
       }
     }
@@ -161,7 +161,7 @@ class SubscribersResponseBuilder {
         'subscriber_id' => (string)$subscriber->getId(),
         'tag_id' => (string)$tag->getId(),
         'created_at' => ($createdAt = $subscriberTag->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-        'updated_at' => $subscriberTag->getUpdatedAt()->format(self::DATE_FORMAT),
+        'updated_at' => ($updatedAt = $subscriberTag->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
         'name' => $tag->getName(),
       ];
     }

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -198,7 +198,7 @@ class Segments {
       'type' => $segment->getType(),
       'description' => $segment->getDescription(),
       'created_at' => ($createdAt = $segment->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $segment->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $segment->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
     ];
   }

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -141,7 +141,8 @@ class Help {
       'id' => $task->getId(),
       'type' => $task->getType(),
       'priority' => $task->getPriority(),
-      'updatedAt' => $task->getUpdatedAt()->format(DateTime::DEFAULT_DATE_TIME_FORMAT),
+      'updatedAt' => $task->getUpdatedAt() ?
+        $task->getUpdatedAt()->format(DateTime::DEFAULT_DATE_TIME_FORMAT) : null,
       'scheduledAt' => $task->getScheduledAt() ?
         $task->getScheduledAt()->format(DateTime::DEFAULT_DATE_TIME_FORMAT)
         : null,

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -163,7 +163,7 @@ class NewsletterEditor {
       'confirmed_at' => ($confirmedAt = $subscriber->getConfirmedAt()) ? $confirmedAt->format(self::DATE_FORMAT) : null,
       'last_subscribed_at' => ($lastSubscribedAt = $subscriber->getLastSubscribedAt()) ? $lastSubscribedAt->format(self::DATE_FORMAT) : null,
       'created_at' => ($createdAt = $subscriber->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
-      'updated_at' => $subscriber->getUpdatedAt()->format(self::DATE_FORMAT),
+      'updated_at' => ($updatedAt = $subscriber->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $subscriber->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'unconfirmed_data' => $subscriber->getUnconfirmedData(),
       'source' => $subscriber->getSource(),


### PR DESCRIPTION


## Description

Refactor updated_at handling in response builders to ensure null safety for date formatting

Discovered out in the wild on a customer site.

## Code review notes

Nothing major was done here except to ensure we check for null safety.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7525

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7525-format-error-on-getupdatedat)

_The latest successful build from `stomail-7525-format-error-on-getupdatedat` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Made updated_at handling null-safe across listings and detail views (custom fields, forms, newsletters, segments, subscribers, admin pages, and API endpoints), preventing "Call to a member function format on null" errors and improving UI/API stability.
  - Included an additional serialized field for segments: showInManageSubscriptionPage.

- Chores
  - Added changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->