### PR TITLE
Release 5.15.1

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,12 @@
 == Changelog ==
 
+= 5.15.1 - 2025-09-30 =
+* Updated: Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2.;
+* Updated: Reporting analytics data;
+* Updated: Clean MailPoet Log table;
+* Improved: Automation endpoint supports filtering, sorting and pagination;
+* Fixed: Fixed a user warning on the registration screen.
+
 = 5.15.0 - 2025-09-22 =
 * Improved: Improve font family handling in WooCommerce transactional emails;
 * Improved: Updated used Email Editor package to 1.6.0;

--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,7 +1,7 @@
 == Changelog ==
 
 = 5.15.1 - 2025-09-30 =
-* Updated: Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2.;
+* Updated: Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2;
 * Updated: Reporting analytics data;
 * Updated: Clean MailPoet Log table;
 * Improved: Automation endpoint supports filtering, sorting and pagination;

--- a/mailpoet/changelog/2025-09-15-10-00-35-updated-bump-the-minimum-required-woocommerce-version-to-1.md
+++ b/mailpoet/changelog/2025-09-15-10-00-35-updated-bump-the-minimum-required-woocommerce-version-to-1.md
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2.

--- a/mailpoet/changelog/2025-09-19-10-32-45-fixed-fixed-a-user-warning-on-the-registration-screen.md
+++ b/mailpoet/changelog/2025-09-19-10-32-45-fixed-fixed-a-user-warning-on-the-registration-screen.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fixed a user warning on the registration screen

--- a/mailpoet/changelog/2025-09-24-10-03-17-updated-reporting-analytics-data.md
+++ b/mailpoet/changelog/2025-09-24-10-03-17-updated-reporting-analytics-data.md
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Reporting analytics data

--- a/mailpoet/changelog/2025-09-26-08-36-57-improved-automation-endpoint-supports-filtering-sorting-and.md
+++ b/mailpoet/changelog/2025-09-26-08-36-57-improved-automation-endpoint-supports-filtering-sorting-and.md
@@ -1,5 +1,0 @@
-# Type: Improved
-
-# Description
-
-Automation endpoint supports filtering, sorting and pagination

--- a/mailpoet/changelog/2025-09-26-16-26-05-updated-clean-mailpoet-log-table.md
+++ b/mailpoet/changelog/2025-09-26-16-26-05-updated-clean-mailpoet-log-table.md
@@ -1,5 +1,0 @@
-# Type: Updated
-
-# Description
-
-Clean MailPoet Log table

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.15.0
+ * Version: 5.15.1
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.15.0',
+  'version' => '5.15.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.7
 Tested up to: 6.8
-Stable tag: 5.15.0
+Stable tag: 5.15.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,11 +227,11 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.15.0 - 2025-09-22 =
-* Improved: Improve font family handling in WooCommerce transactional emails;
-* Improved: Updated used Email Editor package to 1.6.0;
-* Improved: Implement log level filtering for the email editor;
-* Fixed: Fix placeholder images URLs in WooCommerce template customizer;
-* Fixed: Fix hardcoded URL for my account page in new account template.
+= 5.15.1 - 2025-09-30 =
+* Updated: Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2.;
+* Updated: Reporting analytics data;
+* Updated: Clean MailPoet Log table;
+* Improved: Automation endpoint supports filtering, sorting and pagination;
+* Fixed: Fixed a user warning on the registration screen.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -228,7 +228,7 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 == Changelog ==
 
 = 5.15.1 - 2025-09-30 =
-* Updated: Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2.;
+* Updated: Bump the minimum required WooCommerce version to 10.1 and tested up to version to 10.2;
 * Updated: Reporting analytics data;
 * Updated: Clean MailPoet Log table;
 * Improved: Automation endpoint supports filtering, sorting and pagination;


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updated**
  * Raised minimum WooCommerce requirement to 10.1; tested up to 10.2.
  * Enhanced analytics reporting.
  * Cleaned up the MailPoet Log table.
* **Improvements**
  * Automation endpoint now supports filtering, sorting, and pagination.
* **Bug Fixes**
  * Resolved a user warning on the registration screen.
* **Chores**
  * Released version 5.15.1 with updated readme and consolidated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->