### PR TITLE
Add tracking via Tracks API

### DIFF
--- a/mailpoet/assets/js/src/analytics-event.js
+++ b/mailpoet/assets/js/src/analytics-event.js
@@ -197,24 +197,28 @@ function trackTracksIfEnabled(event) {
 }
 
 function trackCachedEvents() {
-  const storageItem = localStorage.getItem(LOCALSTORAGE_KEY);
-  if (storageItem && window.mailpoet_analytics_enabled) {
-    const localEventsCache = JSON.parse(storageItem);
-    localEventsCache.forEach(trackIfEnabled);
-    localStorage.removeItem(LOCALSTORAGE_KEY);
-    return;
+  if (typeof localStorage !== 'undefined') {
+    const storageItem = localStorage.getItem(LOCALSTORAGE_KEY);
+    if (storageItem && window.mailpoet_analytics_enabled) {
+      const localEventsCache = JSON.parse(storageItem);
+      localEventsCache.forEach(trackIfEnabled);
+      localStorage.removeItem(LOCALSTORAGE_KEY);
+      return;
+    }
   }
 
   eventsCache.forEach(trackIfEnabled);
 }
 
 function trackCachedTracksEvents() {
-  const storageItem = localStorage.getItem(TRACKS_LOCALSTORAGE_KEY);
-  if (storageItem && window.mailpoet_analytics_enabled) {
-    const localTracksEventsCache = JSON.parse(storageItem);
-    localTracksEventsCache.forEach(trackTracksIfEnabled);
-    localStorage.removeItem(TRACKS_LOCALSTORAGE_KEY);
-    return;
+  if (typeof localStorage !== 'undefined') {
+    const storageItem = localStorage.getItem(TRACKS_LOCALSTORAGE_KEY);
+    if (storageItem && window.mailpoet_analytics_enabled) {
+      const localTracksEventsCache = JSON.parse(storageItem);
+      localTracksEventsCache.forEach(trackTracksIfEnabled);
+      localStorage.removeItem(TRACKS_LOCALSTORAGE_KEY);
+      return;
+    }
   }
 
   tracksEventsCache.forEach(trackTracksIfEnabled);
@@ -228,7 +232,10 @@ function cacheEvent(forced, name, data, options, callback) {
     callback: callback,
     forced: forced,
   });
-  if (options === CacheEventOptionSaveInStorage) {
+  if (
+    options === CacheEventOptionSaveInStorage &&
+    typeof localStorage !== 'undefined'
+  ) {
     localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(eventsCache));
   }
   if (typeof callback === 'function') {
@@ -243,7 +250,10 @@ function cacheTracksEvent(forced, name, data, options) {
     options: options,
     forced: forced,
   });
-  if (options === CacheEventOptionSaveInStorage) {
+  if (
+    options === CacheEventOptionSaveInStorage &&
+    typeof localStorage !== 'undefined'
+  ) {
     localStorage.setItem(
       TRACKS_LOCALSTORAGE_KEY,
       JSON.stringify(tracksEventsCache),

--- a/mailpoet/assets/js/src/analytics-event.js
+++ b/mailpoet/assets/js/src/analytics-event.js
@@ -1,7 +1,7 @@
 /*
  * This creates two functions and adds them to MailPoet object
  * - `trackEvent` which should be used in normal circumstances.
- *   This function tracks an event and sends it to mixpanel.
+ *   This function tracks an event and sends it to mixpanel and MailPoet Tracks in parallel.
  *   This function does nothing if analytics is disabled.
  * - `forceTrackEvent` which sends given event to analytics
  *   even if it has been disabled.
@@ -10,25 +10,154 @@
 import _ from 'underscore';
 
 /**
- *  This is to cache events which are triggered before the mixpanel
- *  library is loaded. This might happen if an event is tracked
- *  on page load and the mixpanel library takes a long time to load.
- *  After it is loaded all events are posted.
+ *  This is to cache events which are triggered before the analytics
+ *  libraries are loaded. This might happen if an event is tracked
+ *  on page load and the libraries take a long time to load.
+ *  After they are loaded all events are posted.
  * @type {Array.Object}
  */
 var eventsCache = [];
+var tracksEventsCache = [];
 
 const LOCALSTORAGE_KEY = 'mailpoet-track-events-cache';
+const TRACKS_LOCALSTORAGE_KEY = 'mailpoet-tracks-events-cache';
 export const CacheEventOptionSaveInStorage = 'saveInStorage';
 
-function track(name, data = [], options = {}, callback = null) {
-  let trackedData = data;
+function convertDataForTracks(data) {
+  if (!data || typeof data !== 'object') {
+    return {};
+  }
 
+  // Brand names and compound words that should stay together
+  const specialCases = {
+    MailPoet: 'mailpoet',
+    WooCommerce: 'woocommerce',
+    WordPress: 'wordpress',
+  };
+
+  const converted = {};
+  Object.entries(data).forEach(([key, value]) => {
+    let convertedKey = key;
+
+    Object.entries(specialCases).forEach(([original, replacement]) => {
+      convertedKey = convertedKey.replace(
+        new RegExp(original, 'g'),
+        replacement,
+      );
+    });
+
+    convertedKey = convertedKey
+      .replace(/([A-Z])/g, '_$1')
+      .toLowerCase()
+      .replace(/[^a-z0-9_]/g, '_')
+      .replace(/_{2,}/g, '_')
+      .replace(/^_|_$/g, '');
+
+    converted[convertedKey] = value;
+  });
+
+  return converted;
+}
+
+function convertEventNameForTracks(eventName) {
+  return eventName
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+function trackToMixpanel(name, data = [], options = {}, callback = null) {
   const optionsData = options === CacheEventOptionSaveInStorage ? {} : options;
 
   if (typeof window.mixpanel.track !== 'function') {
     window.mixpanel.init(window.mixpanelTrackingId, window.mixpanelInitConfig);
   }
+
+  if (!window.mixpanelIsLoaded) {
+    if (callback) {
+      callback();
+    }
+  } else {
+    window.mixpanel.track(name, data, optionsData, callback);
+  }
+}
+
+let tracksRequestQueue = [];
+
+function createMailPoetTracks() {
+  if (!window.mailpoetTracks) {
+    window.mailpoetTracks = {
+      isEnabled: true,
+      recordEvent: (name, properties) => {
+        const publicId = window.mailpoet_analytics_public_id || '';
+        const eventName = 'mailpoet_' + name;
+
+        if (!publicId) {
+          return;
+        }
+
+        const payload = {
+          commonProps: {
+            public_id: publicId,
+            ...properties,
+          },
+          events: {
+            _ut: 'anon',
+            _ui: publicId,
+            _en: eventName,
+          },
+        };
+
+        tracksRequestQueue.push(payload);
+      },
+      flushQueue: () => {
+        if (tracksRequestQueue.length === 0) {
+          return;
+        }
+
+        tracksRequestQueue.forEach((payload) => {
+          fetch('https://public-api.wordpress.com/rest/v1.1/tracks/record', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+              'User-Agent': 'MailPoet Plugin',
+            },
+            body: JSON.stringify(payload),
+            keepalive: true,
+          }).catch(() => {
+            // Fail silently to avoid breaking the user experience
+          });
+        });
+
+        tracksRequestQueue = [];
+      },
+    };
+  }
+}
+
+function trackToTracks(name, data = []) {
+  try {
+    createMailPoetTracks();
+
+    const tracksEventName = convertEventNameForTracks(name);
+
+    const tracksData = convertDataForTracks(data);
+
+    if (
+      window.mailpoetTracks &&
+      typeof window.mailpoetTracks.recordEvent === 'function'
+    ) {
+      window.mailpoetTracks.recordEvent(tracksEventName, tracksData);
+    }
+  } catch (error) {
+    // Fail silently to avoid breaking the user experience
+  }
+}
+
+function track(name, data = [], options = {}, callback = null) {
+  let trackedData = data;
 
   if (typeof window.mailpoet_version !== 'undefined') {
     trackedData['MailPoet Free version'] = window.mailpoet_version;
@@ -38,41 +167,32 @@ function track(name, data = [], options = {}, callback = null) {
     trackedData['MailPoet Premium version'] = window.mailpoet_premium_version;
   }
 
-  // Fallback when Mixpanel is not loaded (e.g., blocked by AdBlock)
-  if (!window.mixpanelIsLoaded) {
-    if (callback) {
-      callback();
-    }
-  } else {
-    window.mixpanel.track(name, trackedData, optionsData, callback);
-  }
-}
+  // Track to MixPanel immediately
+  trackToMixpanel(name, trackedData, options, callback);
 
-function exportMixpanel() {
-  window.MailPoet.forceTrackEvent = track;
-
-  if (
-    window.mailpoet_analytics_enabled &&
-    window.mailpoet_3rd_party_libs_enabled
-  ) {
-    window.MailPoet.trackEvent = track;
-  } else {
-    window.MailPoet.trackEvent = function emptyFunction(
-      name,
-      data,
-      options,
-      callback,
-    ) {
-      if (typeof callback === 'function') {
-        callback();
-      }
-    };
-  }
+  // For tracks, queue the event to be sent later
+  trackToTracks(name, trackedData);
 }
 
 function trackIfEnabled(event) {
   if (window.mailpoet_analytics_enabled || event.forced) {
-    track(event.name, event.data, event.options);
+    track(event.name, event.data, event.options, event.callback);
+  }
+}
+
+function trackTracksIfEnabled(event) {
+  if (window.mailpoet_analytics_enabled || event.forced) {
+    createMailPoetTracks();
+
+    const tracksEventName = convertEventNameForTracks(event.name);
+    const tracksData = convertDataForTracks(event.data);
+
+    if (
+      window.mailpoetTracks &&
+      typeof window.mailpoetTracks.recordEvent === 'function'
+    ) {
+      window.mailpoetTracks.recordEvent(tracksEventName, tracksData);
+    }
   }
 }
 
@@ -88,11 +208,24 @@ function trackCachedEvents() {
   eventsCache.forEach(trackIfEnabled);
 }
 
+function trackCachedTracksEvents() {
+  const storageItem = localStorage.getItem(TRACKS_LOCALSTORAGE_KEY);
+  if (storageItem && window.mailpoet_analytics_enabled) {
+    const localTracksEventsCache = JSON.parse(storageItem);
+    localTracksEventsCache.forEach(trackTracksIfEnabled);
+    localStorage.removeItem(TRACKS_LOCALSTORAGE_KEY);
+    return;
+  }
+
+  tracksEventsCache.forEach(trackTracksIfEnabled);
+}
+
 function cacheEvent(forced, name, data, options, callback) {
   eventsCache.push({
     name: name,
     data: data,
     options: options,
+    callback: callback,
     forced: forced,
   });
   if (options === CacheEventOptionSaveInStorage) {
@@ -103,23 +236,134 @@ function cacheEvent(forced, name, data, options, callback) {
   }
 }
 
-export function initializeMixpanelWhenLoaded() {
+function cacheTracksEvent(forced, name, data, options) {
+  tracksEventsCache.push({
+    name: name,
+    data: data,
+    options: options,
+    forced: forced,
+  });
+  if (options === CacheEventOptionSaveInStorage) {
+    localStorage.setItem(
+      TRACKS_LOCALSTORAGE_KEY,
+      JSON.stringify(tracksEventsCache),
+    );
+  }
+}
+
+export function queueTrackEvent(
+  name,
+  data = [],
+  options = {},
+  callback = null,
+) {
+  let trackedData = data;
+
+  if (typeof window.mailpoet_version !== 'undefined') {
+    trackedData['MailPoet Free version'] = window.mailpoet_version;
+  }
+
+  if (typeof window.mailpoet_premium_version !== 'undefined') {
+    trackedData['MailPoet Premium version'] = window.mailpoet_premium_version;
+  }
+
+  cacheEvent(false, name, trackedData, options, callback);
+  cacheTracksEvent(false, name, trackedData, options);
+}
+
+export function processAllCachedEvents() {
+  trackCachedEvents();
+  trackCachedTracksEvents();
+
+  if (
+    window.mailpoetTracks &&
+    typeof window.mailpoetTracks.flushQueue === 'function'
+  ) {
+    window.mailpoetTracks.flushQueue();
+  }
+}
+
+function exportAnalytics() {
+  window.MailPoet.forceTrackEvent = track;
+
+  if (
+    window.mailpoet_analytics_enabled &&
+    window.mailpoet_3rd_party_libs_enabled
+  ) {
+    window.MailPoet.trackEvent = track;
+
+    window.MailPoet.queueTrackEvent = queueTrackEvent;
+    window.MailPoet.processAllCachedEvents = processAllCachedEvents;
+  } else {
+    window.MailPoet.trackEvent = function emptyFunction(
+      name,
+      data,
+      options,
+      callback,
+    ) {
+      if (typeof callback === 'function') {
+        callback();
+      }
+    };
+
+    window.MailPoet.queueTrackEvent = function emptyQueueFunction(
+      name,
+      data,
+      options,
+      callback,
+    ) {
+      if (typeof callback === 'function') {
+        callback();
+      }
+    };
+    window.MailPoet.processAllCachedEvents =
+      function emptyProcessAllCachedEvents() {};
+  }
+}
+
+export function initializeAnalyticsWhenLoaded() {
   const MAX_RETRY = 5;
   let intervalId;
   let retryCount = 0;
 
-  const setupMixpanel = () => {
-    exportMixpanel();
+  const setupAnalytics = () => {
+    exportAnalytics();
     trackCachedEvents();
+    trackCachedTracksEvents();
+
+    // Set up event listeners to flush tracks queue on page unload
+    const flushTracksQueue = () => {
+      if (
+        window.mailpoetTracks &&
+        typeof window.mailpoetTracks.flushQueue === 'function'
+      ) {
+        window.mailpoetTracks.flushQueue();
+      }
+    };
+
+    // Flush queue before page unloads
+    window.addEventListener('beforeunload', flushTracksQueue);
+    window.addEventListener('pagehide', flushTracksQueue);
+
+    // Also flush queue periodically (every 30 seconds)
+    setInterval(flushTracksQueue, 30000);
   };
 
-  if (typeof window.mixpanel === 'object') {
-    setupMixpanel();
+  const checkLibrariesReady = () => {
+    const mixpanelReady = typeof window.mixpanel === 'object';
+    // mailpoetTracks is now created by our JS, so always consider it ready
+    const tracksReady = true;
+
+    return mixpanelReady || tracksReady; // At least one should be ready
+  };
+
+  if (checkLibrariesReady()) {
+    setupAnalytics();
   } else {
     intervalId = setInterval(() => {
-      if (typeof window.mixpanel === 'object') {
+      if (checkLibrariesReady()) {
         clearInterval(intervalId);
-        setupMixpanel();
+        setupAnalytics();
       } else {
         retryCount += 1;
       }
@@ -133,3 +377,5 @@ export function initializeMixpanelWhenLoaded() {
 
 export const MailPoetTrackEvent = _.partial(cacheEvent, false);
 export const MailPoetForceTrackEvent = _.partial(cacheEvent, true);
+
+export const initializeMixpanelWhenLoaded = initializeAnalyticsWhenLoaded;

--- a/mailpoet/assets/js/src/analytics-event.js
+++ b/mailpoet/assets/js/src/analytics-event.js
@@ -102,11 +102,13 @@ function createMailPoetTracks() {
             public_id: publicId,
             ...properties,
           },
-          events: {
-            _ut: 'anon',
-            _ui: publicId,
-            _en: eventName,
-          },
+          events: [
+            {
+              _ut: 'anon',
+              _ui: publicId,
+              _en: eventName,
+            },
+          ],
         };
 
         tracksRequestQueue.push(payload);
@@ -184,15 +186,7 @@ function trackTracksIfEnabled(event) {
   if (window.mailpoet_analytics_enabled || event.forced) {
     createMailPoetTracks();
 
-    const tracksEventName = convertEventNameForTracks(event.name);
-    const tracksData = convertDataForTracks(event.data);
-
-    if (
-      window.mailpoetTracks &&
-      typeof window.mailpoetTracks.recordEvent === 'function'
-    ) {
-      window.mailpoetTracks.recordEvent(tracksEventName, tracksData);
-    }
+    trackToTracks(event.name, event.data);
   }
 }
 
@@ -267,7 +261,7 @@ export function queueTrackEvent(
   options = {},
   callback = null,
 ) {
-  let trackedData = data;
+  let trackedData = { ...data };
 
   if (typeof window.mailpoet_version !== 'undefined') {
     trackedData['MailPoet Free version'] = window.mailpoet_version;

--- a/mailpoet/changelog/2025-09-24-10-03-17-updated-reporting-analytics-data.md
+++ b/mailpoet/changelog/2025-09-24-10-03-17-updated-reporting-analytics-data.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Reporting analytics data

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -13,6 +13,7 @@ use MailPoet\Cron\Workers\NewsletterTemplateThumbnails;
 use MailPoet\Cron\Workers\StatsNotifications\Worker;
 use MailPoet\Cron\Workers\SubscriberLinkTokens;
 use MailPoet\Cron\Workers\SubscribersLastEngagement;
+use MailPoet\Cron\Workers\Tracks;
 use MailPoet\Cron\Workers\UnsubscribeTokens;
 use MailPoet\Doctrine\WPDB\Connection;
 use MailPoet\Entities\NewsletterEntity;
@@ -180,6 +181,7 @@ class Populator {
     $this->scheduleNewsletterTemplateThumbnails();
     $this->scheduleBackfillEngagementData();
     $this->scheduleMixpanel();
+    $this->scheduleTracks();
   }
 
   private function createMailPoetPage() {
@@ -677,6 +679,10 @@ class Populator {
 
   private function scheduleMixpanel() {
     $this->scheduleTask(Mixpanel::TASK_TYPE, Carbon::now()->millisecond(0));
+  }
+
+  private function scheduleTracks(): void {
+    $this->scheduleTask(Tracks::TASK_TYPE, Carbon::now()->millisecond(0));
   }
 
   private function scheduleTask($type, $datetime, $priority = null) {

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -113,5 +113,6 @@ class Daemon {
     yield $this->workersFactory->createAbandonedCartWorker();
     yield $this->workersFactory->createBackfillEngagementDataWorker();
     yield $this->workersFactory->createMixpanelWorker();
+    yield $this->workersFactory->createTracksWorker();
   }
 }

--- a/mailpoet/lib/Cron/Workers/Mixpanel.php
+++ b/mailpoet/lib/Cron/Workers/Mixpanel.php
@@ -31,7 +31,7 @@ class Mixpanel extends SimpleWorker {
   }
 
   public function maybeReportAnalyticsToMixpanel(): bool {
-    if (!$this->analytics->shouldSend()) {
+    if (!$this->analytics->shouldSendToMixpanel()) {
       return true;
     }
     return $this->reportAnalyticsToMixpanel();
@@ -50,12 +50,12 @@ class Mixpanel extends SimpleWorker {
     $this->mixpanel->people->set($publicId, $data);
     $this->mixpanel->track('User Properties', $data);
 
-    $this->analytics->recordDataSent();
+    $this->analytics->recordMixpanelDataSent();
 
     return true;
   }
 
   public function getNextRunDate() {
-    return $this->analytics->getNextSendDate()->addMinutes(rand(0, 59));
+    return $this->analytics->getNextSendDateForMixpanel()->addMinutes(rand(0, 59));
   }
 }

--- a/mailpoet/lib/Cron/Workers/Tracks.php
+++ b/mailpoet/lib/Cron/Workers/Tracks.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Analytics\Analytics;
+use MailPoet\Entities\ScheduledTaskEntity;
+
+class Tracks extends SimpleWorker {
+
+  /** @var Analytics */
+  private $analytics;
+
+  const TASK_TYPE = 'tracks';
+
+  public function __construct(
+    Analytics $analytics
+  ) {
+    parent::__construct();
+    $this->analytics = $analytics;
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    return $this->maybeReportAnalyticsToTracks();
+  }
+
+  public function maybeReportAnalyticsToTracks(): bool {
+    if (!$this->analytics->shouldSend()) {
+      return true;
+    }
+    return $this->reportAnalyticsToTracks();
+  }
+
+  public function reportAnalyticsToTracks(): bool {
+    $publicId = $this->analytics->getPublicId();
+
+    if (strlen($publicId) < 1) {
+      return true;
+    }
+
+    $data = $this->analytics->getAnalyticsData();
+
+    $success = $this->sendToTracksAPI($publicId, $data);
+
+    if ($success) {
+      $this->analytics->recordDataSent();
+    }
+
+    return $success;
+  }
+
+  private function convertKeysToSnakeCase(array $data): array {
+    $converted = [];
+
+    foreach ($data as $key => $value) {
+      $snakeKey = $this->normalizeKeyToSnakeCase($key);
+      $converted[$snakeKey] = $value;
+    }
+
+    return $converted;
+  }
+
+  private function normalizeKeyToSnakeCase(string $key): string {
+    // Step 1: Convert to lowercase
+    $key = strtolower($key);
+
+    // Step 2: Remove quotes and apostrophes
+    $key = str_replace(['\'', '"', '`'], '', $key);
+
+    // Step 3: Replace dashes directly with underscores
+    $key = str_replace(['-', '–', '.'], '_', $key);
+
+    // Step 4: Replace other separators with spaces
+    $key = preg_replace('/[_:>()<>\[\]{}|\\\\\/]+/', ' ', $key);
+
+    // Step 5: Remove redundant spaces
+    $key = preg_replace('/\s+/', ' ', trim((string)$key));
+
+    // Step 6: Replace spaces with underscores
+    $key = str_replace(' ', '_', (string)$key);
+
+    return $key;
+  }
+
+  private function sendToTracksAPI(string $publicId, array $data): bool {
+    $url = 'https://public-api.wordpress.com/rest/v1.1/tracks/record';
+
+    // Convert Analytics data keys to snake_case for consistency
+    $convertedData = $this->convertKeysToSnakeCase($data);
+
+    $payload = [
+      'commonProps' => array_merge([
+        'public_id' => $publicId,
+      ], $convertedData),
+      'events' => [
+        [
+          '_ut' => 'anon',
+          '_ui' => $publicId,
+          '_en' => 'mailpoet_user_profile',
+        ],
+      ],
+    ];
+
+    $jsonPayload = json_encode($payload);
+    if ($jsonPayload === false) {
+      return false;
+    }
+
+    $args = [
+      'method' => 'POST',
+      'headers' => [
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json',
+        'User-Agent' => 'MailPoet Plugin',
+      ],
+      'body' => $jsonPayload,
+      'timeout' => 30,
+    ];
+
+    $response = wp_remote_request($url, $args);
+
+    if (is_wp_error($response)) {
+      return false;
+    }
+
+    $statusCode = wp_remote_retrieve_response_code($response);
+    return $statusCode >= 200 && $statusCode < 300;
+  }
+
+  public function getNextRunDate() {
+    return $this->analytics->getNextSendDate()->addMinutes(rand(0, 59));
+  }
+}

--- a/mailpoet/lib/Cron/Workers/Tracks.php
+++ b/mailpoet/lib/Cron/Workers/Tracks.php
@@ -92,11 +92,9 @@ class Tracks extends SimpleWorker {
         'public_id' => $publicId,
       ], $convertedData),
       'events' => [
-        [
-          '_ut' => 'anon',
-          '_ui' => $publicId,
-          '_en' => 'mailpoet_user_profile',
-        ],
+        '_ut' => 'anon',
+        '_ui' => $publicId,
+        '_en' => 'mailpoet_user_profile',
       ],
     ];
 

--- a/mailpoet/lib/Cron/Workers/Tracks.php
+++ b/mailpoet/lib/Cron/Workers/Tracks.php
@@ -91,11 +91,11 @@ class Tracks extends SimpleWorker {
       'commonProps' => array_merge([
         'public_id' => $publicId,
       ], $convertedData),
-      'events' => [
+      'events' => [[
         '_ut' => 'anon',
         '_ui' => $publicId,
         '_en' => 'mailpoet_user_profile',
-      ],
+      ]],
     ];
 
     $jsonPayload = json_encode($payload);

--- a/mailpoet/lib/Cron/Workers/Tracks.php
+++ b/mailpoet/lib/Cron/Workers/Tracks.php
@@ -24,7 +24,7 @@ class Tracks extends SimpleWorker {
   }
 
   public function maybeReportAnalyticsToTracks(): bool {
-    if (!$this->analytics->shouldSend()) {
+    if (!$this->analytics->shouldSendToTracks()) {
       return true;
     }
     return $this->reportAnalyticsToTracks();
@@ -42,7 +42,7 @@ class Tracks extends SimpleWorker {
     $success = $this->sendToTracksAPI($publicId, $data);
 
     if ($success) {
-      $this->analytics->recordDataSent();
+      $this->analytics->recordTracksDataSent();
     }
 
     return $success;
@@ -127,6 +127,6 @@ class Tracks extends SimpleWorker {
   }
 
   public function getNextRunDate() {
-    return $this->analytics->getNextSendDate()->addMinutes(rand(0, 59));
+    return $this->analytics->getNextSendDateForTracks()->addMinutes(rand(0, 59));
   }
 }

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -33,6 +33,7 @@ class WorkersFactory {
     Mixpanel::TASK_TYPE,
     AbandonedCartWorker::TASK_TYPE,
     LogCleanup::TASK_TYPE,
+    Tracks::TASK_TYPE,
   ];
 
   /** @var ContainerWrapper */
@@ -166,5 +167,9 @@ class WorkersFactory {
 
   public function createMixpanelWorker() {
     return $this->container->get(Mixpanel::class);
+  }
+
+  public function createTracksWorker() {
+    return $this->container->get(Tracks::class);
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -327,6 +327,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\SubscribersEmailCount::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\InactiveSubscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\Mixpanel::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\Tracks::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\UnsubscribeTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscriberLinkTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck::class)->setPublic(true);

--- a/mailpoet/tests/integration/Analytics/AnalyticsTest.php
+++ b/mailpoet/tests/integration/Analytics/AnalyticsTest.php
@@ -141,7 +141,7 @@ class AnalyticsTest extends \MailPoetTest {
   public function testGetNextSendDateIsWeekFromLastSend(): void {
     $this->settings->set('analytics_last_sent', Carbon::now());
     $weekFromNow = Carbon::now()->addDays(7);
-    $nextSendDate = $this->analytics->getNextSendDate();
+    $nextSendDate = $this->analytics->getNextSendDateForMixpanel();
     verify($nextSendDate->getTimestamp())->equals($weekFromNow->getTimestamp());
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -320,6 +320,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createAbandonedCartWorker' => $worker,
       'createBackfillEngagementDataWorker' => $worker,
       'createMixpanelWorker' => $worker,
+      'createTracksWorker' => $worker,
       ]);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -120,6 +120,7 @@ class DaemonTest extends \MailPoetTest {
       'createAbandonedCartWorker' => $this->createSimpleWorkerMock(),
       'createBackfillEngagementDataWorker' => $this->createSimpleWorkerMock(),
       'createMixpanelWorker' => $this->createSimpleWorkerMock(),
+      'createTracksWorker' => $this->createSimpleWorkerMock(),
       ]);
   }
 


### PR DESCRIPTION
## Description

- This PR adds a new cron worker that tracks parallel data into Tracks.
- It updates analytics JS to track parallel into Tracks.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7530

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:create-tracks-worker)

_The latest successful build from `create-tracks-worker` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Analytics now sends events to a second provider in parallel with the existing one.
  - Public APIs to queue and flush analytics events added for manual control.

- Improvements
  - Events are cached, queued, retried, and periodically flushed (including on exit) to reduce data loss.
  - Backend scheduling updated to process analytics for both providers.

- Tests
  - Integration tests updated to cover the new analytics workflows and worker scheduling.

- Documentation
  - Changelog entry added for updated reporting analytics data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->