### PR TITLE
Run log cleaning query in a scheduled task

### DIFF
--- a/mailpoet/changelog/2025-09-03-13-15-24-improved-optimized-log-cleanup-by-moving-it-to-a-dedicated-.md
+++ b/mailpoet/changelog/2025-09-03-13-15-24-improved-optimized-log-cleanup-by-moving-it-to-a-dedicated-.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Optimized log cleanup by moving it to a dedicated recurring task.

--- a/mailpoet/lib/Cron/CronWorkerScheduler.php
+++ b/mailpoet/lib/Cron/CronWorkerScheduler.php
@@ -38,6 +38,15 @@ class CronWorkerScheduler {
     if ($alreadyScheduled) {
       return $alreadyScheduled;
     }
+    return $this->createAndPersistTask($taskType, $nextRunDate, $priority);
+  }
+
+  public function scheduleMultiple($taskType, $nextRunDate, $priority = ScheduledTaskEntity::PRIORITY_LOW): ScheduledTaskEntity {
+    // Allow multiple tasks of the same type with different run dates
+    return $this->createAndPersistTask($taskType, $nextRunDate, $priority);
+  }
+
+  private function createAndPersistTask($taskType, $nextRunDate, $priority): ScheduledTaskEntity {
     $task = new ScheduledTaskEntity();
     $task->setType($taskType);
     $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -96,6 +96,7 @@ class Daemon {
     yield $this->workersFactory->createSubscribersStatsReportWorker();
     yield $this->workersFactory->createBounceWorker();
     yield $this->workersFactory->createExportFilesCleanupWorker();
+    yield $this->workersFactory->createLogCleanupWorker();
     yield $this->workersFactory->createSubscribersEmailCountsWorker();
     yield $this->workersFactory->createInactiveSubscribersWorker();
     yield $this->workersFactory->createUnsubscribeTokensWorker();

--- a/mailpoet/lib/Cron/Workers/LogCleanup.php
+++ b/mailpoet/lib/Cron/Workers/LogCleanup.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Logging\LogRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+class LogCleanup extends SimpleWorker {
+  const TASK_TYPE = 'log_cleanup';
+  const DAYS_TO_KEEP_LOGS = 30;
+  const BATCH_SIZE = 5000;
+  const MAX_EXECUTION_TIME = 30;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  public function __construct(
+    LogRepository $logRepository
+  ) {
+    $this->logRepository = $logRepository;
+    parent::__construct();
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    $startTime = microtime(true);
+
+    do {
+      $this->cronHelper->enforceExecutionLimit($timer);
+
+      $deleted = $this->logRepository->purgeOldLogs(
+        self::DAYS_TO_KEEP_LOGS,
+        self::BATCH_SIZE
+      );
+
+      // Stop if we've deleted less than the batch size (meaning we're done)
+      // or if we've exceeded the maximum execution time
+      if (
+        $deleted < self::BATCH_SIZE ||
+          (microtime(true) - $startTime) > self::MAX_EXECUTION_TIME
+      ) {
+        break;
+      }
+
+    } while (true);
+
+    return true;
+  }
+
+  public function schedule() {
+    // Schedule four tasks per day in different 6-hour time slots
+    $baseDate = Carbon::now()->millisecond(0)->startOfDay();
+
+    // Schedule tasks for each 6-hour time slot
+    for ($slot = 0; $slot < 4; $slot++) {
+      $hour = $slot * 6 + mt_rand(0, 5); // 0-5, 6-11, 12-17, 18-23
+      $minute = mt_rand(0, 59);
+      $second = mt_rand(0, 59);
+
+      $scheduleDate = clone $baseDate;
+      $scheduleDate->setTime($hour, $minute, $second);
+
+      // If the time has already passed today, schedule for tomorrow
+      if ($scheduleDate->isPast()) {
+        $scheduleDate->addDay();
+      }
+
+      $this->cronWorkerScheduler->schedule(static::TASK_TYPE, $scheduleDate);
+    }
+  }
+
+  public function getNextRunDate() {
+    // Return a single next run date for backward compatibility
+    // The actual scheduling is handled by the overridden schedule() method
+    $date = Carbon::now()->millisecond(0);
+
+    // Choose one of four 6-hour time slots
+    $timeSlot = mt_rand(0, 3);
+    $hour = $timeSlot * 6 + mt_rand(0, 5); // 0-5, 6-11, 12-17, 18-23
+    $minute = mt_rand(0, 59);
+
+    $date->setTime($hour, $minute, mt_rand(0, 59));
+
+    // If the chosen time has already passed today, schedule for tomorrow
+    if ($date->isPast()) {
+      $date->addDay();
+    }
+
+    return $date;
+  }
+}

--- a/mailpoet/lib/Cron/Workers/LogCleanup.php
+++ b/mailpoet/lib/Cron/Workers/LogCleanup.php
@@ -12,6 +12,7 @@ class LogCleanup extends SimpleWorker {
   const BATCH_SIZE = 5000;
   const MAX_EXECUTION_TIME = 30;
   const SUPPORT_MULTIPLE_INSTANCES = false;
+
   /** @var LogRepository */
   private $logRepository;
 
@@ -65,7 +66,7 @@ class LogCleanup extends SimpleWorker {
         $scheduleDate->addDay();
       }
 
-      $this->cronWorkerScheduler->schedule(static::TASK_TYPE, $scheduleDate);
+      $this->cronWorkerScheduler->scheduleMultiple(static::TASK_TYPE, $scheduleDate);
     }
   }
 

--- a/mailpoet/lib/Cron/Workers/LogCleanup.php
+++ b/mailpoet/lib/Cron/Workers/LogCleanup.php
@@ -11,7 +11,7 @@ class LogCleanup extends SimpleWorker {
   const DAYS_TO_KEEP_LOGS = 30;
   const BATCH_SIZE = 5000;
   const MAX_EXECUTION_TIME = 30;
-
+  const SUPPORT_MULTIPLE_INSTANCES = false;
   /** @var LogRepository */
   private $logRepository;
 

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -32,6 +32,7 @@ class WorkersFactory {
     BackfillEngagementData::TASK_TYPE,
     Mixpanel::TASK_TYPE,
     AbandonedCartWorker::TASK_TYPE,
+    LogCleanup::TASK_TYPE,
   ];
 
   /** @var ContainerWrapper */
@@ -86,6 +87,11 @@ class WorkersFactory {
   /** @return ExportFilesCleanup */
   public function createExportFilesCleanupWorker() {
     return $this->container->get(ExportFilesCleanup::class);
+  }
+
+  /** @return LogCleanup */
+  public function createLogCleanupWorker() {
+    return $this->container->get(LogCleanup::class);
   }
 
   /** @return InactiveSubscribers */

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -322,6 +322,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\Bounce::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\WooCommerceSync::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\ExportFilesCleanup::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\LogCleanup::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscribersEmailCount::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\InactiveSubscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\Mixpanel::class)->setPublic(true);

--- a/mailpoet/lib/Logging/LogHandler.php
+++ b/mailpoet/lib/Logging/LogHandler.php
@@ -6,24 +6,6 @@ use MailPoet\Entities\LogEntity;
 use MailPoetVendor\Monolog\Handler\AbstractProcessingHandler;
 
 class LogHandler extends AbstractProcessingHandler {
-  /**
-   * Logs older than this many days will be deleted
-   */
-  const DAYS_TO_KEEP_LOGS = 30;
-
-  /**
-   * How many records to delete on one run of purge routine
-   */
-  const PURGE_LIMIT = 1000;
-
-  /**
-   * Percentage value, what is the probability of running purge routine
-   * @var int
-   */
-  const LOG_PURGE_PROBABILITY = 5;
-
-  /** @var callable|null */
-  private $randFunction;
 
   /** @var LogRepository */
   private $logRepository;
@@ -31,11 +13,9 @@ class LogHandler extends AbstractProcessingHandler {
   public function __construct(
     LogRepository $logRepository,
     $level = \MailPoetVendor\Monolog\Logger::DEBUG,
-    $bubble = \true,
-    $randFunction = null
+    $bubble = \true
   ) {
     parent::__construct($level, $bubble);
-    $this->randFunction = $randFunction;
     $this->logRepository = $logRepository;
   }
 
@@ -49,20 +29,5 @@ class LogHandler extends AbstractProcessingHandler {
     $entity->setRawMessage($record['message']);
     $entity->setContext($record['context']);
     $this->logRepository->saveLog($entity);
-
-    if ($this->getRandom() <= self::LOG_PURGE_PROBABILITY) {
-      $this->purgeOldLogs();
-    }
-  }
-
-  private function getRandom() {
-    if ($this->randFunction) {
-      return call_user_func($this->randFunction, 0, 100);
-    }
-    return rand(0, 100);
-  }
-
-  private function purgeOldLogs() {
-    $this->logRepository->purgeOldLogs(self::DAYS_TO_KEEP_LOGS, self::PURGE_LIMIT);
   }
 }

--- a/mailpoet/lib/Logging/LogRepository.php
+++ b/mailpoet/lib/Logging/LogRepository.php
@@ -90,13 +90,14 @@ class LogRepository extends Repository {
     return $query->getQuery()->getResult();
   }
 
-  public function purgeOldLogs(int $daysToKeepLogs, int $limit = 1000) {
+  public function purgeOldLogs(int $daysToKeepLogs, int $limit = 1000): int {
     $logsTable = $this->entityManager->getClassMetadata(LogEntity::class)->getTableName();
-    $this->entityManager->getConnection()->executeStatement(
+    $result = $this->entityManager->getConnection()->executeStatement(
       "
-      DELETE FROM $logsTable
+      DELETE FROM `{$logsTable}`
       WHERE `created_at` < :date
-      ORDER BY `id` ASC LIMIT :limit
+      ORDER BY `created_at` ASC, `id` ASC
+      LIMIT :limit
     ",
       [
       'date' => Carbon::now()->subDays($daysToKeepLogs)->toDateTimeString(),
@@ -107,6 +108,8 @@ class LogRepository extends Repository {
       'limit' => ParameterType::INTEGER,
       ]
     );
+
+    return (int)$result;
   }
 
   public function getRawMessagesForNewsletter(NewsletterEntity $newsletter, string $topic): array {

--- a/mailpoet/lib/Migrations/Db/Migration_20250903_151331_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20250903_151331_Db.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20250903_151331_Db extends DbMigration {
+  public function run(): void {
+    $logTable = $this->getTableName(\MailPoet\Entities\LogEntity::class);
+    $indexName = 'idx_log_created_at_id';
+
+    if ($this->indexExists($logTable, $indexName)) {
+      return;
+    }
+
+    $this->connection->executeQuery(
+      "CREATE INDEX `{$indexName}` ON `{$logTable}` (`created_at`, `id`)"
+    );
+  }
+}

--- a/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/CronWorkerSchedulerTest.php
@@ -105,4 +105,22 @@ class CronWorkerSchedulerTest extends \MailPoetTest {
     $timeout = $this->cronWorkerScheduler->rescheduleProgressively($task);
     verify($timeout)->equals(ScheduledTaskEntity::MAX_RESCHEDULE_TIMEOUT);
   }
+
+  public function testItCanScheduleMultipleTasksOfSameType() {
+    $nextRunDate1 = Carbon::now()->addHour();
+    $nextRunDate2 = Carbon::now()->addDay();
+    
+    $task1 = $this->cronWorkerScheduler->scheduleMultiple('test', $nextRunDate1);
+    $task2 = $this->cronWorkerScheduler->scheduleMultiple('test', $nextRunDate2);
+    
+    $tasks = $this->entityManager->getRepository(ScheduledTaskEntity::class)->findAll();
+    verify($tasks)->arrayCount(2);
+    
+    // Verify both tasks have the same type but different IDs and scheduled times
+    verify($task1->getType())->same('test');
+    verify($task2->getType())->same('test');
+    verify($task1->getId())->notEquals($task2->getId());
+    verify($task1->getScheduledAt())->same($nextRunDate1);
+    verify($task2->getScheduledAt())->same($nextRunDate2);
+  }
 }

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -305,6 +305,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createBounceWorker' => $worker,
       'createWooCommerceSyncWorker' => $worker,
       'createExportFilesCleanupWorker' => $worker,
+      'createLogCleanupWorker' => $worker,
       'createSubscribersEmailCountsWorker' => $worker,
       'createInactiveSubscribersWorker' => $worker,
       'createAuthorizedSendingEmailsCheckWorker' => $worker,

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -105,6 +105,7 @@ class DaemonTest extends \MailPoetTest {
       'createBounceWorker' => $this->createSimpleWorkerMock(),
       'createWooCommerceSyncWorker' => $this->createSimpleWorkerMock(),
       'createExportFilesCleanupWorker' => $this->createSimpleWorkerMock(),
+      'createLogCleanupWorker' => $this->createSimpleWorkerMock(),
       'createSubscribersEmailCountsWorker' => $this->createSimpleWorkerMock(),
       'createInactiveSubscribersWorker' => $this->createSimpleWorkerMock(),
       'createAuthorizedSendingEmailsCheckWorker' => $this->createSimpleWorkerMock(),

--- a/mailpoet/tests/integration/Cron/Workers/LogCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/LogCleanupTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\Workers;
+
+use MailPoet\Cron\Workers\LogCleanup;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\Log;
+use MailPoetVendor\Carbon\Carbon;
+
+class LogCleanupTest extends \MailPoetTest {
+  /** @var LogCleanup */
+  private $worker;
+
+  public function _before() {
+    parent::_before();
+    $this->worker = $this->diContainer->get(LogCleanup::class);
+  }
+
+  public function testItDeletesOldLogs() {
+    $logFactory = new Log();
+
+    // Freeze 'now' to avoid drift during assertions
+    $now = Carbon::now();
+    Carbon::setTestNow($now);
+
+    // Create old logs that should be deleted
+    $logFactory->withCreatedAt($now->copy()->subDays(50))->create();
+    $logFactory->withCreatedAt($now->copy()->subDays(40))->create();
+
+    // Create newer logs that should be kept
+    $logFactory->withCreatedAt($now->copy()->subDays(20))->create();
+    $logFactory->withCreatedAt($now->copy())->create();
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    // Verify old logs were deleted
+    $remainingLogs = $this->entityManager->getRepository(\MailPoet\Entities\LogEntity::class)->findAll();
+    verify(count($remainingLogs))->equals(2);
+
+    // Verify only newer logs remain
+    $cutoffDate = $now->copy()->subDays(LogCleanup::DAYS_TO_KEEP_LOGS);
+    foreach ($remainingLogs as $log) {
+      $createdAt = $log->getCreatedAt();
+      verify($createdAt)->notNull();
+      // After verify($createdAt)->notNull(), we know it's not null
+      /** @var \DateTimeInterface $createdAt */
+      verify($createdAt->getTimestamp())->greaterThan($cutoffDate->getTimestamp());
+    }
+  }
+
+  public function testItRespectsBatchSize() {
+    $logFactory = new Log();
+
+    // Create more logs than the batch size
+    for ($i = 0; $i < LogCleanup::BATCH_SIZE + 10; $i++) {
+      $logFactory->withCreatedAt(Carbon::now()->subDays(50))->create();
+    }
+
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+
+    // Should have deleted at least the batch size
+    $remainingLogs = $this->entityManager->getRepository(\MailPoet\Entities\LogEntity::class)->findAll();
+    verify(count($remainingLogs))->lessThan(10);
+  }
+
+  public function testItRespectsExecutionTimeLimit() {
+    $logFactory = new Log();
+
+    // Create many old logs to ensure the worker runs for a while
+    for ($i = 0; $i < LogCleanup::BATCH_SIZE * 3; $i++) {
+      $logFactory->withCreatedAt(Carbon::now()->subDays(50))->create();
+    }
+
+    $startTime = microtime(true);
+    $task = new ScheduledTaskEntity();
+    $this->worker->processTaskStrategy($task, microtime(true));
+    $executionTime = microtime(true) - $startTime;
+
+    // Should respect the execution time limit
+    verify($executionTime)->lessThan(LogCleanup::MAX_EXECUTION_TIME + 1); // Allow 1 second buffer
+  }
+
+  public function testItSchedulesNextRun() {
+    $nextRunDate = $this->worker->getNextRunDate();
+    verify($nextRunDate)->notNull();
+    verify($nextRunDate->getTimestamp())->greaterThan(Carbon::now()->getTimestamp());
+
+    // Verify it's scheduled within the next 24 hours
+    $tomorrow = Carbon::now()->addDay();
+    verify($nextRunDate->getTimestamp())->lessThan($tomorrow->getTimestamp());
+  }
+
+  public function testItSchedulesMultipleTimesPerDay() {
+    // Test that multiple calls can schedule for different times
+    $schedules = [];
+    for ($i = 0; $i < 10; $i++) {
+      $schedule = $this->worker->getNextRunDate();
+      $schedules[] = $schedule->format('H');
+    }
+
+    // Should have schedules in different time slots (0-5, 6-11, 12-17, 18-23)
+    $timeSlots = array_unique(array_map(function($hour) {
+      return intdiv(intval($hour), 6);
+    }, $schedules));
+
+    // Should have at least 2 different time slots
+    verify(count($timeSlots))->greaterThan(1);
+  }
+}

--- a/mailpoet/tests/integration/Logging/LogHandlerTest.php
+++ b/mailpoet/tests/integration/Logging/LogHandlerTest.php
@@ -5,7 +5,6 @@ namespace MailPoet\Logging;
 use MailPoet\Doctrine\EntityManagerFactory;
 use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\SubscriberEntity;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class LogHandlerTest extends \MailPoetTest {
@@ -37,68 +36,6 @@ class LogHandlerTest extends \MailPoetTest {
     $createdAt = $log->getCreatedAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $createdAt);
     verify($createdAt->format('Y-m-d H:i:s'))->equals($time->format('Y-m-d H:i:s'));
-  }
-
-  public function testItPurgesOldLogs() {
-    $entity = new LogEntity();
-    $entity->setName('old name');
-    $entity->setLevel(5);
-    $entity->setMessage('xyz');
-    $entity->setCreatedAt(Carbon::now()->subDays(100));
-    $this->repository->saveLog($entity);
-
-    $random = function() {
-      return 0;
-    };
-
-    $logHandler = new LogHandler(
-      $this->repository,
-      \MailPoetVendor\Monolog\Logger::DEBUG,
-      true,
-      $random
-    );
-    $logHandler->handle([
-      'level' => \MailPoetVendor\Monolog\Logger::EMERGENCY,
-      'extra' => [],
-      'context' => [],
-      'channel' => 'name',
-      'datetime' => new \DateTime(),
-      'message' => 'some log message',
-    ]);
-
-    $log = $this->repository->findBy(['name' => 'old name']);
-    verify($log)->empty();
-  }
-
-  public function testItNotPurgesOldLogs() {
-    $entity = new LogEntity();
-    $entity->setName('old name keep');
-    $entity->setLevel(5);
-    $entity->setMessage('xyz');
-    $entity->setCreatedAt(Carbon::now()->subDays(100));
-    $this->repository->saveLog($entity);
-
-    $random = function() {
-      return 100;
-    };
-
-    $logHandler = new LogHandler(
-      $this->repository,
-      \MailPoetVendor\Monolog\Logger::DEBUG,
-      true,
-      $random
-    );
-    $logHandler->handle([
-      'level' => \MailPoetVendor\Monolog\Logger::EMERGENCY,
-      'extra' => [],
-      'context' => [],
-      'channel' => 'name',
-      'datetime' => new \DateTime(),
-      'message' => 'some log message',
-    ]);
-
-    $log = $this->repository->findBy(['name' => 'old name keep']);
-    verify($log)->notEmpty();
   }
 
   public function testItResilientToSqlError(): void {


### PR DESCRIPTION
## Description

The original cleaning was running in an `init` this changes that and creates a new scheduled task.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7545]

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7545-run-log-cleaning-query-in-a-scheduled-task)

_The latest successful build from `stomail-7545-run-log-cleaning-query-in-a-scheduled-task` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Log maintenance now runs as a dedicated, regularly scheduled worker (batched, time-limited) with multiple daily slots for more predictable cleanup and consistent performance.
  - Cron scheduler supports creating multiple scheduled tasks of the same type.

- Database
  - Added an index to speed up log-related operations on large datasets.

- Logging
  - Removed automatic on-write random log purges to avoid intermittent slowdowns.

- Documentation
  - Added a changelog entry describing the optimization.

- Tests
  - Added integration tests for the scheduled log maintenance and updated cron tests to include the new worker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->