### PR TITLE
Bump WC to 10.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.2.2
+            ./do download:woo-commerce-zip 10.3.0
             ./do download:woo-commerce-subscriptions-zip 8.0.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.18
@@ -1182,7 +1182,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_oldest
-          woo_core_version: 10.1.2
+          woo_core_version: 10.2.2
           woo_subscriptions_version: 7.9.0
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
@@ -1222,7 +1222,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_oldest
-          woo_core_version: 10.1.2
+          woo_core_version: 10.2.2
           woo_subscriptions_version: 7.9.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
@@ -1284,7 +1284,7 @@ workflows:
       - acceptance_tests:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
-          woo_core_version: 10.1.2
+          woo_core_version: 10.2.2
           woo_subscriptions_version: 7.9.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
@@ -1295,7 +1295,7 @@ workflows:
       - integration_tests:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
-          woo_core_version: 10.1.2
+          woo_core_version: 10.2.2
           woo_subscriptions_version: 7.9.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0


### PR DESCRIPTION
## Description

I'm doing this mostly to get `nightly` tests to run on 10.3 sooner than next week.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-woocommerce)

_The latest successful build from `update-woocommerce` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated testing and build infrastructure versions to ensure compatibility with newer WooCommerce releases across acceptance and integration test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->