### PR TITLE
Allow cancel/resume automation run for a single subscriber

### DIFF
--- a/mailpoet/assets/css/src/components-automation-analytics/tabs/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-automation-analytics/tabs/_subscribers.scss
@@ -91,3 +91,7 @@
     margin-top: 8px;
   }
 }
+
+.mailpoet-analytics-subscribers-activity-cell {
+  display: flex;
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/subscribers/cells/activity.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/subscribers/cells/activity.tsx
@@ -1,5 +1,10 @@
+import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, DropdownMenu } from '@wordpress/components';
+import {
+  Button,
+  DropdownMenu,
+  __experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch } from '@wordpress/data';
@@ -12,6 +17,8 @@ export function ActivityCell({
   runId: number;
   status: string;
 }): JSX.Element {
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+  const [showResumeConfirm, setShowResumeConfirm] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const { updateRunStatus } = useDispatch(storeName);
@@ -22,20 +29,16 @@ export function ActivityCell({
     navigate({ search: params.toString() });
   };
 
-  const handleStatusChange = (newStatus: string) => {
-    void updateRunStatus(runId, newStatus);
-  };
-
   const menuControls = [];
   if (status === 'running') {
     menuControls.push({
       title: __('Cancel run', 'mailpoet'),
-      onClick: () => handleStatusChange('cancelled'),
+      onClick: () => setShowCancelConfirm(true),
     });
   } else if (status === 'cancelled') {
     menuControls.push({
       title: __('Resume run', 'mailpoet'),
-      onClick: () => handleStatusChange('running'),
+      onClick: () => setShowResumeConfirm(true),
     });
   }
 
@@ -44,6 +47,35 @@ export function ActivityCell({
       <Button variant="tertiary" onClick={openActivityModal}>
         {__('View activity', 'mailpoet')}
       </Button>
+      <ConfirmDialog
+        isOpen={showCancelConfirm}
+        title={__('Cancel run', 'mailpoet')}
+        confirmButtonText={__('Yes, cancel run', 'mailpoet')}
+        __experimentalHideHeader={false}
+        onConfirm={() => {
+          void updateRunStatus(runId, 'cancelled');
+          setShowCancelConfirm(false);
+        }}
+        onCancel={() => setShowCancelConfirm(false)}
+      >
+        {__(
+          'Are you sure you want to cancel this run for this subscriber?',
+          'mailpoet',
+        )}
+      </ConfirmDialog>
+      <ConfirmDialog
+        isOpen={showResumeConfirm}
+        title={__('Resume run', 'mailpoet')}
+        confirmButtonText={__('Yes, resume', 'mailpoet')}
+        __experimentalHideHeader={false}
+        onConfirm={() => {
+          void updateRunStatus(runId, 'running');
+          setShowResumeConfirm(false);
+        }}
+        onCancel={() => setShowResumeConfirm(false)}
+      >
+        {__('Are you sure you want to resume this run?', 'mailpoet')}
+      </ConfirmDialog>
       {menuControls.length > 0 && (
         <DropdownMenu
           className="mailpoet-analytics-subscribers-more-button"

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/subscribers/cells/activity.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/subscribers/cells/activity.tsx
@@ -1,10 +1,20 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, DropdownMenu } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useDispatch } from '@wordpress/data';
+import { storeName } from '../../../../store';
 
-export function ActivityCell({ runId }: { runId: number }): JSX.Element {
+export function ActivityCell({
+  runId,
+  status,
+}: {
+  runId: number;
+  status: string;
+}): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
+  const { updateRunStatus } = useDispatch(storeName);
 
   const openActivityModal = () => {
     const params = new URLSearchParams(location.search);
@@ -12,9 +22,38 @@ export function ActivityCell({ runId }: { runId: number }): JSX.Element {
     navigate({ search: params.toString() });
   };
 
+  const handleStatusChange = (newStatus: string) => {
+    void updateRunStatus(runId, newStatus);
+  };
+
+  const menuControls = [];
+  if (status === 'running') {
+    menuControls.push({
+      title: __('Cancel run', 'mailpoet'),
+      onClick: () => handleStatusChange('cancelled'),
+    });
+  } else if (status === 'cancelled') {
+    menuControls.push({
+      title: __('Resume run', 'mailpoet'),
+      onClick: () => handleStatusChange('running'),
+    });
+  }
+
   return (
-    <Button variant="tertiary" onClick={openActivityModal}>
-      {__('View activity', 'mailpoet')}
-    </Button>
+    <div className="mailpoet-analytics-subscribers-activity-cell">
+      <Button variant="tertiary" onClick={openActivityModal}>
+        {__('View activity', 'mailpoet')}
+      </Button>
+      {menuControls.length > 0 && (
+        <DropdownMenu
+          className="mailpoet-analytics-subscribers-more-button"
+          label={__('More', 'mailpoet')}
+          icon={moreVertical}
+          controls={menuControls}
+          popoverProps={{ placement: 'bottom-start' }}
+          variant="tertiary"
+        />
+      )}
+    </div>
   );
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/subscribers/rows.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/tabs/subscribers/rows.tsx
@@ -37,7 +37,12 @@ export function transformSubscribersToRows(data: SubscriberSection['data']) {
           value: subscriber.date,
         },
         {
-          display: <ActivityCell runId={subscriber.run.id} />,
+          display: (
+            <ActivityCell
+              runId={subscriber.run.id}
+              status={subscriber.run.status}
+            />
+          ),
         },
       ]);
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
@@ -81,4 +81,5 @@ export const getInitialState = (): State => ({
     after: undefined,
     before: undefined,
   },
+  runStatusUpdates: {},
 });

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
@@ -2,6 +2,24 @@ import { State, SubscriberSection } from './types';
 
 export function reducer(state: State, action): State {
   switch (action.type) {
+    case 'RUN_STATUS_UPDATE_REQUEST': {
+      const { runId, status } = action.payload;
+      return {
+        ...state,
+        runStatusUpdates: {
+          ...state.runStatusUpdates,
+          [runId]: { status },
+        },
+      };
+    }
+    case 'RUN_STATUS_UPDATE_FAILURE': {
+      const { [action.payload.runId]: removedUpdate, ...rest } =
+        state.runStatusUpdates;
+      return {
+        ...state,
+        runStatusUpdates: rest,
+      };
+    }
     case 'SET_QUERY':
       return {
         ...state,
@@ -33,7 +51,12 @@ export function reducer(state: State, action): State {
       const subscribersSection = state.sections
         .subscribers as SubscriberSection;
       if (!subscribersSection?.data?.items) {
-        return state;
+        const { [action.payload.runId]: removedUpdate, ...rest } =
+          state.runStatusUpdates;
+        return {
+          ...state,
+          runStatusUpdates: rest,
+        };
       }
 
       const updatedItems = subscribersSection.data.items.map((item) => {
@@ -61,6 +84,11 @@ export function reducer(state: State, action): State {
             },
           },
         },
+        runStatusUpdates: (() => {
+          const { [action.payload.runId]: removedUpdate, ...rest } =
+            state.runStatusUpdates;
+          return rest;
+        })(),
       };
     }
     default:

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
@@ -1,4 +1,4 @@
-import { State } from './types';
+import { State, SubscriberSection } from './types';
 
 export function reducer(state: State, action): State {
   switch (action.type) {
@@ -29,6 +29,40 @@ export function reducer(state: State, action): State {
         ...state,
         premiumModal: undefined,
       };
+    case 'UPDATE_RUN_STATUS': {
+      const subscribersSection = state.sections
+        .subscribers as SubscriberSection;
+      if (!subscribersSection?.data?.items) {
+        return state;
+      }
+
+      const updatedItems = subscribersSection.data.items.map((item) => {
+        if (item.run.id === action.payload.runId) {
+          return {
+            ...item,
+            run: {
+              ...item.run,
+              status: action.payload.status,
+            },
+          };
+        }
+        return item;
+      });
+
+      return {
+        ...state,
+        sections: {
+          ...state.sections,
+          subscribers: {
+            ...subscribersSection,
+            data: {
+              ...subscribersSection.data,
+              items: updatedItems,
+            },
+          },
+        },
+      };
+    }
     default:
       return state;
   }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/selectors/index.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/selectors/index.ts
@@ -15,3 +15,7 @@ export function getSection(state: State, id: string): Section | undefined {
 export function getPremiumModal(state: State): State['premiumModal'] {
   return state.premiumModal;
 }
+
+export function getRunStatusUpdate(state: State, runId: number) {
+  return state.runStatusUpdates[runId];
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -180,9 +180,14 @@ export type AutomationFlowSectionData = SectionData & {
 export type AutomationFlowSection = Section & {
   data: undefined | AutomationFlowSectionData;
 };
+export type RunStatusUpdate = {
+  status: string;
+  error?: string;
+};
 export type State = {
   sections: Record<string, Section>;
   query: Query;
+  runStatusUpdates: Record<number, RunStatusUpdate>;
   premiumModal?: {
     content: string | JSX.Element;
     utmCampaign?: string;

--- a/mailpoet/changelog/2025-11-24-16-01-20-added-ability-to-cancel-an-automation-run-for-a-single-s.md
+++ b/mailpoet/changelog/2025-11-24-16-01-20-added-ability-to-cancel-an-automation-run-for-a-single-s.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Ability to cancel an automation run for a single subscriber

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -284,6 +284,23 @@ class AutomationRunStorage {
     }
   }
 
+  public function getNextStepId(int $id): ?string {
+    global $wpdb;
+    $result = $wpdb->get_row(
+      $wpdb->prepare(
+        'SELECT next_step_id FROM %i WHERE id = %d',
+        $this->table,
+        $id
+      ),
+      ARRAY_A
+    );
+    if (!is_array($result) || !array_key_exists('next_step_id', $result)) {
+      return null;
+    }
+    $value = $result['next_step_id'];
+    return $value !== null ? (string)$value : null;
+  }
+
   public function getAutomationStepStatisticForTimeFrame(int $automationId, string $status, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
     global $wpdb;
     $andWhere = $versionId ? 'AND version_id = %d' : '';

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Analytics.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Analytics.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints\AutomationFlowEndpoint;
 use MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints\OverviewEndpoint;
+use MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints\UpdateRunStatusEndpoint;
 
 class Analytics {
 
@@ -23,6 +24,7 @@ class Analytics {
     $this->wordPress->addAction(Hooks::API_INITIALIZE, function (API $api) {
       $api->registerGetRoute('automation/analytics/automation_flow', AutomationFlowEndpoint::class);
       $api->registerGetRoute('automation/analytics/overview', OverviewEndpoint::class);
+      $api->registerPutRoute('automation/analytics/runs/(?P<id>\d+)/status', UpdateRunStatusEndpoint::class);
     });
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/UpdateRunStatusEndpoint.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/UpdateRunStatusEndpoint.php
@@ -2,12 +2,15 @@
 
 namespace MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints;
 
+use ActionScheduler_Store;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Control\ActionScheduler as ASWrapper;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Validator\Builder;
 
@@ -16,10 +19,15 @@ class UpdateRunStatusEndpoint extends Endpoint {
   /** @var AutomationRunStorage */
   private $automationRunStorage;
 
+  /** @var ASWrapper */
+  private $actionScheduler;
+
   public function __construct(
-    AutomationRunStorage $automationRunStorage
+    AutomationRunStorage $automationRunStorage,
+    ASWrapper $actionScheduler
   ) {
     $this->automationRunStorage = $automationRunStorage;
+    $this->actionScheduler = $actionScheduler;
   }
 
   public function handle(Request $request): Response {
@@ -84,6 +92,19 @@ class UpdateRunStatusEndpoint extends Endpoint {
     // Update run status
     $this->automationRunStorage->updateStatus($runId, $targetStatus);
 
+    // Schedule/unschedule actions based on status change
+    if ($targetStatus === AutomationRun::STATUS_CANCELLED) {
+      $this->unschedulePendingForRun($runId);
+    } elseif ($targetStatus === AutomationRun::STATUS_RUNNING) {
+      // If nothing pending for this run, enqueue next step based on stored next_step_id
+      if (!$this->hasPendingForRun($runId)) {
+        $nextStepId = $this->automationRunStorage->getNextStepId($runId);
+        if ($nextStepId) {
+          $this->enqueueStep($runId, (string)$nextStepId, 1);
+        }
+      }
+    }
+
     // Get updated run
     $updatedRun = $this->automationRunStorage->getAutomationRun($runId);
     if (!$updatedRun) {
@@ -103,5 +124,40 @@ class UpdateRunStatusEndpoint extends Endpoint {
       'id' => Builder::integer()->required(),
       'status' => Builder::string()->required(),
     ];
+  }
+
+  private function unschedulePendingForRun(int $runId): void {
+    $actions = $this->actionScheduler->getScheduledActions([
+      'hook' => Hooks::AUTOMATION_STEP,
+      'status' => ActionScheduler_Store::STATUS_PENDING,
+    ]);
+    foreach ($actions as $action) {
+      $args = $action->get_args();
+      if (is_array($args) && isset($args[0]['automation_run_id']) && (int)$args[0]['automation_run_id'] === $runId) {
+        $this->actionScheduler->unscheduleAction(Hooks::AUTOMATION_STEP, $args);
+      }
+    }
+  }
+
+  private function hasPendingForRun(int $runId): bool {
+    $actions = $this->actionScheduler->getScheduledActions([
+      'hook' => Hooks::AUTOMATION_STEP,
+      'status' => ActionScheduler_Store::STATUS_PENDING,
+    ]);
+    foreach ($actions as $action) {
+      $args = $action->get_args();
+      if (is_array($args) && isset($args[0]['automation_run_id']) && (int)$args[0]['automation_run_id'] === $runId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private function enqueueStep(int $runId, string $stepId, int $runNumber = 1): int {
+    return $this->actionScheduler->enqueue(Hooks::AUTOMATION_STEP, [[
+      'automation_run_id' => $runId,
+      'step_id' => $stepId,
+      'run_number' => $runNumber,
+    ]]);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/UpdateRunStatusEndpoint.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/UpdateRunStatusEndpoint.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Validator\Builder;
+
+class UpdateRunStatusEndpoint extends Endpoint {
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  public function __construct(
+    AutomationRunStorage $automationRunStorage
+  ) {
+    $this->automationRunStorage = $automationRunStorage;
+  }
+
+  public function handle(Request $request): Response {
+    /** @var int $runId */
+    $runId = $request->getParam('id');
+    $runId = intval($runId);
+
+    /** @var string|null $status */
+    $status = $request->getParam('status');
+
+    $run = $this->automationRunStorage->getAutomationRun($runId);
+    if (!$run) {
+      throw Exceptions::automationRunNotFound($runId);
+    }
+
+    $currentStatus = $run->getStatus();
+    $targetStatus = $status;
+
+    // Validate allowed status values
+    $allowedStatuses = [
+      AutomationRun::STATUS_RUNNING,
+      AutomationRun::STATUS_CANCELLED,
+    ];
+    if (!in_array($targetStatus, $allowedStatuses, true)) {
+      throw UnexpectedValueException::create()
+        ->withMessage(__('Invalid status value.', 'mailpoet'))
+        ->withErrors(['status' => __('Status must be "running" or "cancelled".', 'mailpoet')]);
+    }
+
+    // Validate status transitions
+    if ($currentStatus === $targetStatus) {
+      // Same status, no change needed
+      return new Response([
+        'id' => $run->getId(),
+        'status' => $run->getStatus(),
+        'updated_at' => $run->getUpdatedAt()->format(\DateTimeImmutable::W3C),
+      ]);
+    }
+
+    // Allow transitions: running → cancelled, cancelled → running
+    $allowedTransitions = [
+      AutomationRun::STATUS_RUNNING => [AutomationRun::STATUS_CANCELLED],
+      AutomationRun::STATUS_CANCELLED => [AutomationRun::STATUS_RUNNING],
+    ];
+
+    if (
+      !isset($allowedTransitions[$currentStatus]) ||
+      !in_array($targetStatus, $allowedTransitions[$currentStatus], true)
+    ) {
+      throw UnexpectedValueException::create()
+        ->withMessage(
+          sprintf(
+            // translators: This is an error message for an invalid status transition for an automation run. %1$s is the current status, %2$s is the target status.
+            __('Cannot transition run from "%1$s" to "%2$s".', 'mailpoet'),
+            $currentStatus,
+            $targetStatus
+          )
+        )
+        ->withErrors(['status' => __('Invalid status transition.', 'mailpoet')]);
+    }
+
+    // Update run status
+    $this->automationRunStorage->updateStatus($runId, $targetStatus);
+
+    // Get updated run
+    $updatedRun = $this->automationRunStorage->getAutomationRun($runId);
+    if (!$updatedRun) {
+      throw Exceptions::automationRunNotFound($runId);
+    }
+
+    // Return updated run data
+    return new Response([
+      'id' => $updatedRun->getId(),
+      'status' => $updatedRun->getStatus(),
+      'updated_at' => $updatedRun->getUpdatedAt()->format(\DateTimeImmutable::W3C),
+    ]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+      'status' => Builder::string()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -233,6 +233,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     //Automation Analytics
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Analytics\Analytics::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints\AutomationFlowEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints\UpdateRunStatusEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Analytics\Endpoints\OverviewEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Analytics\Controller\AutomationTimeSpanController::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\MailPoet\Analytics\Controller\StepStatisticController::class)->setPublic(true);

--- a/mailpoet/tests/integration/REST/Automation/Analytics/UpdateRunStatusEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Analytics/UpdateRunStatusEndpointTest.php
@@ -1,0 +1,228 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\REST\Automation\Analytics;
+
+use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\REST\Automation\AutomationTest;
+use MailPoet\Test\DataFactories\AutomationRun as AutomationRunFactory;
+
+require_once __DIR__ . '/../AutomationTest.php';
+
+class UpdateRunStatusEndpointTest extends AutomationTest {
+  private const ENDPOINT_PATH = '/mailpoet/v1/automation/analytics/runs/%d/status';
+
+  /** @var AutomationRunStorage */
+  private $automationRunStorage;
+
+  /** @var AutomationRun */
+  private $runningRun;
+
+  /** @var AutomationRun */
+  private $cancelledRun;
+
+  public function _before() {
+    parent::_before();
+    $this->automationRunStorage = $this->diContainer->get(AutomationRunStorage::class);
+
+    // Create a running automation run
+    $this->runningRun = (new AutomationRunFactory())
+      ->withStatus(AutomationRun::STATUS_RUNNING)
+      ->create();
+
+    // Create a cancelled automation run
+    $this->cancelledRun = (new AutomationRunFactory())
+      ->withStatus(AutomationRun::STATUS_CANCELLED)
+      ->create();
+  }
+
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_CANCELLED,
+        ],
+      ]
+    );
+
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $data['data']['status']);
+
+    $updatedRun = $this->automationRunStorage->getAutomationRun($this->runningRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $updatedRun);
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $updatedRun->getStatus());
+  }
+
+  public function testGuestNotAllowed(): void {
+    wp_set_current_user(0);
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_CANCELLED,
+        ],
+      ]
+    );
+
+    $this->assertSame([
+      'code' => 'rest_forbidden',
+      'message' => 'Sorry, you are not allowed to do that.',
+      'data' => ['status' => 401],
+    ], $data);
+
+    $run = $this->automationRunStorage->getAutomationRun($this->runningRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $run);
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $run->getStatus());
+  }
+
+  public function testItUpdatesStatusFromRunningToCancelled(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_CANCELLED,
+        ],
+      ]
+    );
+
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $data['data']['status']);
+    $this->assertArrayHasKey('id', $data['data']);
+    $this->assertArrayHasKey('updated_at', $data['data']);
+
+    $updatedRun = $this->automationRunStorage->getAutomationRun($this->runningRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $updatedRun);
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $updatedRun->getStatus());
+  }
+
+  public function testItUpdatesStatusFromCancelledToRunning(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->cancelledRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_RUNNING,
+        ],
+      ]
+    );
+
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $data['data']['status']);
+
+    $updatedRun = $this->automationRunStorage->getAutomationRun($this->cancelledRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $updatedRun);
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $updatedRun->getStatus());
+  }
+
+  public function testItReturnsSameStatusWhenNoChangeNeeded(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_RUNNING,
+        ],
+      ]
+    );
+
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $data['data']['status']);
+
+    $run = $this->automationRunStorage->getAutomationRun($this->runningRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $run);
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $run->getStatus());
+  }
+
+  public function testItReturnsErrorWhenStatusParameterMissing(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [],
+      ]
+    );
+    $this->assertSame('rest_missing_callback_param', $data['code']);
+    $this->assertSame('Missing parameter(s): status', $data['message']);
+  }
+
+  public function testItReturnsErrorWhenRunNotFound(): void {
+    $nonExistentId = 99999;
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $nonExistentId),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_CANCELLED,
+        ],
+      ]
+    );
+
+    $this->assertSame('mailpoet_automation_run_not_found', $data['code']);
+  }
+
+  public function testItReturnsErrorWhenInvalidStatusValue(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => 'invalid-status',
+        ],
+      ]
+    );
+
+    $this->assertSame('mailpoet_automation_unknown_error', $data['code']);
+    $this->assertArrayHasKey('errors', $data['data']);
+    $this->assertArrayHasKey('status', $data['data']['errors']);
+  }
+
+  public function testItReturnsErrorWhenInvalidTransition(): void {
+    $completeRun = (new AutomationRunFactory())
+      ->withStatus(AutomationRun::STATUS_COMPLETE)
+      ->create();
+
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $completeRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_RUNNING,
+        ],
+      ]
+    );
+
+    $this->assertSame('mailpoet_automation_unknown_error', $data['code']);
+    $this->assertArrayHasKey('errors', $data['data']);
+    $this->assertArrayHasKey('status', $data['data']['errors']);
+
+    $run = $this->automationRunStorage->getAutomationRun($completeRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $run);
+    $this->assertSame(AutomationRun::STATUS_COMPLETE, $run->getStatus());
+  }
+
+  public function testItReturnsErrorWhenTransitioningToComplete(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_COMPLETE,
+        ],
+      ]
+    );
+
+    $this->assertSame('mailpoet_automation_unknown_error', $data['code']);
+
+    $run = $this->automationRunStorage->getAutomationRun($this->runningRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $run);
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $run->getStatus());
+  }
+
+  public function testItReturnsErrorWhenTransitioningToFailed(): void {
+    $data = $this->put(
+      sprintf(self::ENDPOINT_PATH, $this->runningRun->getId()),
+      [
+        'json' => [
+          'status' => AutomationRun::STATUS_FAILED,
+        ],
+      ]
+    );
+
+    $this->assertSame('mailpoet_automation_unknown_error', $data['code']);
+
+    $run = $this->automationRunStorage->getAutomationRun($this->runningRun->getId());
+    $this->assertInstanceOf(AutomationRun::class, $run);
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $run->getStatus());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds functionality that allows users to cancel or resume (cancelled) automation run.
The functionality is accessible via Automation Analytics in the Subscribers tab.

