### PR TITLE
Improve font family handling in WooCommerce transactional emails

### DIFF
--- a/mailpoet/changelog/2025-09-11-06-41-08-improved-improve-font-family-handling-in-woocommerce-transa.md
+++ b/mailpoet/changelog/2025-09-11-06-41-08-improved-improve-font-family-handling-in-woocommerce-transa.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improve font family handling in WooCommerce transactional emails

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -643,6 +643,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\WooCommerce\Tracker::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\Template::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\Renderer::class)->setPublic(true);
+    $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\FontFamilyValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\TransactionalEmails\ContentPreprocessor::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\CouponPreProcessor::class)->setPublic(true);
     $container->autowire(\MailPoet\WooCommerce\WooSystemInfo::class)->setPublic(true);

--- a/mailpoet/lib/WooCommerce/TransactionalEmails/FontFamilyValidator.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/FontFamilyValidator.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce\TransactionalEmails;
+
+/**
+ * Validator for font family values in CSS styles.
+ */
+class FontFamilyValidator {
+
+  const DEFAULT_FONT_FAMILY = 'Arial, sans-serif';
+
+  public function validateFontFamily(?string $fontFamily): string {
+    if (empty($fontFamily)) {
+      return self::DEFAULT_FONT_FAMILY;
+    }
+
+    $sanitized = $this->sanitizeFontFamily($fontFamily);
+
+    if (empty($sanitized)) {
+      return self::DEFAULT_FONT_FAMILY;
+    }
+
+    return $sanitized;
+  }
+
+  private function sanitizeFontFamily(string $fontFamily): string {
+    // Remove characters that could break CSS context
+    $sanitized = str_replace([
+      '"', "'", ';', '<', '>', '\\', '/', '(', ')', '{', '}', '[', ']',
+      '=', '+', '*', '^', '$', '@', '!', '~', '`', '|', '#', '%', '&', '?', ':',
+    ], '', $fontFamily);
+
+    // Normalize whitespace
+    $sanitized = preg_replace('/\s+/u', ' ', $sanitized);
+    if ($sanitized === null) {
+      return '';
+    }
+    
+    $sanitized = preg_replace('/\s*,\s*/u', ', ', $sanitized);
+    if ($sanitized === null) {
+      return '';
+    }
+
+    return trim($sanitized);
+  }
+}

