### PR TITLE
Add WC Email for marketing confrimation

### DIFF
--- a/mailpoet/changelog/2025-10-07-14-27-49-added-add-woocommerce-email-for-marketing-confrimation.md
+++ b/mailpoet/changelog/2025-10-07-14-27-49-added-add-woocommerce-email-for-marketing-confrimation.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add WooCommerce email for marketing confirmation

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -326,6 +326,7 @@ class Initializer {
       $this->renderer = $this->rendererFactory->getRenderer();
       $this->setupWidget();
       $this->setupWoocommerceTransactionalEmails();
+      $this->setupMarketingConfirmationEmail();
       $this->assetsLoader->loadStyles();
       $this->emailEditorLogger->set_logger(new Logger());
     } catch (\Exception $e) {
@@ -563,6 +564,14 @@ class Initializer {
     if ($wcEnabled && $optInEnabled) {
       $this->wcTransactionalEmails->overrideStylesForWooEmails();
       $this->wcTransactionalEmails->useTemplateForWoocommerceEmails();
+    }
+  }
+
+  private function setupMarketingConfirmationEmail() {
+    $wcEnabled = $this->wcHelper->isWooCommerceActive();
+    if ($wcEnabled) {
+      $emails = new \MailPoet\WooCommerce\Emails();
+      $emails->init();
     }
   }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -61,6 +61,15 @@ class PersonalizationTagManager {
         null,
         [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
       ));
+      $registry->register(new Personalization_Tag(
+        __('Activation Link', 'mailpoet'),
+        'mailpoet/subscriber-activation-link',
+        __('Subscriber', 'mailpoet'),
+        [$this->subscriber, 'getActivationLink'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
 
       // Site Personalization Tags
       $registry->register(new Personalization_Tag(

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Subscriber.php
@@ -3,15 +3,18 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags;
 
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Subscription\SubscriptionUrlFactory;
 
 class Subscriber {
 
   private SubscribersRepository $subscribersRepository;
+  private SubscriptionUrlFactory $subscriptionUrlFactory;
 
   public function __construct(
     SubscribersRepository $subscribersRepository
   ) {
     $this->subscribersRepository = $subscribersRepository;
+    $this->subscriptionUrlFactory = SubscriptionUrlFactory::getInstance();
   }
 
   public function getFirstName(array $context, array $args = []): string {
@@ -30,5 +33,16 @@ class Subscriber {
 
   public function getEmail(array $context, array $args = []): string {
     return $context['recipient_email'] ?? '';
+  }
+
+  public function getActivationLink(array $context, array $args = []): string {
+    $subscriberEmail = $context['recipient_email'] ?? null;
+    $subscriber = $subscriberEmail ? $this->subscribersRepository->findOneBy(['email' => $subscriberEmail]) : null;
+
+    if (!$subscriber) {
+      return '';
+    }
+
+    return $this->subscriptionUrlFactory->getConfirmationUrl($subscriber);
   }
 }

--- a/mailpoet/lib/WooCommerce/Emails.php
+++ b/mailpoet/lib/WooCommerce/Emails.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce;
+
+use MailPoet\WooCommerce\Emails\MarketingConfirmation;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+/**
+ * WooCommerce Emails Manager
+ * 
+ * Manages registration of MailPoet emails with WooCommerce.
+ * Only available in Garden environment.
+ */
+class Emails {
+
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct() {
+    $this->dotcomHelperFunctions = new DotcomHelperFunctions();
+    $this->wp = new WPFunctions();
+  }
+
+  /**
+   * Initialize the email registration.
+   */
+  public function init() {
+    // Only register in Garden environment.
+    if (!$this->dotcomHelperFunctions->isGarden()) {
+      return;
+    }
+
+    // Register the email classes with WooCommerce.
+    $this->wp->addFilter('woocommerce_email_classes', [$this, 'registerEmailClasses']);
+    // Register the emails for the block editor.
+    $this->wp->addFilter('woocommerce_transactional_emails_for_block_editor', [$this, 'registerTransactionalEmailsForBlockEditor']);
+    // This filter is required because WCTransactionalEmailPostsGenerator does not provide the email's $template_base property when loading templates.
+    // As a result, WooCommerce attempts to load the template from its default template directory instead of MailPoet's.
+    // We need to apply this filter until this issue is addressed upstream to ensure MailPoet email templates are found.
+    $this->wp->addFilter('wc_get_template', [$this, 'locateBlockTemplate'], 10, 4);
+  }
+
+  /**
+   * Register MailPoet email classes with WooCommerce.
+   *
+   * @param array $email_classes Array of email classes.
+   * @return array Modified array of email classes.
+   */
+  public function registerEmailClasses($email_classes) {
+    $email_classes['mailpoet_marketing_confirmation'] = new MarketingConfirmation();
+    
+    return $email_classes;
+  }
+
+  /**
+   * Register MailPoet transactional emails for the block editor.
+   *
+   * @param array $emails Array of email IDs.
+   * @return array Modified array of email IDs.
+   */
+  public function registerTransactionalEmailsForBlockEditor($emails) {
+    // Register marketing confirmation email for block editor
+    $emails[] = 'mailpoet_marketing_confirmation';
+    
+    return $emails;
+  }
+
+  /**
+   * Locate block templates for MailPoet emails.
+   *
+   * @param string $template The template path.
+   * @param string $template_name The template name.
+   * @param array $args The template arguments.
+   * @param string $template_path The template path.
+   * @return string The located template path.
+   */
+  public function locateBlockTemplate($template, $template_name, $args, $template_path) {
+    // Only handle block templates for MailPoet emails
+    if (strpos($template_name, 'emails/block/marketing-confirmation.php') !== 0) {
+      return $template;
+    }
+
+    if (file_exists($template_path)) {
+        return $template;
+    }
+
+    $mailpoet_template = __DIR__ . '/Emails/Templates/' . $template_name;
+    if (file_exists($mailpoet_template)) {
+        return $mailpoet_template;
+    }
+
+    return $template;
+  }
+}

--- a/mailpoet/lib/WooCommerce/Emails.php
+++ b/mailpoet/lib/WooCommerce/Emails.php
@@ -40,6 +40,8 @@ class Emails {
     $this->wp->addFilter('woocommerce_email_classes', [$this, 'registerEmailClasses']);
     // Register the emails for the block editor.
     $this->wp->addFilter('woocommerce_transactional_emails_for_block_editor', [$this, 'registerTransactionalEmailsForBlockEditor']);
+    // Register the marketing email group title.
+    $this->wp->addFilter('woocommerce_email_groups', [$this, 'registerEmailGroups']);
     // This filter is required because WCTransactionalEmailPostsGenerator does not provide the email's $template_base property when loading templates.
     // As a result, WooCommerce attempts to load the template from its default template directory instead of MailPoet's.
     // We need to apply this filter until this issue is addressed upstream to ensure MailPoet email templates are found.
@@ -69,6 +71,20 @@ class Emails {
     $emails[] = 'mailpoet_marketing_confirmation';
     
     return $emails;
+  }
+
+  /**
+   * Register email group titles.
+   *
+   * @param array $email_groups Array of email groups.
+   * @return array Modified array of email groups.
+   */
+  public function registerEmailGroups($email_groups) {
+    if (!isset($email_groups['marketing'])) {
+      $email_groups['marketing'] = __('Marketing', 'mailpoet');
+    }
+
+    return $email_groups;
   }
 
   /**

--- a/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
@@ -16,11 +16,19 @@ if (!defined('ABSPATH')) exit;
  * Only available in Garden environment.
  */
 class MarketingConfirmation extends \WC_Email {
+  /**
+   * Email group slug.
+   *
+   * @var string
+   */
+  protected $email_group;
+
   public function __construct() {
     $this->id = 'mailpoet_marketing_confirmation';
     $this->title = __('MailPoet Marketing Confirmation', 'mailpoet');
     $this->description = __('Email sent to confirm marketing subscriptions.', 'mailpoet');
     $this->customer_email = true;
+    $this->email_group = 'marketing';
     $this->heading = $this->get_default_heading();
     $this->subject = $this->get_default_subject();
     $this->template_base = $this->get_template_base_path();

--- a/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
@@ -26,7 +26,7 @@ class MarketingConfirmation extends \WC_Email {
   public function __construct() {
     $this->id = 'mailpoet_marketing_confirmation';
     $this->title = __('MailPoet Marketing Confirmation', 'mailpoet');
-    $this->description = __('Email sent to confirm marketing subscriptions.', 'mailpoet');
+    $this->description = __('Send an email for customers to confirm their subscription to marketing emails.', 'mailpoet');
     $this->customer_email = true;
     $this->email_group = 'marketing';
     $this->heading = $this->get_default_heading();

--- a/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\WooCommerce\Emails;
+
+use MailPoet\WPCOM\DotcomHelperFunctions;
+
+if (!defined('ABSPATH')) exit;
+
+// phpcs:disable Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps -- WC_Email properties use snake case.
+// phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- WC_Email methods use snake case.
+
+/**
+ * Marketing Confirmation Email
+ * 
+ * This email is sent to confirm marketing subscriptions.
+ * Only available in Garden environment.
+ */
+class MarketingConfirmation extends \WC_Email {
+  public function __construct() {
+    $this->id = 'mailpoet_marketing_confirmation';
+    $this->title = __('MailPoet Marketing Confirmation', 'mailpoet');
+    $this->description = __('Email sent to confirm marketing subscriptions.', 'mailpoet');
+    $this->customer_email = true;
+    $this->heading = __('Confirm your subscription to {site_title}', 'mailpoet');
+    $this->subject = __('Confirm your subscription to {site_title}', 'mailpoet');
+    $this->template_base = $this->get_template_base_path();
+    $this->template_html = 'emails/marketing-confirmation.php';
+    $this->template_plain = 'emails/plain/marketing-confirmation.php';
+    $this->placeholders = [
+      '{site_title}' => $this->get_blogname(),
+      '{activation_link}' => '',
+      '{subscriber_firstname}' => '',
+    ];
+
+    // Call parent constructor
+    parent::__construct();
+  }
+
+  /**
+   * Get template base path.
+   */
+  public function get_template_base_path() {
+    return __DIR__ . '/Templates/';
+  }
+
+  /**
+   * Get email subject.
+   */
+  public function get_default_subject() {
+    return __('Confirm your subscription to {site_title}', 'mailpoet');
+  }
+
+  /**
+   * Get email heading.
+   */
+  public function get_default_heading() {
+    return __('Confirm your subscription to {site_title}', 'mailpoet');
+  }
+
+  /**
+   * Trigger the sending of this email.
+   *
+   * @param string $to Email address to send to.
+   * @param string $activation_link Activation link for the subscriber.
+   * @param string $subscriber_firstname First name of the subscriber.
+   */
+  public function trigger($to, $activation_link = '', $subscriber_firstname = '') {
+    $this->setup_locale();
+
+    if ($this->is_enabled() && $to) {
+      $this->recipient = $to;
+      $this->placeholders['{activation_link}'] = $activation_link;
+      $this->placeholders['{subscriber_firstname}'] = $subscriber_firstname;
+      
+      $this->send($to, $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments());
+    }
+
+    $this->restore_locale();
+  }
+
+  /**
+   * Get content html.
+   */
+  public function get_content_html() {
+    return wc_get_template_html(
+      $this->template_html,
+      [
+        'email_heading' => $this->get_heading(),
+        'additional_content' => $this->get_additional_content(),
+        'email' => $this,
+        'activation_link' => $this->placeholders['{activation_link}'],
+        'subscriber_firstname' => $this->placeholders['{subscriber_firstname}'],
+      ],
+      '',
+      $this->template_base
+    );
+  }
+
+  /**
+   * Get content plain.
+   */
+  public function get_content_plain() {
+    return wc_get_template_html(
+      $this->template_plain,
+      [
+        'email_heading' => $this->get_heading(),
+        'additional_content' => $this->get_additional_content(),
+        'email' => $this,
+        'activation_link' => $this->placeholders['{activation_link}'],
+        'subscriber_firstname' => $this->placeholders['{subscriber_firstname}'],
+      ],
+      '',
+      $this->template_base
+    );
+  }
+
+  /**
+   * Initialize settings form fields.
+   */
+  public function init_form_fields() {
+    $this->form_fields = [
+      'enabled' => [
+        'title' => __('Enable/Disable', 'mailpoet'),
+        'type' => 'checkbox',
+        'label' => __('Enable this email notification', 'mailpoet'),
+        'default' => 'yes',
+      ],
+      'subject' => [
+        'title' => __('Subject', 'mailpoet'),
+        'type' => 'text',
+        'desc_tip' => true,
+        'description' => sprintf(
+          // translators: %s is a list of available placeholders
+          __('Available placeholders: %s', 'mailpoet'),
+          '<code>{site_title}, {activation_link}, {subscriber_firstname}</code>'
+        ),
+        'placeholder' => $this->get_default_subject(),
+        'default' => '',
+      ],
+      'heading' => [
+        'title' => __('Email heading', 'mailpoet'),
+        'type' => 'text',
+        'desc_tip' => true,
+        'description' => sprintf(
+          // translators: %s is a list of available placeholders
+          __('Available placeholders: %s', 'mailpoet'),
+          '<code>{site_title}, {activation_link}, {subscriber_firstname}</code>'
+        ),
+        'placeholder' => $this->get_default_heading(),
+        'default' => '',
+      ],
+      'additional_content' => [
+        'title' => __('Additional content', 'mailpoet'),
+        'description' => __('Text to appear below the main email content.', 'mailpoet'),
+        'type' => 'textarea',
+        'default' => '',
+        'desc_tip' => true,
+      ],
+      'email_type' => [
+        'title' => __('Email type', 'mailpoet'),
+        'type' => 'select',
+        'description' => __('Choose which format of email to send.', 'mailpoet'),
+        'default' => 'html',
+        'class' => 'email_type wc-enhanced-select',
+        'options' => $this->get_email_type_options(),
+        'desc_tip' => true,
+      ],
+    ];
+  }
+
+  /**
+   * Check if this email should be available.
+   */
+  public static function is_available() {
+    $dotcomHelperFunctions = new DotcomHelperFunctions();
+    // Only available in Garden environment.
+    return $dotcomHelperFunctions->isGarden();
+  }
+}

--- a/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
@@ -21,7 +21,7 @@ class MarketingConfirmation extends \WC_Email {
    *
    * @var string
    */
-  protected $email_group;
+  public $email_group;
 
   public function __construct() {
     $this->id = 'mailpoet_marketing_confirmation';

--- a/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
@@ -21,8 +21,8 @@ class MarketingConfirmation extends \WC_Email {
     $this->title = __('MailPoet Marketing Confirmation', 'mailpoet');
     $this->description = __('Email sent to confirm marketing subscriptions.', 'mailpoet');
     $this->customer_email = true;
-    $this->heading = __('Confirm your subscription to {site_title}', 'mailpoet');
-    $this->subject = __('Confirm your subscription to {site_title}', 'mailpoet');
+    $this->heading = $this->get_default_heading();
+    $this->subject = $this->get_default_subject();
     $this->template_base = $this->get_template_base_path();
     $this->template_html = 'emails/marketing-confirmation.php';
     $this->template_plain = 'emails/plain/marketing-confirmation.php';

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/block/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/block/marketing-confirmation.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Marketing Confirmation Email Template (Blocks)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/block/marketing-confirmation.php.
+ *
+ * @package MailPoet
+ * @version 1.0.0
+ */
+
+defined('ABSPATH') || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+// phpcs:disable Generic.Files.InlineHTML.Found
+?>
+
+<!-- wp:heading {"level":1,"textAlign":"center"} -->
+<h1 class="wp-block-heading has-text-align-center"><?php
+  /* translators: %s: Site title */
+  printf(esc_html__('Confirm your subscription to %s', 'mailpoet'), '<!--[woocommerce/site-title]-->');
+?></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>
+  <?php
+  echo sprintf(
+    /* translators: %s: Subscriber first name */
+    esc_html__('Hello %s,', 'mailpoet'),
+    sprintf(
+      '<!--[mailpoet/subscriber-firstname default="%s"]-->',
+      /* translators: %s: Default placeholder used when no subscriber name is available, e.g. "Hello there" */
+      esc_html(_x('there', 'subscriber name placeholder', 'mailpoet'))
+    )
+  );
+  ?>
+<br>
+<?php
+  /* translators: %s: Site title */
+  printf(esc_html__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), '<!--[woocommerce/site-title]-->');
+?></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="[mailpoet/subscriber-activation-link]"><?php echo esc_html__('Click here to confirm your subscription', 'mailpoet'); ?></a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:paragraph -->
+<p><?php echo esc_html__('Thank you,', 'mailpoet'); ?><br>
+<a href="[woocommerce/site-homepage-url]"><!--[woocommerce/site-title]--></a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p><?php echo esc_html__('If you received this email by mistake, simply delete it. You won\'t receive any more emails from us unless you confirm your subscription using the link above.', 'mailpoet'); ?></p>
+<!-- /wp:paragraph -->
+

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
@@ -29,14 +29,14 @@ do_action('woocommerce_email_header', $email_heading, $email); ?>
 <p>
 <?php
   /* translators: %s: Subscriber first name */
-  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), esc_html($subscriber_firstname ?: _x('there', 'subscriber name placeholder', 'mailpoet'))));
+  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: _x('there', 'subscriber name placeholder', 'mailpoet')));
 ?>
 </p>
 
 <p>
 <?php
   /* translators: %s: Site name */
-  echo esc_html(sprintf(__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), esc_html(get_bloginfo('name'))));
+  echo esc_html(sprintf(__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), get_bloginfo('name')));
 ?>
 </p>
 

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Marketing Confirmation Email Template
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/marketing-confirmation.php.
+ *
+ * @var WC_Email $email
+ * @var string $email_heading
+ * @var string $subscriber_firstname
+ * @var string $activation_link
+ * @var string $additional_content
+ *
+ * @package MailPoet
+ * @version 1.0.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// @phpcs:disable Generic.Files.InlineHTML.Found
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action('woocommerce_email_header', $email_heading, $email); ?>
+
+<p>
+<?php
+  /* translators: %s: Subscriber first name */
+  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), esc_html($subscriber_firstname ?: _x('there', 'subscriber name placeholder', 'mailpoet'))));
+?>
+</p>
+
+<p>
+<?php
+  /* translators: %s: Site name */
+  echo esc_html(sprintf(__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), esc_html(get_bloginfo('name'))));
+?>
+</p>
+
+<p><a href="<?php echo esc_url($activation_link); ?>"><?php esc_html_e('Click here to confirm your subscription', 'mailpoet'); ?></a></p>
+
+<p><?php esc_html_e('Thank you,', 'mailpoet'); ?><br>
+<a href="<?php echo esc_url(home_url()); ?>"><?php echo esc_html(get_bloginfo('name')); ?></a>
+</p>
+
+<?php if ($additional_content) : ?>
+    <p><?php echo wp_kses_post($additional_content); ?></p>
+<?php endif; ?>
+
+<p><?php echo esc_html__('If you received this email by mistake, simply delete it. You won\'t receive any more emails from us unless you confirm your subscription using the link above.', 'mailpoet'); ?></p>
+
+<?php
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action('woocommerce_email_footer', $email);

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
@@ -24,11 +24,11 @@ echo esc_html($email_heading);
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Subscriber first name */
-echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), esc_html($subscriber_firstname ?: __('there', 'mailpoet'))));
+echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: __('there', 'mailpoet')));
 echo "\n\n";
 
 /* translators: %s: Site name */
