### PR TITLE
Prevent auto-updating premium plugin with incompatible free version

### DIFF
--- a/mailpoet/changelog/2025-11-14-15-21-29-improved-prevent-auto-updating-the-premium-plugin-with-vers.md
+++ b/mailpoet/changelog/2025-11-14-15-21-29-improved-prevent-auto-updating-the-premium-plugin-with-vers.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Prevent auto-updating the premium plugin to avoid version mismatches.

--- a/mailpoet/lib/Config/Updater.php
+++ b/mailpoet/lib/Config/Updater.php
@@ -38,27 +38,32 @@ class Updater {
       $updateTransient = new \stdClass;
     }
 
+    $latestVersion = $this->getLatestVersion();
+
+    if (!isset($latestVersion->new_version)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return $updateTransient; // no latest version found.
+    }
+
     if (property_exists($updateTransient, 'response') && isset($updateTransient->response[$this->plugin])) {
       unset($updateTransient->response[$this->plugin]); // remove the cached version from the transient.
     }
 
-    $latestVersion = $this->getLatestVersion();
-
-    $latestFreeVersion = $updateTransient->response[Env::$pluginPath]->new_version ?? null;
+    $latestFreeVersion = null;
+    if (property_exists($updateTransient, 'response') && isset($updateTransient->response[Env::$pluginPath]->new_version)) {
+      $latestFreeVersion = $updateTransient->response[Env::$pluginPath]->new_version;
+    }
 
     if (!$this->shouldShowUpdateNotice($latestVersion->new_version, $latestFreeVersion)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       return $updateTransient; // skip update notice.
     }
 
-    if (isset($latestVersion->new_version)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      if (version_compare((string)$this->version, $latestVersion->new_version, '<')) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-        $updateTransient->response[$this->plugin] = $latestVersion;
-      } else {
-        $updateTransient->no_update[$this->plugin] = $latestVersion; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      }
-      $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      $updateTransient->checked[$this->plugin] = $this->version;
+    if (version_compare((string)$this->version, $latestVersion->new_version, '<')) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $updateTransient->response[$this->plugin] = $latestVersion;
+    } else {
+      $updateTransient->no_update[$this->plugin] = $latestVersion; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
+    $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $updateTransient->checked[$this->plugin] = $this->version;
 
     return $updateTransient;
   }

--- a/mailpoet/lib/Config/Updater.php
+++ b/mailpoet/lib/Config/Updater.php
@@ -77,19 +77,23 @@ class Updater {
 
   public function isVersionCompatible($premiumVersion, $freeVersion): bool {
     if (empty($premiumVersion) || empty($freeVersion)) {
-      return false;
+        return false;
     }
 
-    // Extract required main plugin version from premium version
-    preg_match('/(\d+\.\d+)\.\d+/i', $premiumVersion, $matches);
-    $requiredMainVersion = end($matches);
+    // Extract major.minor from premium version (e.g., "5.17.0" -> "5.17")
+    $premiumParts = explode('.', $premiumVersion);
+    $requiredMainVersion = isset($premiumParts[0], $premiumParts[1])
+        ? $premiumParts[0] . '.' . $premiumParts[1]
+        : $premiumVersion;
 
-    // Extract current main plugin minor version
-    preg_match('/^\d\.\d+/', $freeVersion, $match);
-    $currentMainVersion = !empty($match[0]) ? $match[0] : $freeVersion;
+    // Extract major.minor from free version (e.g., "5.17.5" -> "5.17")
+    $freeParts = explode('.', $freeVersion);
+    $currentMainVersion = isset($freeParts[0], $freeParts[1])
+        ? $freeParts[0] . '.' . $freeParts[1]
+        : $freeVersion;
 
-    // Check compatibility
-    return version_compare($currentMainVersion, (string)$requiredMainVersion, '>=');
+    // Check compatibility: free version must be >= required version
+    return version_compare($currentMainVersion, $requiredMainVersion, '>=');
   }
 
   public function shouldShowUpdateNotice($premiumLatestVersion, $latestFreeVersion = null): bool {

--- a/mailpoet/tests/integration/Config/UpdaterTest.php
+++ b/mailpoet/tests/integration/Config/UpdaterTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\Config;
 
 use Codeception\Stub;
 use Codeception\Stub\Expected;
+use MailPoet\Config\Env;
 use MailPoet\Config\Updater;
 
 class UpdaterTest extends \MailPoetTest {
@@ -62,6 +63,7 @@ class UpdaterTest extends \MailPoetTest {
             'package' => home_url() . '/wp-content/uploads/mailpoet-premium.zip',
           ];
         },
+        'shouldShowUpdateNotice' => true,
       ],
       $this
     );
