### PR TITLE
Add automation last run and email stats into listing endpoint

### DIFF
--- a/mailpoet/changelog/2025-09-30-16-34-28-added-include-last-automation-run-details-and-email-stat.md
+++ b/mailpoet/changelog/2025-09-30-16-34-28-added-include-last-automation-run-details-and-email-stat.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Include last automation run details and email statistics in Automations listing endpoint.

--- a/mailpoet/lib/Automation/Engine/Data/AutomationStatistics.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationStatistics.php
@@ -8,17 +8,32 @@ class AutomationStatistics {
   private $versionId;
   private $entered;
   private $inProgress;
+  private $emailsSent;
+  private $emailsOpened;
+  private $emailsClicked;
+  private $orders;
+  private $revenue;
 
   public function __construct(
     int $automationId,
     int $entered = 0,
     int $inProcess = 0,
-    ?int $versionId = null
+    ?int $versionId = null,
+    int $emailsSent = 0,
+    int $emailsOpened = 0,
+    int $emailsClicked = 0,
+    int $orders = 0,
+    float $revenue = 0.0
   ) {
     $this->automationId = $automationId;
     $this->entered = $entered;
     $this->inProgress = $inProcess;
     $this->versionId = $versionId;
+    $this->emailsSent = $emailsSent;
+    $this->emailsOpened = $emailsOpened;
+    $this->emailsClicked = $emailsClicked;
+    $this->orders = $orders;
+    $this->revenue = $revenue;
   }
 
   public function getAutomationId(): int {
@@ -41,6 +56,26 @@ class AutomationStatistics {
     return $this->getEntered() - $this->getInProgress();
   }
 
+  public function getEmailsSent(): int {
+    return $this->emailsSent;
+  }
+
+  public function getEmailsOpened(): int {
+    return $this->emailsOpened;
+  }
+
+  public function getEmailsClicked(): int {
+    return $this->emailsClicked;
+  }
+
+  public function getOrders(): int {
+    return $this->orders;
+  }
+
+  public function getRevenue(): float {
+    return $this->revenue;
+  }
+
   public function toArray(): array {
     return [
       'automation_id' => $this->getAutomationId(),
@@ -48,6 +83,13 @@ class AutomationStatistics {
         'entered' => $this->getEntered(),
         'in_progress' => $this->getInProgress(),
         'exited' => $this->getExited(),
+      ],
+      'emails' => [
+        'sent' => $this->getEmailsSent(),
+        'opened' => $this->getEmailsOpened(),
+        'clicked' => $this->getEmailsClicked(),
+        'orders' => $this->getOrders(),
+        'revenue' => $this->getRevenue(),
       ],
     ];
   }

--- a/mailpoet/lib/Automation/Engine/Data/AutomationStatistics.php
+++ b/mailpoet/lib/Automation/Engine/Data/AutomationStatistics.php
@@ -88,8 +88,11 @@ class AutomationStatistics {
         'sent' => $this->getEmailsSent(),
         'opened' => $this->getEmailsOpened(),
         'clicked' => $this->getEmailsClicked(),
-        'orders' => $this->getOrders(),
-        'revenue' => $this->getRevenue(),
+        'revenue' => [
+          'currency' => function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : '',
+          'value' => $this->getRevenue(),
+          'count' => $this->getOrders(),
+        ],
       ],
     ];
   }

