### PR TITLE
Release 5.13.2

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 5.13.2 - 2025-08-20 =
+* Improved: minor changes and fixes.
+
 = 5.13.1 - 2025-08-18 =
 * Added: Explanation to Subscribe In Comments that only native WP comments are supported;
 * Improved: used the last version of the WooCommerce email editor packages;

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.13.1
+ * Version: 5.13.2
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.13.1',
+  'version' => '5.13.2',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 5.13.1
+Stable tag: 5.13.2
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,10 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.13.1 - 2025-08-18 =
-* Added: Explanation to Subscribe In Comments that only native WP comments are supported;
-* Improved: used the last version of the WooCommerce email editor packages;
-* Improved: Allow saving email template image with allow_url_fopen disabled;
-* Fixed: anchor links in posts added to emails were not working.
+= 5.13.2 - 2025-08-20 =
+* Improved: minor changes and fixes.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated changelog and readme for version 5.13.2 (2025-08-20), noting “Improved: minor changes and fixes.”
* Chores
  * Bumped plugin version to 5.13.2 to prepare the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->