### PR TITLE
Hide automation actions in the garden environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ There is a `./do` command that helps with the development process. See [README](
 - Javascript code should follow the [Airbnb style guide](https://github.com/airbnb/javascript).
 - Prefer named export before default export in JS and TS files
 - Default to TypeScript for new files.
+- Code formatting is handled automatically by Prettier. Run `./do qa:prettier-write` to format your code.
 
 ## Disabling linting rules
 
@@ -40,6 +41,7 @@ There is a `./do` command that helps with the development process. See [README](
 - Open a short-living feature branch.
 - Use good commit messages as explained here https://chris.beams.io/posts/git-commit. Include Linear issue ID in the commit message.
 - Use the `./do qa` command to check your code style before pushing.
+- Run `./do qa:prettier-write` to format your code with Prettier.
 - Create a pull request when finished.
 - Wait for review from another developer.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
    2. [Available PHP versions](#available-php-versions)
    3. [Disabling the Tracy panel](#disabling-the-tracy-panel)
    4. [Running individual tests](#running-individual-tests)
-6. [TODO](#todo)
+6. [Code Formatting](#code-formatting)
+7. [TODO](#todo)
 
 ## MailPoet
 
@@ -209,6 +210,17 @@ cd ../mailpoet-premium # switch to premium plugin directory
 ```shell
 cd ./mailpoet-premium # switch to premium plugin directory on your local machine
 ./do test:acceptance --skip-deps --file tests/acceptance/PremiumCheckCest.php
+```
+
+## Code Formatting
+
+We use [Prettier](https://prettier.io/) to ensure consistent code formatting across the project.
+
+### Quick Commands
+
+```bash
+./do qa:prettier-write    # Format all files
+./do qa:prettier-check    # Check if files are properly formatted
 ```
 
 ## TODO

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
@@ -20,17 +20,25 @@ import { step as WpUserRoleChangedTrigger } from './steps/wp-user-role-changed';
 // Insert new imports here
 
 export const initialize = (): void => {
+  const isGarden =
+    (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+      .mailpoet_automation_context?.is_garden === true;
+
   registerStepType(SendEmailStep);
   registerStepType(WpUserRegisteredTrigger);
   registerStepType(WpUserRoleChangedTrigger);
   registerStepType(SomeoneSubscribesTrigger);
   registerStepType(CustomTriggerStep);
-  registerStepType(CustomActionStep);
-  registerStepType(AddTagsAction);
-  registerStepType(RemoveTagsAction);
-  registerStepType(AddToListStep);
-  registerStepType(RemoveFromListStep);
-  registerStepType(UpdateSubscriberStep);
+
+  if (!isGarden) {
+    registerStepType(CustomActionStep);
+    registerStepType(AddTagsAction);
+    registerStepType(RemoveTagsAction);
+    registerStepType(AddToListStep);
+    registerStepType(RemoveFromListStep);
+    registerStepType(UpdateSubscriberStep);
+  }
+
   registerStepType(UnsubscribeStep);
   registerStepType(NotificationEmail);
   registerStepType(TagAddedTrigger);

--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -14,6 +14,7 @@ use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice as WPNotice;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 class AutomationEditor {
   /** @var AssetsController */
@@ -37,6 +38,9 @@ class AutomationEditor {
   /** @var SubjectTransformerHandler */
   private $subjectTransformerHandler;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     AssetsController $assetsController,
     AutomationMapper $automationMapper,
@@ -44,7 +48,8 @@ class AutomationEditor {
     PageRenderer $pageRenderer,
     Registry $registry,
     WPFunctions $wp,
-    SubjectTransformerHandler $subjectTransformerHandler
+    SubjectTransformerHandler $subjectTransformerHandler,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->assetsController = $assetsController;
     $this->automationMapper = $automationMapper;
@@ -53,6 +58,7 @@ class AutomationEditor {
     $this->registry = $registry;
     $this->wp = $wp;
     $this->subjectTransformerHandler = $subjectTransformerHandler;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function render() {
@@ -159,6 +165,9 @@ class AutomationEditor {
     foreach ($this->registry->getContextFactories() as $key => $factory) {
       $data[$key] = $factory();
     }
+
+    $data['is_garden'] = $this->dotcomHelperFunctions->isGarden();
+
     return $data;
   }
 }


### PR DESCRIPTION
## Description

**Before:**

<img width="1960" height="1886" alt="Markup 2025-09-09 at 13 30 49" src="https://github.com/user-attachments/assets/704e3b90-5ec3-4498-9f2b-bcabbcc592ca" />

**After:**

<img width="1952" height="1776" alt="Markup 2025-09-09 at 13 33 05" src="https://github.com/user-attachments/assets/b57a4b62-82a1-41c1-96a3-4371dc967935" />


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7554]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7554-next-admin-hide-unused-automation-actions)

_The latest successful build from `stomail-7554-next-admin-hide-unused-automation-actions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation editor now adapts to hosting mode, hiding certain MailPoet steps in Garden environments for a streamlined experience.

* **Documentation**
  * Added a Code Formatting section with Prettier instructions and quick commands in the README.
  * Updated Table of Contents to include the new Code Formatting section.
  * CONTRIBUTING guidelines now clarify how to run Prettier for consistent code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->