--- a/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
+++ b/mailpoet/lib/Automation/Engine/Mappers/AutomationMapper.php
@@ -4,19 +4,26 @@ namespace MailPoet\Automation\Engine\Mappers;
 
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 
 class AutomationMapper {
   /** @var AutomationStatisticsStorage */
   private $statisticsStorage;
 
+  /** @var AutomationRunStorage */
+  private $runStorage;
+
   public function __construct(
-    AutomationStatisticsStorage $statisticsStorage
+    AutomationStatisticsStorage $statisticsStorage,
+    AutomationRunStorage $runStorage
   ) {
     $this->statisticsStorage = $statisticsStorage;
+    $this->runStorage = $runStorage;
   }
 
   public function buildAutomation(Automation $automation, ?AutomationStatistics $statistics = null): array {
@@ -52,12 +59,17 @@ class AutomationMapper {
   /** @param Automation[] $automations */
   public function buildAutomationList(array $automations): array {
     $statistics = $this->statisticsStorage->getAutomationStatisticsForAutomations(...$automations);
-    return array_map(function (Automation $automation) use ($statistics) {
-      return $this->buildAutomationListItem($automation, $statistics[$automation->getId()]);
+    $lastRuns = $this->runStorage->getLastAutomationRunsForAutomations(...$automations);
+    return array_map(function (Automation $automation) use ($statistics, $lastRuns) {
+      return $this->buildAutomationListItem(
+        $automation,
+        $statistics[$automation->getId()],
+        $lastRuns[$automation->getId()] ?? null
+      );
     }, $automations);
   }
 
-  private function buildAutomationListItem(Automation $automation, AutomationStatistics $statistics): array {
+  private function buildAutomationListItem(Automation $automation, AutomationStatistics $statistics, ?AutomationRun $lastRun): array {
     return [
       'id' => $automation->getId(),
       'name' => $automation->getName(),
@@ -70,6 +82,12 @@ class AutomationMapper {
         'id' => $automation->getAuthor()->ID,
         'name' => $automation->getAuthor()->display_name,
       ],
+      'last_run' => $lastRun ? [
+        'id' => $lastRun->getId(),
+        'status' => $lastRun->getStatus(),
+        'created_at' => $lastRun->getCreatedAt()->format(DateTimeImmutable::W3C),
+        'updated_at' => $lastRun->getUpdatedAt()->format(DateTimeImmutable::W3C),
+      ] : null,
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -180,6 +180,72 @@ class AutomationRunStorage {
     return $result ? (int)current($result) : 0;
   }
 
+  /**
+   * @return array<int, AutomationRun|null>
+   */
+  public function getLastAutomationRunsForAutomations(Automation ...$automations): array {
+    global $wpdb;
+
+    if (!count($automations)) {
+      return [];
+    }
+
+    $automationIds = array_map(function (Automation $automation) {
+      return $automation->getId();
+    }, $automations);
+
+    // Using a subquery to get the max ID per automation_id (most recent run)
+    // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The number of replacements is dynamic.
+    $runs = $wpdb->get_results(
+      $wpdb->prepare(
+        '
+          SELECT r.*
+          FROM %i AS r
+          INNER JOIN (
+            SELECT automation_id, MAX(id) AS max_id
+            FROM %i
+            WHERE automation_id IN (' . implode(',', array_fill(0, count($automationIds), '%d')) . ')
+            GROUP BY automation_id
+          ) AS latest ON r.id = latest.max_id
+        ',
+        array_merge([$this->table, $this->table], $automationIds)
+      ),
+      ARRAY_A
+    );
+
+    if (!is_array($runs) || !$runs) {
+      return array_fill_keys($automationIds, null);
+    }
+
+    // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- The number of replacements is dynamic.
+    $subjects = $wpdb->get_results(
+      $wpdb->prepare(
+        '
+          SELECT *
+          FROM %i
+          WHERE automation_run_id IN (' . implode(',', array_fill(0, count($runs), '%d')) . ')
+        ',
+        array_merge([$this->subjectTable], array_column($runs, 'id'))
+      ),
+      ARRAY_A
+    );
+
+    $result = array_fill_keys($automationIds, null);
+
+    foreach ($runs as $runData) {
+      $runData['subjects'] = array_values(array_filter(
+        is_array($subjects) ? $subjects : [],
+        function($subjectData) use ($runData): bool {
+          /** @var array $subjectData */
+          return (int)$subjectData['automation_run_id'] === (int)$runData['id'];
+        }
+      ));
+      $result[(int)$runData['automation_id']] = AutomationRun::fromArray($runData);
+    }
+
+    return $result;
+  }
+
   public function updateStatus(int $id, string $status): void {
     global $wpdb;
     $result = $wpdb->query(

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStatisticsStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStatisticsStorage.php
@@ -7,7 +7,7 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\AutomationStatistics;
 
 class AutomationStatisticsStorage {
-  /** @var string  */
+  /** @var string */
   private $table;
 
   public function __construct() {
@@ -30,10 +30,17 @@ class AutomationStatisticsStorage {
     $data = $this->getStatistics($automationIds);
     $statistics = [];
     foreach ($automationIds as $id) {
+      $emailStats = $this->getEmailStatistics($id);
       $statistics[$id] = new AutomationStatistics(
         $id,
         (int)($data[$id]['total'] ?? 0),
-        (int)($data[$id]['running'] ?? 0)
+        (int)($data[$id]['running'] ?? 0),
+        null,
+        $emailStats['sent'],
+        $emailStats['opened'],
+        $emailStats['clicked'],
+        $emailStats['orders'],
+        $emailStats['revenue']
       );
     }
     return $statistics;
@@ -41,11 +48,18 @@ class AutomationStatisticsStorage {
 
   public function getAutomationStats(int $automationId, ?int $versionId = null, ?\DateTimeImmutable $after = null, ?\DateTimeImmutable $before = null): AutomationStatistics {
     $data = $this->getStatistics([$automationId], $versionId, $after, $before);
+    $emailStats = $this->getEmailStatistics($automationId, $versionId, $after, $before);
+
     return new AutomationStatistics(
       $automationId,
       (int)($data[$automationId]['total'] ?? 0),
       (int)($data[$automationId]['running'] ?? 0),
-      $versionId
+      $versionId,
+      $emailStats['sent'],
+      $emailStats['opened'],
+      $emailStats['clicked'],
+      $emailStats['orders'],
+      $emailStats['revenue']
     );
   }
 
@@ -96,5 +110,233 @@ class AutomationStatisticsStorage {
       )
     );
     return strval($query);
+  }
+
+  private function getAutomationEmailIds(int $automationId, ?int $versionId = null): array {
+    global $wpdb;
+
+    $versionsTable = $wpdb->prefix . 'mailpoet_automation_versions';
+
+    if ($versionId) {
+      $query = $wpdb->prepare(
+        '
+          SELECT steps
+          FROM %i
+          WHERE automation_id = %d
+          AND version_id = %d
+        ',
+        [$versionsTable, $automationId, $versionId]
+      );
+    } else {
+      $query = $wpdb->prepare(
+        '
+          SELECT steps
+          FROM %i
+          WHERE automation_id = %d
+        ',
+        [$versionsTable, $automationId]
+      );
+    }
+
+    $results = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $emailIds = [];
+
+    foreach ($results as $result) {
+      $steps = json_decode($result['steps'], true);
+      if (!is_array($steps)) {
+        continue;
+      }
+
+      foreach ($steps as $step) {
+        if (isset($step['key']) && $step['key'] === 'mailpoet:send-email' && isset($step['args']['email_id'])) {
+          $emailIds[] = (int)$step['args']['email_id'];
+        }
+      }
+    }
+
+    return array_unique($emailIds);
+  }
+
+  private function queryEmailStatistics(array $emailIds, ?\DateTimeImmutable $after = null, ?\DateTimeImmutable $before = null): array {
+    if (empty($emailIds)) {
+      return ['sent' => 0, 'opened' => 0, 'clicked' => 0, 'orders' => 0, 'revenue' => 0.0];
+    }
+
+    $dateCondition = '';
+    $dateParams = [];
+    if ($after && $before) {
+      $dateCondition = 'AND created_at BETWEEN %s AND %s';
+      $dateParams = [$after->format('Y-m-d H:i:s'), $before->format('Y-m-d H:i:s')];
+    } elseif ($after && $before === null) {
+      $dateCondition = 'AND created_at >= %s';
+      $dateParams = [$after->format('Y-m-d H:i:s')];
+    } elseif ($after === null && $before) {
+      $dateCondition = 'AND created_at <= %s';
+      $dateParams = [$before->format('Y-m-d H:i:s')];
+    }
+
+    $sentCounts = $this->getEmailSentCounts($emailIds, $dateCondition, $dateParams);
+    $openCounts = $this->getEmailOpenCounts($emailIds, $dateCondition, $dateParams);
+    $clickCounts = $this->getEmailClickCounts($emailIds, $dateCondition, $dateParams);
+    $revenueData = $this->getEmailRevenueCounts($emailIds, $dateCondition, $dateParams);
+
+    // Sum all the per-email results
+    $totalSent = array_sum($sentCounts);
+    $totalOpened = array_sum($openCounts);
+    $totalClicked = array_sum($clickCounts);
+    $totalOrders = array_sum(array_column($revenueData, 'orders'));
+    $totalRevenue = array_sum(array_column($revenueData, 'revenue'));
+
+    return [
+      'sent' => $totalSent,
+      'opened' => $totalOpened,
+      'clicked' => $totalClicked,
+      'orders' => $totalOrders,
+      'revenue' => $totalRevenue,
+    ];
+  }
+
+  private function getEmailSentCounts(array $emailIds, string $dateCondition, array $dateParams): array {
+    global $wpdb;
+
+    if (empty($emailIds)) {
+      return [];
+    }
+
+    // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.NotPrepared -- The number of replacements is dynamic.
+    $results = $wpdb->get_results(
+      $wpdb->prepare(
+        '
+          SELECT sq.newsletter_id, SUM(sq.count_processed) as total
+          FROM %i sq
+          JOIN %i st ON sq.task_id = st.id
+          WHERE sq.newsletter_id IN (' . implode(',', array_fill(0, count($emailIds), '%d')) . ')
+          AND st.status = %s
+          ' . ($dateCondition ? str_replace('created_at', 'sq.created_at', $dateCondition) : '') . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The condition uses placeholders. */ '
+          GROUP BY sq.newsletter_id
+        ',
+        array_merge(
+          [$wpdb->prefix . 'mailpoet_sending_queues', $wpdb->prefix . 'mailpoet_scheduled_tasks'],
+          $emailIds,
+          ['completed'],
+          $dateParams
+        )
+      ),
+      ARRAY_A
+    );
+    $counts = [];
+    foreach ($results as $result) {
+      $counts[(int)$result['newsletter_id']] = (int)$result['total'];
+    }
+    return $counts;
+  }
+
+  private function getEmailOpenCounts(array $emailIds, string $dateCondition, array $dateParams): array {
+    global $wpdb;
+
+    if (empty($emailIds)) {
+      return [];
+    }
+
+    $query = $wpdb->prepare('
+      SELECT newsletter_id, COUNT(DISTINCT subscriber_id) as total
+      FROM %i
+      WHERE newsletter_id IN (' . implode(',', array_fill(0, count($emailIds), '%d')) . ')
+      AND ((user_agent_type = %d) OR (user_agent_type IS NULL))
+      ' . $dateCondition /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The date condition uses placeholders. */ . '
+      GROUP BY newsletter_id
+    ', array_merge(
+        [$wpdb->prefix . 'mailpoet_statistics_opens'],
+        $emailIds,
+        [0], // USER_AGENT_TYPE_HUMAN = 0
+        $dateParams
+      ));
+    $results = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $counts = [];
+    foreach ($results as $result) {
+      $counts[(int)$result['newsletter_id']] = (int)$result['total'];
+    }
+    return $counts;
+  }
+
+  private function getEmailClickCounts(array $emailIds, string $dateCondition, array $dateParams): array {
+    global $wpdb;
+
+    if (empty($emailIds)) {
+      return [];
+    }
+
+    // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholders are used with prepare().
+    $query = $wpdb->prepare('
+      SELECT newsletter_id, COUNT(DISTINCT subscriber_id) as total
+      FROM %i
+      WHERE newsletter_id IN (' . implode(',', array_fill(0, count($emailIds), '%d')) . ')
+      AND ((user_agent_type = %d) OR (user_agent_type IS NULL))
+      ' . $dateCondition /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The date condition uses placeholders. */ . '
+      GROUP BY newsletter_id
+    ', array_merge(
+        [$wpdb->prefix . 'mailpoet_statistics_clicks'],
+        $emailIds,
+        [0], // USER_AGENT_TYPE_HUMAN = 0
+        $dateParams
+      ));
+    $results = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $counts = [];
+    foreach ($results as $result) {
+      $counts[(int)$result['newsletter_id']] = (int)$result['total'];
+    }
+    return $counts;
+  }
+
+  private function getEmailRevenueCounts(array $emailIds, string $dateCondition, array $dateParams): array {
+    global $wpdb;
+
+    // Check if WooCommerce is active before querying
+    if (!function_exists('get_woocommerce_currency')) {
+      return [];
+    }
+
+    if (empty($emailIds)) {
+      return [];
+    }
+
+    $currency = get_woocommerce_currency();
+
+    // Use the same purchase states as overview (defaults to ['completed'] but could be filtered)
+    $purchaseStates = ['completed']; // Default value matching WCHelper::getPurchaseStates()
+    if (function_exists('apply_filters')) {
+      $purchaseStates = apply_filters('mailpoet_purchase_order_states', $purchaseStates);
+    }
+
+    // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Dynamic placeholders are used with prepare().
+    $query = $wpdb->prepare('
+      SELECT newsletter_id, COUNT(id) as orders, SUM(order_price_total) as revenue
+      FROM %i
+      WHERE newsletter_id IN (' . implode(',', array_fill(0, count($emailIds), '%d')) . ')
+      AND status IN (' . implode(',', array_fill(0, count($purchaseStates), '%s')) . ')
+      AND order_currency = %s
+      ' . $dateCondition . /* phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The date condition uses placeholders. */ '
+      GROUP BY newsletter_id
+    ', array_merge(
+        [$wpdb->prefix . 'mailpoet_statistics_woocommerce_purchases'],
+        $emailIds,
+        $purchaseStates,
+        [$currency],
+        $dateParams
+      ));
+    $results = $wpdb->get_results($query, ARRAY_A); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
+    $revenueData = [];
+    foreach ($results as $result) {
+      $revenueData[(int)$result['newsletter_id']] = [
+        'orders' => (int)$result['orders'],
+        'revenue' => (float)$result['revenue'],
+      ];
+    }
+    return $revenueData;
+  }
+
+  private function getEmailStatistics(int $automationId, ?int $versionId = null, ?\DateTimeImmutable $after = null, ?\DateTimeImmutable $before = null): array {
+    $emailIds = $this->getAutomationEmailIds($automationId, $versionId);
+    return $this->queryEmailStatistics($emailIds, $after, $before);
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunStorageTest.php
@@ -64,4 +64,63 @@ class AutomationRunStorageTest extends \MailPoetTest {
     ];
     $this->assertEquals($expected, $result);
   }
+
+  public function testGetLastAutomationRunsForAutomations() {
+    $automation1 = (new \MailPoet\Test\DataFactories\Automation())->withName('Automation 1')->create();
+    $automation2 = (new \MailPoet\Test\DataFactories\Automation())->withName('Automation 2')->create();
+    $automation3 = (new \MailPoet\Test\DataFactories\Automation())->withName('Automation 3')->create();
+
+    // Create multiple runs for automation1
+    $run1 = (new \MailPoet\Test\DataFactories\AutomationRun())
+      ->withAutomation($automation1)
+      ->withTriggerKey('trigger1')
+      ->withStatus(AutomationRun::STATUS_COMPLETE)
+      ->withCreatedAt(new \DateTimeImmutable('2020-01-01 10:00:00'))
+      ->create();
+
+    $run2 = (new \MailPoet\Test\DataFactories\AutomationRun())
+      ->withAutomation($automation1)
+      ->withTriggerKey('trigger1')
+      ->withStatus(AutomationRun::STATUS_RUNNING)
+      ->withCreatedAt(new \DateTimeImmutable('2020-01-02 10:00:00'))
+      ->create();
+
+    $run3 = (new \MailPoet\Test\DataFactories\AutomationRun())
+      ->withAutomation($automation1)
+      ->withTriggerKey('trigger1')
+      ->withStatus(AutomationRun::STATUS_COMPLETE)
+      ->withCreatedAt(new \DateTimeImmutable('2020-01-03 10:00:00'))
+      ->create();
+
+    // Create one run for automation2
+    $run4 = (new \MailPoet\Test\DataFactories\AutomationRun())
+      ->withAutomation($automation2)
+      ->withTriggerKey('trigger2')
+      ->withStatus(AutomationRun::STATUS_FAILED)
+      ->withCreatedAt(new \DateTimeImmutable('2020-01-01 12:00:00'))
+      ->create();
+
+    // No runs for automation3
+
+    $result = $this->testee->getLastAutomationRunsForAutomations($automation1, $automation2, $automation3);
+
+    $this->assertCount(3, $result);
+    $this->assertArrayHasKey($automation1->getId(), $result);
+    $this->assertArrayHasKey($automation2->getId(), $result);
+    $this->assertArrayHasKey($automation3->getId(), $result);
+
+    // Check automation1 has the latest run (run3)
+    $this->assertInstanceOf(AutomationRun::class, $result[$automation1->getId()]);
+    $this->assertEquals($run3->getId(), $result[$automation1->getId()]->getId());
+    $this->assertEquals(AutomationRun::STATUS_COMPLETE, $result[$automation1->getId()]->getStatus());
+    $this->assertEquals('2020-01-03 10:00:00', $result[$automation1->getId()]->getCreatedAt()->format('Y-m-d H:i:s'));
+
+    // Check automation2 has the only run (run4)
+    $this->assertInstanceOf(AutomationRun::class, $result[$automation2->getId()]);
+    $this->assertEquals($run4->getId(), $result[$automation2->getId()]->getId());
+    $this->assertEquals(AutomationRun::STATUS_FAILED, $result[$automation2->getId()]->getStatus());
+
+    // Check automation3 has no runs
+    $this->assertNull($result[$automation3->getId()]);
+  }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -62,6 +62,13 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
         'in_progress' => $expectedInProgress,
         'exited' => $expectedExited,
       ],
+      'emails' => [
+        'sent' => 0,
+        'opened' => 0,
+        'clicked' => 0,
+        'orders' => 0,
+        'revenue' => 0.0,
+      ],
     ], $statistics->toArray());
   }
 
@@ -99,6 +106,12 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
       $this->assertEquals($statistic->getExited(), $pluralStatistics[$automationId]->getExited());
       $this->assertEquals($statistic->getVersionId(), $pluralStatistics[$automationId]->getVersionId());
       $this->assertEquals($statistic->getAutomationId(), $pluralStatistics[$automationId]->getAutomationId());
+      // Test new email statistics getters
+      $this->assertEquals($statistic->getEmailsSent(), $pluralStatistics[$automationId]->getEmailsSent());
+      $this->assertEquals($statistic->getEmailsOpened(), $pluralStatistics[$automationId]->getEmailsOpened());
+      $this->assertEquals($statistic->getEmailsClicked(), $pluralStatistics[$automationId]->getEmailsClicked());
+      $this->assertEquals($statistic->getOrders(), $pluralStatistics[$automationId]->getOrders());
+      $this->assertEquals($statistic->getRevenue(), $pluralStatistics[$automationId]->getRevenue());
     }
 
 
@@ -167,6 +180,31 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
 
     $stats = $this->testee->getAutomationStats($newestAutomation->getId(), $oldestAutomation->getVersionId());
     $this->assertEquals(1, $stats->getEntered());
+  }
+
+  public function testEmailStatisticsDefaultsToZero() {
+    $automation = $this->automationStorage->getAutomation($this->automations[0]);
+    $this->assertInstanceOf(Automation::class, $automation);
+
+    $statistics = $this->testee->getAutomationStats($automation->getId());
+
+    // Test that email statistics default to zero when no emails exist
+    $this->assertEquals(0, $statistics->getEmailsSent());
+    $this->assertEquals(0, $statistics->getEmailsOpened());
+    $this->assertEquals(0, $statistics->getEmailsClicked());
+    $this->assertEquals(0, $statistics->getOrders());
+    $this->assertEquals(0.0, $statistics->getRevenue());
+
+    // Test that toArray includes email statistics
+    $array = $statistics->toArray();
+    $this->assertArrayHasKey('emails', $array);
+    $this->assertEquals([
+      'sent' => 0,
+      'opened' => 0,
+      'clicked' => 0,
+      'orders' => 0,
+      'revenue' => 0.0,
+    ], $array['emails']);
   }
 
   private function createRun(Automation $automation, string $status) {

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -66,8 +66,11 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
         'sent' => 0,
         'opened' => 0,
         'clicked' => 0,
-        'orders' => 0,
-        'revenue' => 0.0,
+        'revenue' => [
+          'currency' => function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : '',
+          'count' => 0,
+          'value' => 0.0,
+        ],
       ],
     ], $statistics->toArray());
   }
