### PR TITLE
Add patching of PHP production libraries in zip build

### DIFF
--- a/mailpoet/build.sh
+++ b/mailpoet/build.sh
@@ -52,6 +52,9 @@ COMPOSER_MIRROR_PATH_REPOS=1 ./tools/vendor/composer.phar install --no-dev --pre
 echo '[BUILD] Fetching prefixed production libraries'
 ./tools/vendor/composer.phar install --no-dev --prefer-dist --working-dir=./prefixer/
 
+# Run patches for production libraries
+./tools/vendor/composer.phar run-script patch-production-libraries
+
 # Remove Doctrine Annotations (no need since generated metadata are packed)
 # Should be removed before `dump-autoload` to not include the annotations classes on the autoloader.
 rm -rf vendor-prefixed/doctrine/annotations

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -84,6 +84,10 @@
       "php ./tasks/fix-codeception-stub.php",
       "php ./tasks/fix-requests.php",
       "php ./tasks/fix-php82-robo.php"
+    ],
+    "patch-production-libraries": [
+      "php ./tasks/fix-php82-deprecations.php",
+      "php ./tasks/FixPhp84Deprecations.php"
     ]
   },
   "config": {


### PR DESCRIPTION
## Description

This PR updates build.sh to include a couple of patches that we used by mistake only in development.

## Code review notes

You can check zip in the build.
<img width="704" height="239" alt="Screenshot 2025-11-14 at 10 38 04" src="https://github.com/user-attachments/assets/6753c94b-f21e-4aff-9e1b-b50062c51df0" />

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7630

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7630-production-php-dependencies-are-not-patched-in-zip-file)

_The latest successful build from `stomail-7630-production-php-dependencies-are-not-patched-in-zip-file` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build process to automatically patch production libraries for PHP compatibility during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->