### PR TITLE
Add filter allowing controlling cookie tracking

### DIFF
--- a/mailpoet/changelog/2025-12-02-13-08-27-added-filter-mailpoetiscookietrackingenabled-allowing-co.md
+++ b/mailpoet/changelog/2025-12-02-13-08-27-added-filter-mailpoetiscookietrackingenabled-allowing-co.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Filter mailpoet_is_cookie_tracking_enabled allowing control of cookie tracking

--- a/mailpoet/lib/Settings/TrackingConfig.php
+++ b/mailpoet/lib/Settings/TrackingConfig.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Settings;
 
+use MailPoet\WP\Functions as WPFunctions;
+
 class TrackingConfig {
   const LEVEL_FULL = 'full';
   const LEVEL_PARTIAL = 'partial';
@@ -10,13 +12,16 @@ class TrackingConfig {
   const OPENS_MERGED = 'merged';
   const OPENS_SEPARATED = 'separated';
 
-  /** @var SettingsController */
-  private $settings;
+  private SettingsController $settings;
+
+  private WPFunctions $wp;
 
   public function __construct(
-    SettingsController $settings
+    SettingsController $settings,
+    WPFunctions $wp
   ) {
     $this->settings = $settings;
+    $this->wp = $wp;
   }
 
   public function isEmailTrackingEnabled(?string $level = null): bool {
@@ -26,7 +31,7 @@ class TrackingConfig {
 
   public function isCookieTrackingEnabled(?string $level = null): bool {
     $level = $level ?? $this->settings->get('tracking.level', self::LEVEL_FULL);
-    return $level === self::LEVEL_FULL;
+    return (bool)$this->wp->applyFilters('mailpoet_is_cookie_tracking_enabled', $level === self::LEVEL_FULL);
   }
 
   public function areOpensMerged(?string $opens = null): bool {

--- a/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
+++ b/mailpoet/tests/integration/AutomaticEmails/WooCommerce/Events/AbandonedCartTest.php
@@ -112,7 +112,7 @@ class AbandonedCartTest extends \MailPoetTest {
     $wp = new WPFunctions();
     $wcHelper = new WooCommerceHelper($wp);
     $cookies = new Cookies();
-    $subscriberCookie = new SubscriberCookie($cookies, new TrackingConfig($settings));
+    $subscriberCookie = new SubscriberCookie($cookies, new TrackingConfig($settings, $wp));
     $event = new AbandonedCart(
       $wp,
       $wcHelper,
@@ -184,6 +184,10 @@ class AbandonedCartTest extends \MailPoetTest {
         'exists' => false,
       ])
     );
+
+    $this->wp->method('applyFilters')->willReturnCallback(function ($hookName, $value) {
+        return $value;
+    });
 
     $_COOKIE['mailpoet_subscriber'] = json_encode([
       'subscriber_id' => $subscriber->getId(),
@@ -337,7 +341,7 @@ class AbandonedCartTest extends \MailPoetTest {
     return $this->make(AbandonedCart::class, [
       'wp' => $this->wp,
       'wooCommerceHelper' => $this->wooCommerceHelperMock,
-      'subscriberCookie' => new SubscriberCookie(new Cookies(), new TrackingConfig($settings)),
+      'subscriberCookie' => new SubscriberCookie(new Cookies(), new TrackingConfig($settings, $this->wp)),
       'subscriberActivityTracker' => $this->subscriberActivityTrackerMock,
       'scheduler' => $automaticEmailScheduler,
       'subscribersRepository' => $subscribersRepository,

--- a/mailpoet/tests/unit/Settings/TrackingConfigTest.php
+++ b/mailpoet/tests/unit/Settings/TrackingConfigTest.php
@@ -63,36 +63,25 @@ class TrackingConfigTest extends \MailPoetUnitTest {
       ->with('tracking.level', TrackingConfig::LEVEL_FULL)
       ->willReturn(TrackingConfig::LEVEL_FULL);
 
+    // Mock filter as pass-through to test the actual logic
     $this->wpMock->expects($this->once())
       ->method('applyFilters')
       ->with('mailpoet_is_cookie_tracking_enabled', true)
-      ->willReturn(true);
+      ->willReturnArgument(1);
 
     verify($this->trackingConfig->isCookieTrackingEnabled())->true();
   }
 
-  public function testIsCookieTrackingEnabledWithPartialLevel() {
+  public function testIsCookieTrackingEnabledWithNonFullLevel() {
     $this->settingsMock->method('get')
       ->with('tracking.level', TrackingConfig::LEVEL_FULL)
       ->willReturn(TrackingConfig::LEVEL_PARTIAL);
 
+    // Mock filter as pass-through to test the actual logic
     $this->wpMock->expects($this->once())
       ->method('applyFilters')
       ->with('mailpoet_is_cookie_tracking_enabled', false)
-      ->willReturn(false);
-
-    verify($this->trackingConfig->isCookieTrackingEnabled())->false();
-  }
-
-  public function testIsCookieTrackingEnabledWithBasicLevel() {
-    $this->settingsMock->method('get')
-      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
-      ->willReturn(TrackingConfig::LEVEL_BASIC);
-
-    $this->wpMock->expects($this->once())
-      ->method('applyFilters')
-      ->with('mailpoet_is_cookie_tracking_enabled', false)
-      ->willReturn(false);
+      ->willReturnArgument(1);
 
     verify($this->trackingConfig->isCookieTrackingEnabled())->false();
   }
@@ -102,7 +91,7 @@ class TrackingConfigTest extends \MailPoetUnitTest {
       ->with('tracking.level', TrackingConfig::LEVEL_FULL)
       ->willReturn(TrackingConfig::LEVEL_FULL);
 
-    // Filter can override the result
+    // Test that filter can override the result
     $this->wpMock->expects($this->once())
       ->method('applyFilters')
       ->with('mailpoet_is_cookie_tracking_enabled', true)
@@ -118,7 +107,7 @@ class TrackingConfigTest extends \MailPoetUnitTest {
     $this->wpMock->expects($this->once())
       ->method('applyFilters')
       ->with('mailpoet_is_cookie_tracking_enabled', true)
-      ->willReturn(true);
+      ->willReturnArgument(1);
 
     verify($this->trackingConfig->isCookieTrackingEnabled(TrackingConfig::LEVEL_FULL))->true();
   }
@@ -179,8 +168,7 @@ class TrackingConfigTest extends \MailPoetUnitTest {
       ]);
 
     $this->wpMock->method('applyFilters')
-      ->with('mailpoet_is_cookie_tracking_enabled', false)
-      ->willReturn(false);
+      ->willReturnArgument(1);
 
     $config = $this->trackingConfig->getConfig();
 
@@ -197,44 +185,5 @@ class TrackingConfigTest extends \MailPoetUnitTest {
     verify($config['opens'])->equals(TrackingConfig::OPENS_SEPARATED);
     verify($config['opensMerged'])->false();
     verify($config['opensSeparated'])->true();
-  }
-
-  public function testGetConfigWithFullTrackingLevel() {
-    $this->settingsMock->method('get')
-      ->willReturnMap([
-        ['tracking.level', TrackingConfig::LEVEL_FULL, TrackingConfig::LEVEL_FULL],
-        ['tracking.opens', TrackingConfig::OPENS_MERGED, TrackingConfig::OPENS_MERGED],
-      ]);
-
-    $this->wpMock->method('applyFilters')
-      ->with('mailpoet_is_cookie_tracking_enabled', true)
-      ->willReturn(true);
-
-    $config = $this->trackingConfig->getConfig();
-
-    verify($config['level'])->equals(TrackingConfig::LEVEL_FULL);
-    verify($config['emailTrackingEnabled'])->true();
-    verify($config['cookieTrackingEnabled'])->true();
-    verify($config['opens'])->equals(TrackingConfig::OPENS_MERGED);
-    verify($config['opensMerged'])->true();
-    verify($config['opensSeparated'])->false();
-  }
-
-  public function testGetConfigWithBasicTrackingLevel() {
-    $this->settingsMock->method('get')
-      ->willReturnMap([
-        ['tracking.level', TrackingConfig::LEVEL_FULL, TrackingConfig::LEVEL_BASIC],
-        ['tracking.opens', TrackingConfig::OPENS_MERGED, TrackingConfig::OPENS_MERGED],
-      ]);
-
-    $this->wpMock->method('applyFilters')
-      ->with('mailpoet_is_cookie_tracking_enabled', false)
-      ->willReturn(false);
-
-    $config = $this->trackingConfig->getConfig();
-
-    verify($config['level'])->equals(TrackingConfig::LEVEL_BASIC);
-    verify($config['emailTrackingEnabled'])->false();
-    verify($config['cookieTrackingEnabled'])->false();
   }
 }

--- a/mailpoet/tests/unit/Settings/TrackingConfigTest.php
+++ b/mailpoet/tests/unit/Settings/TrackingConfigTest.php
@@ -1,0 +1,240 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Settings;
+
+use MailPoet\Settings\SettingsController;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class TrackingConfigTest extends \MailPoetUnitTest {
+
+  /** @var MockObject|SettingsController */
+  private $settingsMock;
+
+  /** @var MockObject|WPFunctions */
+  private $wpMock;
+
+  /** @var TrackingConfig */
+  private $trackingConfig;
+
+  public function _before() {
+    parent::_before();
+    $this->settingsMock = $this->createMock(SettingsController::class);
+    $this->wpMock = $this->createMock(WPFunctions::class);
+    $this->trackingConfig = new TrackingConfig($this->settingsMock, $this->wpMock);
+  }
+
+  public function testIsEmailTrackingEnabledWithFullLevel() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_FULL);
+
+    verify($this->trackingConfig->isEmailTrackingEnabled())->true();
+  }
+
+  public function testIsEmailTrackingEnabledWithPartialLevel() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_PARTIAL);
+
+    verify($this->trackingConfig->isEmailTrackingEnabled())->true();
+  }
+
+  public function testIsEmailTrackingEnabledWithBasicLevel() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_BASIC);
+
+    verify($this->trackingConfig->isEmailTrackingEnabled())->false();
+  }
+
+  public function testIsEmailTrackingEnabledWithExplicitLevel() {
+    // Should not call settings->get when explicit level is provided
+    $this->settingsMock->expects($this->never())->method('get');
+
+    verify($this->trackingConfig->isEmailTrackingEnabled(TrackingConfig::LEVEL_FULL))->true();
+    verify($this->trackingConfig->isEmailTrackingEnabled(TrackingConfig::LEVEL_PARTIAL))->true();
+    verify($this->trackingConfig->isEmailTrackingEnabled(TrackingConfig::LEVEL_BASIC))->false();
+  }
+
+  public function testIsCookieTrackingEnabledWithFullLevel() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_FULL);
+
+    $this->wpMock->expects($this->once())
+      ->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', true)
+      ->willReturn(true);
+
+    verify($this->trackingConfig->isCookieTrackingEnabled())->true();
+  }
+
+  public function testIsCookieTrackingEnabledWithPartialLevel() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_PARTIAL);
+
+    $this->wpMock->expects($this->once())
+      ->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', false)
+      ->willReturn(false);
+
+    verify($this->trackingConfig->isCookieTrackingEnabled())->false();
+  }
+
+  public function testIsCookieTrackingEnabledWithBasicLevel() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_BASIC);
+
+    $this->wpMock->expects($this->once())
+      ->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', false)
+      ->willReturn(false);
+
+    verify($this->trackingConfig->isCookieTrackingEnabled())->false();
+  }
+
+  public function testIsCookieTrackingEnabledWithFilterOverride() {
+    $this->settingsMock->method('get')
+      ->with('tracking.level', TrackingConfig::LEVEL_FULL)
+      ->willReturn(TrackingConfig::LEVEL_FULL);
+
+    // Filter can override the result
+    $this->wpMock->expects($this->once())
+      ->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', true)
+      ->willReturn(false);
+
+    verify($this->trackingConfig->isCookieTrackingEnabled())->false();
+  }
+
+  public function testIsCookieTrackingEnabledWithExplicitLevel() {
+    // Should not call settings->get when explicit level is provided
+    $this->settingsMock->expects($this->never())->method('get');
+
+    $this->wpMock->expects($this->once())
+      ->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', true)
+      ->willReturn(true);
+
+    verify($this->trackingConfig->isCookieTrackingEnabled(TrackingConfig::LEVEL_FULL))->true();
+  }
+
+  public function testAreOpensMergedWithMergedSetting() {
+    $this->settingsMock->method('get')
+      ->with('tracking.opens', TrackingConfig::OPENS_MERGED)
+      ->willReturn(TrackingConfig::OPENS_MERGED);
+
+    verify($this->trackingConfig->areOpensMerged())->true();
+  }
+
+  public function testAreOpensMergedWithSeparatedSetting() {
+    $this->settingsMock->method('get')
+      ->with('tracking.opens', TrackingConfig::OPENS_MERGED)
+      ->willReturn(TrackingConfig::OPENS_SEPARATED);
+
+    verify($this->trackingConfig->areOpensMerged())->false();
+  }
+
+  public function testAreOpensMergedWithExplicitParameter() {
+    // Should not call settings->get when explicit parameter is provided
+    $this->settingsMock->expects($this->never())->method('get');
+
+    verify($this->trackingConfig->areOpensMerged(TrackingConfig::OPENS_MERGED))->true();
+    verify($this->trackingConfig->areOpensMerged(TrackingConfig::OPENS_SEPARATED))->false();
+  }
+
+  public function testAreOpensSeparatedWithMergedSetting() {
+    $this->settingsMock->method('get')
+      ->with('tracking.opens', TrackingConfig::OPENS_MERGED)
+      ->willReturn(TrackingConfig::OPENS_MERGED);
+
+    verify($this->trackingConfig->areOpensSeparated())->false();
+  }
+
+  public function testAreOpensSeparatedWithSeparatedSetting() {
+    $this->settingsMock->method('get')
+      ->with('tracking.opens', TrackingConfig::OPENS_MERGED)
+      ->willReturn(TrackingConfig::OPENS_SEPARATED);
+
+    verify($this->trackingConfig->areOpensSeparated())->true();
+  }
+
+  public function testAreOpensSeparatedWithExplicitParameter() {
+    // Should not call settings->get when explicit parameter is provided
+    $this->settingsMock->expects($this->never())->method('get');
+
+    verify($this->trackingConfig->areOpensSeparated(TrackingConfig::OPENS_MERGED))->false();
+    verify($this->trackingConfig->areOpensSeparated(TrackingConfig::OPENS_SEPARATED))->true();
+  }
+
+  public function testGetConfigReturnsCompleteConfiguration() {
+    $this->settingsMock->method('get')
+      ->willReturnMap([
+        ['tracking.level', TrackingConfig::LEVEL_FULL, TrackingConfig::LEVEL_PARTIAL],
+        ['tracking.opens', TrackingConfig::OPENS_MERGED, TrackingConfig::OPENS_SEPARATED],
+      ]);
+
+    $this->wpMock->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', false)
+      ->willReturn(false);
+
+    $config = $this->trackingConfig->getConfig();
+
+    verify($config)->arrayHasKey('level');
+    verify($config)->arrayHasKey('emailTrackingEnabled');
+    verify($config)->arrayHasKey('cookieTrackingEnabled');
+    verify($config)->arrayHasKey('opens');
+    verify($config)->arrayHasKey('opensMerged');
+    verify($config)->arrayHasKey('opensSeparated');
+
+    verify($config['level'])->equals(TrackingConfig::LEVEL_PARTIAL);
+    verify($config['emailTrackingEnabled'])->true();
+    verify($config['cookieTrackingEnabled'])->false();
+    verify($config['opens'])->equals(TrackingConfig::OPENS_SEPARATED);
+    verify($config['opensMerged'])->false();
+    verify($config['opensSeparated'])->true();
+  }
+
+  public function testGetConfigWithFullTrackingLevel() {
+    $this->settingsMock->method('get')
+      ->willReturnMap([
+        ['tracking.level', TrackingConfig::LEVEL_FULL, TrackingConfig::LEVEL_FULL],
+        ['tracking.opens', TrackingConfig::OPENS_MERGED, TrackingConfig::OPENS_MERGED],
+      ]);
+
+    $this->wpMock->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', true)
+      ->willReturn(true);
+
+    $config = $this->trackingConfig->getConfig();
+
+    verify($config['level'])->equals(TrackingConfig::LEVEL_FULL);
+    verify($config['emailTrackingEnabled'])->true();
+    verify($config['cookieTrackingEnabled'])->true();
+    verify($config['opens'])->equals(TrackingConfig::OPENS_MERGED);
+    verify($config['opensMerged'])->true();
+    verify($config['opensSeparated'])->false();
+  }
+
+  public function testGetConfigWithBasicTrackingLevel() {
+    $this->settingsMock->method('get')
+      ->willReturnMap([
+        ['tracking.level', TrackingConfig::LEVEL_FULL, TrackingConfig::LEVEL_BASIC],
+        ['tracking.opens', TrackingConfig::OPENS_MERGED, TrackingConfig::OPENS_MERGED],
+      ]);
+
+    $this->wpMock->method('applyFilters')
+      ->with('mailpoet_is_cookie_tracking_enabled', false)
+      ->willReturn(false);
+
+    $config = $this->trackingConfig->getConfig();
+
+    verify($config['level'])->equals(TrackingConfig::LEVEL_BASIC);
+    verify($config['emailTrackingEnabled'])->false();
+    verify($config['cookieTrackingEnabled'])->false();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a filter `mailpoet_is_cookie_tracking_enabled` that allows controlling cookie tracking. The idea is that 3rd party plugins for cookie consent could use the filter to control the behavior.

## Code review notes

_N/A_

## QA notes

- zip file with build [mailpoet-filter.zip](https://github.com/user-attachments/files/23882196/mailpoet-filter.zip)

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7650

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7650-add-filter-for-iscookietrackingenabled)

_The latest successful build from `stomail-7650-add-filter-for-iscookietrackingenabled` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a filter to control cookie tracking settings, allowing customization of email tracking behavior.

* **Tests**
  * Added comprehensive unit tests for tracking configuration and updated integration tests to align with the new behavior.

* **Changelog**
  * Added a changelog entry documenting the new cookie-tracking control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->