### PR TITLE
Improve form image block rendering

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/PoweredByMailpoet.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Blocks/BlockTypes/PoweredByMailpoet.php
@@ -29,7 +29,7 @@ class PoweredByMailpoet extends AbstractBlock {
     return $this->addSpacer(sprintf(
       '<div class="%1$s" style="text-align:center">%2$s</div>',
       esc_attr('wp-block-' . $this->blockName),
-      '<img src="' . esc_attr($logoUrl) . '" alt="Powered by MailPoet" width="100px" />'
+      '<img src="' . esc_url($logoUrl) . '" alt="Powered by MailPoet" width="100px" />'
     ), $block->parsed_block['email_attrs'] ?? []); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
 }

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -38,7 +38,7 @@ class AssetsController {
     ob_start();
     $captcha = $this->settings->get('captcha');
     if (!empty($captcha['type']) && CaptchaConstants::isReCaptcha($captcha['type'])) {
-      echo '<script src="' . esc_attr(self::RECAPTCHA_API_URL) . '" async defer></script>';
+      echo '<script src="' . esc_url(self::RECAPTCHA_API_URL) . '" async defer></script>';
     }
 
     $this->wp->wpPrintScripts('jquery');

--- a/mailpoet/lib/Form/Block/Image.php
+++ b/mailpoet/lib/Form/Block/Image.php
@@ -30,7 +30,7 @@ class Image {
   private function renderImage(array $params): string {
     $attributes = [];
     $styles = [];
-    $attributes[] = 'src="' . $this->wp->escAttr($params['url']) . '"';
+    $attributes[] = 'src="' . $this->wp->escUrl($params['url']) . '"';
     $attributes[] = $params['alt'] ? 'alt="' . $this->wp->escAttr($params['alt']) . '"' : 'alt';
     if ($params['title']) {
       $attributes[] = 'title="' . $this->wp->escAttr($params['title']) . '"';
@@ -74,7 +74,7 @@ class Image {
   }
 
   private function wrapToLink(array $params, string $img): string {
-    $attributes = ['href="' . $this->wp->escAttr($params['href']) . '"'];
+    $attributes = ['href="' . $this->wp->escUrl($params['href']) . '"'];
     if ($params['link_class']) {
       $attributes[] = 'class="' . $this->wp->escAttr($params['link_class']) . '"';
     }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7553

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:form-image-block-rendering)

_The latest successful build from `form-image-block-rendering` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling across email footer, form scripts, and image blocks to ensure links and assets are correctly validated and rendered.
  * Reduced risk of malformed or unsafe URLs appearing in emails and forms, improving overall security and reliability.
  * Enhanced compatibility with external resources (e.g., reCAPTCHA) by tightening URL validation.

* **Tests**
  * Added unit tests to verify correct URL escaping in image block links, preventing injection of unsafe characters and ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->