### PR TITLE
Update CAPTCHA form rendering - STOMAIL-7551

### DIFF
--- a/mailpoet/changelog/2025-09-08-09-23-29-improved-enhanced-captcha-form-html-output-processing.md
+++ b/mailpoet/changelog/2025-09-08-09-23-29-improved-enhanced-captcha-form-html-output-processing.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Enhanced CAPTCHA form HTML output processing

--- a/mailpoet/lib/Captcha/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaFormRenderer.php
@@ -63,11 +63,12 @@ class CaptchaFormRenderer {
       return false;
     }
 
-    if ($data['referrer_form'] == CaptchaUrlFactory::REFERER_MP_FORM) {
+    $ref = $data['referrer_form'] ?? null;
+    if ($ref === CaptchaUrlFactory::REFERER_MP_FORM) {
       return $this->renderFormInSubscriptionForm($sessionId);
-    } elseif ($data['referrer_form'] == CaptchaUrlFactory::REFERER_WP_FORM) {
+    } elseif ($ref === CaptchaUrlFactory::REFERER_WP_FORM) {
       return $this->renderFormInWPRegisterForm($data, 'wp-submit');
-    } elseif ($data['referrer_form'] == CaptchaUrlFactory::REFERER_WC_FORM) {
+    } elseif ($ref === CaptchaUrlFactory::REFERER_WC_FORM) {
       return $this->renderFormInWPRegisterForm($data, 'register');
     }
 
@@ -131,6 +132,7 @@ class CaptchaFormRenderer {
 
     unset($data['referrer_form']);
     foreach ($data as $key => $value) {
+      if (!is_scalar($value)) continue;
       $hiddenFields .= '<input type="hidden" name="' . $this->wp->escAttr($key) . '" value="' . $this->wp->escAttr($value) . '" />';
     }
 
@@ -226,8 +228,10 @@ class CaptchaFormRenderer {
     $settings = $formModel->getSettings() ?? [];
     $errorMessage = __('The characters you entered did not match the CAPTCHA image. Please try again with this new image.', 'mailpoet');
 
+    $success = isset($settings['success_message']) ? (string)$settings['success_message'] : '';
+
     $formHtml = '<div class="mailpoet_message" role="alert" aria-live="assertive">';
-    $formHtml .= '<p class="mailpoet_validate_success" ' . ($showSuccessMessage ? '' : ' style="display:none;"') . '>' . $this->wp->escHtml($settings['success_message']) . '</p>';
+    $formHtml .= '<p class="mailpoet_validate_success" ' . ($showSuccessMessage ? '' : ' style="display:none;"') . '>' . $this->wp->escHtml($success) . '</p>';
     $formHtml .= '<p class="mailpoet_validate_error" ' . ($showErrorMessage ? '' : ' style="display:none;"') . '>' . $this->wp->escHtml($errorMessage) . '</p>';
     $formHtml .= '</div>';
 

--- a/mailpoet/lib/Captcha/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaFormRenderer.php
@@ -196,10 +196,10 @@ class CaptchaFormRenderer {
 
     $formHtml .= '<div class="mailpoet_form_hide_on_success">';
     $formHtml .= '<p class="mailpoet_paragraph">';
-    $formHtml .= '<img class="mailpoet_captcha" src="' . $this->wp->escAttr($captchaUrl) . '" width="' . $this->wp->escAttr($width) . '" height="' . $this->wp->escAttr($height) . '" title="' . esc_attr__('CAPTCHA', 'mailpoet') . '" />';
+    $formHtml .= '<img class="mailpoet_captcha" src="' . $this->wp->escUrl($captchaUrl) . '" width="' . $this->wp->escAttr($width) . '" height="' . $this->wp->escAttr($height) . '" title="' . esc_attr__('CAPTCHA', 'mailpoet') . '" />';
     $formHtml .= '</p>';
-    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_update" title="' . esc_attr(__('Reload CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escAttr($reloadIcon) . '" alt="" /></button>';
-    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_audio" title="' . esc_attr(__('Play CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escAttr($playIcon) . '" alt="" /></button>';
+    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_update" title="' . esc_attr(__('Reload CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escUrl($reloadIcon) . '" alt="" /></button>';
+    $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_audio" title="' . esc_attr(__('Play CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escUrl($playIcon) . '" alt="" /></button>';
     $formHtml .= '<audio class="mailpoet_captcha_player">';
     $formHtml .= '<source src="' . $this->wp->escUrl($mp3CaptchaUrl) . '" type="audio/mpeg">';
     $formHtml .= '</audio>';

--- a/mailpoet/lib/Captcha/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaFormRenderer.php
@@ -102,7 +102,7 @@ class CaptchaFormRenderer {
     $hiddenFields .= '<input type="hidden" name="api_version" value="v1" />';
     $hiddenFields .= '<input type="hidden" name="endpoint" value="subscribers" />';
     $hiddenFields .= '<input type="hidden" name="mailpoet_method" value="subscribe" />';
-    $hiddenFields .= '<input type="hidden" name="mailpoet_redirect" value="' . $this->wp->escAttr($redirectUrl) . '" />';
+    $hiddenFields .= '<input type="hidden" name="mailpoet_redirect" value="' . $this->wp->escUrl($redirectUrl) . '" />';
 
     $actionUrl = admin_url('admin-post.php?action=mailpoet_subscription_form');
 
@@ -131,7 +131,7 @@ class CaptchaFormRenderer {
 
     unset($data['referrer_form']);
     foreach ($data as $key => $value) {
-      $hiddenFields .= '<input type="hidden" name="' . $key . '" value="' . $this->wp->escAttr($value) . '" />';
+      $hiddenFields .= '<input type="hidden" name="' . $this->wp->escAttr($key) . '" value="' . $this->wp->escAttr($value) . '" />';
     }
 
     $submitLabel = $data[$submitLabelKey] ?? esc_attr_e('Register'); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
@@ -182,7 +182,7 @@ class CaptchaFormRenderer {
       $classes = 'mailpoet_captcha_form';
     }
 
-    $formHtml = '<form method="POST" action="' . $this->wp->escAttr($actionUrl) . '" class="' . $this->wp->escAttr($classes) . '" id="mailpoet_captcha_form" novalidate>';
+    $formHtml = '<form method="POST" action="' . $this->wp->escUrl($actionUrl) . '" class="' . $this->wp->escAttr($classes) . '" id="mailpoet_captcha_form" novalidate>';
     $formHtml .= $hiddenFields;
 
     $width = 220;
@@ -199,7 +199,7 @@ class CaptchaFormRenderer {
     $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_update" title="' . esc_attr(__('Reload CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escAttr($reloadIcon) . '" alt="" /></button>';
     $formHtml .= '<button type="button" class="mailpoet_icon_button mailpoet_captcha_audio" title="' . esc_attr(__('Play CAPTCHA', 'mailpoet')) . '"><img src="' . $this->wp->escAttr($playIcon) . '" alt="" /></button>';
     $formHtml .= '<audio class="mailpoet_captcha_player">';
-    $formHtml .= '<source src="' . $this->wp->escAttr($mp3CaptchaUrl) . '" type="audio/mpeg">';
+    $formHtml .= '<source src="' . $this->wp->escUrl($mp3CaptchaUrl) . '" type="audio/mpeg">';
     $formHtml .= '</audio>';
 
     $formHtml .= $this->formRenderer->renderBlocks($form, [], null, $honeypot = false);

--- a/mailpoet/tests/integration/Captcha/CaptchaFormRendererTest.php
+++ b/mailpoet/tests/integration/Captcha/CaptchaFormRendererTest.php
@@ -321,11 +321,12 @@ class CaptchaFormRendererTest extends \MailPoetTest {
     ];
 
     foreach ($validTypes as $validType) {
+      $submitKey = ($validType === CaptchaUrlFactory::REFERER_WC_FORM) ? 'register' : 'wp-submit';
       $validData = [
         'captcha_session_id' => $sessionId,
         'referrer_form' => $validType,
         'referrer_form_url' => 'https://example.com',
-        'wp-submit' => 'Register',
+        $submitKey => 'Register',
       ];
 
       $result = $testee->render($validData);


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

1. Verify that all Captcha use-cases are without issues
   - Using in the WP registration form
   - Using in the WC registration form
   - Using the regular subscription form

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7551

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:captcha-rendering)

_The latest successful build from `captcha-rendering` will be used. If none is available, the link won't work._

