### PR TITLE
Bump minimum WordPress version to 6.8, tested up to 6.9

### DIFF
--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -7,7 +7,7 @@
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
  * Author URI: https://www.mailpoet.com
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
@@ -27,7 +27,7 @@ $mailpoetPlugin = [
   'initializer' => dirname(__FILE__) . '/mailpoet_initializer.php',
 ];
 
-const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.7'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.8'; // L-1 version, not the latest
 const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.2'; // L-1 version, not the latest
 
 

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -1,8 +1,8 @@
 === MailPoet - Newsletters, Email Marketing, and Automation ===
 Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
-Requires at least: 6.7
-Tested up to: 6.8
+Requires at least: 6.8
+Tested up to: 6.9
 Stable tag: 5.17.2
 Requires PHP: 7.4
 License: GPLv3


### PR DESCRIPTION
## Description

This PR bumps the minimum and tested up to WordPress versions to 6.8 and 6.9 respectively.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/bump-wp-version)

_The latest successful build from `update/bump-wp-version` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased minimum required WordPress version to 6.8.
  * Updated maximum tested WordPress version to 6.9.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->