### PR TITLE
Add WooCommerce email context filters for newsletter rendering to include recipient email and type

### DIFF
--- a/mailpoet/changelog/2025-11-06-18-46-40-improved-block-email-editor-starts-supporting-the-product-c.md
+++ b/mailpoet/changelog/2025-11-06-18-46-40-improved-block-email-editor-starts-supporting-the-product-c.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Block email editor starts supporting the Product collection block variant Cart contents

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -83,24 +83,38 @@ class Renderer {
     $wpPostEntity = $newsletter->getWpPost();
     $wpPost = $wpPostEntity ? $wpPostEntity->getWpPostInstance() : null;
     if ($wpPost instanceof \WP_Post) {
-      $filterCallback = function($context) use ($newsletter, $sendingQueue): array {
-        if ($sendingQueue) {
-          $task = $sendingQueue->getTask();
-          $subscribers = $task ? $task->getSubscribers() : null;
-          $subscriber = ($subscribers && $subscriber = $subscribers->first()) ? $subscriber->getSubscriber() : null;
+      // Only add the email context filter for automation emails.
+      // For bulk emails like newsletters, the first subscriber in the task isn't the unique recipient.
+      $automationTypes = [
+        NewsletterEntity::TYPE_AUTOMATION,
+        NewsletterEntity::TYPE_AUTOMATION_NOTIFICATION,
+        NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+      ];
+      $isAutomationType = in_array($newsletter->getType(), $automationTypes, true);
 
-          if ($subscriber) {
-            $context['recipient_email'] = $subscriber->getEmail();
+      $filterCallback = null;
+      if ($isAutomationType && $sendingQueue) {
+        $task = $sendingQueue->getTask();
+        $subscribers = $task ? $task->getSubscribers() : null;
+        $firstSubscriber = $subscribers ? $subscribers->first() : null;
+        $subscriber = $firstSubscriber ? $firstSubscriber->getSubscriber() : null;
+        $recipientEmail = $subscriber ? $subscriber->getEmail() : null;
+
+        $filterCallback = function (array $context) use ($newsletter, $recipientEmail): array {
+          if ($recipientEmail) {
+            $context['recipient_email'] = $recipientEmail;
           }
-        }
-        $context['email_type'] = $newsletter->getType();
-        return $context;
-      };
-      $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+          $context['email_type'] = $newsletter->getType();
+          return $context;
+        };
+        $this->wp->addFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+      }
 
       $renderedNewsletter = $this->guntenbergRenderer->render($wpPost, $subject, $newsletter->getPreheader(), $language, $metaRobots);
 
-      $this->wp->removeFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+      if ($filterCallback) {
+        $this->wp->removeFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
+      }
     } else {
       $body = (is_array($newsletter->getBody()))
         ? $newsletter->getBody()


### PR DESCRIPTION
## Description

This PR updates the email-editor package, allowing the use of the Cart contents block in block emails.

<img width="1725" height="1212" alt="Screenshot 2025-11-06 at 19 44 11" src="https://github.com/user-attachments/assets/86afdcca-884a-464b-b452-55753f814fa7" />

## Code review notes

_N/A_

## QA notes

Prerequisites: Install WooCommerce built from the trunk branch. 
You can use this zip [woocommerce.zip](https://github.com/user-attachments/files/23417667/woocommerce.zip)


1. Activate the email block editor for automations in MailPoet settings
2. Use the new block in Abandoned cart automation
3. Verify that email sent by automations contain the expected products

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7500

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7500-cart-contents-in-email)

_The latest successful build from `stomail-7500-cart-contents-in-email` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * Mail editor now supports the Product collection block variant for Cart contents in email templates, enabling enhanced customization options for displaying shopping cart information.
  * Email rendering improved for automation-type newsletters, providing better context handling for automated communications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->