### PR TITLE
Restart the premium build only when releasing premium

### DIFF
--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -1006,8 +1006,8 @@ class RoboFile extends \Robo\Tasks {
       ->addCode(function () use ($version) {
         $this->releaseCreatePullRequest($version);
       })
-      ->addCode(function () use ($version) {
-        $this->releaseRerunCircleWorkflow(\MailPoetTasks\Release\CircleCiController::PROJECT_PREMIUM);
+      ->addCode(function () {
+        $this->releaseRerunCircleWorkflowForPremium();
       })
       ->addCode(function () use ($version) {
         $this->translationsPrepareLanguagePacks($version);
@@ -1298,9 +1298,20 @@ class RoboFile extends \Robo\Tasks {
     // Sometimes can be useful to know which Circle project workflow was restarted
     $project = $project ? " for the project '{$project}'" : '';
     if (!$result) {
-      $this->yell("Circle Workflow{$project} was not restarted", 40, 'red');
+      $this->say("Rerunning the CircleCI workflow{$project} ... failed");
     } else {
-      $this->say("Circle Workflow{$project} was started from the beginning");
+      $this->say("Rerunning the CircleCI workflow{$project} ... done");
+    }
+  }
+
+  public function releaseRerunCircleWorkflowForPremium() {
+    $isPremiumReleased = $this->createGitHubController()->projectBranchExists(
+      \MailPoetTasks\Release\GitHubController::PROJECT_PREMIUM,
+      \MailPoetTasks\Release\GitHubController::RELEASE_SOURCE_BRANCH
+    );
+
+    if ($isPremiumReleased) {
+      $this->releaseRerunCircleWorkflow(\MailPoetTasks\Release\CircleCiController::PROJECT_PREMIUM);
     }
   }
 


### PR DESCRIPTION
## Description

In https://github.com/mailpoet/mailpoet/pull/4537, we added code to rerun the latest CircleCI build for the premium plugin when releasing both plugins.

The problem is that this introduced an error that can be misleading and suggests there is an issue when releasing only the free plugin. This changes the behaviour so that the premium build is only restarted when releasing the premium plugin.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7275

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced premium release automation process to include conditional branch validation before triggering workflow reruns.
  * Updated CircleCI workflow status messaging for improved clarity on release operation outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->