### PR TITLE
Restrict sendPreviewEmail filter to mailpoet_email post type

### DIFF
--- a/mailpoet/changelog/2025-09-29-15-39-22-fixed-restrict-sendpreviewemail-filter-to-mailpoetemail-.md
+++ b/mailpoet/changelog/2025-09-29-15-39-22-fixed-restrict-sendpreviewemail-filter-to-mailpoetemail-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Restrict sendPreviewEmail filter to mailpoet_email post type

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
@@ -7,8 +7,6 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
 
 class EmailEditorPreviewEmail {
-  const MAILPOET_EMAIL_POST_TYPE = 'mailpoet_email';
-
   private NewslettersRepository $newslettersRepository;
 
   private SendPreviewController $sendPreviewController;
@@ -28,7 +26,7 @@ class EmailEditorPreviewEmail {
    * @throws \Exception
    */
   public function sendPreviewEmail($postData) {
-    if (is_bool($postData) || !isset($postData['postId']) || get_post_type((int)$postData['postId']) !== self::MAILPOET_EMAIL_POST_TYPE) {
+    if (is_bool($postData) || !isset($postData['postId']) || get_post_type((int)$postData['postId']) !== EmailEditor::MAILPOET_EMAIL_POST_TYPE) {
       return $postData;
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditorPreviewEmail.php
@@ -7,6 +7,8 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
 
 class EmailEditorPreviewEmail {
+  const MAILPOET_EMAIL_POST_TYPE = 'mailpoet_email';
+
   private NewslettersRepository $newslettersRepository;
 
   private SendPreviewController $sendPreviewController;
@@ -21,9 +23,15 @@ class EmailEditorPreviewEmail {
 
   /**
    * Sends preview email
+   * @param bool|array $postData
+   * @return bool|array
    * @throws \Exception
    */
-  public function sendPreviewEmail($postData): bool {
+  public function sendPreviewEmail($postData) {
+    if (is_bool($postData) || !isset($postData['postId']) || get_post_type((int)$postData['postId']) !== self::MAILPOET_EMAIL_POST_TYPE) {
+      return $postData;
+    }
+
     $this->validateData($postData);
 
     $newsletter = $this->fetchNewsletter($postData);


### PR DESCRIPTION
## Description

Restrict the send `EmailEditorPreviewEmail::sendPreviewEmail` (`woocommerce_email_editor_send_preview_email`) filter to `mailpoet_email` post type to prevent handling email previews from other plugins (such as WooCommerce) that use the `@woocommerce/email-editor` package.

Closes [WOOPRD-850: Send preview doesn't work when MailPoet is active](https://linear.app/a8c/issue/WOOPRD-850/send-preview-doesnt-work-when-mailpoet-is-active)

## Code review notes

_N/A_

## QA notes

1. Install and acivate both MailPoet and WooCommerce.
2. Enable Block Email Editor in WooCommerce from **WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)** .
3. Open any email in the email editor from **WooCommerce → Settings → Emails**.
4. Send a test email and confirm it works correctly.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wooprd-850-send-preview-doesnt-work-when-mailpoet-is-active)

_The latest successful build from `wooprd-850-send-preview-doesnt-work-when-mailpoet-is-active` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview sends are now restricted to MailPoet email content, preventing accidental preview sends for other post types and reducing unexpected editor behavior.

* **Documentation**
  * Added changelog entry documenting the restriction of preview email sending to MailPoet emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->