### PR TITLE
Bump minimum WooCommerce to 10.1, tested up to 10.2

### DIFF
--- a/mailpoet/changelog/2025-09-15-10-00-35-updated-bump-the-minimum-required-woocommerce-version-to-1.md
+++ b/mailpoet/changelog/2025-09-15-10-00-35-updated-bump-the-minimum-required-woocommerce-version-to-1.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2.

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 10.0
- * WC tested up to: 10.1
+ * WC requires at least: 10.1
+ * WC tested up to: 10.2
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.7'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.0'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.1'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/woocommerce-10-2-compatibility)

_The latest successful build from `update/woocommerce-10-2-compatibility` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum required WooCommerce version to 10.1.
  * Verified compatibility up through WooCommerce 10.2.

* **Documentation**
  * Updated plugin metadata to reflect new WooCommerce requirements.
  * Added a changelog entry documenting the updated minimum and tested versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->