### PR TITLE
Update integration tests to work with WP 6.9

### DIFF
--- a/mailpoet/tests/_support/IntegrationTester.php
+++ b/mailpoet/tests/_support/IntegrationTester.php
@@ -69,9 +69,9 @@ class IntegrationTester extends \Codeception\Actor {
     $this->entityManager = ContainerWrapper::getInstance()->get(EntityManager::class);
   }
 
-  public function createWordPressUser(string $email, string $role) {
+  public function createWordPressUser(string $email, string $role, ?string $username = null) {
     $userId = wp_insert_user([
-      'user_login' => explode('@', $email)[0],
+      'user_login' => $username ?? explode('@', $email)[0],
       'user_email' => $email,
       'role' => $role,
       'user_pass' => '12123154',

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -908,7 +908,7 @@ class SchedulerTest extends \MailPoetTest {
     return $newsletter;
   }
 
-  public function _createOrUpdateWPUser($role = null) {
+  public function _createOrUpdateWPUser(string $role) {
     $email = 'test@example.com';
     $username = 'phoenix_test_user';
     if (email_exists($email) === false) {

--- a/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/SchedulerTest.php
@@ -912,13 +912,7 @@ class SchedulerTest extends \MailPoetTest {
     $email = 'test@example.com';
     $username = 'phoenix_test_user';
     if (email_exists($email) === false) {
-      wp_insert_user(
-        [
-          'user_login' => $username,
-          'user_email' => $email,
-          'user_pass' => '',
-        ]
-      );
+      $this->tester->createWordPressUser($email, $role, $username);
     }
     $user = get_user_by('login', $username);
     $this->assertInstanceOf(WP_User::class, $user);

--- a/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/AmazonSESTest.php
@@ -121,12 +121,12 @@ class AmazonSESTest extends \MailPoetTest {
     verify($mailer->getAllRecipientAddresses())->equals(['blackhole@mailpoet.com' => true]);
     verify($mailer->From)->equals($this->sender['from_email']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->FromName)->equals($this->sender['from_name']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    verify($mailer->getReplyToAddresses())->equals([
-      $this->replyTo['reply_to_email'] => [
+    $replyToAddresses = $mailer->getReplyToAddresses();
+    verify(reset($replyToAddresses))
+      ->equals([
         $this->replyTo['reply_to_email'],
         $this->replyTo['reply_to_name'],
-      ],
-    ]);
+      ]);
     verify($mailer->Sender)->equals($this->returnPath); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->ContentType)->equals('text/html'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->Subject)->equals($this->newsletter['subject']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/PHPMailTest.php
@@ -77,14 +77,12 @@ class PHPMailTest extends \MailPoetTest {
       ->equals(['blackhole@mailpoet.com' => true]);
     verify($mailer->From)->equals($this->sender['from_email']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->FromName)->equals($this->sender['from_name']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    verify($mailer->getReplyToAddresses())->equals(
-      [
-        'reply-to@mailpoet.com' => [
-          'reply-to@mailpoet.com',
-          'Reply To',
-        ],
-      ]
-    );
+    $replyToAddresses = $mailer->getReplyToAddresses();
+    verify(reset($replyToAddresses))
+      ->equals([
+        $this->replyTo['reply_to_email'],
+        $this->replyTo['reply_to_name'],
+      ]);
     verify($mailer->Sender)->equals($this->returnPath); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->ContentType)->equals('text/html'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->Subject)->equals($this->newsletter['subject']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
+++ b/mailpoet/tests/integration/Mailer/Methods/SMTPTest.php
@@ -101,9 +101,12 @@ class SMTPTest extends \MailPoetTest {
     verify($mailer->getAllRecipientAddresses())->equals(['blackhole@mailpoet.com' => true]);
     verify($mailer->From)->equals($this->sender['from_email']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->FromName)->equals($this->sender['from_name']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-    verify($mailer->getReplyToAddresses())->equals([
-      'reply-to@mailpoet.com' => ['reply-to@mailpoet.com', 'Reply To'],
-    ]);
+    $replyToAddresses = $mailer->getReplyToAddresses();
+    verify(reset($replyToAddresses))
+      ->equals([
+        $this->replyTo['reply_to_email'],
+        $this->replyTo['reply_to_name'],
+      ]);
     verify($mailer->Sender)->equals($this->returnPath); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->ContentType)->equals('text/html'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     verify($mailer->Subject)->equals($this->newsletter['subject']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/AutomatedLatestContentAPITest.php
@@ -128,14 +128,8 @@ class AutomatedLatestContentAPITest extends \MailPoetTest {
       wp_delete_user($existingUser->ID);
     }
 
-    wp_insert_user([
-      'user_login' => $username,
-      'user_email' => $email,
-      'user_pass' => '',
-    ]);
+    $this->tester->createWordPressUser($email, $role, $username);
     $user = $this->wp->getUserBy("email", $email);
-
-    $user->add_role($role);
 
     wp_set_current_user($user->ID);
     $this->createdUsers[] = $user;

--- a/mailpoet/tests/integration/Newsletter/DynamicProductsAPITest.php
+++ b/mailpoet/tests/integration/Newsletter/DynamicProductsAPITest.php
@@ -13,10 +13,6 @@ use MailPoet\WP\Functions as WPFunctions;
  * @group woo
  */
 class DynamicProductsAPITest extends \MailPoetTest {
-
-  /*** @var array WP_User[] */
-  private $createdUsers = [];
-
   /*** @var DynamicProductsAPI */
   private $dpAPI;
 
@@ -115,14 +111,6 @@ class DynamicProductsAPITest extends \MailPoetTest {
     if (is_multisite()) {
       restore_current_blog();
     }
-
-    foreach ($this->createdUsers as $user) {
-      if (is_multisite()) {
-        wpmu_delete_user($user->ID);
-      } else {
-        wp_delete_user($user->ID);
-      }
-    }
   }
 
   private function loginWithRole(string $role): \WP_User {
@@ -138,17 +126,9 @@ class DynamicProductsAPITest extends \MailPoetTest {
       }
     }
 
-    wp_insert_user([
-      'user_login' => $username,
-      'user_email' => $email,
-      'user_pass' => '',
-    ]);
+    $this->tester->createWordPressUser($email, $role, $username);
     $user = $this->wp->getUserBy("email", $email);
-
-    $user->add_role($role);
-
     wp_set_current_user($user->ID);
-    $this->createdUsers[] = $user;
 
     return $user;
   }


### PR DESCRIPTION
## Description

The PR updated integration tests to work with WP 6.9

There were two issues:

- empty passwords in wp_insert_user started throwing warnings  - fixed by switching to the helper for creating users
- updated PHPMailer, changed indexes in the array that holds addresses, causing tests to fail

Closes STOMAIL-7607

## Code review notes

There is a [test run where I switched integration tests to use WP 6.9](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21642/workflows/454bd025-ff3f-415f-b353-ce6e2e2cda41)

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wp69-fixes)

_The latest successful build from `wp69-fixes` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Streamlined test user creation by centralizing and extending the test helper to accept an optional username.
  * Replaced direct user creation in tests with the helper for consistent role assignment.
  * Simplified mailer reply-to assertions to validate the primary reply-to entry.
  * Removed some per-test manual user cleanup to rely on the centralized test harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->