### PR TITLE
Update email editor package

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "1.8.1"
+    "woocommerce/email-editor": "1.9.0"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0655ac31b6f4857cb6fe63c205602218",
+    "content-hash": "de2d289f3a5a76e56e1080cad124dbd0",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "1.8.1",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "e78a8d605d2cbb45f92e0146d477abd7b6ad4b9d"
+                "reference": "8e4d9352b2742b2c07b20140995d264673960f45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/e78a8d605d2cbb45f92e0146d477abd7b6ad4b9d",
-                "reference": "e78a8d605d2cbb45f92e0146d477abd7b6ad4b9d",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/8e4d9352b2742b2c07b20140995d264673960f45",
+                "reference": "8e4d9352b2742b2c07b20140995d264673960f45",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/1.8.1"
+                "source": "https://github.com/woocommerce/email-editor/tree/1.9.0"
             },
-            "time": "2025-10-27T13:02:16+00:00"
+            "time": "2025-10-31T12:36:12+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Description

This PR updates the composer `woocommerce/email-editor` package.

## Code review notes

_N/A_

## QA notes

* Run some smoke tests on the block email editor.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wooprd-1010-allow-woocommerce-personalization-tags-in-marketing-emails)

_The latest successful build from `wooprd-1010-allow-woocommerce-personalization-tags-in-marketing-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email editor dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->