### PR TITLE
Enable Block Email Editor Support for Automation Newsletters - STOMAIL-7541

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/actions.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/actions.tsx
@@ -1,12 +1,25 @@
 import { __ } from '@wordpress/i18n';
 import { DropdownMenu } from '@wordpress/components';
 import { moreVertical, pencil, seen } from '@wordpress/icons';
+import { MailPoet } from '../../../../../../../mailpoet';
+
+const getEditorLink = (id: number, wpPostId: number) => {
+  if (wpPostId) {
+    return MailPoet.getBlockEmailEditorUrl(wpPostId);
+  }
+  return MailPoet.getNewsletterEditorUrl(id, 'automation');
+};
 
 type ActionsProps = {
   id: number;
   previewUrl: string;
+  wpPostId?: number;
 };
-export function Actions({ id, previewUrl }: ActionsProps): JSX.Element {
+export function Actions({
+  id,
+  previewUrl,
+  wpPostId,
+}: ActionsProps): JSX.Element {
   const controls = [
     {
       title: __('Preview email', 'mailpoet'),
@@ -19,7 +32,7 @@ export function Actions({ id, previewUrl }: ActionsProps): JSX.Element {
       title: __('Edit email', 'mailpoet'),
       icon: pencil,
       onClick: () => {
-        window.location.href = `?page=mailpoet-newsletter-editor&id=${id}&context=automation`;
+        window.location.href = getEditorLink(id, wpPostId);
       },
     },
   ];

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/actions.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/actions.tsx
@@ -3,7 +3,7 @@ import { DropdownMenu } from '@wordpress/components';
 import { moreVertical, pencil, seen } from '@wordpress/icons';
 import { MailPoet } from '../../../../../../../mailpoet';
 
-const getEditorLink = (id: number, wpPostId: number) => {
+const getEditorLink = (id: number, wpPostId?: number) => {
   if (wpPostId) {
     return MailPoet.getBlockEmailEditorUrl(wpPostId);
   }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/actions.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/actions.tsx
@@ -13,7 +13,7 @@ const getEditorLink = (id: number, wpPostId?: number) => {
 type ActionsProps = {
   id: number;
   previewUrl: string;
-  wpPostId?: number;
+  wpPostId?: number | null;
 };
 export function Actions({
   id,

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
@@ -131,7 +131,13 @@ export function transformEmailsToRows(emails: EmailStats[]) {
         value: email.unsubscribed,
       },
       {
-        display: <Actions id={email.id} previewUrl={email.previewUrl} />,
+        display: (
+          <Actions
+            id={email.id}
+            previewUrl={email.previewUrl}
+            wpPostId={email?.wpPostId ?? 0}
+          />
+        ),
         value: null,
       },
     ]);

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/emails/rows.tsx
@@ -135,7 +135,7 @@ export function transformEmailsToRows(emails: EmailStats[]) {
           <Actions
             id={email.id}
             previewUrl={email.previewUrl}
-            wpPostId={email?.wpPostId ?? 0}
+            wpPostId={email?.wpPostId ?? null}
           />
         ),
         value: null,

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -21,7 +21,7 @@ export type EmailStats = {
   orders: number;
   revenue: number;
   unsubscribed: number;
-  wpPostId?: number;
+  wpPostId?: number | null;
 };
 
 type OverviewSectionData = SectionData & {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -21,6 +21,7 @@ export type EmailStats = {
   orders: number;
   revenue: number;
   unsubscribed: number;
+  wpPostId?: number;
 };
 
 type OverviewSectionData = SectionData & {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -151,7 +151,13 @@ export function EditNewsletter(): JSX.Element {
     if (isDuplicatedStep) {
       setIsHandlingDuplicatedStep(true);
 
-      const { newEmailId, newEmailWpPostId } = await handleDuplicatedStep();
+      const info = await handleDuplicatedStep();
+      if (!info) {
+        setIsHandlingDuplicatedStep(false);
+        return;
+      }
+
+      const { newEmailId, newEmailWpPostId } = info;
 
       if (newEmailWpPostId) {
         newUrl = MailPoet.getBlockEmailEditorUrl(newEmailWpPostId);

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -74,7 +74,7 @@ export function EditNewsletter(): JSX.Element {
         type: 'automation',
         subject: '',
         options,
-        new_editor: true,
+        new_editor: MailPoet.useBlockEmailEditorForAutomationNewsletter,
       },
     });
 

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -207,7 +207,7 @@ interface Window {
   mailpoet_installed_days_ago: number;
   mailpoet_send_transactional_emails: boolean;
   mailpoet_transactional_emails_opt_in_notice_dismissed: boolean;
-  mailpoet_use_block_email_editor_for_automation_newsletter: boolean;
+  mailpoet_use_block_email_editor_for_automation_emails: boolean;
 
   mailpoet_mta_log?: MtaLog;
   mailpoet_listing: {

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -207,6 +207,7 @@ interface Window {
   mailpoet_installed_days_ago: number;
   mailpoet_send_transactional_emails: boolean;
   mailpoet_transactional_emails_opt_in_notice_dismissed: boolean;
+  mailpoet_use_block_email_editor_for_automation_newsletter: boolean;
 
   mailpoet_mta_log?: MtaLog;
   mailpoet_listing: {

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/global.d.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/global.d.ts
@@ -1,0 +1,18 @@
+interface Window {
+  WooCommerceEmailEditor: {
+    current_post_type: string;
+    current_post_id: string;
+    current_wp_user_email: string;
+    editor_settings: {
+      [key: string]: string | boolean | number | object;
+    };
+    editor_theme: string;
+    user_theme_post_id: string;
+    urls: {
+      listings: string;
+      send: string;
+      back: string;
+    };
+  };
+  mailpoet_is_automation_newsletter: boolean;
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -85,8 +85,8 @@ if (!isAutomationNewsletter) {
   addFilter(
     'woocommerce_email_editor_setting_sidebar_extension_component',
     'mailpoet/email-editor-integration',
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     (RichTextWithButton) =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       EmailSidebarExtension.bind(null, RichTextWithButton),
   );
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -3,6 +3,7 @@
 // Here, we can expose MailPoet specific components for use in the Email editor.
 
 import { addFilter, addAction } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { initializeEditor } from '@woocommerce/email-editor';
 import { EmailContentValidationRule } from '@woocommerce/email-editor/build-types/store';
@@ -28,6 +29,18 @@ addFilter(
     emailValidationRule,
   ],
 );
+
+const isAutomationNewsletter = window?.mailpoet_is_automation_newsletter;
+
+// Show custom label for Automation emails.
+// Using the same label as /assets/js/src/newsletter-editor/initializer.jsx#L49
+if (isAutomationNewsletter) {
+  addFilter(
+    'woocommerce_email_editor_send_button_label',
+    'mailpoet/email-editor-integration',
+    () => __('Save and continue', 'mailpoet'),
+  );
+}
 
 const EVENTS_TO_TRACK = [
   'email_editor_events_editor_layout_loaded', // email editor was opened
@@ -66,12 +79,17 @@ addFilter(
 );
 
 // integration point for settings sidebar
-addFilter(
-  'woocommerce_email_editor_setting_sidebar_extension_component',
-  'mailpoet/email-editor-integration',
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  (RichTextWithButton) => EmailSidebarExtension.bind(null, RichTextWithButton),
-);
+// Hide subject and preview text fields for Automation emails.
+// This is because the Automation editor has its own subject and preview text fields and there isn't a need to show them again in the email editor.
+if (!isAutomationNewsletter) {
+  addFilter(
+    'woocommerce_email_editor_setting_sidebar_extension_component',
+    'mailpoet/email-editor-integration',
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    (RichTextWithButton) =>
+      EmailSidebarExtension.bind(null, RichTextWithButton),
+  );
+}
 
 // use mailpoet data subject if available
 addFilter(

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -13,9 +13,33 @@ import {
 import { MailPoetNum } from './num';
 import { MailPoetHelpTooltip } from './help-tooltip-helper';
 import { MailPoetIframe } from './iframe';
+import { NewsletterType } from './newsletters/campaign-stats/newsletter-type';
 
 const getBlockEmailEditorUrl = (postId: string | number): string =>
   `post.php?post=${postId}&action=edit`;
+
+const getNewsletterEditorUrl = (
+  newsletterId: string | number,
+  context = '',
+): string =>
+  context
+    ? `?page=mailpoet-newsletter-editor&id=${newsletterId}&context=${context}`
+    : `?page=mailpoet-newsletter-editor&id=${newsletterId}`;
+
+const getTheEmailEditorUrl = (
+  newsletter: NewsletterType,
+  context = '',
+): string => {
+  if (!newsletter || !newsletter.id) {
+    return '';
+  }
+
+  if (newsletter.wp_post_id) {
+    return getBlockEmailEditorUrl(newsletter.wp_post_id);
+  }
+
+  return getNewsletterEditorUrl(newsletter.id, context);
+};
 
 // A placeholder for MailPoet object
 export const MailPoet = {
@@ -93,6 +117,8 @@ export const MailPoet = {
   isDotcom: window.mailpoet_is_dotcom,
   cronTriggerMethod: window.mailpoet_cron_trigger_method,
   getBlockEmailEditorUrl,
+  getNewsletterEditorUrl,
+  getTheEmailEditorUrl,
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -21,17 +21,20 @@ const getBlockEmailEditorUrl = (postId: string | number): string =>
 const getNewsletterEditorUrl = (
   newsletterId: string | number,
   context = '',
-): string =>
-  context
-    ? `?page=mailpoet-newsletter-editor&id=${newsletterId}&context=${context}`
-    : `?page=mailpoet-newsletter-editor&id=${newsletterId}`;
+): string => {
+  const base = 'admin.php?page=mailpoet-newsletter-editor';
+  const id = encodeURIComponent(String(newsletterId));
+  return context
+    ? `${base}&id=${id}&context=${encodeURIComponent(context)}`
+    : `${base}&id=${id}`;
+};
 
 const getTheEmailEditorUrl = (
   newsletter: NewsletterType,
   context = '',
 ): string => {
   if (!newsletter || !newsletter.id) {
-    return '';
+    return '#';
   }
 
   if (newsletter.wp_post_id) {

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -29,7 +29,7 @@ const getNewsletterEditorUrl = (
     : `${base}&id=${id}`;
 };
 
-const getTheEmailEditorUrl = (
+const getActiveEmailEditorUrl = (
   newsletter: NewsletterType,
   context = '',
 ): string => {
@@ -123,7 +123,7 @@ export const MailPoet = {
     window?.mailpoet_use_block_email_editor_for_automation_emails ?? false,
   getBlockEmailEditorUrl,
   getNewsletterEditorUrl,
-  getTheEmailEditorUrl,
+  getActiveEmailEditorUrl,
 } as const;
 
 declare global {

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -116,6 +116,8 @@ export const MailPoet = {
   adminPluginsUrl: window.mailpoet_admin_plugins_url,
   isDotcom: window.mailpoet_is_dotcom,
   cronTriggerMethod: window.mailpoet_cron_trigger_method,
+  useBlockEmailEditorForAutomationNewsletter:
+    window?.mailpoet_use_block_email_editor_for_automation_newsletter ?? false,
   getBlockEmailEditorUrl,
   getNewsletterEditorUrl,
   getTheEmailEditorUrl,

--- a/mailpoet/assets/js/src/mailpoet.ts
+++ b/mailpoet/assets/js/src/mailpoet.ts
@@ -120,7 +120,7 @@ export const MailPoet = {
   isDotcom: window.mailpoet_is_dotcom,
   cronTriggerMethod: window.mailpoet_cron_trigger_method,
   useBlockEmailEditorForAutomationNewsletter:
-    window?.mailpoet_use_block_email_editor_for_automation_newsletter ?? false,
+    window?.mailpoet_use_block_email_editor_for_automation_emails ?? false,
   getBlockEmailEditorUrl,
   getNewsletterEditorUrl,
   getTheEmailEditorUrl,

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -33,7 +33,7 @@ const redirectToNewsletterHome = () => {
 };
 
 const getEditorLink = (newsletter: NewsletterType) =>
-  MailPoet.getTheEmailEditorUrl(newsletter);
+  MailPoet.getActiveEmailEditorUrl(newsletter);
 
 const editNewsletter = (newsletter: NewsletterType) => {
   const editorHref = getEditorLink(newsletter);

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -32,13 +32,8 @@ const redirectToNewsletterHome = () => {
   window.location.href = '?page=mailpoet-newsletters';
 };
 
-const getEditorLink = (newsletter: NewsletterType) => {
-  let editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  if (newsletter.wp_post_id) {
-    editorHref = MailPoet.getBlockEmailEditorUrl(newsletter.wp_post_id);
-  }
-  return editorHref;
-};
+const getEditorLink = (newsletter: NewsletterType) =>
+  MailPoet.getTheEmailEditorUrl(newsletter);
 
 const editNewsletter = (newsletter: NewsletterType) => {
   const editorHref = getEditorLink(newsletter);

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -339,7 +339,7 @@ class NewsletterListNotificationComponent extends Component {
         <td className={rowClasses}>
           <a
             className="mailpoet-listing-title"
-            href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}
+            href={MailPoet.getTheEmailEditorUrl(newsletter)}
             onClick={(event) => {
               event.preventDefault();
               confirmEdit(newsletter);

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -339,7 +339,7 @@ class NewsletterListNotificationComponent extends Component {
         <td className={rowClasses}>
           <a
             className="mailpoet-listing-title"
-            href={MailPoet.getTheEmailEditorUrl(newsletter)}
+            href={MailPoet.getActiveEmailEditorUrl(newsletter)}
             onClick={(event) => {
               event.preventDefault();
               confirmEdit(newsletter);

--- a/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
@@ -322,7 +322,7 @@ class NewsletterListReEngagementComponent extends Component {
         <td className={rowClasses}>
           <a
             className="mailpoet-listing-title"
-            href={MailPoet.getTheEmailEditorUrl(newsletter)}
+            href={MailPoet.getActiveEmailEditorUrl(newsletter)}
             onClick={(event) => {
               event.preventDefault();
               confirmEdit(newsletter);

--- a/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
@@ -322,7 +322,7 @@ class NewsletterListReEngagementComponent extends Component {
         <td className={rowClasses}>
           <a
             className="mailpoet-listing-title"
-            href={`?page=mailpoet-newsletter-editor&id=${newsletter.id}`}
+            href={MailPoet.getTheEmailEditorUrl(newsletter)}
             onClick={(event) => {
               event.preventDefault();
               confirmEdit(newsletter);

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -109,7 +109,7 @@ const bulkActions = [
 ];
 
 const confirmEdit = (newsletter) => {
-  const editorHref = MailPoet.getTheEmailEditorUrl(newsletter);
+  const editorHref = MailPoet.getActiveEmailEditorUrl(newsletter);
 
   if (
     !newsletter.queue ||

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -109,10 +109,7 @@ const bulkActions = [
 ];
 
 const confirmEdit = (newsletter) => {
-  let editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
-  if (newsletter.wp_post_id) {
-    editorHref = MailPoet.getBlockEmailEditorUrl(newsletter.wp_post_id);
-  }
+  const editorHref = MailPoet.getTheEmailEditorUrl(newsletter);
 
   if (
     !newsletter.queue ||

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -102,7 +102,7 @@ export const newsletterTypesWithActivation = [
 export const automationTypes = ['automation', 'automation_transactional'];
 
 export const confirmEdit = (newsletter) => {
-  const editorHref = `?page=mailpoet-newsletter-editor&id=${newsletter.id}`;
+  const editorHref = MailPoet.getTheEmailEditorUrl(newsletter);
 
   if (
     newsletterTypesWithActivation.includes(newsletter.type) &&

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -102,7 +102,7 @@ export const newsletterTypesWithActivation = [
 export const automationTypes = ['automation', 'automation_transactional'];
 
 export const confirmEdit = (newsletter) => {
-  const editorHref = MailPoet.getTheEmailEditorUrl(newsletter);
+  const editorHref = MailPoet.getActiveEmailEditorUrl(newsletter);
 
   if (
     newsletterTypesWithActivation.includes(newsletter.type) &&

--- a/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
@@ -13,6 +13,7 @@ import { RecalculateSubscriberScore } from './recalculate-subscriber-score';
 import { Logging } from './logging';
 import { BounceAddress } from './bounce-address';
 import { CaptchaOnSignup } from './captcha-on-signup';
+import { UseBlockEditorForAutomation } from './use-block-editor-for-automation';
 
 export function Advanced() {
   return (
@@ -29,6 +30,7 @@ export function Advanced() {
       <Libs3rdParty />
       <Captcha />
       <CaptchaOnSignup />
+      <UseBlockEditorForAutomation />
       <Reinstall />
       <Logging />
       <SaveButton />

--- a/mailpoet/assets/js/src/settings/pages/advanced/use-block-editor-for-automation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/use-block-editor-for-automation.tsx
@@ -1,0 +1,42 @@
+import { t } from 'common/functions';
+import { Radio } from 'common/form/radio/radio';
+import { useSetting } from 'settings/store/hooks';
+import { Label, Inputs } from 'settings/components';
+
+export function UseBlockEditorForAutomation() {
+  const [enabled, setEnabled] = useSetting(
+    'use_block_email_editor_for_automation_newsletter',
+    'enabled',
+  );
+
+  return (
+    <>
+      <Label
+        title={t('useBlockEditorForAutomationTitle')}
+        description={t('useBlockEditorForAutomationDescription')}
+        htmlFor=""
+      />
+      <Inputs>
+        <Radio
+          id="use-block-editor-for-automation-enabled"
+          value="1"
+          checked={enabled === '1'}
+          onCheck={setEnabled}
+        />
+        <label htmlFor="use-block-editor-for-automation-enabled">
+          {t('yes')}
+        </label>
+        <span className="mailpoet-gap" />
+        <Radio
+          id="use-block-editor-for-automation-disabled"
+          value=""
+          checked={enabled === ''}
+          onCheck={setEnabled}
+        />
+        <label htmlFor="use-block-editor-for-automation-disabled">
+          {t('no')}
+        </label>
+      </Inputs>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/settings/pages/advanced/use-block-editor-for-automation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/use-block-editor-for-automation.tsx
@@ -22,6 +22,7 @@ export function UseBlockEditorForAutomation() {
           value="1"
           checked={enabled === '1'}
           onCheck={setEnabled}
+          automationId="block-editor-for-automation-enabled"
         />
         <label htmlFor="use-block-editor-for-automation-enabled">
           {t('yes')}
@@ -32,6 +33,7 @@ export function UseBlockEditorForAutomation() {
           value=""
           checked={enabled === ''}
           onCheck={setEnabled}
+          automationId="block-editor-for-automation-disabled"
         />
         <label htmlFor="use-block-editor-for-automation-disabled">
           {t('no')}

--- a/mailpoet/assets/js/src/settings/pages/advanced/use-block-editor-for-automation.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/use-block-editor-for-automation.tsx
@@ -5,7 +5,7 @@ import { Label, Inputs } from 'settings/components';
 
 export function UseBlockEditorForAutomation() {
   const [enabled, setEnabled] = useSetting(
-    'use_block_email_editor_for_automation_newsletter',
+    'use_block_email_editor_for_automation_emails',
     'enabled',
   );
 

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -127,6 +127,9 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
     ),
     analytics: asObject({ enabled: disabledRadio }),
     '3rd_party_libs': asObject({ enabled: disabledRadio }),
+    use_block_email_editor_for_automation_newsletter: asObject({
+      enabled: disabledRadio,
+    }),
     captcha: asObject({
       type: asEnum(
         ['', 'built-in', 'recaptcha', 'recaptcha-invisible'],

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -127,7 +127,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
     ),
     analytics: asObject({ enabled: disabledRadio }),
     '3rd_party_libs': asObject({ enabled: disabledRadio }),
-    use_block_email_editor_for_automation_newsletter: asObject({
+    use_block_email_editor_for_automation_emails: asObject({
       enabled: disabledRadio,
     }),
     captcha: asObject({

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -54,7 +54,7 @@ export type Settings = {
   '3rd_party_libs': {
     enabled: '' | '1';
   };
-  use_block_email_editor_for_automation_newsletter: {
+  use_block_email_editor_for_automation_emails: {
     enabled: '' | '1';
   };
   send_transactional_emails: '' | '1';

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -54,6 +54,9 @@ export type Settings = {
   '3rd_party_libs': {
     enabled: '' | '1';
   };
+  use_block_email_editor_for_automation_newsletter: {
+    enabled: '' | '1';
+  };
   send_transactional_emails: '' | '1';
   deactivate_subscriber_after_inactive_days: '' | '90' | '180' | '365' | '540';
   analytics: {

--- a/mailpoet/changelog/2025-09-01-12-58-52-added-enable-support-for-creating-and-editing-automation.md
+++ b/mailpoet/changelog/2025-09-01-12-58-52-added-enable-support-for-creating-and-editing-automation.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Enable support for creating and editing Automation newsletters with the block email editor.

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -207,7 +207,7 @@ class PageRenderer {
       'display_chatbot_widget' => $this->displayChatBotWidget(),
       'is_woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
       'cron_trigger_method' => $this->settings->get('cron_trigger.method'),
-      'use_block_email_editor_for_automation_newsletter' => $this->useBlockEmailEditorForAutomationNewsletter(),
+      'use_block_email_editor_for_automation_emails' => $this->useBlockEmailEditorForAutomationNewsletter(),
     ];
 
     if (!$defaults['premium_plugin_active']) {
@@ -259,8 +259,8 @@ class PageRenderer {
   }
 
   public function useBlockEmailEditorForAutomationNewsletter(): bool {
-    $default = $this->settings->get('use_block_email_editor_for_automation_newsletter.enabled') === '1';
-    $status = $this->wp->applyFilters('mailpoet_use_block_email_editor_for_automation_newsletter', $default);
+    $default = $this->settings->get('use_block_email_editor_for_automation_emails.enabled') === '1';
+    $status = $this->wp->applyFilters('mailpoet_use_block_email_editor_for_automation_emails', $default);
     return (bool)$status;
   }
 }

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -207,6 +207,7 @@ class PageRenderer {
       'display_chatbot_widget' => $this->displayChatBotWidget(),
       'is_woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
       'cron_trigger_method' => $this->settings->get('cron_trigger.method'),
+      'use_block_email_editor_for_automation_newsletter' => $this->useBlockEmailEditorForAutomationNewsletter(),
     ];
 
     if (!$defaults['premium_plugin_active']) {
@@ -255,5 +256,11 @@ class PageRenderer {
   public function displayChatBotWidget(): bool {
     $display = $this->wp->applyFilters('mailpoet_display_docsbot_widget', $this->settings->get('3rd_party_libs.enabled') === '1');
     return (bool)$display;
+  }
+
+  public function useBlockEmailEditorForAutomationNewsletter(): bool {
+    $default = $this->settings->get('use_block_email_editor_for_automation_newsletter.enabled') === '1';
+    $status = $this->wp->applyFilters('mailpoet_use_block_email_editor_for_automation_newsletter', $default);
+    return (bool)$status;
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
@@ -84,6 +84,7 @@ class OverviewStatisticsController {
       $data['emails'][$newsletterId]['revenue'] = $statistic->getWooCommerceRevenue() ? $statistic->getWooCommerceRevenue()->getValue() : 0;
       $data['emails'][$newsletterId]['previewUrl'] = $newsletter ? $this->newsletterUrl->getViewInBrowserUrl($newsletter) : '';
       $data['emails'][$newsletterId]['order'] = count($data['emails']);
+      $data['emails'][$newsletterId]['wpPostId'] = $newsletter ? $newsletter->getWpPostId() : 0;
     }
 
     $previousStatistics = $this->newsletterStatisticsRepository->getBatchStatistics(

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Hooks/AutomationEditorLoadingHooks.php
@@ -72,9 +72,22 @@ class AutomationEditorLoadingHooks {
         continue;
       }
 
+      if ($newsletterEntity && $newsletterEntity->getWpPostId()) {
+        $wpPost = $this->wp->getPost($newsletterEntity->getWpPostId());
+        // Skip if the wp post has content for emails created by the new block editor.
+        if ($wpPost && $wpPost instanceof \WP_Post && !empty($wpPost->post_content)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          continue;
+        }
+      }
+
       $this->newsletterDeleteController->bulkDelete([$emailId]);
       $args = $step->getArgs();
       unset($args['email_id']);
+
+      if (isset($args['email_wp_post_id'])) {
+        unset($args['email_wp_post_id']);
+      }
+
       $updatedStep = new Step(
         $step->getId(),
         $step->getType(),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -152,7 +152,7 @@ class EditorPageRenderer {
     $backUrl = 'page=mailpoet-newsletters';
 
     if ($isAutomationNewsletter) {
-      $listingUrl = 'page=mailpoet-automations';
+      $listingUrl = 'page=mailpoet-automation';
       $sendUrl = 'page=mailpoet-automation-editor&id=' . $automationId;
       $backUrl = $sendUrl;
     }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -143,6 +143,20 @@ class EditorPageRenderer {
     $editorSettings['displaySendEmailButton'] = true;
 
     $currentUserEmail = $this->wp->wpGetCurrentUser()->user_email;
+
+    $isAutomationNewsletter = $newsletter->isAutomation() || $newsletter->isAutomationTransactional();
+    $automationId = $newsletter->getOptionValue('automationId');
+
+    $listingUrl = 'page=mailpoet-newsletters';
+    $sendUrl = 'page=mailpoet-newsletters#/send/' . $newsletter->getId();
+    $backUrl = 'page=mailpoet-newsletters';
+
+    if ($isAutomationNewsletter) {
+      $listingUrl = 'page=mailpoet-automations';
+      $sendUrl = 'page=mailpoet-automation-editor&id=' . $automationId;
+      $backUrl = $sendUrl;
+    }
+
     $this->wp->wpLocalizeScript(
       'email_editor_integration',
       'WooCommerceEmailEditor',
@@ -154,9 +168,9 @@ class EditorPageRenderer {
         'editor_theme' => $this->themeController->get_base_theme()->get_raw_data(),
         'user_theme_post_id' => $this->userTheme->get_user_theme_post()->ID,
         'urls' => [
-          'listings' => admin_url('admin.php?page=mailpoet-newsletters'),
-          'send' => admin_url('admin.php?page=mailpoet-newsletters#/send/' . $newsletter->getId()),
-          'back' => admin_url('admin.php?page=mailpoet-newsletters'),
+          'listings' => admin_url('admin.php?' . $listingUrl),
+          'send' => admin_url('admin.php?' . $sendUrl),
+          'back' => admin_url('admin.php?' . $backUrl),
         ],
       ]
     );
@@ -191,6 +205,8 @@ class EditorPageRenderer {
       'mailpoet_site_url' => $this->wp->siteUrl(),
       'mailpoet_review_request_illustration_url' => $this->cdnAssetUrl->generateCdnUrl('review-request/review-request-illustration.20190815-1427.svg'),
       'mailpoet_installed_days_ago' => (int)$installedAtDiff->format('%a'),
+      'mailpoet_is_automation_newsletter' => $isAutomationNewsletter,
+      'mailpoet_automation_id' => $automationId,
     ];
     $this->wp->wpAddInlineScript('email_editor_integration', implode('', array_map(function ($key) use ($inline_script_data) {
       return sprintf("var %s=%s;", $key, wp_json_encode($inline_script_data[$key]));

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -652,4 +652,12 @@ class NewsletterEntity {
       NewsletterEntity::TYPE_WC_TRANSACTIONAL_EMAIL,
     ]);
   }
+
+  public function isAutomation(): bool {
+    return $this->getType() === NewsletterEntity::TYPE_AUTOMATION;
+  }
+
+  public function isAutomationTransactional(): bool {
+    return $this->getType() === NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL;
+  }
 }

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -163,10 +163,17 @@ class NewsletterSaveController {
     if (!isset($data['new_editor'])) {
       return false;
     }
-    if (is_string($data['new_editor'])) {
-      return strtolower(trim($data['new_editor'])) === 'true';
+
+    $value = $data['new_editor'];
+
+    if (is_bool($value)) return $value;
+    if (is_int($value)) return $value === 1;
+    if (is_string($value)) {
+      $norm = strtolower(trim($value));
+      if (in_array($norm, ['1', 'true', 'yes', 'on'], true)) return true;
+      if (in_array($norm, ['0', 'false', 'no', 'off', ''], true)) return false;
     }
-    return (bool)$data['new_editor'];
+    return (bool)$value;
   }
 
   private function sanitizeAutomationEmailData(array $data, NewsletterEntity $newsletter): array {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -153,10 +153,20 @@ class NewsletterSaveController {
     $this->rescheduleIfNeeded($newsletter);
     $this->updateQueue($newsletter, $data['options'] ?? []);
     $this->authorizedEmailsController->onNewsletterSenderAddressUpdate($newsletter, $oldSenderAddress);
-    if (isset($data['new_editor']) && $data['new_editor']) {
+    if ($this->isNewEditor($data)) {
       $this->ensureWpPost($newsletter);
     }
     return $newsletter;
+  }
+
+  private function isNewEditor(array $data): bool {
+    if (!isset($data['new_editor'])) {
+      return false;
+    }
+    if (is_string($data['new_editor'])) {
+      return strtolower(trim($data['new_editor'])) === 'true';
+    }
+    return (bool)$data['new_editor'];
   }
 
   private function sanitizeAutomationEmailData(array $data, NewsletterEntity $newsletter): array {

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -22,7 +22,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->wantTo('Enable block email editor for automation newsletters in settings');
     $i->amOnMailpoetPage('Settings');
     $i->click('[data-automation-id="settings-advanced-tab"]');
-    $i->waitForText('Use block email editor for automation eamils');
+    $i->waitForText('Use block email editor for automation emails');
     $i->click('[data-automation-id="block-editor-for-automation-enabled"]');
     $i->click('[data-automation-id="settings-submit-button"]');
     $i->waitForText('Settings saved');
@@ -117,7 +117,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->wantTo('Ensure block email editor for automation newsletters is disabled');
     $i->amOnMailpoetPage('Settings');
     $i->click('[data-automation-id="settings-advanced-tab"]');
-    $i->waitForText('Use block email editor for automation eamils');
+    $i->waitForText('Use block email editor for automation emails');
     $i->click('[data-automation-id="block-editor-for-automation-disabled"]');
     $i->click('[data-automation-id="settings-submit-button"]');
     $i->waitForText('Settings saved');

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+use MailPoet\Test\DataFactories\Settings;
+
+class CreateAutomationEmailWithBlockEditorCest {
+  public function _before(\AcceptanceTester $i) {
+    $settings = new Settings();
+    $settings->withCronTriggerMethod('Action Scheduler');
+    $settings->withSender('John Doe', 'john@doe.com');
+  }
+
+  public function createAutomationEmailWithBlockEditor(\AcceptanceTester $i, $scenario) {
+    if (!$i->checkEmailEditorRequiredWordpressVersion()) {
+      $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
+    }
+
+    $i->wantTo('Create an automation email using the block email editor');
+    $i->login();
+
+    $i->wantTo('Enable block email editor for automation newsletters in settings');
+    $i->amOnMailpoetPage('Settings');
+    $i->click('[data-automation-id="settings-advanced-tab"]');
+    $i->waitForText('Use block email editor for automation newsletter');
+    $i->click('[data-automation-id="block-editor-for-automation-enabled"]');
+    $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForText('Settings saved');
+
+    $i->wantTo('Create a new automation');
+    $i->amOnMailpoetPage('Automation');
+    $i->see('Automations');
+    $i->waitForText('Better engagement begins with automation');
+
+    $i->click('Start with a template');
+    $i->see('Start with a template', 'h1');
+    $i->click('Welcome new subscribers');
+    $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
+    $i->click('Start building');
+
+    $i->waitForText('Draft');
+    $i->click('Trigger');
+    $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
+
+    $i->wantTo('Configure the send email step to use block editor');
+    $i->click('Send email');
+    $i->fillField('"From" name', 'From Test');
+    $i->fillField('"From" email address', 'test@mailpoet.com');
+    $i->fillField('Subject', 'Automation-Block-Editor-Subject');
+
+    $i->wantTo('Verify that clicking Design email redirects to block editor');
+    $i->click('Design email');
+    $i->waitForText('Start with an email preset');
+
+    $this->closeTemplateSelectionModal($i);
+
+    $i->wantTo('Verify we are in the block editor interface');
+    $i->waitForElement('[name="editor-canvas"]');
+    $i->wait(1); // we need to wait for the iframe to initialize otherwise the switch does not work properly
+    $i->switchToIFrame('[name="editor-canvas"]');
+    $i->waitForElementVisible('.is-root-container', 20);
+    $i->waitForElementVisible('[aria-label="Block: Image"]');
+    $i->waitForElementVisible('[aria-label="Block: Heading"]');
+
+    $i->wantTo('Add content to the email using block editor');
+    $i->click('[aria-label="Block: Paragraph"]');
+    $i->type('This is automation email content created with block editor');
+    $i->switchToIFrame();
+
+    $i->wantTo('Confirm we do not see email subject and preheader fields');
+    $i->click('Email', '.editor-sidebar__panel-tabs');
+    $i->dontSeeElement('[data-automation-id="email_subject"]');
+    $i->dontSeeElement('[data-automation-id="email_preheader"]');
+
+    $i->wantTo('Save the email draft');
+    $i->click('Save draft', '.edit-post-header');
+    $i->waitForText('Saved');
+
+    $i->wantTo('Return to automation editor and verify email is configured');
+    $i->click('[aria-label="Close Settings"]', '.editor-sidebar__panel-tabs'); // Close the side panel as it obstructs the view of the save and continue button.
+    $i->see('Save and continue');
+    $i->click('[data-automation-id="email_editor_send_button"]'); // Save and continue button.
+    $i->waitForText('Draft');
+
+    $i->wantTo('Activate the automation');
+    $i->click('Activate');
+    $i->waitForText('Are you ready to activate?');
+
+    // We use a selector to be specific about which Activate button we want to click.
+    $panelActivateButton = '.mailpoet-automation-activate-panel__header-activate-button button';
+    $i->click($panelActivateButton);
+
+    // Check automation is activated
+    $i->waitForText('"Welcome new subscribers" is now live.');
+    $i->click('View all automations');
+    $i->waitForText('Name');
+    $i->see('Welcome new subscribers');
+    $i->see('Active');
+
+    $i->wantTo('Test editing existing automation email with block editor');
+    $i->click('Edit', '.mailpoet-automation-listing');
+    $i->waitForText('Active');
+    $i->click('Send email');
+    $i->click('Edit content');
+
+    $i->wantTo('Verify we return to block editor for editing');
+    $i->waitForElement('[name="editor-canvas"]');
+    $i->wait(1);
+    $i->switchToIFrame('[name="editor-canvas"]');
+    $i->see('This is automation email content created with block editor');
+  }
+
+  public function testAutomationEmailWithoutBlockEditorSetting(\AcceptanceTester $i) {
+    $i->wantTo('Verify automation emails use legacy editor when block editor setting is disabled');
+    $i->login();
+
+    $i->wantTo('Ensure block email editor for automation newsletters is disabled');
+    $i->amOnMailpoetPage('Settings');
+    $i->click('[data-automation-id="settings-advanced-tab"]');
+    $i->waitForText('Use block email editor for automation newsletter');
+    $i->click('[data-automation-id="block-editor-for-automation-disabled"]');
+    $i->click('[data-automation-id="settings-submit-button"]');
+    $i->waitForText('Settings saved');
+
+    $i->wantTo('Create a new automation and verify it uses legacy editor');
+    $i->amOnMailpoetPage('Automation');
+    $i->click('Start with a template');
+    $i->click('Welcome new subscribers');
+    $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
+    $i->click('Start building');
+
+    $i->waitForText('Draft');
+    $i->click('Trigger');
+    $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
+
+    $i->click('Send email');
+    $i->fillField('"From" name', 'From Test');
+    $i->fillField('"From" email address', 'test@mailpoet.com');
+    $i->fillField('Subject', 'Legacy-Editor-Subject');
+
+    $i->wantTo('Verify that clicking Design email redirects to legacy newsletter editor');
+    $i->click('Design email');
+    $i->waitForText('Newsletters');
+    $i->click('Newsletters');
+    $i->click('button[data-automation-id="select_template_0"]');
+    $i->waitForText('Design');
+
+    $i->wantTo('Verify we are in the legacy newsletter editor interface');
+    $i->dontSeeElement('[name="editor-canvas"]'); // Block editor iframe should not be present
+    $i->see('Design'); // Legacy editor header
+  }
+
+  private function closeTemplateSelectionModal(\AcceptanceTester $i): void {
+    $i->wantTo('Close template selector');
+    $i->waitForElementClickable('.email-editor-start_from_scratch_button');
+    $i->click('[aria-label="Basic"]');
+    $i->waitForElementVisible('.block-editor-block-preview__container');
+    $i->click('[aria-label="Close"]');
+  }
+}

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -22,7 +22,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->wantTo('Enable block email editor for automation newsletters in settings');
     $i->amOnMailpoetPage('Settings');
     $i->click('[data-automation-id="settings-advanced-tab"]');
-    $i->waitForText('Use block email editor for automation newsletter');
+    $i->waitForText('Use block email editor for automation eamils');
     $i->click('[data-automation-id="block-editor-for-automation-enabled"]');
     $i->click('[data-automation-id="settings-submit-button"]');
     $i->waitForText('Settings saved');
@@ -117,7 +117,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->wantTo('Ensure block email editor for automation newsletters is disabled');
     $i->amOnMailpoetPage('Settings');
     $i->click('[data-automation-id="settings-advanced-tab"]');
-    $i->waitForText('Use block email editor for automation newsletter');
+    $i->waitForText('Use block email editor for automation eamils');
     $i->click('[data-automation-id="block-editor-for-automation-disabled"]');
     $i->click('[data-automation-id="settings-submit-button"]');
     $i->waitForText('Settings saved');

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -71,7 +71,7 @@
   var mailpoet_admin_plugins_url = '<%= admin_plugins_url %>';
   var mailpoet_is_dotcom = <%= json_encode(is_dotcom()) %>;
   var mailpoet_cron_trigger_method = <%= json_encode(cron_trigger_method) %>;
-  var mailpoet_use_block_email_editor_for_automation_newsletter = <%= json_encode(use_block_email_editor_for_automation_newsletter) %>;
+  var mailpoet_use_block_email_editor_for_automation_emails = <%= json_encode(use_block_email_editor_for_automation_emails) %>;
 
   var mailpoet_site_name = '<%= site_name %>';
   var mailpoet_site_url = "<%= site_url %>";

--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -71,6 +71,7 @@
   var mailpoet_admin_plugins_url = '<%= admin_plugins_url %>';
   var mailpoet_is_dotcom = <%= json_encode(is_dotcom()) %>;
   var mailpoet_cron_trigger_method = <%= json_encode(cron_trigger_method) %>;
+  var mailpoet_use_block_email_editor_for_automation_newsletter = <%= json_encode(use_block_email_editor_for_automation_newsletter) %>;
 
   var mailpoet_site_name = '<%= site_name %>';
   var mailpoet_site_url = "<%= site_url %>";

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -107,6 +107,8 @@
   'after18months': __('After 18 months'),
   'libs3rdPartyTitle': __('Load 3rd-party libraries'),
   'libs3rdPartyDescription': __('E.g. Google Fonts in the Form and Email editor and WordPress.com to get help. When disabled, you can still reach support at [link]www.mailpoet.com/support/[/link].'),
+  'useBlockEditorForAutomationTitle': __('Use block email editor for automation newsletter'),
+  'useBlockEditorForAutomationDescription': __('Use the alpha block email editor for creating and editing automation newsletters. Note: newsletters created with this editor will not be visible in the classic editor.'),
   'shareDataTitle': __('Share anonymous data'),
   'shareDataDescription': __('Share anonymous data and help us improve the plugin. We appreciate your help!'),
   'captchaTitle': __('Protect your MailPoet forms against spam signups'),

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -107,7 +107,7 @@
   'after18months': __('After 18 months'),
   'libs3rdPartyTitle': __('Load 3rd-party libraries'),
   'libs3rdPartyDescription': __('E.g. Google Fonts in the Form and Email editor and WordPress.com to get help. When disabled, you can still reach support at [link]www.mailpoet.com/support/[/link].'),
-  'useBlockEditorForAutomationTitle': __('Use block email editor for automation newsletter'),
+  'useBlockEditorForAutomationTitle': __('Use block email editor for automation eamils'),
   'useBlockEditorForAutomationDescription': __('Use the alpha block email editor for creating and editing automation newsletters. Note: newsletters created with this editor will not be visible in the classic editor.'),
   'shareDataTitle': __('Share anonymous data'),
   'shareDataDescription': __('Share anonymous data and help us improve the plugin. We appreciate your help!'),

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -107,7 +107,7 @@
   'after18months': __('After 18 months'),
   'libs3rdPartyTitle': __('Load 3rd-party libraries'),
   'libs3rdPartyDescription': __('E.g. Google Fonts in the Form and Email editor and WordPress.com to get help. When disabled, you can still reach support at [link]www.mailpoet.com/support/[/link].'),
-  'useBlockEditorForAutomationTitle': __('Use block email editor for automation eamils'),
+  'useBlockEditorForAutomationTitle': __('Use block email editor for automation emails'),
   'useBlockEditorForAutomationDescription': __('Use the alpha block email editor for creating and editing automation newsletters. Note: newsletters created with this editor will not be visible in the classic editor.'),
   'shareDataTitle': __('Share anonymous data'),
   'shareDataDescription': __('Share anonymous data and help us improve the plugin. We appreciate your help!'),


### PR DESCRIPTION
## Description

This PR introduces comprehensive support for using the modern block email editor (WooCommerce Email Editor) when creating and editing automation newsletters in MailPoet. This enhancement provides users with a more modern, flexible, and powerful email editing experience for automation workflows.

## Why

Previously, automation newsletters were limited to the legacy MailPoet newsletter editor, which lacked the modern block-based editing capabilities available to other email types. This created an inconsistent user experience and prevented automation emails from leveraging the enhanced design capabilities of the block editor.

The block email editor offers:
- Modern block-based interface with better UX
- Enhanced design flexibility and customization options
- Consistent editing experience across different email types
- Future-proof foundation for email editing features

### Key Changes

1. **Settings Integration**
   - Added new setting "Use block email editor for automation newsletter" in Advanced settings
   <img width="1052" height="134" alt="Screenshot 2025-09-01 at 12 56 37 PM" src="https://github.com/user-attachments/assets/187972c8-fc87-47ef-a994-f01dce58fc65" />

2. **Editor Integration**
   - Enhanced `EditNewsletter` component to detect and redirect to the appropriate editor
   - Added support for `wp_post_id` tracking for block editor emails
   - Implemented proper URL generation for both legacy and block editors

3. **New filter**
- Add filter `mailpoet_use_block_email_editor_for_automation_emails` to control the feature.
- Returning `false` will disable the feature.

4. **UI/UX Improvements**
   - Context-aware editor labels ("Save and continue" for automation emails)
   - Hidden unnecessary fields (subject/preheader) in block editor for automation emails
   - Proper navigation and URL handling between automation editor and email editor

5. **Infrastructure**
   - Centralized URL generation utilities (`getNewsletterEditorUrl`, `getTheEmailEditorUrl`)
   - Enhanced cleanup logic for unused automation steps
   - Comprehensive acceptance test coverage

## Code review notes

_N/A_

## QA notes

**UI Mode**
1. Enable the feature in `/wp-admin/admin.php?page=mailpoet-settings#/advanced`, 
2. Scroll down to `Use block email editor for automation newsletter`, select `Yes`, and click on "Save settings"
3. Create a new automation in `/wp-admin/admin.php?page=mailpoet-automation`
4. Ensure you have the "Send email" step, click on design, notice you are redirected to the block email page
5. Design an email, save, and activate the automation.

**Filter Mode**
1. Add filter for `mailpoet_use_block_email_editor_for_automation_newsletter` (code below)
2. Create a new automation in `/wp-admin/admin.php?page=mailpoet-automation`
3. Ensure you have the "Send email" step, click on design, notice you are redirected to the block email page
4. Design an email, save, and activate the automation.

```php
add_filter('mailpoet_use_block_email_editor_for_automation_emails', '__return_true', 10, 1);
```

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7541](https://linear.app/a8c/issue/STOMAIL-7541/spike-on-using-the-block-email-editor-for-creating-automations-emails)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7541-spike-on-using-the-block-email-editor-for-automation-emails)

_The latest successful build from `stomail-7541-spike-on-using-the-block-email-editor-for-automation-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enable creating and editing automation emails with the block email editor; edit/preview links now open the appropriate editor and block-editor UI hides subject/preview fields.
- Settings
  - Advanced settings toggle to choose block editor for automation newsletters; translations and a global flag added.
- Refactor
  - Centralized editor URL generation and exposed feature flag to drive editor selection.
- Bug Fixes
  - Prevent removal of emails tied to WP posts with block-editor content.
- Tests
  - Add end-to-end tests covering block-editor enabled/disabled automation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->