### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.2.1
+            ./do download:woo-commerce-zip 10.2.2
             ./do download:woo-commerce-subscriptions-zip 7.9.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
             ./do download:woo-commerce-zip 10.2.2
             ./do download:woo-commerce-subscriptions-zip 7.9.0
             ./do download:woo-commerce-memberships-zip
-            ./do download:automate-woo-zip 6.1.16
+            ./do download:automate-woo-zip 6.1.17
       - run:
           name: Dump tests ENV variables for acceptance tests
           command: |

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.8.2-php8.3}
+    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.8.3-php8.3}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WordPress image used in the testing environment to 6.8.3 (PHP 8.3).
  * Bumped plugin patch versions used during CI/test setup: WooCommerce to 10.2.2 and AutomateWoo to 6.1.17.

* **Tests**
  * Aligns automated test environment with the latest WordPress and plugin patch releases to maintain compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->