### PR TITLE
Add email campaign sending option panels to the editor

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -304,4 +304,10 @@ interface Window {
   mailpoet_legacy_automatic_emails_count: number;
   mailpoet_legacy_automatic_emails_notice_dismissed: boolean;
   mailpoet_newsletters_count: number;
+  mailpoet_settings?: {
+    sender?: {
+      name: string;
+      address: string;
+    };
+  };
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/email-sidebar-extension.tsx
@@ -1,147 +1,15 @@
-import { ExternalLink } from '@wordpress/components';
-import { select, dispatch } from '@wordpress/data';
-import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
-import classnames from 'classnames';
+import { EmailStatus } from './sidebar/email-status';
+import { ContentSettingsPanel } from './sidebar/content-settings-panel';
+import { InboxPreviewPanel } from './sidebar/inbox-preview-panel';
+import { TrackingPanel } from './sidebar/tracking-panel';
 
-const previewTextMaxLength = 150;
-const previewTextRecommendedLength = 80;
-
-export function EmailSidebarExtensionBody({ RichTextWithButton }) {
-  const [mailpoetEmailData] = useEntityProp(
-    'postType',
-    'mailpoet_email',
-    'mailpoet_data',
-  );
-
-  const updateEmailMailPoetProperty = (name: string, value: string) => {
-    const postId = select(editorStore).getCurrentPostId();
-    const currentPostType = 'mailpoet_email'; // only for mailpoet_email post-type
-
-    const editedPost = select(coreDataStore).getEditedEntityRecord(
-      'postType',
-      currentPostType,
-      postId,
-    );
-
-    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
-    const mailpoetData = editedPost?.mailpoet_data || {};
-    void dispatch(coreDataStore).editEntityRecord(
-      'postType',
-      currentPostType,
-      postId,
-      {
-        mailpoet_data: {
-          ...mailpoetData,
-          [name]: value,
-        },
-      },
-    );
-  };
-
-  const subjectHelp = createInterpolateElement(
-    __(
-      'Use personalization tags to personalize your email, or learn more about <bestPracticeLink>best practices</bestPracticeLink> and using <emojiLink>emoji in subject lines</emojiLink>.',
-      'mailpoet',
-    ),
-    {
-      bestPracticeLink: (
-        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-        <a
-          href="https://www.mailpoet.com/blog/17-email-subject-line-best-practices-to-boost-engagement/"
-          target="_blank"
-          rel="noopener noreferrer"
-        />
-      ),
-      emojiLink: (
-        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-        <a
-          href="https://www.mailpoet.com/blog/tips-using-emojis-in-subject-lines/"
-          target="_blank"
-          rel="noopener noreferrer"
-        />
-      ),
-    },
-  );
-
-  const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
-
-  const preheaderHelp = createInterpolateElement(
-    __(
-      '<link>This text</link> will appear in the inbox, underneath the subject line.',
-      'mailpoet',
-    ),
-    {
-      link: (
-        // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-        <a
-          href={new URL(
-            'article/418-preview-text',
-            'https://kb.mailpoet.com/',
-          ).toString()}
-          key="preview-text-kb"
-          target="_blank"
-          rel="noopener noreferrer"
-        />
-      ),
-    },
-  );
-
+export function EmailSidebarExtension() {
   return (
     <>
-      <br />
-
-      <RichTextWithButton
-        attributeName="subject"
-        attributeValue={mailpoetEmailData?.subject}
-        updateProperty={updateEmailMailPoetProperty}
-        label={__('Subject', 'mailpoet')}
-        labelSuffix={
-          <ExternalLink
-            href="https://kb.mailpoet.com/article/435-a-guide-to-personalisation-tags-for-tailored-newsletters#list"
-            className="mailpoet-settings-panel__subject-label-suffix"
-          >
-            {__('Guide', 'mailpoet')}
-          </ExternalLink>
-        }
-        help={subjectHelp}
-        placeholder={__('Eg. The summer sale is here!', 'mailpoet')}
-      />
-
-      <br />
-
-      <RichTextWithButton
-        attributeName="preheader"
-        attributeValue={mailpoetEmailData?.preheader}
-        updateProperty={updateEmailMailPoetProperty}
-        label={__('Preview text', 'mailpoet')}
-        labelSuffix={
-          <span
-            className={classnames(
-              'mailpoet-settings-panel__preview-text-length',
-              {
-                'mailpoet-settings-panel__preview-text-length-warning':
-                  previewTextLength > previewTextRecommendedLength,
-                'mailpoet-settings-panel__preview-text-length-error':
-                  previewTextLength > previewTextMaxLength,
-              },
-            )}
-          >
-            {previewTextLength}/{previewTextMaxLength}
-          </span>
-        }
-        help={preheaderHelp}
-        placeholder={__(
-          "Add a preview text to capture subscribers' attention and increase open rates.",
-          'mailpoet',
-        )}
-      />
+      <EmailStatus />
+      <ContentSettingsPanel />
+      <InboxPreviewPanel />
+      <TrackingPanel />
     </>
   );
-}
-
-export function EmailSidebarExtension(RichTextWithButton: JSX.Element) {
-  return <EmailSidebarExtensionBody RichTextWithButton={RichTextWithButton} />;
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -1,3 +1,6 @@
+/* stylelint-disable selector-nested-pattern */
+@import '~@wordpress/base-styles/variables';
+
 .mailpoet-editor-feedback-button {
   bottom: 5px;
   position: absolute;
@@ -24,5 +27,64 @@
   }
   .mailpoet-settings-panel__preview-text-length-error {
     color: #cc1818;
+  }
+}
+
+.mailpoet-status-panel {
+  &__date-time-picker {
+    min-width: 320px;
+    padding: $grid-unit-10;
+  }
+
+  &__recipients-selector {
+    min-width: 280px;
+    padding: $grid-unit-10;
+  }
+
+  &__recipients-segments {
+    margin-top: $grid-unit-20;
+  }
+
+  &__recipients-total-count {
+    color: $gray-700;
+    font-size: $font-size-small;
+  }
+}
+
+.mailpoet-content-settings-panel {
+  &__help-text {
+    flex: 1;
+  }
+
+  &__text-length {
+    color: $gray-900;
+    font-weight: 500;
+
+    &--warning {
+      color: $alert-yellow;
+    }
+
+    &--error {
+      color: $alert-red;
+    }
+  }
+}
+
+.mailpoet-inbox-preview-panel {
+  &__card {
+    padding: $grid-unit-15;
+  }
+
+  &__from-address {
+    color: $gray-700;
+    font-size: $font-size-small;
+  }
+
+  &__subject {
+    color: $gray-900;
+  }
+
+  &__preheader {
+    color: $gray-700;
   }
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/recipients-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/recipients-row.tsx
@@ -79,7 +79,11 @@ export function RecipientsRow() {
           setSegments([]);
         }
       })
-      .always(() => setIsLoadingSegments(false));
+      .always(() => {
+        if (mounted) {
+          setIsLoadingSegments(false);
+        }
+      });
     return () => {
       mounted = false;
     };

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/recipients-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/recipients-row.tsx
@@ -1,0 +1,315 @@
+import {
+  PanelRow,
+  Flex,
+  FlexItem,
+  Button,
+  Dropdown,
+  FormTokenField,
+  RadioControl,
+  Spinner,
+  __experimentalVStack as VStack,
+  __experimentalHStack as HStack,
+  __experimentalHeading as Heading,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useRef, useState, useEffect } from '@wordpress/element';
+import { closeSmall } from '@wordpress/icons';
+import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { MailPoet } from 'mailpoet';
+
+type Segment = {
+  id: string;
+  name: string;
+  type: string;
+  subscribers: string;
+  deleted_at?: string;
+  subscribers_count?: {
+    all: string;
+    subscribed: string;
+    unsubscribed: string;
+    unconfirmed: string;
+    bounced: string;
+    inactive: string;
+    trash: string;
+  };
+};
+
+const EMPTY_ARRAY = [];
+
+export function RecipientsRow() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+
+  const selectedSegmentIds = mailpoetEmailData?.segment_ids || EMPTY_ARRAY;
+  const recipientsPopoverAnchor = useRef(null);
+
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [isLoadingSegments, setIsLoadingSegments] = useState(true);
+  const [recipientType, setRecipientType] = useState<
+    'all_customers' | 'segment'
+  >('segment');
+
+  // Fetch segments on mount.
+  useEffect(() => {
+    let mounted = true;
+    setIsLoadingSegments(true);
+    void MailPoet.Ajax.post({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'segments',
+      action: 'listing',
+      data: {},
+    })
+      .done((response) => {
+        const allSegments = response.data || [];
+        const activeSegments = allSegments.filter(
+          (segment: Segment) => !segment.deleted_at,
+        );
+        if (mounted) {
+          setSegments(activeSegments as Segment[]);
+        }
+      })
+      .fail(() => {
+        if (mounted) {
+          setSegments([]);
+        }
+      })
+      .always(() => setIsLoadingSegments(false));
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // Determine recipient type based on selected segments.
+  useEffect(() => {
+    if (segments.length === 0) {
+      return;
+    }
+
+    if (selectedSegmentIds.length === 0) {
+      setRecipientType('segment');
+      return;
+    }
+
+    const firstSegment = segments.find(
+      (segment) => segment.id.toString() === selectedSegmentIds[0].toString(),
+    );
+    if (firstSegment?.type === 'woocommerce_users') {
+      setRecipientType('all_customers');
+    } else {
+      setRecipientType('segment');
+    }
+  }, [selectedSegmentIds, segments]);
+
+  const updateEmailMailPoetProperty = (name: string, value: unknown) => {
+    const postId = select(editorStore).getCurrentPostId();
+    const currentPostType = 'mailpoet_email';
+
+    const editedPost = select(coreDataStore).getEditedEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+    );
+
+    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+    const mailpoetData = editedPost?.mailpoet_data || {};
+    void dispatch(coreDataStore).editEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+      {
+        mailpoet_data: {
+          ...mailpoetData,
+          [name]: value,
+        },
+      },
+    );
+  };
+
+  const setSelectedSegments = (segmentNames: string[]) => {
+    const defaultSegments = segments.filter(
+      (segment) => segment.type === 'default',
+    );
+    const segmentIds = segmentNames
+      .map((name) => {
+        const segment = defaultSegments.find(
+          (_segment) => _segment.name === name,
+        );
+        return segment ? segment.id : null;
+      })
+      .filter((id): id is string => id !== null);
+
+    updateEmailMailPoetProperty('segment_ids', segmentIds);
+  };
+
+  const handleRecipientTypeChange = (newType: 'all_customers' | 'segment') => {
+    setRecipientType(newType);
+
+    if (newType === 'all_customers') {
+      const allCustomersSegment = segments.find(
+        (segment) => segment.type === 'woocommerce_users',
+      );
+      if (allCustomersSegment) {
+        updateEmailMailPoetProperty('segment_ids', [allCustomersSegment.id]);
+      }
+    } else {
+      updateEmailMailPoetProperty('segment_ids', []);
+    }
+  };
+
+  // Filter segments by type
+  const defaultSegments = segments.filter((s) => s.type === 'default');
+  const allCustomersSegment = segments.find(
+    (s) => s.type === 'woocommerce_users',
+  );
+  const allCustomersSegmentCount = parseInt(
+    allCustomersSegment?.subscribers_count?.all || '0',
+    10,
+  );
+
+  const selectedSegments: Segment[] = selectedSegmentIds
+    .map((id: string): Segment | undefined =>
+      segments.find(
+        (segment: Segment) => segment.id.toString() === id.toString(),
+      ),
+    )
+    .filter((segment) => segment !== undefined);
+
+  // Calculate total recipients from selected segments
+  const recipientCount = selectedSegments.reduce((total, segment) => {
+    const count = parseInt(segment.subscribers_count?.all || '0', 10);
+    return total + count;
+  }, 0);
+
+  // Filter selected segments to only show default type segments
+  const selectedDefaultSegments = selectedSegments.filter(
+    (segment) => segment.type === 'default',
+  );
+
+  let buttonLabel = __('Select recipients', 'mailpoet');
+  if (recipientType === 'all_customers') {
+    buttonLabel = __('All customers', 'mailpoet');
+  } else if (selectedDefaultSegments.length > 0) {
+    buttonLabel = selectedDefaultSegments
+      .map((segment) => segment.name)
+      .join(', ');
+  }
+
+  return (
+    <PanelRow>
+      <Flex justify="start" ref={recipientsPopoverAnchor}>
+        <FlexItem className="editor-post-panel__row-label">
+          {__('Recipients', 'mailpoet')}
+        </FlexItem>
+        <FlexItem className="editor-post-panel__row-control">
+          <Dropdown
+            popoverProps={{
+              anchor: recipientsPopoverAnchor.current,
+              placement: 'left-start',
+              offset: 36,
+              shift: true,
+            }}
+            renderToggle={({ isOpen, onToggle }) => (
+              <Button
+                variant="tertiary"
+                onClick={onToggle}
+                aria-expanded={isOpen}
+                disabled={isLoadingSegments}
+              >
+                {buttonLabel}
+              </Button>
+            )}
+            renderContent={({ onClose }) => (
+              <div className="mailpoet-status-panel__recipients-selector">
+                <VStack
+                  className="block-editor-inspector-popover-header"
+                  spacing={4}
+                >
+                  <HStack alignment="center">
+                    {/* @ts-expect-error size prop is available in the external @wordpress/components package */}
+                    <Heading
+                      className="block-editor-inspector-popover-header__heading"
+                      level={2}
+                      size={13}
+                    >
+                      {__('Select recipients', 'mailpoet')}
+                    </Heading>
+                    <Spacer />
+                    <Button
+                      size="small"
+                      className="block-editor-inspector-popover-header__action"
+                      label={__('Close', 'mailpoet')}
+                      icon={closeSmall}
+                      onClick={onClose}
+                    />
+                  </HStack>
+                </VStack>
+                {isLoadingSegments ? (
+                  <Spinner />
+                ) : (
+                  <>
+                    <RadioControl
+                      selected={recipientType}
+                      options={[
+                        {
+                          label: __('Send to all customers', 'mailpoet'),
+                          value: 'all_customers',
+                          /* @ts-expect-error description prop is available in the external @wordpress/components package */
+                          description: sprintf(
+                            _n(
+                              '%s recipient',
+                              '%s recipients',
+                              allCustomersSegmentCount,
+                              'mailpoet',
+                            ),
+                            allCustomersSegmentCount,
+                          ),
+                        },
+                        {
+                          label: __('Send to a segment', 'mailpoet'),
+                          value: 'segment',
+                        },
+                      ]}
+                      onChange={(value) =>
+                        handleRecipientTypeChange(
+                          value as 'all_customers' | 'segment',
+                        )
+                      }
+                    />
+
+                    {recipientType === 'segment' && (
+                      <div className="mailpoet-status-panel__recipients-segments">
+                        <FormTokenField
+                          label={__('Select segment(s)', 'mailpoet')}
+                          value={selectedDefaultSegments.map(
+                            (segment) => segment.name,
+                          )}
+                          suggestions={defaultSegments.map(
+                            (segment) => segment.name,
+                          )}
+                          onChange={setSelectedSegments}
+                          __experimentalExpandOnFocus
+                          __experimentalAutoSelectFirstMatch
+                          __experimentalShowHowTo={false}
+                        />
+                        <div className="mailpoet-status-panel__recipients-total-count">
+                          {__('Total recipients: ', 'mailpoet')}{' '}
+                          {recipientCount.toLocaleString()}
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+          />
+        </FlexItem>
+      </Flex>
+    </PanelRow>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
@@ -1,0 +1,148 @@
+import {
+  PanelRow,
+  Flex,
+  FlexItem,
+  Button,
+  Dropdown,
+  DateTimePicker,
+  __experimentalVStack as VStack,
+  __experimentalHStack as HStack,
+  __experimentalHeading as Heading,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useRef } from '@wordpress/element';
+import { dateI18n, getSettings } from '@wordpress/date';
+import { closeSmall } from '@wordpress/icons';
+import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+
+export function ScheduledRow() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+
+  const scheduledDate = (mailpoetEmailData?.scheduled_at as string) || null;
+  const sendPopoverAnchor = useRef(null);
+  const settings = getSettings();
+
+  const setScheduledDate = (date: string | null) => {
+    const postId = select(editorStore).getCurrentPostId();
+    const currentPostType = 'mailpoet_email';
+
+    const editedPost = select(coreDataStore).getEditedEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+    );
+
+    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+    const mailpoetData = editedPost?.mailpoet_data || {};
+    void dispatch(coreDataStore).editEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+      {
+        mailpoet_data: {
+          ...mailpoetData,
+          scheduled_at: date,
+        },
+      },
+    );
+  };
+
+  const getFormattedDate = () => {
+    if (!scheduledDate) {
+      return __('Immediately', 'mailpoet');
+    }
+    return dateI18n(
+      settings.formats.datetime,
+      scheduledDate,
+      settings.timezone.string,
+    );
+  };
+
+  const is12HourTime = /a(?!\\)/i.test(
+    settings.formats.time
+      .toLowerCase() // Test only the lower case a.
+      .replace(/\\\\/g, '') // Replace "//" with empty strings.
+      .split('')
+      .reverse()
+      .join(''), // Reverse the string and test for "a" not followed by a slash.
+  );
+
+  return (
+    <PanelRow>
+      <Flex justify="start" ref={sendPopoverAnchor}>
+        <FlexItem className="editor-post-panel__row-label">
+          {__('Send', 'mailpoet')}
+        </FlexItem>
+        <FlexItem className="editor-post-panel__row-control">
+          <Dropdown
+            popoverProps={{
+              anchor: sendPopoverAnchor.current,
+              placement: 'left-start',
+              offset: 36,
+              shift: true,
+            }}
+            renderToggle={({ isOpen, onToggle }) => (
+              <Button
+                variant="tertiary"
+                onClick={onToggle}
+                aria-expanded={isOpen}
+              >
+                {getFormattedDate()}
+              </Button>
+            )}
+            renderContent={({ onClose }) => (
+              <div className="mailpoet-status-panel__date-time-picker">
+                <VStack
+                  className="block-editor-inspector-popover-header"
+                  spacing={4}
+                >
+                  <HStack alignment="center">
+                    {/* @ts-expect-error size prop is available in the external @wordpress/components package */}
+                    <Heading
+                      className="block-editor-inspector-popover-header__heading"
+                      level={2}
+                      size={13}
+                    >
+                      {__('Send', 'mailpoet')}
+                    </Heading>
+                    <Spacer />
+                    <Button
+                      size="small"
+                      className="block-editor-inspector-popover-header__action"
+                      label={__('Now', 'mailpoet')}
+                      variant="tertiary"
+                      onClick={() => setScheduledDate(null)}
+                    >
+                      {__('Now', 'mailpoet')}
+                    </Button>
+                    <Button
+                      size="small"
+                      className="block-editor-inspector-popover-header__action"
+                      label={__('Close', 'mailpoet')}
+                      icon={closeSmall}
+                      onClick={onClose}
+                    />
+                  </HStack>
+                </VStack>
+                <DateTimePicker
+                  currentDate={scheduledDate}
+                  onChange={(newDate) => setScheduledDate(newDate)}
+                  /* @ts-expect-error dateOrder prop is available in the external @wordpress/components package */
+                  dateOrder="dmy"
+                  is12Hour={is12HourTime}
+                />
+              </div>
+            )}
+          />
+        </FlexItem>
+      </Flex>
+    </PanelRow>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
@@ -10,7 +10,7 @@ import {
   __experimentalHeading as Heading,
   __experimentalSpacer as Spacer,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { closeSmall } from '@wordpress/icons';
@@ -135,7 +135,10 @@ export function ScheduledRow() {
                   currentDate={scheduledDate}
                   onChange={(newDate) => setScheduledDate(newDate)}
                   /* @ts-expect-error dateOrder prop is available in the external @wordpress/components package */
-                  dateOrder="dmy"
+                  dateOrder={
+                    /* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
+                    _x('dmy', 'date order', 'mailpoet')
+                  }
                   is12Hour={is12HourTime}
                 />
               </div>

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/content-settings-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/content-settings-panel.tsx
@@ -103,6 +103,7 @@ export function ContentSettingsPanel() {
         onChange={(value) => updateEmailMailPoetProperty('subject', value)}
         help={subjectHelp}
         placeholder={__('Eg. The summer sale is here!', 'mailpoet')}
+        data-automation-id="email_subject"
       />
 
       <TextareaControl
@@ -114,6 +115,7 @@ export function ContentSettingsPanel() {
           "Add a preview text to capture subscribers' attention and increase open rates.",
           'mailpoet',
         )}
+        data-automation-id="email_preheader"
       />
     </PluginDocumentSettingPanel>
   );

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/content-settings-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/content-settings-panel.tsx
@@ -1,0 +1,120 @@
+import {
+  TextareaControl,
+  __experimentalHStack as HStack,
+} from '@wordpress/components';
+import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import {
+  // @ts-expect-error Type for PluginDocumentSettingPanel is missing in @types/wordpress__editor
+  PluginDocumentSettingPanel,
+  store as editorStore,
+} from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+
+const subjectMaxLength = 60;
+const previewTextMaxLength = 150;
+const previewTextRecommendedLength = 80;
+
+export function ContentSettingsPanel() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+
+  const updateEmailMailPoetProperty = (name: string, value: string) => {
+    const postId = select(editorStore).getCurrentPostId();
+    const currentPostType = 'mailpoet_email'; // only for mailpoet_email post-type
+
+    const editedPost = select(coreDataStore).getEditedEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+    );
+
+    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+    const mailpoetData = editedPost?.mailpoet_data || {};
+    void dispatch(coreDataStore).editEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+      {
+        mailpoet_data: {
+          ...mailpoetData,
+          [name]: value,
+        },
+      },
+    );
+  };
+
+  const subjectLength = mailpoetEmailData?.subject?.length ?? 0;
+  const previewTextLength = mailpoetEmailData?.preheader?.length ?? 0;
+
+  const subjectHelp = (
+    <HStack spacing={2} alignment="top">
+      <span className="mailpoet-content-settings-panel__help-text">
+        {__(
+          'Personalise with tags: [site-title], [customer-firstname], [customer-lastname], [customer-email]',
+          'mailpoet',
+        )}
+      </span>
+      <span
+        className={classNames('mailpoet-content-settings-panel__text-length', {
+          'mailpoet-content-settings-panel__text-length--error':
+            subjectLength > subjectMaxLength,
+        })}
+      >
+        {subjectLength}/{subjectMaxLength}
+      </span>
+    </HStack>
+  );
+
+  const preheaderHelp = (
+    <HStack spacing={2} alignment="top">
+      <span className="mailpoet-content-settings-panel__help-text">
+        {__(
+          'Shown as a preview in the Inbox, next to the subject line.',
+          'mailpoet',
+        )}
+      </span>
+      <span
+        className={classNames('mailpoet-content-settings-panel__text-length', {
+          'mailpoet-content-settings-panel__text-length--warning':
+            previewTextLength > previewTextRecommendedLength,
+          'mailpoet-content-settings-panel__text-length--error':
+            previewTextLength > previewTextMaxLength,
+        })}
+      >
+        {previewTextLength}/{previewTextMaxLength}
+      </span>
+    </HStack>
+  );
+
+  return (
+    <PluginDocumentSettingPanel
+      name="mailpoet-content-settings"
+      title={__('Content settings', 'mailpoet')}
+      className="mailpoet-content-settings-panel"
+    >
+      <TextareaControl
+        label={__('Subject', 'mailpoet')}
+        value={mailpoetEmailData?.subject || ''}
+        onChange={(value) => updateEmailMailPoetProperty('subject', value)}
+        help={subjectHelp}
+        placeholder={__('Eg. The summer sale is here!', 'mailpoet')}
+      />
+
+      <TextareaControl
+        label={__('Preview text', 'mailpoet')}
+        value={mailpoetEmailData?.preheader || ''}
+        onChange={(value) => updateEmailMailPoetProperty('preheader', value)}
+        help={preheaderHelp}
+        placeholder={__(
+          "Add a preview text to capture subscribers' attention and increase open rates.",
+          'mailpoet',
+        )}
+      />
+    </PluginDocumentSettingPanel>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/email-status.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/email-status.tsx
@@ -1,0 +1,11 @@
+import { ScheduledRow } from './components/scheduled-row';
+import { RecipientsRow } from './components/recipients-row';
+
+export function EmailStatus() {
+  return (
+    <>
+      <ScheduledRow />
+      <RecipientsRow />
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/inbox-preview-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/inbox-preview-panel.tsx
@@ -1,0 +1,47 @@
+import { Card } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import {
+  // @ts-expect-error Type for PluginDocumentSettingPanel is missing in @types/wordpress__editor
+  PluginDocumentSettingPanel,
+} from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+export function InboxPreviewPanel() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+
+  const siteData = useSelect((select) => {
+    // @ts-expect-error getSite is not typed
+    const site = select('core').getSite();
+    return {
+      title: (site?.title as string) || '',
+      email: (site?.email as string) || '',
+    };
+  }, []);
+
+  return (
+    <PluginDocumentSettingPanel
+      name="mailpoet-inbox-preview"
+      title={__('Inbox preview', 'mailpoet')}
+      className="mailpoet-inbox-preview-panel"
+    >
+      <Card className="mailpoet-inbox-preview-panel__card">
+        <div className="mailpoet-inbox-preview-panel__from-address">
+          {siteData.title && siteData.email
+            ? `${siteData.title} <${siteData.email}>`
+            : __('(No sender)', 'mailpoet')}
+        </div>
+        <div className="mailpoet-inbox-preview-panel__subject">
+          {mailpoetEmailData?.subject || __('(No subject)', 'mailpoet')}
+        </div>
+        <div className="mailpoet-inbox-preview-panel__preheader">
+          {mailpoetEmailData?.preheader || __('(No preview text)', 'mailpoet')}
+        </div>
+      </Card>
+    </PluginDocumentSettingPanel>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/tracking-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/tracking-panel.tsx
@@ -1,0 +1,59 @@
+import { TextControl } from '@wordpress/components';
+import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import {
+  // @ts-expect-error Type for PluginDocumentSettingPanel is missing in @types/wordpress__editor
+  PluginDocumentSettingPanel,
+  store as editorStore,
+} from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+export function TrackingPanel() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+
+  const updateEmailMailPoetProperty = (name: string, value: string) => {
+    const postId = select(editorStore).getCurrentPostId();
+    const currentPostType = 'mailpoet_email'; // only for mailpoet_email post-type
+
+    const editedPost = select(coreDataStore).getEditedEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+    );
+
+    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+    const mailpoetData = editedPost?.mailpoet_data || {};
+    void dispatch(coreDataStore).editEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+      {
+        mailpoet_data: {
+          ...mailpoetData,
+          [name]: value,
+        },
+      },
+    );
+  };
+
+  return (
+    <PluginDocumentSettingPanel
+      name="mailpoet-tracking"
+      title={__('Tracking', 'mailpoet')}
+    >
+      <TextControl
+        label={__('utm_campaign', 'mailpoet')}
+        value={mailpoetEmailData?.utm_campaign || ''}
+        onChange={(value) => updateEmailMailPoetProperty('utm_campaign', value)}
+        help={__(
+          'Add a tracking code to use with Google Analytics',
+          'mailpoet',
+        )}
+      />
+    </PluginDocumentSettingPanel>
+  );
+}

--- a/mailpoet/changelog/2025-10-24-09-07-39-added-add-email-campaign-sending-option-panels-to-the-ed.md
+++ b/mailpoet/changelog/2025-10-24-09-07-39-added-add-email-campaign-sending-option-panels-to-the-ed.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add email campaign sending option panels to the editor

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -110,6 +110,15 @@ class EmailApiController {
   }
 
   private function updateScheduledAtOption($newsletter, $scheduledAtValue): void {
+    // Validate the scheduled_at value
+    if ($scheduledAtValue !== null && $scheduledAtValue !== '') {
+      try {
+        new \DateTime($scheduledAtValue);
+      } catch (\Exception $e) {
+        throw new UnexpectedValueException('Invalid scheduled_at format. Expected a valid datetime string.');
+      }
+    }
+
     $optionField = $this->newsletterOptionFieldsRepository->findOneBy([
       'name' => NewsletterOptionFieldEntity::NAME_SCHEDULED_AT,
       'newsletterType' => $newsletter->getType(),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -2,11 +2,19 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\Entities\NewsletterOptionEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\NewsletterSegmentEntity;
+use MailPoet\Entities\SegmentEntity;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
+use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
+use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\NotFoundException;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Validator\Builder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class EmailApiController {
   /** @var NewslettersRepository */
@@ -15,12 +23,32 @@ class EmailApiController {
   /** @var NewsletterUrl */
   private $newsletterUrl;
 
+  /** @var NewsletterOptionFieldsRepository */
+  private $newsletterOptionFieldsRepository;
+
+  /** @var NewsletterOptionsRepository */
+  private $newsletterOptionsRepository;
+
+  /** @var NewsletterSegmentRepository */
+  private $newsletterSegmentRepository;
+
+  /** @var EntityManager */
+  private $entityManager;
+
   public function __construct(
     NewslettersRepository $newsletterRepository,
-    NewsletterUrl $newsletterUrl
+    NewsletterUrl $newsletterUrl,
+    NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository,
+    NewsletterOptionsRepository $newsletterOptionsRepository,
+    NewsletterSegmentRepository $newsletterSegmentRepository,
+    EntityManager $entityManager
   ) {
     $this->newsletterRepository = $newsletterRepository;
     $this->newsletterUrl = $newsletterUrl;
+    $this->newsletterOptionFieldsRepository = $newsletterOptionFieldsRepository;
+    $this->newsletterOptionsRepository = $newsletterOptionsRepository;
+    $this->newsletterSegmentRepository = $newsletterSegmentRepository;
+    $this->entityManager = $entityManager;
   }
 
   /**
@@ -35,6 +63,9 @@ class EmailApiController {
       'preheader' => $newsletter ? $newsletter->getPreheader() : '',
       'preview_url' => $this->newsletterUrl->getViewInBrowserUrl($newsletter),
       'deleted_at' => $newsletter && $newsletter->getDeletedAt() !== null ? $newsletter->getDeletedAt()->format('c') : null,
+      'scheduled_at' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT) : null,
+      'utm_campaign' => $newsletter ? $newsletter->getGaCampaign() : '',
+      'segment_ids' => $newsletter ? $newsletter->getSegmentIds() : [],
     ];
   }
 
@@ -53,6 +84,10 @@ class EmailApiController {
     $newsletter->setSubject($data['subject']);
     $newsletter->setPreheader($data['preheader']);
 
+    if (isset($data['utm_campaign'])) {
+      $newsletter->setGaCampaign($data['utm_campaign']);
+    }
+
     if (isset($data['deleted_at'])) {
       if (empty($data['deleted_at'])) {
         $data['deleted_at'] = null;
@@ -62,7 +97,77 @@ class EmailApiController {
       $newsletter->setDeletedAt($data['deleted_at']);
     }
 
+    if (isset($data['scheduled_at'])) {
+      $this->updateScheduledAtOption($newsletter, $data['scheduled_at']);
+    }
+
+    if (isset($data['segment_ids']) && is_array($data['segment_ids'])) {
+      $this->updateSegments($newsletter, $data['segment_ids']);
+      $this->entityManager->refresh($newsletter);
+    }
+
     $this->newsletterRepository->flush();
+  }
+
+  private function updateScheduledAtOption($newsletter, $scheduledAtValue): void {
+    $optionField = $this->newsletterOptionFieldsRepository->findOneBy([
+      'name' => NewsletterOptionFieldEntity::NAME_SCHEDULED_AT,
+      'newsletterType' => $newsletter->getType(),
+    ]);
+
+    if (!$optionField) {
+      // If the option field doesn't exist for this newsletter type, skip
+      return;
+    }
+
+    $option = $this->newsletterOptionsRepository->findOneBy([
+      'newsletter' => $newsletter,
+      'optionField' => $optionField,
+    ]);
+
+    if (!$option) {
+      $option = new NewsletterOptionEntity($newsletter, $optionField);
+      $this->newsletterOptionsRepository->persist($option);
+      $newsletter->getOptions()->add($option);
+    }
+
+    // Set the value (null or the datetime string)
+    $option->setValue($scheduledAtValue);
+  }
+
+  /**
+   * @param array $segmentIds Array of segment IDs as strings
+   */
+  private function updateSegments($newsletter, array $segmentIds): void {
+    // Remove existing segments that are not in the new list
+    $existingSegments = $newsletter->getNewsletterSegments();
+    foreach ($existingSegments as $newsletterSegment) {
+      $segment = $newsletterSegment->getSegment();
+      if (!$segment || !in_array((string)$segment->getId(), $segmentIds, true)) {
+        $this->entityManager->remove($newsletterSegment);
+      }
+    }
+
+    // Add new segments
+    foreach ($segmentIds as $segmentId) {
+      $segmentIdInt = (int)$segmentId;
+      $segment = $this->entityManager->getReference(SegmentEntity::class, $segmentIdInt);
+      if (!$segment) {
+        continue;
+      }
+
+      // Check if the newsletter-segment relationship already exists
+      $existingRelation = $this->newsletterSegmentRepository->findOneBy([
+        'newsletter' => $newsletter,
+        'segment' => $segment,
+      ]);
+
+      if (!$existingRelation) {
+        $newsletterSegment = new NewsletterSegmentEntity($newsletter, $segment);
+        $this->entityManager->persist($newsletterSegment);
+      }
+    }
+    $this->entityManager->flush();
   }
 
   public function trashEmail(\WP_Post $wpPost) {
@@ -83,6 +188,9 @@ class EmailApiController {
       'preheader' => Builder::string(),
       'preview_url' => Builder::string(),
       'deleted_at' => Builder::string()->nullable(),
+      'scheduled_at' => Builder::string()->nullable(),
+      'utm_campaign' => Builder::string(),
+      'segment_ids' => Builder::array(),
     ])->toArray();
   }
 }

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -49,6 +49,7 @@ class CreateAndSendEmailUsingGutenbergCest {
 
     $i->wantTo('Change subject and preheader in the settings panel');
     $i->click('Settings', '.woocommerce-email-editor__settings-panel');
+    $i->click('Content settings', '.mailpoet-content-settings-panel');
     $i->fillField('[data-automation-id="email_subject"]', 'My New Subject');
     $i->fillField('[data-automation-id="email_preheader"]', 'My New Preview Text');
 

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -48,7 +48,7 @@ class EmailTemplatesCest {
     $i->click('Save', '.editor-header__settings');
     $i->waitForText('Are you ready to save?', 10, '.entities-saved-states__panel');
     $i->click('Save', '.entities-saved-states__panel');
-    $i->waitForText('Send', 10, '.editor-header__settings');
+    $i->waitForText('Review & send', 10, '.editor-header__settings');
     $this->checkTextIsInEmail($i, $textInTemplate);
 
     $i->wantTo('Edit template');


### PR DESCRIPTION
## Description

This PR adds campaign sending option panels to the Document (Email) tab in the email editor sidebar, including controls to schedule the email, select recipients, utm_campaign, subject and preview text, and inbox preview.

See [STOMAIL-7587: Add email campaign sending options to email editor](https://linear.app/a8c/issue/STOMAIL-7587/add-email-campaign-sending-options-to-email-editor).

| Before | After |
| - | - |
| <img width="2050" height="1255" alt="xcCsaUdlzRwotoMs" src="https://github.com/user-attachments/assets/b08bd9ac-a132-4477-a02a-c8259cf6e2d5" /> | <img width="2050" height="1255" alt="UE6klj8nxXiL48bX" src="https://github.com/user-attachments/assets/e1d3f6b0-dc48-4833-b140-7668d71d63fa" /> |
| - | <img width="2050" height="1255" alt="iVz8L4C1ulwKr4d5" src="https://github.com/user-attachments/assets/c1dca133-c16a-4767-8dd1-f2219b1b2765" /> |

## Code review notes

_N/A_

## QA notes

- Navigate to MailPoet → Emails → Newsletter → **Create using the new email editor (Alpha)**
- Confirm the UI works correctly and the Send, Recipients, Subject, Preview text, and UTM_Campaign options are saved correctly.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7587-add-email-campaign-sending-options-to-email-editor)

_The latest successful build from `stomail-7587-add-email-campaign-sending-options-to-email-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email editor: added Status, Content, Inbox Preview and Tracking panels (scheduling, subject/preview editing, sender preview, UTM).
  * Recipient selection with segment targeting and recipient counts; dynamic send-button labels based on scheduling/automation.

* **Bug Fixes / Server**
  * Server-side persistence for schedule, UTM campaign and selected segments.

* **Style**
  * Styling for the new panels.

* **Documentation**
  * New changelog entry documenting the editor panels.

* **Tests**
  * Acceptance tests updated for new send-button labels and content settings flow.

* **Chores**
  * Minor type declaration for optional sender settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->