### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
           name: Download additional WP Plugins for tests
           command: |
             ./do download:woo-commerce-zip 10.3.5
-            ./do download:woo-commerce-subscriptions-zip 8.0.0
+            ./do download:woo-commerce-subscriptions-zip 8.1.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.19
       - run:
@@ -1193,7 +1193,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_oldest
           woo_core_version: 10.2.2
-          woo_subscriptions_version: 7.9.0
+          woo_subscriptions_version: 8.0.0
           automate_woo_version: 6.0.33
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
@@ -1233,7 +1233,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_oldest
           woo_core_version: 10.2.2
-          woo_subscriptions_version: 7.9.0
+          woo_subscriptions_version: 8.0.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1295,7 +1295,7 @@ workflows:
           <<: *slack-fail-post-step
           name: acceptance_with_premium_oldest
           woo_core_version: 10.2.2
-          woo_subscriptions_version: 7.9.0
+          woo_subscriptions_version: 8.0.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
@@ -1306,7 +1306,7 @@ workflows:
           <<: *slack-fail-post-step
           name: integration_with_premium_oldest
           woo_core_version: 10.2.2
-          woo_subscriptions_version: 7.9.0
+          woo_subscriptions_version: 8.0.0
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.3.4
+            ./do download:woo-commerce-zip 10.3.5
             ./do download:woo-commerce-subscriptions-zip 8.0.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.19


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-plugins-and-wordpress)

_The latest successful build from `update-plugins-and-wordpress` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline configuration with newer versions of WooCommerce core and subscription plugins to ensure compatibility across test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->