### PR TITLE
Provide automation subject fields as tags in email block editor

### DIFF
--- a/mailpoet/changelog/2025-11-14-07-06-45-added-provide-automation-subject-fields-as-tags-in-email.md
+++ b/mailpoet/changelog/2025-11-14-07-06-45-added-provide-automation-subject-fields-as-tags-in-email.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Provide automation subject fields as tags in email block editor

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -357,6 +357,22 @@ class SendEmailAction implements Action {
       ],
     ];
 
+    // Store all automation subjects and their arguments for personalization tags
+    $subjects = [];
+    foreach ($args->getSubjectEntries() as $key => $entries) {
+      // For each subject, store its key and args
+      foreach ($entries as $entry) {
+        $subjectData = $entry->getSubjectData();
+        $subjects[$key] = [
+          'key' => $subjectData->getKey(),
+          'args' => $subjectData->getArgs(),
+        ];
+      }
+    }
+    if (!empty($subjects)) {
+      $meta['automation']['subjects'] = $subjects;
+    }
+
     if ($this->automationHasAbandonedCartTrigger($args->getAutomation())) {
       $payload = $args->getSinglePayloadByClass(AbandonedCartPayload::class);
       $meta[AbandonedCart::TASK_META_NAME] = $payload->getProductIds();

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -357,22 +357,6 @@ class SendEmailAction implements Action {
       ],
     ];
 
