### PR TITLE
Log error and provide default values for invalid segment statistics result

### DIFF
--- a/mailpoet/changelog/2025-08-27-18-33-54-improved-error-handling-statistics-queries
+++ b/mailpoet/changelog/2025-08-27-18-33-54-improved-error-handling-statistics-queries
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Improved error handling for invalid segment statistics results.

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\InvalidStateException;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\NotFoundException;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\FilterHandler;
@@ -488,6 +489,26 @@ class SegmentSubscribersRepository {
     }
 
     $statement = $this->executeQuery($queryBuilder);
-    return $statement->fetch();
+    $result = $statement->fetch();
+    if (is_array($result)) {
+      return $result;
+    }
+
+    $logger = LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_SEGMENTS);
+    $logger->error('Invalid result for segment statistics count', [
+      'segment_id' => $segment->getId(),
+      'result' => $result,
+      'query' => $queryBuilder->getSQL(),
+    ]);
+
+    return [
+      'all' => 0,
+      'trash' => 0,
+      'subscribed' => 0,
+      'unsubscribed' => 0,
+      'inactive' => 0,
+      'unconfirmed' => 0,
+      'bounced' => 0,
+    ];
   }
 }

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -507,11 +507,6 @@ parameters:
 			path: ../../lib/Segments/SegmentSubscribersRepository.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersStatisticsCount\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentSubscribersRepository.php
-
-		-
 			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersWithoutSegmentStatisticsCount\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Segments/SegmentSubscribersRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -502,16 +502,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersGlobalStatusStatisticsCount\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentSubscribersRepository.php
-
-		-
-			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersWithoutSegmentStatisticsCount\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentSubscribersRepository.php
-
-		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 3
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -492,16 +492,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersGlobalStatusStatisticsCount\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentSubscribersRepository.php
-
-		-
-			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersWithoutSegmentStatisticsCount\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentSubscribersRepository.php
-
-		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 3
 			path: ../../lib/Segments/SegmentsSimpleListRepository.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -497,11 +497,6 @@ parameters:
 			path: ../../lib/Segments/SegmentSubscribersRepository.php
 
 		-
-			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersStatisticsCount\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: ../../lib/Segments/SegmentSubscribersRepository.php
-
-		-
 			message: "#^Method MailPoet\\\\Segments\\\\SegmentSubscribersRepository\\:\\:getSubscribersWithoutSegmentStatisticsCount\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: ../../lib/Segments/SegmentSubscribersRepository.php


### PR DESCRIPTION
## Description

This PR adds a fallback with logging when a segment statistics count query returns false.

## Code review notes

_N/A_

## QA notes

I guess we can skip QA here.

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7537

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7537-imported-subscribers-not-showing-across-dashboard-pages)

_The latest successful build from `stomail-7537-imported-subscribers-not-showing-across-dashboard-pages` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for segment statistics: invalid or unexpected results are now logged and safely replaced with zeroed counts to prevent failures and ensure stable display.

* **Chores**
  * Added changelog entry for the fix.
  * Tightened static analysis baselines to remove previous suppressions and reflect stricter type checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->