### PR TITLE
Use specific version when downloading premium plugin

### DIFF
--- a/mailpoet/changelog/2025-08-28-16-45-32-improved-use-specific-version-when-downloading-premium-plug.md
+++ b/mailpoet/changelog/2025-08-28-16-45-32-improved-use-specific-version-when-downloading-premium-plug.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Use specific version when downloading premium plugin

--- a/mailpoet/lib/API/JSON/v1/Premium.php
+++ b/mailpoet/lib/API/JSON/v1/Premium.php
@@ -5,10 +5,10 @@ namespace MailPoet\API\JSON\v1;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\Config\AccessControl;
+use MailPoet\Config\Installer;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WPCOM\DotcomHelperFunctions;
-use WP_Error;
 
 class Premium extends APIEndpoint {
   const PREMIUM_PLUGIN_SLUG = 'mailpoet-premium';
@@ -20,23 +20,24 @@ class Premium extends APIEndpoint {
     'global' => AccessControl::PERMISSION_MANAGE_SETTINGS,
   ];
 
-  /** @var ServicesChecker */
-  private $servicesChecker;
+  private ServicesChecker $servicesChecker;
 
-  /** @var WPFunctions */
-  private $wp;
+  private WPFunctions $wp;
 
-  /** @var DotcomHelperFunctions */
-  private $dotcomHelperFunctions;
+  private DotcomHelperFunctions $dotcomHelperFunctions;
+
+  private Installer $premiumInstaller;
 
   public function __construct(
     ServicesChecker $servicesChecker,
     WPFunctions $wp,
-    DotcomHelperFunctions $dotcomHelperFunctions
+    DotcomHelperFunctions $dotcomHelperFunctions,
+    ?Installer $premiumInstaller = null
   ) {
     $this->servicesChecker = $servicesChecker;
     $this->wp = $wp;
     $this->dotcomHelperFunctions = $dotcomHelperFunctions;
+    $this->premiumInstaller = $premiumInstaller ?? new Installer(Installer::PREMIUM_PLUGIN_SLUG);
   }
 
   public function installPlugin() {
@@ -44,16 +45,6 @@ class Premium extends APIEndpoint {
     if (!$premiumKeyValid) {
       return $this->error(__('Premium key is not valid.', 'mailpoet'));
     }
-
-    $pluginInfo = $this->wp->pluginsApi('plugin_information', [
-      'slug' => self::PREMIUM_PLUGIN_SLUG,
-    ]);
-
-    if (!$pluginInfo || $pluginInfo instanceof WP_Error) {
-      return $this->error(__('Error when installing MailPoet Premium plugin.', 'mailpoet'));
-    }
-
-    $pluginInfo = (array)$pluginInfo;
 
     // If we are in Dotcom platform, we try to symlink the plugin instead of downloading it
     try {
@@ -67,7 +58,7 @@ class Premium extends APIEndpoint {
       // Do nothing and continue with a regular installation
     }
 
-    $result = $this->wp->installPlugin($pluginInfo['download_link']);
+    $result = $this->wp->installPlugin($this->premiumInstaller->generatePluginDownloadUrl());
     if ($result !== true) {
       return $this->error(__('Error when installing MailPoet Premium plugin.', 'mailpoet'));
     }

--- a/mailpoet/lib/Config/Installer.php
+++ b/mailpoet/lib/Config/Installer.php
@@ -30,7 +30,8 @@ class Installer {
 
   public function generatePluginDownloadUrl(): string {
     $premiumKey = $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
-    return "https://release.mailpoet.com/downloads/mailpoet-premium/$premiumKey/latest/mailpoet-premium.zip";
+    $freeMinorVersion = self::getFreeMinorVersionZero();
+    return "https://release.mailpoet.com/downloads/mailpoet-premium/$premiumKey/$freeMinorVersion/mailpoet-premium.zip";
   }
 
   public function generatePluginActivationUrl(string $plugin): string {
@@ -96,5 +97,17 @@ class Installer {
     $key = $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
     $api = new API($key);
     return $api->getPluginInformation($this->slug);
+  }
+
+  private static function getFreeMinorVersionZero(): string {
+    $version = defined('MAILPOET_VERSION') ? (string)MAILPOET_VERSION : '';
+    if ($version === '') {
+      return 'latest';
+    }
+
+    $parts = explode('.', $version);
+    $major = $parts[0] ?? '0';
+    $minor = $parts[1] ?? '0';
+    return $major . '.' . $minor . '.0';
   }
 }

--- a/mailpoet/lib/Config/Installer.php
+++ b/mailpoet/lib/Config/Installer.php
@@ -31,7 +31,11 @@ class Installer {
   public function generatePluginDownloadUrl(): string {
     $premiumKey = $this->settings->get(Bridge::PREMIUM_KEY_SETTING_NAME);
     $freeMinorVersion = self::getFreeMinorVersionZero();
-    return "https://release.mailpoet.com/downloads/mailpoet-premium/$premiumKey/$freeMinorVersion/mailpoet-premium.zip";
+    return sprintf(
+      'https://release.mailpoet.com/downloads/mailpoet-premium/%s/%s/mailpoet-premium.zip',
+      rawurlencode((string)$premiumKey),
+      rawurlencode($freeMinorVersion)
+    );
   }
 
   public function generatePluginActivationUrl(string $plugin): string {

--- a/mailpoet/tests/integration/Config/InstallerTest.php
+++ b/mailpoet/tests/integration/Config/InstallerTest.php
@@ -41,7 +41,16 @@ class InstallerTest extends \MailPoetTest {
     $key = 'premium-key';
     $this->diContainer->get(SettingsController::class)->set(Bridge::PREMIUM_KEY_SETTING_NAME, $key);
     $url = $this->installer->generatePluginDownloadUrl();
-    verify($url)->same("https://release.mailpoet.com/downloads/mailpoet-premium/$key/latest/mailpoet-premium.zip");
+    $version = defined('MAILPOET_VERSION') ? (string)MAILPOET_VERSION : '';
+    if ($version === '') {
+      $expectedSegment = 'latest';
+    } else {
+      $parts = explode('.', $version);
+      $major = $parts[0] ?? '0';
+      $minor = $parts[1] ?? '0';
+      $expectedSegment = $major . '.' . $minor . '.0';
+    }
+    verify($url)->same("https://release.mailpoet.com/downloads/mailpoet-premium/$key/$expectedSegment/mailpoet-premium.zip");
   }
 
   public function testItGetsPluginInformation() {


### PR DESCRIPTION
## Description

This PR improves premium plugin download links in the free plugin.

## Code review notes

_N/A_

## QA notes

1. Use different free plugin versions without the premium
2. Ensure you have set your premium key
3. Use a different minor plugin version
4. Ensure that download links for the premium plugin match your free plugin version

## Linked PRs

Closes STOMAIL-7526

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7526-use-specific-version-when-downloading-premium-plugin)

_The latest successful build from `stomail-7526-use-specific-version-when-downloading-premium-plugin` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Premium add-on installation now downloads a version aligned with your MailPoet minor version, improving compatibility and reducing installation/activation failures in managed or locked environments.

* **Documentation**
  * Added a changelog entry describing the improved premium plugin download behavior.

* **Tests**
  * Updated tests to validate the version-specific download URL generation and installation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->