### PR TITLE
Fix early translation function calls in settings defaults [STOMAIL-7559]

### DIFF
--- a/mailpoet/changelog/2025-09-19-10-32-45-fixed-fixed-a-user-warning-on-the-registration-screen.md
+++ b/mailpoet/changelog/2025-09-19-10-32-45-fixed-fixed-a-user-warning-on-the-registration-screen.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fixed a user warning on the registration screen

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -67,8 +67,6 @@ class SettingsController {
         'signup_confirmation' => [
           'enabled' => true,
           'use_mailpoet_editor' => true,
-          'subject' => __('Confirm your subscription to [site:title]', 'mailpoet'),
-          'body' => __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_url]\">[site:title]</a>", 'mailpoet'),
         ],
         'tracking' => [
           'level' => TrackingConfig::LEVEL_FULL,
@@ -80,7 +78,60 @@ class SettingsController {
         'deactivate_subscriber_after_inactive_days' => self::DEFAULT_DEACTIVATE_SUBSCRIBER_AFTER_INACTIVE_DAYS,
       ];
     }
+
+    // Always include subject and body in defaults, using translated versions when available
+    $this->defaults['signup_confirmation']['subject'] = $this->getTranslatedDefaultSubject();
+    $this->defaults['signup_confirmation']['body'] = $this->getTranslatedDefaultBody();
+
     return $this->defaults;
+  }
+
+  /**
+   * Get translated default subject with fallback
+   *
+   * @return string
+   */
+  private function getTranslatedDefaultSubject(): string {
+    if ($this->isTranslationReady()) {
+      return __('Confirm your subscription to [site:title]', 'mailpoet');
+    }
+    return 'Confirm your subscription to [site:title]';
+  }
+
+  /**
+   * Get translated default body with fallback
+   *
+   * @return string
+   */
+  private function getTranslatedDefaultBody(): string {
+    if ($this->isTranslationReady()) {
+      return __("Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_url]\">[site:title]</a>", 'mailpoet');
+    }
+    return "Hello [subscriber:firstname | default:there],\n\nYou've received this message because you subscribed to [site:title]. Please confirm your subscription to receive emails from us:\n\n[activation_link]Click here to confirm your subscription.[/activation_link] \n\nIf you received this email by mistake, simply delete it. You won't receive any more emails from us unless you confirm your subscription using the link above.\n\nThank you,\n\n<a target=\"_blank\" href=\"[site:homepage_url]\">[site:title]</a>";
+  }
+
+  /**
+   * Check if translations are ready to be used
+   *
+   * @return bool
+   */
+  private function isTranslationReady(): bool {
+    if (!function_exists('__')) {
+      return false;
+    }
+
+    // Prefer using is_textdomain_loaded to confirm the 'mailpoet' text domain is present
+    if (function_exists('is_textdomain_loaded')) {
+      return (bool)is_textdomain_loaded('mailpoet');
+    }
+
+    // Fall back to did_action('init') if is_textdomain_loaded is unavailable
+    // Guard did_action() with function_exists to avoid fatals in non-WP contexts
+    if (function_exists('did_action')) {
+      return (bool)did_action('init');
+    }
+
+    return false;
   }
 
   /**
@@ -156,6 +207,7 @@ class SettingsController {
         return null;
       }
     }
+
     return $default;
   }
 


### PR DESCRIPTION
## Description

Resolves "Function _load_textdomain_just_in_time was called
  Incorrectly," notice when 'Protect registration forms' is enabled.

Translation functions were being called during settings
  initialisation before WordPress text domains were loaded. Now
  uses lazy loading with WordPress readiness checks and fallbacks.

### Before

<img width="3354" height="2340" alt="Screenshot 2025-09-19 at 11 02 26" src="https://github.com/user-attachments/assets/f4428ef4-2b78-4b5f-a101-064439f94b72" />

### After

<img width="3566" height="2444" alt="Screenshot 2025-09-19 at 13 39 56" src="https://github.com/user-attachments/assets/9e0ac807-0518-45a8-81a5-523e8a2c5016" />


## Code review notes

_N/A_

## QA notes

This is a notice that is displayed on the WordPress registration page. 

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7559-php-user-notice-function-_load_textdomain_just_in_time-was)

_The latest successful build from `stomail-7559-php-user-notice-function-_load_textdomain_just_in_time-was` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed a user-facing warning on the registration screen.
  - Improved localization for signup confirmation emails: subject and body use translated content when available, with an English fallback if translations aren’t ready.

- Documentation
  - Added a changelog entry describing the registration warning fix and the localization improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->