### PR TITLE
Release 5.14.0

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,10 @@
 == Changelog ==
 
+= 5.14.0 - 2025-08-25 =
+* Updated: Update the email editor version;
+* Fixed: Fix: license expiration notice was displayed only on the Plugins page; it now appears on all MailPoet admin pages;
+* Fixed: Fix the error "Call to a member function format on null"..
+
 = 5.13.1 - 2025-08-18 =
 * Added: Explanation to Subscribe In Comments that only native WP comments are supported;
 * Improved: used the last version of the WooCommerce email editor packages;

--- a/mailpoet/changelog/2025-08-15-13-38-56-fixed-fix-license-expiration-notice-only-showing-on-plug.md
+++ b/mailpoet/changelog/2025-08-15-13-38-56-fixed-fix-license-expiration-notice-only-showing-on-plug.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fix: license expiration notice was displayed only on the Plugins page; it now appears on all MailPoet admin pages

--- a/mailpoet/changelog/2025-08-18-10-24-17-fixed-fix-the-error-call-to-a-member-function-format-on-.md
+++ b/mailpoet/changelog/2025-08-18-10-24-17-fixed-fix-the-error-call-to-a-member-function-format-on-.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fix the error "Call to a member function format on null".

--- a/mailpoet/changelog/2025-08-21-08-40-28-updated-update-the-email-editor-version.md
+++ b/mailpoet/changelog/2025-08-21-08-40-28-updated-update-the-email-editor-version.md
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Update the email editor version

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.13.1
+ * Version: 5.14.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.13.1',
+  'version' => '5.14.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 5.13.1
+Stable tag: 5.14.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,10 +227,9 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.13.1 - 2025-08-18 =
-* Added: Explanation to Subscribe In Comments that only native WP comments are supported;
-* Improved: used the last version of the WooCommerce email editor packages;
-* Improved: Allow saving email template image with allow_url_fopen disabled;
-* Fixed: anchor links in posts added to emails were not working.
+= 5.14.0 - 2025-08-25 =
+* Updated: Update the email editor version;
+* Fixed: Fix: license expiration notice was displayed only on the Plugins page; it now appears on all MailPoet admin pages;
+* Fixed: Fix the error "Call to a member function format on null"..
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated the email editor to the latest version.

- Bug Fixes
  - License expiration notice now appears across all MailPoet admin pages (not just the Plugins page).
  - Resolved the PHP error: “Call to a member function format on null.”

- Documentation
  - Updated changelog and readme for version 5.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->