### PR TITLE
Fix SwitchingLanguages test for `acceptance_oldest` job

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -74,7 +74,8 @@ class SwitchingLanguagesCest {
         // Wait before clicking the update button to prevent triggering too many requests too translate.wordpress.com within one second
         $i->wait(1);
         $i->click('Übersetzungen aktualisieren');
-        $i->waitForText('Zur WordPress-Aktualisierungsseite');
+        // Covers both current and old German translations of the "Go to WordPress Updates page" link, to ensure compatibility with WordPress 6.7.2 and older translations.
+        $i->waitForElement(['xpath' => "//*[text()='Zur WordPress-Aktualisierungsseite' or text()='Weiter zur WordPress-Aktualisierungs-Seite']"]);
         break;
       } catch (ElementNotFound $e) {
         // translations are not yet scheduled for update, or are already up-to-date


### PR DESCRIPTION
## Description

https://github.com/mailpoet/mailpoet/pull/6328 updated the German translation for `Go to WordPress Updates page` link in the `SwitchingLanguagesCest` to match the current translation. However, the test runs in `acceptance_oldest` job in WordPress 6.7.2 environment using the old translation, and thus [the updated step times out](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21393/workflows/c5247127-759c-4bae-b16c-d8aead8317a8/jobs/369465).

This PR updates the step so that it covers both the current and old translation.

## Code review notes

Confirm the updated step passes successfully:

```
./do test:acceptance --wordpress-version=latest --file=tests/acceptance/Misc/SwitchingLanguagesCest.php --skip-deps
./do test:acceptance --wordpress-version=6.7.2 --file=tests/acceptance/Misc/SwitchingLanguagesCest.php --skip-deps
```

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/acceptance-oldest-switching-language)

_The latest successful build from `fix/acceptance-oldest-switching-language` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced language-switching acceptance test to recognize both current and legacy German translations on the WordPress update page.
  - Broadened element matching to reduce flakiness across environments and translation versions.
  - Added a clarifying comment to improve test readability and maintenance.
  - Maintains existing control flow and error handling; no changes to product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->