### PR TITLE
feat: add WPML translation support for WooCommerce subscription opt-in label

### DIFF
--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -139,6 +139,11 @@ class Settings extends APIEndpoint {
       $signupConfirmation = $this->settings->get('signup_confirmation.enabled');
       foreach ($settings as $name => $value) {
         $this->settings->set($name, $value);
+        
+        // Register WooCommerce opt-in message with WPML for translation
+        if ($name === 'woocommerce.optin_on_checkout.message' && function_exists('icl_register_string')) {
+          icl_register_string('mailpoet', 'woocommerce_checkout_optin_message', $value);
+        }
       }
 
       $this->onSettingsChange($oldSettings, $this->settings->getAll());

--- a/mailpoet/lib/API/JSON/v1/Settings.php
+++ b/mailpoet/lib/API/JSON/v1/Settings.php
@@ -141,8 +141,8 @@ class Settings extends APIEndpoint {
         $this->settings->set($name, $value);
         
         // Register WooCommerce opt-in message with WPML for translation
-        if ($name === 'woocommerce.optin_on_checkout.message' && function_exists('icl_register_string')) {
-          icl_register_string('mailpoet', 'woocommerce_checkout_optin_message', $value);
+        if ($name === 'woocommerce.optin_on_checkout.message') {
+          \MailPoet\WooCommerce\Subscription::registerOptinMessageWithWPML($value);
         }
       }
 

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -310,20 +310,15 @@ class Hooks {
     // In some cases on multisite instance, this code may run before DB migrator and settings table is not ready at that time
     try {
       $optInEnabled = (bool)$this->settings->get(Subscription::OPTIN_ENABLED_SETTING_NAME, false);
+      
+      // Register WooCommerce opt-in message with WPML for translation
+      $optInMessage = $this->settings->get(Subscription::OPTIN_MESSAGE_SETTING_NAME);
+      if ($optInMessage) {
+        Subscription::registerOptinMessageWithWPML($optInMessage);
+      }
     } catch (\Exception $e) {
       $optInEnabled = false;
-    }
-    
-    // Register WooCommerce opt-in message with WPML for translation
-    if (function_exists('icl_register_string')) {
-      try {
-        $optInMessage = $this->settings->get(Subscription::OPTIN_MESSAGE_SETTING_NAME);
-        if ($optInMessage) {
-          icl_register_string('mailpoet', 'woocommerce_checkout_optin_message', $optInMessage);
-        }
-      } catch (\Exception $e) {
-        // Silently fail if settings are not ready
-      }
+      // Silently fail if settings are not ready
     }
     
     // WooCommerce: subscribe on checkout

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -313,6 +313,19 @@ class Hooks {
     } catch (\Exception $e) {
       $optInEnabled = false;
     }
+    
+    // Register WooCommerce opt-in message with WPML for translation
+    if (function_exists('icl_register_string')) {
+      try {
+        $optInMessage = $this->settings->get(Subscription::OPTIN_MESSAGE_SETTING_NAME);
+        if ($optInMessage) {
+          icl_register_string('mailpoet', 'woocommerce_checkout_optin_message', $optInMessage);
+        }
+      } catch (\Exception $e) {
+        // Silently fail if settings are not ready
+      }
+    }
+    
     // WooCommerce: subscribe on checkout
     if ($optInEnabled) {
       $optInPosition = $this->settings->get(Subscription::OPTIN_POSITION_SETTING_NAME, self::DEFAULT_OPTIN_POSITION);

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -111,6 +111,23 @@ class Subscription {
   }
 
   /**
+   * Register opt-in message string with WPML for translation.
+   *
+   * @param string $message The opt-in message to register
+   */
+  public static function registerOptinMessageWithWPML($message) {
+    if (function_exists('icl_register_string')) {
+      try {
+        if (is_string($message) && !empty($message)) {
+          icl_register_string('mailpoet', 'woocommerce_checkout_optin_message', $message);
+        }
+      } catch (\Exception $e) {
+        // Silently fail if WPML registration fails
+      }
+    }
+  }
+
+  /**
    * Generate the subscription checkbox field HTML with WPML translation support.
    *
    * @param string $inputName The name attribute for the checkbox input

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -113,9 +113,12 @@ class Subscription {
   private function getSubscriptionField($inputName, $checked, $labelString) {
     $checked = checked($checked, true, false);
 
+    // Make the label string translatable with WPML
+    $translatedLabel = $this->wp->applyFilters('wpml_translate_single_string', $labelString, 'mailpoet', 'woocommerce_checkout_optin_message');
+    
     return '<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox" data-automation-id="woo-commerce-subscription-opt-in">
       <input id="mailpoet_woocommerce_checkout_optin" class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" ' . $checked . ' type="checkbox" name="' . $this->wp->escAttr($inputName) . '" value="1" />
-      <span>' . $this->wp->escHtml($labelString) . '</span>
+      <span>' . $this->wp->escHtml($translatedLabel) . '</span>
     </label>';
   }
 

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -110,6 +110,14 @@ class Subscription {
     }
   }
 
+  /**
+   * Generate the subscription checkbox field HTML with WPML translation support.
+   *
+   * @param string $inputName The name attribute for the checkbox input
+   * @param bool $checked Whether the checkbox should be checked
+   * @param string $labelString The label text to display (will be translated via WPML if available)
+   * @return string HTML markup for the subscription checkbox field
+   */
   private function getSubscriptionField($inputName, $checked, $labelString) {
     $checked = checked($checked, true, false);
 


### PR DESCRIPTION
## Description
Added WPML translation support for the WooCommerce checkout opt-in message to enable multilingual stores to translate the subscription checkbox label.

## QA notes
- Install and activate WPML
- Go to MailPoet → Settings → WooCommerce and set a custom opt-in message
- Go to WPML → String Translation
- Search for "mailpoet" or "woocommerce_checkout_optin_message"
- Translate the string to another language
- Switch site language and verify the translated message appears on WooCommerce checkout

## Linked ticket(s)
#6365

## Changelog entry
- Changed: WooCommerce checkout opt-in message is now translatable with WPML

## Translation best practices
✅ Translation ready

## Test coverage
✅ Existing tests cover the functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added translation support for the WooCommerce checkout opt‑in message via WPML, enabling multilingual stores to localize the consent text.
  * Subscription field labels in WooCommerce are now translatable via WPML for consistent localization across checkout.
* Bug Fixes
  * Ensured the translated value is correctly displayed for subscription fields when translations are available.
* Chores
  * Automatically registers the checkout opt‑in message for translation when settings are saved, reducing manual setup for multilingual sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->