### PR TITLE
Add JSON encoding flags for script tag output

### DIFF
--- a/mailpoet/changelog/2025-10-16-11-29-54-improved-improved-json-encoding-for-data-output-in-script-t.md
+++ b/mailpoet/changelog/2025-10-16-11-29-54-improved-improved-json-encoding-for-data-output-in-script-t.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improved JSON encoding for data output in script tags to prevent HTML parsing issues

--- a/mailpoet/lib/Automation/Engine/Utils/Json.php
+++ b/mailpoet/lib/Automation/Engine/Utils/Json.php
@@ -7,7 +7,7 @@ use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
 
 class Json {
   public static function encode(array $value): string {
-    $json = json_encode((object)$value, JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION);
+    $json = json_encode((object)$value, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION);
     $error = json_last_error();
     if ($error || $json === false) {
       throw new InvalidStateException(json_last_error_msg(), (string)$error);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -128,7 +128,7 @@ class EditorPageRenderer {
     // See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L116-L120.
     wp_add_inline_script(
       'wp-blocks',
-      sprintf('wp.blocks.setCategories( %s );', wp_json_encode(get_block_categories($post))),
+      sprintf('wp.blocks.setCategories( %s );', wp_json_encode(get_block_categories($post), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES)),
       'after'
     );
 
@@ -136,7 +136,7 @@ class EditorPageRenderer {
     // See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L144C1-L148C3.
     wp_add_inline_script(
       'wp-blocks',
-      sprintf('wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode(get_block_editor_server_block_settings()))
+      sprintf('wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode(get_block_editor_server_block_settings(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES))
     );
 
     $editorSettings = $this->settingsController->get_settings();
@@ -209,7 +209,7 @@ class EditorPageRenderer {
       'mailpoet_automation_id' => $automationId,
     ];
     $this->wp->wpAddInlineScript('email_editor_integration', implode('', array_map(function ($key) use ($inline_script_data) {
-      return sprintf("var %s=%s;", $key, wp_json_encode($inline_script_data[$key]));
+      return sprintf("var %s=%s;", $key, wp_json_encode($inline_script_data[$key], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES));
     }, array_keys($inline_script_data))), 'before');
 
     // Load CSS from Post Editor
@@ -259,7 +259,7 @@ class EditorPageRenderer {
       'wp-blocks',
       sprintf(
         'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-        wp_json_encode($preloadData)
+        wp_json_encode($preloadData, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES)
       )
     );
   }
@@ -275,8 +275,8 @@ class EditorPageRenderer {
       <script type="text/javascript"> <?php // phpcs:ignore ?>
         window.mailpoet_analytics_enabled = true;
         window.mailpoet_analytics_public_id = '<?php echo esc_js($publicId); ?>';
-        window.mailpoet_analytics_new_public_id = <?php echo wp_json_encode($isPublicIdNew); ?>;
-        window.mailpoet_3rd_party_libs_enabled = <?php echo wp_json_encode($libs3rdPartyEnabled); ?>;
+        window.mailpoet_analytics_new_public_id = <?php echo wp_json_encode($isPublicIdNew, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES); ?>;
+        window.mailpoet_3rd_party_libs_enabled = <?php echo wp_json_encode($libs3rdPartyEnabled, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES); ?>;
         window.mailpoet_version = '<?php echo esc_js(MAILPOET_VERSION); ?>';
         window.mailpoet_premium_version = '<?php echo esc_js((defined('MAILPOET_PREMIUM_VERSION')) ? MAILPOET_PREMIUM_VERSION : ''); ?>';
       </script>

--- a/mailpoet/lib/PostEditorBlocks/SubscriptionFormBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/SubscriptionFormBlock.php
@@ -49,7 +49,8 @@ class SubscriptionFormBlock {
             return $form->toArray();
           },
           $forms
-        )
+        ),
+        JSON_HEX_TAG | JSON_UNESCAPED_SLASHES
       );
       ?>
       <script type="text/javascript">

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -74,7 +74,7 @@ class Functions extends AbstractExtension {
     return [
       new TwigFunction(
         'json_encode',
-        'json_encode',
+        [$this, 'jsonEncode'],
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
@@ -403,5 +403,19 @@ class Functions extends AbstractExtension {
 
   public function wcPageUrl(string $page): string {
     return esc_url($this->getWooCommerceHelper()->wcGetPagePermalink($page));
+  }
+
+  /**
+   * Safely encodes data to JSON for use in script tags.
+   * Always includes JSON_HEX_TAG to prevent breaking out of script context
+   * and JSON_UNESCAPED_SLASHES for better readability.
+   *
+   * @param mixed $data
+   * @param int $flags
+   * @return string|false
+   */
+  public function jsonEncode($data, $flags = 0) {
+    $flags = $flags | JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
+    return json_encode($data, $flags);
   }
 }

--- a/mailpoet/lib/Validator/Schema.php
+++ b/mailpoet/lib/Validator/Schema.php
@@ -62,7 +62,7 @@ abstract class Schema {
   }
 
   public function toString(): string {
-    $json = json_encode($this->schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION);
+    $json = json_encode($this->schema, JSON_HEX_TAG | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION);
     $error = json_last_error();
     if ($error || $json === false) {
       throw new InvalidStateException(json_last_error_msg(), (string)$error);

--- a/mailpoet/tests/integration/Twig/FunctionsTest.php
+++ b/mailpoet/tests/integration/Twig/FunctionsTest.php
@@ -21,4 +21,27 @@ class FunctionsTest extends \MailPoetTest {
     $resultNoRtl = $twig->render('template');
     verify($resultNoRtl)->empty();
   }
+
+  public function testItEscapesScriptTagsInJsonEncode() {
+    // Test that json_encode escapes </script> tags to prevent breaking out of script context
+    $template = ['template' => '{{ json_encode(data) }}'];
+    $twig = new Environment(new \MailPoetVendor\Twig\Loader\ArrayLoader($template));
+    $twig->addExtension(new Functions());
+
+    // Test data containing </script> which should be escaped
+    $dataWithScriptTag = ['content' => 'Hello </script><script>alert("XSS")</script>'];
+    $result = $twig->render('template', ['data' => $dataWithScriptTag]);
+
+    // Verify that < and > are encoded (JSON_HEX_TAG converts them to \u003C and \u003E)
+    verify($result)->stringContainsString('\u003C');
+    verify($result)->stringContainsString('\u003E');
+    // The dangerous </script> should not appear unescaped in the JSON value
+    verify($result)->stringNotContainsString('"content":"Hello </script>');
+
+    // Also verify JSON_UNESCAPED_SLASHES is working (forward slashes should not be escaped)
+    $dataWithUrl = ['url' => 'https://example.com/path'];
+    $result = $twig->render('template', ['data' => $dataWithUrl]);
+    verify($result)->stringContainsString('https://example.com/path');
+    verify($result)->stringNotContainsString('https:\\/\\/example.com\\/path');
+  }
 }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

- Test the block `mailpoet/subscription-form-block`
- Test the new email block editor and its functionality

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7577

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7577-add-save-script-tags-to-wp_json_encode-usage)

_The latest successful build from `stomail-7577-add-save-script-tags-to-wp_json_encode-usage` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON encoding in script tags to prevent HTML parsing issues.

* **Tests**
  * Added tests verifying proper escaping of script tags in JSON-encoded data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->