### PR TITLE
Add a new Trigger: Booking Created [STOMAIL-7376]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-bookings/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-bookings/index.tsx
@@ -1,4 +1,5 @@
 import { MailPoet } from '../../../mailpoet';
+import { step as BookingCreated } from './steps/booking-created';
 import { step as BookingStatusChanged } from './steps/bookings-status-changed';
 import { registerStepType } from '../../editor/store';
 
@@ -6,6 +7,7 @@ export const initialize = (): void => {
   if (!MailPoet.isWoocommerceBookingsActive) {
     return;
   }
+  registerStepType(BookingCreated);
   registerStepType(BookingStatusChanged);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-bookings/steps/booking-created/icon.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-bookings/steps/booking-created/icon.tsx
@@ -1,0 +1,24 @@
+export function Icon(): JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      {/* Calendar base */}
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M19 3H18V1H16V3H8V1H6V3H5C3.89 3 3 3.89 3 5V19C3 20.1 3.89 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.89 20.1 3 19 3ZM19 19H5V8H19V19Z"
+      />
+      {/* Calendar grid lines */}
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M7 10H9V12H7V10ZM11 10H13V12H11V10ZM15 10H17V12H15V10ZM7 14H9V16H7V14ZM11 14H13V16H11V14ZM15 14H17V16H15V14Z"
+      />
+      {/* Check mark to indicate "created/confirmed" */}
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M9 16L7 14L8.41 12.59L9 13.17L10.59 11.58L12 13L9 16Z"
+      />
+    </svg>
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-bookings/steps/booking-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-bookings/steps/booking-created/index.tsx
@@ -1,0 +1,44 @@
+import { __, _x } from '@wordpress/i18n';
+import { StepType } from '../../../../editor/store';
+import { Icon } from './icon';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+
+const keywords = [
+  // translators: noun, used as a search keyword for "Woo Booking Created" trigger
+  __('woocommerce', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Woo Booking Created" trigger
+  __('bookings', 'mailpoet'),
+  // translators: verb, used as a search keyword for "Woo Booking Created" trigger
+  __('created', 'mailpoet'),
+  // translators: adjective, used as a search keyword for "Woo Booking Created" trigger
+  __('new', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce-bookings:booking-created',
+  group: 'triggers',
+  title: () => __('Booking Created', 'mailpoet'),
+  description: () =>
+    __(
+      'This trigger fires when a new booking is created. This includes bookings initiated by shoppers on store front end and manually created by admin users. This trigger doesn’t fire for “in-cart” bookings and a valid customer is needed to trigger this automation.',
+      'mailpoet',
+    ),
+  subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => <Icon />,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_booking_created',
+      }}
+    >
+      {__(
+        'Starting an automation when a booking is created is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -100,13 +100,45 @@ namespace {
       }
 
       /**
-       * @return WC_Order|Boolean
+       * @return WC_Order|false
        */
       public function get_order() {
-        return true;
+        return false;
       }
 
       public function get_customer_id() {
+        return 1;
+      }
+
+      /**
+       * Get meta data.
+       *
+       * @param string $key     Meta key. Default empty string.
+       * @param bool   $single  Whether to return a single value. Default true.
+       * @param string $context What the value is for. Default 'view'.
+       * @return mixed
+       */
+      public function get_meta( $key = '', $single = true, $context = 'view' ) {
+        return '';
+      }
+
+      /**
+       * Update meta data.
+       *
+       * @param string $key    Meta key.
+       * @param mixed  $value  Meta value.
+       * @param bool   $unique Whether the meta key should be unique. Default false.
+       * @return void
+       */
+      public function update_meta_data( $key, $value, $unique = false ) {
+      }
+
+      /**
+       * Save the booking.
+       *
+       * @return int The booking ID.
+       */
+      public function save(): int {
         return 1;
       }
     }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/compare/stomail-7376-trigger-booking-created

## Linked tickets

 [STOMAIL-7376]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7376-trigger-booking-created)

_The latest successful build from `stomail-7376-trigger-booking-created` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “Booking Created” automation trigger for WooCommerce Bookings, available when the integration is active; editing it shows a premium upgrade prompt.

- UI
  - Added a calendar with checkmark icon for the “Booking Created” trigger.

- Chores
  - Updated WooCommerce Bookings stubs to improve static analysis and API consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->