<img width="1488" height="332" alt="Screenshot 2025-11-24 at 15 27 06" src="https://github.com/user-attachments/assets/ff5abd65-1598-4a77-a240-442e25ddac30" />
<img width="1483" height="366" alt="Screenshot 2025-11-24 at 15 27 22" src="https://github.com/user-attachments/assets/2f890a7f-c2b2-489c-aafa-4816eeeebeb0" />
<img width="1482" height="342" alt="Screenshot 2025-11-24 at 15 27 32" src="https://github.com/user-attachments/assets/2d09ef20-ab58-45ff-b168-5ec9cd71c012" />
<img width="1488" height="356" alt="Screenshot 2025-11-24 at 15 27 41" src="https://github.com/user-attachments/assets/3545226c-8a5d-49d7-b028-2e09ad9b0237" />


## Code review notes

I'm not 100ure we can resume all the automations that were cancelled. From my observation, I think we can, because the action scheduler run seems to carry only the next step ID, and we don't delete any data when we cancel. But I'm not sure if there are some special cases.
Alternatively, we could allow only canceling.

## QA notes

### Testing instructions
1) Create an automation and do the action that triggers a run
2) Go to Automations > Your Automation > Analytics > Subscribers
3) Cancel the run. Note you are able to cancel only runs that are in progress.
4) Observe that run is cancelled and the next step is not executed.
5) Resume the cancelled automation. Note: you can resume only cancelled automation
6) Observe that the run continues

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7549

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7549-removing-subscriber-from-automation)

_The latest successful build from `stomail-7549-removing-subscriber-from-automation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel running automation runs and resume cancelled runs from the analytics dashboard with in-place controls and success/error feedback.
  * Confirmation dialogs added to prevent accidental status changes; per-run actions available via a dropdown menu.

* **UI Improvements**
  * Minor layout adjustment to the subscribers activity cell for improved alignment.

* **Tests**
  * Added comprehensive integration tests covering status transitions and side effects.

* **Documentation**
  * Changelog entry documenting the new run status controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->