@@ -99,6 +101,7 @@ class UpdaterTest extends \MailPoetTest {
             'package' => home_url() . '/wp-content/uploads/mailpoet-premium.zip',
           ];
         },
+        'shouldShowUpdateNotice' => true,
       ],
       $this
     );
@@ -117,5 +120,255 @@ class UpdaterTest extends \MailPoetTest {
   public function testItReturnsObjectIfPassedNonObjectWhenCheckingForUpdates() {
     $result = $this->updater->checkForUpdate(null);
     verify($result instanceof \stdClass)->true();
+  }
+
+  public function testItSkipsUpdateNoticeWhenCurrentFreeVersionIsIncompatible() {
+    $updateTransient = new \stdClass;
+    $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'getLatestVersion' => Expected::exactly(1, function () {
+          return (object)[
+            'id' => 76630,
+            'slug' => $this->slug,
+            'plugin' => $this->pluginName,
+            'new_version' => '9.5.0', // a very far future version
+            'url' => 'https://www.mailpoet.com/wordpress-newsletter-plugin-premium/',
+            'package' => home_url() . '/wp-content/uploads/mailpoet-premium.zip',
+          ];
+        }),
+      ],
+      $this
+    );
+    $updater->currentFreeVersion = '5.16.0';
+
+    $result = $updater->checkForUpdate($updateTransient);
+    verify(isset($result->response[$this->pluginName]))->false();
+    verify(isset($result->no_update[$this->pluginName]))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  public function testItSkipsUpdateNoticeWhenVersionsAreIncompatible() {
+    $updateTransient = new \stdClass;
+    $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'getLatestVersion' => function () {
+          return (object)[
+            'id' => 76630,
+            'slug' => $this->slug,
+            'plugin' => $this->pluginName,
+            'new_version' => '6.0.0', // Incompatible version
+            'url' => 'https://www.mailpoet.com/wordpress-newsletter-plugin-premium/',
+            'package' => home_url() . '/wp-content/uploads/mailpoet-premium.zip',
+          ];
+        },
+      ],
+      $this
+    );
+    $updater->currentFreeVersion = '5.16.0';
+
+    $result = $updater->checkForUpdate($updateTransient);
+
+    // Should return the original transient without modifications when incompatible
+    verify(isset($result->response[$this->pluginName]))->false();
+    verify(isset($result->no_update[$this->pluginName]))->false(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  public function testItChecksForUpdatesWithFreeVersionInTransient() {
+    $updateTransient = new \stdClass;
+    $updateTransient->last_checked = time(); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    // Mock free plugin update in transient
+    $updateTransient->response = [];
+    $updateTransient->response[Env::$pluginPath] = (object)[
+      'id' => 'w.org/plugins/mailpoet',
+      'slug' => 'mailpoet',
+      'plugin' => 'mailpoet/mailpoet.php',
+      'new_version' => '5.17.0',
+    ];
+
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'getLatestVersion' => function () {
+          return (object)[
+            'id' => 76630,
+            'slug' => $this->slug,
+            'plugin' => $this->pluginName,
+            'new_version' => '5.17.0',
+            'url' => 'https://www.mailpoet.com/wordpress-newsletter-plugin-premium/',
+            'package' => home_url() . '/wp-content/uploads/mailpoet-premium.zip',
+          ];
+        },
+      ],
+      $this
+    );
+    $updater->currentFreeVersion = '5.16.0';
+    $result = $updater->checkForUpdate($updateTransient);
+
+    // Should process the update since versions are compatible
+    verify($result->response[$this->pluginName]->new_version)->equals('5.17.0'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  }
+
+  public function testIsVersionCompatibleReturnsTrueForCompatibleVersions() {
+    // Test compatible versions (same minor version)
+    verify($this->updater->isVersionCompatible('5.17.0', '5.17.0'))->true();
+    verify($this->updater->isVersionCompatible('5.17.1', '5.17.0'))->true();
+    verify($this->updater->isVersionCompatible('5.17.0', '5.17.5'))->true();
+
+    // Test compatible versions (free version higher minor)
+    verify($this->updater->isVersionCompatible('5.16.0', '5.17.0'))->true();
+    verify($this->updater->isVersionCompatible('4.20.0', '5.1.0'))->true();
+  }
+
+  public function testIsVersionCompatibleReturnsFalseForIncompatibleVersions() {
+    // Test incompatible versions (premium requires higher free version)
+    verify($this->updater->isVersionCompatible('5.18.0', '5.17.0'))->false();
+    verify($this->updater->isVersionCompatible('6.0.0', '5.17.0'))->false();
+    verify($this->updater->isVersionCompatible('5.17.0', '5.16.0'))->false();
+  }
+
+  public function testIsVersionCompatibleReturnsFalseForEmptyVersions() {
+    verify($this->updater->isVersionCompatible('', '5.17.0'))->false();
+    verify($this->updater->isVersionCompatible('5.17.0', ''))->false();
+    verify($this->updater->isVersionCompatible('', ''))->false();
+    verify($this->updater->isVersionCompatible(null, '5.17.0'))->false();
+    verify($this->updater->isVersionCompatible('5.17.0', null))->false();
+  }
+
+  public function testIsVersionCompatibleHandlesIrregularVersionFormats() {
+    // Test with different version formats
+    verify($this->updater->isVersionCompatible('5.17', '5.17.0'))->true();
+    verify($this->updater->isVersionCompatible('5.17.0', '5.17'))->true();
+    verify($this->updater->isVersionCompatible('5.17.0-beta', '5.17.0'))->true();
+    verify($this->updater->isVersionCompatible('5.17.0', '5.17.0-alpha'))->true();
+  }
+
+  public function testShouldShowUpdateNoticeReturnsTrueWhenFreeVersionInTransientIsCompatible() {
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'isVersionCompatible' => Expected::exactly(1, true), // Should only call once and return true
+      ],
+      $this
+    );
+
+    $result = $updater->shouldShowUpdateNotice('5.17.0', '5.17.0');
+    verify($result)->true();
+  }
+
+  public function testShouldShowUpdateNoticeReturnsTrueWhenCurrentFreeVersionIsCompatible() {
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+
+      ],
+      $this
+    );
+    $updater->currentFreeVersion = '5.16.0';
+
+    $result = $updater->shouldShowUpdateNotice('5.17.0', '5.18.0'); // Incompatible latest, but current is compatible
+    verify($result)->true();
+  }
+
+  public function testShouldShowUpdateNoticeReturnsFalseWhenCurrentFreeVersionIsIncompatible() {
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+      ],
+      $this
+    );
+    $updater->currentFreeVersion = '5.16.0';
+
+    $result = $updater->shouldShowUpdateNotice('5.17.0', null); // no free version in transient and current free version is incompatible
+    verify($result)->false();
+  }
+
+  public function testShouldShowUpdateNoticeReturnsFalseWhenNoVersionsAreCompatible() {
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'isVersionCompatible' => Expected::exactly(2, false), // Both calls should return false
+      ],
+      $this
+    );
+
+    $result = $updater->shouldShowUpdateNotice('6.0.0', '5.18.0'); // Both incompatible
+    verify($result)->false();
+  }
+
+  public function testShouldShowUpdateNoticeHandlesNullLatestFreeVersion() {
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'isVersionCompatible' => Expected::once(true), // Should only call once with MAILPOET_VERSION
+      ],
+      $this
+    );
+
+    $result = $updater->shouldShowUpdateNotice('5.17.0', null);
+    verify($result)->true();
+  }
+
+  public function testShouldShowUpdateNoticeHandlesEmptyLatestFreeVersion() {
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $this->pluginName,
+        $this->slug,
+        $this->version,
+      ],
+      [
+        'isVersionCompatible' => Expected::once(true), // Should only call once with MAILPOET_VERSION
+      ],
+      $this
+    );
+
+    $result = $updater->shouldShowUpdateNotice('5.17.0', '');
+    verify($result)->true();
   }
 }

