### PR TITLE
Update translated German strings and Fix flaky tests

### DIFF
--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -93,7 +93,7 @@ class SwitchingLanguagesCest {
     $i->waitForText('Listen');
     $i->waitForText('Einstellungen');
     $i->waitForText('Hilfe');
-    $i->waitForText('Add new email'); // This will fail in the future when the string is translated
+    $i->waitForText('Neue E-Mail hinzufügen');
 
     $i->wantTo('Check Emails filter strings');
     $i->waitForText('Alle');
@@ -111,7 +111,7 @@ class SwitchingLanguagesCest {
     $i->wantTo('Check Automation listing strings (translated with @wordpress/i18n)');
     $i->amOnMailpoetPage('automation');
     $i->waitForText('Erstelle deine eigenen Automatisierungen');
-    $i->waitForText('Add new automation'); // This will fail in the future when the string is translated
+    $i->waitForText('Neue Automatisierung hinzufügen');
     $i->waitForText('Wesentliche Dinge erforschen');
     $i->waitForText('Bearbeiten');
     $i->waitForText('Eingetragen');
@@ -119,14 +119,14 @@ class SwitchingLanguagesCest {
 
     $i->wantTo('Check some Forms page strings');
     $i->amOnMailpoetPage('forms');
-    $i->waitForText('Add new form'); // This will fail in the future when the string is translated
-    $i->waitForText('Below pages'); // This will fail in the future when the string is translated
+    $i->waitForText('Neues Formular hinzufügen');
+    $i->waitForText('Unter Seiten');
     $i->waitForText('Registrierungen');
     $i->waitForText('Änderungsdatum');
 
     $i->wantTo('Check Subscribers filter strings and button');
     $i->amOnMailpoetPage('subscribers');
-    $i->waitForText('Add new subscriber'); // This will fail in the future when the string is translated
+    $i->waitForText('Neuen Abonnenten hinzufügen');
     $i->waitForText('Alle');
     $i->waitForText('Eingetragen');
     $i->waitForText('Unbestätigt');

--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -291,6 +291,7 @@ class WooCheckoutBlocksCest {
   private function placeOrder(\AcceptanceTester $i): void {
     // Add a note to order just to avoid flakiness due to race conditions
     $i->click(Locator::contains('label', 'Add a note to your order'));
+    $i->waitForElementVisible('.wc-block-components-textarea');
     $i->fillField('.wc-block-components-textarea', 'This is a note');
     $i->waitForText('Place Order');
     $i->waitForElementClickable('.wc-block-components-checkout-place-order-button');


### PR DESCRIPTION
## Description

Update the Acceptance test case to check for translated German strings

## Code review notes

Merge when test passes.

## QA notes

Skip.

## Linked PRs

Skip

## Linked tickets

Skip.

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-failing-test)

_The latest successful build from `fix-failing-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated language-switching acceptance tests to assert German UI text across emails, automations, forms, subscribers, lists, and settings.
  * Improved subscription/checkout test synchronization when adding an order note to reduce flakiness.
  * Strengthens confidence in multilingual behavior and test reliability; no functional or UI changes for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->