### PR TITLE
extend mailpoet_form_widget_post_process filter args

### DIFF
--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -290,7 +290,7 @@ class Widget extends \WP_Widget {
         * @since TBD Added the $data context parameter.
         *
         * @param string                $output Rendered form HTML.
-        * @param array<string, mixed>  $filter_context_data   Rendering context (form id, type, success/error flags, etc.).
+        * @param array<string, mixed>  $filter_context_data   Rendering context (form id, type, styles, and more).
         * @return string Filtered HTML.
         */
         $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output, $filter_context_data);

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -2,9 +2,6 @@
 
 namespace MailPoet\Form;
 
-if (!defined('ABSPATH')) exit;
-
-
 use MailPoet\API\JSON\API;
 use MailPoet\Config\Env;
 use MailPoet\Config\RendererFactory;
@@ -267,16 +264,36 @@ class Widget extends \WP_Widget {
       try {
         $output = $renderer->render('form/front_end_form.html', $data);
         $output = WPFunctions::get()->doShortcode($output);
-      /**
+
+        // Define the exact keys we want to keep for the filter context
+        $allowed_keys = [
+            'form_html_id' => null,
+            'form_id' => null,
+            'form_type' => null,
+            'form_success_message' => null,
+            'title' => null,
+            'styles' => null,
+            'html' => null,
+            'before_widget' => null,
+            'after_widget' => null,
+            'before_title' => null,
+            'after_title' => null,
+        ];
+
+        // Create a new context array for the filter, containing only the allowed keys.
+        // This automatically excludes 'success', 'error', 'token', and 'api_version'.
+        $filter_context_data = array_intersect_key($data, $allowed_keys);
+        
+        /**
         * Filters the rendered MailPoet form HTML after shortcodes are processed.
         *
         * @since TBD Added the $data context parameter.
         *
         * @param string                $output Rendered form HTML.
-        * @param array<string, mixed>  $data   Rendering context (form id, type, success/error flags, nonce, etc.).
+        * @param array<string, mixed>  $filter_context_data   Rendering context (form id, type, success/error flags, etc.).
         * @return string Filtered HTML.
         */
-        $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output, $data);
+        $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output, $filter_context_data);
       } catch (\Exception $e) {
         $output = $e->getMessage();
       }

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -267,6 +267,15 @@ class Widget extends \WP_Widget {
       try {
         $output = $renderer->render('form/front_end_form.html', $data);
         $output = WPFunctions::get()->doShortcode($output);
+      /**
+        * Filters the rendered MailPoet form HTML after shortcodes are processed.
+        *
+        * @since TBD Added the $data context parameter.
+        *
+        * @param string                $output Rendered form HTML.
+        * @param array<string, mixed>  $data   Rendering context (form id, type, success/error flags, nonce, etc.).
+        * @return string Filtered HTML.
+        */
         $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output, $data);
       } catch (\Exception $e) {
         $output = $e->getMessage();

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Form;
 
+if (!defined('ABSPATH')) exit;
+
+
 use MailPoet\API\JSON\API;
 use MailPoet\Config\Env;
 use MailPoet\Config\RendererFactory;
@@ -264,7 +267,7 @@ class Widget extends \WP_Widget {
       try {
         $output = $renderer->render('form/front_end_form.html', $data);
         $output = WPFunctions::get()->doShortcode($output);
-        $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output);
+        $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output, $data);
       } catch (\Exception $e) {
         $output = $e->getMessage();
       }


### PR DESCRIPTION
…lter

## Description

This pull request simply adds the $data form data var as arg to the mailpoet_form_widget_post_process filter. By passing the $data var, users can roll there own form rendering logic with the mailpoet_form_widget_post_process widget, thereby bypass shortcommings of mailpoets own twig templates.

## Code review notes

The only change is the $data array is passed to the mailpoet_form_widget_post_process in line 270 of widget.php

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form widgets now supply a filtered rendering context to post-processing hooks, allowing plugins and extensions to make more precise, controlled modifications to widget output.
* **Chores**
  * Updated documentation and internal handling to reflect the enhanced filter parameters and ensure compatibility with third-party integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->