@@ -202,8 +205,11 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
       'sent' => 0,
       'opened' => 0,
       'clicked' => 0,
-      'orders' => 0,
-      'revenue' => 0.0,
+      'revenue' => [
+        'currency' => function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : '',
+        'count' => 0,
+        'value' => 0.0,
+      ],
     ], $array['emails']);
   }
 

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -90,6 +90,13 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
           'in_progress' => 0,
           'exited' => 0,
         ],
+        'emails' => [
+          'sent' => 0,
+          'opened' => 0,
+          'clicked' => 0,
+          'orders' => 0,
+          'revenue' => 0,
+        ],
       ],
       'steps' => [
         'root' => [

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -94,8 +94,11 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
           'sent' => 0,
           'opened' => 0,
           'clicked' => 0,
-          'orders' => 0,
-          'revenue' => 0,
+          'revenue' => [
+            'currency' => function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : '',
+            'value' => 0,
+            'count' => 0,
+          ],
         ],
       ],
       'steps' => [

--- a/mailpoet/tests/unit/Automation/Engine/Data/AutomationStatisticsTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Data/AutomationStatisticsTest.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Data\AutomationStatistics;
+
+class AutomationStatisticsTest extends \MailPoetUnitTest {
+  public function testConstructorAndGetters() {
+    $stats = new AutomationStatistics(
+      123,
+      50,
+      10,
+      456,
+      30,
+      25,
+      15,
+      5,
+      299.99
+    );
+
+    $this->assertEquals(123, $stats->getAutomationId());
+    $this->assertEquals(50, $stats->getEntered());
+    $this->assertEquals(10, $stats->getInProgress());
+    $this->assertEquals(40, $stats->getExited()); // entered - inProgress
+    $this->assertEquals(456, $stats->getVersionId());
+    $this->assertEquals(30, $stats->getEmailsSent());
+    $this->assertEquals(25, $stats->getEmailsOpened());
+    $this->assertEquals(15, $stats->getEmailsClicked());
+    $this->assertEquals(5, $stats->getOrders());
+    $this->assertEquals(299.99, $stats->getRevenue());
+  }
+
+  public function testConstructorWithDefaults() {
+    $stats = new AutomationStatistics(123);
+
+    $this->assertEquals(123, $stats->getAutomationId());
+    $this->assertEquals(0, $stats->getEntered());
+    $this->assertEquals(0, $stats->getInProgress());
+    $this->assertEquals(0, $stats->getExited());
+    $this->assertNull($stats->getVersionId());
+    $this->assertEquals(0, $stats->getEmailsSent());
+    $this->assertEquals(0, $stats->getEmailsOpened());
+    $this->assertEquals(0, $stats->getEmailsClicked());
+    $this->assertEquals(0, $stats->getOrders());
+    $this->assertEquals(0.0, $stats->getRevenue());
+  }
+
+  public function testToArray() {
+    $stats = new AutomationStatistics(
+      123,
+      50,
+      10,
+      456,
+      30,
+      25,
+      15,
+      5,
+      299.99
+    );
+
+    $expected = [
+      'automation_id' => 123,
+      'totals' => [
+        'entered' => 50,
+        'in_progress' => 10,
+        'exited' => 40,
+      ],
+      'emails' => [
+        'sent' => 30,
+        'opened' => 25,
+        'clicked' => 15,
+        'orders' => 5,
+        'revenue' => 299.99,
+      ],
+    ];
+
+    $this->assertEquals($expected, $stats->toArray());
+  }
+
+  public function testToArrayWithDefaults() {
+    $stats = new AutomationStatistics(123);
+
+    $expected = [
+      'automation_id' => 123,
+      'totals' => [
+        'entered' => 0,
+        'in_progress' => 0,
+        'exited' => 0,
+      ],
+      'emails' => [
+        'sent' => 0,
+        'opened' => 0,
+        'clicked' => 0,
+        'orders' => 0,
+        'revenue' => 0.0,
+      ],
+    ];
+
+    $this->assertEquals($expected, $stats->toArray());
+  }
+
+  public function testExitedCalculation() {
+    // Test that exited is correctly calculated as entered - inProgress
+    $stats = new AutomationStatistics(123, 100, 30);
+    $this->assertEquals(70, $stats->getExited());
+
+    // Test edge case where inProgress equals entered
+    $stats = new AutomationStatistics(123, 50, 50);
+    $this->assertEquals(0, $stats->getExited());
+
+    // Test edge case where inProgress is 0
+    $stats = new AutomationStatistics(123, 25, 0);
+    $this->assertEquals(25, $stats->getExited());
+  }
+}

--- a/mailpoet/tests/unit/Automation/Engine/Data/AutomationStatisticsTest.php
+++ b/mailpoet/tests/unit/Automation/Engine/Data/AutomationStatisticsTest.php
@@ -69,8 +69,11 @@ class AutomationStatisticsTest extends \MailPoetUnitTest {
         'sent' => 30,
         'opened' => 25,
         'clicked' => 15,
-        'orders' => 5,
-        'revenue' => 299.99,
+        'revenue' => [
+          'currency' => '',
+          'value' => 299.99,
+          'count' => 5,
+        ],
       ],
     ];
 
@@ -91,8 +94,11 @@ class AutomationStatisticsTest extends \MailPoetUnitTest {
         'sent' => 0,
         'opened' => 0,
         'clicked' => 0,
-        'orders' => 0,
-        'revenue' => 0.0,
+        'revenue' => [
+          'currency' => '',
+          'value' => 0.0,
+          'count' => 0,
+        ],
       ],
     ];
 


### PR DESCRIPTION
## Description

  - Adds last automation run details to the Automations listing endpoint
  - Adds email statistics (sent, opened, clicked, revenue) to automation statistics

## Code review notes

_N/A_

## QA notes

1. Verify that automation listing works as expected

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7563](https://linear.app/a8c/issue/STOMAIL-7563)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7563-automation-listing-stats)

_The latest successful build from `stomail-7563-automation-listing-stats` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automations list now shows each automation’s most recent run (id, status, created/updated) and includes email performance metrics: sent, opened, clicked, orders, and revenue (currency, value, count).

- **Documentation**
  - Changelog updated to note inclusion of last-run details and email statistics in the Automations listing endpoint.

- **Tests**
  - Added unit and integration tests covering last-run retrieval, email statistics aggregation, defaults, and output structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->