### PR TITLE
Add pagination, filtering and sorting into Automation endpoint

### DIFF
--- a/mailpoet/assets/js/src/automation/listing/store/actions.tsx
+++ b/mailpoet/assets/js/src/automation/listing/store/actions.tsx
@@ -17,7 +17,7 @@ export function* loadAutomations() {
 
   return {
     type: 'SET_AUTOMATIONS',
-    automations: data.data,
+    automations: Array.isArray(data.data?.items) ? data.data.items : [],
   } as const;
 }
 

--- a/mailpoet/changelog/2025-09-26-08-36-57-improved-automation-endpoint-supports-filtering-sorting-and.md
+++ b/mailpoet/changelog/2025-09-26-08-36-57-improved-automation-endpoint-supports-filtering-sorting-and.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Automation endpoint supports filtering, sorting and pagination

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsGetEndpoint.php
@@ -34,10 +34,10 @@ class AutomationsGetEndpoint extends Endpoint {
     $order = is_string($orderParam) ? $orderParam : null;
 
     $pageParam = $request->getParam('page');
-    $page = is_numeric($pageParam) ? (int)$pageParam : null;
+    $page = is_numeric($pageParam) ? max(1, (int)$pageParam) : 1;
 
     $perPageParam = $request->getParam('per_page');
-    $perPage = is_numeric($perPageParam) ? (int)$perPageParam : null;
+    $perPage = is_numeric($perPageParam) ? max(1, (int)$perPageParam) : null;
 
     $searchParam = $request->getParam('search');
     $search = is_string($searchParam) ? $searchParam : null;
@@ -45,9 +45,12 @@ class AutomationsGetEndpoint extends Endpoint {
     $automations = $this->automationStorage->getAutomations($status, $orderBy, $order, $page, $perPage, $search);
     $automationCount = $this->automationStorage->getAutomationCount($status, $search);
 
-    $pages = $automationCount;
-    if ($perPage !== null && $perPage > 0) {
+    if ($automationCount === 0) {
+      $pages = 0;
+    } elseif ($perPage !== null) {
       $pages = (int)ceil($automationCount / $perPage);
+    } else {
+      $pages = 1;
     }
 
     return new Response([

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
@@ -153,10 +153,44 @@ class AutomationStorage {
   }
 
   /** @return Automation[] */
-  public function getAutomations(?array $status = null): array {
+  public function getAutomations(
+    ?array $status = null,
+    ?string $orderBy = 'id',
+    ?string $order = 'DESC',
+    ?int $page = null,
+    ?int $perPage = null,
+    ?string $search = null
+  ): array {
     global $wpdb;
 
-    $statusFilter = $status ? 'AND a.status IN (' . implode(',', array_fill(0, count($status), '%s')) . ')' : '';
+    $statusFilter = '';
+    $statusParams = [];
+    if ($status) {
+      $statusFilter = ' AND a.status IN (' . implode(',', array_fill(0, count($status), '%s')) . ')';
+      $statusParams = $status;
+    }
+
+    // Handle search
+    $searchFilter = '';
+    $searchParams = [];
+    if ($search !== null && trim($search) !== '') {
+      $searchFilter = ' AND a.name LIKE %s';
+      $searchParams[] = '%' . $wpdb->esc_like($search) . '%';
+    }
+
+    // Handle ordering
+    $validOrderByColumns = ['id', 'name', 'status', 'created_at', 'updated_at'];
+    $orderByColumn = $orderBy && in_array($orderBy, $validOrderByColumns, true) ? $orderBy : 'id';
+    $orderDirection = $order && strtoupper($order) === 'ASC' ? 'ASC' : 'DESC';
+    $orderClause = " ORDER BY a.{$orderByColumn} {$orderDirection}";
+
+    // Handle pagination
+    $limitClause = '';
+    if ($page !== null && $perPage !== null && $perPage > 0) {
+      $offset = ($page - 1) * $perPage;
+      $limitClause = $wpdb->prepare(' LIMIT %d OFFSET %d', $perPage, $offset);
+    }
+
     $data = $wpdb->get_results(
       // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The number of replacements is dynamic.
       $wpdb->prepare(
@@ -167,13 +201,19 @@ class AutomationStorage {
           WHERE v.id = (
             SELECT MAX(id) FROM %i WHERE automation_id = v.automation_id
           )
-          ' . $statusFilter . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The condition uses placeholders. */ '
-          ORDER BY a.id DESC
-        ',
-        $this->automationsTable,
-        $this->versionsTable,
-        $this->versionsTable,
-        ...($status ?? []),
+          ' . $statusFilter . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The status filter uses placeholders. */ '
+          ' . $searchFilter . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The search filter uses placeholders. */ '
+          ' . $orderClause . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The order clause is sanitized. */ '
+          ' . $limitClause, /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The limit clause is prepared. */
+        array_merge(
+          [
+            $this->automationsTable,
+            $this->versionsTable,
+            $this->versionsTable,
+          ],
+          $statusParams,
+          $searchParams
+        )
       ),
       ARRAY_A
     );
@@ -218,10 +258,34 @@ class AutomationStorage {
     return array_map('intval', $result);
   }
 
-  public function getAutomationCount(): int {
+  public function getAutomationCount(?array $status = null, ?string $search = null): int {
     global $wpdb;
+
+    $statusFilter = '';
+    $statusParams = [];
+    if ($status) {
+      $statusFilter = ' AND a.status IN (' . implode(',', array_fill(0, count($status), '%s')) . ')';
+      $statusParams = $status;
+    }
+
+    $searchFilter = '';
+    $searchParams = [];
+    if ($search !== null && trim($search) !== '') {
+      $searchFilter = ' AND a.name LIKE %s';
+      $searchParams[] = '%' . $wpdb->esc_like($search) . '%';
+    }
+
     return (int)$wpdb->get_var(
-      $wpdb->prepare('SELECT COUNT(*) FROM %i', $this->automationsTable)
+      $wpdb->prepare(
+        'SELECT COUNT(*) FROM %i AS a WHERE 1=1'
+        . $statusFilter /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The status filter uses placeholders. */
+        . $searchFilter, /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The search filter uses placeholders. */
+        array_merge(
+          [$this->automationsTable],
+          $statusParams,
+          $searchParams
+        )
+      )
     );
   }
 

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStorage.php
@@ -187,7 +187,8 @@ class AutomationStorage {
     // Handle pagination
     $limitClause = '';
     if ($page !== null && $perPage !== null && $perPage > 0) {
-      $offset = ($page - 1) * $perPage;
+      $currentPage = max(1, $page);
+      $offset = ($currentPage - 1) * $perPage;
       $limitClause = $wpdb->prepare(' LIMIT %d OFFSET %d', $perPage, $offset);
     }
 

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStorageTest.php
@@ -232,6 +232,137 @@ class AutomationStorageTest extends \MailPoetTest {
       ->equals(0);
   }
 
+  public function testItCanFilterAutomationsByStatus(): void {
+    $activeAutomation = $this->createEmptyAutomation('active-automation');
+    $activeAutomation->setStatus(Automation::STATUS_ACTIVE);
+    $this->testee->updateAutomation($activeAutomation);
+
+    $draftAutomation = $this->createEmptyAutomation('draft-automation');
+    $draftAutomation->setStatus(Automation::STATUS_DRAFT);
+    $this->testee->updateAutomation($draftAutomation);
+
+    // Test without filter
+    $allAutomations = $this->testee->getAutomations();
+    verify($allAutomations)->arrayCount(2);
+
+    // Test with active filter
+    $activeAutomations = $this->testee->getAutomations([Automation::STATUS_ACTIVE]);
+    verify($activeAutomations)->arrayCount(1);
+    verify($activeAutomations[0]->getStatus())->equals(Automation::STATUS_ACTIVE);
+
+    // Test with draft filter
+    $draftAutomations = $this->testee->getAutomations([Automation::STATUS_DRAFT]);
+    verify($draftAutomations)->arrayCount(1);
+    verify($draftAutomations[0]->getStatus())->equals(Automation::STATUS_DRAFT);
+
+    // Test with multiple status filter
+    $filteredAutomations = $this->testee->getAutomations([Automation::STATUS_ACTIVE, Automation::STATUS_DRAFT]);
+    verify($filteredAutomations)->arrayCount(2);
+  }
+
+  public function testItCanSearchAutomationsByName(): void {
+    $automation1 = $this->createEmptyAutomation('Welcome Email');
+    $automation2 = $this->createEmptyAutomation('Purchase Follow-up');
+    $automation3 = $this->createEmptyAutomation('Welcome SMS');
+
+    // Test search for "Welcome"
+    $welcomeAutomations = $this->testee->getAutomations(null, null, null, null, null, 'Welcome');
+    verify($welcomeAutomations)->arrayCount(2);
+
+    // Test search for "Email"
+    $emailAutomations = $this->testee->getAutomations(null, null, null, null, null, 'Email');
+    verify($emailAutomations)->arrayCount(1);
+    verify($emailAutomations[0]->getName())->equals('Welcome Email');
+
+    // Test search for non-existent term
+    $noResults = $this->testee->getAutomations(null, null, null, null, null, 'NonExistent');
+    verify($noResults)->arrayCount(0);
+
+    // Test empty search
+    $emptySearch = $this->testee->getAutomations(null, null, null, null, null, '');
+    verify($emptySearch)->arrayCount(3);
+  }
+
+  public function testItCanOrderAutomationsByDifferentColumns(): void {
+    $automation1 = $this->createEmptyAutomation('Alpha');
+    $automation2 = $this->createEmptyAutomation('Beta');
+    $automation3 = $this->createEmptyAutomation('Gamma');
+
+    // Test order by name ASC
+    $ascAutomations = $this->testee->getAutomations(null, 'name', 'ASC');
+    verify($ascAutomations[0]->getName())->equals('Alpha');
+    verify($ascAutomations[1]->getName())->equals('Beta');
+    verify($ascAutomations[2]->getName())->equals('Gamma');
+
+    // Test order by name DESC
+    $descAutomations = $this->testee->getAutomations(null, 'name', 'DESC');
+    verify($descAutomations[0]->getName())->equals('Gamma');
+    verify($descAutomations[1]->getName())->equals('Beta');
+    verify($descAutomations[2]->getName())->equals('Alpha');
+
+    // Test order by id (default DESC)
+    $idAutomations = $this->testee->getAutomations(null, 'id', 'DESC');
+    verify($idAutomations[0]->getId())->equals($automation3->getId());
+    verify($idAutomations[2]->getId())->equals($automation1->getId());
+  }
+
+  public function testItCanPaginateAutomations(): void {
+    // Create 5 automations
+    for ($i = 1; $i <= 5; $i++) {
+      $this->createEmptyAutomation("Automation $i");
+    }
+
+    // Test first page with 2 per page
+    $page1 = $this->testee->getAutomations(null, null, null, 1, 2);
+    verify($page1)->arrayCount(2);
+
+    // Test second page with 2 per page
+    $page2 = $this->testee->getAutomations(null, null, null, 2, 2);
+    verify($page2)->arrayCount(2);
+
+    // Test third page with 2 per page
+    $page3 = $this->testee->getAutomations(null, null, null, 3, 2);
+    verify($page3)->arrayCount(1);
+
+    // Verify different results
+    verify($page1[0]->getId())->notEquals($page2[0]->getId());
+  }
+
+  public function testItCanCountAutomationsWithFilters(): void {
+    $activeAutomation = $this->createEmptyAutomation('Active Test');
+    $activeAutomation->setStatus(Automation::STATUS_ACTIVE);
+    $this->testee->updateAutomation($activeAutomation);
+
+    $draftAutomation = $this->createEmptyAutomation('Draft Test');
+    $draftAutomation->setStatus(Automation::STATUS_DRAFT);
+    $this->testee->updateAutomation($draftAutomation);
+
+    // Test total count
+    $totalCount = $this->testee->getAutomationCount();
+    verify($totalCount)->equals(2);
+
+    // Test count with status filter
+    $activeCount = $this->testee->getAutomationCount([Automation::STATUS_ACTIVE]);
+    verify($activeCount)->equals(1);
+
+    $draftCount = $this->testee->getAutomationCount([Automation::STATUS_DRAFT]);
+    verify($draftCount)->equals(1);
+
+    // Test count with search filter
+    $searchCount = $this->testee->getAutomationCount(null, 'Test');
+    verify($searchCount)->equals(2);
+
+    $specificSearchCount = $this->testee->getAutomationCount(null, 'Active');
+    verify($specificSearchCount)->equals(1);
+
+    // Test count with combined filters
+    $combinedCount = $this->testee->getAutomationCount([Automation::STATUS_ACTIVE], 'Active');
+    verify($combinedCount)->equals(1);
+
+    $noResultsCount = $this->testee->getAutomationCount([Automation::STATUS_DRAFT], 'Active');
+    verify($noResultsCount)->equals(0);
+  }
+
   private function createEmptyAutomation(string $name = "test"): Automation {
     $automation = new Automation($name, [], new \WP_User());
     $automationId = $this->testee->createAutomation($automation);

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsGetTest.php
@@ -34,9 +34,12 @@ class AutomationsGetTest extends AutomationTest {
 
   public function testEditorIsAllowed(): void {
     wp_set_current_user($this->editorUserId);
-    $data = $this->get(self::ENDPOINT_PATH);
+    $data = $this->get(self::ENDPOINT_PATH)['data'];
 
-    $this->assertCount(0, $data['data']);
+    $this->assertCount(0, $data['items']);
+    $this->assertArrayHasKey('meta', $data);
+    $this->assertArrayHasKey('count', $data['meta']);
+    $this->assertEquals(0, $data['meta']['count']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -52,7 +55,15 @@ class AutomationsGetTest extends AutomationTest {
 
   public function testRequest(): void {
     $data = $this->get(self::ENDPOINT_PATH);
-    $this->assertSame(['data' => []], $data);
+    $this->assertSame([
+      'data' => [
+        'items' => [],
+        'meta' => [
+          'pages' => 0,
+          'count' => 0,
+        ],
+      ],
+    ], $data);
   }
 
   public function testGetAll() {
@@ -82,11 +93,24 @@ class AutomationsGetTest extends AutomationTest {
       'name' => (new \WP_User($automation2Data['author']))->display_name,
     ];
 
-    $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertIsArray($result['data']);
-    $this->assertCount(2, $result['data']);
-    $this->assertAutomationRestData($expectedAutomation1Data, $result['data'][1]);
-    $this->assertAutomationRestData($expectedAutomation2Data, $result['data'][0]);
+    $result = $this->get(self::ENDPOINT_PATH, [])['data'];
+    $this->assertIsArray($result['items']);
+    $this->assertCount(2, $result['items']);
+    $this->assertEquals(2, $result['meta']['count']);
+    // Find automations by ID to avoid ordering assumptions
+    $automation1Found = false;
+    $automation2Found = false;
+    foreach ($result['items'] as $item) {
+      if ($item['id'] === $expectedAutomation1Data['id']) {
+        $this->assertAutomationRestData($expectedAutomation1Data, $item);
+        $automation1Found = true;
+      } elseif ($item['id'] === $expectedAutomation2Data['id']) {
+        $this->assertAutomationRestData($expectedAutomation2Data, $item);
+        $automation2Found = true;
+      }
+    }
+    $this->assertTrue($automation1Found, 'Automation 1 not found in results');
+    $this->assertTrue($automation2Found, 'Automation 2 not found in results');
   }
 
   public function testStatusFilterWorks() {
@@ -100,11 +124,100 @@ class AutomationsGetTest extends AutomationTest {
     }
 
     foreach (Automation::STATUS_ALL as $status) {
-      $result = $this->get(self::ENDPOINT_PATH, ['query' => ['status' => $status]]);
-      $this->assertCount(1, $result['data']);
-      $this->assertEquals($status, $result['data'][0]['name']);
-      $this->assertEquals($status, $result['data'][0]['status']);
+      $result = $this->get(self::ENDPOINT_PATH, ['query' => ['status' => $status]])['data'];
+      $this->assertCount(1, $result['items']);
+      $this->assertEquals(1, $result['meta']['count']);
+      $this->assertEquals($status, $result['items'][0]['name']);
+      $this->assertEquals($status, $result['items'][0]['status']);
     }
+  }
+
+  public function testSearchParameterWorks(): void {
+    $this->createNewAutomation(['name' => 'Welcome Email Sequence']);
+    $this->createNewAutomation(['name' => 'Purchase Follow-up']);
+    $this->createNewAutomation(['name' => 'Welcome SMS Campaign']);
+
+    // Test search for "Welcome"
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['search' => 'Welcome']])['data'];
+    $this->assertCount(2, $result['items']);
+    $this->assertEquals(2, $result['meta']['count']);
+
+    // Test search for "Email"
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['search' => 'Email']])['data'];
+    $this->assertCount(1, $result['items']);
+    $this->assertEquals(1, $result['meta']['count']);
+    $this->assertEquals('Welcome Email Sequence', $result['items'][0]['name']);
+
+    // Test search for non-existent term
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['search' => 'NonExistent']])['data'];
+    $this->assertCount(0, $result['items']);
+    $this->assertEquals(0, $result['meta']['count']);
+  }
+
+  public function testOrderingParametersWork(): void {
+    $this->createNewAutomation(['name' => 'Alpha']);
+    $this->createNewAutomation(['name' => 'Beta']);
+    $this->createNewAutomation(['name' => 'Gamma']);
+
+    // Test order by name ASC
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['orderby' => 'name', 'order' => 'ASC']])['data'];
+    $this->assertCount(3, $result['items']);
+    $this->assertEquals('Alpha', $result['items'][0]['name']);
+    $this->assertEquals('Beta', $result['items'][1]['name']);
+    $this->assertEquals('Gamma', $result['items'][2]['name']);
+
+    // Test order by name DESC
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['orderby' => 'name', 'order' => 'DESC']])['data'];
+    $this->assertCount(3, $result['items']);
+    $this->assertEquals('Gamma', $result['items'][0]['name']);
+    $this->assertEquals('Beta', $result['items'][1]['name']);
+    $this->assertEquals('Alpha', $result['items'][2]['name']);
+  }
+
+  public function testPaginationParametersWork(): void {
+    // Create 5 automations
+    for ($i = 1; $i <= 5; $i++) {
+      $this->createNewAutomation(['name' => "Automation $i"]);
+    }
+
+    // Test first page with 2 per page
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['page' => 1, 'per_page' => 2]])['data'];
+    $this->assertCount(2, $result['items']);
+    $this->assertEquals(5, $result['meta']['count']); // Total count should still be 5
+    $this->assertEquals(3, $result['meta']['pages']); // ceil(5/2) = 3 pages
+
+    // Test second page with 2 per page
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['page' => 2, 'per_page' => 2]])['data'];
+    $this->assertCount(2, $result['items']);
+    $this->assertEquals(5, $result['meta']['count']);
+
+    // Test third page with 2 per page (should have 1 item)
+    $result = $this->get(self::ENDPOINT_PATH, ['query' => ['page' => 3, 'per_page' => 2]])['data'];
+    $this->assertCount(1, $result['items']);
+    $this->assertEquals(5, $result['meta']['count']);
+
+    // Verify different pages return different items
+    $page1 = $this->get(self::ENDPOINT_PATH, ['query' => ['page' => 1, 'per_page' => 2]])['data'];
+    $page2 = $this->get(self::ENDPOINT_PATH, ['query' => ['page' => 2, 'per_page' => 2]])['data'];
+    $this->assertNotEquals($page1['items'][0]['id'], $page2['items'][0]['id']);
+  }
+
+  public function testCombinedParametersWork(): void {
+    $this->createNewAutomation(['name' => 'Active Welcome', 'status' => Automation::STATUS_ACTIVE]);
+    $this->createNewAutomation(['name' => 'Draft Welcome', 'status' => Automation::STATUS_DRAFT]);
+    $this->createNewAutomation(['name' => 'Active Purchase', 'status' => Automation::STATUS_ACTIVE]);
+
+    // Test combined search + status filter
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'query' => [
+        'search' => 'Welcome',
+        'status' => Automation::STATUS_ACTIVE,
+      ],
+    ])['data'];
+    $this->assertCount(1, $result['items']);
+    $this->assertEquals(1, $result['meta']['count']);
+    $this->assertEquals('Active Welcome', $result['items'][0]['name']);
+    $this->assertEquals(Automation::STATUS_ACTIVE, $result['items'][0]['status']);
   }
 
   /**


### PR DESCRIPTION
## Description

Add a new automation endpoint parameters for filtering, sorting and pagination.

## Code review notes

Using the new Automation endpoint parameters will be addressed in a new PR.

## QA notes

1. Verify that automation listing works as expected

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7569

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7569-automations-listing-doesnt-consider-unicode-chars-when)

_The latest successful build from `stomail-7569-automations-listing-doesnt-consider-unicode-chars-when` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automations list now supports search, sorting, and pagination; responses include items plus meta (total count and pages).
- Bug Fixes
  - UI now handles missing/empty automation payloads gracefully (avoids breaking when no items present).
- Refactor
  - Response shape standardized to a payload with items and meta for consistent UI/API behavior.
- Tests
  - Added comprehensive tests for filtering, search, ordering, pagination, and combined scenarios.
- Documentation
  - Changelog entry documenting improved automation endpoint capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->