-echo esc_html(sprintf(__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), esc_html(get_bloginfo('name'))));
+echo esc_html(sprintf(__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), get_bloginfo('name')));
 echo "\n\n";
 
 esc_html_e('Click here to confirm your subscription:', 'mailpoet');

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Marketing Confirmation Email Template (Plain)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/marketing-confirmation.php.
+ *
+ * @var WC_Email $email
+ * @var string $email_heading
+ * @var string $subscriber_firstname
+ * @var string $activation_link
+ * @var string $additional_content
+ *
+ * @package MailPoet
+ * @version 1.0.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html($email_heading);
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %s: Subscriber first name */
+echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), esc_html($subscriber_firstname ?: __('there', 'mailpoet'))));
+echo "\n\n";
+
+/* translators: %s: Site name */
+echo esc_html(sprintf(__('You\'ve received this message because you subscribed to %s. Please confirm your subscription to receive emails from us:', 'mailpoet'), esc_html(get_bloginfo('name'))));
+echo "\n\n";
+
+esc_html_e('Click here to confirm your subscription:', 'mailpoet');
+echo "\n";
+echo esc_url($activation_link);
+echo "\n\n";
+
+esc_html_e('Thank you,', 'mailpoet');
+echo "\n";
+echo esc_html(get_bloginfo('name'));
+echo "\n";
+echo esc_url(home_url());
+
+if ($additional_content) {
+    echo "\n\n" . esc_html(wp_strip_all_tags($additional_content));
+}
+
+echo "\n\n" . esc_html__('If you received this email by mistake, simply delete it. You won\'t receive any more emails from us unless you confirm your subscription using the link above.', 'mailpoet');


