### PR TITLE
Include segments in Recipients dropdown in email editor sidebar

### DIFF
--- a/mailpoet/changelog/2025-11-11-12-34-45-fixed-include-segments-in-recipients-dropdown-in-email-e.md
+++ b/mailpoet/changelog/2025-11-11-12-34-45-fixed-include-segments-in-recipients-dropdown-in-email-e.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Include segments in Recipients dropdown in email editor sidebar


### PR DESCRIPTION
## Description

This PR updates the recipients field in the email editor sidebar to additionally fetch and display the dynamic segments as options in the dropdown.

| Before | After |
| - | - |
| <img width="589" height="358" alt="rompHbTHD8NMwPBN" src="https://github.com/user-attachments/assets/63994355-f047-49aa-ac1d-5367f2dcaa3d" /> | <img width="589" height="358" alt="LaXhBtq0OJ6EYmWL" src="https://github.com/user-attachments/assets/a286777e-cc27-4902-9279-cb79abfe5fd6" /> |

## Code review notes

_N/A_

## QA notes

* Add a new segment from MailPoet → Segments → **Add new segment**
* Create a new email using the email editor from MailPoet → Emails → Add new email → **Create using the new email editor (Alpha)**.
* Open the **Recipients** dropdown from the sidebar and confirm the dynamic segment is visible.
* Save the email and navigate to the `Review & send` to verify the dynamic segment has been saved correctly.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7623-include-segments-in-recipients-dropdown-in-email-editor)

_The latest successful build from `stomail-7623-include-segments-in-recipients-dropdown-in-email-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Segments now reliably appear in the Recipients dropdown in the email editor sidebar, including dynamic segments alongside default ones.

* **Improvements**
  * Recipient counts and loading states display correctly; selected segment labels, suggestions and filtering now reflect both default and dynamic segments for clearer selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->