### PR TITLE
Prevent Segments page crashes due to an invalid product attribute

### DIFF
--- a/mailpoet/changelog/2025-09-08-13-23-30-fixed-invalid-product-attributes-may-break-the-segments-.md
+++ b/mailpoet/changelog/2025-09-08-13-23-30-fixed-invalid-product-attributes-may-break-the-segments-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Invalid product attributes may break the Segments page

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -143,7 +143,7 @@ class DynamicSegments {
           ]
         );
 
-        if (!isset($attributeTerms['errors'])) {
+        if ((!$attributeTerms instanceof \WP_Error) && !isset($attributeTerms['errors'])) {
           $data['product_attributes'][$taxonomy] = [ // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
             'id' => $attribute->attribute_id, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
             'label' => $attribute->attribute_label, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps


### PR DESCRIPTION
## Description

A user reported that the Segments page in admin crashes when `get_terms` returns WP_Error. This may happen when there is an issue with taxonomies (e.g., a taxonomy for a product attribute doesn't exist).

This PR fixes the crashes by skipping the product_attributes that fail to load via get_terms.

Closes STOMAIL-7550

## Code review notes

_N/A_

## QA notes

The easiest way to replicate the issue is by setting changing `'pa_'` to something else in https://github.com/mailpoet/mailpoet/blob/6d5ad333c8cc057ca167e6ddc8caaf4ef836a8cc/mailpoet/lib/AdminPages/Pages/DynamicSegments.php#L138

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7550](https://linear.app/a8c/issue/STOMAIL-7550)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7550-user-experiencing-an-error-of-type-e_error-in-segments)

_The latest successful build from `stomail-7550-user-experiencing-an-error-of-type-e_error-in-segments` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid product attributes could break the Segments page. The page now handles problematic attributes gracefully by skipping them, improving stability when viewing or creating segments that use product attribute filters.

* **Documentation**
  * Added a changelog entry noting the fix for Segments page errors caused by invalid product attributes, improving transparency for users reviewing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->