### PR TITLE
Add garden helper functions [STOMAIL-7555]

### DIFF
--- a/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
+++ b/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
@@ -48,6 +48,40 @@ class DotcomHelperFunctions {
     return function_exists('wc_calypso_bridge_is_ecommerce_plan') && wc_calypso_bridge_is_ecommerce_plan();
   }
 
+  public function isGarden(): bool {
+    if (!function_exists('is_blog_garden')) {
+      return false;
+    }
+    $blog_id = \get_current_blog_id();
+    $site = function_exists('get_site')
+      ? \get_site($blog_id)
+      : (function_exists('get_blog_details') ? \get_blog_details($blog_id) : null);
+    return $site ? \is_blog_garden($site) : false;
+  }
+
+  protected function getSiteMetaValue(string $meta_key): ?string {
+    if (!function_exists('get_site_meta')) {
+      return null;
+    }
+    $blog_id = \get_current_blog_id();
+    $value = \get_site_meta($blog_id, $meta_key, true);
+    return is_string($value) && $value !== '' ? $value : null;
+  }
+
+  public function gardenName(): ?string {
+    if (!$this->isGarden()) {
+      return null;
+    }
+    return $this->getSiteMetaValue('garden_name');
+  }
+
+  public function gardenPartner(): ?string {
+    if (!$this->isGarden()) {
+      return null;
+    }
+    return $this->getSiteMetaValue('garden_partner');
+  }
+
   /**
    * Returns the plan name for the current site if hosted on WordPress.com.
    * Empty otherwise.

--- a/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
+++ b/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
@@ -60,4 +60,72 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
     $dotcomHelper->method('isEcommerce')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('ecommerce');
   }
+
+  public function testIsGardenReturnsFalseWhenFunctionDoesNotExist() {
+    verify($this->dotcomHelper->isGarden())->false();
+  }
+
+  public function testGardenNameReturnsNullWhenNotGarden() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden']);
+    $dotcomHelper->method('isGarden')->willReturn(false);
+    verify($dotcomHelper->gardenName())->null();
+  }
+
+  public function testGardenNameReturnsNullWhenGetSiteMetaNotAvailable() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+
+    // Mock getSiteMetaValue to return null when get_site_meta is not available
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+    $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
+
+    verify($dotcomHelper->gardenName())->null();
+  }
+
+  public function testGardenNameReturnsNullWhenMetaValueIsEmpty() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+    $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
+
+    verify($dotcomHelper->gardenName())->null();
+  }
+
+  public function testGardenNameReturnsValueWhenMetaValueIsValid() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+    $dotcomHelper->method('getSiteMetaValue')->willReturn('My Garden');
+
+    verify($dotcomHelper->gardenName())->equals('My Garden');
+  }
+
+  public function testGardenPartnerReturnsNullWhenNotGarden() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden']);
+    $dotcomHelper->method('isGarden')->willReturn(false);
+    verify($dotcomHelper->gardenPartner())->null();
+  }
+
+  public function testGardenPartnerReturnsNullWhenGetSiteMetaNotAvailable() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+    $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
+
+    verify($dotcomHelper->gardenPartner())->null();
+  }
+
+  public function testGardenPartnerReturnsNullWhenMetaValueIsEmpty() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+    $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
+
+    verify($dotcomHelper->gardenPartner())->null();
+  }
+
+  public function testGardenPartnerReturnsValueWhenMetaValueIsValid() {
+    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper->method('isGarden')->willReturn(true);
+    $dotcomHelper->method('getSiteMetaValue')->willReturn('Partner Name');
+
+    verify($dotcomHelper->gardenPartner())->equals('Partner Name');
+  }
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7555]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-ciab-helper-functions)

_The latest successful build from `add-ciab-helper-functions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Garden environment detection and API to check Garden status.
  * Expose a site’s Garden name and Garden partner when available to improve contextual display and integrations.

* **Tests**
  * Added unit tests covering Garden detection and retrieval of Garden name/partner, including edge cases and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->