--- a/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
+++ b/mailpoet/lib/WooCommerce/TransactionalEmails/Renderer.php
@@ -26,16 +26,21 @@ class Renderer {
   /** @var Shortcodes */
   private $shortcodes;
 
+  /** @var FontFamilyValidator */
+  private $fontFamilyValidator;
+
   public function __construct(
     csstidy $cssParser,
     NewsletterRenderer $renderer,
-    Shortcodes $shortcodes
+    Shortcodes $shortcodes,
+    FontFamilyValidator $fontFamilyValidator
   ) {
     $this->cssParser = $cssParser;
     $this->htmlBeforeContent = '';
     $this->htmlAfterContent = '';
     $this->renderer = $renderer;
     $this->shortcodes = $shortcodes;
+    $this->fontFamilyValidator = $fontFamilyValidator;
   }
 
   public function render(NewsletterEntity $newsletter, ?string $subject = null) {
@@ -82,15 +87,65 @@ class Renderer {
     }
     [$beforeWooContent, $wooContent, $afterWooContent] = $contentParts;
     $fontFamily = $newsletter->getGlobalStyle('text', 'fontFamily');
-    $replaceFontFamilyCallback = function ($matches) use ($fontFamily) {
-      $pattern = '/font-family\s*:\s*[^;]+;/i';
-      $style = $matches[1];
-      $style = preg_replace($pattern, "font-family:$fontFamily;", $style);
-      return 'style="' . esc_attr($style) . '"';
-    };
-    $stylePattern = '/style="(.*?)"/i';
-    $wooContent = (string)preg_replace_callback($stylePattern, $replaceFontFamilyCallback, $wooContent);
+
+    // Only replace font family if user provided a custom font
+    if (!empty($fontFamily)) {
+      // Validate and sanitize font family
+      $safeFontFamily = $this->fontFamilyValidator->validateFontFamily($fontFamily);
+      $wooContent = $this->replaceFontFamily($wooContent, $safeFontFamily);
+    }
+    
     return implode('', [$beforeWooContent, $wooContent, $afterWooContent]);
+  }
+
+  private function replaceFontFamily(string $content, string $fontFamily): string {
+    $processor = new \WP_HTML_Tag_Processor($content);
+
+    // Process all tags that might have style attributes
+    while ($processor->next_tag()) {
+      $styleAttr = $processor->get_attribute('style');
+      if (empty($styleAttr)) {
+        continue;
+      }
+
+      // Fast path: avoid parsing when no font-family present
+      if (stripos($styleAttr, 'font-family') === false) {
+        continue;
+      }
+
+      // Use CSS parser for CSS manipulation
+      // Wrap inline style in a selector so csstidy can parse it properly
+      $cssParser = new csstidy();
+      $cssParser->settings['compress_colors'] = false;
+      $cssParser->settings['remove_last_;'] = false;
+      $cssParser->parse('x { ' . $styleAttr . ' }');
+
+      // Update font-family in parsed CSS
+      $updated = false;
+      foreach ($cssParser->css as $index => $rules) {
+        foreach ($rules as $selector => $properties) {
+          if (isset($properties['font-family'])) {
+            $properties['font-family'] = $fontFamily;
+            $cssParser->css[$index][$selector] = $properties;
+            $updated = true;
+          }
+        }
+      }
+
+      // Only update the attribute if we made changes
+      if ($updated) {
+        /** @var csstidy_print $print */
+        $print = $cssParser->print;
+        $fullCss = $print->plain();
+        // Extract the properties from "x { ... }" format
+        if (preg_match('/x\s*{\s*(.*)\s*}/s', $fullCss, $matches)) {
+          $updatedStyle = trim($matches[1]);
+          $processor->set_attribute('style', $updatedStyle);
+        }
+      }
+    }
+
+    return $processor->get_updated_html();
   }
 
   /**
@@ -142,8 +197,8 @@ class Renderer {
    */
   private function prepareNewsletterForRendering(NewsletterEntity $newsletter): NewsletterEntity {
     $newsletterClone = clone($newsletter);
-    $headingFontFamily = $newsletter->getGlobalStyle('woocommerce', 'headingFontFamily');
-    if ($headingFontFamily) {
+    $headingFontFamily = $this->fontFamilyValidator->validateFontFamily($newsletter->getGlobalStyle('woocommerce', 'headingFontFamily'));
+    if ($headingFontFamily !== FontFamilyValidator::DEFAULT_FONT_FAMILY) {
       $newsletterClone->setGlobalStyle('h1', 'fontFamily', $headingFontFamily);
       $newsletterClone->setGlobalStyle('h2', 'fontFamily', $headingFontFamily);
       $newsletterClone->setGlobalStyle('h3', 'fontFamily', $headingFontFamily);
@@ -169,14 +224,16 @@ class Renderer {
     if (!is_array($properties)) {
       $properties = [];
     }
-    $fontFamily = $newsletter->getGlobalStyle('text', 'fontFamily');
-    $headingFontFamily = $newsletter->getGlobalStyle('woocommerce', 'headingFontFamily');
+    $fontFamilyRaw = $newsletter->getGlobalStyle('text', 'fontFamily');
+    $headingFontFamilyRaw = $newsletter->getGlobalStyle('woocommerce', 'headingFontFamily');
+    $fontFamily = $fontFamilyRaw !== null ? $this->fontFamilyValidator->validateFontFamily($fontFamilyRaw) : null;
+    $headingFontFamily = $headingFontFamilyRaw !== null ? $this->fontFamilyValidator->validateFontFamily($headingFontFamilyRaw) : null;
     $fontSize = $newsletter->getGlobalStyle('text', 'fontSize');
     $brandingColor = $newsletter->getGlobalStyle('woocommerce', 'brandingColor');
     $contentHeadingColor = $newsletter->getGlobalStyle('woocommerce', 'contentHeadingFontColor') ?? $brandingColor;
 
     // Update font family if it's set in the editor
-    if ($fontFamily && !empty($properties['font-family'])) {
+    if (!empty($fontFamilyRaw) && !empty($properties['font-family'])) {
       $properties['font-family'] = $fontFamily;
     }
     // Update font size for inner content
@@ -191,7 +248,7 @@ class Renderer {
       if ($headingFontSize && ($selectors === $heading)) {
         $properties['font-size'] = $headingFontSize;
       }
-      if ($headingFontFamily && ($selectors === $heading)) {
+      if (!empty($headingFontFamilyRaw) && ($selectors === $heading)) {
         $properties['font-family'] = $headingFontFamily;
       }
       if ($contentHeadingColor && ($selectors === $heading)) {

--- a/mailpoet/tests/unit/WooCommerce/TransactionalEmails/FontFamilyValidatorTest.php
+++ b/mailpoet/tests/unit/WooCommerce/TransactionalEmails/FontFamilyValidatorTest.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\WooCommerce\TransactionalEmails;
+
+use MailPoet\WooCommerce\TransactionalEmails\FontFamilyValidator;
+
+class FontFamilyValidatorTest extends \MailPoetUnitTest {
+
+  /** @var FontFamilyValidator */
+  private $validator;
+
+  public function _before() {
+    parent::_before();
+    $this->validator = new FontFamilyValidator();
+  }
+
+  public function testValidateFontFamilyWithValidFont() {
+    $result = $this->validator->validateFontFamily('Arial');
+    $this->assertEquals('Arial', $result);
+  }
+
+  public function testValidateFontFamilyWithValidFontList() {
+    $result = $this->validator->validateFontFamily('Arial, sans-serif');
+    $this->assertEquals('Arial, sans-serif', $result);
+  }
+
+  public function testValidateFontFamilyWithCaseInsensitiveFont() {
+    $result = $this->validator->validateFontFamily('arial');
+    $this->assertEquals('arial', $result);
+  }
+
+  public function testValidateFontFamilyWithQuotedFont() {
+    $result = $this->validator->validateFontFamily('"Times New Roman"');
+    $this->assertEquals('Times New Roman', $result);
+  }
+
+  public function testValidateFontFamilyWithEmptyValue() {
+    $result = $this->validator->validateFontFamily('');
+    $this->assertEquals(FontFamilyValidator::DEFAULT_FONT_FAMILY, $result);
+  }
+
+  public function testValidateFontFamilyWithNullValue() {
+    $result = $this->validator->validateFontFamily(null);
+    $this->assertEquals(FontFamilyValidator::DEFAULT_FONT_FAMILY, $result);
+  }
+
+  public function testValidateFontFamilyWithCustomFont() {
+    $result = $this->validator->validateFontFamily('MyCustomFont123');
+    $this->assertEquals('MyCustomFont123', $result);
+  }
+
+  public function testValidateFontFamilyHandlesMaliciousInput() {
+    $maliciousInputs = [
+      'Arial" onload="alert(1)" x="' => 'Arial onloadalert1 x',
+      'Times" onclick="alert(\'XSS\')" data="' => 'Times onclickalertXSS data',
+      'Arial; background: url(javascript:alert(1));' => 'Arial background urljavascriptalert1',
+      'Arial</style><script>alert(1)</script><style>' => 'Arialstylescriptalert1scriptstyle',
+      'Times"</style><script>alert(1)</script><style a="' => 'Timesstylescriptalert1scriptstyle a',
+    ];
+
+    foreach ($maliciousInputs as $input => $expected) {
+      $result = $this->validator->validateFontFamily($input);
+
+      // Assert the sanitized output matches the expected result
+      $this->assertEquals($expected, $result);
+
+      // Verify dangerous characters are removed
+      $this->assertStringNotContainsString('"', $result);
+      $this->assertStringNotContainsString('<', $result);
+      $this->assertStringNotContainsString('>', $result);
+      $this->assertStringNotContainsString(';', $result);
+      $this->assertStringNotContainsString('\\', $result);
+
+      // Result should still be a non-empty string
+      $this->assertNotEmpty($result);
+    }
+  }
+
+  public function testSanitizationRemovesDangerousCharacters() {
+    $dangerousInputs = [
+      'Arial<script>alert(1)</script>',
+      'Times"onclick="alert(1)"',
+      'Verdana;background:red;',
+      'Georgia{color:red}',
+      'Helvetica>body{color:red}',
+      'Arial[onclick=alert(1)]',
+      'Times(javascript:alert(1))',
+      'Comic Sans MS=evil',
+      'Arial+Times',
+      'Verdana*{color:red}',
+      'Georgia^[onclick=alert]',
+      'Times|onclick|',
+      'Arial\\onclick\\',
+      'Helvetica/onclick/',
+      'Arial@import',
+      'Times#id',
+      'Verdana$var',
+      'Georgia%3Cscript%3E',
+      'Arial&lt;script&gt;',
+      'Times~hover',
+      'Arial!important',
+      'Verdana?query',
+    ];
+
+    foreach ($dangerousInputs as $input) {
+      $result = $this->validator->validateFontFamily($input);
+      // Should either be sanitized to safe version or default font
+      $this->assertNotEquals($input, $result, "Dangerous input should be sanitized: $input");
+      // Should not contain dangerous characters in the result
+      $this->assertStringNotContainsString('<', $result);
+      $this->assertStringNotContainsString('>', $result);
+      $this->assertStringNotContainsString(';', $result);
+      $this->assertStringNotContainsString('\\', $result);
+      $this->assertStringNotContainsString('[', $result);
+      $this->assertStringNotContainsString(']', $result);
+    }
+  }
+
+  /**
+   * Test font family lists with custom fonts
+   */
+  public function testValidateFontFamilyWithCustomFontLists() {
+    // Should accept custom fonts in lists
+    $result = $this->validator->validateFontFamily('Arial, MyCustomFont123');
+    $this->assertEquals('Arial, MyCustomFont123', $result);
+
+    $result = $this->validator->validateFontFamily('CustomFont, Helvetica');
+    $this->assertEquals('CustomFont, Helvetica', $result);
+
+    $result = $this->validator->validateFontFamily('Arial, Helvetica, CustomWebFont');
+    $this->assertEquals('Arial, Helvetica, CustomWebFont', $result);
+  }
+
+  /**
+   * Test performance with long input strings
+   */
+  public function testValidateFontFamilyWithLongInput() {
+    $longInput = str_repeat('A', 1000) . '" onclick="alert(1)" x="';
+    $result = $this->validator->validateFontFamily($longInput);
+    // Should sanitize and still return a font name (not default)
+    $this->assertStringNotContainsString('"', $result);
+    $this->assertStringNotContainsString('=', $result);
+    $this->assertStringNotContainsString('(', $result);
+    $this->assertStringNotContainsString(')', $result);
+    $this->assertNotEmpty($result);
+    $this->assertNotEquals(FontFamilyValidator::DEFAULT_FONT_FAMILY, $result);
+  }
+
+  /**
+   * Test edge cases with whitespace
+   */
+  public function testValidateFontFamilyHandlesWhitespace() {
+    $result = $this->validator->validateFontFamily('  Arial  ');
+    $this->assertEquals('Arial', $result);
+
+    $result = $this->validator->validateFontFamily('Arial  ,  Helvetica');
+    $this->assertEquals('Arial, Helvetica', $result);
+
+    $result = $this->validator->validateFontFamily("Arial\n,\tHelvetica");
+    $this->assertEquals('Arial, Helvetica', $result);
+  }
+}


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7558-audit-the-mailpoet-plugin-for-use-of-greedy-and-non-greedy)

_The latest successful build from `stomail-7558-audit-the-mailpoet-plugin-for-use-of-greedy-and-non-greedy` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Centralized font-family validation applied to WooCommerce transactional emails for more consistent rendering.
- Improvements
  - Safer processing and normalization of custom font lists and whitespace; headings respect a reliable default fallback.
- Bug Fixes
  - Prevents malformed or unsafe font-family values from altering layout or enabling attribute/script injection.
- Documentation
  - Added changelog entry describing the font-family handling improvement.
- Tests
  - Added unit and integration tests covering valid, edge-case, and malicious font-family inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->