### PR TITLE
Track "Logging level"

### DIFF
--- a/mailpoet/lib/Analytics/Reporter.php
+++ b/mailpoet/lib/Analytics/Reporter.php
@@ -185,6 +185,7 @@ class Reporter {
       'Newsletter task scheduler (cron)' => $isCronTriggerMethodWP ? 'visitors' : 'script',
       'Open and click tracking' => $this->trackingConfig->isEmailTrackingEnabled(),
       'Tracking level' => $this->settings->get('tracking.level', TrackingConfig::LEVEL_FULL),
+      'Logging level' => $this->settings->get('logging', 'errors'),
       'Premium key valid' => $this->servicesChecker->isPremiumKeyValid(),
       'New subscriber notifications' => NewSubscriberNotificationMailer::isDisabled($this->settings->get(NewSubscriberNotificationMailer::SETTINGS_KEY)),
       'Number of active post notifications' => $newsletters['notifications_count'],


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7547

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7547-track-logging-setting)

_The latest successful build from `stomail-7547-track-logging-setting` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Analytics reports now include the site’s logging level. This value is automatically included in analytics payloads and related dashboards, with a default applied when not configured. No user action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->