### PR TITLE
Fix hardcoded URL for my account page in new account template

### DIFF
--- a/mailpoet/changelog/2025-09-19-15-32-17-fixed-fix-hardcoded-url-for-my-account-page-in-new-accou.md
+++ b/mailpoet/changelog/2025-09-19-15-32-17-fixed-fix-hardcoded-url-for-my-account-page-in-new-accou.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix hardcoded URL for my account page in new account template

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -227,6 +227,11 @@ class Functions extends AbstractExtension {
         [$this, 'wcPlaceholderImgSrc'],
         ['is_safe' => ['all']]
       ),
+      new TwigFunction(
+        'get_wc_page_url',
+        [$this, 'wcPageUrl'],
+        ['is_safe' => ['all']]
+      ),
     ];
   }
 
@@ -394,5 +399,9 @@ class Functions extends AbstractExtension {
 
   public function wcPlaceholderImgSrc(string $size = 'woocommerce_thumbnail'): string {
     return esc_url($this->getWooCommerceHelper()->wcPlaceholderImgSrc($size));
+  }
+
+  public function wcPageUrl(string $page): string {
+    return esc_url($this->getWooCommerceHelper()->wcGetPagePermalink($page));
   }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -364,4 +364,12 @@ class Helper {
 
     return wc_placeholder_img_src($size);
   }
+
+  public function wcGetPagePermalink(string $page): string {
+    if (!$this->isWooCommerceActive() || !function_exists('wc_get_page_permalink')) {
+      return '';
+    }
+
+    return wc_get_page_permalink($page);
+  }
 }

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/new_account.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/new_account.hbs
@@ -12,7 +12,7 @@
 		<p style="margin: 0 0 16px;"><%= __('Username:', 'woocommerce') %> <b>jane</b></p>
 		<div class="hr hr-bottom" style="border-bottom: 1px solid #1e1e1e; opacity: .2; margin: 16px 0; margin-bottom: 32px;"></div>
 		<p style="margin: 0 0 16px;"><%= __('You can access your account area to view orders, change your password, and more via the link below:', 'woocommerce') %></p>
-		<p style="margin: 0 0 16px;"><a target="_blank" href="http://mailpoet.plugin:8002/my-account/" style="color: #7f54b3; font-weight: normal; text-decoration: underline;"><%= __('My account', 'woocommerce') %></a></p>
+		<p style="margin: 0 0 16px;"><a target="_blank" href="<%= get_wc_page_url('myaccount') %>" style="color: #7f54b3; font-weight: normal; text-decoration: underline;"><%= __('My account', 'woocommerce') %></a></p>
 	</div>
 	<table border="0" cellpadding="0" cellspacing="0" width="100%">
 		<tr>


### PR DESCRIPTION
## Description

Fix [hardcoded URL for my account page](https://github.com/mailpoet/mailpoet/blob/160e277dab170a8ac1f6f7e383be51d29ed0239e/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/new_account.hbs#L15) in new account template.

Closes [STOMAIL-7562: Broken placeholder images in Woo template customizer](https://linear.app/a8c/issue/STOMAIL-7562/broken-placeholder-images-in-woo-template-customizer)

## Code review notes

_N/A_

## QA notes

1. Navigate to **WooCommerce → Settings → Emails** and click on **Customize with MailPoet**
2. Load dummy data for email - **New account**.
3. Inspect the email preview and confirm the link for the `My Account` link has the correct URL.

Note that the Twig templates might be cached, so in case you're still seeing the hardcoded URL, you can try deleting the cache in `wp-content/plugins/mailpoet/generated/twig`.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/hardcoded-url-in-new-account-template)

_The latest successful build from `fix/hardcoded-url-in-new-account-template` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - The “My Account” link in new account emails now uses the configured WooCommerce page URL dynamically, ensuring correct links with custom slugs, permalink changes, or multilingual setups.
- Chores
  - Added a changelog entry documenting this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->