### PR TITLE
Allow customizing built-in CAPTCHA page

### DIFF
--- a/mailpoet/assets/js/src/settings/components/pages-select.tsx
+++ b/mailpoet/assets/js/src/settings/components/pages-select.tsx
@@ -13,7 +13,8 @@ type Props = {
     | 'unsubscribe'
     | 'confirm'
     | 'confirm_unsubscribe'
-    | 're_engagement';
+    | 're_engagement'
+    | 'captcha';
 };
 
 export function PageSelect(props: Props) {

--- a/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
@@ -13,6 +13,7 @@ import { RecalculateSubscriberScore } from './recalculate-subscriber-score';
 import { Logging } from './logging';
 import { BounceAddress } from './bounce-address';
 import { CaptchaOnSignup } from './captcha-on-signup';
+import { CaptchaPage } from './captcha-page';
 import { UseBlockEditorForAutomation } from './use-block-editor-for-automation';
 
 export function Advanced() {
@@ -29,6 +30,7 @@ export function Advanced() {
       <ShareData />
       <Libs3rdParty />
       <Captcha />
+      <CaptchaPage />
       <CaptchaOnSignup />
       <UseBlockEditorForAutomation />
       <Reinstall />

--- a/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
@@ -1,4 +1,5 @@
 import { SaveButton } from 'settings/components';
+import { useSetting } from 'settings/store/hooks';
 import { TaskScheduler } from './task-scheduler';
 import { Roles } from './roles';
 import { EngagementTracking } from './engagement-tracking';
@@ -17,6 +18,8 @@ import { CaptchaPage } from './captcha-page';
 import { UseBlockEditorForAutomation } from './use-block-editor-for-automation';
 
 export function Advanced() {
+  const [captchaType] = useSetting('captcha', 'type');
+
   return (
     <div className="mailpoet-settings-grid">
       <BounceAddress />
@@ -30,7 +33,7 @@ export function Advanced() {
       <ShareData />
       <Libs3rdParty />
       <Captcha />
-      <CaptchaPage />
+      {captchaType === 'built-in' && <CaptchaPage />}
       <CaptchaOnSignup />
       <UseBlockEditorForAutomation />
       <Reinstall />

--- a/mailpoet/assets/js/src/settings/pages/advanced/captcha-page.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/captcha-page.tsx
@@ -18,7 +18,7 @@ export function CaptchaPage() {
           <>
             {ReactStringReplace(
               __(
-                "Built-in CAPTCHA is shown when users need to verify they're not a robot. You can customize this page by editing it in WordPress and using the [mailpoet_page] shortcode to display the CAPTCHA form.",
+                'Built-in CAPTCHA is shown when users need to verify they’re not a robot. You can customize this page by editing it in WordPress and using the [mailpoet_page] shortcode to display the CAPTCHA form.',
                 'mailpoet',
               ),
               '[mailpoet_page]',

--- a/mailpoet/assets/js/src/settings/pages/advanced/captcha-page.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/captcha-page.tsx
@@ -1,0 +1,43 @@
+import ReactStringReplace from 'react-string-replace';
+import { __ } from '@wordpress/i18n';
+import { useSetting } from 'settings/store/hooks';
+import { Inputs, Label, PageSelect } from 'settings/components';
+
+export function CaptchaPage() {
+  const [captchaPage, setCaptchaPage] = useSetting(
+    'subscription',
+    'pages',
+    'captcha',
+  );
+
+  return (
+    <>
+      <Label
+        title={__('Built-in CAPTCHA page', 'mailpoet')}
+        description={
+          <>
+            {ReactStringReplace(
+              __(
+                "Built-in CAPTCHA is shown when users need to verify they're not a robot. You can customize this page by editing it in WordPress and using the [mailpoet_page] shortcode to display the CAPTCHA form.",
+                'mailpoet',
+              ),
+              '[mailpoet_page]',
+              () => (
+                <code key="mp">[mailpoet_page]</code>
+              ),
+            )}
+          </>
+        }
+        htmlFor="subscription-pages-captcha"
+      />
+      <Inputs>
+        <PageSelect
+          value={captchaPage}
+          preview="captcha"
+          setValue={setCaptchaPage}
+          id="subscription-pages-captcha"
+        />
+      </Inputs>
+    </>
+  );
+}

--- a/mailpoet/changelog/2025-10-11-21-07-55-added-setting-to-customize-built-in-captcha-page.md
+++ b/mailpoet/changelog/2025-10-11-21-07-55-added-setting-to-customize-built-in-captcha-page.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+setting to customize built-in CAPTCHA page

--- a/mailpoet/lib/Captcha/CaptchaUrlFactory.php
+++ b/mailpoet/lib/Captcha/CaptchaUrlFactory.php
@@ -57,6 +57,38 @@ class CaptchaUrlFactory {
     );
   }
 
+  public function getCaptchaPreviewUrl($post = null) {
+    if ($post === null) {
+      $post = $this->wp->getPost($this->settings->get('subscription.pages.captcha'));
+    }
+    if ($post === null) return;
+
+    $url = $this->wp->getPermalink($post);
+
+    // Use preview session ID for preview
+    $data = [
+      'captcha_session_id' => 'preview',
+      'referrer_form' => self::REFERER_MP_FORM,
+      'preview' => 1,
+    ];
+
+    $params = [
+      Router::NAME,
+      'endpoint=' . CaptchaEndpoint::ENDPOINT,
+      'action=' . CaptchaEndpoint::ACTION_RENDER,
+      'data=' . Router::encodeRequestData($data),
+    ];
+
+    $url .= (parse_url($url, PHP_URL_QUERY) ? '&' : '?') . join('&', $params);
+
+    $urlParams = parse_url($url);
+    if (!is_array($urlParams) || empty($urlParams['scheme'])) {
+      $url = $this->wp->getBloginfo('url') . $url;
+    }
+
+    return $url;
+  }
+
   private function getUrl(string $action, array $data) {
     $post = $this->wp->getPost($this->settings->get('subscription.pages.captcha'));
     $url = $this->wp->getPermalink($post);

--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -70,9 +70,17 @@ class PageRenderer {
   public function setPageContent($pageContent) {
     $this->assetsController->setupFrontEndDependencies();
 
-    $content = $this->formRenderer->render($this->data);
-    if (!$content) {
-      return false;
+    // For preview, show a placeholder message since we don't have a real captcha session
+    if (isset($this->data['preview']) && $this->data['preview']) {
+      $content = '<div class="mailpoet_captcha_preview">' .
+        '<p>' . __('This is a preview of the CAPTCHA page.', 'mailpoet') . '</p>' .
+        '<p>' . __('When users need to verify they\'re not a robot, the CAPTCHA form will be displayed here.', 'mailpoet') . '</p>' .
+        '</div>';
+    } else {
+      $content = $this->formRenderer->render($this->data);
+      if (!$content) {
+        return false;
+      }
     }
 
     return str_replace('[mailpoet_page]', trim($content), $pageContent);

--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -74,7 +74,7 @@ class PageRenderer {
     if (isset($this->data['preview']) && $this->data['preview']) {
       $content = '<div class="mailpoet_captcha_preview">' .
         '<p>' . __('This is a preview of the CAPTCHA page.', 'mailpoet') . '</p>' .
-        '<p>' . __('When users need to verify they\'re not a robot, the CAPTCHA form will be displayed here.', 'mailpoet') . '</p>' .
+        '<p>' . __('When users need to verify they’re not a robot, the CAPTCHA form will be displayed here.', 'mailpoet') . '</p>' .
         '</div>';
     } else {
       $content = $this->formRenderer->render($this->data);

--- a/mailpoet/lib/Settings/Pages.php
+++ b/mailpoet/lib/Settings/Pages.php
@@ -117,6 +117,7 @@ class Pages {
 
   public static function getPageData($page) {
     $subscriptionUrlFactory = Subscription\SubscriptionUrlFactory::getInstance();
+    $captchaUrlFactory = \MailPoet\DI\ContainerWrapper::getInstance()->get(\MailPoet\Captcha\CaptchaUrlFactory::class);
     return [
       'id' => $page->ID,
       'title' => $page->post_title, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
@@ -126,6 +127,7 @@ class Pages {
         'confirm' => $subscriptionUrlFactory->getSubscriptionUrl($page, 'confirm'),
         'confirm_unsubscribe' => $subscriptionUrlFactory->getSubscriptionUrl($page, 'confirm_unsubscribe'),
         're_engagement' => $subscriptionUrlFactory->getSubscriptionUrl($page, 're_engagement'),
+        'captcha' => $captchaUrlFactory->getCaptchaPreviewUrl($page),
       ],
     ];
   }

--- a/mailpoet/tests/integration/Captcha/CaptchaUrlFactoryTest.php
+++ b/mailpoet/tests/integration/Captcha/CaptchaUrlFactoryTest.php
@@ -53,4 +53,24 @@ class CaptchaUrlFactoryTest extends \MailPoetTest {
     verify($url)->stringContainsString('endpoint=' . CaptchaEndpoint::ENDPOINT);
     verify($url)->stringContainsString('data=');
   }
+
+  public function testItReturnsCaptchaPreviewUrl() {
+    $url = $this->urlFactory->getCaptchaPreviewUrl();
+
+    verify($url)->notNull();
+    verify($url)->stringContainsString(Router::NAME);
+    verify($url)->stringContainsString('mailpoet_page=' . Pages::PAGE_CAPTCHA);
+    verify($url)->stringContainsString('action=' . CaptchaEndpoint::ACTION_RENDER);
+    verify($url)->stringContainsString('endpoint=' . CaptchaEndpoint::ENDPOINT);
+    verify($url)->stringContainsString('data=');
+  }
+
+  public function testItReturnsNullWhenNoCaptchaPageSet() {
+    $settings = $this->diContainer->get(\MailPoet\Settings\SettingsController::class);
+    $settings->set('subscription.pages.captcha', null);
+
+    $url = $this->urlFactory->getCaptchaPreviewUrl();
+
+    verify($url)->null();
+  }
 }

--- a/mailpoet/tests/integration/Settings/PagesTest.php
+++ b/mailpoet/tests/integration/Settings/PagesTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Settings;
+
+use MailPoet\Settings\Pages;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+
+class PagesTest extends \MailPoetTest {
+
+  private SettingsController $settings;
+  private WPFunctions $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->settings = $this->diContainer->get(SettingsController::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+  }
+
+  public function testGetPageDataIncludesCaptchaUrl() {
+    // Create a test page
+    $postId = Pages::createMailPoetPage('test-page');
+    $post = $this->wp->getPost($postId);
+
+    // Set up captcha page setting
+    $captchaPostId = Pages::createMailPoetPage('captcha-page');
+    $this->settings->set('subscription.pages.captcha', $captchaPostId);
+
+    $pageData = Pages::getPageData($post);
+
+    verify($pageData)->isArray();
+    verify($pageData['id'])->equals($postId);
+    verify($pageData['title'])->equals(Pages::PAGE_TITLE);
+    verify($pageData['url'])->isArray();
+    verify($pageData['url']['captcha'])->notNull();
+  }
+
+  public function testGetPageDataIncludesAllRequiredUrls() {
+    // Create a test page
+    $postId = Pages::createMailPoetPage('test-page');
+    $post = $this->wp->getPost($postId);
+
+    // Set up captcha page setting
+    $captchaPostId = Pages::createMailPoetPage('captcha-page');
+    $this->settings->set('subscription.pages.captcha', $captchaPostId);
+
+    $pageData = Pages::getPageData($post);
+
+    verify($pageData['url'])->isArray();
+    verify($pageData['url'])->arrayHasKey('unsubscribe');
+    verify($pageData['url'])->arrayHasKey('manage');
+    verify($pageData['url'])->arrayHasKey('confirm');
+    verify($pageData['url'])->arrayHasKey('confirm_unsubscribe');
+    verify($pageData['url'])->arrayHasKey('re_engagement');
+    verify($pageData['url'])->arrayHasKey('captcha');
+  }
+}


### PR DESCRIPTION
## Description

Add new setting to allow customizing a page for built-in CAPTCHA, similarly to how other pages can be set.

| <img width="719" height="347" alt="Screenshot 2025-10-11 at 23 01 42" src="https://github.com/user-attachments/assets/25dea93d-165f-436d-a558-fcbdc5b261b5" /> |  <img width="984" height="1072" alt="Screenshot 2025-10-11 at 23 02 26" src="https://github.com/user-attachments/assets/e0934f2a-3a5d-480b-8746-783b5bf4c978" /> |
| ----- | ---- |

## Code review notes

_N/A_

## QA notes

1. Check that built-in CAPTCHA continues to render properly by default.
2. Change the new setting to any different page and verify, that it still renders as expected. 

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7586

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7586-allow-customizing-captcha-page)

_The latest successful build from `stomail-7586-allow-customizing-captcha-page` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to select and customize the built-in CAPTCHA page; CAPTCHA now appears in the page selector with live preview support.
  * Advanced settings display the CAPTCHA page option when the built-in CAPTCHA is enabled.
  * Backend can generate CAPTCHA preview URLs and render a preview placeholder for previews.

* **Documentation**
  * Changelog updated to document the new CAPTCHA customization setting.

* **Tests**
  * Integration tests added to validate CAPTCHA preview URL generation and inclusion in page data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->