### PR TITLE
Re-enable email editor template test

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/EmailTemplatesCest.php
@@ -8,11 +8,6 @@ class EmailTemplatesCest {
       $scenario->skip('Temporally skip this test because new email editor is not compatible with WP versions below ' . \AcceptanceTester::EMAIL_EDITOR_MINIMAL_WP_VERSION);
     }
 
-    $wordPressVersion = $i->getWordPressVersion();
-    if (version_compare($wordPressVersion, '6.9', '>=')) {
-      $scenario->skip('Skipping this test for WP 6.9+ due to template changes');
-    }
-
     $i->wantTo('Create standard newsletter using Gutenberg editor');
     $i->login();
     $i->amOnMailpoetPage('Emails');


### PR DESCRIPTION
## Description

WP 6.9 RC1 reverted the breaking change. We can enable the test.

## Code review notes

You can test locally `./do test:acceptance --skip-deps --file=./tests/acceptance/EmailEditor/EmailTemplatesCest.php --wordpress-version=6.9-RC1`

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:re-enable-temlate-test)

_The latest successful build from `re-enable-temlate-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated email editor tests to execute across all WordPress versions, removing previous version-specific restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->