### PR TITLE
Update copy in new email editor modal

### DIFF
--- a/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
+++ b/mailpoet/assets/js/src/newsletters/editor-select-modal.tsx
@@ -76,19 +76,13 @@ export function EditorSelectModal({
       </div>
       <p>
         {__(
-          'Get a sneak peek of an early version of the upcoming email design experience and help shape its development.',
-          'mailpoet',
-        )}
-      </p>
-      <p>
-        {__(
-          'Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.',
+          'Take a first look at our new email editor. It introduces a more flexible, modern way to design your emails. This version is still evolving, and your feedback will help guide what comes next.',
           'mailpoet',
         )}
       </p>
       <p className="mailpoet-new-editor-modal-note">
         {__(
-          'Emails created in the new editor cannot be reverted to the legacy version.',
+          "Note: Emails created here can't be opened in the legacy editor.",
           'mailpoet',
         )}
       </p>
@@ -120,7 +114,7 @@ export function EditorSelectModal({
             );
           }}
         >
-          {__('Continue', 'mailpoet')}
+          {__('Try it now', 'mailpoet')}
         </Button>
       </div>
     </Modal>

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -20,8 +20,8 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('[data-automation-id="create_standard_email_dropdown"]');
     $i->waitForText('Create using the new email editor (Alpha)');
     $i->click('Create using the new email editor (Alpha)');
-    $i->waitForText('Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.');
-    $i->click('//button[text()="Continue"]');
+    $i->waitForText('Take a first look at our new email editor. It introduces a more flexible, modern way to design your emails.');
+    $i->click('//button[text()="Try it now"]');
 
     $this->closeTemplateSelectionModal($i);
 
@@ -93,8 +93,8 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->click('[data-automation-id="create_standard_email_dropdown"]');
     $i->waitForText('Create using the new email editor (Alpha)');
     $i->click('Create using the new email editor (Alpha)');
-    $i->waitForText('Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.');
-    $i->click('//button[text()="Continue"]');
+    $i->waitForText('Take a first look at our new email editor. It introduces a more flexible, modern way to design your emails.');
+    $i->click('//button[text()="Try it now"]');
 
     $this->closeTemplateSelectionModal($i);
 

--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -14,8 +14,8 @@ class EmailTemplatesCest {
     $i->click('[data-automation-id="create_standard_email_dropdown"]');
     $i->waitForText('Create using the new email editor (Alpha)');
     $i->click('Create using the new email editor (Alpha)');
-    $i->waitForText('Create modern, beautiful emails that embody your brand with advanced customization and editing capabilities.');
-    $i->click('//button[text()="Continue"]');
+    $i->waitForText('Take a first look at our new email editor. It introduces a more flexible, modern way to design your emails.');
+    $i->click('//button[text()="Try it now"]');
 
     $this->selectTemplate($i, 'Newsletter - 1 Column');
 


### PR DESCRIPTION
## Description

| Before | After | 
| ----- | ----- | 
|  <img width="439" height="550" alt="Screenshot 2025-10-31 at 15 03 05" src="https://github.com/user-attachments/assets/2c4f1b6e-de73-4459-8ac0-573951cf4ed1" /> | <img width="431" height="487" alt="Screenshot 2025-10-31 at 22 32 01" src="https://github.com/user-attachments/assets/df5d0cb6-6a95-4cfb-9867-744fc7e6875d" /> |

## Code review notes

I haven't added the `New` badge, because the current modal only accepts `string` as title, and any other solution I could think of would require a lot of refactors which I don't think is worth doing just to add the badge. 

## QA notes

Skipping both reviews as this is just updated copy.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7595

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7595-enhance-try-the-new-email-editor-modal)

_The latest successful build from `stomail-7595-enhance-try-the-new-email-editor-modal` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated email editor modal messaging to a new first-look introduction.
  * Changed primary action label to "Try it now".
  * Clarified compatibility note: emails created in the new editor can’t be opened in the legacy editor.

* **Tests**
  * Updated acceptance tests to reflect the revised onboarding copy and button label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->