### PR TITLE
Update copy in automation triggers and actions

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
@@ -25,6 +25,7 @@ const keywords = [
 export const step: StepType = {
   key: 'core:delay',
   group: 'actions',
+  // translators: automation action title
   title: () => _x('Delay', 'noun', 'mailpoet'),
   description: () =>
     __('Wait for a set amount of time before moving to the next step.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
@@ -28,7 +28,10 @@ export const step: StepType = {
   // translators: automation action title
   title: () => _x('Delay', 'noun', 'mailpoet'),
   description: () =>
-    __('Wait for a set amount of time before moving to the next step.', 'mailpoet'),
+    __(
+      'Wait for a set amount of time before moving to the next step.',
+      'mailpoet',
+    ),
   subtitle: (data): string => {
     if (!data.args.delay || !data.args.delay_type) {
       return __('Not set up yet', 'mailpoet');

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/delay/index.tsx
@@ -27,7 +27,7 @@ export const step: StepType = {
   group: 'actions',
   title: () => _x('Delay', 'noun', 'mailpoet'),
   description: () =>
-    __('Wait some time before proceeding with the steps below.', 'mailpoet'),
+    __('Wait for a set amount of time before moving to the next step.', 'mailpoet'),
   subtitle: (data): string => {
     if (!data.args.delay || !data.args.delay_type) {
       return __('Not set up yet', 'mailpoet');

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/if-else/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/if-else/index.tsx
@@ -18,6 +18,7 @@ const keywords = [
 export const step: StepType = {
   key: 'core:if-else',
   group: 'actions',
+  // translators: automation action title
   title: () => _x('If / Else', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/if-else/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/if-else/index.tsx
@@ -18,10 +18,10 @@ const keywords = [
 export const step: StepType = {
   key: 'core:if-else',
   group: 'actions',
-  title: () => _x('If/Else', 'mailpoet'),
+  title: () => _x('If / Else', 'mailpoet'),
   description: () =>
     __(
-      'The automation follows a different path based on specified conditions.',
+      'Branch the automation based on specific conditions.',
       'mailpoet',
     ),
   subtitle: (data) => {

--- a/mailpoet/assets/js/src/automation/integrations/core/steps/if-else/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/core/steps/if-else/index.tsx
@@ -21,10 +21,7 @@ export const step: StepType = {
   // translators: automation action title
   title: () => _x('If / Else', 'mailpoet'),
   description: () =>
-    __(
-      'Branch the automation based on specific conditions.',
-      'mailpoet',
-    ),
+    __('Branch the automation based on specific conditions.', 'mailpoet'),
   subtitle: (data) => {
     const fieldKeys = [
       ...new Set(

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
@@ -20,6 +20,7 @@ const keywords = [
 export const step: StepType = {
   key: 'mailpoet:send-email',
   group: 'actions',
+  // translators: automation action title
   title: (data, context) => {
     if (context !== 'automation') {
       return __('Send email', 'mailpoet');

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
@@ -35,7 +35,7 @@ export const step: StepType = {
   description: (data) => {
     const text = (
       <span className="mailpoet-sendemail-description-main">
-        {__('An email will be sent to subscriber.', 'mailpoet')}
+        {__('Send an email to the subscriber.', 'mailpoet')}
       </span>
     );
     if (isTransactional(data)) {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/index.tsx
@@ -17,10 +17,7 @@ export const step: StepType = {
   // translators: automation trigger title
   title: () => __('New email subscriber added', 'mailpoet'),
   description: () =>
-    __(
-      'Starts when a new person subscribes to your email list.',
-      'mailpoet',
-    ),
+    __('Starts when a new person subscribes to your email list.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   foreground: '#2271b1',

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/index.tsx
@@ -14,6 +14,7 @@ const keywords = [
 export const step: StepType = {
   key: 'mailpoet:someone-subscribes',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('New email subscriber added', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/someone-subscribes/index.tsx
@@ -14,10 +14,10 @@ const keywords = [
 export const step: StepType = {
   key: 'mailpoet:someone-subscribes',
   group: 'triggers',
-  title: () => __('Someone subscribes', 'mailpoet'),
+  title: () => __('New email subscriber added', 'mailpoet'),
   description: () =>
     __(
-      'Starts the automation when a new subscriber is added to MailPoet.',
+      'Starts when a new person subscribes to your email list.',
       'mailpoet',
     ),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
@@ -13,6 +13,7 @@ const keywords = [
 export const step: StepType = {
   key: 'mailpoet:wp-user-registered',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('New user registered', 'mailpoet'),
   foreground: '#2271b1',
   background: '#f0f6fc',

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
@@ -13,12 +13,12 @@ const keywords = [
 export const step: StepType = {
   key: 'mailpoet:wp-user-registered',
   group: 'triggers',
-  title: () => __('WordPress user registers', 'mailpoet'),
+  title: () => __('New user registered', 'mailpoet'),
   foreground: '#2271b1',
   background: '#f0f6fc',
   description: () =>
     __(
-      'Starts the automation when a new user registered in WordPress.',
+      'Starts when a new user account is created.',
       'mailpoet',
     ),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/wp-user-registered/index.tsx
@@ -18,10 +18,7 @@ export const step: StepType = {
   foreground: '#2271b1',
   background: '#f0f6fc',
   description: () =>
-    __(
-      'Starts when a new user account is created.',
-      'mailpoet',
-    ),
+    __('Starts when a new user account is created.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   icon: () => wordpress,

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/abandoned-cart/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/abandoned-cart/index.tsx
@@ -20,6 +20,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:abandoned-cart',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Cart abandoned', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/abandoned-cart/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/abandoned-cart/index.tsx
@@ -20,10 +20,10 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:abandoned-cart',
   group: 'triggers',
-  title: () => __('User abandons cart', 'mailpoet'),
+  title: () => __('Cart abandoned', 'mailpoet'),
   description: () =>
     __(
-      'Start the automation when a user who has items in the shopping cart leaves your website without checking out.',
+      'Starts when a shopper leaves your site with items in their cart without checking out.',
       'mailpoet',
     ),
   subtitle: (): JSX.Element | string => __('Trigger', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
@@ -22,8 +22,7 @@ export const step: StepType = {
   group: 'triggers',
   // translators: automation trigger title
   title: () => __('Product purchased', 'mailpoet'),
-  description: () =>
-    __('Starts when a customer buys a product.', 'mailpoet'),
+  description: () => __('Starts when a customer buys a product.', 'mailpoet'),
 
   subtitle: () => __('Trigger', 'mailpoet'),
   keywords,

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
@@ -20,9 +20,9 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:buys-a-product',
   group: 'triggers',
-  title: () => __('Customer buys a product', 'mailpoet'),
+  title: () => __('Product purchased', 'mailpoet'),
   description: () =>
-    __('Start the automation when a customer buys a product.', 'mailpoet'),
+    __('Starts when a customer buys a product.', 'mailpoet'),
 
   subtitle: () => __('Trigger', 'mailpoet'),
   keywords,

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-a-product/index.tsx
@@ -20,6 +20,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:buys-a-product',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Product purchased', 'mailpoet'),
   description: () =>
     __('Starts when a customer buys a product.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-category/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-category/index.tsx
@@ -22,6 +22,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:buys-from-a-category',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Product purchased (category)', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-category/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-category/index.tsx
@@ -22,10 +22,10 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:buys-from-a-category',
   group: 'triggers',
-  title: () => __('Customer buys from a category', 'mailpoet'),
+  title: () => __('Product purchased (category)', 'mailpoet'),
   description: () =>
     __(
-      'Start the automation when a customer buys a product from a category.',
+      'Starts when a customer buys a product from a selected category.',
       'mailpoet',
     ),
 

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-tag/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-tag/index.tsx
@@ -22,10 +22,10 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:buys-from-a-tag',
   group: 'triggers',
-  title: () => __('Customer buys from a tag', 'mailpoet'),
+  title: () => __('Product purchased (tag)', 'mailpoet'),
   description: () =>
     __(
-      'Start the automation when a customer buys a product from a tag.',
+      'Starts when a customer buys a product with a selected tag.',
       'mailpoet',
     ),
 

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-tag/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/buys-from-a-tag/index.tsx
@@ -22,6 +22,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:buys-from-a-tag',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Product purchased (tag)', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
@@ -13,6 +13,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:order-cancelled',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Order canceled', 'mailpoet'),
   description: () =>
     __('Starts when an order is canceled.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
@@ -15,8 +15,7 @@ export const step: StepType = {
   group: 'triggers',
   // translators: automation trigger title
   title: () => __('Order canceled', 'mailpoet'),
-  description: () =>
-    __('Starts when an order is canceled.', 'mailpoet'),
+  description: () => __('Starts when an order is canceled.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   foreground: '#2271b1',

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-cancelled/index.tsx
@@ -13,9 +13,9 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:order-cancelled',
   group: 'triggers',
-  title: () => __('Order cancelled', 'mailpoet'),
+  title: () => __('Order canceled', 'mailpoet'),
   description: () =>
-    __('Start the automation when an order is cancelled.', 'mailpoet'),
+    __('Starts when an order is canceled.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   foreground: '#2271b1',

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-completed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-completed/index.tsx
@@ -15,7 +15,7 @@ export const step: StepType = {
   group: 'triggers',
   title: () => __('Order completed', 'mailpoet'),
   description: () =>
-    __('Start the automation when an order is completed.', 'mailpoet'),
+    __('Starts when an order is marked as completed.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   foreground: '#2271b1',

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-completed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-completed/index.tsx
@@ -13,6 +13,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:order-completed',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Order completed', 'mailpoet'),
   description: () =>
     __('Starts when an order is marked as completed.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
@@ -17,8 +17,7 @@ export const step: StepType = {
   group: 'triggers',
   // translators: automation trigger title
   title: () => __('Order created', 'mailpoet'),
-  description: () =>
-    __('Starts when a new order is created.', 'mailpoet'),
+  description: () => __('Starts when a new order is created.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   foreground: '#2271b1',

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
@@ -17,7 +17,7 @@ export const step: StepType = {
   group: 'triggers',
   title: () => __('Order created', 'mailpoet'),
   description: () =>
-    __('Start the automation when an order is created.', 'mailpoet'),
+    __('Starts when a new order is created.', 'mailpoet'),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),
   keywords,
   foreground: '#2271b1',

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-created/index.tsx
@@ -15,6 +15,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:order-created',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Order created', 'mailpoet'),
   description: () =>
     __('Starts when a new order is created.', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
@@ -19,7 +19,7 @@ export const step: StepType = {
   title: () => __('Order note added', 'mailpoet'),
   description: () =>
     __(
-      'Fires when any note is added to an order, can include both private notes and notes to the customer. These notes appear on the right of the order edit screen.',
+      'Starts when a note is added to an order, including private notes and customer notes.',
       'mailpoet',
     ),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-note-added/index.tsx
@@ -16,6 +16,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:order-note-added',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Order note added', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-status-changed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-status-changed/index.tsx
@@ -16,6 +16,7 @@ const keywords = [
 export const step: StepType = {
   key: 'woocommerce:order-status-changed',
   group: 'triggers',
+  // translators: automation trigger title
   title: () => __('Order status changed', 'mailpoet'),
   description: () =>
     __(

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-status-changed/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-status-changed/index.tsx
@@ -19,7 +19,7 @@ export const step: StepType = {
   title: () => __('Order status changed', 'mailpoet'),
   description: () =>
     __(
-      'Start the automation when an order is created or changed to a specific status.',
+      'Starts when an order is created or changes to a selected status.',
       'mailpoet',
     ),
   subtitle: () => _x('Trigger', 'noun', 'mailpoet'),

--- a/mailpoet/changelog/2025-11-07-21-30-14-improved-titles-and-descriptions-for-automation-triggers-an.md
+++ b/mailpoet/changelog/2025-11-07-21-30-14-improved-titles-and-descriptions-for-automation-triggers-an.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Titles and descriptions for automation triggers and actions

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -53,7 +53,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->amOnPage('wp-admin/admin.php?page=mailpoet-automation-editor&id=' . $automationId);
     $i->waitForText('Draft');
     $i->waitForText('Move to Trash');
-    $i->waitForText('Someone subscribes');
+    $i->waitForText('New email subscriber added');
     $i->waitForText('Wait for 5 minutes');
   }
 }


### PR DESCRIPTION
## Description

Update automation trigger and action titles and description after review by copywriter.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/985

## Linked tickets

Closes STOMAIL-7616

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7616-update-copy-in-automation-triggers-and-actions)

_The latest successful build from `stomail-7616-update-copy-in-automation-triggers-and-actions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved automation trigger and action titles and descriptions for clearer, more consistent wording across email, WooCommerce, and core automation steps.
  * Refined subscriber signup and purchase messaging to better reflect events and improve comprehension in the automation builder.

* **Tests**
  * Updated acceptance test text to match revised UI wording.

* **Chore**
  * Added changelog entry documenting the improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->