### PR TITLE
Fix custom link shortcodes with arguments not working in URL fields

### DIFF
--- a/mailpoet/changelog/2025-11-05-08-58-25-fixed-fix-custom-link-shortcodes-with-arguments-not-work.md
+++ b/mailpoet/changelog/2025-11-05-08-58-25-fixed-fix-custom-link-shortcodes-with-arguments-not-work.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix custom link shortcodes with arguments not working in URL fields (buttons)

--- a/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Shortcodes.php
@@ -113,6 +113,9 @@ class Shortcodes {
    * The syntax is [category:action arg1="value1" arg2="value2"], it can have multiple arguments.
    */
   public function matchWPShortcode($shortcode) {
+    // Decode HTML entities in case the shortcode came from HTML content (e.g., &quot; -> ")
+    $shortcode = html_entity_decode($shortcode, ENT_QUOTES, 'UTF-8');
+
     $atts = $this->wp->shortcodeParseAtts(trim($shortcode, '[]/'));
     if (empty($atts[0])) {
       return [];
@@ -127,11 +130,13 @@ class Shortcodes {
       if (is_numeric($attrName)) {
         continue; // Skip unnamed attributes
       }
-      $shortcodeDetails['arguments'][$attrName] = $attrValue;
+      // Strip surrounding quotes from attribute values
+      $cleanValue = trim($attrValue, '"\' ');
+      $shortcodeDetails['arguments'][$attrName] = $cleanValue;
       // Make a shortcut to the first argument
       if (!isset($shortcodeDetails['argument'])) {
         $shortcodeDetails['argument'] = $attrName;
-        $shortcodeDetails['argument_value'] = $attrValue;
+        $shortcodeDetails['argument_value'] = $cleanValue;
       }
     }
     return $shortcodeDetails;

--- a/mailpoet/lib/Statistics/Track/Clicks.php
+++ b/mailpoet/lib/Statistics/Track/Clicks.php
@@ -154,14 +154,19 @@ class Clicks {
     bool $wpUserPreview
   ) {
     if (preg_match('/\[link:(?P<action>.*?)\]/', $url, $shortcode)) {
-      if (!$shortcode['action']) $this->abort();
-      $url = $this->linkShortcodeCategory->processShortcodeAction(
-        $shortcode['action'],
+      if (empty($shortcode['action'])) $this->abort();
+      $processedUrl = $this->linkShortcodeCategory->processShortcodeAction(
+        $shortcode[0],
         $newsletter,
         $subscriber,
         $queue,
         $wpUserPreview
       );
+      // If shortcode was not processed, return original shortcode unchanged
+      if ($processedUrl === null) {
+        return $shortcode[0];
+      }
+      $url = $processedUrl;
       // We need to know the original method for unsubscribe actions
       if ($this->request->isPost() && $url) {
         $url = $url . (parse_url($url, PHP_URL_QUERY) ? '&' : '?') . 'request_method=POST';


### PR DESCRIPTION
## Description

Fixes a bug where custom link shortcodes with arguments (e.g., [link:express_login valid_for="1month" link="https://example.com"]) were not working correctly when used in URL fields such as button URLs. 

Arguments were correctly passed in the email body, but were missing from the click-tracking for the URL fields. 

The Link::processShortcodeAction() method was not parsing shortcode arguments and was only passing 5 parameters to the mailpoet_newsletter_shortcode_link filter instead of 6, omitting the $arguments parameter. 


## Code review notes

_N/A_

## QA notes

To test manually:
1. Add a custom filter for testing:

```
add_filter('mailpoet_newsletter_shortcode_link', function($shortcode, $newsletter, $subscriber, $queue, $arguments, $wpUserPreview) {
    if ($shortcode === '[link:test_link]') {
        $token = $arguments['token'] ?? 'default';
        return "https://example.com/test?token={$token}";
    }
    return $shortcode;
}, 10, 6);

```

2. Create an email with a button
3. Set the button URL to: [link:test_link token="abc123"]
4. Send a test email
5. Click the button - should redirect to https://example.com/test?token=abc123
6. Verify arguments are now properly received (previously would have been empty)

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7612-shortcode-arguments-not-passed-in-url-fields-vs-email-body)

_The latest successful build from `stomail-7612-shortcode-arguments-not-passed-in-url-fields-vs-email-body` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom link shortcodes with arguments now work correctly in URL fields (e.g., buttons), handling quoted and HTML‑encoded values, WP-style attributes, and MailPoet pipe syntax so dynamic URLs match expected arguments.

* **Tests**
  * Added integration and unit tests covering argument passing, quote/HTML‑entity stripping, pipe-syntax parsing, and end-to-end click-tracking URL processing.

* **Documentation**
  * Added a changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->