### PR TITLE
Cleanup the Env class from db related constants

### DIFF
--- a/mailpoet/changelog/2025-11-21-10-28-36-removed-remove-unused-database-related-parameters-from-env.md
+++ b/mailpoet/changelog/2025-11-21-10-28-36-removed-remove-unused-database-related-parameters-from-env.md
@@ -1,0 +1,5 @@
+# Type: Removed
+
+# Description
+
+Remove unused database-related parameters from Env class after WPDB migration

--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -25,6 +25,54 @@ class Env {
   public static $pluginPrefix;
   /** @var string WP DB prefix + plugin prefix */
   public static $dbPrefix;
+  /**
+   * @deprecated Use global $wpdb->prefix instead
+   */
+  public static $wpDbPrefix = '';
+  /**
+   * @deprecated Database connection is handled by WordPress $wpdb
+   */
+  public static $dbHost = '';
+  /**
+   * @deprecated Database connection is handled by WordPress $wpdb
+   */
+  public static $dbIsIpv6 = '';
+  /**
+   * @deprecated Database connection is handled by WordPress $wpdb
+   */
+  public static $dbSocket = '';
+  /**
+   * @deprecated Database connection is handled by WordPress $wpdb
+   */
+  public static $dbPort = '';
+  /**
+   * @deprecated Use global $wpdb->dbname instead
+   */
+  public static $dbName = '';
+  /**
+   * @deprecated Database connection is handled by WordPress $wpdb
+   */
+  public static $dbUsername = '';
+  /**
+   * @deprecated Database connection is handled by WordPress $wpdb
+   */
+  public static $dbPassword = '';
+  /**
+   * @deprecated Use global $wpdb->charset instead
+   */
+  public static $dbCharset = '';
+  /**
+   * @deprecated Use global $wpdb->collate instead
+   */
+  public static $dbCollation = '';
+  /**
+   * @deprecated Use global $wpdb->get_charset_collate() instead
+   */
+  public static $dbCharsetCollate = '';
+  /**
+   * @deprecated Calculate timezone offset from WordPress gmt_offset option if needed
+   */
+  public static $dbTimezoneOffset = '';
 
   // back compatibility for older Premium plugin with underscore naming
   // (we need to allow it to activate so it can render an update notice)

--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -25,26 +25,13 @@ class Env {
   public static $pluginPrefix;
   /** @var string WP DB prefix + plugin prefix */
   public static $dbPrefix;
-  /** @var string WP DB prefix only */
-  public static $wpDbPrefix;
-  public static $dbHost;
-  public static $dbIsIpv6;
-  public static $dbSocket;
-  public static $dbPort;
-  public static $dbName;
-  public static $dbUsername;
-  public static $dbPassword;
-  public static $dbCharset;
-  public static $dbCollation;
-  public static $dbCharsetCollate;
-  public static $dbTimezoneOffset;
 
   // back compatibility for older Premium plugin with underscore naming
   // (we need to allow it to activate so it can render an update notice)
   public static $plugin_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   public static $temp_path; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-  public static function init($file, $version, $dbHost, $dbUser, $dbPassword, $dbName) {
+  public static function init($file, $version) {
     self::$version = $version;
     self::$file = $file;
     self::$path = dirname(self::$file);
@@ -62,47 +49,12 @@ class Env {
     self::$languagesPath = self::$path . '/../../languages/plugins/';
     self::$libPath = self::$path . '/lib';
     self::$pluginPrefix = WPFunctions::get()->applyFilters('mailpoet_db_prefix', 'mailpoet_');
-    self::initDbParameters($dbHost, $dbUser, $dbPassword, $dbName);
+
+    global $wpdb;
+    self::$dbPrefix = $wpdb->prefix . self::$pluginPrefix;
 
     // back compatibility for older Premium plugin with underscore naming
     self::$plugin_name = self::$pluginName; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     self::$temp_path = self::$tempPath; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  }
-
-  /**
-   * @see https://codex.wordpress.org/Editing_wp-config.php#Set_Database_Host for possible DB_HOSTS values
-   */
-  private static function initDbParameters($dbHost, $dbUser, $dbPassword, $dbName) {
-    $parsedHost = WPFunctions::get()->parseDbHost($dbHost);
-    if ($parsedHost === false) {
-      throw new \InvalidArgumentException('Invalid db host configuration.');
-    }
-    [$host, $port, $socket, $isIpv6] = $parsedHost;
-
-    global $wpdb;
-    self::$dbPrefix = $wpdb->prefix . self::$pluginPrefix;
-    self::$wpDbPrefix = $wpdb->prefix;
-    self::$dbHost = $host;
-    self::$dbIsIpv6 = $isIpv6;
-    self::$dbPort = $port;
-    self::$dbSocket = $socket;
-    self::$dbName = $dbName;
-    self::$dbUsername = $dbUser;
-    self::$dbPassword = $dbPassword;
-    self::$dbCharset = $wpdb->charset;
-    self::$dbCollation = $wpdb->collate;
-    self::$dbCharsetCollate = $wpdb->get_charset_collate();
-    self::$dbTimezoneOffset = self::getDbTimezoneOffset();
-  }
-
-  public static function getDbTimezoneOffset($offset = false) {
-    $offset = ($offset) ? $offset : WPFunctions::get()->getOption('gmt_offset');
-    $offset = (float)($offset);
-    $mins = $offset * 60;
-    $sgn = ($mins < 0 ? -1 : 1);
-    $mins = abs($mins);
-    $hrs = floor($mins / 60);
-    $mins -= $hrs * 60;
-    return sprintf('%+03d:%02d', $hrs * $sgn, $mins);
   }
 }

--- a/mailpoet/lib/Config/Env.php
+++ b/mailpoet/lib/Config/Env.php
@@ -105,4 +105,18 @@ class Env {
     self::$plugin_name = self::$pluginName; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     self::$temp_path = self::$tempPath; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   }
+
+  /**
+   * @deprecated Calculate timezone offset from WordPress gmt_offset option directly if needed
+   */
+  public static function getDbTimezoneOffset($offset = false) {
+    $offset = ($offset) ? $offset : WPFunctions::get()->getOption('gmt_offset');
+    $offset = (float)($offset);
+    $mins = $offset * 60;
+    $sgn = ($mins < 0 ? -1 : 1);
+    $mins = abs($mins);
+    $hrs = floor($mins / 60);
+    $mins -= $hrs * 60;
+    return sprintf('%+03d:%02d', $hrs * $sgn, $mins);
+  }
 }

--- a/mailpoet/lib/Doctrine/TablePrefixMetadataFactory.php
+++ b/mailpoet/lib/Doctrine/TablePrefixMetadataFactory.php
@@ -29,8 +29,9 @@ class TablePrefixMetadataFactory extends ClassMetadataFactory {
     if (Env::$dbPrefix === null) {
       throw new \RuntimeException('DB table prefix not initialized');
     }
+    global $wpdb;
     $this->prefix = Env::$dbPrefix;
-    $this->wpDbPrefix = Env::$wpDbPrefix;
+    $this->wpDbPrefix = $wpdb->prefix ?? ''; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $this->setProxyClassNameResolver(new ProxyClassNameResolver());
   }
 

--- a/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php
@@ -72,8 +72,9 @@ class Migration_20221028_105818 extends DbMigration {
   ];
 
   public function run(): void {
+    global $wpdb;
     $this->prefix = Env::$dbPrefix;
-    $this->charsetCollate = Env::$dbCharsetCollate;
+    $this->charsetCollate = $wpdb->get_charset_collate();
 
     // Ensure dbDelta function
     require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
@@ -706,7 +707,6 @@ class Migration_20221028_105818 extends DbMigration {
       return false;
     }
 
-    $dbName = Env::$dbName;
     $statisticsTables = [
       esc_sql("{$this->prefix}statistics_clicks"),
       esc_sql("{$this->prefix}statistics_opens"),

--- a/mailpoet/lib/Migrator/DbMigration.php
+++ b/mailpoet/lib/Migrator/DbMigration.php
@@ -32,8 +32,9 @@ abstract class DbMigration {
   }
 
   protected function createTable(string $tableName, array $attributes): void {
+    global $wpdb;
     $prefix = Env::$dbPrefix;
-    $charsetCollate = Env::$dbCharsetCollate;
+    $charsetCollate = $wpdb->get_charset_collate();
     $sql = implode(",\n", $attributes);
     $this->connection->executeStatement("
       CREATE TABLE IF NOT EXISTS {$prefix}{$tableName} (

--- a/mailpoet/lib/Migrator/Store.php
+++ b/mailpoet/lib/Migrator/Store.php
@@ -70,7 +70,8 @@ class Store {
   }
 
   public function ensureMigrationsTable(): void {
-    $collate = Env::$dbCharsetCollate;
+    global $wpdb;
+    $collate = $wpdb->get_charset_collate();
     $this->connection->executeStatement("
       CREATE TABLE IF NOT EXISTS {$this->table} (
         id int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/mailpoet/mailpoet_initializer.php
+++ b/mailpoet/mailpoet_initializer.php
@@ -65,11 +65,7 @@ define('MAILPOET_VERSION', $mailpoetPlugin['version']);
 
 Env::init(
   $mailpoetPlugin['filename'],
-  $mailpoetPlugin['version'],
-  DB_HOST,
-  DB_USER,
-  DB_PASSWORD,
-  DB_NAME
+  $mailpoetPlugin['version']
 );
 
 $requirements = new RequirementsChecker();

--- a/mailpoet/tasks/phpstan/bootstrap.php
+++ b/mailpoet/tasks/phpstan/bootstrap.php
@@ -5,10 +5,6 @@ define('WPINC', 'wp-includes');
 define('WP_MEMORY_LIMIT', 268435456);
 define('WP_MAX_MEMORY_LIMIT', 268435456);
 define('MAILPOET_VERSION', '1.0.0');
-define('DB_HOST', 'localhost');
-define('DB_NAME', 'wordpress');
-define('DB_USER', 'wordpress');
-define('DB_PASSWORD', '12345');
 define('MAILPOET_PREMIUM_VERSION', '1.0.0');
 
 // This needs to be set because \MailPoet\Doctrine\TablePrefixMetadataFactory can't construct without it

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -131,11 +131,6 @@ parameters:
 			path: ../../lib/Cache/TransientCache.php
 
 		-
-			message: "#^Cannot use array destructuring on array\\|true\\.$#"
-			count: 1
-			path: ../../lib/Config/Env.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: ../../lib/Config/Populator.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: ../../lib/Cache/TransientCache.php
 
 		-
-			message: "#^Cannot use array destructuring on array\\|true\\.$#"
-			count: 1
-			path: ../../lib/Config/Env.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: ../../lib/Config/Populator.php

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -37,6 +37,13 @@ class EnvTest extends \MailPoetTest {
     verify(Env::$dbTimezoneOffset)->equals('');
   }
 
+  public function testDeprecatedGetDbTimezoneOffset() {
+    verify(Env::getDbTimezoneOffset('+1.5'))->equals('+01:30');
+    verify(Env::getDbTimezoneOffset('+11'))->equals('+11:00');
+    verify(Env::getDbTimezoneOffset('-5.5'))->equals('-05:30');
+    verify(Env::getDbTimezoneOffset('xyz'))->equals('+00:00');
+  }
+
   public function _after() {
     parent::_after();
     // Restore the original environment

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -26,6 +26,17 @@ class EnvTest extends \MailPoetTest {
     verify(Env::$dbPrefix)->equals($dbPrefix);
   }
 
+  public function testDeprecatedPropertiesExistAsEmptyStrings() {
+    // Deprecated properties should exist (to prevent fatal errors) but be empty strings
+    verify(Env::$wpDbPrefix)->equals('');
+    verify(Env::$dbName)->equals('');
+    verify(Env::$dbCharset)->equals('');
+    verify(Env::$dbCollation)->equals('');
+    verify(Env::$dbCharsetCollate)->equals('');
+    verify(Env::$dbHost)->equals('');
+    verify(Env::$dbTimezoneOffset)->equals('');
+  }
+
   public function _after() {
     parent::_after();
     // Restore the original environment

--- a/mailpoet/tests/integration/Config/EnvTest.php
+++ b/mailpoet/tests/integration/Config/EnvTest.php
@@ -13,7 +13,7 @@ class EnvTest extends \MailPoetTest {
     // Back up original environment values
     $this->file = Env::$file;
     $this->version = Env::$version;
-    Env::init('file', '1.0.0', 'localhost:3306', DB_USER, DB_PASSWORD, DB_NAME);
+    Env::init('file', '1.0.0');
   }
 
   public function testItCanReturnPluginPrefix() {
@@ -26,72 +26,9 @@ class EnvTest extends \MailPoetTest {
     verify(Env::$dbPrefix)->equals($dbPrefix);
   }
 
-  public function testItProcessDBHost() {
-    Env::init('file', '1.0.0', 'localhost', 'db_user', 'pass123', 'db_name');
-    verify(Env::$dbHost)->equals('localhost');
-    verify(Env::$dbPort)->null();
-
-    Env::init('file', '1.0.0', 'localhost:3307', 'db_user', 'pass123', 'db_name');
-    verify(Env::$dbHost)->equals('localhost');
-    verify(Env::$dbPort)->equals('3307');
-  }
-
-  public function testItProcessDBHostWithSocket() {
-    Env::init('file', '1.0.0', 'localhost:/var/lib/mysql/mysql55.sock', 'db_user', 'pass123', 'db_name');
-    verify(Env::$dbHost)->equals('localhost');
-    verify(Env::$dbSocket)->equals('/var/lib/mysql/mysql55.sock');
-  }
-
-  public function testItProcessDBHostWithIpV6Address() {
-    Env::init('file', '1.0.0', '::1', 'db_user', 'pass123', 'db_name');
-    verify(Env::$dbHost)->equals('::1');
-    verify(Env::$dbSocket)->equals(null);
-
-    Env::init('file', '1.0.0', 'b57e:9b70:ab96:6a0b:5ba2:49e3:ebba:a036', 'db_user', 'pass123', 'db_name');
-    verify(Env::$dbHost)->equals('b57e:9b70:ab96:6a0b:5ba2:49e3:ebba:a036');
-    verify(Env::$dbSocket)->equals(null);
-  }
-
-  public function testItCanReturnDbName() {
-    verify(Env::$dbName)->equals(DB_NAME);
-  }
-
-  public function testItCanReturnDbUser() {
-    verify(Env::$dbUsername)->equals(DB_USER);
-  }
-
-  public function testItCanReturnDbPassword() {
-    verify(Env::$dbPassword)->equals(DB_PASSWORD);
-  }
-
-  public function testItCanReturnDbCharset() {
-    global $wpdb;
-    $charset = $wpdb->charset;
-    verify(Env::$dbCharset)->equals($charset);
-  }
-
-  public function testItCanReturnDbCollation() {
-    global $wpdb;
-    $collation = $wpdb->collate;
-    verify(Env::$dbCollation)->equals($collation);
-  }
-
-  public function testItCanReturnDbCharsetCollate() {
-    global $wpdb;
-    $charsetCollate = $wpdb->get_charset_collate();
-    verify(Env::$dbCharsetCollate)->equals($charsetCollate);
-  }
-
-  public function testItCanGetDbTimezoneOffset() {
-    verify(Env::getDbTimezoneOffset('+1.5'))->equals("+01:30");
-    verify(Env::getDbTimezoneOffset('+11'))->equals("+11:00");
-    verify(Env::getDbTimezoneOffset('-5.5'))->equals("-05:30");
-    verify(Env::getDbTimezoneOffset('xyz'))->equals("+00:00");
-  }
-
   public function _after() {
     parent::_after();
     // Restore the original environment
-    Env::init($this->file, $this->version, DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
+    Env::init($this->file, $this->version);
   }
 }

--- a/mailpoet/tests/integration/Doctrine/WPDB/ConnectionTest.php
+++ b/mailpoet/tests/integration/Doctrine/WPDB/ConnectionTest.php
@@ -140,10 +140,11 @@ class ConnectionTest extends MailPoetTest {
     $connection->exec(sprintf("INSERT INTO %s (value) VALUES ('one')", self::TEST_TABLE_NAME));
     $connection->exec(sprintf("INSERT INTO %s (value) VALUES ('two')", self::TEST_TABLE_NAME));
     $connection->exec(sprintf("INSERT INTO %s (value) VALUES ('three')", self::TEST_TABLE_NAME));
+    global $wpdb;
     $autoIncrement = $connection->query(
       sprintf(
         "SELECT auto_increment FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'",
-        DB_NAME,
+        $wpdb->dbname, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         self::TEST_TABLE_NAME
       )
     )->fetchOne();
@@ -172,8 +173,9 @@ class ConnectionTest extends MailPoetTest {
       $exception = $e;
     }
 
+    global $wpdb;
     $this->assertInstanceOf(QueryException::class, $exception);
-    $this->assertSame(sprintf("Table '%s.non_existent_table' doesn't exist", DB_NAME), $exception->getMessage());
+    $this->assertSame(sprintf("Table '%s.non_existent_table' doesn't exist", $wpdb->dbname), $exception->getMessage()); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $this->assertSame('42S02', $exception->getSQLState());
     $this->assertSame(1146, $exception->getCode());
   }

--- a/mailpoet/tests/integration/Doctrine/WPDB/StatementTest.php
+++ b/mailpoet/tests/integration/Doctrine/WPDB/StatementTest.php
@@ -26,10 +26,9 @@ class StatementTest extends MailPoetTest {
       $exception = $e;
     }
 
-    $this->assertInstanceOf(QueryException::class, $exception);
-    $this->assertEquals(sprintf("Table '%s.test_table' doesn't exist", DB_NAME), $exception->getMessage());
-
     global $wpdb;
+    $this->assertInstanceOf(QueryException::class, $exception);
+    $this->assertEquals(sprintf("Table '%s.test_table' doesn't exist", $wpdb->dbname), $exception->getMessage()); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $this->assertSame("SELECT * FROM test_table WHERE id = '123' AND name = 'Test' AND value = 'abc'", $wpdb->last_query);
   }
 }


### PR DESCRIPTION
 ## Description

  Clean up unused database-related parameters from the `Env` class after migrating to WordPress's `$wpdb` database abstraction layer. This reduces
  technical debt and simplifies the codebase by removing 12 parameters that were only needed for direct database connections.

  ### What changed:
  - **Removed 12 unused static properties** from `Env` class:
    - `$dbHost`, `$dbIsIpv6`, `$dbSocket`, `$dbPort`, `$dbName`
    - `$dbUsername`, `$dbPassword`, `$dbCharset`, `$dbCollation`
    - `$dbTimezoneOffset`, `$dbCharsetCollate`, `$wpDbPrefix`
  - **Kept only** `$dbPrefix` (WP prefix + plugin prefix)
  - **Simplified** `Env::init()` signature from 6 parameters to 2
  - **Replaced cached values** with direct `$wpdb` calls:
    - `Env::$dbCharsetCollate` → `$wpdb->get_charset_collate()`
    - `Env::$wpDbPrefix` → `$wpdb->prefix`
    - `DB_NAME` constant → `$wpdb->dbname`
  - **Updated tests** to use `$wpdb` properties instead of WordPress constants

  ### Impact:
  - 📊 **92

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7361-cleanup-env-class-from-db-related-constants)

_The latest successful build from `stomail-7361-cleanup-env-class-from-db-related-constants` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Database setup now uses WordPress's native DB settings; legacy per-parameter DB configuration was removed and related properties marked deprecated.

* **Chores**
  * Removed unused DB initialization parameters and simplified initialization flow.

* **Tests**
  * Updated integration tests to rely on WordPress runtime DB values and adjusted deprecated-property expectations.

* **Documentation**
  * Added changelog entry noting removal of unused DB-related parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->