### PR TITLE
Allow filtering newsletters by segments and sent_at date

### DIFF
--- a/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
+++ b/mailpoet/lib/Newsletter/Listing/NewsletterListingRepository.php
@@ -223,11 +223,11 @@ class NewsletterListingRepository extends ListingRepository {
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
     $segmentId = $filters['segment'] ?? null;
-    if ($segmentId) {
+    if ($segmentId && is_numeric($segmentId)) {
       $queryBuilder
         ->join('n.newsletterSegments', 'ns')
         ->andWhere('ns.segment = :segmentId')
-        ->setParameter('segmentId', $segmentId);
+        ->setParameter('segmentId', (int)$segmentId);
     }
   }
 


### PR DESCRIPTION
## Description

Improve `NewsletterListingRepository.php` to accept and implement filtering by `sent_at` and `segment_ids`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7571

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7571)

_The latest successful build from `stomail-7571` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced newsletter filters: sent date range (from/to) with validation and stricter validation for segment inputs.
  * Added segment operators to include any selected segments or exclude selected segments; supports combining date and segment filters.

* **Tests**
  * Added integration tests covering date range filtering, segment operator behaviors (any/none), multi-segment scenarios, scheduled newsletters, and combined filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->