### PR TITLE
Add filter for Atomic platform detection

### DIFF
--- a/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
+++ b/mailpoet/lib/WPCOM/DotcomHelperFunctions.php
@@ -2,11 +2,22 @@
 
 namespace MailPoet\WPCOM;
 
+use MailPoet\WP\Functions;
+
 /**
  * Plan detection documentation:
  * https://github.com/Automattic/wc-calypso-bridge#active-plan-detection
  */
 class DotcomHelperFunctions {
+
+  private Functions $wp;
+
+  public function __construct(
+    Functions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
   /**
    * Returns true if in the context of WordPress.com Atomic platform.
    *
@@ -14,7 +25,8 @@ class DotcomHelperFunctions {
    */
   public function isAtomicPlatform(): bool {
     // ATOMIC_CLIENT_ID === '2' corresponds to WordPress.com client on the Atomic platform
-    return defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
+    $is_atomic_platform = defined('IS_ATOMIC') && IS_ATOMIC && defined('ATOMIC_CLIENT_ID') && (ATOMIC_CLIENT_ID === '2');
+    return (bool)$this->wp->applyFilters('mailpoet_is_atomic_platform', $is_atomic_platform);
   }
 
   /**

--- a/mailpoet/lib/WooCommerce/Emails.php
+++ b/mailpoet/lib/WooCommerce/Emails.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) exit;
 
 /**
  * WooCommerce Emails Manager
- * 
+ *
  * Manages registration of MailPoet emails with WooCommerce.
  * Only available in Garden environment.
  */
@@ -23,8 +23,8 @@ class Emails {
   private $wp;
 
   public function __construct() {
-    $this->dotcomHelperFunctions = new DotcomHelperFunctions();
     $this->wp = new WPFunctions();
+    $this->dotcomHelperFunctions = new DotcomHelperFunctions($this->wp);
   }
 
   /**
@@ -56,7 +56,7 @@ class Emails {
    */
   public function registerEmailClasses($email_classes) {
     $email_classes['mailpoet_marketing_confirmation'] = new MarketingConfirmation();
-    
+
     return $email_classes;
   }
 
@@ -69,7 +69,7 @@ class Emails {
   public function registerTransactionalEmailsForBlockEditor($emails) {
     // Register marketing confirmation email for block editor
     $emails[] = 'mailpoet_marketing_confirmation';
-    
+
     return $emails;
   }
 

--- a/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/MarketingConfirmation.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\WooCommerce\Emails;
 
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WPCOM\DotcomHelperFunctions;
 
 if (!defined('ABSPATH')) exit;
@@ -11,7 +12,7 @@ if (!defined('ABSPATH')) exit;
 
 /**
  * Marketing Confirmation Email
- * 
+ *
  * This email is sent to confirm marketing subscriptions.
  * Only available in Garden environment.
  */
@@ -79,7 +80,7 @@ class MarketingConfirmation extends \WC_Email {
       $this->recipient = $to;
       $this->placeholders['{activation_link}'] = $activation_link;
       $this->placeholders['{subscriber_firstname}'] = $subscriber_firstname;
-      
+
       $this->send($to, $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments());
     }
 
@@ -180,7 +181,7 @@ class MarketingConfirmation extends \WC_Email {
    * Check if this email should be available.
    */
   public static function is_available() {
-    $dotcomHelperFunctions = new DotcomHelperFunctions();
+    $dotcomHelperFunctions = new DotcomHelperFunctions(WPFunctions::get());
     // Only available in Garden environment.
     return $dotcomHelperFunctions->isGarden();
   }

--- a/mailpoet/tests/unit/API/JSON/PremiumTest.php
+++ b/mailpoet/tests/unit/API/JSON/PremiumTest.php
@@ -19,6 +19,9 @@ class PremiumTest extends \MailPoetUnitTest {
 
     $wp = $this->make(WPFunctions::class, [
       'installPlugin' => Expected::once(true),
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
     ]);
 
     $installer = $this->makeEmpty(Installer::class, [
@@ -39,11 +42,15 @@ class PremiumTest extends \MailPoetUnitTest {
       'isPremiumKeyValid' => Expected::once(false),
     ]);
 
-    $wp = $this->makeEmpty(WPFunctions::class);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
+    ]);
 
     $installer = $this->makeEmpty(Installer::class);
 
-    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions(), $installer);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions($wp), $installer);
     $response = $premium->installPlugin();
     verify($response)->instanceOf(ErrorResponse::class);
     verify($response->getData()['errors'][0])->same([
@@ -59,13 +66,16 @@ class PremiumTest extends \MailPoetUnitTest {
 
     $wp = $this->make(WPFunctions::class, [
       'installPlugin' => Expected::once(false),
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
     ]);
 
     $installer = $this->makeEmpty(Installer::class, [
       'generatePluginDownloadUrl' => Expected::once(''),
     ]);
 
-    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions(), $installer);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions($wp), $installer);
     $response = $premium->installPlugin();
     verify($response)->instanceOf(ErrorResponse::class);
     verify($response->getData()['errors'][0])->same([
@@ -81,11 +91,14 @@ class PremiumTest extends \MailPoetUnitTest {
 
     $wp = $this->make(WPFunctions::class, [
       'installPlugin' => Expected::once(false),
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
     ]);
 
     $installer = $this->makeEmpty(Installer::class);
 
-    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions(), $installer);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions($wp), $installer);
     $response = $premium->installPlugin();
     verify($response)->instanceOf(ErrorResponse::class);
     verify($response->getData()['errors'][0])->same([
@@ -101,11 +114,14 @@ class PremiumTest extends \MailPoetUnitTest {
 
     $wp = $this->make(WPFunctions::class, [
       'activatePlugin' => Expected::once(null),
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
     ]);
 
     $installer = $this->makeEmpty(Installer::class);
 
-    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions(), $installer);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions($wp), $installer);
     $response = $premium->activatePlugin();
     verify($response)->instanceOf(SuccessResponse::class);
   }
@@ -115,9 +131,14 @@ class PremiumTest extends \MailPoetUnitTest {
       'isPremiumKeyValid' => Expected::once(false),
     ]);
 
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
+    ]);
     $installer = $this->makeEmpty(Installer::class);
 
-    $premium = new Premium($servicesChecker, new WPFunctions(), new DotcomHelperFunctions(), $installer);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions($wp), $installer);
     $response = $premium->activatePlugin();
     verify($response)->instanceOf(ErrorResponse::class);
     verify($response->getData()['errors'][0])->same([
@@ -133,11 +154,14 @@ class PremiumTest extends \MailPoetUnitTest {
 
     $wp = $this->make(WPFunctions::class, [
       'activatePlugin' => Expected::once('error'),
+      'applyFilters' => function ($tag, $value) {
+        return $value;
+      },
     ]);
 
     $installer = $this->makeEmpty(Installer::class);
 
-    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions(), $installer);
+    $premium = new Premium($servicesChecker, $wp, new DotcomHelperFunctions($wp), $installer);
     $response = $premium->activatePlugin();
     verify($response)->instanceOf(ErrorResponse::class);
     verify($response->getData()['errors'][0])->same([

--- a/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
+++ b/mailpoet/tests/unit/WPCOM/DotcomHelperFunctionsTest.php
@@ -2,13 +2,24 @@
 
 namespace MailPoet\WPCOM;
 
+use MailPoet\WP\Functions as WPFunctions;
+
 class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   /*** @var DotcomHelperFunctions */
   private $dotcomHelper;
 
+  /*** @var WPFunctions */
+  private $wp;
+
   public function _before() {
     parent::_before();
-    $this->dotcomHelper = new DotcomHelperFunctions();
+    $this->wp = $this->createMock(WPFunctions::class);
+    $this->wp->expects($this->any())
+      ->method('applyFilters')
+      ->willReturnCallback(function ($tag, $value) {
+        return $value;
+      });
+    $this->dotcomHelper = new DotcomHelperFunctions($this->wp);
   }
 
   public function testItReturnsFalseIfNotDotcom() {
@@ -26,37 +37,55 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testItReturnsPerformanceIfWooExpressPerformance() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isWooExpressPerformance']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isWooExpressPerformance'])
+      ->getMock();
     $dotcomHelper->method('isWooExpressPerformance')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('performance');
   }
 
   public function testItReturnsEssentialIfWooExpressEssential() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isWooExpressEssential']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isWooExpressEssential'])
+      ->getMock();
     $dotcomHelper->method('isWooExpressEssential')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('essential');
   }
 
   public function testItReturnsBusinessIfWooBusiness() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isBusiness']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isBusiness'])
