### PR TITLE
Add capability to filter subscribers by status and created date

### DIFF
--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -59,6 +59,7 @@ class SubscribersResponseBuilder {
       'wp_user_id' => $subscriber->getWpUserId(),
       'is_woocommerce_user' => $subscriber->getIsWoocommerceUser(),
       'created_at' => ($createdAt = $subscriber->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
+      'deleted_at' => ($deletedAt = $subscriber->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'last_subscribed_at' => ($lastSubscribedAt = $subscriber->getLastSubscribedAt()) ? $lastSubscribedAt->format(self::DATE_FORMAT) : null,
       'engagement_score' => $subscriber->getEngagementScore(),
       'tags' => $this->buildTags($subscriber),

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -104,7 +104,7 @@ class SubscriberListingRepository extends ListingRepository {
   }
 
   protected function applySelectClause(QueryBuilder $queryBuilder) {
-    $queryBuilder->select("PARTIAL s.{id,email,firstName,lastName,status,createdAt,updatedAt,countConfirmations,wpUserId,isWoocommerceUser,engagementScore,lastSubscribedAt}");
+    $queryBuilder->select("PARTIAL s.{id,email,firstName,lastName,status,createdAt,deletedAt,updatedAt,countConfirmations,wpUserId,isWoocommerceUser,engagementScore,lastSubscribedAt}");
   }
 
   protected function applyFromClause(QueryBuilder $queryBuilder) {

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -178,6 +178,34 @@ class SubscriberListingRepository extends ListingRepository {
       }
     }
 
+    // Status inclusion filter
+    $statusInclude = $filters['statusInclude'] ?? [];
+    if (!empty($statusInclude)) {
+      $statusInclude = is_array($statusInclude) ? $statusInclude : [$statusInclude];
+      // Sanitize: only allow valid status values
+      $statusInclude = array_filter($statusInclude, function($status) {
+        return is_string($status) && in_array($status, self::$supportedStatuses, true);
+      });
+      if (!empty($statusInclude)) {
+        $queryBuilder->andWhere('s.status IN (:statusInclude)')
+          ->setParameter('statusInclude', $statusInclude);
+      }
+    }
+
+    // Status exclusion filter
+    $statusExclude = $filters['statusExclude'] ?? [];
+    if (!empty($statusExclude)) {
+      $statusExclude = is_array($statusExclude) ? $statusExclude : [$statusExclude];
+      // Sanitize: only allow valid status values
+      $statusExclude = array_filter($statusExclude, function($status) {
+        return is_string($status) && in_array($status, self::$supportedStatuses, true);
+      });
+      if (!empty($statusExclude)) {
+        $queryBuilder->andWhere('s.status NOT IN (:statusExclude)')
+          ->setParameter('statusExclude', $statusExclude);
+      }
+    }
+
     // Filter by created_at date
     $createdAtFrom = $filters['createdAtFrom'] ?? null;
     if ($createdAtFrom && is_string($createdAtFrom) && $this->isValidDateTime($createdAtFrom)) {

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -177,6 +177,30 @@ class SubscriberListingRepository extends ListingRepository {
           ->setParameter('stTag', $tag);
       }
     }
+
+    // Filter by created_at date
+    $createdAtFrom = $filters['createdAtFrom'] ?? null;
+    if ($createdAtFrom && is_string($createdAtFrom) && $this->isValidDateTime($createdAtFrom)) {
+      $queryBuilder
+        ->andWhere('s.createdAt >= :createdAtFrom')
+        ->setParameter('createdAtFrom', $createdAtFrom);
+    }
+
+    $createdAtTo = $filters['createdAtTo'] ?? null;
+    if ($createdAtTo && is_string($createdAtTo) && $this->isValidDateTime($createdAtTo)) {
+      $queryBuilder
+        ->andWhere('s.createdAt <= :createdAtTo')
+        ->setParameter('createdAtTo', $createdAtTo);
+    }
+  }
+
+  private function isValidDateTime(string $dateTime): bool {
+    try {
+      new \DateTime($dateTime);
+      return true;
+    } catch (\Exception $e) {
+      return false;
+    }
   }
 
   protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SubscribersResponseBuilderTest.php
@@ -110,6 +110,7 @@ class SubscribersResponseBuilderTest extends \MailPoetTest {
       $this->assertEquals($subscriber->getIsWoocommerceUser(), $item['is_woocommerce_user']);
       $this->assertEquals($subscriber->getStatus(), $item['status']);
       $this->assertArrayHasKey('created_at', $item);
+      $this->assertArrayHasKey('deleted_at', $item);
       $this->assertArrayHasKey('last_subscribed_at', $item);
       $this->assertArrayHasKey('count_confirmations', $item);
       $this->assertArrayHasKey('engagement_score', $item);

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -310,6 +310,96 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     verify($data[1]->getEmail())->equals($subscriber3->getEmail());
   }
 
+  public function testFilterSubscribersByCreatedAtFrom() {
+    $subscriber1 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-10 12:00:00'))
+      ->create();
+    $subscriber2 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-11 12:00:00'))
+      ->create();
+    $subscriber3 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-12 12:00:00'))
+      ->create();
+
+    $this->listingData['filter'] = ['createdAtFrom' => '2022-10-11 12:00:00'];
+    $this->listingData['sort_by'] = 'id';
+    $data = $this->repository->getData($this->getListingDefinition());
+    verify(count($data))->equals(2);
+    verify($data[0]->getEmail())->equals($subscriber2->getEmail());
+    verify($data[1]->getEmail())->equals($subscriber3->getEmail());
+    $this->listingData['sort_by'] = '';
+    $this->listingData['filter'] = [];
+  }
+
+  public function testFilterSubscribersByCreatedAtTo() {
+    $subscriber1 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-10 12:00:00'))
+      ->create();
+    $subscriber2 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-11 12:00:00'))
+      ->create();
+    $subscriber3 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-12 12:00:00'))
+      ->create();
+
+    $this->listingData['filter'] = ['createdAtTo' => '2022-10-11 12:00:00'];
+    $this->listingData['sort_by'] = 'id';
+    $data = $this->repository->getData($this->getListingDefinition());
+    verify(count($data))->equals(2);
+    verify($data[0]->getEmail())->equals($subscriber1->getEmail());
+    verify($data[1]->getEmail())->equals($subscriber2->getEmail());
+    $this->listingData['sort_by'] = '';
+    $this->listingData['filter'] = [];
+  }
+
+  public function testFilterSubscribersByCreatedAtRange() {
+    $subscriber1 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-10 12:00:00'))
+      ->create();
+    $subscriber2 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-11 12:00:00'))
+      ->create();
+    $subscriber3 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-12 12:00:00'))
+      ->create();
+    $subscriber4 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-13 12:00:00'))
+      ->create();
+
+    $this->listingData['filter'] = [
+      'createdAtFrom' => '2022-10-11 12:00:00',
+      'createdAtTo' => '2022-10-12 12:00:00',
+    ];
+    $this->listingData['sort_by'] = 'id';
+    $data = $this->repository->getData($this->getListingDefinition());
+    verify(count($data))->equals(2);
+    verify($data[0]->getEmail())->equals($subscriber2->getEmail());
+    verify($data[1]->getEmail())->equals($subscriber3->getEmail());
+    $this->listingData['sort_by'] = '';
+    $this->listingData['filter'] = [];
+  }
+
+  public function testFilterSubscribersByCreatedAtWithInvalidDate() {
+    $subscriber1 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-10 12:00:00'))
+      ->create();
+    $subscriber2 = (new Subscriber())
+      ->withCreatedAt(new Carbon('2022-10-11 12:00:00'))
+      ->create();
+
+    // Test with invalid createdAtFrom - should be ignored
+    $this->listingData['filter'] = ['createdAtFrom' => 'invalid-date'];
+    $data = $this->repository->getData($this->getListingDefinition());
+    verify(count($data))->equals(2); // All subscribers returned
+
+    // Test with invalid createdAtTo - should be ignored
+    $this->listingData['filter'] = ['createdAtTo' => 'not-a-date'];
+    $data = $this->repository->getData($this->getListingDefinition());
+    verify(count($data))->equals(2); // All subscribers returned
+
+    $this->listingData['filter'] = [];
+  }
+
   public function testLoadSubscribersInDefaultSegmentConsideringSubscriberStatusPerSegmentAndNotGlobally() {
     $list = $this->segmentRepository->createOrUpdate('Segment 5');
     $subscriberUnsubscribedFromAList = $this->createSubscriberEntity();


### PR DESCRIPTION
## Description

Allow filtering by statuses and created date in `SubscriberListingRepository`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Related to STOMAIL-7614

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7614-add-subscribers-filters)

_The latest successful build from `stomail-7614-add-subscribers-filters` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added filtering capabilities for subscribers by creation date range and status (include/exclude filters).
  * Added 'deleted_at' field to subscriber listing responses.

* **Tests**
  * Expanded test coverage for subscriber filtering functionality with comprehensive edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->