### PR TITLE
Fix fatal error when activating MailPoet on multisite websites

### DIFF
--- a/mailpoet/lib/Captcha/CaptchaHooks.php
+++ b/mailpoet/lib/Captcha/CaptchaHooks.php
@@ -23,13 +23,19 @@ class CaptchaHooks {
   }
 
   public function isEnabled(): bool {
-    if (!$this->settings->get(CaptchaConstants::ON_REGISTER_FORMS_SETTING_NAME, false)) {
+    // In some cases on multisite instance or during fresh install, this code may run
+    // before DB migrator and settings table is not ready at that time
+    try {
+      if (!$this->settings->get(CaptchaConstants::ON_REGISTER_FORMS_SETTING_NAME, false)) {
+        return false;
+      }
+
+      $type = $this->settings->get('captcha.type');
+      return CaptchaConstants::isBuiltIn($type)
+        || (CaptchaConstants::isDisabled($type) && $this->captchaRenderer->isSupported());
+    } catch (\Exception $e) {
       return false;
     }
-
-    $type = $this->settings->get('captcha.type');
-    return CaptchaConstants::isBuiltIn($type)
-      || (CaptchaConstants::isDisabled($type) && $this->captchaRenderer->isSupported());
   }
 
   public function renderInWPRegisterForm() {

--- a/mailpoet/lib/Captcha/ReCaptchaHooks.php
+++ b/mailpoet/lib/Captcha/ReCaptchaHooks.php
@@ -41,13 +41,19 @@ class ReCaptchaHooks {
   }
 
   public function isEnabled(): bool {
-    if (!$this->settings->get(CaptchaConstants::ON_REGISTER_FORMS_SETTING_NAME, false)) {
+    // In some cases on multisite instance or during fresh install, this code may run
+    // before DB migrator and settings table is not ready at that time
+    try {
+      if (!$this->settings->get(CaptchaConstants::ON_REGISTER_FORMS_SETTING_NAME, false)) {
+        return false;
+      }
+
+      return CaptchaConstants::isReCaptcha(
+        $this->settings->get('captcha.type')
+      );
+    } catch (\Exception $e) {
       return false;
     }
-
-    return CaptchaConstants::isReCaptcha(
-      $this->settings->get('captcha.type')
-    );
   }
 
   public function enqueueScripts() {


### PR DESCRIPTION
## Description

Hooks are setup during `plugins_loaded` action (during which Captcha and ReCaptcha tries to fetch settings from non-existent database tables), which is triggered before `init` when the database is initialized. For some reason, this works on normal website. But it doesn't on multisite installations. This try/catch fixes that. 

Related discussion - p1760105796165939/1759390744.524029-slack-C02G2HLNB1R

## Code review notes

The same was already implemented in https://github.com/mailpoet/mailpoet/blob/fed992a7f59be3aa723f6b5cedc2d94401a7e331/mailpoet/lib/Config/Hooks.php#L176-L182 and https://github.com/mailpoet/mailpoet/blob/fed992a7f59be3aa723f6b5cedc2d94401a7e331/mailpoet/lib/Config/Hooks.php#L309-L315

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7431

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7431)

_The latest successful build from `stomail-7431` will be used. If none is available, the link won't work._