### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           name: Download additional WP Plugins for tests
           command: |
             ./do download:woo-commerce-zip 10.2.1
-            ./do download:woo-commerce-subscriptions-zip 7.7.0
+            ./do download:woo-commerce-subscriptions-zip 7.9.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.16
       - run:
@@ -1183,7 +1183,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_oldest
           woo_core_version: 10.1.2
-          woo_subscriptions_version: 7.6.0
+          woo_subscriptions_version: 7.8.2
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
@@ -1223,7 +1223,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           woo_core_version: 10.1.2
-          woo_subscriptions_version: 7.6.0
+          woo_subscriptions_version: 7.8.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1285,7 +1285,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
           woo_core_version: 10.1.2
-          woo_subscriptions_version: 7.6.0
+          woo_subscriptions_version: 7.8.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1296,7 +1296,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
           woo_core_version: 10.1.2
-          woo_subscriptions_version: 7.6.0
+          woo_subscriptions_version: 7.8.2
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             ./do download:woo-commerce-zip 10.2.1
             ./do download:woo-commerce-subscriptions-zip 7.7.0
             ./do download:woo-commerce-memberships-zip
-            ./do download:automate-woo-zip 6.1.15
+            ./do download:automate-woo-zip 6.1.16
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow dependencies to use newer versions of WooCommerce Subscriptions and AutomateWoo for build consistency and maintenance.
* **Tests**
  * Refreshed acceptance and integration test matrices to validate against WooCommerce Subscriptions 7.8.2 and AutomateWoo 6.1.16, improving coverage and reliability.
* **Notes**
  * No user-facing changes; these updates enhance pipeline stability and test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->