### PR TITLE
Update WordPress and plugins in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - run:
           name: Download additional WP Plugins for tests
           command: |
-            ./do download:woo-commerce-zip 10.3.5
+            ./do download:woo-commerce-zip 10.3.6
             ./do download:woo-commerce-subscriptions-zip 8.1.0
             ./do download:woo-commerce-memberships-zip
             ./do download:automate-woo-zip 6.1.20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1199,7 +1199,7 @@ workflows:
           mysql_image: mysql:5.6
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           requires:
             - build
       - performance_tests:
@@ -1237,7 +1237,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           requires:
@@ -1299,7 +1299,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           requires:
             - build_premium
       - integration_tests:
@@ -1310,7 +1310,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           requires:

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - mailhog-data:/mailhog-data
 
   wordpress:
-    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.8.3-php8.3}
+    image: wordpress:${WORDPRESS_IMAGE_VERSION:-6.9.0-php8.3}
     container_name: wordpress_${CIRCLE_NODE_INDEX:-default}
     depends_on:
       smtp:


### PR DESCRIPTION
1. If all checks passed, you can merge this PR.
2. If the build failed, please investigate the failure and either address the issues or delegate the job. Then, make sure these changes are merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WooCommerce testing dependency to version 10.3.6.
  * Bumped WordPress versions used in CI workflows from 6.7.2 → 6.8.3 → 6.8.3/6.8.3 → 6.8.3 to align with current releases.
  * Updated local/test container WordPress image used in test compose to version 6.9.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->