### PR TITLE
Bump email editor packages 

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "1.6.0"
+    "woocommerce/email-editor": "1.7.0"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b14fc9bd1660daefb94618d6dfaf02bf",
+    "content-hash": "059d2c86b74ae8ac6d545a31632bcaaf",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -584,16 +584,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "d3514f3bcb4a228287e1f77e617b0780da0e573d"
+                "reference": "18499b06c6876845e291a9dbfecd621c54c98907"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/d3514f3bcb4a228287e1f77e617b0780da0e573d",
-                "reference": "d3514f3bcb4a228287e1f77e617b0780da0e573d",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/18499b06c6876845e291a9dbfecd621c54c98907",
+                "reference": "18499b06c6876845e291a9dbfecd621c54c98907",
                 "shasum": ""
             },
             "require": {
@@ -635,9 +635,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/1.6.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/1.7.0"
             },
-            "time": "2025-09-18T09:08:50+00:00"
+            "time": "2025-09-26T08:50:33+00:00"
         }
     ],
     "packages-dev": [

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -31,7 +31,7 @@
     "@woocommerce/components": "^12.3.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "1.1.0",
+    "@woocommerce/email-editor": "1.1.1",
     "@wordpress/a11y": "^4.0.0",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.17.21)
       '@woocommerce/email-editor':
-        specifier: 1.1.0
-        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)
+        specifier: 1.1.1
+        version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)
       '@wordpress/a11y':
         specifier: ^4.0.0
         version: 4.0.0
@@ -5418,21 +5418,21 @@ packages:
       qs: 6.12.1
     dev: false
 
-  /@woocommerce/email-editor@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3):
-    resolution: {integrity: sha512-h9mG86KIltXO8ebsu/KtMioDNqUTUqeZEkjLibMaxqLL9FI6ojBBoRgg+G+wcRZHL+9Z1qPjb9E1P1YaANU23A==}
+  /@woocommerce/email-editor@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3):
+    resolution: {integrity: sha512-BtLy7O/1HYvzdmtV9URljUQlg7Is+HJJniLXaY31GG0Zq1bVzWQJ64dUGQQCMjRHVpevkf/Ta81vA1HkuTYiJQ==}
     dependencies:
       '@wordpress/api-fetch': 7.0.0
       '@wordpress/base-styles': 5.0.0
       '@wordpress/block-editor': 13.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/block-library': 9.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/blocks': 13.0.0(react@18.3.1)
-      '@wordpress/commands': 1.30.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/commands': 1.31.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/components': 28.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/compose': 7.0.0(react@18.3.1)
       '@wordpress/core-data': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/data': 10.0.0(react@18.3.1)
       '@wordpress/data-controls': 4.0.0(react@18.3.1)
-      '@wordpress/dom-ready': 4.30.0
+      '@wordpress/dom-ready': 4.31.0
       '@wordpress/editor': 14.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/element': 6.0.0
       '@wordpress/format-library': 5.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
@@ -5525,6 +5525,15 @@ packages:
       '@babel/runtime': 7.26.10
       '@wordpress/dom-ready': 4.30.0
       '@wordpress/i18n': 6.3.0
+    dev: false
+
+  /@wordpress/a11y@4.31.0:
+    resolution: {integrity: sha512-LU2Ea+RRaqe1Q8u15Y1dBxXfGwPsOtqXLZR7Bfk7y9yMsJnKqymovR7yvoPYe/4dWXy0B9sK1jUJtPAMUFfOng==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/dom-ready': 4.31.0
+      '@wordpress/i18n': 6.4.0
     dev: false
 
   /@wordpress/api-fetch@6.55.0:
@@ -5991,21 +6000,21 @@ packages:
       - supports-color
     dev: false
 
-  /@wordpress/commands@1.30.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-1ErowcNAfn0sC6/KkFQje/F+pR1PGsoSbtxk8fxg2ZbDiINZnEMy/sc5yin+7nVLiC4QncAKnwdysbqnBAHb5Q==}
+  /@wordpress/commands@1.31.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-PaBQVIHNGBn2sMxPj5ILJPAe4h79MvUcb5DzgiXA+H+0nNHLsQxg2u8Cfm2spct37dqOLMnQ6PVMRS+SwCLESQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
     dependencies:
       '@babel/runtime': 7.26.10