-    // Store all automation subjects and their arguments for personalization tags
-    $subjects = [];
-    foreach ($args->getSubjectEntries() as $key => $entries) {
-      // For each subject, store its key and args
-      foreach ($entries as $entry) {
-        $subjectData = $entry->getSubjectData();
-        $subjects[$key] = [
-          'key' => $subjectData->getKey(),
-          'args' => $subjectData->getArgs(),
-        ];
-      }
-    }
-    if (!empty($subjects)) {
-      $meta['automation']['subjects'] = $subjects;
-    }
-
     if ($this->automationHasAbandonedCartTrigger($args->getAutomation())) {
       $payload = $args->getSinglePayloadByClass(AbandonedCartPayload::class);
       $meta[AbandonedCart::TASK_META_NAME] = $payload->getProductIds();

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -125,12 +125,14 @@ class EmailFactory {
     }
 
     // Create a WordPress post with the pattern content
+    // The meta_input flag prevents other plugins from creating duplicate newsletters
     $postId = $this->wpFunctions->wpInsertPost([
       'post_content' => $patternContent,
       'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
       'post_status' => 'draft',
       'post_author' => $this->wpFunctions->getCurrentUserId(),
       'post_title' => $data['subject'] ?? __('New Email', 'mailpoet'),
+      'meta_input' => ['_mailpoet_is_automation_email' => '1'],
     ]);
 
     if (!is_int($postId) || $postId <= 0) {

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -301,10 +301,7 @@ class Newsletter {
       ];
 
       $queueMeta = $queue->getMeta();
-      if (
-        is_array($queueMeta)
-        && isset($queueMeta['automation']['run_id'])
-      ) {
+      if (isset($queueMeta['automation']['run_id'])) {
         $runId = (int)$queueMeta['automation']['run_id'];
         $automationRun = $this->automationRunStorage->getAutomationRun($runId);
 

--- a/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php
@@ -324,6 +324,10 @@ class Newsletter {
             $context['customer'] = $customer;
           }
         }
+
+        // Allow extensions to add their own subject context
+        /** @var array<string, mixed> $context */
+        $context = $this->wp->applyFilters('mailpoet_automation_email_personalization_context', $context, $queueMeta['automation']['subjects']);
       }
 
       $this->personalizer->set_context($context);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -613,6 +613,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterCoupon::class)->setPublic(true);
     $container->autowire(\MailPoet\Statistics\GATracking::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Preview\WooCommerceDummyData::class)->setPublic(true);
     // Newsletter templates
     $container->autowire(\MailPoet\NewsletterTemplates\NewsletterTemplatesRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\NewsletterTemplates\TemplateImageLoader::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -44,6 +44,8 @@ class EditorPageRenderer {
 
   private Analytics $analytics;
 
+  private PersonalizationTagManager $personalizationTagManager;
+
   public function __construct(
     WPFunctions $wp,
     CdnAssetUrl $cdnAssetUrl,
@@ -53,7 +55,8 @@ class EditorPageRenderer {
     MailPoetSettings $mailpoetSettings,
     NewslettersRepository $newslettersRepository,
     UserFlagsController $userFlagsController,
-    Analytics $analytics
+    Analytics $analytics,
+    PersonalizationTagManager $personalizationTagManager
   ) {
     $this->wp = $wp;
     $this->settingsController = Email_Editor_Container::container()->get(Settings_Controller::class);
@@ -67,6 +70,7 @@ class EditorPageRenderer {
     $this->newslettersRepository = $newslettersRepository;
     $this->userFlagsController = $userFlagsController;
     $this->analytics = $analytics;
+    $this->personalizationTagManager = $personalizationTagManager;
   }
 
   public function render() {
@@ -146,6 +150,10 @@ class EditorPageRenderer {
 
     $isAutomationNewsletter = $newsletter->isAutomation() || $newsletter->isAutomationTransactional();
     $automationId = $newsletter->getOptionValue('automationId');
+
+    if ($isAutomationNewsletter && $automationId) {
+      $this->personalizationTagManager->extendPersonalizationTagsByAutomationSubjects((int)$automationId);
+    }
 
     $listingUrl = 'page=mailpoet-newsletters';
     $sendUrl = 'page=mailpoet-newsletters#/send/' . $newsletter->getId();

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -67,7 +67,7 @@ class PersonalizationTagManager {
    * @return void
    */
   public function maybeExtendTagsForRestRequest(): void {
-    $this->wp->addFilter('rest_pre_dispatch', function($result, $server, $request) {
+    $this->wp->addFilter('rest_pre_dispatch', function($result, $_server, $request) {
       $route = $request->get_route();
 
       // Only process personalization tags endpoints
@@ -79,7 +79,7 @@ class PersonalizationTagManager {
       $postId = null;
       if (isset($_SERVER['HTTP_REFERER'])) {
         $referer = sanitize_text_field(wp_unslash($_SERVER['HTTP_REFERER']));
-        $queryString = parse_url($referer, PHP_URL_QUERY);
+        $queryString = $this->wp->wpParseUrl($referer, PHP_URL_QUERY);
         if ($queryString) {
           parse_str($queryString, $params);
           if (isset($params['post'])) {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -79,8 +79,12 @@ class PersonalizationTagManager {
       $postId = null;
       if (isset($_SERVER['HTTP_REFERER'])) {
         $referer = sanitize_text_field(wp_unslash($_SERVER['HTTP_REFERER']));
-        if (preg_match('/[?&]post=(\d+)/', $referer, $matches)) {
-          $postId = (int)$matches[1];
+        $queryString = parse_url($referer, PHP_URL_QUERY);
+        if ($queryString) {
+          parse_str($queryString, $params);
+          if (isset($params['post'])) {
+            $postId = (int)$params['post'];
+          }
         }
       }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -273,7 +273,12 @@ class PersonalizationTagManager {
   private function shouldExtendTagCategory(string $category, array $availableSubjects): bool {
     $categoryToSubjects = $this->getCategoryToSubjectsMapping();
 
-    $requiredSubjects = $categoryToSubjects[$category] ?? [];
+    // Unknown categories should not be extended
+    if (!array_key_exists($category, $categoryToSubjects)) {
+      return false;
+    }
+
+    $requiredSubjects = $categoryToSubjects[$category];
 
     // If no subjects required (e.g., Store), always extend
     if (empty($requiredSubjects)) {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -2,12 +2,16 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
 use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tag;
 use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Link;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\LinksToShortcodesConvertor;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Site;
 use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTags\Subscriber;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class PersonalizationTagManager {
@@ -16,22 +20,89 @@ class PersonalizationTagManager {
   private Link $link;
   private WPFunctions $wp;
   private LinksToShortcodesConvertor $linksToShortcodesConvertor;
+  private AutomationStorage $automationStorage;
+  private Registry $registry;
+  private NewslettersRepository $newslettersRepository;
 
   public function __construct(
     Subscriber $subscriber,
     Site $site,
     Link $link,
     WPFunctions $wp,
-    LinksToShortcodesConvertor $linksToShortcodesConvertor
+    LinksToShortcodesConvertor $linksToShortcodesConvertor,
+    AutomationStorage $automationStorage,
+    Registry $registry,
+    NewslettersRepository $newslettersRepository
   ) {
     $this->subscriber = $subscriber;
     $this->site = $site;
     $this->link = $link;
     $this->wp = $wp;
     $this->linksToShortcodesConvertor = $linksToShortcodesConvertor;
+    $this->automationStorage = $automationStorage;
+    $this->registry = $registry;
+    $this->newslettersRepository = $newslettersRepository;
+  }
+
+  /**
+   * Re-extend WooCommerce tags with current automation context.
+   *
+   * @return void
+   */
+  public function extendPersonalizationTagsByAutomationSubjects(int $automationId): void {
+    $registry = Email_Editor_Container::container()->get(
+      Personalization_Tags_Registry::class
+    );
+
+    $this->extendWooCommerceTagsForMailPoet($registry, $automationId);
+  }
+
+  /**
+   * Extend tags for REST API requests to personalization tags endpoint.
+   * This is necessary because the registry is initialized early and preloading fetches from it immediately.
+   *
+   * @return void
+   */
+  public function maybeExtendTagsForRestRequest(): void {
+    $this->wp->addFilter('rest_pre_dispatch', function($result, $server, $request) {
+      $route = $request->get_route();
+
+      // Only process personalization tags endpoints
+      if (strpos($route, '/woocommerce-email-editor/v1/personalization_tags') === false) {
+        return $result;
+      }
+
+      // Try to get post ID from referer
+      $postId = null;
+      if (isset($_SERVER['HTTP_REFERER'])) {
+        $referer = sanitize_text_field(wp_unslash($_SERVER['HTTP_REFERER']));
+        if (preg_match('/[?&]post=(\d+)/', $referer, $matches)) {
+          $postId = (int)$matches[1];
+        }
+      }
+
+      if (!$postId) {
+        return $result;
+      }
+
+      $newsletter = $this->newslettersRepository->findOneBy(['wpPost' => $postId]);
+      if (!$newsletter || (!$newsletter->isAutomation() && !$newsletter->isAutomationTransactional())) {
+        return $result;
+      }
+
+      $automationId = $newsletter->getOptionValue('automationId');
+      if ($automationId) {
+        $this->extendPersonalizationTagsByAutomationSubjects((int)$automationId);
+      }
+
+      return $result;
+    }, 10, 3);
   }
 
   public function initialize() {
+    // Extend tags for REST API requests (needed for preloading and dynamic fetching)
+    $this->wp->addAction('rest_api_init', [$this, 'maybeExtendTagsForRestRequest']);
+
     $this->wp->addFilter('woocommerce_email_editor_register_personalization_tags', function( Personalization_Tags_Registry $registry ): Personalization_Tags_Registry {
       // Subscriber Personalization Tags
       $registry->register(new Personalization_Tag(
@@ -146,5 +217,108 @@ class PersonalizationTagManager {
     }
     $emailContent['html'] = $this->linksToShortcodesConvertor->convertLinkTagsToShortcodes($emailContent['html']);
     return $emailContent;
+  }
+
+  /**
+   * Extend WooCommerce personalization tags to also work with MailPoet email post type.
+   * This allows WooCommerce Order and Customer tags to be used in MailPoet automation emails
+   * when the appropriate subjects (order, customer) are available.
+   */
+  public function extendWooCommerceTagsForMailPoet(Personalization_Tags_Registry $registry, int $automationId): Personalization_Tags_Registry {
+    $availableSubjects = $this->getAutomationSubjects($automationId);
+
+    $tags = $registry->get_all();
+
+    foreach ($tags as $tag) {
+      $postTypes = $tag->get_post_types();
+
+      // If this is a WooCommerce tag (Order, Customer, Site, Store) and doesn't already support mailpoet_email
+      if (!empty($postTypes) && !in_array(EmailEditor::MAILPOET_EMAIL_POST_TYPE, $postTypes, true)) {
+        // Check if we should extend this tag based on its category and available subjects
+        $category = $tag->get_category();
+        $shouldExtend = $this->shouldExtendTagCategory($category, $availableSubjects);
+
+        if ($shouldExtend) {
+          // Add mailpoet_email to the list of supported post types
+          $postTypes[] = EmailEditor::MAILPOET_EMAIL_POST_TYPE;
+
+          $registry->unregister($tag);
+          // Re-register the tag with extended post types
+          $registry->register(new Personalization_Tag(
+            $tag->get_name(),
+            $tag->get_token(),
+            $tag->get_category(),
+            $tag->get_callback(),
+            $tag->get_attributes(),
+            $tag->get_value_to_insert(),
+            $postTypes
+          ));
+        }
+      }
+    }
+
+    return $registry;
+  }
+
+  /**
+   * Determine if a tag category should be extended to MailPoet emails.
+   * This checks if the required subjects are available for the current automation.
+   *
+   * @param string $category The tag category (e.g., 'Order', 'Customer', 'Site')
+   * @param string[]|null $availableSubjects Available subject keys, or null if no automation context
+   * @return bool Whether to extend tags in this category
+   */
+  private function shouldExtendTagCategory(string $category, ?array $availableSubjects): bool {
+    // Map categories to required subjects
+    $categoryToSubjects = [
+      'Order' => ['woocommerce:order'],
+      'Customer' => ['woocommerce:customer'],
+      'Store' => [], // Always available
+    ];
+
+    $requiredSubjects = $categoryToSubjects[$category] ?? [];
+
+    // If no subjects required (e.g., Store), always extend
+    if (empty($requiredSubjects)) {
+      return true;
+    }
+
+    // If no automation context (not in automation email), don't extend subject-dependent tags
+    if ($availableSubjects === null) {
+      return false;
+    }
+
+    // Check if at least one required subject is available
+    foreach ($requiredSubjects as $required) {
+      if (in_array($required, $availableSubjects, true)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get subject keys available in an automation based on its triggers.
+   *
+   * @param int $automationId The automation ID
+   * @return string[] Array of subject keys
+   */
+  private function getAutomationSubjects(int $automationId): array {
+    $automation = $this->automationStorage->getAutomation($automationId);
+    if (!$automation) {
+      return [];
+    }
+
+    $subjects = [];
+    foreach ($automation->getTriggers() as $triggerStep) {
+      $trigger = $this->registry->getTrigger($triggerStep->getKey());
+      if ($trigger) {
+        $subjectKeys = $trigger->getSubjectKeys();
+        $subjects = array_merge($subjects, $subjectKeys);
+      }
+    }
+
+    return array_unique($subjects);
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/PersonalizationTagManager.php
@@ -54,7 +54,10 @@ class PersonalizationTagManager {
       Personalization_Tags_Registry::class
     );
 
-    $this->extendWooCommerceTagsForMailPoet($registry, $automationId);
+    $availableSubjects = $this->getAutomationSubjects($automationId);
+    $this->extendWooCommerceTagsForMailPoet($registry, $availableSubjects);
+
+    $this->wp->applyFilters('mailpoet_automation_email_extend_personalization_tags', $registry, $availableSubjects);
   }
 
   /**
@@ -224,9 +227,7 @@ class PersonalizationTagManager {
    * This allows WooCommerce Order and Customer tags to be used in MailPoet automation emails
    * when the appropriate subjects (order, customer) are available.
    */
-  public function extendWooCommerceTagsForMailPoet(Personalization_Tags_Registry $registry, int $automationId): Personalization_Tags_Registry {
-    $availableSubjects = $this->getAutomationSubjects($automationId);
-
+  public function extendWooCommerceTagsForMailPoet(Personalization_Tags_Registry $registry, array $availableSubjects): Personalization_Tags_Registry {
     $tags = $registry->get_all();
 
     foreach ($tags as $tag) {
@@ -270,6 +271,7 @@ class PersonalizationTagManager {
    */
   private function shouldExtendTagCategory(string $category, ?array $availableSubjects): bool {
     // Map categories to required subjects
+    /** @var array<string, string[]> $categoryToSubjects */
     $categoryToSubjects = [
       'Order' => ['woocommerce:order'],
       'Customer' => ['woocommerce:customer'],

--- a/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
+++ b/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
@@ -41,7 +41,7 @@ class SendPreviewController {
     Renderer $renderer,
     WPFunctions $wp,
     SubscribersRepository $subscribersRepository,
-    Shortcodes $shortcodes
+    Shortcodes $shortcodes,
   ) {
     $this->mailerFactory = $mailerFactory;
     $this->mailerMetaInfo = $mailerMetaInfo;
@@ -76,11 +76,21 @@ class SendPreviewController {
     ] = explode($divider, $this->shortcodes->replace($body));
 
     if ($newsletter->getWpPostId()) {
-      $this->personalizer->set_context([
+      $context = [
         'recipient_email' => $subscriber ? $subscriber->getEmail() : $emailAddress,
         'newsletter_id' => $newsletter->getId(),
         'is_preview' => true,
-      ]);
+      ];
+
+      // For automation emails, add sample WooCommerce order/customer data for preview
+      if ($newsletter->isAutomation() || $newsletter->isAutomationTransactional()) {
+        $automationId = $newsletter->getOptionValue('automationId');
+        if ($automationId) {
+          $context = $this->addSampleDataToContext($context);
+        }
+      }
+
+      $this->personalizer->set_context($context);
       $renderedNewsletter['subject'] = $this->personalizer->personalize_content($renderedNewsletter['subject']);
       $renderedNewsletter['body']['html'] = $this->personalizer->personalize_content($renderedNewsletter['body']['html']);
       $renderedNewsletter['body']['text'] = $this->personalizer->personalize_content($renderedNewsletter['body']['text']);
@@ -101,6 +111,121 @@ class SendPreviewController {
         $result['error']->getMessage()
       );
       throw new SendPreviewException($error);
+    }
+  }
+
+  /**
+   * Add sample WooCommerce order/customer data to context for preview.
+   * Uses WooCommerce's dummy data for consistent, predictable previews.
+   *
+   * @param array $context Existing context
+   * @return array Context with sample data added
+   */
+  private function addSampleDataToContext(array $context): array {
+    $dummyOrder = $this->getWooCommerceDummyOrder();
+    if ($dummyOrder instanceof \WC_Order) {
+      $context['order'] = $dummyOrder;
+    }
+
+    $dummyCustomer = $this->getWooCommerceDummyCustomer();
+    if ($dummyCustomer instanceof \WC_Customer) {
+      $context['customer'] = $dummyCustomer;
+    }
+
+    return $context;
+  }
+
+  /**
+   * Get a dummy WooCommerce order using WooCommerce's EmailPreview class.
+   * This reuses WooCommerce's placeholder generation logic.
+   *
+   * @return \WC_Order|null Dummy order or null if unavailable
+   */
+  private function getWooCommerceDummyOrder(): ?\WC_Order {
+    // Check if WooCommerce EmailPreview class exists
+    if (!class_exists('Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview')) {
+      return null;
+    }
+
+    try {
+      // Access WooCommerce EmailPreview singleton
+      $emailPreview = \Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview::instance();
+
+      // Use reflection to call the private get_dummy_order() method
+      $reflectionClass = new \ReflectionClass($emailPreview);
+      $method = $reflectionClass->getMethod('get_dummy_order');
+      $method->setAccessible(true);
+
+      $dummyOrder = $method->invoke($emailPreview);
+
+      return $dummyOrder instanceof \WC_Order ? $dummyOrder : null;
+    } catch (\Throwable $e) {
+      // If reflection fails, try the filter as fallback
+      $dummyOrder = $this->wp->applyFilters('woocommerce_email_preview_dummy_order', null, null);
+      return $dummyOrder instanceof \WC_Order ? $dummyOrder : null;
+    }
+  }
+
+  /**
+   * Get a dummy WooCommerce customer using WooCommerce's dummy address data.
+   * Creates a WC_Customer with placeholder data matching WooCommerce's approach.
+   *
+   * @return \WC_Customer|null Dummy customer or null if unavailable
+   */
+  private function getWooCommerceDummyCustomer(): ?\WC_Customer {
+    if (!class_exists(\WC_Customer::class)) {
+      return null;
+    }
+
+    try {
+      $dummyAddress = $this->wp->applyFilters('woocommerce_email_preview_dummy_address', [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'company' => 'Company',
+        'email' => 'john@company.com',
+        'phone' => '555-555-5555',
+        'address_1' => '123 Fake Street',
+        'city' => 'Faketown',
+        'postcode' => '12345',
+        'country' => 'US',
+        'state' => 'CA',
+      ], null);
+
+      // Ensure the filter result is an array
+      if (!is_array($dummyAddress)) {
+        $dummyAddress = [];
+      }
+
+      // Create a dummy customer with WooCommerce's placeholder data
+      $customer = new \WC_Customer();
+      $customer->set_id(0); // Mark as unsaved
+      $customer->set_first_name((string)($dummyAddress['first_name'] ?? 'John'));
+      $customer->set_last_name((string)($dummyAddress['last_name'] ?? 'Doe'));
+      $customer->set_email((string)($dummyAddress['email'] ?? 'john@company.com'));
+      $customer->set_billing_first_name((string)($dummyAddress['first_name'] ?? 'John'));
+      $customer->set_billing_last_name((string)($dummyAddress['last_name'] ?? 'Doe'));
+      $customer->set_billing_company((string)($dummyAddress['company'] ?? 'Company'));
+      $customer->set_billing_address_1((string)($dummyAddress['address_1'] ?? '123 Fake Street'));
+      $customer->set_billing_city((string)($dummyAddress['city'] ?? 'Faketown'));
+      $customer->set_billing_state((string)($dummyAddress['state'] ?? 'CA'));
+      $customer->set_billing_postcode((string)($dummyAddress['postcode'] ?? '12345'));
+      $customer->set_billing_country((string)($dummyAddress['country'] ?? 'US'));
+      $customer->set_billing_phone((string)($dummyAddress['phone'] ?? '555-555-5555'));
+      $customer->set_billing_email((string)($dummyAddress['email'] ?? 'john@company.com'));
+
+      // Set shipping address (same as billing for dummy data)
+      $customer->set_shipping_first_name((string)($dummyAddress['first_name'] ?? 'John'));
+      $customer->set_shipping_last_name((string)($dummyAddress['last_name'] ?? 'Doe'));
+      $customer->set_shipping_company((string)($dummyAddress['company'] ?? 'Company'));
+      $customer->set_shipping_address_1((string)($dummyAddress['address_1'] ?? '123 Fake Street'));
+      $customer->set_shipping_city((string)($dummyAddress['city'] ?? 'Faketown'));
+      $customer->set_shipping_state((string)($dummyAddress['state'] ?? 'CA'));
+      $customer->set_shipping_postcode((string)($dummyAddress['postcode'] ?? '12345'));
+      $customer->set_shipping_country((string)($dummyAddress['country'] ?? 'US'));
+
+      return $customer;
+    } catch (\Throwable $e) {
+      return null;
     }
   }
 }

--- a/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
+++ b/mailpoet/lib/Newsletter/Preview/SendPreviewController.php
@@ -39,6 +39,9 @@ class SendPreviewController {
   /** @var PersonalizationTagManager */
   private $personalizationTagManager;
 
+  /** @var WooCommerceDummyData */
+  private $wooCommerceDummyData;
+
   public function __construct(
     MailerFactory $mailerFactory,
     MetaInfo $mailerMetaInfo,
@@ -46,7 +49,8 @@ class SendPreviewController {
     WPFunctions $wp,
     SubscribersRepository $subscribersRepository,
     Shortcodes $shortcodes,
-    PersonalizationTagManager $personalizationTagManager
+    PersonalizationTagManager $personalizationTagManager,
+    WooCommerceDummyData $wooCommerceDummyData
   ) {
     $this->mailerFactory = $mailerFactory;
     $this->mailerMetaInfo = $mailerMetaInfo;
@@ -56,6 +60,7 @@ class SendPreviewController {
     $this->subscribersRepository = $subscribersRepository;
     $this->personalizer = Email_Editor_Container::container()->get(Personalizer::class);
     $this->personalizationTagManager = $personalizationTagManager;
+    $this->wooCommerceDummyData = $wooCommerceDummyData;
   }
 
   public function sendPreview(NewsletterEntity $newsletter, string $emailAddress) {
@@ -124,20 +129,19 @@ class SendPreviewController {
 
   /**
    * Add sample WooCommerce order/customer data to context for preview.
-   * Uses WooCommerce's dummy data for consistent, predictable previews.
    *
    * @param array<string, mixed> $context Existing context
    * @return array<string, mixed> Context with sample data added
    */
   private function addSampleDataToContext(array $context): array {
-    $dummyOrder = $this->getWooCommerceDummyOrder();
-    if ($dummyOrder instanceof \WC_Order) {
-      $context['order'] = $dummyOrder;
+    $order = $this->wooCommerceDummyData->getOrder();
+    if ($order instanceof \WC_Order) {
+      $context['order'] = $order;
     }
 
-    $dummyCustomer = $this->getWooCommerceDummyCustomer();
-    if ($dummyCustomer instanceof \WC_Customer) {
-      $context['customer'] = $dummyCustomer;
+    $customer = $this->wooCommerceDummyData->getCustomer();
+    if ($customer instanceof \WC_Customer) {
+      $context['customer'] = $customer;
     }
 
     // Allow extensions (like premium plugin) to add additional sample data for preview
@@ -145,102 +149,5 @@ class SendPreviewController {
     $context = $this->wp->applyFilters('mailpoet_automation_email_preview_sample_data', $context);
 
     return $context;
-  }
-
-  /**
-   * Get a dummy WooCommerce order using WooCommerce's EmailPreview class.
-   * This reuses WooCommerce's placeholder generation logic.
-   *
-   * @return \WC_Order|null Dummy order or null if unavailable
-   */
-  private function getWooCommerceDummyOrder(): ?\WC_Order {
-    // Check if WooCommerce EmailPreview class exists
-    if (!class_exists('Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview')) {
-      return null;
-    }
-
-    try {
-      $emailPreview = \Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview::instance();
-
-      // Check if get_dummy_order() is public (WooCommerce 9.8+)
-      $reflectionClass = new \ReflectionClass($emailPreview);
-      $method = $reflectionClass->getMethod('get_dummy_order');
-
-      if ($method->isPublic()) {
-        // Method is public, call it directly
-        $dummyOrder = $emailPreview->get_dummy_order();
-      } else {
-        // Backward compatibility: method is private in older WooCommerce versions
-        $method->setAccessible(true);
-        $dummyOrder = $method->invoke($emailPreview);
-      }
-
-      return $dummyOrder instanceof \WC_Order ? $dummyOrder : null;
-    } catch (\Throwable $e) {
-      return null;
-    }
-  }
-
-  /**
-   * Get a dummy WooCommerce customer using WooCommerce's dummy address data.
-   * Creates a WC_Customer with placeholder data matching WooCommerce's approach.
-   *
-   * @return \WC_Customer|null Dummy customer or null if unavailable
-   */
-  private function getWooCommerceDummyCustomer(): ?\WC_Customer {
-    if (!class_exists(\WC_Customer::class)) {
-      return null;
-    }
-
-    try {
-      $dummyAddress = $this->wp->applyFilters('woocommerce_email_preview_dummy_address', [
-        'first_name' => 'John',
-        'last_name' => 'Doe',
-        'company' => 'Company',
-        'email' => 'john@company.com',
-        'phone' => '555-555-5555',
-        'address_1' => '123 Fake Street',
-        'city' => 'Faketown',
-        'postcode' => '12345',
-        'country' => 'US',
-        'state' => 'CA',
-      ], null);
-
-      // Ensure the filter result is an array
-      if (!is_array($dummyAddress)) {
-        $dummyAddress = [];
-      }
-
-      // Create a dummy customer with WooCommerce's placeholder data
-      $customer = new \WC_Customer();
-      $customer->set_id(0); // Mark as unsaved
-      $customer->set_first_name((string)($dummyAddress['first_name'] ?? 'John'));
-      $customer->set_last_name((string)($dummyAddress['last_name'] ?? 'Doe'));
-      $customer->set_email((string)($dummyAddress['email'] ?? 'john@company.com'));
-      $customer->set_billing_first_name((string)($dummyAddress['first_name'] ?? 'John'));
-      $customer->set_billing_last_name((string)($dummyAddress['last_name'] ?? 'Doe'));
-      $customer->set_billing_company((string)($dummyAddress['company'] ?? 'Company'));
-      $customer->set_billing_address_1((string)($dummyAddress['address_1'] ?? '123 Fake Street'));
-      $customer->set_billing_city((string)($dummyAddress['city'] ?? 'Faketown'));
-      $customer->set_billing_state((string)($dummyAddress['state'] ?? 'CA'));
-      $customer->set_billing_postcode((string)($dummyAddress['postcode'] ?? '12345'));
-      $customer->set_billing_country((string)($dummyAddress['country'] ?? 'US'));
-      $customer->set_billing_phone((string)($dummyAddress['phone'] ?? '555-555-5555'));
-      $customer->set_billing_email((string)($dummyAddress['email'] ?? 'john@company.com'));
-
-      // Set shipping address (same as billing for dummy data)
-      $customer->set_shipping_first_name((string)($dummyAddress['first_name'] ?? 'John'));
-      $customer->set_shipping_last_name((string)($dummyAddress['last_name'] ?? 'Doe'));
-      $customer->set_shipping_company((string)($dummyAddress['company'] ?? 'Company'));
-      $customer->set_shipping_address_1((string)($dummyAddress['address_1'] ?? '123 Fake Street'));
-      $customer->set_shipping_city((string)($dummyAddress['city'] ?? 'Faketown'));
-      $customer->set_shipping_state((string)($dummyAddress['state'] ?? 'CA'));
-      $customer->set_shipping_postcode((string)($dummyAddress['postcode'] ?? '12345'));
-      $customer->set_shipping_country((string)($dummyAddress['country'] ?? 'US'));
-
-      return $customer;
-    } catch (\Throwable $e) {
-      return null;
-    }
   }
 }

--- a/mailpoet/lib/Newsletter/Preview/WooCommerceDummyData.php
+++ b/mailpoet/lib/Newsletter/Preview/WooCommerceDummyData.php
@@ -1,0 +1,256 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Preview;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Provides dummy WooCommerce data for email previews.
+ * Uses WooCommerce filters when available, with fallback to default data.
+ */
+class WooCommerceDummyData {
+  private WPFunctions $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  /**
+   * Get a dummy WooCommerce order with placeholder data for preview.
+   *
+   * @return \WC_Order|null Dummy order or null if WooCommerce is unavailable
+   */
+  public function getOrder(): ?\WC_Order {
+    if (!class_exists(\WC_Order::class)) {
+      return null;
+    }
+
+    try {
+      $order = new \WC_Order();
+      $order->set_id(12345);
+
+      $this->setOrderAddress($order);
+      $this->addOrderItems($order);
+      $this->setOrderMetadata($order);
+
+      return $order;
+    } catch (\Throwable $e) {
+      return null;
+    }
+  }
+
+  /**
+   * Get a dummy WooCommerce customer with placeholder data for preview.
+   *
+   * @return \WC_Customer|null Dummy customer or null if WooCommerce is unavailable
+   */
+  public function getCustomer(): ?\WC_Customer {
+    if (!class_exists(\WC_Customer::class)) {
+      return null;
+    }
+
+    try {
+      $address = $this->getAddress();
+      $customer = new \WC_Customer();
+      $customer->set_id(0);
+
+      // Set basic info
+      $customer->set_first_name($address['first_name']);
+      $customer->set_last_name($address['last_name']);
+      $customer->set_email($address['email']);
+
+      // Set billing address
+      $customer->set_billing_first_name($address['first_name']);
+      $customer->set_billing_last_name($address['last_name']);
+      $customer->set_billing_company($address['company']);
+      $customer->set_billing_address_1($address['address_1']);
+      $customer->set_billing_city($address['city']);
+      $customer->set_billing_state($address['state']);
+      $customer->set_billing_postcode($address['postcode']);
+      $customer->set_billing_country($address['country']);
+      $customer->set_billing_phone($address['phone']);
+      $customer->set_billing_email($address['email']);
+
+      // Set shipping address (same as billing)
+      $customer->set_shipping_first_name($address['first_name']);
+      $customer->set_shipping_last_name($address['last_name']);
+      $customer->set_shipping_company($address['company']);
+      $customer->set_shipping_address_1($address['address_1']);
+      $customer->set_shipping_city($address['city']);
+      $customer->set_shipping_state($address['state']);
+      $customer->set_shipping_postcode($address['postcode']);
+      $customer->set_shipping_country($address['country']);
+
+      return $customer;
+    } catch (\Throwable $e) {
+      return null;
+    }
+  }
+
+  /**
+   * Get dummy address data using WooCommerce filter with fallback.
+   *
+   * @return array{first_name: string, last_name: string, company: string, email: string, phone: string, address_1: string, city: string, postcode: string, country: string, state: string}
+   */
+  private function getAddress(): array {
+    $default = [
+      'first_name' => 'John',
+      'last_name' => 'Doe',
+      'company' => 'Company',
+      'email' => 'john@company.com',
+      'phone' => '555-555-5555',
+      'address_1' => '123 Fake Street',
+      'city' => 'Faketown',
+      'postcode' => '12345',
+      'country' => 'US',
+      'state' => 'CA',
+    ];
+
+    $address = $this->wp->applyFilters('woocommerce_email_preview_dummy_address', $default, null);
+
+    if (!is_array($address)) {
+      return $default;
+    }
+
+    return [
+      'first_name' => (string)($address['first_name'] ?? $default['first_name']),
+      'last_name' => (string)($address['last_name'] ?? $default['last_name']),
+      'company' => (string)($address['company'] ?? $default['company']),
+      'email' => (string)($address['email'] ?? $default['email']),
+      'phone' => (string)($address['phone'] ?? $default['phone']),
+      'address_1' => (string)($address['address_1'] ?? $default['address_1']),
+      'city' => (string)($address['city'] ?? $default['city']),
+      'postcode' => (string)($address['postcode'] ?? $default['postcode']),
+      'country' => (string)($address['country'] ?? $default['country']),
+      'state' => (string)($address['state'] ?? $default['state']),
+    ];
+  }
+
+  /**
+   * Set billing and shipping address on order.
+   */
+  private function setOrderAddress(\WC_Order $order): void {
+    $address = $this->getAddress();
+
+    // Billing
+    $order->set_billing_first_name($address['first_name']);
+    $order->set_billing_last_name($address['last_name']);
+    $order->set_billing_company($address['company']);
+    $order->set_billing_email($address['email']);
+    $order->set_billing_phone($address['phone']);
+    $order->set_billing_address_1($address['address_1']);
+    $order->set_billing_city($address['city']);
+    $order->set_billing_state($address['state']);
+    $order->set_billing_postcode($address['postcode']);
+    $order->set_billing_country($address['country']);
+
+    // Shipping (same as billing)
+    $order->set_shipping_first_name($address['first_name']);
+    $order->set_shipping_last_name($address['last_name']);
+    $order->set_shipping_company($address['company']);
+    $order->set_shipping_address_1($address['address_1']);
+    $order->set_shipping_city($address['city']);
+    $order->set_shipping_state($address['state']);
+    $order->set_shipping_postcode($address['postcode']);
+    $order->set_shipping_country($address['country']);
+  }
+
+  /**
+   * Set order metadata (status, totals, payment, etc.).
+   */
+  private function setOrderMetadata(\WC_Order $order): void {
+    $order->set_status('completed');
+    $order->set_currency(function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : 'USD');
+    $order->set_total('99.99');
+    $order->set_discount_total('10');
+    $order->set_shipping_total('5');
+    $order->set_date_created(time());
+    $order->set_payment_method('bacs');
+    $order->set_payment_method_title('Direct Bank Transfer');
+  }
+
+  /**
+   * Add dummy line items to the order.
+   * Uses WooCommerce filters when available, with fallback to default products.
+   */
+  private function addOrderItems(\WC_Order $order): void {
+    if (!class_exists(\WC_Order_Item_Product::class)) {
+      return;
+    }
+
+    $product = $this->getProduct();
+    if ($product) {
+      $item = new \WC_Order_Item_Product();
+      $item->set_props([
+        'name' => $product->get_name(),
+        'product_id' => $product->get_id(),
+        'quantity' => 2,
+        'subtotal' => (string)((float)$product->get_price() * 2),
+        'total' => (string)((float)$product->get_price() * 2),
+      ]);
+      $order->add_item($item);
+    }
+
+    $variation = $this->getProductVariation();
+    if ($variation) {
+      $item = new \WC_Order_Item_Product();
+      $item->set_props([
+        'name' => $variation->get_name(),
+        'product_id' => $variation->get_parent_id(),
+        'variation_id' => $variation->get_id(),
+        'quantity' => 1,
+        'subtotal' => $variation->get_price(),
+        'total' => $variation->get_price(),
+      ]);
+      $order->add_item($item);
+    }
+  }
+
+  /**
+   * Get a dummy product using WooCommerce filter with fallback.
+   */
+  private function getProduct(): ?\WC_Product {
+    if (!class_exists(\WC_Product::class)) {
+      return null;
+    }
+
+    // Try to get from filter first
+    $product = $this->wp->applyFilters('woocommerce_email_preview_dummy_product', null, null);
+
+    if ($product instanceof \WC_Product) {
+      return $product;
+    }
+
+    // Fallback: create default dummy product
+    $product = new \WC_Product();
+    $product->set_name(__('Dummy Product', 'woocommerce'));
+    $product->set_price('25');
+
+    return $product;
+  }
+
+  /**
+   * Get a dummy product variation using WooCommerce filter with fallback.
+   */
+  private function getProductVariation(): ?\WC_Product_Variation {
+    if (!class_exists(\WC_Product_Variation::class)) {
+      return null;
+    }
+
+    // Try to get from filter first
+    $variation = $this->wp->applyFilters('woocommerce_email_preview_dummy_product_variation', null, null);
+
+    if ($variation instanceof \WC_Product_Variation) {
+      return $variation;
+    }
+
+    // Fallback: create default dummy variation
+    $variation = new \WC_Product_Variation();
+    $variation->set_name(__('Dummy Product Variation', 'woocommerce'));
+    $variation->set_price('20');
+
+    return $variation;
+  }
+}

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -56,6 +56,21 @@ namespace {
       public function get_date(string $dateType, string $timeZone = 'gmt') {
         return 0;
       }
+
+      public function set_billing_period($period) {
+      }
+
+      public function set_billing_interval($interval) {
+      }
+
+      public function set_requires_manual_renewal($manual) {
+      }
+
+      public function set_cancelled_email_sent($sent) {
+      }
+
+      public function update_dates($dates) {
+      }
     }
   }
 
@@ -140,6 +155,27 @@ namespace {
        */
       public function save(): int {
         return 1;
+      }
+
+      public function set_id($id) {
+      }
+
+      public function set_status($status) {
+      }
+
+      public function set_start($start) {
+      }
+
+      public function set_end($end) {
+      }
+
+      public function set_all_day($all_day) {
+      }
+
+      public function set_date_created($date) {
+      }
+
+      public function set_date_modified($date) {
       }
     }
   }

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -71,6 +71,10 @@ namespace {
 
       public function update_dates($dates) {
       }
+
+      public function get_time($date_type, $timezone = 'gmt') {
+        return 0;
+      }
     }
   }
 

--- a/mailpoet/tasks/phpstan/custom-stubs.php
+++ b/mailpoet/tasks/phpstan/custom-stubs.php
@@ -181,6 +181,12 @@ namespace {
 
       public function set_date_modified($date) {
       }
+
+      /**
+       * @param int|array<int, int> $persons
+       */
+      public function set_persons($persons) {
+      }
     }
   }
 

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -92,7 +92,8 @@ class SendPreviewControllerTest extends \MailPoetTest {
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
       $shortcodes,
-      $this->diContainer->get(PersonalizationTagManager::class)
+      $this->diContainer->get(PersonalizationTagManager::class),
+      $this->diContainer->get(WooCommerceDummyData::class)
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }
@@ -124,7 +125,8 @@ class SendPreviewControllerTest extends \MailPoetTest {
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(Shortcodes::class),
-      $this->diContainer->get(PersonalizationTagManager::class)
+      $this->diContainer->get(PersonalizationTagManager::class),
+      $this->diContainer->get(WooCommerceDummyData::class)
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }

--- a/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Preview/SendPreviewControllerTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Newsletter\Preview;
 
 use Codeception\Stub\Expected;
 use Codeception\Util\Fixtures;
+use MailPoet\EmailEditor\Integrations\MailPoet\PersonalizationTagManager;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Mailer\Mailer;
@@ -91,6 +92,7 @@ class SendPreviewControllerTest extends \MailPoetTest {
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
       $shortcodes,
+      $this->diContainer->get(PersonalizationTagManager::class)
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }
@@ -122,6 +124,7 @@ class SendPreviewControllerTest extends \MailPoetTest {
       new WPFunctions(),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(Shortcodes::class),
+      $this->diContainer->get(PersonalizationTagManager::class)
     );
     $sendPreviewController->sendPreview($this->newsletter, 'test@subscriber.com');
   }


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

1. Install WooCommerce, WooCommerce Bookings, and WooCommerce Subscriptions plugins
2. Set `Use block email editor for automation emails` to `Yes`
3. Create automation, for example, `Purchased a product`
4. Design an email in the block email editor and try to use WooCommerce Personalization tags
5. Verify that tags are replaced in the browser preview, email preview, and sent emails

Repeat steps 3 - 5 for the different automation triggers for WooCommerce Bookings and Subscriptions.
There should be related personalization tags based on the automation subjects.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/991

## Linked tickets

STOMAIL-7353

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7353-provide-subject-fields-as-tags-in-new-editor)

_The latest successful build from `stomail-7353-provide-subject-fields-as-tags-in-new-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation subject fields are now available as personalization tags in the email block editor, previews, and sends.
  * Editor previews and preview emails include sample WooCommerce order and customer data so personalization tags render correctly.
* **Documentation**
  * Added a changelog entry describing these personalization and preview enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->