### PR TITLE
Release 5.15.0

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,12 @@
 == Changelog ==
 
+= 5.15.0 - 2025-09-22 =
+* Improved: Improve font family handling in WooCommerce transactional emails;
+* Improved: Updated used Email Editor package to 1.6.0;
+* Improved: Implement log level filtering for the email editor;
+* Fixed: Fix placeholder images URLs in WooCommerce template customizer;
+* Fixed: Fix hardcoded URL for my account page in new account template.
+
 = 5.14.3 - 2025-09-15 =
 * Added: Enable support for creating and editing Automation newsletters with the block email editor.;
 * Updated: Update the email editor version.

--- a/mailpoet/changelog/2025-09-11-06-41-08-improved-improve-font-family-handling-in-woocommerce-transa.md
+++ b/mailpoet/changelog/2025-09-11-06-41-08-improved-improve-font-family-handling-in-woocommerce-transa.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Improve font family handling in WooCommerce transactional emails

--- a/mailpoet/changelog/2025-09-18-10-16-53-improved-updated-used-email-editor-package-to-160.md
+++ b/mailpoet/changelog/2025-09-18-10-16-53-improved-updated-used-email-editor-package-to-160.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Updated used Email Editor package to 1.6.0

--- a/mailpoet/changelog/2025-09-18-16-16-45-improved-implement-log-level-filtering-for-the-email-editor.md
+++ b/mailpoet/changelog/2025-09-18-16-16-45-improved-implement-log-level-filtering-for-the-email-editor.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Implement log level filtering for the email editor

--- a/mailpoet/changelog/2025-09-19-10-44-47-fixed-fix-placeholder-images-urls-in-woocommerce-templat.md
+++ b/mailpoet/changelog/2025-09-19-10-44-47-fixed-fix-placeholder-images-urls-in-woocommerce-templat.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fix placeholder images URLs in WooCommerce template customizer

--- a/mailpoet/changelog/2025-09-19-15-32-17-fixed-fix-hardcoded-url-for-my-account-page-in-new-accou.md
+++ b/mailpoet/changelog/2025-09-19-15-32-17-fixed-fix-hardcoded-url-for-my-account-page-in-new-accou.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fix hardcoded URL for my account page in new account template

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.14.3
+ * Version: 5.15.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.14.3',
+  'version' => '5.15.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 5.14.3
+Stable tag: 5.15.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,8 +227,11 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.14.3 - 2025-09-15 =
-* Added: Enable support for creating and editing Automation newsletters with the block email editor.;
-* Updated: Update the email editor version.
+= 5.15.0 - 2025-09-22 =
+* Improved: Improve font family handling in WooCommerce transactional emails;
+* Improved: Updated used Email Editor package to 1.6.0;
+* Improved: Implement log level filtering for the email editor;
+* Fixed: Fix placeholder images URLs in WooCommerce template customizer;
+* Fixed: Fix hardcoded URL for my account page in new account template.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Improvements
  * Better font family handling in WooCommerce transactional emails.
  * Email Editor updated to version 1.6.0.
  * Added log level filtering in the Email Editor.
* Bug Fixes
  * Corrected placeholder image URLs in the WooCommerce template customizer.
  * Fixed hardcoded “My Account” URL in the new account template.
* Documentation
  * Changelog updated with 5.15.0 entries.
* Chores
  * Bumped plugin version to 5.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->