-      '@wordpress/components': 30.3.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/data': 10.30.0(react@18.3.1)
-      '@wordpress/element': 6.30.0
-      '@wordpress/i18n': 6.3.0
-      '@wordpress/icons': 10.30.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.30.0(react@18.3.1)
-      '@wordpress/private-apis': 1.30.0
+      '@wordpress/components': 30.4.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/data': 10.31.0(react@18.3.1)
+      '@wordpress/element': 6.31.0
+      '@wordpress/i18n': 6.4.0
+      '@wordpress/icons': 10.31.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.31.0(react@18.3.1)
+      '@wordpress/private-apis': 1.31.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
@@ -6315,6 +6324,67 @@ packages:
       - supports-color
     dev: false
 
+  /@wordpress/components@30.4.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-PrZ8+VMCciVkWna//AH55Xg+TALw/E67358B5w/qiBohZ0CaoL1z4UcltkO+Gd5BJ1E14HbD8vC/6ao8dMXEJg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+    dependencies:
+      '@ariakit/react': 0.4.18(react-dom@18.3.1)(react@18.3.1)
+      '@babel/runtime': 7.26.10
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1)(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.31.0
+      '@wordpress/compose': 7.31.0(react@18.3.1)
+      '@wordpress/date': 5.31.0
+      '@wordpress/deprecated': 4.31.0
+      '@wordpress/dom': 4.31.0
+      '@wordpress/element': 6.31.0
+      '@wordpress/escape-html': 3.31.0
+      '@wordpress/hooks': 4.31.0
+      '@wordpress/html-entities': 4.31.0
+      '@wordpress/i18n': 6.4.0
+      '@wordpress/icons': 10.31.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.31.0
+      '@wordpress/keycodes': 4.31.0
+      '@wordpress/primitives': 4.31.0(react@18.3.1)
+      '@wordpress/private-apis': 1.31.0
+      '@wordpress/rich-text': 7.31.0(react@18.3.1)
+      '@wordpress/warning': 3.31.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 3.6.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1)(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1)(react@18.3.1)
+      react-day-picker: 9.11.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - supports-color
+    dev: false
+
   /@wordpress/compose@3.25.3(react@18.3.1):
     resolution: {integrity: sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==}
     dependencies:
@@ -6412,6 +6482,28 @@ packages:
       '@wordpress/keycodes': 4.30.0
       '@wordpress/priority-queue': 3.30.0
       '@wordpress/undo-manager': 1.30.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+    dev: false
