### PR TITLE
Add Smoke tests for E2E WooCommerce and WordPress [STOMAIL-7533]

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -758,8 +758,8 @@ class AcceptanceTester extends \Codeception\Actor {
     $postData = $this->cliToString(['post', 'get', $post, '--format=json']);
     $postData = json_decode($postData, true);
     Assert::assertIsArray($postData);
-    Assert::assertIsString($postData['guid']);
-    return $postData['guid'];
+    Assert::assertIsString($postData['url']);
+    return $postData['url'];
   }
 
   public function addFromBlockInEditor($name, $context = null) {

--- a/mailpoet/tests/acceptance/Misc/WordPressSiteEditorCest.php
+++ b/mailpoet/tests/acceptance/Misc/WordPressSiteEditorCest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+/**
+ * @group frontend
+ */
+class WordPressSiteEditorCest {
+  public function testSiteEditorBasicFunctionality(\AcceptanceTester $i) {
+    $i->wantTo('Test WordPress site editor basic functionality');
+
+    $i->login();
+
+    // Switch to a block theme (required for site editor)
+    $i->cli(['theme', 'activate', 'twentytwentyfive']);
+    $i->wait(2); // Wait for theme activation
+
+    // Navigate to site editor
+    $i->amOnPage('/wp-admin/site-editor.php');
+    $i->waitForElement('.edit-site-layout', 10);
+
+    // Verify site editor is working by checking for key elements
+    $i->seeElement('.edit-site-layout');
+    $i->seeElement('.edit-site-site-hub');
+    $i->seeElement('.edit-site-sidebar-navigation-screen__title');
+
+    // Check if we can access the navigation items
+    $i->see('Navigation');
+    $i->see('Styles');
+    $i->see('Pages');
+    $i->see('Templates');
+    $i->see('Patterns');
+  }
+
+  public function testFrontendPropagation(\AcceptanceTester $i) {
+    $i->wantTo('Test that changes in site editor are propagated to frontend');
+
+    $i->login();
+
+    // Switch to a block theme (required for site editor)
+    $i->cli(['theme', 'activate', 'twentytwentyfive']);
+    $i->wait(2); // Wait for theme activation
+
+    // Create a test page first
+    $pageTitle = 'Test Page for Site Editor';
+    $pageContent = 'This is test content for site editor propagation test.';
+    $pageUrl = $i->createPost($pageTitle, $pageContent);
+
+    // Navigate to site editor
+    $i->amOnPage('/wp-admin/site-editor.php');
+    $i->waitForElement('.edit-site-layout', 10);
+
+    // Click on Templates to access template editing
+    $i->click('Templates');
+    $i->waitForElement('.edit-site-sidebar-navigation-screen__content');
+
+    // Verify we can access the template editor
+    $i->seeElement('.edit-site-layout__content');
+
+    // Navigate to frontend to verify the page exists
+    $i->amOnUrl($pageUrl);
+    $i->waitForText($pageTitle);
+    $i->see($pageContent);
+
+    // Verify the page is using the theme's styling (basic check)
+    $i->seeElement('body');
+    $i->seeElement('header');
+    $i->seeElement('main');
+  }
+}

--- a/mailpoet/tests/acceptance/Misc/WordPressSiteEditorCest.php
+++ b/mailpoet/tests/acceptance/Misc/WordPressSiteEditorCest.php
@@ -6,25 +6,32 @@ namespace MailPoet\Test\Acceptance;
  * @group frontend
  */
 class WordPressSiteEditorCest {
+  public function _before(\AcceptanceTester $i) {
+    $i->login();
+
+    $i->wantTo('Switch to a block theme (required for site editor)');
+    $i->cli(['theme', 'activate', 'twentytwentyfive']);
+
+    $i->wantTo('Wait for theme activation to complete and ensure admin is ready');
+    $i->amOnPage('/wp-admin/');
+    $i->waitForElement('#wpbody', 10);
+  }
+
   public function testSiteEditorBasicFunctionality(\AcceptanceTester $i) {
     $i->wantTo('Test WordPress site editor basic functionality');
 
-    $i->login();
-
-    // Switch to a block theme (required for site editor)
-    $i->cli(['theme', 'activate', 'twentytwentyfive']);
-    $i->wait(2); // Wait for theme activation
-
-    // Navigate to site editor
+    $i->wantTo('Navigate to site editor');
     $i->amOnPage('/wp-admin/site-editor.php');
-    $i->waitForElement('.edit-site-layout', 10);
 
-    // Verify site editor is working by checking for key elements
-    $i->seeElement('.edit-site-layout');
-    $i->seeElement('.edit-site-site-hub');
-    $i->seeElement('.edit-site-sidebar-navigation-screen__title');
+    $i->wantTo('Wait for the site editor to load - try multiple possible indicators');
+    try {
+      $i->waitForText('Site Editor', 10);
+    } catch (\Exception $e) {
+      // Fallback: wait for any of the navigation items that should be present
+      $i->waitForText('Navigation', 10);
+    }
 
-    // Check if we can access the navigation items
+    $i->wantTo('Verify site editor is working by checking for key navigation items');
     $i->see('Navigation');
     $i->see('Styles');
     $i->see('Pages');
@@ -35,36 +42,37 @@ class WordPressSiteEditorCest {
   public function testFrontendPropagation(\AcceptanceTester $i) {
     $i->wantTo('Test that changes in site editor are propagated to frontend');
 
-    $i->login();
+    $i->wantTo('Create a test post first');
+    $postTitle = 'Test Post for Site Editor';
+    $postContent = 'This is test content for site editor propagation test.';
+    $postUrl = $i->createPost($postTitle, $postContent);
 
-    // Switch to a block theme (required for site editor)
-    $i->cli(['theme', 'activate', 'twentytwentyfive']);
-    $i->wait(2); // Wait for theme activation
-
-    // Create a test page first
-    $pageTitle = 'Test Page for Site Editor';
-    $pageContent = 'This is test content for site editor propagation test.';
-    $pageUrl = $i->createPost($pageTitle, $pageContent);
-
-    // Navigate to site editor
+    $i->wantTo('Navigate to site editor');
     $i->amOnPage('/wp-admin/site-editor.php');
-    $i->waitForElement('.edit-site-layout', 10);
 
-    // Click on Templates to access template editing
+    $i->wantTo('Wait for the site editor to load - try multiple possible indicators');
+    try {
+      $i->waitForText('Site Editor', 10);
+    } catch (\Exception $e) {
+      // Fallback: wait for any of the navigation items that should be present
+      $i->waitForText('Navigation', 10);
+    }
+
+    $i->wantTo('Click on Templates to access template editing');
     $i->click('Templates');
-    $i->waitForElement('.edit-site-sidebar-navigation-screen__content');
+    $i->waitForText('Templates', 10);
 
-    // Verify we can access the template editor
-    $i->seeElement('.edit-site-layout__content');
+    $i->wantTo('Verify we can access the template editor by checking for template-related content');
+    $i->see('Add Template');
+    $i->see('All templates');
 
-    // Navigate to frontend to verify the page exists
-    $i->amOnUrl($pageUrl);
-    $i->waitForText($pageTitle);
-    $i->see($pageContent);
+    $i->wantTo('Navigate to frontend to verify the post exists');
+    $i->amOnUrl($postUrl);
+    $i->waitForText($postTitle);
+    $i->see($postContent);
 
-    // Verify the page is using the theme's styling (basic check)
+    $i->wantTo("Verify the post is using the theme's styling (basic check)");
     $i->seeElement('body');
-    $i->seeElement('header');
     $i->seeElement('main');
   }
 }

--- a/mailpoet/tests/acceptance/WooCommerce/WooCommerceBasicFunctionalityCest.php
+++ b/mailpoet/tests/acceptance/WooCommerce/WooCommerceBasicFunctionalityCest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Settings;
+use MailPoet\Test\DataFactories\WooCommerceCustomer;
+use MailPoet\Test\DataFactories\WooCommerceOrder;
+use MailPoet\Test\DataFactories\WooCommerceProduct;
+
+/**
+ * @group woo
+ * @group frontend
+ */
+class WooCommerceBasicFunctionalityCest {
+  private Settings $settingsFactory;
+
+  public function _before(\AcceptanceTester $i) {
+    $i->login();
+    $i->activateWooCommerce();
+    $this->settingsFactory = new Settings();
+    $this->settingsFactory->withWooCommerceListImportPageDisplayed(true);
+    $this->settingsFactory->withCookieRevenueTrackingDisabled();
+  }
+
+  public function testWooCommercePluginWorks(\AcceptanceTester $i) {
+    $i->wantTo('Verify that WooCommerce plugin is working properly');
+
+    $i->wantTo('Check WooCommerce admin menu is present');
+    $i->amOnPage('/wp-admin');
+    $i->see('WooCommerce');
+
+    $i->wantTo('Navigate to WooCommerce products page');
+    $i->amOnPage('/wp-admin/edit.php?post_type=product');
+    $i->waitForText('Products', 10);
+
+    $i->wantTo('Check that WooCommerce is properly activated');
+    $i->amOnPage('/wp-admin/plugins.php');
+    $i->seeElement('tr[data-slug="woocommerce"]');
+    $i->see('Deactivate', 'tr[data-slug="woocommerce"] .row-actions .deactivate');
+  }
+
+  public function testCustomerCanCreateOrder(\AcceptanceTester $i) {
+    $i->wantTo('Verify that a customer can create a new order');
+
+    $i->wantTo('Create a test product using WooCommerce data factory');
+    $productFactory = new WooCommerceProduct($i);
+    $product = $productFactory
+      ->withName('Test Product for Order')
+      ->withPrice(2999)
+      ->create();
+
+    $i->wantTo('Create a test customer using WooCommerce data factory');
+    $customerFactory = new WooCommerceCustomer($i);
+    $customer = $customerFactory
+      ->withFirstName('Test')
+      ->withLastName('Customer')
+      ->withEmail('test.customer@example.com')
+      ->create();
+
+    $i->wantTo('Create an order using WooCommerce data factory');
+    $orderFactory = new WooCommerceOrder($i);
+    $order = $orderFactory
+      ->withCustomer($customer)
+      ->withProducts([$product])
+      ->create();
+
+    $i->wantTo('Verify the order was created successfully');
+    // Order creation successful if we reach this point without errors
+
+    $i->wantTo('Test basic WooCommerce functionality');
+    $i->wantTo('Check that the product was created');
+    $i->amOnPage('/wp-admin/edit.php?post_type=product');
+    $i->waitForText('Products', 10);
+    $i->see($product['name']);
+
+    $i->wantTo('Check that the order was created');
+    $i->amOnPage('/wp-admin/edit.php?post_type=shop_order');
+    $i->waitForText('Orders', 10);
+    $i->see('#' . $order['id']);
+
+    $i->wantTo('Verify WooCommerce is working by checking for basic elements');
+    $i->amOnPage('/wp-admin/admin.php?page=wc-admin');
+    $i->waitForText('WooCommerce', 10);
+  }
+
+  public function testWooCommerceIntegrationWithMailPoet(\AcceptanceTester $i) {
+    $i->wantTo('Verify WooCommerce integration with MailPoet');
+
+    $i->wantTo('Check that WooCommerce marketing integration is working');
+    $i->amOnPage('/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing');
+    $i->waitForText('Channels', 10);
+    $i->see('MailPoet');
+
+    $i->wantTo('Check MailPoet WooCommerce settings');
+    $i->amOnMailPoetPage('Settings');
+    $i->see('WooCommerce');
+  }
+}


### PR DESCRIPTION
## Description

Add some tests for WooCommerce and WordPress to catch any potential issues

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7533]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7533-add-some-smoke-tests-for-e2e-woocommerce-and-wordpress)

_The latest successful build from `stomail-7533-add-some-smoke-tests-for-e2e-woocommerce-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end acceptance tests for the WordPress Site Editor, checking editor UI, template access, and frontend propagation of content.
  - Added end-to-end tests for WooCommerce basics: plugin presence, product/order creation flows, and MailPoet–WooCommerce integration.
  - Updated test helper to return created post URLs.
  - Expanded coverage to better simulate real user scenarios and speed regression detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->