+      ->getMock();
     $dotcomHelper->method('isBusiness')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('business');
   }
 
   public function testItReturnsEcommerceTrialIfEcommerceTrial() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isEcommerceTrial']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isEcommerceTrial'])
+      ->getMock();
     $dotcomHelper->method('isEcommerceTrial')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('ecommerce_trial');
   }
 
   public function testItReturnsEcommerceWPComIfEcommerceWPCom() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isEcommerceWPCom']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isEcommerceWPCom'])
+      ->getMock();
     $dotcomHelper->method('isEcommerceWPCom')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('ecommerce_wpcom');
   }
 
   public function testItReturnsEcommerceIfEcommerce() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isEcommerce']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isEcommerce'])
+      ->getMock();
     $dotcomHelper->method('isEcommerce')->willReturn(true);
     verify($dotcomHelper->getDotcomPlan())->equals('ecommerce');
   }
@@ -66,17 +95,19 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testGardenNameReturnsNullWhenNotGarden() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(false);
     verify($dotcomHelper->gardenName())->null();
   }
 
   public function testGardenNameReturnsNullWhenGetSiteMetaNotAvailable() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden']);
-    $dotcomHelper->method('isGarden')->willReturn(true);
-
-    // Mock getSiteMetaValue to return null when get_site_meta is not available
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden', 'getSiteMetaValue'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(true);
     $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
 
