### PR TITLE
Fix the failing woo checkout blocks test

### DIFF
--- a/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
+++ b/mailpoet/tests/acceptance/Subscriptions/WooCheckoutBlocksCest.php
@@ -290,7 +290,16 @@ class WooCheckoutBlocksCest {
 
   private function placeOrder(\AcceptanceTester $i): void {
     // Add a note to order just to avoid flakiness due to race conditions
-    $i->click(Locator::contains('label', 'Add a note to your order'));
+    $i->scrollTo('.wc-block-components-checkout-place-order-button');
+    $locator = Locator::contains('label', 'Add a note to your order');
+    $i->waitForElementClickable($locator);
+    $i->wait(0.5); 
+    $i->click($locator);
+
+    // Find the checkbox and verify it's checked
+    $checkboxId = $i->grabAttributeFrom($locator, 'for');
+    $i->seeCheckboxIsChecked('#' . $checkboxId);
+
     $i->waitForElementVisible('.wc-block-components-textarea');
     $i->fillField('.wc-block-components-textarea', 'This is a note');
     $i->waitForText('Place Order');


### PR DESCRIPTION
## Description

This test has been flakey a lot recently.  And none of the builds could pass, because at least one of these tests failed. The issue was that the checkbox on the order page was not checked, and the text area didn't appear on the page, which caused the test to fail. Example is [here](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21516/workflows/855f0d8a-5e14-4985-9552-e9c18ccdcb3a/jobs/372097/tests):

<img width="1358" height="854" alt="MailPoet Test Acceptance WooCheckoutBlocksCest checkoutOptInDisabled fail" src="https://github.com/user-attachments/assets/17c8a386-7de9-4896-b32e-33a936adf071" />

The tests passed twice with this change.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-failing-woo-checkout-test)

_The latest successful build from `fix-failing-woo-checkout-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the checkout flow test for adding an order note by using more robust interactions and assertions for the note checkbox and textarea.
  * Reduced flakiness in CI by ensuring elements are visible and clickable before interaction.
  * No changes to user-facing behavior; this update strengthens automated test coverage and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->