### PR TITLE
Ensure the correct version of Woo Core is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,7 @@ jobs:
                 name: Download WooCommerce Core
                 command: |
                   cd ../tests_env/docker
+                  echo "Downloading WooCommerce Core with tag: '${WOOCOMMERCE_VERSION}'"
                   docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_acceptance
       - when:
           condition: << parameters.woo_subscriptions_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,9 +467,13 @@ jobs:
             - run:
                 name: Download WooCommerce Core
                 command: |
-                  cd ../tests_env/docker
-                  echo "Downloading WooCommerce Core with tag: '${WOOCOMMERCE_VERSION}'"
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_acceptance
+                  if [ -z "${WOOCOMMERCE_VERSION}" ]; then
+                    echo "The test run doesn't require a special WooCommerce version. Skipping download and continuing with the default version."
+                  else
+                    cd ../tests_env/docker
+                    echo "Downloading WooCommerce Core with tag: '${WOOCOMMERCE_VERSION}'"
+                    docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_acceptance
+                  fi
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:
@@ -753,8 +757,13 @@ jobs:
             - run:
                 name: Download WooCommerce Core
                 command: |
-                  cd ../tests_env/docker
-                  docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_integration
+                  if [ -z "${WOOCOMMERCE_VERSION}" ]; then
+                    echo "The test run doesn't require a special WooCommerce version. Skipping download and continuing with the default version."
+                  else
+                    cd ../tests_env/docker
+                    echo "Downloading WooCommerce Core with tag: '${WOOCOMMERCE_VERSION}'"
+                    docker compose run --rm -w /project --entrypoint "./do download:woo-commerce-zip ${WOOCOMMERCE_VERSION}" --no-deps -e WP_GITHUB_USERNAME=${WP_GITHUB_USERNAME} -e WP_GITHUB_WOOCOMMERCE_TOKEN=${WP_GITHUB_WOOCOMMERCE_TOKEN} codeception_integration
+                  fi
       - when:
           condition: << parameters.woo_subscriptions_version >>
           steps:

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1310,6 +1310,7 @@ class RoboFile extends \Robo\Tasks {
       $this->yell("Skipping download of WooCommerce Memberships", 40, 'red');
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
+    $this->say('Downloading WooCommerce Memberships plugin');
     $this->createGithubClient('woocommerce/all-plugins', $token)
       ->downloadRawFile('https://api.github.com/repos/woocommerce/all-plugins/contents/product-packages/woocommerce-memberships/woocommerce-memberships.zip?ref=master', 'woocommerce-memberships.zip', __DIR__ . '/tests/plugins/');
   }
@@ -1321,6 +1322,7 @@ class RoboFile extends \Robo\Tasks {
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
 
+    $this->say('Downloading WooCommerce Subscriptions plugin with tag: ' . $tag);
     $this->createGithubClient('woocommerce/woocommerce-subscriptions', $token)
       ->downloadReleaseZip('woocommerce-subscriptions.zip', __DIR__ . '/tests/plugins/', $tag);
   }
@@ -1331,11 +1333,13 @@ class RoboFile extends \Robo\Tasks {
       $this->yell("Skipping download of Automate Woo", 40, 'red');
       exit(0); // Exit with 0 since it is a valid state for some environments
     }
+    $this->say('Downloading Automate Woo plugin with tag: ' . $tag);
     $this->createGithubClient('woocommerce/automatewoo', $token)
       ->downloadReleaseZip('automatewoo.zip', __DIR__ . '/tests/plugins/', $tag);
   }
 
   public function downloadWooCommerceZip($tag = null) {
+    $this->say('Downloading WooCommerce plugin with tag: ' . $tag);
     $this->createWpOrgDownloader('woocommerce')
     ->downloadPluginZip('woocommerce.zip', __DIR__ . '/tests/plugins/', $tag);
   }


### PR DESCRIPTION
## Description

Previously the build on alwasy CI used the latest version version of WooCommerce Core. This PR changes that and  ensures we use the version that is configured.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:print-plugins-versions)

_The latest successful build from `print-plugins-versions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added conditional checks to skip core downloads when no specific WooCommerce version is specified, improving CI behavior.
  * Added clear, user-facing progress messages for plugin download steps (Memberships, Subscriptions, AutomateWoo, WooCommerce) to provide better build feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->