### PR TITLE
Don't translate `WordPress` in automation step keywords

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
@@ -4,8 +4,7 @@ import { StepType } from '../../../../editor/store';
 import { Edit } from './edit';
 
 const keywords = [
-  // translators: noun, used as a search keyword for "WordPress user registers" trigger
-  __('wordpress', 'mailpoet'),
+  'WordPress',
   // translators: noun, used as a search keyword for "WordPress user registers" trigger
   __('user', 'mailpoet'),
   // translators: verb, used as a search keyword for "WordPress user registers" trigger

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-role-changed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-role-changed/index.tsx
@@ -5,8 +5,7 @@ import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
 import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 
 const keywords = [
-  // translators: used as a search keyword for "WordPress user role changes" automation trigger
-  __('wordpress', 'mailpoet'),
+  'WordPress',
   // translators: used as a search keyword for "WordPress user role changes" automation trigger
   __('user', 'mailpoet'),
   // translators: used as a search keyword for "WordPress user role changes" automation trigger


### PR DESCRIPTION
## Description

p1757943627239799-slack-C01HUN2F7EH

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:automation-wordpress-keywords)

_The latest successful build from `automation-wordpress-keywords` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the “WordPress” keyword in automation steps to ensure consistent display and search across languages.
  * Improved discoverability of the “User registered” and “User role changed” steps when searching for “WordPress”.

* **Style**
  * Minor copy consistency updates to step keywords for clearer labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->