@@ -84,7 +115,10 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testGardenNameReturnsNullWhenMetaValueIsEmpty() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden', 'getSiteMetaValue'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(true);
     $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
 
@@ -92,7 +126,10 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testGardenNameReturnsValueWhenMetaValueIsValid() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden', 'getSiteMetaValue'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(true);
     $dotcomHelper->method('getSiteMetaValue')->willReturn('My Garden');
 
@@ -100,13 +137,19 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testGardenPartnerReturnsNullWhenNotGarden() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(false);
     verify($dotcomHelper->gardenPartner())->null();
   }
 
   public function testGardenPartnerReturnsNullWhenGetSiteMetaNotAvailable() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden', 'getSiteMetaValue'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(true);
     $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
 
@@ -114,7 +157,10 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testGardenPartnerReturnsNullWhenMetaValueIsEmpty() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden', 'getSiteMetaValue'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(true);
     $dotcomHelper->method('getSiteMetaValue')->willReturn(null);
 
@@ -122,7 +168,10 @@ class DotcomHelperFunctionsTest extends \MailPoetUnitTest {
   }
 
   public function testGardenPartnerReturnsValueWhenMetaValueIsValid() {
-    $dotcomHelper = $this->createPartialMock(DotcomHelperFunctions::class, ['isGarden', 'getSiteMetaValue']);
+    $dotcomHelper = $this->getMockBuilder(DotcomHelperFunctions::class)
+      ->setConstructorArgs([$this->wp])
+      ->onlyMethods(['isGarden', 'getSiteMetaValue'])
+      ->getMock();
     $dotcomHelper->method('isGarden')->willReturn(true);
     $dotcomHelper->method('getSiteMetaValue')->willReturn('Partner Name');
 


### PR DESCRIPTION
## Description

Add new filter for Atomic platform.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7611

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:garden-add-filter)

_The latest successful build from `garden-add-filter` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code structure and dependency management for improved maintainability and stability.
  * Introduced `mailpoet_is_atomic_platform` filter hook, enabling developers to customize platform detection behavior within MailPoet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->