### PR TITLE
Add admin footer rating prompt

### DIFF
--- a/mailpoet/changelog/2025-11-21-06-55-33-added-new-prompt-asking-users-for-review.md
+++ b/mailpoet/changelog/2025-11-21-06-55-33-added-new-prompt-asking-users-for-review.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+New prompt asking users for review

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -638,6 +638,14 @@ class Hooks {
   }
 
   public function setFooterRated(): void {
+    if (!$this->wp->currentUserCan('manage_options')) {
+      $this->wp->wpDie(
+        esc_html__('You do not have permission to perform this action.', 'mailpoet'),
+        esc_html__('Unauthorized', 'mailpoet'),
+        ['response' => 403]
+      );
+    }
+
     $nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
 
     if (!$this->wp->wpVerifyNonce($nonce, 'mailpoet-rated')) {

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -37,6 +37,7 @@ class Hooks {
     self::OPTIN_POSITION_BEFORE_PAYMENT_METHODS => 'woocommerce_review_order_before_payment',
     self::OPTIN_POSITION_BEFORE_TERMS_AND_CONDITIONS => 'woocommerce_checkout_before_terms_and_conditions',
   ];
+  const FOOTER_RATED_OPTION = 'mailpoet_admin_footer_text_rated';
 
   /** @var Form */
   private $subscriptionForm;
@@ -581,7 +582,7 @@ class Hooks {
       return;
     }
 
-    if (!$this->wp->getOption('mailpoet_admin_footer_text_rated')) {
+    if (!$this->wp->getOption(self::FOOTER_RATED_OPTION)) {
       $handle = 'mailpoet-admin-footer-rating';
       $this->wp->wpRegisterScript($handle, false, [], Env::$version, true);
       $this->wp->wpEnqueueScript($handle);
@@ -627,7 +628,7 @@ class Hooks {
 
     $feedbackLink = '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">' . esc_html__('Give feedback', 'mailpoet') . '</a>';
 
-    if (!$this->wp->getOption('mailpoet_admin_footer_text_rated')) {
+    if (!$this->wp->getOption(self::FOOTER_RATED_OPTION)) {
       $reviewLink = '<a href="https://wordpress.org/support/plugin/mailpoet/reviews/#new-post" rel="noopener noreferrer" target="_blank" class="mailpoet-rating-link" aria-label="' . esc_attr__('five star', 'mailpoet') . '" data-rated="' . esc_attr__('Thanks :)', 'mailpoet') . '">' . esc_html__('Help other businesses grow their email lists – share your ★★★★★ MailPoet experience!', 'mailpoet') . '</a>';
 
       return $reviewLink . ' | ' . $feedbackLink;
@@ -647,7 +648,7 @@ class Hooks {
       );
     }
 
-    $this->wp->updateOption('mailpoet_admin_footer_text_rated', 1);
+    $this->wp->updateOption(self::FOOTER_RATED_OPTION, 1);
     $this->wp->wpDie();
   }
 

--- a/mailpoet/lib/Config/Hooks.php
+++ b/mailpoet/lib/Config/Hooks.php
@@ -552,22 +552,89 @@ class Hooks {
   }
 
   public function setupFooter() {
-    if (!Menu::isOnMailPoetAdminPage()) {
-      return;
-    }
+    // Register AJAX handler on all admin pages (AJAX requests go to admin-ajax.php)
+    $this->wp->addAction(
+      'wp_ajax_mailpoet_rated',
+      [$this, 'setFooterRated']
+    );
+
+    // Register hooks that will check the page later
     $this->wp->addFilter(
       'admin_footer_text',
       [$this, 'setFooter'],
       1,
       1
     );
+    $this->wp->addAction(
+      'admin_enqueue_scripts',
+      [$this, 'enqueueFooterRatingScript']
+    );
+  }
+
+  public function enqueueFooterRatingScript(): void {
+    // Only show on MailPoet pages
+    if (!Menu::isOnMailPoetAdminPage()) {
+      return;
+    }
+
+    if (Menu::isOnMailPoetAutomationPage()) {
+      return;
+    }
+
+    if (!$this->wp->getOption('mailpoet_admin_footer_text_rated')) {
+      $handle = 'mailpoet-admin-footer-rating';
+      $this->wp->wpRegisterScript($handle, false, [], Env::$version, true);
+      $this->wp->wpEnqueueScript($handle);
+
+      $script = "(function() {
+        'use strict';
+        var ratingLink = document.querySelector('a.mailpoet-rating-link');
+        if (ratingLink) {
+          ratingLink.addEventListener('click', function(e) {
+            var link = e.currentTarget;
+            var formData = new FormData();
+            formData.append('action', 'mailpoet_rated');
+
+            fetch('" . esc_js(admin_url('admin-ajax.php')) . "', {
+              method: 'POST',
+              body: formData,
+              credentials: 'same-origin'
+            });
+
+            if (link) {
+              link.textContent = link.getAttribute('data-rated');
+            }
+          });
+        }
+      })();";
+
+      $this->wp->wpAddInlineScript($handle, $script);
+    }
   }
 
   public function setFooter(): string {
+    // Only show footer on MailPoet pages
+    if (!Menu::isOnMailPoetAdminPage()) {
+      return '';
+    }
+
     if (Menu::isOnMailPoetAutomationPage()) {
       return '';
     }
-    return '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">' . esc_html__('Give feedback', 'mailpoet') . '</a>';
+
+    $feedbackLink = '<a href="https://feedback.mailpoet.com/" rel="noopener noreferrer" target="_blank">' . esc_html__('Give feedback', 'mailpoet') . '</a>';
+
+    if (!$this->wp->getOption('mailpoet_admin_footer_text_rated')) {
+      $reviewLink = '<a href="https://wordpress.org/support/plugin/mailpoet/reviews/#new-post" rel="noopener noreferrer" target="_blank" class="mailpoet-rating-link" aria-label="' . esc_attr__('five star', 'mailpoet') . '" data-rated="' . esc_attr__('Thanks :)', 'mailpoet') . '">' . esc_html__('Help other businesses grow their email lists – share your ★★★★★ MailPoet experience!', 'mailpoet') . '</a>';
+
+      return $reviewLink . ' | ' . $feedbackLink;
+    } else {
+      return esc_html__('Thank you for using MailPoet.', 'mailpoet') . ' | ' . $feedbackLink;
+    }
+  }
+
+  public function setFooterRated(): void {
+    $this->wp->updateOption('mailpoet_admin_footer_text_rated', 1);
   }
 
   public function setupSettingsLinkInPluginPage() {

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -1016,6 +1016,10 @@ class Functions {
     nocache_headers();
   }
 
+  public function wpDie(): void {
+    wp_die();
+  }
+
   public function wpUniqueId($prefix = ''): string {
     return wp_unique_id($prefix);
   }

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -1016,8 +1016,9 @@ class Functions {
     nocache_headers();
   }
 
-  public function wpDie(): void {
-    wp_die();
+  public function wpDie($message = '', $title = '', $args = []): void {
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    wp_die($message, $title, $args);
   }
 
   public function wpUniqueId($prefix = ''): string {


### PR DESCRIPTION
## Description

Adds a new rating prompt in the admin footer that encourages users to leave a 5-star review on WordPress.org.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7609

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7609-prompt-mailpoet-users-for-5-reviews)

_The latest successful build from `stomail-7609-prompt-mailpoet-users-for-5-reviews` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive rating prompt in the admin footer — one-click rating updates the footer to a thanked state, retains a feedback link, and is shown only on MailPoet admin pages (not automation pages).
* **Documentation**
  * Added a changelog entry announcing the new review prompt.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->