### PR TITLE
Skip the email template test in WP6.9 

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -8,6 +8,11 @@ class EmailTemplatesCest {
       $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
     }
 
+    $wordPressVersion = $i->getWordPressVersion();
+    if (version_compare($wordPressVersion, '6.9', '>=')) {
+      $scenario->skip('Skipping this test for WP 6.9+ due to template changes');
+    }
+
     $i->wantTo('Create standard newsletter using Gutenberg editor');
     $i->login();
     $i->amOnMailpoetPage('Emails');


### PR DESCRIPTION
## Description

WordPress 6.9 introduces changes to the template editing flow, affecting the email editor. The changes include:
- Template edits create a custom template in the database, leaving the original theme file untouched.
- Multiple templates can be created for the same slug, with only one active at a time.
- Custom templates persist across theme switches.

We are going to temporarily skip the test until we figure out how to proceed. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[WOOPRD-1074]

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:skip-template-test)

_The latest successful build from `skip-template-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test compatibility for WordPress 6.9 and later versions to account for template changes in the email editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->