### PR TITLE
Make the subscribers migration compatible with SQLite

### DIFF
--- a/mailpoet/lib/Migrations/App/Migration_20250501_114655_App.php
+++ b/mailpoet/lib/Migrations/App/Migration_20250501_114655_App.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Migrations\App;
 
+use MailPoet\Doctrine\WPDB\Connection as WPDBConnection;
 use MailPoet\Entities\StatisticsClickEntity;
 use MailPoet\Entities\StatisticsUnsubscribeEntity;
 use MailPoet\Entities\SubscriberEntity;
@@ -13,6 +14,12 @@ class Migration_20250501_114655_App extends AppMigration {
   private const DB_QUERY_CHUNK_SIZE = 1000;
 
   public function run(): void {
+    $isSQLite = WPDBConnection::isSQLite();
+    if ($isSQLite) {
+      // SQLite (used in WP Studio) does not support the TIMESTAMPDIFF function, so we skip the migration
+      return;
+    }
+
     $clicksStatsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
     $unsubscribeStatsTable = $this->entityManager->getClassMetadata(StatisticsUnsubscribeEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();


### PR DESCRIPTION
## Description

WordPress studio uses SQLite and the QIT tests
were failing because of this migration.

This PR fixes the issue

## Code review notes

_N/A_

## QA notes

We don't need QA for this.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-studio-warning)

_The latest successful build from `fix-studio-warning` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Avoids running a specific upgrade step on SQLite to prevent errors with time-difference calculations; migration proceeds normally on other databases.
  * Preserves consistent time-difference handling for correlating subscriber updates and unsubscribes on supported databases.

* Chores
  * Internal streamlining for more predictable time-difference processing across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->