### PR TITLE
add front end form preprocess filter

### DIFF
--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Form;
 
+if (!defined('ABSPATH')) exit;
+
+
 use MailPoet\API\JSON\API;
 use MailPoet\Config\Env;
 use MailPoet\Config\RendererFactory;
@@ -262,6 +265,7 @@ class Widget extends \WP_Widget {
       // render form
       $renderer = (new RendererFactory())->getRenderer();
       try {
+        $data = $this->wp->applyFilters('mailpoet_form_widget_pre_process', $data);
         $output = $renderer->render('form/front_end_form.html', $data);
         $output = WPFunctions::get()->doShortcode($output);
         $output = $this->wp->applyFilters('mailpoet_form_widget_post_process', $output);


### PR DESCRIPTION
## Description

If there is a mailpoet_form_widget_post_process filter there should also be a mailpoet_form_widget_pre_process where users have the chance to change the form title, styles etc... So i would say a filter where we pass the data array would be sufficient.

## Code review notes

Just added the filter.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form widget with a pre-processing step that allows adjustments before display, enabling greater customization and better compatibility with themes and plugins. Existing forms continue to work without changes.

* **Chores**
  * Hardened the form widget against direct file access to improve security and stability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->