### PR TITLE
Fix schedule and recipients controls in email editor

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
@@ -73,6 +73,9 @@ export function ScheduledRow() {
       .reverse()
       .join(''), // Reverse the string and test for "a" not followed by a slash.
   );
+  // Used for comparing today with DateTimePicker dates to determine validity.
+  // We set the hours to 0:00:00 to match the time format of DateTimePicker dates.
+  const today = new Date().setHours(0, 0, 0, 0);
 
   return (
     <PanelRow>
@@ -140,6 +143,7 @@ export function ScheduledRow() {
                     _x('dmy', 'date order', 'mailpoet')
                   }
                   is12Hour={is12HourTime}
+                  isInvalidDate={(date) => date.getTime() < today}
                 />
               </div>
             )}

--- a/mailpoet/assets/js/src/newsletters/send/time-select.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/time-select.jsx
@@ -18,6 +18,20 @@ class TimeSelect extends Component {
         {timeOfDayItems[val]}
       </option>
     ));
+    // If the current value is not in the predefined timeOfDayItems list,
+    // create a custom option for it. This handles cases where the scheduled time
+    // is set from within the email editor, as the datetime picker allows for
+    // setting any time (not just the predefined options). This ensures the select
+    // renders the correct value and doesn't fall back to the first predefined time.
+    const predefinedTimeKeys = Object.keys(timeOfDayItems);
+    const isCustomTime = value && !predefinedTimeKeys.includes(value);
+    // To match the format of the predefined time options, we remove the seconds from the custom time value.
+    const lastColonIndex = value.lastIndexOf(':');
+    const customOptionLabel =
+      lastColonIndex > 0 ? value.slice(0, lastColonIndex) : value;
+    const customOption = isCustomTime ? (
+      <option value={value}>{customOptionLabel}</option>
+    ) : null;
 
     return (
       <Select
@@ -28,6 +42,7 @@ class TimeSelect extends Component {
         isMinWidth
         {...validation}
       >
+        {customOption}
         {options}
       </Select>
     );

--- a/mailpoet/changelog/2025-11-11-08-21-11-fixed-fixed-the-schedule-and-recipients-fields-in-the-em.md
+++ b/mailpoet/changelog/2025-11-11-08-21-11-fixed-fixed-the-schedule-and-recipients-fields-in-the-em.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fixed the schedule and recipients fields in the email editor sidebar not working correctly

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailApiControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailApiControllerTest.php
@@ -4,9 +4,12 @@ namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\NotFoundException;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\NewsletterOptionField;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\UnexpectedValueException;
 
 class EmailApiControllerTest extends \MailPoetTest {
@@ -87,6 +90,186 @@ class EmailApiControllerTest extends \MailPoetTest {
       verify($exception->getHttpStatusCode())->equals(APIResponse::STATUS_BAD_REQUEST);
       verify($exception->getMessage())->stringContainsString('Newsletter ID does not match the post ID');
     }
+  }
+
+  public function testItUpdatesScheduledAtAndSetsIsScheduledTo1(): void {
+    $wpPostId = 7;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_SCHEDULED_AT,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_IS_SCHEDULED,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    $this->entityManager->flush();
+
+    $scheduledAt = '2024-12-25 14:30:00';
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'scheduled_at' => $scheduledAt,
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT))->equals($scheduledAt);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_IS_SCHEDULED))->equals('1');
+  }
+
+  public function testItUpdatesScheduledAtToNullAndSetsIsScheduledTo0(): void {
+    $wpPostId = 8;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_SCHEDULED_AT,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_IS_SCHEDULED,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    $this->entityManager->flush();
+
+    // First set a scheduled time.
+    $scheduledAt = '2024-12-25 14:30:00';
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'scheduled_at' => $scheduledAt,
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    // Then clear it by setting to null.
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'scheduled_at' => null,
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT))->null();
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_IS_SCHEDULED))->equals('0');
+  }
+
+  public function testItUpdatesSegmentIds(): void {
+    $wpPostId = 11;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $segment1 = (new SegmentFactory())->create();
+    $segment2 = (new SegmentFactory())->create();
+
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'segment_ids' => [$segment1->getId(), $segment2->getId()],
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $segmentIds = $newsletter->getSegmentIds();
+    verify($segmentIds)->arrayCount(2);
+    $this->assertContains($segment1->getId(), $segmentIds);
+    $this->assertContains($segment2->getId(), $segmentIds);
+  }
+
+  public function testItRemovesSegmentsNotInNewList(): void {
+    $wpPostId = 12;
+    $segment1 = (new SegmentFactory())->create();
+    $segment2 = (new SegmentFactory())->create();
+    $segment3 = (new SegmentFactory())->create();
+
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->withSegments([$segment1, $segment2])
+      ->create();
+
+    // Update to only include segment3, removing segment1 and segment2.
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'segment_ids' => [$segment3->getId()],
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $segmentIds = $newsletter->getSegmentIds();
+    verify($segmentIds)->arrayCount(1);
+    $this->assertContains($segment3->getId(), $segmentIds);
+    $this->assertNotContains($segment1->getId(), $segmentIds);
+    $this->assertNotContains($segment2->getId(), $segmentIds);
+  }
+
+  public function testItNormalizesSegmentIdsToIntegers(): void {
+    $wpPostId = 13;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $segment1 = (new SegmentFactory())->create();
+    $segment2 = (new SegmentFactory())->create();
+
+    // Pass segment IDs as strings to test normalization.
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'segment_ids' => [(string)$segment1->getId(), (string)$segment2->getId()],
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $segmentIds = $newsletter->getSegmentIds();
+    verify($segmentIds)->arrayCount(2);
+    $this->assertContains($segment1->getId(), $segmentIds);
+    $this->assertContains($segment2->getId(), $segmentIds);
+
+    foreach ($segmentIds as $segmentId) {
+      verify($segmentId)->isInt();
+    }
+  }
+
+  public function testItHandlesEmptySegmentIdsArray(): void {
+    $wpPostId = 14;
+    $segment1 = (new SegmentFactory())->create();
+    $segment2 = (new SegmentFactory())->create();
+
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->withSegments([$segment1, $segment2])
+      ->create();
+
+    // Clear all segments by passing empty array.
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'segment_ids' => [],
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $segmentIds = $newsletter->getSegmentIds();
+    verify($segmentIds)->arrayCount(0);
   }
 
   public function _after() {


### PR DESCRIPTION
## Description

This PR resolves the following issues with the schedule and recipients fields in the email editor sidebar:

1. Set the `isScheduled` newsletter option accordingly when updating the `scheduledAt` from the email editor sidebar field.
2. Mark past dates in the scheduled date time picker as invalid.
3. Add a custom time option on the `/wp-admin/admin.php?page=mailpoet-newsletters#/send/<id>` screen to properly render a custom times set from the email editor.
4. Fix a bug with recipients lists being removed on subsequent email settings updates from within the email editor.

## Code review notes

_N/A_

## QA notes

* Navigate to MailPoet → Emails → Add New Email → Create using the new email editor (Alpha).
* Select a date to schedule the email and choose your recipients.
* Save the email, then go to Review & Schedule.
* Confirm that the recipients and scheduled date match your selections.
* Return to the email editor and update the recipients.
* Verify that the changes are reflected correctly on the Review & Schedule screen.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7622: Newsletter Send and Recipients controls in Email Editor sidebar not working correctly](https://linear.app/a8c/issue/STOMAIL-7622/newsletter-send-and-recipients-controls-in-email-editor-sidebar-not)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7622-newsletter-send-and-recipients-controls-in-email-editor)

_The latest successful build from `stomail-7622-newsletter-send-and-recipients-controls-in-email-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schedule and recipients fields in the email editor sidebar.
  * Scheduling status now saves and displays correctly.
  * Prevents selecting past dates when scheduling (aligned to day boundary).

* **Improvements**
  * Time selector accepts and shows custom time values when not in presets.

* **Tests**
  * Added integration tests covering scheduling and segment management.

* **Documentation**
  * Added changelog entry describing the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->