### PR TITLE
Improve the changelog creation

### DIFF
--- a/mailpoet/tasks/release/Changelogger.php
+++ b/mailpoet/tasks/release/Changelogger.php
@@ -169,6 +169,16 @@ class Changelogger {
       throw new \Exception("Invalid changelog type: $type");
     }
 
+    // Trim whitespace and remove trailing punctuation
+    $description = trim($description);
+    $description = rtrim($description, '.!?;,');
+    // Ensure description starts with a capital letter
+    $description = ucfirst($description);
+
+    if (empty($description)) {
+      throw new \Exception("Description cannot be empty");
+    }
+
     if (!is_dir($this->changelogDir)) {
       mkdir($this->changelogDir, 0755, true);
     }


### PR DESCRIPTION
## Description

Remove any trailing space, interpunction and make sure the changelog starts with a capital letter

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:improve-changelog-generation)

_The latest successful build from `improve-changelog-generation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardizes changelog entry text: trims whitespace, strips trailing punctuation (., !, ?, ;, ,), and capitalizes the first character for improved readability.

* **Chores**
  * Normalizes descriptions before changelog entries are created and validates them; empty descriptions are now rejected to ensure meaningful entries and consistent release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->