### PR TITLE
A11Y - Improve accessing the new editor [STOMAIL-7619]

### DIFF
--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -117,7 +117,6 @@ export function NewsletterTypes({
         {__('Create', 'mailpoet')}
       </Button>
       <Dropdown
-        focusOnMount={false}
         className="mailpoet-dropdown-button"
         contentClassName="mailpoet-dropdown-button-content"
         popoverProps={{ placement: 'bottom-end' }}
@@ -129,6 +128,7 @@ export function NewsletterTypes({
             isBusy={isCreating === 'standard'}
             disabled={isCreating !== null}
             aria-expanded={isOpen}
+            aria-label={__('Open dropdown menu', 'mailpoet')}
             data-automation-id="create_standard_email_dropdown"
           >
             <Icon icon={chevronDown} size={24} />

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -129,7 +129,7 @@ export function NewsletterTypes({
             isBusy={isCreating === 'standard'}
             disabled={isCreating !== null}
             aria-expanded={isOpen}
-            aria-label={__('Open dropdown menu', 'mailpoet')}
+            aria-label={__('Choose editor version', 'mailpoet')}
             data-automation-id="create_standard_email_dropdown"
           >
             <Icon icon={chevronDown} size={24} />

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -112,6 +112,7 @@ export function NewsletterTypes({
         onClick={createStandardNewsletter}
         isBusy={isCreating === 'standard'}
         disabled={isCreating !== null}
+        aria-label={__('Create Newsletter', 'mailpoet')}
         data-automation-id="create_standard"
       >
         {__('Create', 'mailpoet')}
@@ -196,6 +197,7 @@ export function NewsletterTypes({
           onClick={createAutomation}
           isBusy={isCreating === 'automation'}
           disabled={isCreating !== null}
+          aria-label={__('Create Automation', 'mailpoet')}
           data-automation-id="create_automation"
         >
           {__('Create', 'mailpoet')}
@@ -217,6 +219,7 @@ export function NewsletterTypes({
           onClick={createNotificationNewsletter}
           isBusy={isCreating === 'notification'}
           disabled={isCreating !== null}
+          aria-label={__('Create Latest Post Notification', 'mailpoet')}
           data-automation-id="create_notification"
         >
           {__('Create', 'mailpoet')}
@@ -236,6 +239,7 @@ export function NewsletterTypes({
           onClick={createReEngagementNewsletter}
           isBusy={isCreating === 're_engagement'}
           disabled={isCreating !== null}
+          aria-label={__('Create Re-engagement Email', 'mailpoet')}
           data-automation-id="create_notification"
         >
           {__('Create', 'mailpoet')}

--- a/mailpoet/assets/js/src/newsletters/types.tsx
+++ b/mailpoet/assets/js/src/newsletters/types.tsx
@@ -240,7 +240,7 @@ export function NewsletterTypes({
           isBusy={isCreating === 're_engagement'}
           disabled={isCreating !== null}
           aria-label={__('Create Re-engagement Email', 'mailpoet')}
-          data-automation-id="create_notification"
+          data-automation-id="create_re_engagement"
         >
           {__('Create', 'mailpoet')}
         </Button>

--- a/mailpoet/changelog/2025-11-10-10-46-32-improved-accessibility-to-the-new-newsletter-editor.md
+++ b/mailpoet/changelog/2025-11-10-10-46-32-improved-accessibility-to-the-new-newsletter-editor.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Accessibility to the new newsletter editor


### PR DESCRIPTION
## Description
It is hard to access the new editor using only the keyboard.

1. The dropdown opening button has only an SVG, so screen readers would not communicate its purpose
2. The tab order was manipulated. A user would expect to enter the dropdown using tab, but instead the focus would jump into automations. 

This PR adds a `aria-label` to the button and focuses the dropdown on mount. Using git-blame I could not find a reason why we disabled this behavior. The documentation states:

> Specifying a false value disables the focus handling entirely (this should only be done when an appropriately accessible substitute behavior exists).
https://developer.wordpress.org/block-editor/reference-guides/components/dropdown/#focusonmount-firstelement-boolean

Additionally, I added some `aria-labels` for the "Create"-buttons, so it reads more precisely what is created.

Before:

https://github.com/user-attachments/assets/51a89cd7-c73e-40e2-8cae-0196fe398c5e

After:

https://github.com/user-attachments/assets/4ea5fe13-f927-41bf-8626-c62b3c3c40e1



## Code review notes

I tried also to get the info-toggle next to automations to be read out as the cursor stops at the heading, but this seems not to work. I used only text without div in the `<Tooltip>`, but this did not do the trick. Maybe we can revisit this the next time.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7619-tab-order-for-create-using-the-new-email-editor-is-wrong)

_The latest successful build from `stomail-7619-tab-order-for-create-using-the-new-email-editor-is-wrong` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added descriptive ARIA labels to action buttons and dropdowns (create newsletter, choose editor version, create automation, create latest post notification, create re-engagement email) to improve screen reader support.
  * Adjusted dropdown focus behavior for a smoother keyboard navigation experience.

* **Documentation**
  * Added a changelog entry noting the accessibility improvements to the new newsletter editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->