### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.1.1
+            ./do download:woo-commerce-zip 10.1.2
             ./do download:woo-commerce-subscriptions-zip 7.7.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.15


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated test environment to use WooCommerce Core 10.1.2 (previously 10.1.1) for integration tests, aligning CI with the latest patch release.
  * No impact on product functionality, user workflows, or performance; build and deployment behavior remain unchanged.
  * Keeps test coverage current and improves confidence in compatibility with the latest WooCommerce core.
  * No changes to public interfaces or documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->