### PR TITLE
Fix the SwitchingLanguagesCest:switchLanguage test

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -74,7 +74,7 @@ class SwitchingLanguagesCest {
         // Wait before clicking the update button to prevent triggering too many requests too translate.wordpress.com within one second
         $i->wait(1);
         $i->click('Übersetzungen aktualisieren');
-        $i->waitForText('Weiter zur WordPress-Aktualisierungs-Seite');
+        $i->waitForText('Zur WordPress-Aktualisierungsseite');
         break;
       } catch (ElementNotFound $e) {
         // translations are not yet scheduled for update, or are already up-to-date


### PR DESCRIPTION
## Description

The translation for the `Go to WordPress Updates page` link [has been updated](https://translate.wordpress.org/projects/wp/dev/admin/de/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=12787&filters%5Btranslation_id%5D=135260936), causing the `SwitchingLanguagesCest:switchLanguage` [test to fail](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21375/workflows/98327c7b-7b7b-4bdf-b2df-386c9d96c4fd/jobs/369094/parallel-runs/13).

This PR updates the expected text to match the current translation for the exected link.

## Code review notes

Confirm the acceptance tests pass.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes