### PR TITLE
Add email templates for garden environment

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -5,6 +5,7 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
 use MailPoet\EmailEditor\Integrations\MailPoet\Templates\TemplatesController;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 class EmailEditor {
   const MAILPOET_EMAIL_POST_TYPE = 'mailpoet_email';
@@ -25,6 +26,8 @@ class EmailEditor {
 
   private TemplatesController $templatesController;
 
+  private DotcomHelperFunctions $dotcomHelperFunctions;
+
   public function __construct(
     WPFunctions $wp,
     EmailApiController $emailApiController,
@@ -33,6 +36,7 @@ class EmailEditor {
     PatternsController $patternsController,
     TemplatesController $templatesController,
     Cli $cli,
+    DotcomHelperFunctions $dotcomHelperFunctions,
     PersonalizationTagManager $personalizationTagManager
   ) {
     $this->wp = $wp;
@@ -41,6 +45,7 @@ class EmailEditor {
     $this->patternsController = $patternsController;
     $this->templatesController = $templatesController;
     $this->cli = $cli;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
     $this->emailEditorPreviewEmail = $emailEditorPreviewEmail;
     $this->personalizationTagManager = $personalizationTagManager;
   }
@@ -52,8 +57,11 @@ class EmailEditor {
     $this->wp->addFilter('woocommerce_is_email_editor_page', [$this, 'isEditorPage'], 10, 1);
     $this->wp->addFilter('replace_editor', [$this, 'replaceEditor'], 10, 2);
     $this->wp->addFilter('woocommerce_email_editor_send_preview_email', [$this->emailEditorPreviewEmail, 'sendPreviewEmail'], 10, 1);
-    $this->patternsController->registerPatterns();
-    $this->templatesController->initialize();
+    // Skip classic patterns and templates in Garden environment.
+    if (!$this->dotcomHelperFunctions->isGarden()) {
+      $this->patternsController->registerPatterns();
+      $this->templatesController->initialize();
+    }
     $this->extendEmailPostApi();
     $this->personalizationTagManager->initialize();
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -82,6 +82,15 @@ class PersonalizationTagManager {
         [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
       ));
       $registry->register(new Personalization_Tag(
+        __('Site Description', 'mailpoet'),
+        'mailpoet/site-description',
+        __('Site', 'mailpoet'),
+        [$this->site, 'getDescription'],
+        [],
+        null,
+        [EmailEditor::MAILPOET_EMAIL_POST_TYPE]
+      ));
+      $registry->register(new Personalization_Tag(
         __('Homepage URL', 'mailpoet'),
         'mailpoet/site-homepage-url',
         __('Site', 'mailpoet'),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Site.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTags/Site.php
@@ -21,4 +21,8 @@ class Site {
   public function getHomepageURL(array $context, array $args = []): string {
     return $this->wp->getBloginfo('url');
   }
+
+  public function getDescription(array $context, array $args = []): string {
+    return htmlspecialchars_decode($this->wp->getBloginfo('description'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+  }
 }


### PR DESCRIPTION
## Description

This PR disables classic email templates when the plugin runs in a garden environment. It also adds a new personalized tag for the site description.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Related to STOMAIL-7574

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Site Description as a new personalization tag, enabling editors to dynamically include their site's description in email templates alongside existing personalization options for enhanced message customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->