### PR TITLE
Run QIT tests twice every week [STOMAIL-7542]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1309,7 +1309,7 @@ workflows:
   nightly_qit:
     triggers:
       - schedule:
-          cron: '0 2 * * 3' # Every Wednesday at 2am UTC
+          cron: '0 2 * * 2,3' # Every Tuesday and Wednesday at 2am UTC
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description

To catch potential problems with the release we shoud run the tests before the release. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7542]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7542-run-qit-tests-before-release)

_The latest successful build from `stomail-7542-run-qit-tests-before-release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted nightly test schedule to run twice weekly (Tuesdays and Wednesdays) at 02:00 UTC instead of Wednesdays only, improving coverage and earlier issue detection. No impact on app functionality.
* **Documentation**
  * Updated inline comment to reflect the new schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->