### PR TITLE
Allow removing opt-in block when opt-in on checkout is disabled

### DIFF
--- a/mailpoet/assets/js/src/marketing-optin-block/attributes.ts
+++ b/mailpoet/assets/js/src/marketing-optin-block/attributes.ts
@@ -3,10 +3,17 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
-const { defaultText } = getSetting('mailpoet_data');
+const { optinEnabled, defaultText } = getSetting('mailpoet_data');
 export const marketingOptinAttributes = {
   text: {
     type: 'string',
     default: defaultText,
+  },
+  lock: {
+    type: 'object',
+    default: {
+      remove: !!optinEnabled,
+      move: false,
+    },
   },
 };

--- a/mailpoet/changelog/2025-11-21-04-31-03-improved-allow-removing-opt-in-block-when-opt-in-on-checkou.md
+++ b/mailpoet/changelog/2025-11-21-04-31-03-improved-allow-removing-opt-in-block-when-opt-in-on-checkou.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Allow removing opt-in block when opt-in on checkout is disabled


### PR DESCRIPTION
## Description

When `Opt-in on checkout` is disabled in **MailPoet > Settings > WooCommerce**, don't lock the **MailPoet Marketing Opt-in** block in the checkout, so it can be removed. 

| Before | After | 
| ---- | ----- | 
|  <img width="1087" height="681" alt="Screenshot 2025-11-21 at 11 25 44" src="https://github.com/user-attachments/assets/039b6ca3-a000-497c-a08e-2e621e78b957" /> |  <img width="1122" height="688" alt="Screenshot 2025-11-21 at 11 28 28" src="https://github.com/user-attachments/assets/1bd68557-717f-4f30-9d9c-b19b3997ac41" /> <img width="1124" height="672" alt="Screenshot 2025-11-21 at 11 28 37" src="https://github.com/user-attachments/assets/e4fd82b9-8abb-42b4-9a14-9eef352e3c70" />  |

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7476

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7476-mailpoetautomatewoo-marketing-opt-block-always-visible)

_The latest successful build from `stomail-7476-mailpoetautomatewoo-marketing-opt-block-always-visible` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * You can now remove the opt-in block when opt-in on checkout is disabled, providing greater flexibility in managing your checkout form configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->