### PR TITLE
Fix GitHub Workflow for updating plugins in CircleCI

### DIFF
--- a/.github/workflows/scripts/check_woocommerce_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_versions.php
@@ -41,5 +41,3 @@ if ($previousVersion) {
 } else {
   echo "No previous version found.\n";
 }
-
-saveVersionsToFiles($latestVersion, $previousVersion, $versionsFilenameSuffix);

--- a/.github/workflows/scripts/check_wordpress_versions.php
+++ b/.github/workflows/scripts/check_wordpress_versions.php
@@ -134,5 +134,3 @@ if ($previousVersion) {
 } else {
   echo "No previous version found.\n";
 }
-
-saveVersionsToFiles($latestVersion, $previousVersion, 'wordpress_version.txt');

--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -33,23 +33,17 @@ function filterStableVersions(array $versions): array {
 }
 
 /**
- * Function to get the latest and previous versions from a list of versions.
- * First tries to find the immediate previous version (patch-level), then falls back to previous minor/major version.
+ * Function to get the latest and previous minor/major versions from a list of versions.
  */
 function getLatestAndPreviousMinorMajorVersions(array $versions): array {
   usort($versions, 'version_compare');
   $currentVersion = end($versions);
 
-  // First, try to find the immediate previous version (any version lower than current)
-  $previousVersion = getActualPreviousVersion($versions, $currentVersion);
-  
-  // If no immediate previous version found, fall back to the old logic for major.minor differences
-  if ($previousVersion === null) {
-    foreach (array_reverse($versions) as $version) {
-      if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
-        $previousVersion = $version;
-        break;
-      }
+  $previousVersion = null;
+  foreach (array_reverse($versions) as $version) {
+    if (version_compare($version, $currentVersion, '<') && getMinorMajorVersion($version) !== getMinorMajorVersion($currentVersion)) {
+      $previousVersion = $version;
+      break;
     }
   }
 
@@ -59,21 +53,6 @@ function getLatestAndPreviousMinorMajorVersions(array $versions): array {
 function getMinorMajorVersion(string $version): string {
   $parts = explode('.', $version);
   return $parts[0] . '.' . $parts[1];
-}
-
-/**
- * Function to find the immediate previous version from a list of versions.
- * Returns the highest version that is still lower than the current version.
- */
-function getActualPreviousVersion(array $versions, string $currentVersion): ?string {
-  $previousVersion = null;
-  foreach (array_reverse($versions) as $version) {
-    if (version_compare($version, $currentVersion, '<')) {
-      $previousVersion = $version;
-      break;
-    }
-  }
-  return $previousVersion;
 }
 
 /**

--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -82,15 +82,6 @@ function fetchGitHubTags(string $repo, string $token, int $page = 1, int $limit 
   return array_column($data, 'name');
 }
 
-/**
- * Function saving versions to a temporary files.
- * File containing latest version is prefixed with 'latest_' and previous version is prefixed with 'previous_'.
- */
-function saveVersionsToFiles(?string $latestVersion, ?string $previousVersion, string $fileNameSuffix): void {
-  file_put_contents("/tmp/latest_{$fileNameSuffix}", $latestVersion);
-  file_put_contents("/tmp/previous_{$fileNameSuffix}", $previousVersion);
-}
-
 function replaceLatestVersion(string $latestVersion, string $downloadCommand): void {
   replaceVersionInFile(
     __DIR__ . '/../../../.circleci/config.yml',
@@ -162,6 +153,4 @@ function replacePrivatePluginVersion(
   } else {
     echo "No previous version found.\n";
   }
-
-  saveVersionsToFiles($latestVersion, $previousVersion, $versionsFilename);
 }

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -34,17 +34,11 @@ jobs:
             echo "WORDPRESS_CHANGES=true" >> $GITHUB_ENV
           fi
 
-      - name: Get WordPress versions from files
-        id: get_wp_versions
-        run: |
-          echo "WORDPRESS_LATEST_VERSION=$(cat /tmp/latest_wordpress_version.txt)" >> $GITHUB_ENV
-          echo "WORDPRESS_PREVIOUS_VERSION=$(cat /tmp/previous_wordpress_version.txt)" >> $GITHUB_ENV
-
       - name: Commit WordPress changes
         if: env.WORDPRESS_CHANGES == 'true'
         run: |
           git add .
-          git commit -m $'Update used WordPress images in Circle CI\n\n - latest version: ${{ env.WORDPRESS_LATEST_VERSION }}\n - previous version: ${{ env.WORDPRESS_PREVIOUS_VERSION }}'
+          git commit -m $'Update used WordPress images in Circle CI'
 
       # Updating used WooCommerce plugin
       - name: Check WooCommerce Versions
@@ -60,17 +54,11 @@ jobs:
             echo "WOOCOMMERCE_CHANGES=true" >> $GITHUB_ENV
           fi
 
-      - name: Get WooCommerce versions from files
-        id: get_wc_versions
-        run: |
-          echo "WOOCOMMERCE_LATEST_VERSION=$(cat /tmp/latest_woocommerce_version.txt)" >> $GITHUB_ENV
-          echo "WOOCOMMERCE_PREVIOUS_VERSION=$(cat /tmp/previous_woocommerce_version.txt)" >> $GITHUB_ENV
-
       - name: Commit WooCommerce changes
         if: env.WOOCOMMERCE_CHANGES == 'true'
         run: |
           git add .
-          git commit -m $'Update used WooCommerce plugin in Circle CI\n\n - latest version: ${{ env.WOOCOMMERCE_LATEST_VERSION }}\n - previous version: ${{ env.WOOCOMMERCE_PREVIOUS_VERSION }}'
+          git commit -m $'Update used WooCommerce plugin in Circle CI'
 
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
@@ -88,17 +76,11 @@ jobs:
             echo "AUTOMATE_WOO_CHANGES=true" >> $GITHUB_ENV
           fi
 
-      - name: Get Automate Woo versions from files
-        id: get_aw_versions
-        run: |
-          echo "AUTOMATE_WOO_LATEST_VERSION=$(cat /tmp/latest_automate_woo_version.txt)" >> $GITHUB_ENV
-          echo "AUTOMATE_WOO_PREVIOUS_VERSION=$(cat /tmp/previous_automate_woo_version.txt)" >> $GITHUB_ENV
-
       - name: Commit Automate Woo changes
         if: env.AUTOMATE_WOO_CHANGES == 'true'
         run: |
           git add .
-          git commit -m $'Update used Automate Woo plugin in Circle CI\n\n - latest version: ${{ env.AUTOMATE_WOO_LATEST_VERSION }}\n - previous version: ${{ env.AUTOMATE_WOO_PREVIOUS_VERSION }}'
+          git commit -m $'Update used Automate Woo plugin in Circle CI'
 
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
@@ -116,17 +98,11 @@ jobs:
             echo "SUBSCRIPTIONS_CHANGES=true" >> $GITHUB_ENV
           fi
 
-      - name: Get WooCommerce Subscriptions versions from files
-        id: get_ws_versions
-        run: |
-          echo "WOOCOMMERCE_SUBSCRIPTIONS_LATEST_VERSION=$(cat /tmp/latest_woocommerce_subscriptions_version.txt)" >> $GITHUB_ENV
-          echo "WOOCOMMERCE_SUBSCRIPTIONS_PREVIOUS_VERSION=$(cat /tmp/previous_woocommerce_subscriptions_version.txt)" >> $GITHUB_ENV
-
       - name: Commit WooCommerce Subscriptions changes
         if: env.SUBSCRIPTIONS_CHANGES == 'true'
         run: |
           git add .
-          git commit -m $'Update used WooCommerce Subscriptions plugin in Circle CI\n\n - latest version: ${{ env.WOOCOMMERCE_SUBSCRIPTIONS_LATEST_VERSION }}\n - previous version: ${{ env.WOOCOMMERCE_SUBSCRIPTIONS_PREVIOUS_VERSION }}'
+          git commit -m $'Update used WooCommerce Subscriptions plugin in Circle CI'
 
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
@@ -144,17 +120,11 @@ jobs:
             echo "MEMBERSHIPS_CHANGES=true" >> $GITHUB_ENV
           fi
 
-      - name: Get WooCommerce Memberships versions from files
-        id: get_wm_versions
-        run: |
-          echo "WOOCOMMERCE_MEMBERSHIPS_LATEST_VERSION=$(cat /tmp/latest_woocommerce_memberships_version.txt)" >> $GITHUB_ENV
-          echo "WOOCOMMERCE_MEMBERSHIPS_PREVIOUS_VERSION=$(cat /tmp/previous_woocommerce_memberships_version.txt)" >> $GITHUB_ENV
-
       - name: Commit WooCommerce Memberships changes
         if: env.MEMBERSHIPS_CHANGES == 'true'
         run: |
           git add .
-          git commit -m $'Update used WooCommerce Memberships plugin in Circle CI\n\n - latest version: ${{ env.WOOCOMMERCE_MEMBERSHIPS_LATEST_VERSION }}\n - previous version: ${{ env.WOOCOMMERCE_MEMBERSHIPS_PREVIOUS_VERSION }}'
+          git commit -m $'Update used WooCommerce Memberships plugin in Circle CI'
 
       # Push all changes at the end if any changes were detected
       #


### PR DESCRIPTION
## Description

Because the version used in the commit messages could sometimes be confusing, I decided to remove them and simplify the GitHub Action script.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[[STOMAIL-7506](https://linear.app/a8c/issue/STOMAIL-7506)]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-updating-used-circle-plugins)

_The latest successful build from `fix-updating-used-circle-plugins` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Simplified CI workflows by removing temporary version file handling and related steps.
  - Automated update commits now use shorter, cleaner messages.
- Refactor
  - Updated version selection to choose the previous minor/major release instead of a patch-level fallback.
- Documentation
  - Clarified internal documentation around version determination logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->