### PR DESCRIPTION
## Description

This PR introduces WooCommerce email for the Marketing Confirmation email. It is intended for use within the CIAB environment.

Closes [WOOPRD-815: Add email for marketing confirmation](https://linear.app/a8c/issue/WOOPRD-815/add-email-for-marketing-confirmation).

## Code review notes

This PR implements a `wc_get_template` filter as a temporary workaround for an issue where the `WCTransactionalEmailPostsGenerator` attempts to load the block template from the core templates directory.

An upstream fix has been proposed in https://github.com/woocommerce/woocommerce/pull/61305 to address this issue permanently.

## QA notes

To simulate Garden environment, you can use the following snippet (added via plugin like `Code Snippets` or creating a custom plugin):

```php
if (!function_exists('get_site')) {
	function get_site() {
		return true;
	}
}

if (!function_exists('is_blog_garden')) {
	function is_blog_garden() {
		return true;
	}
}
```

1. Install and activate WooCommerce.
2. Enable email block editor from WooCommerce > Settings > Advanced > Features > **Block Email Editor (alpha)**
3. If you had the email editor enabled prior to testing this PR, you may need to force the email templates generation by deleting the `_transient_wc_email_editor_initial_templates_generated` option.
4. Navigate to WooCommerce > Settings > **Emails** and confirm the `MailPoet Marketing Confirmation` is in the emails list.
5. Add a new subscriber from MailPoet > Subscribers > **Add new subscriber** and then use the **Resend confirmation email** action from the subscribers listing MailPoet > **Subscribers**.
6. Disable the email editor from WooCommerce > Settings > Advanced > Features > **Block Email Editor (alpha)** and **Resend confirmation email** confirmation again to confirm the non-block editor templates work correctly.


## Linked PRs

https://github.com/woocommerce/woocommerce/pull/61305

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wooprd-815-add-email-for-marketing-confirmation)

_The latest successful build from `wooprd-815-add-email-for-marketing-confirmation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WooCommerce-powered marketing confirmation email (HTML, plain-text, and block templates), registerable and configurable in WooCommerce when integration is active.
  * Added a personalization tag for inserting a subscriber activation link into emails.
  * Confirmation emails will prefer WooCommerce delivery when available, with fallback to the existing MailPoet path.

* **Documentation**
  * Added changelog entry documenting the new marketing confirmation email and activation-link tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->