### PR TITLE
Update the Email Editor JS package to version 1.4.0 to resolve a conflict with the latest version of the Gutenberg plugin

### DIFF
--- a/mailpoet/changelog/2025-11-12-08-23-25-updated-update-email-editor-js-package-to-140-to-fix-crash.md
+++ b/mailpoet/changelog/2025-11-12-08-23-25-updated-update-email-editor-js-package-to-140-to-fix-crash.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Update the Email Editor JS package to version 1.4.0 to resolve a conflict with the latest version of the Gutenberg plugin.

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -31,7 +31,7 @@
     "@woocommerce/components": "^12.3.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "1.1.3",
+    "@woocommerce/email-editor": "1.4.0",
     "@wordpress/a11y": "^4.0.0",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.17.21)
       '@woocommerce/email-editor':
-        specifier: 1.1.3
-        version: 1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)
+        specifier: 1.4.0
+        version: 1.4.0(@types/react-dom@18.3.0)(@types/react@18.3.3)
       '@wordpress/a11y':
         specifier: ^4.0.0
         version: 4.0.0
@@ -5395,8 +5395,8 @@ packages:
       qs: 6.12.1
     dev: false
 
-  /@woocommerce/email-editor@1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3):
-    resolution: {integrity: sha512-5t0Txaa8OAL75uxpwRyyWA8BTdiOx2TG0DPEZekfOn5+6RA/8yv2rEdBsBDtOj/6eE1ui9BJlUgWftkgYvH9zA==}
+  /@woocommerce/email-editor@1.4.0(@types/react-dom@18.3.0)(@types/react@18.3.3):
+    resolution: {integrity: sha512-wJETILYZ6hi38D/hgWWjjNQNEAtd6zFDIhPSFGp/CZuNHM1uuoaU6lxB8dTSm0URzGjrUY7f7QKBqOVrTW/h7w==}
     dependencies:
       '@wordpress/api-fetch': 7.0.0
       '@wordpress/base-styles': 5.23.0
@@ -5423,6 +5423,7 @@ packages:
       '@wordpress/keycodes': 4.34.0
       '@wordpress/media-utils': 5.0.0
       '@wordpress/notices': 5.0.0(react@18.3.1)
+      '@wordpress/plugins': 7.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/preferences': 4.30.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/priority-queue': 3.34.0
       '@wordpress/private-apis': 1.34.0


### PR DESCRIPTION


## Description

Update the Email Editor JS package to version 1.4.0 to resolve a conflict with the latest version of the Gutenberg plugin

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-email-editor-js-package)

_The latest successful build from `update-email-editor-js-package` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Email Editor JS package to version 1.4.0

* **Documentation**
  * Added changelog entry documenting the Email Editor package update

<!-- end of auto-generated comment: release notes by coderabbit.ai -->