### PR TITLE
Fix the missing tokens for GitHub Actions workflow used to update plugin versions in CircleCI

### DIFF
--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -110,20 +110,9 @@ function replacePrivatePluginVersion(
   string $versionsFilename
 ): void {
   // Read the GitHub token from environment variable. Set at https://github.com/mailpoet/mailpoet/settings/secrets/actions.
-
-  // If the repository is woocommerce, use the WooCommerce token, otherwise use the general token.
-  $isWooCommerceRepository = strpos($repository, 'woocommerce/') !== false;
-  if ($isWooCommerceRepository) {
-    $token = getenv('WP_GITHUB_WOOCOMMERCE_TOKEN');
-  } else {
-    $token = getenv('WP_GITHUB_TOKEN');
-  }
+  $token = getenv('GH_TOKEN');
   if (!$token) {
-    if ($isWooCommerceRepository) {
-      die("WooCommerce token not found. For WooCommerce repositories requests, make sure to set the token in the environment variable 'WP_GITHUB_WOOCOMMERCE_TOKEN'.");
-    } else {
-      die("GitHub token not found. Make sure it's set in the environment variable 'WP_GITHUB_TOKEN'.");
-    }
+    die("GitHub token not found. Make sure it's set in the environment variable 'GH_TOKEN'.");
   }
 
   $page = 1;

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -63,7 +63,7 @@ jobs:
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_automate_woo_versions.php
 
       - name: Check for Automate Woo changes
@@ -85,7 +85,7 @@ jobs:
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
 
       - name: Check for WooCommerce Subscriptions changes
@@ -107,7 +107,7 @@ jobs:
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
 
       - name: Check for WooCommerce Memberships changes

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 6 * * 1' # At 06:00 on Monday
   workflow_dispatch: # Allows manual triggering
+  push:
+    branches:
+      - stomail-7573-fix-token-for-gh-workflow-update-wordpress-and-plugins
 
 jobs:
   check-versions:
@@ -20,67 +23,16 @@ jobs:
         with:
           php-version: ${{ env.MAX_PHP_VERSION }}
 
-      # Updating used WordPress
-      - name: Check WordPress Docker Versions
-        run: php .github/workflows/scripts/check_wordpress_versions.php ${{ env.MAX_PHP_VERSION }}
-
-      - name: Check for WordPress changes
-        id: check_wp_changes
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if [ "$(git status --porcelain)" != "" ]; then
-            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            echo "WORDPRESS_CHANGES=true" >> $GITHUB_ENV
-          fi
-
-      - name: Commit WordPress changes
-        if: env.WORDPRESS_CHANGES == 'true'
-        run: |
-          git add .
-          git commit -m $'Update used WordPress images in Circle CI'
-
-      # Updating used WooCommerce plugin
-      - name: Check WooCommerce Versions
-        run: php .github/workflows/scripts/check_woocommerce_versions.php
-
-      - name: Check for WooCommerce changes
-        id: check_wc_changes
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if [ "$(git status --porcelain)" != "" ]; then
-            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            echo "WOOCOMMERCE_CHANGES=true" >> $GITHUB_ENV
-          fi
-
-      - name: Commit WooCommerce changes
-        if: env.WOOCOMMERCE_CHANGES == 'true'
-        run: |
-          git add .
-          git commit -m $'Update used WooCommerce plugin in Circle CI'
-
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
         env:
           GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_automate_woo_versions.php
 
-      - name: Check for Automate Woo changes
-        id: check_aw_changes
+      - name: Diff Automate Woo changes
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if [ "$(git status --porcelain)" != "" ]; then
-            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            echo "AUTOMATE_WOO_CHANGES=true" >> $GITHUB_ENV
-          fi
-
-      - name: Commit Automate Woo changes
-        if: env.AUTOMATE_WOO_CHANGES == 'true'
-        run: |
-          git add .
-          git commit -m $'Update used Automate Woo plugin in Circle CI'
+          git diff
+          git restore .
 
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
@@ -88,21 +40,10 @@ jobs:
           GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
 
-      - name: Check for WooCommerce Subscriptions changes
-        id: check_ws_changes
+      - name: Diff WooCommerce Subscriptions changes
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if [ "$(git status --porcelain)" != "" ]; then
-            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            echo "SUBSCRIPTIONS_CHANGES=true" >> $GITHUB_ENV
-          fi
-
-      - name: Commit WooCommerce Subscriptions changes
-        if: env.SUBSCRIPTIONS_CHANGES == 'true'
-        run: |
-          git add .
-          git commit -m $'Update used WooCommerce Subscriptions plugin in Circle CI'
+          git diff
+          git restore .
 
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
@@ -110,45 +51,7 @@ jobs:
           GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
 
-      - name: Check for WooCommerce Memberships changes
-        id: check_wm_changes
+      - name: Diff WooCommerce Memberships changes
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if [ "$(git status --porcelain)" != "" ]; then
-            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            echo "MEMBERSHIPS_CHANGES=true" >> $GITHUB_ENV
-          fi
-
-      - name: Commit WooCommerce Memberships changes
-        if: env.MEMBERSHIPS_CHANGES == 'true'
-        run: |
-          git add .
-          git commit -m $'Update used WooCommerce Memberships plugin in Circle CI'
-
-      # Push all changes at the end if any changes were detected
-      #
-      # For local testing with act tool add following:
-      # env:
-      #   GH_PAT: ${{ secrets.GH_TOKEN }}
-      # run: |
-      #   git remote set-url origin https://${GH_PAT}@github.com/mailpoet/mailpoet
-      #   git push -f origin HEAD:refs/heads/update-plugins-and-wordpress-test
-      - name: Push changes
-        if: env.CHANGES_DETECTED == 'true'
-        run: |
-          git push -f origin HEAD:refs/heads/update-plugins-and-wordpress
-
-      # Create a pull request if there are changes
-      - name: Create Pull Request
-        if: env.CHANGES_DETECTED == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          branch: update-plugins-and-wordpress
-          title: Update WordPress and plugins in CI jobs
-          base: trunk
-          labels: automated, check-versions
-          body: |
-            1. If all checks passed, you can merge this PR.
-            2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.
+          git diff
+          git restore .

--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 6 * * 1' # At 06:00 on Monday
   workflow_dispatch: # Allows manual triggering
-  push:
-    branches:
-      - stomail-7573-fix-token-for-gh-workflow-update-wordpress-and-plugins
 
 jobs:
   check-versions:
@@ -23,16 +20,67 @@ jobs:
         with:
           php-version: ${{ env.MAX_PHP_VERSION }}
 
+      # Updating used WordPress
+      - name: Check WordPress Docker Versions
+        run: php .github/workflows/scripts/check_wordpress_versions.php ${{ env.MAX_PHP_VERSION }}
+
+      - name: Check for WordPress changes
+        id: check_wp_changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "WORDPRESS_CHANGES=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit WordPress changes
+        if: env.WORDPRESS_CHANGES == 'true'
+        run: |
+          git add .
+          git commit -m $'Update used WordPress images in Circle CI'
+
+      # Updating used WooCommerce plugin
+      - name: Check WooCommerce Versions
+        run: php .github/workflows/scripts/check_woocommerce_versions.php
+
+      - name: Check for WooCommerce changes
+        id: check_wc_changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "WOOCOMMERCE_CHANGES=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit WooCommerce changes
+        if: env.WOOCOMMERCE_CHANGES == 'true'
+        run: |
+          git add .
+          git commit -m $'Update used WooCommerce plugin in Circle CI'
+
       # Updating used Automate Woo plugin
       - name: Check Automate Woo Versions
         env:
           GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_automate_woo_versions.php
 
-      - name: Diff Automate Woo changes
+      - name: Check for Automate Woo changes
+        id: check_aw_changes
         run: |
-          git diff
-          git restore .
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "AUTOMATE_WOO_CHANGES=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit Automate Woo changes
+        if: env.AUTOMATE_WOO_CHANGES == 'true'
+        run: |
+          git add .
+          git commit -m $'Update used Automate Woo plugin in Circle CI'
 
       # Updating used WooCommerce Subscriptions plugin
       - name: Check WooCommerce Subscriptions Versions
@@ -40,10 +88,21 @@ jobs:
           GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
 
-      - name: Diff WooCommerce Subscriptions changes
+      - name: Check for WooCommerce Subscriptions changes
+        id: check_ws_changes
         run: |
-          git diff
-          git restore .
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "SUBSCRIPTIONS_CHANGES=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit WooCommerce Subscriptions changes
+        if: env.SUBSCRIPTIONS_CHANGES == 'true'
+        run: |
+          git add .
+          git commit -m $'Update used WooCommerce Subscriptions plugin in Circle CI'
 
       # Updating used WooCommerce Memberships plugin
       - name: Check WooCommerce Memberships Versions
@@ -51,7 +110,45 @@ jobs:
           GH_TOKEN: ${{ secrets.WP_GITHUB_WOOCOMMERCE_TOKEN }}
         run: php .github/workflows/scripts/check_woocommerce_memberships_versions.php
 
-      - name: Diff WooCommerce Memberships changes
+      - name: Check for WooCommerce Memberships changes
+        id: check_wm_changes
         run: |
-          git diff
-          git restore .
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if [ "$(git status --porcelain)" != "" ]; then
+            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+            echo "MEMBERSHIPS_CHANGES=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit WooCommerce Memberships changes
+        if: env.MEMBERSHIPS_CHANGES == 'true'
+        run: |
+          git add .
+          git commit -m $'Update used WooCommerce Memberships plugin in Circle CI'
+
+      # Push all changes at the end if any changes were detected
+      #
+      # For local testing with act tool add following:
+      # env:
+      #   GH_PAT: ${{ secrets.GH_TOKEN }}
+      # run: |
+      #   git remote set-url origin https://${GH_PAT}@github.com/mailpoet/mailpoet
+      #   git push -f origin HEAD:refs/heads/update-plugins-and-wordpress-test
+      - name: Push changes
+        if: env.CHANGES_DETECTED == 'true'
+        run: |
+          git push -f origin HEAD:refs/heads/update-plugins-and-wordpress
+
+      # Create a pull request if there are changes
+      - name: Create Pull Request
+        if: env.CHANGES_DETECTED == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          branch: update-plugins-and-wordpress
+          title: Update WordPress and plugins in CI jobs
+          base: trunk
+          labels: automated, check-versions
+          body: |
+            1. If all checks passed, you can merge this PR.
+            2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.


### PR DESCRIPTION
## Description

This PR fixes the missing tokens for GitHub Actions workflow used to update plugin versions in CircleCI.

- The workflow failed to update versions because the new token was not properly set as GitHub Actions environment variables.
- Remove all handling related to `WP_GITHUB_TOKEN`, as it is currently unused.

## Code review notes

I will be skipping code review as it's a dev-only change and it's easier to perform a complete verification after merging it into `trunk`.

In addition, A preliminary validation has been completed through temporary revision 5ef02766b3639be5a8cdfd6865dfb696c09b3712 and [this workflow run](https://github.com/mailpoet/mailpoet/actions/runs/18092910102/job/51477450460).

<img width="1059" height="526" alt="image" src="https://github.com/user-attachments/assets/b765126d-5f6b-417b-b5b0-60530496e85d" />

<img width="1061" height="697" alt="image" src="https://github.com/user-attachments/assets/3be291f9-afed-4d7d-b351-058751c9b46d" />

<img width="1060" height="329" alt="image" src="https://github.com/user-attachments/assets/2955bf66-ae25-4b87-8b81-969b441bf187" />


## QA notes

No need for QA in this Pull Request

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7573]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7573-fix-token-for-gh-workflow-update-wordpress-and-plugins)

_The latest successful build from `stomail-7573-fix-token-for-gh-workflow-update-wordpress-and-plugins` will be used. If none is available, the link won't work._