### PR TITLE
Added echo to esc_attr() in Widget.php

### DIFF
--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -138,7 +138,7 @@ class Widget extends \WP_Widget {
     // get forms list
     $forms = $this->formsRepository->findBy(['deletedAt' => null], ['name' => 'asc']);
     ?><p>
-      <label for="<?php esc_attr($this->get_field_id('title')) ?>"><?php echo esc_html(__('Title:', 'mailpoet')); ?></label>
+      <label for="<?php echo esc_attr($this->get_field_id('title')) ?>"><?php echo esc_html(__('Title:', 'mailpoet')); ?></label>
       <input
         type="text"
         class="widefat"


### PR DESCRIPTION
## Description

Added echo to esc_attr() in Widget.php

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the widget form so the title label correctly references its input field via the for attribute. This restores proper HTML output, improves accessibility for assistive technologies, and lets users click the label to focus the input.
  * Enhances consistency across browsers and themes by ensuring label-input association works reliably, reducing confusion and minor UI quirks when configuring widget titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->