### PR TITLE
Update WordPress version in oldest tests in nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1199,7 +1199,7 @@ workflows:
           mysql_image: mysql:5.6
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           requires:
             - build
       - performance_tests:
@@ -1237,7 +1237,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           requires:
@@ -1299,7 +1299,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           requires:
             - build_premium
       - integration_tests:
@@ -1310,7 +1310,7 @@ workflows:
           automate_woo_version: 6.0.33
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
-          wordpress_version: 6.7.2
+          wordpress_version: 6.8.3
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           requires:


### PR DESCRIPTION
## Description

This PR updates the WordPress version in the oldest tests in nightly build to match the [minimum required WordPress version](https://github.com/mailpoet/mailpoet/pull/6421).

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/wp-oldest-nightly-tests)

_The latest successful build from `update/wp-oldest-nightly-tests` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated WordPress version used in automated testing and validation workflows from 6.7.2 to 6.8.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->