### PR TITLE
Release 5.14.1

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 5.14.1 - 2025-09-01 =
+* Improved: Use specific version when downloading premium plugin.
+
 = 5.14.0 - 2025-08-25 =
 * Updated: Update the email editor version;
 * Fixed: Fix: license expiration notice was displayed only on the Plugins page; it now appears on all MailPoet admin pages;

--- a/mailpoet/changelog/2025-08-28-16-45-32-improved-use-specific-version-when-downloading-premium-plug.md
+++ b/mailpoet/changelog/2025-08-28-16-45-32-improved-use-specific-version-when-downloading-premium-plug.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Use specific version when downloading premium plugin

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.14.0
+ * Version: 5.14.1
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.14.0',
+  'version' => '5.14.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 5.14.0
+Stable tag: 5.14.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,9 +227,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.14.0 - 2025-08-25 =
-* Updated: Update the email editor version;
-* Fixed: Fix: license expiration notice was displayed only on the Plugins page; it now appears on all MailPoet admin pages;
-* Fixed: Fix the error "Call to a member function format on null"..
+= 5.14.1 - 2025-09-01 =
+* Improved: Use specific version when downloading premium plugin.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for version 5.14.1 (2025-09-01): “Improved: Use specific version when downloading premium plugin.”
  * Updated readme stable tag to 5.14.1 and refreshed the changelog section to reflect the new release, removing the previous 5.14.0 notes.

* **Chores**
  * Bumped plugin version to 5.14.1 to align with the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->