### PR TITLE
Add changelog for WordPress version bump

### DIFF
--- a/mailpoet/changelog/2025-12-05-12-53-21-updated-bump-the-minimum-required-wordpress-version-to-68-.md
+++ b/mailpoet/changelog/2025-12-05-12-53-21-updated-bump-the-minimum-required-wordpress-version-to-68-.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Bump the minimum required WordPress version to 6.8 and tested up to version to 6.9


### PR DESCRIPTION
## Description

Add changelog for WordPress version bump changes in https://github.com/mailpoet/mailpoet/pull/6421.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/changelog-wp-version-bump)

_The latest successful build from `add/changelog-wp-version-bump` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Minimum required WordPress version updated to 6.8, with testing up to version 6.9.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->