+
+  /@wordpress/compose@7.31.0(react@18.3.1):
+    resolution: {integrity: sha512-kxb1qHhiFwUDifBM9r4JZ3gYC1ZUvck5tgjmaWeg8EqIEnVn+Z7C+ntNA9ySLWrmDYc4Gki7YJZbfVHzrtcDLg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.31.0
+      '@wordpress/dom': 4.31.0
+      '@wordpress/element': 6.31.0
+      '@wordpress/is-shallow-equal': 5.31.0
+      '@wordpress/keycodes': 4.31.0
+      '@wordpress/priority-queue': 3.31.0
+      '@wordpress/undo-manager': 1.31.0
       change-case: 4.1.2
       clipboard: 2.0.11
       mousetrap: 1.6.5
@@ -6623,6 +6715,30 @@ packages:
       use-memo-one: 1.1.3(react@18.3.1)
     dev: false
 
+  /@wordpress/data@10.31.0(react@18.3.1):
+    resolution: {integrity: sha512-iuQxrmbW55q+xy7lnXH8D6qHFAoG0/YcnjZ6jvqpDekRhdgl4kAPE+crx/kJ5RkrIIo38a+cLgVskCaKo+9E3w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/compose': 7.31.0(react@18.3.1)
+      '@wordpress/deprecated': 4.31.0
+      '@wordpress/element': 6.31.0
+      '@wordpress/is-shallow-equal': 5.31.0
+      '@wordpress/priority-queue': 3.31.0
+      '@wordpress/private-apis': 1.31.0
+      '@wordpress/redux-routine': 5.31.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+    dev: false
+
   /@wordpress/data@7.6.0(react@18.3.1):
     resolution: {integrity: sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==}
     engines: {node: '>=12'}
@@ -6722,6 +6838,16 @@ packages:
       moment-timezone: 0.5.48
     dev: false
 
+  /@wordpress/date@5.31.0:
+    resolution: {integrity: sha512-xqKytkb60N9i+ETqTI+Asgb1myZIgnUne8zsGaYQU+B7H1M3ELw4lmc+ptDXjXrpI1Yb6BGUad4EIHBGVk+mog==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/deprecated': 4.31.0
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+    dev: false
+
   /@wordpress/dependency-extraction-webpack-plugin@5.9.0(webpack@5.94.0):
     resolution: {integrity: sha512-hXbCkbG1XES47t7hFSETRrLfaRSPyQPlCnhlCx7FfhYFD0wh1jVArApXX5dD+A6wTrayXX/a16MpfaNqE662XA==}
     engines: {node: '>=18'}
@@ -6761,6 +6887,14 @@ packages:
       '@wordpress/hooks': 4.30.0
     dev: false
 
+  /@wordpress/deprecated@4.31.0:
+    resolution: {integrity: sha512-bbDrL2lp7crFfvmJ1EYVxPDcheTIwimt3gVzqQWCDr0SSCQw4fii5NEKOrUnWhz51YCuPbfWXUBaFlbAMS2CXw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/hooks': 4.31.0
+    dev: false
+
   /@wordpress/dom-ready@3.58.0:
     resolution: {integrity: sha512-sDgRPjNBToRKgYrpwvMRv2Yc7/17+sp8hm/rRnbubwb+d/DbGkK4Tc/r4sNLSZCqUAtcBXq9uk1lzvhge3QUSg==}
     engines: {node: '>=12'}
@@ -6775,6 +6909,13 @@ packages:
 
   /@wordpress/dom-ready@4.30.0:
     resolution: {integrity: sha512-hD5mU0KkgNN4DzBDbBLfRKfZyja4CePK+nRlVTFn8Yo3dGdMAlOjJGaJS1szz7XflDv/ekngj72KoqvJGrrPmg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+    dev: false
+
+  /@wordpress/dom-ready@4.31.0:
+    resolution: {integrity: sha512-aRM4l5wzkrqAU686s4fz1bb+/7/BOFp+sXB0kx1vkiXl3ocfmHAr3jwEYU+OH/sX6Is3Ntkfh0uZe3EJLsqHTQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.26.10
@@ -6807,6 +6948,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@wordpress/deprecated': 4.30.0
+    dev: false
+
+  /@wordpress/dom@4.31.0:
+    resolution: {integrity: sha512-5/RBy9OreQktnBE75cB3R6Lva5c6hUlXvPo1NFfAebLeXX+7swZBmLYZnyf7dZbARRdqSwkundHZoKLcHa+20A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/deprecated': 4.31.0
     dev: false
 
   /@wordpress/e2e-test-utils-playwright@0.26.0(typescript@5.0.2):
@@ -7075,6 +7224,20 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@wordpress/element@6.31.0:
+    resolution: {integrity: sha512-KOier6Y4b4Y5yEV1GYen81R9gCEOvJT6eVbsc93w2fFEKi2FK/oI7IKzGv9GeJMkoCWvTSX6C/ZYTWk6fCUfeA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+      '@wordpress/escape-html': 3.31.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@wordpress/escape-html@1.12.2:
     resolution: {integrity: sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==}
     dependencies:
@@ -7095,6 +7258,13 @@ packages:
 
   /@wordpress/escape-html@3.30.0:
     resolution: {integrity: sha512-qlyyPKiize/uEyqL1nRMce9GuReZyOum81tOTR14YAngvyRIGz3K3hGwWWf9VrITZrjwuZgqMJc2udSC1uKmKg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+    dev: false
+
+  /@wordpress/escape-html@3.31.0:
+    resolution: {integrity: sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.26.10
@@ -7196,6 +7366,13 @@ packages:
       '@babel/runtime': 7.26.10
     dev: false
 
+  /@wordpress/hooks@4.31.0:
+    resolution: {integrity: sha512-8YOftWP54V4hvO46/FgXnpiB/fAC72CWD/F1JYtcfZcrWgbR96MGZxKXNvn5BgLx6juO36QQuFhJ5y2ZUEulkw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+    dev: false
+
   /@wordpress/html-entities@3.58.0:
     resolution: {integrity: sha512-FU7b6QZdwTCuLKq6wCl0IZqqOMcMRxMcekVVytzTse7hYk9dvL1qQL/U4eQ/CNyKqiT9u7fb5NKTQILOzoolVQ==}
     engines: {node: '>=12'}
@@ -7211,6 +7388,13 @@ packages:
 
   /@wordpress/html-entities@4.30.0:
     resolution: {integrity: sha512-SlJ9HM3LYO5cDzLHAP5UytbnI3u2N770JwJkLK1mfCoEIjxa+3cl9faI2ClJp1DvIzGCE4f5LliHdit/D+pARg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+    dev: false
+
+  /@wordpress/html-entities@4.31.0:
+    resolution: {integrity: sha512-5dk9h16jSXDTSdk0HnyXEOgZd7VSsMtr3YCSUQvzIYOFkpW2q1eB10coXHiuz0Z5ArlTuNYSfBd2J02xnG+a8g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.26.10
@@ -7279,6 +7463,19 @@ packages:
       tannin: 1.2.0
     dev: false
 
+  /@wordpress/i18n@6.4.0:
+    resolution: {integrity: sha512-tLTjdLw8H778K4fmEo5NDLYJOAgvHxgfLU5N7lPuBy2TKi8tQl24xgmJOlDLiMzbmbSEwvUBZ/4xWJsGq9ITDQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.31.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+    dev: false
+
   /@wordpress/icons@10.0.0:
     resolution: {integrity: sha512-BL1LtPgfFZdMLd2EUmckX8EXo10LDGDlQZx4CyyL0Vnx/6HcR/H3Z5EN6yeJl57fbjPg7noyOZVCdvG1EiiZnA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7295,6 +7492,17 @@ packages:
       '@babel/runtime': 7.26.10
       '@wordpress/element': 6.30.0
       '@wordpress/primitives': 4.30.0(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+    dev: false
+
+  /@wordpress/icons@10.31.0(react@18.3.1):
+    resolution: {integrity: sha512-Bfwt3SyjqClG6mwY78zhlzVRRW/OIqej09NLOGO0CDtjfrgQqD5HAK8kk2CayQr4hWeKMoFxzPBevMxWumBMPA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/element': 6.31.0
+      '@wordpress/primitives': 4.31.0(react@18.3.1)
     transitivePeerDependencies:
       - react
     dev: false
@@ -7412,6 +7620,13 @@ packages:
       '@babel/runtime': 7.26.10
     dev: false
 
+  /@wordpress/is-shallow-equal@5.31.0:
+    resolution: {integrity: sha512-jqGEw+5DLNf2kNbjaNxIKWQGYkqxygRYDYTdhZ+f+Btw/gMKILJq0sZGRD8YjJFGG0cOC2qxtJnr9oF36Iu96Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+    dev: false
+
   /@wordpress/jest-console@7.29.0(jest@29.7.0):
     resolution: {integrity: sha512-/9PZJhyszdRX4mka7t1WzoooM+Q/DwC4jkNVtJxqci5lbL3Lrhy1cCJGCgMr1n/9w+zs7eLmExFBvV4v44iyNw==}
     engines: {node: '>=14'}
@@ -7464,16 +7679,16 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@wordpress/keyboard-shortcuts@5.30.0(react@18.3.1):
-    resolution: {integrity: sha512-X1LGeoqyWFH1lGXUjJ+QUXEBnf5+ty3iO9a5MQecCpSF94ZajPAcN/17LnaftftqF81PantfG2TkXNQ7HydnTg==}
+  /@wordpress/keyboard-shortcuts@5.31.0(react@18.3.1):
+    resolution: {integrity: sha512-7rEarvwA93+tNC/HPTMK5kuXLBHSSOXgKJz3H2ZPCsYnk6Jf34QeMHOsCJvzA8MuMbx+TBihpEM8JkAkeko60w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: 18.3.1
     dependencies:
       '@babel/runtime': 7.26.10
-      '@wordpress/data': 10.30.0(react@18.3.1)
-      '@wordpress/element': 6.30.0
-      '@wordpress/keycodes': 4.30.0
+      '@wordpress/data': 10.31.0(react@18.3.1)
+      '@wordpress/element': 6.31.0
+      '@wordpress/keycodes': 4.31.0
       react: 18.3.1
     dev: false
 
@@ -7505,6 +7720,14 @@ packages:
     dependencies:
       '@babel/runtime': 7.26.10
       '@wordpress/i18n': 6.3.0
+    dev: false
+
+  /@wordpress/keycodes@4.31.0:
+    resolution: {integrity: sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/i18n': 6.4.0
     dev: false
 
   /@wordpress/media-utils@5.0.0:
@@ -7757,6 +7980,18 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@wordpress/primitives@4.31.0(react@18.3.1):
+    resolution: {integrity: sha512-cY4EKYQRqHu9NZuoWchxc/KWiofwGskzxz0oCfgbdkRlfTag8yBjWMayz+fRNaenw0l5pzLyIg3rcNDN8xLezw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/element': 6.31.0
+      clsx: 2.1.1
+      react: 18.3.1
+    dev: false
+
   /@wordpress/priority-queue@1.11.2:
     resolution: {integrity: sha512-ulwmUOklY3orn1xXpcPnTyGWV5B/oycxI+cHZ6EevBVgM5sq+BW3xo0PKLR/MMm6UNBtFTu/71QAJrNZcD6V1g==}
     dependencies:
@@ -7785,6 +8020,14 @@ packages:
       requestidlecallback: 0.3.0
     dev: false
 
+  /@wordpress/priority-queue@3.31.0:
+    resolution: {integrity: sha512-OuHq9iGB8wppHfoMHs4g07Cc2yh2DyyqySDn+bpyXPbDcuqxU9s9EgjY08ZVjJEYMuFz2sjC16HlOFqv3NBYAg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      requestidlecallback: 0.3.0
+    dev: false
+
   /@wordpress/private-apis@0.40.0:
     resolution: {integrity: sha512-ZX/9Y8eA3C3K6LOj32bHFj+9tNV819CBd8+chqMmmlvQRcTngiuXbMbnSdZnnAr1gLQgNpH9PJ60dIwJnGSEtQ==}
     engines: {node: '>=12'}
@@ -7799,6 +8042,13 @@ packages:
 
   /@wordpress/private-apis@1.30.0:
     resolution: {integrity: sha512-0EaWB+JxJ4t3Bylzk3xXu7Khqi0TOXYX9qDOm9W0Wy+J6xGzlkz8rSF73MvT+6JQTNNwietWHqkkHcn6dFGIXQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+    dev: false
+
+  /@wordpress/private-apis@1.31.0:
+    resolution: {integrity: sha512-OS/OvnUFj2QKeAsPGwgzETLPQhN8Ek1AC3q7rpuu+kZhZxB5hOsHDF/759XxH0fGPL/n0/Xqo4ZlnVYwPwqMPg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.26.10
@@ -7840,6 +8090,19 @@ packages:
 
   /@wordpress/redux-routine@5.30.0(redux@5.0.1):
     resolution: {integrity: sha512-1cabT7u4pryjnsAe5uG6hV1Rwhh1HC+VIMz41wuMQCZ3Te1xYIjj4uWAf+u1H2Vrcz6an0pijh4OLXq/S/AB5A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      redux: '>=4'
+    dependencies:
+      '@babel/runtime': 7.26.10
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      redux: 5.0.1
+      rungen: 0.3.2
+    dev: false
+
+  /@wordpress/redux-routine@5.31.0(redux@5.0.1):
+    resolution: {integrity: sha512-J16NmvIxWMU4lJMWrAshLCac5qjIs1QZnSzQXNKBXxg78ZjB7sa5Q9Qb8/aYxFVIIzTvpvDQVyHhHPcUnB4KYA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       redux: '>=4'
@@ -7951,6 +8214,26 @@ packages:
       '@wordpress/escape-html': 3.30.0
       '@wordpress/i18n': 6.3.0
       '@wordpress/keycodes': 4.30.0
+      colord: 2.9.3
+      memize: 2.1.1
+      react: 18.3.1
+    dev: false
+
+  /@wordpress/rich-text@7.31.0(react@18.3.1):
+    resolution: {integrity: sha512-s1CHb9vFYxa/fOPXSMn8GauOYb+gSVczHHx06Hj86JilGNAKmALADqzR+6D6ACKjahQypduYsF9P669PY7+PrQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/a11y': 4.31.0
+      '@wordpress/compose': 7.31.0(react@18.3.1)
+      '@wordpress/data': 10.31.0(react@18.3.1)
+      '@wordpress/deprecated': 4.31.0
+      '@wordpress/element': 6.31.0
+      '@wordpress/escape-html': 3.31.0
+      '@wordpress/i18n': 6.4.0
+      '@wordpress/keycodes': 4.31.0
       colord: 2.9.3
       memize: 2.1.1
       react: 18.3.1
@@ -8216,6 +8499,14 @@ packages:
       '@wordpress/is-shallow-equal': 5.30.0
     dev: false
 
+  /@wordpress/undo-manager@1.31.0:
+    resolution: {integrity: sha512-4jsvLaf+O/AMX/2m34BHS4Jz/Z+9vfxkNLP0mhuqftOWRC66XFseMqU19VszQypL7VxWKMahenYqZw4O22JNnQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@wordpress/is-shallow-equal': 5.31.0
+    dev: false
+
   /@wordpress/url@3.59.0:
     resolution: {integrity: sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==}
     engines: {node: '>=12'}
@@ -8267,6 +8558,11 @@ packages:
 
   /@wordpress/warning@3.30.0:
     resolution: {integrity: sha512-ZtkpSe3DhtUzIrwf+5slGkJJCxy1xn56fZ6atUaJWRbjsKnIZlTcPgahPUJZ2bugsGS5BlmDEuVI8C4NUdbwvQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dev: false
+
+  /@wordpress/warning@3.31.0:
+    resolution: {integrity: sha512-Npw1Apa6r+K+jtX40ABWAXv7J1bVnOi6h9VPiMY8l/iZoRHBXao8HTgQnIoCm+GzymaQs6NQoH4X8UAClggeXA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dev: false
 
@@ -9146,14 +9442,14 @@ packages:
     dev: true
     optional: true
 
-  /bare-events@2.6.1:
-    resolution: {integrity: sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==}
+  /bare-events@2.7.0:
+    resolution: {integrity: sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==}
     requiresBuild: true
     dev: true
     optional: true
 
-  /bare-fs@4.3.1:
-    resolution: {integrity: sha512-UX6lTDlUxjfrwDpr3eShAlpOF3PRHwNSPU7gY6FZU0bY3XivPmbndKCU6P3V0wS3o4xdDKalXqZsyEhYP2l+DQ==}
+  /bare-fs@4.4.4:
+    resolution: {integrity: sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==}
     engines: {bare: '>=1.16.0'}
     requiresBuild: true
     peerDependencies:
@@ -9166,6 +9462,7 @@ packages:
       bare-path: 3.0.0
       bare-stream: 2.6.5(bare-events@2.5.4)
       bare-url: 2.2.2
+      fast-fifo: 1.3.2
     dev: true
     optional: true
 
@@ -16871,6 +17168,18 @@ packages:
       react-with-styles-interface-css: 6.0.0(@babel/runtime@7.26.10)(react-with-styles@4.2.0)
     dev: false
 
+  /react-day-picker@9.11.0(react@18.3.1):
+    resolution: {integrity: sha512-L4FYOaPrr3+AEROeP6IG2mCORZZfxJDkJI2df8mv1jyPrNYeccgmFPZDaHyAuPCBCddQFozkxbikj2NhMEYfDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 18.3.1
+    dev: false
+
   /react-day-picker@9.9.0(react@18.3.1):
     resolution: {integrity: sha512-NtkJbuX6cl/VaGNb3sVVhmMA6LSMnL5G3xNL+61IyoZj0mUZFWTg4hmj7PHjIQ8MXN9dHWhUHFoJWG6y60DKSg==}
     engines: {node: '>=18'}
@@ -18349,7 +18658,7 @@ packages:
       queue-tick: 1.0.1
       text-decoder: 1.1.1
     optionalDependencies:
-      bare-events: 2.6.1
+      bare-events: 2.7.0
     dev: true
 
   /streamx@2.22.1:
@@ -18843,7 +19152,7 @@ packages:
       pump: 3.0.0
       tar-stream: 3.1.7
     optionalDependencies:
-      bare-fs: 4.3.1
+      bare-fs: 4.4.4
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-buffer


### PR DESCRIPTION
## Description

This PR updates email editor packages to 1.7.0 (PHP) and 1.1.1 (JS).
There are no user-facing changes.

## Code review notes

_N/A_

## QA notes

Please do somebasic smoketesting of the editor

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:bump-email-editor-packages)

_The latest successful build from `bump-email-editor-packages` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WooCommerce Email Editor dependencies to newer versions to align with upstream fixes and improvements.
  * Backend dependency upgraded to 1.7.0; frontend package bumped to 1.1.1 for better stability and compatibility with recent WooCommerce updates.
  * No functional or UI changes expected; this is routine maintenance to ensure smoother integrations and reduced risk of compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->