--- a/mailpoet/tests/integration/Config/UpdaterTest.php
+++ b/mailpoet/tests/integration/Config/UpdaterTest.php
@@ -240,6 +240,9 @@ class UpdaterTest extends \MailPoetTest {
     verify($this->updater->isVersionCompatible('4.20.0', '5.1.0'))->true();
     // multi-digit major versions
     verify($this->updater->isVersionCompatible('10.2.0', '10.3.1'))->true();
+    verify($this->updater->isVersionCompatible('5.4.3', '10.4.3'))->true();
+    verify($this->updater->isVersionCompatible('10.4.3', '10.4.3'))->true();
+    verify($this->updater->isVersionCompatible('10.4.2', '10.4.3'))->true();
   }
 
   public function testIsVersionCompatibleReturnsFalseForIncompatibleVersions() {

--- a/mailpoet/tests/integration/Config/UpdaterTest.php
+++ b/mailpoet/tests/integration/Config/UpdaterTest.php
@@ -238,6 +238,8 @@ class UpdaterTest extends \MailPoetTest {
     // Test compatible versions (free version higher minor)
     verify($this->updater->isVersionCompatible('5.16.0', '5.17.0'))->true();
     verify($this->updater->isVersionCompatible('4.20.0', '5.1.0'))->true();
+    // multi-digit major versions
+    verify($this->updater->isVersionCompatible('10.2.0', '10.3.1'))->true();
   }
 
   public function testIsVersionCompatibleReturnsFalseForIncompatibleVersions() {
@@ -245,6 +247,7 @@ class UpdaterTest extends \MailPoetTest {
     verify($this->updater->isVersionCompatible('5.18.0', '5.17.0'))->false();
     verify($this->updater->isVersionCompatible('6.0.0', '5.17.0'))->false();
     verify($this->updater->isVersionCompatible('5.17.0', '5.16.0'))->false();
+    verify($this->updater->isVersionCompatible('11.0.0', '10.9.9'))->false();
   }
 
   public function testIsVersionCompatibleReturnsFalseForEmptyVersions() {
@@ -294,9 +297,10 @@ class UpdaterTest extends \MailPoetTest {
       ],
       $this
     );
-    $updater->currentFreeVersion = '5.16.0';
+    $updater->currentFreeVersion = '5.17.0';
 
-    $result = $updater->shouldShowUpdateNotice('5.17.0', '5.18.0'); // Incompatible latest, but current is compatible
+    // Latest free version in transient is lower than required, but the currently installed free version is compatible.
+    $result = $updater->shouldShowUpdateNotice('5.17.0', '5.16.0');
     verify($result)->true();
   }
 


### PR DESCRIPTION
## Description

This PR adds version compatibility checking to prevent the MailPoet Premium plugin from auto-updating when the installed free plugin version is incompatible, avoiding potential version mismatches and compatibility issues.

## Why

Currently, the premium plugin update mechanism doesn't verify version compatibility with the free plugin before showing update notices. This can lead to scenarios where:

- The premium plugin auto-updates to a version that requires a newer free plugin version than what's installed
- Users end up with incompatible premium/free plugin combinations
- Plugin functionality may break due to version mismatches
- Users experience errors or unexpected behavior

This issue is particularly problematic when:
- WordPress auto-updates are enabled
- The free plugin hasn't been updated yet (e.g., pending WordPress.org review)
- The premium plugin releases ahead of the free plugin

Fixes: STOMAIL-7527

| Before | After |
| ------ | ----- |
|    <img width="1578" height="300" alt="Screenshot 2025-11-14 at 3 52 22 PM" src="https://github.com/user-attachments/assets/47dd1d9a-674e-41d3-a8aa-0260391c3260" />  |     <img width="1512" height="254" alt="Screenshot 2025-11-14 at 3 54 06 PM" src="https://github.com/user-attachments/assets/fda697cb-ed1e-47c3-9ec3-58acdc5611bc" /> |

## Code review notes

### Version Compatibility Logic

The compatibility check works as follows:

1. **Extract major.minor versions**:
   - Premium `5.17.0` → `5.17`
   - Free `5.17.5` → `5.17`

2. **Compare versions**:
   - Compatible: Free version `>=` required premium version (e.g., `5.17` >= `5.17`)
   - Incompatible: Free version `<` required premium version (e.g., `5.16` < `5.17`)

3. **Compatibility examples**:
   - ✅ Premium `5.17.0` + Free `5.17.0` → Compatible
   - ✅ Premium `5.17.0` + Free `5.17.5` → Compatible
   - ✅ Premium `5.16.0` + Free `5.17.0` → Compatible
   - ❌ Premium `5.18.0` + Free `5.17.0` → Incompatible
   - ❌ Premium `6.0.0` + Free `5.17.0` → Incompatible



## QA notes

Before testing, ensure both the Free and Premium plugin versions are on 5.17.0 (the most recent version)

* Perform testing on the Updates page `/wp-admin/update-core.php` 
* Before checking out this branch, force a Premium plugin version update. You can do that by adding `$latestVersion->new_version = '5.18.0';` to this line https://github.com/mailpoet/mailpoet/blob/d3720e8d1ddb5d3c1a720742c8c1c0f59f84c7e2/mailpoet/lib/Config/Updater.php#L46
* Visit the update page. Force reload if necessary. Notice the website prompt for a MailPoet premium plugin update
* Checkout this PR
* Reload the update page.  
* Notice the MailPoet premium plugin update is gone.

Click here to force reload
<img width="581" height="192" alt="Screenshot 2025-11-14 at 3 52 37 PM" src="https://github.com/user-attachments/assets/143e1e52-6dc5-434c-a348-f62d588733e4" />


## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7527

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7527-prevent-auto-updating-the-premium-plugin-with-version)

_The latest successful build from `stomail-7527-prevent-auto-updating-the-premium-plugin-with-version` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents incompatible premium plugin updates and suppresses update notices for versions that would conflict with the installed free plugin, avoiding failed or partial updates.

* **Documentation**
  * Added a changelog entry describing the improved update behavior.

* **Tests**
  * Expanded test coverage for update-check and version-compatibility scenarios to ensure correct notice and update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->