### PR TITLE
Fix errors with log table

### DIFF
--- a/mailpoet/changelog/2025-09-26-16-26-05-updated-clean-mailpoet-log-table.md
+++ b/mailpoet/changelog/2025-09-26-16-26-05-updated-clean-mailpoet-log-table.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Clean MailPoet Log table

--- a/mailpoet/lib/Migrations/Db/Migration_20250926_153050_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20250926_153050_Db.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SettingEntity;
+use MailPoet\Migrator\DbMigration;
+
+/**
+ * Updates the logging level to 'errors' if it is 'everything'
+ * and prunes the log table if needed.
+ *
+ * This is a one time fix for users who had logging level set to 'everything' and table was filled
+ * with email editor logs.
+ */
+class Migration_20250926_153050_Db extends DbMigration {
+  public function run(): void {
+    $this->updateLoggingLevel();
+    $this->pruneLogTableIfNeeded();
+  }
+
+  private function updateLoggingLevel(): void {
+    $settingsTable = $this->getTableName(SettingEntity::class);
+
+    // Check if logging level is 'everything'
+    $loggingLevel = $this->connection->fetchOne("
+      SELECT value
+      FROM {$settingsTable}
+      WHERE name = 'logging'
+    ");
+
+    if ($loggingLevel !== 'everything') {
+      return;
+    }
+
+    // Update logging level from 'everything' to 'errors'
+    $this->connection->executeStatement("
+      UPDATE {$settingsTable}
+      SET value = 'errors'
+      WHERE name = 'logging' AND value = 'everything'
+    ");
+  }
+
+  private function pruneLogTableIfNeeded(): void {
+    $settingsTable = $this->getTableName(SettingEntity::class);
+    $logTable = $this->getTableName(\MailPoet\Entities\LogEntity::class);
+
+    // Check if pruning flag exists and is true
+    $flagResult = $this->connection->fetchOne("
+      SELECT value
+      FROM {$settingsTable}
+      WHERE name = 'log_table_pruned_migration_20250926'
+    ");
+
+    // If flag doesn't exist or is not '1', proceed with pruning
+    if ($flagResult !== '1') {
+      // Truncate the log table
+      $this->connection->executeStatement("TRUNCATE TABLE {$logTable}");
+
+      // Set the pruning flag to true
+      $this->connection->executeStatement("
+        INSERT INTO {$settingsTable} (name, value, created_at, updated_at)
+        VALUES ('log_table_pruned_migration_20250926', '1', NOW(), NOW())
+        ON DUPLICATE KEY UPDATE
+          value = '1',
+          updated_at = NOW()
+      ");
+    }
+  }
+}

--- a/mailpoet/lib/Migrations/Db/Migration_20250926_153050_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20250926_153050_Db.php
@@ -21,6 +21,10 @@ class Migration_20250926_153050_Db extends DbMigration {
   private function updateLoggingLevel(): void {
     $settingsTable = $this->getTableName(SettingEntity::class);
 
+    if (!$this->tableExists($settingsTable)) {
+      return;
+    }
+
     // Check if logging level is 'everything'
     $loggingLevel = $this->connection->fetchOne("
       SELECT value
@@ -43,6 +47,10 @@ class Migration_20250926_153050_Db extends DbMigration {
   private function pruneLogTableIfNeeded(): void {
     $settingsTable = $this->getTableName(SettingEntity::class);
     $logTable = $this->getTableName(\MailPoet\Entities\LogEntity::class);
+
+    if (!$this->tableExists($settingsTable) || !$this->tableExists($logTable)) {
+      return;
+    }
 
     // Check if pruning flag exists and is true
     $flagResult = $this->connection->fetchOne("

--- a/mailpoet/lib/Migrations/Db/Migration_20250926_153050_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20250926_153050_Db.php
@@ -62,7 +62,13 @@ class Migration_20250926_153050_Db extends DbMigration {
     // If flag doesn't exist or is not '1', proceed with pruning
     if ($flagResult !== '1') {
       // Truncate the log table
-      $this->connection->executeStatement("TRUNCATE TABLE {$logTable}");
+      try {
+        // Prefer fast path
+        $this->connection->executeStatement("TRUNCATE TABLE {$logTable}");
+      } catch (\Throwable $e) {
+        // Fallback for environments without TRUNCATE privileges
+        $this->connection->executeStatement("DELETE FROM {$logTable}");
+      }
 
       // Set the pruning flag to true
       $this->connection->executeStatement("

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20250926_153050_Db_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20250926_153050_Db_Test.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Migrations\Db;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Migrations\Db\Migration_20250926_153050_Db;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\Log;
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20250926_153050_Db_Test extends \MailPoetTest {
+
+  /** @var Migration_20250926_153050_Db */
+  private $migration;
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20250926_153050_Db($this->diContainer);
+    $this->settings = $this->diContainer->get(SettingsController::class);
+  }
+
+  public function testUpdatesLoggingLevelFromEverythingToErrors() {
+    // Set logging to 'everything'
+    $this->settings->set('logging', 'everything');
+    verify($this->settings->fetch('logging'))->equals('everything');
+
+    // Run migration
+    $this->migration->run();
+
+    // Verify logging is now set to 'errors'
+    verify($this->settings->fetch('logging'))->equals('errors');
+  }
+
+  public function testDoesNotUpdateLoggingLevelWhenNotEverything() {
+    // Set logging to 'nothing'
+    $this->settings->set('logging', 'nothing');
+    verify($this->settings->fetch('logging'))->equals('nothing');
+
+    // Run migration
+    $this->migration->run();
+
+    // Verify logging remains 'nothing'
+    verify($this->settings->fetch('logging'))->equals('nothing');
+  }
+
+  public function testTruncatesLogTableAndSetsFlagOnFirstRun() {
+    // Create some log entries
+    $logFactory = new Log();
+    $logFactory->create();
+    $logFactory->create();
+
+    // Verify logs exist
+    $logCount = $this->entityManager->getRepository(LogEntity::class)->count([]);
+    verify($logCount)->equals(2);
+
+    // Ensure pruning flag doesn't exist
+    $this->settings->delete('log_table_pruned_migration_20250926');
+
+    // Run migration
+    $this->migration->run();
+
+    // Verify logs are truncated
+    $logCount = $this->entityManager->getRepository(LogEntity::class)->count([]);
+    verify($logCount)->equals(0);
+
+    // Verify flag is set
+    verify($this->settings->fetch('log_table_pruned_migration_20250926'))->equals('1');
+  }
+
+  public function testDoesNotTruncateLogTableOnSecondRun() {
+    // Set pruning flag to indicate already pruned
+    $this->settings->set('log_table_pruned_migration_20250926', '1');
+
+    // Create some log entries
+    $logFactory = new Log();
+    $logFactory->create();
+    $logFactory->create();
+
+    // Verify logs exist
+    $logCount = $this->entityManager->getRepository(LogEntity::class)->count([]);
+    verify($logCount)->equals(2);
+
+    // Run migration
+    $this->migration->run();
+
+    // Verify logs are NOT truncated
+    $logCount = $this->entityManager->getRepository(LogEntity::class)->count([]);
+    verify($logCount)->equals(2);
+
+    // Verify flag remains set
+    verify($this->settings->fetch('log_table_pruned_migration_20250926'))->equals('1');
+  }
+
+  public function testCompleteScenarioWithLoggingUpdateAndLogPruning() {
+    // Set up initial state
+    $this->settings->set('logging', 'everything');
+
+    $logFactory = new Log();
+    $logFactory->create();
+    $logFactory->create();
+    $logFactory->create();
+
+    // Verify initial state
+    verify($this->settings->fetch('logging'))->equals('everything');
+    $logCount = $this->entityManager->getRepository(LogEntity::class)->count([]);
+    verify($logCount)->equals(3);
+
+    // Run migration
+    $this->migration->run();
+
+    // Verify both operations completed
+    verify($this->settings->fetch('logging'))->equals('errors');
+    $logCount = $this->entityManager->getRepository(LogEntity::class)->count([]);
+    verify($logCount)->equals(0);
+    verify($this->settings->fetch('log_table_pruned_migration_20250926'))->equals('1');
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes the issues with the log table by cleaning it. The Log table is not an important table, so it's fine to clear it out once in a while.

It also updates the logging level to 'errors' for users who set theirs to 'everything'

More information here p1758792009531759-slack-C0602LR6D55

## Code review notes

NOTE: This PR will clean your Log table. 
Please back up the table if you still need it.

## QA notes

We can skip QA.

* Pull the PR
* Deactivate the MailPoet plugin
* Re-activate the MailPoet plugin
* Confirm empty logs at `/wp-admin/admin.php?page=mailpoet-logs`

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-email-listing-reading-from-log-table)

_The latest successful build from `fix-email-listing-reading-from-log-table` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * One-time cleanup of the MailPoet log table to reduce size and improve performance.
  * Automatically adjusts overly verbose logging configurations to “Errors”; non-verbose settings remain unchanged.
  * Runs once per installation (no action required).

* **Documentation**
  * Added a changelog entry describing the log table cleanup update.

* **Tests**
  * Added integration tests validating logging-level adjustment and one-time log pruning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->