### PR TITLE
Per-list confirmation emails and confirmation pages

### DIFF
--- a/mailpoet/assets/js/src/segments/static/form.tsx
+++ b/mailpoet/assets/js/src/segments/static/form.tsx
@@ -1,10 +1,118 @@
+import { useCallback, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Form } from 'form/form.jsx';
 import { SubscribersLimitNotice } from 'notices/subscribers-limit-notice';
 import { MailPoet } from 'mailpoet';
 import { useParams } from 'react-router-dom';
+import { Button } from 'common/button/button';
+import { Select } from '../../common/form/select/select';
 import { BackButton, PageHeader } from '../../common/page-header';
 import { TopBarWithBoundary } from '../../common/top-bar/top-bar';
+
+declare global {
+  interface Window {
+    mailpoet_confirmation_emails?: Array<{ id: number; subject: string }>;
+    mailpoet_pages?: Array<{ id: number; title: string }>;
+  }
+}
+
+const initialConfirmationEmails = window.mailpoet_confirmation_emails || [];
+const pages = window.mailpoet_pages || [];
+
+const confirmationPageValues: Record<string, string> = {
+  '0': __('Use global default', 'mailpoet'),
+};
+pages.forEach((page) => {
+  confirmationPageValues[String(page.id)] = page.title;
+});
+
+function ConfirmationEmailField({
+  onValueChange,
+  item,
+}: {
+  onValueChange: (e: { target: { name: string; value: string } }) => void;
+  item: Record<string, string>;
+}) {
+  const [emails, setEmails] = useState<Array<{ id: number; subject: string }>>(
+    initialConfirmationEmails,
+  );
+  const [isCreating, setIsCreating] = useState(false);
+
+  const selectedId = item.confirmation_email_id || '0';
+
+  const handleCreate = useCallback(async () => {
+    setIsCreating(true);
+    try {
+      const response = await MailPoet.Ajax.post({
+        api_version: MailPoet.apiVersion,
+        endpoint: 'newsletters',
+        action: 'createConfirmationEmail',
+      });
+      const newEmail = response.data as { id: number; subject: string };
+      setEmails((prev) => [...prev, newEmail]);
+      onValueChange({
+        target: { name: 'confirmation_email_id', value: String(newEmail.id) },
+      });
+      const editUrl = `admin.php?page=mailpoet-newsletter-editor&id=${newEmail.id}`;
+      MailPoet.Notice.success(
+        `${__(
+          'Confirmation email created.',
+          'mailpoet',
+        )} <a href="${editUrl}" target="_blank" rel="noopener noreferrer">${__(
+          'Edit it now',
+          'mailpoet',
+        )}</a>`,
+      );
+    } catch (errorResponse) {
+      MailPoet.Notice.showApiErrorNotice(errorResponse, {
+        scroll: true,
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  }, [onValueChange]);
+
+  return (
+    <>
+      <Select
+        name="confirmation_email_id"
+        id="field_confirmation_email_id"
+        value={selectedId}
+        onChange={onValueChange}
+      >
+        <option value="0">{__('Use global default', 'mailpoet')}</option>
+        {emails.map((email) => (
+          <option key={email.id} value={String(email.id)}>
+            {email.subject}
+          </option>
+        ))}
+      </Select>
+      <div className="mailpoet-gap" />
+      <Button
+        type="button"
+        variant="secondary"
+        dimension="small"
+        onClick={handleCreate}
+        isDisabled={isCreating}
+      >
+        {isCreating
+          ? __('Creating…', 'mailpoet')
+          : __('Create new', 'mailpoet')}
+      </Button>
+      {selectedId !== '0' && (
+        <Button
+          variant="secondary"
+          dimension="small"
+          href={`admin.php?page=mailpoet-newsletter-editor&id=${selectedId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {__('Edit', 'mailpoet')}
+        </Button>
+      )}
+    </>
+  );
+}
 
 const fields = [
   {
@@ -28,7 +136,27 @@ const fields = [
         'showInManageSubscriptionPageTip',
       ),
     },
-    isChecked: true, // default checked state
+    isChecked: true,
+  },
+  {
+    name: 'confirmation_email_id',
+    label: __('Confirmation email', 'mailpoet'),
+    type: 'reactComponent',
+    component: ConfirmationEmailField,
+    tip: __(
+      'Choose a custom confirmation email for subscribers joining this list. If not set, the global default is used.',
+      'mailpoet',
+    ),
+  },
+  {
+    name: 'confirmation_page_id',
+    label: __('Confirmation page', 'mailpoet'),
+    type: 'select',
+    values: confirmationPageValues,
+    tip: __(
+      'Choose a custom confirmation page for subscribers joining this list. If not set, the global default is used.',
+      'mailpoet',
+    ),
   },
 ];
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -35,6 +35,8 @@ class SegmentsResponseBuilder {
       'average_engagement_score' => $segment->getAverageEngagementScore(),
       'filters_connect' => $segment->getFiltersConnectOperator(),
       'show_in_manage_subscription_page' => (int)$segment->getDisplayInManageSubscriptionPage(),
+      'confirmation_email_id' => $segment->getConfirmationEmailId(),
+      'confirmation_page_id' => $segment->getConfirmationPageId(),
     ];
   }
 

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -31,6 +31,7 @@ use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\ConfirmationEmailCustomizer;
 use MailPoet\UnexpectedValueException;
 use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -103,6 +104,9 @@ class Newsletters extends APIEndpoint {
   /** @var CapabilitiesManager */
   private $capabilitiesManager;
 
+  /** @var ConfirmationEmailCustomizer */
+  private $confirmationEmailCustomizer;
+
   public function __construct(
     Listing\Handler $listingHandler,
     WPFunctions $wp,
@@ -123,7 +127,8 @@ class Newsletters extends APIEndpoint {
     NewsletterValidator $newsletterValidator,
     AuthorizedEmailsController $authorizedEmailsController,
     ScheduledTasksRepository $scheduledTasksRepository,
-    CapabilitiesManager $capabilitiesManager
+    CapabilitiesManager $capabilitiesManager,
+    ConfirmationEmailCustomizer $confirmationEmailCustomizer
   ) {
     $this->listingHandler = $listingHandler;
     $this->wp = $wp;
@@ -145,6 +150,7 @@ class Newsletters extends APIEndpoint {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->scheduledTasksRepository = $scheduledTasksRepository;
     $this->capabilitiesManager = $capabilitiesManager;
+    $this->confirmationEmailCustomizer = $confirmationEmailCustomizer;
   }
 
   public function get($data = []) {
@@ -522,5 +528,52 @@ class Newsletters extends APIEndpoint {
     $url = $this->newsletterUrl->getViewInBrowserUrl($newsletter);
     // strip protocol to avoid mix content error
     return preg_replace('/^https?:/i', '', $url);
+  }
+
+  /**
+   * Get all confirmation email newsletters for use in form editor.
+   * @return Response
+   */
+  public function getConfirmationEmails() {
+    $newsletters = $this->newslettersRepository->findBy([
+      'type' => NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER,
+      'deletedAt' => null,
+    ]);
+
+    $result = [];
+    foreach ($newsletters as $newsletter) {
+      $id = $newsletter->getId();
+      if ($id === null) {
+        continue;
+      }
+      $result[] = [
+        'id' => $id,
+        'subject' => $newsletter->getSubject() ?: __('(no subject)', 'mailpoet'),
+      ];
+    }
+
+    return $this->successResponse($result);
+  }
+
+  /**
+   * Create a new confirmation email from the global default template.
+   * @return Response
+   */
+  public function createConfirmationEmail() {
+    // Get the global default confirmation email as a base
+    $defaultNewsletter = $this->confirmationEmailCustomizer->getNewsletter();
+
+    $newsletterData = [
+      'type' => NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER,
+      'subject' => $defaultNewsletter->getSubject(),
+      'body' => json_encode($defaultNewsletter->getBody()),
+    ];
+
+    $newsletter = $this->newsletterSaveController->save($newsletterData);
+
+    return $this->successResponse([
+      'id' => $newsletter->getId(),
+      'subject' => $newsletter->getSubject(),
+    ]);
   }
 }

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -231,6 +231,8 @@ class Subscribers extends APIEndpoint {
     $subscriber = $this->subscribersRepository->findOneById($id);
     if ($subscriber instanceof SubscriberEntity) {
       try {
+        // Per-list confirmation settings are not resolved for manual resends;
+        // the global default is used to avoid ambiguity across multiple segments.
         if ($this->confirmationEmailMailer->sendConfirmationEmail($subscriber)) {
           return $this->successResponse();
         } else {

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -14,6 +14,7 @@ use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\Unsubscribes;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\ConfirmationEmailResolver;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\RequiredCustomFieldValidator;
 use MailPoet\Subscribers\Source;
@@ -76,6 +77,9 @@ class Subscribers {
   /** @var SubscriberTagRepository */
   private $subscriberTagRepository;
 
+  /** @var ConfirmationEmailResolver */
+  private $confirmationEmailResolver;
+
   public function __construct (
     ConfirmationEmailMailer $confirmationEmailMailer,
     NewSubscriberNotificationMailer $newSubscriberNotificationMailer,
@@ -91,7 +95,8 @@ class Subscribers {
     WPFunctions $wp,
     Unsubscribes $unsubscribesTracker,
     TagRepository $tagRepository,
-    SubscriberTagRepository $subscriberTagRepository
+    SubscriberTagRepository $subscriberTagRepository,
+    ConfirmationEmailResolver $confirmationEmailResolver
   ) {
     $this->confirmationEmailMailer = $confirmationEmailMailer;
     $this->newSubscriberNotificationMailer = $newSubscriberNotificationMailer;
@@ -108,6 +113,7 @@ class Subscribers {
     $this->unsubscribesTracker = $unsubscribesTracker;
     $this->tagRepository = $tagRepository;
     $this->subscriberTagRepository = $subscriberTagRepository;
+    $this->confirmationEmailResolver = $confirmationEmailResolver;
   }
 
   public function getSubscriber($subscriberIdOrEmail): array {
@@ -374,7 +380,8 @@ class Subscribers {
 
     // send confirmation email
     if ($sendConfirmationEmail) {
-      $this->_sendConfirmationEmail($subscriber);
+      [$confirmationEmailId, $confirmationPageId] = $this->confirmationEmailResolver->resolveFromSegments($foundSegments);
+      $this->_sendConfirmationEmail($subscriber, $confirmationEmailId, $confirmationPageId);
     }
 
     if (!$skipSubscriberNotification && ($subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED)) {
@@ -477,9 +484,9 @@ class Subscribers {
   /**
    * @throws APIException
    */
-  protected function _sendConfirmationEmail(SubscriberEntity $subscriberEntity) {
+  protected function _sendConfirmationEmail(SubscriberEntity $subscriberEntity, ?int $confirmationEmailId = null, ?int $confirmationPageId = null) {
     try {
-      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity);
+      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriberEntity, $confirmationEmailId, $confirmationPageId);
     } catch (\Exception $e) {
       throw new APIException(
         // translators: %s is the error message

--- a/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/NewsletterEditor.php
@@ -4,14 +4,15 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Util\CustomFonts;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Blocks\Coupon;
 use MailPoet\Newsletter\Shortcodes\ShortcodesHelper;
 use MailPoet\NewsletterTemplates\BrandStyles;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\UserFlagsController;
-use MailPoet\Subscribers\ConfirmationEmailCustomizer;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WooCommerce\TransactionalEmailHooks;
@@ -37,6 +38,7 @@ class NewsletterEditor {
   private AssetsController $assetsController;
   private BrandStyles $brandStyles;
   private WooTransactionalEmailTemplate $template;
+  private NewslettersRepository $newslettersRepository;
 
   public function __construct(
     PageRenderer $pageRenderer,
@@ -52,7 +54,8 @@ class NewsletterEditor {
     CustomFonts $customFonts,
     AssetsController $assetsController,
     WooTransactionalEmailTemplate $template,
-    BrandStyles $brandStyles
+    BrandStyles $brandStyles,
+    NewslettersRepository $newslettersRepository
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->settings = $settings;
@@ -68,6 +71,7 @@ class NewsletterEditor {
     $this->assetsController = $assetsController;
     $this->template = $template;
     $this->brandStyles = $brandStyles;
+    $this->newslettersRepository = $newslettersRepository;
   }
 
   public function render() {
@@ -125,7 +129,9 @@ class NewsletterEditor {
       $woocommerceData = array_merge($wcEmailSettings, $woocommerceData);
     }
 
-    $confirmationEmailTemplateId = (int)$this->settings->get(ConfirmationEmailCustomizer::SETTING_EMAIL_ID, null);
+    // Check if newsletter is a confirmation email type (includes per-list confirmation emails)
+    $newsletter = $newsletterId ? $this->newslettersRepository->findOneById($newsletterId) : null;
+    $isConfirmationEmailType = $newsletter && $newsletter->getType() === NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER;
 
     $data = [
       'customFontsEnabled' => $this->customFonts->displayCustomFonts(),
@@ -135,7 +141,7 @@ class NewsletterEditor {
       'current_wp_user' => array_merge($subscriberData, $this->wp->wpGetCurrentUser()->to_array()),
       'woocommerce' => $woocommerceData,
       'is_wc_transactional_email' => $newsletterId === $woocommerceTemplateId,
-      'is_confirmation_email_template' => $newsletterId === $confirmationEmailTemplateId,
+      'is_confirmation_email_type' => $isConfirmationEmailType,
       'is_confirmation_email_customizer_enabled' => (bool)$this->settings->get('signup_confirmation.use_mailpoet_editor', false),
       'original_template_body' => $originalTemplateBody,
       'product_categories' => $this->wpPostListLoader->getWooCommerceCategories(),

--- a/mailpoet/lib/AdminPages/Pages/StaticSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/StaticSegments.php
@@ -4,7 +4,9 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Listing\PageLimit;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\WP\Functions as WPFunctions;
 
 class StaticSegments {
@@ -17,6 +19,9 @@ class StaticSegments {
   /** @var PageLimit */
   private $listingPageLimit;
 
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
   /** @var WPFunctions */
   private $wp;
 
@@ -24,11 +29,13 @@ class StaticSegments {
     AssetsController $assetsController,
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
+    NewslettersRepository $newslettersRepository,
     WPFunctions $wp
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
+    $this->newslettersRepository = $newslettersRepository;
     $this->wp = $wp;
   }
 
@@ -44,7 +51,42 @@ class StaticSegments {
       'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
       'nonce' => $this->wp->wpCreateNonce('wp_rest'),
     ];
+    $data['confirmation_emails'] = $this->getConfirmationEmails();
+    $data['pages'] = $this->getPages();
 
     $this->pageRenderer->displayPage('segments/static.html', $data);
+  }
+
+  /** @return array<int, array{id: int, subject: string}> */
+  private function getConfirmationEmails(): array {
+    $newsletters = $this->newslettersRepository->findBy(
+      ['type' => NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER, 'deletedAt' => null],
+      ['subject' => 'ASC']
+    );
+
+    return array_map(function (NewsletterEntity $newsletter) {
+      return [
+        'id' => (int)$newsletter->getId(),
+        'subject' => $newsletter->getSubject() ?: __('(no subject)', 'mailpoet'),
+      ];
+    }, $newsletters);
+  }
+
+  /** @return array<int, array{id: int, title: string}> */
+  private function getPages(): array {
+    $wpPages = $this->wp->getPosts([
+      'post_type' => 'page',
+      'post_status' => 'publish',
+      'orderby' => 'title',
+      'order' => 'ASC',
+      'posts_per_page' => -1,
+    ]);
+
+    return array_map(function ($page) {
+      return [
+        'id' => (int)$page->ID,
+        'title' => $page->post_title, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      ];
+    }, $wpPages);
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -492,6 +492,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Subscribers\Statistics\SubscriberStatisticsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscribersCountsController::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailCustomizer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\ConfirmationEmailResolver::class)->setPublic(true);
     // Segments
     $container->autowire(\MailPoet\Segments\WooCommerce::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\WP::class)->setPublic(true);

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -80,6 +80,18 @@ class SegmentEntity {
    */
   private $displayInManageSubscriptionPage = false;
 
+  /**
+   * @ORM\Column(type="integer", nullable=true)
+   * @var int|null
+   */
+  private $confirmationEmailId;
+
+  /**
+   * @ORM\Column(type="integer", nullable=true)
+   * @var int|null
+   */
+  private $confirmationPageId;
+
   public function __construct(
     string $name,
     string $type,
@@ -176,6 +188,22 @@ class SegmentEntity {
 
   public function setDisplayInManageSubscriptionPage(bool $state): void {
     $this->displayInManageSubscriptionPage = $state;
+  }
+
+  public function getConfirmationEmailId(): ?int {
+    return $this->confirmationEmailId;
+  }
+
+  public function setConfirmationEmailId(?int $confirmationEmailId): void {
+    $this->confirmationEmailId = $confirmationEmailId;
+  }
+
+  public function getConfirmationPageId(): ?int {
+    return $this->confirmationPageId;
+  }
+
+  public function setConfirmationPageId(?int $confirmationPageId): void {
+    $this->confirmationPageId = $confirmationPageId;
   }
 
   /**

--- a/mailpoet/lib/Migrations/Db/Migration_20260415_090055_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260415_090055_Db.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260415_090055_Db extends DbMigration {
+  public function run(): void {
+    $tableName = $this->getTableName(SegmentEntity::class);
+
+    if (!$this->columnExists($tableName, 'confirmation_email_id')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$tableName}`
+          ADD COLUMN `confirmation_email_id` INT(11) UNSIGNED NULL DEFAULT NULL"
+      );
+    }
+
+    if (!$this->columnExists($tableName, 'confirmation_page_id')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$tableName}`
+          ADD COLUMN `confirmation_page_id` INT(11) UNSIGNED NULL DEFAULT NULL"
+      );
+    }
+  }
+}

--- a/mailpoet/lib/Segments/SegmentSaveController.php
+++ b/mailpoet/lib/Segments/SegmentSaveController.php
@@ -34,8 +34,16 @@ class SegmentSaveController {
     $name = $data['name'] ?? '';
     $description = $data['description'] ?? '';
     $displayInManageSubPage = isset($data['show_in_manage_subscription_page']) ? (int)$data['show_in_manage_subscription_page'] : false;
+    $confirmationEmailId = isset($data['confirmation_email_id']) ? (int)$data['confirmation_email_id'] : null;
+    if ($confirmationEmailId === 0) {
+      $confirmationEmailId = null;
+    }
+    $confirmationPageId = isset($data['confirmation_page_id']) ? (int)$data['confirmation_page_id'] : null;
+    if ($confirmationPageId === 0) {
+      $confirmationPageId = null;
+    }
 
-    return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id, (bool)$displayInManageSubPage);
+    return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id, (bool)$displayInManageSubPage, $confirmationEmailId, $confirmationPageId);
   }
 
   /**

--- a/mailpoet/lib/Segments/SegmentsRepository.php
+++ b/mailpoet/lib/Segments/SegmentsRepository.php
@@ -197,8 +197,16 @@ class SegmentsRepository extends Repository {
     string $type = SegmentEntity::TYPE_DEFAULT,
     array $filtersData = [],
     ?int $id = null,
-    bool $displayInManageSubscriptionPage = true
+    bool $displayInManageSubscriptionPage = true,
+    ?int $confirmationEmailId = null,
+    ?int $confirmationPageId = null
   ): SegmentEntity {
+    if ($confirmationEmailId !== null && $confirmationEmailId <= 0) {
+      $confirmationEmailId = null;
+    }
+    if ($confirmationPageId !== null && $confirmationPageId <= 0) {
+      $confirmationPageId = null;
+    }
     $displayInManageSubPage = $type === SegmentEntity::TYPE_DEFAULT ? $displayInManageSubscriptionPage : false;
 
     if ($id) {
@@ -212,10 +220,14 @@ class SegmentsRepository extends Repository {
       }
       $segment->setDescription($description);
       $segment->setDisplayInManageSubscriptionPage($displayInManageSubPage);
+      $segment->setConfirmationEmailId($confirmationEmailId);
+      $segment->setConfirmationPageId($confirmationPageId);
     } else {
       $this->verifyNameIsUnique($name, $id);
       $segment = new SegmentEntity($name, $type, $description);
       $segment->setDisplayInManageSubscriptionPage($displayInManageSubPage);
+      $segment->setConfirmationEmailId($confirmationEmailId);
+      $segment->setConfirmationPageId($confirmationPageId);
       $this->persist($segment);
     }
 

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -247,6 +247,9 @@ class WP {
       /** @var ConfirmationEmailMailer $confirmationEmailMailer */
       $confirmationEmailMailer = ContainerWrapper::getInstance()->get(ConfirmationEmailMailer::class);
       try {
+        // Per-list confirmation settings are not resolved here because this path
+        // subscribes to the WordPress Users segment (TYPE_WP_USERS),
+        // which does not support custom confirmation overrides.
         $confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
       } catch (\Exception $e) {
         // ignore errors

--- a/mailpoet/lib/Subscribers/ConfirmationEmailCustomizer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailCustomizer.php
@@ -52,7 +52,7 @@ class ConfirmationEmailCustomizer {
 
     $newsletter = new NewsletterEntity;
     $newsletter->setType(NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER);
-    $newsletter->setSubject($this->settings->get('signup_confirmation.subject', 'Confirm your subscription to [site:title]'));
+    $newsletter->setSubject($this->settings->get('signup_confirmation.subject', __('Confirm your subscription to [site:title]', 'mailpoet')));
     $newsletter->setBody($emailTemplate);
     $newsletter->setHash(Security::generateHash());
     $this->newslettersRepository->persist($newsletter);

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -4,6 +4,7 @@ namespace MailPoet\Subscribers;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Html2Text;
 use MailPoet\Cron\Workers\SendingQueue\Tasks\Shortcodes;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Logging\LoggerFactory;
@@ -11,6 +12,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Mailer\MetaInfo;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -47,6 +49,9 @@ class ConfirmationEmailMailer {
   /** @var ConfirmationEmailCustomizer */
   private $confirmationEmailCustomizer;
 
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
   /** @var LoggerFactory */
   private $loggerFactory;
 
@@ -59,7 +64,8 @@ class ConfirmationEmailMailer {
     SettingsController $settings,
     SubscribersRepository $subscribersRepository,
     SubscriptionUrlFactory $subscriptionUrlFactory,
-    ConfirmationEmailCustomizer $confirmationEmailCustomizer
+    ConfirmationEmailCustomizer $confirmationEmailCustomizer,
+    NewslettersRepository $newslettersRepository
   ) {
     $this->mailerFactory = $mailerFactory;
     $this->wp = $wp;
@@ -68,6 +74,7 @@ class ConfirmationEmailMailer {
     $this->subscriptionUrlFactory = $subscriptionUrlFactory;
     $this->subscribersRepository = $subscribersRepository;
     $this->confirmationEmailCustomizer = $confirmationEmailCustomizer;
+    $this->newslettersRepository = $newslettersRepository;
     $this->loggerFactory = LoggerFactory::getInstance();
   }
 
@@ -75,13 +82,16 @@ class ConfirmationEmailMailer {
    * Use this method if you want to make sure the confirmation email
    * is not sent multiple times within a single request
    * e.g. if sending confirmation emails from hooks
+   * @param SubscriberEntity $subscriber The subscriber to send the confirmation email to.
+   * @param int|null $confirmationEmailId Optional ID of a specific confirmation email newsletter to use.
+   * @param int|null $confirmationPageId Optional ID of a specific page to use for the confirmation link.
    * @throws \Exception if unable to send the email.
    */
-  public function sendConfirmationEmailOnce(SubscriberEntity $subscriber, bool $isPublicFormSend = false): bool {
+  public function sendConfirmationEmailOnce(SubscriberEntity $subscriber, ?int $confirmationEmailId = null, ?int $confirmationPageId = null, bool $isPublicFormSend = false): bool {
     if (isset($this->sentEmails[$subscriber->getId()])) {
       return true;
     }
-    return $this->sendConfirmationEmail($subscriber, $isPublicFormSend);
+    return $this->sendConfirmationEmail($subscriber, $confirmationEmailId, $confirmationPageId, $isPublicFormSend);
   }
 
   public function clearSentEmailsCache(): void {
@@ -93,7 +103,7 @@ class ConfirmationEmailMailer {
    *
    * @return string
    */
-  protected function sendWCConfirmationEmail(SubscriberEntity $subscriber): string {
+  protected function sendWCConfirmationEmail(SubscriberEntity $subscriber, ?int $confirmationPageId = null): string {
     try {
       if (!function_exists('WC')) {
         return self::WC_CONFIRMATION_UNAVAILABLE;
@@ -115,7 +125,7 @@ class ConfirmationEmailMailer {
       $email = $emails['mailpoet_marketing_confirmation'];
 
       $subscriber_email = $subscriber->getEmail();
-      $activation_link = $this->subscriptionUrlFactory->getConfirmationUrl($subscriber);
+      $activation_link = $this->subscriptionUrlFactory->getConfirmationUrl($subscriber, $confirmationPageId);
       $subscriber_firstname = $subscriber->getFirstName() ?: '';
 
       if (!$email->trigger($subscriber_email, $activation_link, $subscriber_firstname)) {
@@ -143,7 +153,7 @@ class ConfirmationEmailMailer {
     ];
   }
 
-  public function getMailBody(array $signupConfirmation, SubscriberEntity $subscriber, array $segmentNames): array {
+  public function getMailBody(array $signupConfirmation, SubscriberEntity $subscriber, array $segmentNames, ?int $confirmationPageId = null): array {
     $body = nl2br($signupConfirmation['body']);
 
     // replace list of segments shortcode
@@ -156,7 +166,7 @@ class ConfirmationEmailMailer {
     // replace activation link
     $body = Helpers::replaceLinkTags(
       $body,
-      $this->subscriptionUrlFactory->getConfirmationUrl($subscriber),
+      $this->subscriptionUrlFactory->getConfirmationUrl($subscriber, $confirmationPageId),
       ['target' => '_blank'],
       'activation_link'
     );
@@ -174,8 +184,10 @@ class ConfirmationEmailMailer {
     return $this->buildEmailData($subject, $body, $text);
   }
 
-  public function getMailBodyWithCustomizer(SubscriberEntity $subscriber, array $segmentNames): array {
-    $newsletter = $this->confirmationEmailCustomizer->getNewsletter();
+  public function getMailBodyWithCustomizer(SubscriberEntity $subscriber, array $segmentNames, ?NewsletterEntity $newsletter = null, ?int $confirmationPageId = null): array {
+    if ($newsletter === null) {
+      $newsletter = $this->confirmationEmailCustomizer->getNewsletter();
+    }
 
     $renderedNewsletter = $this->confirmationEmailCustomizer->render($newsletter);
 
@@ -194,7 +206,7 @@ class ConfirmationEmailMailer {
         'http://[activation_link]', // See MAILPOET-5253
         '[activation_link]',
       ],
-      $this->subscriptionUrlFactory->getConfirmationUrl($subscriber),
+      $this->subscriptionUrlFactory->getConfirmationUrl($subscriber, $confirmationPageId),
       $body
     );
 
@@ -204,13 +216,25 @@ class ConfirmationEmailMailer {
       $subject,
     ] = Helpers::splitObject(Shortcodes::process($body, null, $newsletter, $subscriber, null));
 
+    // Fallback to newsletter subject if extracted subject is empty
+    if (empty($subject)) {
+      $subject = $newsletter->getSubject();
+    }
+    // Final fallback to default subject if still empty
+    if (empty($subject)) {
+      $subject = $this->settings->get('signup_confirmation.subject', __('Confirm your subscription', 'mailpoet'));
+    }
+
     return $this->buildEmailData($subject, $html, $text);
   }
 
   /**
+   * @param SubscriberEntity $subscriber The subscriber to send the confirmation email to.
+   * @param int|null $confirmationEmailId Optional ID of a specific confirmation email newsletter to use.
+   * @param int|null $confirmationPageId Optional ID of a specific page to use for the confirmation link.
    * @throws \Exception if unable to send the email.
    */
-  public function sendConfirmationEmail(SubscriberEntity $subscriber, bool $isPublicFormSend = false) {
+  public function sendConfirmationEmail(SubscriberEntity $subscriber, ?int $confirmationEmailId = null, ?int $confirmationPageId = null, bool $isPublicFormSend = false) {
     $signupConfirmation = $this->settings->get('signup_confirmation');
     if ((bool)$signupConfirmation['enabled'] === false) {
       return false;
@@ -220,8 +244,8 @@ class ConfirmationEmailMailer {
       return $this->subscribersRepository->sendPublicConfirmationEmailWithCap(
         $subscriber,
         self::MAX_CONFIRMATION_EMAILS,
-        function() use ($subscriber, $signupConfirmation): bool {
-          $sent = $this->sendConfirmationEmailMessage($subscriber, $signupConfirmation);
+        function() use ($subscriber, $signupConfirmation, $confirmationEmailId, $confirmationPageId): bool {
+          $sent = $this->sendConfirmationEmailMessage($subscriber, $signupConfirmation, $confirmationEmailId, $confirmationPageId);
           if ($sent) {
             $this->sentEmails[$subscriber->getId()] = true;
           }
@@ -235,7 +259,7 @@ class ConfirmationEmailMailer {
       return false;
     }
 
-    $sent = $this->sendConfirmationEmailMessage($subscriber, $signupConfirmation);
+    $sent = $this->sendConfirmationEmailMessage($subscriber, $signupConfirmation, $confirmationEmailId, $confirmationPageId);
     if (!$sent) {
       return false;
     }
@@ -249,16 +273,20 @@ class ConfirmationEmailMailer {
   /**
    * @throws \Exception if unable to send the email.
    */
-  private function sendConfirmationEmailMessage(SubscriberEntity $subscriber, array $signupConfirmation): bool {
+  private function sendConfirmationEmailMessage(SubscriberEntity $subscriber, array $signupConfirmation, ?int $confirmationEmailId = null, ?int $confirmationPageId = null): bool {
     $authorizationEmailsValidation = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
     $unauthorizedSenderEmail = isset($authorizationEmailsValidation['invalid_sender_address']);
     if (Bridge::isMPSendingServiceEnabled() && $unauthorizedSenderEmail) {
       return false;
     }
 
-    $wcConfirmationEmailResult = $this->sendWCConfirmationEmail($subscriber);
-    if ($wcConfirmationEmailResult === self::WC_CONFIRMATION_SENT) {
-      return true;
+    // Try to send using WooCommerce email first. Only available in Garden environment.
+    // Skip WC path when a per-list confirmation email is set, since WC doesn't support custom templates.
+    if ($confirmationEmailId === null) {
+      $wcConfirmationEmailResult = $this->sendWCConfirmationEmail($subscriber, $confirmationPageId);
+      if ($wcConfirmationEmailResult === self::WC_CONFIRMATION_SENT) {
+        return true;
+      }
     }
 
     $segments = $subscriber->getSegments()->toArray();
@@ -266,11 +294,7 @@ class ConfirmationEmailMailer {
       return $segment->getName();
     }, $segments);
 
-    $IsConfirmationEmailCustomizerEnabled = (bool)$this->settings->get(ConfirmationEmailCustomizer::SETTING_ENABLE_EMAIL_CUSTOMIZER, false);
-
-    $email = $IsConfirmationEmailCustomizerEnabled ?
-      $this->getMailBodyWithCustomizer($subscriber, $segmentNames) :
-      $this->getMailBody($signupConfirmation, $subscriber, $segmentNames);
+    $email = $this->getConfirmationEmailBody($signupConfirmation, $subscriber, $segmentNames, $confirmationEmailId, $confirmationPageId);
 
     // send email
     $extraParams = [
@@ -311,5 +335,25 @@ class ConfirmationEmailMailer {
     $subscriber->setLastConfirmationEmailSentAt(Carbon::now()->millisecond(0));
     $this->subscribersRepository->persist($subscriber);
     $this->subscribersRepository->flush();
+  }
+
+  /**
+   * Determines which confirmation email body to use based on settings and optional override.
+   */
+  private function getConfirmationEmailBody(array $signupConfirmation, SubscriberEntity $subscriber, array $segmentNames, ?int $confirmationEmailId = null, ?int $confirmationPageId = null): array {
+    // If a specific confirmation email ID is provided, try to use it
+    if ($confirmationEmailId !== null) {
+      $newsletter = $this->newslettersRepository->findOneById($confirmationEmailId);
+      if ($newsletter !== null && $newsletter->getType() === NewsletterEntity::TYPE_CONFIRMATION_EMAIL_CUSTOMIZER) {
+        return $this->getMailBodyWithCustomizer($subscriber, $segmentNames, $newsletter, $confirmationPageId);
+      }
+    }
+
+    // Fall back to global settings
+    $IsConfirmationEmailCustomizerEnabled = (bool)$this->settings->get(ConfirmationEmailCustomizer::SETTING_ENABLE_EMAIL_CUSTOMIZER, false);
+
+    return $IsConfirmationEmailCustomizerEnabled ?
+      $this->getMailBodyWithCustomizer($subscriber, $segmentNames, null, $confirmationPageId) :
+      $this->getMailBody($signupConfirmation, $subscriber, $segmentNames, $confirmationPageId);
   }
 }

--- a/mailpoet/lib/Subscribers/ConfirmationEmailResolver.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailResolver.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Entities\SegmentEntity;
+
+class ConfirmationEmailResolver {
+  /**
+   * Resolves which confirmation email and page to use based on segment settings.
+   *
+   * Rules:
+   * - If no segments have custom settings, returns [null, null] (use global).
+   * - If exactly one unique custom email/page is set, use it.
+   * - If segments conflict (different custom values), fall back to global (null).
+   *
+   * Email and page are resolved independently.
+   *
+   * @param SegmentEntity[] $segments
+   * @return array{0: int|null, 1: int|null} [confirmationEmailId, confirmationPageId]
+   */
+  public function resolveFromSegments(array $segments): array {
+    $emailIds = [];
+    $pageIds = [];
+
+    foreach ($segments as $segment) {
+      $emailId = $segment->getConfirmationEmailId();
+      if ($emailId !== null) {
+        $emailIds[] = $emailId;
+      }
+
+      $pageId = $segment->getConfirmationPageId();
+      if ($pageId !== null) {
+        $pageIds[] = $pageId;
+      }
+    }
+
+    $resolvedEmailId = $this->resolveValue($emailIds);
+    $resolvedPageId = $this->resolveValue($pageIds);
+
+    return [$resolvedEmailId, $resolvedPageId];
+  }
+
+  /**
+   * @param int[] $values
+   */
+  private function resolveValue(array $values): ?int {
+    $unique = array_unique($values);
+    if (count($unique) === 1) {
+      return $unique[0];
+    }
+    return null;
+  }
+}

--- a/mailpoet/lib/Subscribers/SubscriberActions.php
+++ b/mailpoet/lib/Subscribers/SubscriberActions.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\ConfirmationEmailResolver;
 use MailPoet\Util\Helpers;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -34,6 +35,9 @@ class SubscriberActions {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var ConfirmationEmailResolver */
+  private $confirmationEmailResolver;
+
   public function __construct(
     SettingsController $settings,
     NewSubscriberNotificationMailer $newSubscriberNotificationMailer,
@@ -42,7 +46,8 @@ class SubscriberActions {
     SegmentsRepository $segmentsRepository,
     SubscriberSaveController $subscriberSaveController,
     SubscribersRepository $subscribersRepository,
-    SubscriberSegmentRepository $subscriberSegmentRepository
+    SubscriberSegmentRepository $subscriberSegmentRepository,
+    ConfirmationEmailResolver $confirmationEmailResolver
   ) {
     $this->settings = $settings;
     $this->newSubscriberNotificationMailer = $newSubscriberNotificationMailer;
@@ -52,10 +57,13 @@ class SubscriberActions {
     $this->subscribersRepository = $subscribersRepository;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
     $this->segmentsRepository = $segmentsRepository;
+    $this->confirmationEmailResolver = $confirmationEmailResolver;
   }
 
   /**
    * Returns SubscriberEntity and associative array with some metadata related to the subscription (e.g. ['confirmationEmailResult' => $exception])
+   * @param array $subscriberData Subscriber data (email, first_name, last_name, etc.)
+   * @param array $segmentIds IDs of segments to subscribe to
    * @return array{0: SubscriberEntity, 1: array{confirmationEmailResult: bool|\Exception, error?: string}}
    */
   public function subscribe($subscriberData = [], $segmentIds = []): array {
@@ -117,6 +125,9 @@ class SubscriberActions {
     $segments = $this->segmentsRepository->findByIds($segmentIds);
     $this->subscriberSegmentRepository->subscribeToSegments($subscriber, $segments);
 
+    // resolve confirmation settings from segment-level overrides
+    [$confirmationEmailId, $confirmationPageId] = $this->confirmationEmailResolver->resolveFromSegments($segments);
+
     try {
       if (
         $signupConfirmationEnabled
@@ -125,7 +136,7 @@ class SubscriberActions {
       ) {
         $metaData['error'] = $this->getMaxConfirmationEmailsReachedError();
       } else {
-        $metaData['confirmationEmailResult'] = $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber, true);
+        $metaData['confirmationEmailResult'] = $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber, $confirmationEmailId, $confirmationPageId, true);
       }
     } catch (\Exception $e) {
       $metaData['confirmationEmailResult'] = $e;

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -161,9 +161,8 @@ class SubscriberSubscribeController {
     // record form statistics
     $this->statisticsFormsRepository->record($form, $subscriber);
 
-    $formSettings = $form->getSettings();
-
     // add tags to subscriber if they are filled
+    $formSettings = $form->getSettings();
     $this->addTagsToSubscriber($formSettings['tags'] ?? [], $subscriber);
 
     // Confirmation email failed. We want to show the error message

--- a/mailpoet/lib/Subscription/AdminUserSubscription.php
+++ b/mailpoet/lib/Subscription/AdminUserSubscription.php
@@ -160,7 +160,8 @@ class AdminUserSubscription {
       return;
     }
 
-    // Send confirmation email
+    // Send confirmation email. Per-list confirmation settings are not resolved
+    // here because admin-created users are subscribed via the WP Users segment.
     try {
       $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber);
     } catch (\Exception $e) {

--- a/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
+++ b/mailpoet/lib/Subscription/SubscriptionUrlFactory.php
@@ -35,8 +35,9 @@ class SubscriptionUrlFactory {
     $this->linkTokens = $linkTokens;
   }
 
-  public function getConfirmationUrl(?SubscriberEntity $subscriber = null) {
-    $post = $this->getPost($this->settings->get('subscription.pages.confirmation'));
+  public function getConfirmationUrl(?SubscriberEntity $subscriber = null, ?int $confirmationPageId = null) {
+    $pageId = $confirmationPageId ?? $this->settings->get('subscription.pages.confirmation');
+    $post = $this->getPost($pageId);
     return $this->getSubscriptionUrl($post, 'confirm', $subscriber);
   }
 

--- a/mailpoet/lib/WooCommerce/Subscription.php
+++ b/mailpoet/lib/WooCommerce/Subscription.php
@@ -252,7 +252,10 @@ class Subscription {
     $this->subscribersRepository->flush();
 
     try {
-      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber, true);
+      // Per-list confirmation settings are not resolved here because this path
+      // subscribes to the WooCommerce Customers segment (TYPE_WC_USERS),
+      // which does not support custom confirmation overrides.
+      $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber, null, null, true);
     } catch (\Exception $e) {
       // ignore errors
     }

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -21,6 +21,7 @@ use MailPoet\Newsletter\Scheduler\WelcomeScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\ConfirmationEmailResolver;
 use MailPoet\Subscribers\NewSubscriberNotificationMailer;
 use MailPoet\Subscribers\RequiredCustomFieldValidator;
 use MailPoet\Subscribers\SubscriberSaveController;
@@ -190,6 +191,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => SettingsController::getInstance(),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
       ]
     );
 
@@ -262,6 +264,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => SettingsController::getInstance(),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
       ],
       $this
     );
@@ -287,6 +290,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => SettingsController::getInstance(),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
       ],
       $this
     );
@@ -602,6 +606,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => $settings,
         'requiredCustomFieldsValidator' => Stub::makeEmpty(RequiredCustomFieldValidator::class, ['validate' => true]),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
       ],
       $this
     );
@@ -654,6 +659,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => SettingsController::getInstance(),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
       ],
       $this
     );
@@ -684,6 +690,7 @@ class SubscribersTest extends \MailPoetTest {
         'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
         'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
         'settings' => SettingsController::getInstance(),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
       ],
       $this
     );

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -286,16 +286,17 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
-    verify($sender->sendConfirmationEmail($this->subscriber, true))->equals(true);
+    verify($sender->sendConfirmationEmail($this->subscriber, null, null, true))->equals(true);
     $this->subscribersRepository->refresh($this->subscriber);
     verify($this->subscriber->getConfirmationsCount())->equals(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
     verify($this->subscriber->getLastConfirmationEmailSentAt())->notNull();
     $lastConfirmationEmailSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
 
-    verify($sender->sendConfirmationEmail($this->subscriber, true))->equals(false);
+    verify($sender->sendConfirmationEmail($this->subscriber, null, null, true))->equals(false);
     $this->subscribersRepository->refresh($this->subscriber);
     verify($this->subscriber->getConfirmationsCount())->equals(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
     verify($this->subscriber->getLastConfirmationEmailSentAt())->equals($lastConfirmationEmailSentAt);
@@ -318,11 +319,12 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     try {
-      $sender->sendConfirmationEmail($this->subscriber, true);
+      $sender->sendConfirmationEmail($this->subscriber, null, null, true);
     } catch (\Exception $e) {
       verify($e->getMessage())->equals(__('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet'));
     }
@@ -355,10 +357,11 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
-    verify($sender->sendConfirmationEmail($this->subscriber, true))->false();
+    verify($sender->sendConfirmationEmail($this->subscriber, null, null, true))->false();
 
     verify($this->subscriber->getConfirmationsCount())->equals(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
   }
@@ -380,14 +383,15 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     ) extends ConfirmationEmailMailer {
-      protected function sendWCConfirmationEmail(SubscriberEntity $subscriber): string {
+      protected function sendWCConfirmationEmail(SubscriberEntity $subscriber, ?int $confirmationPageId = null): string {
         return self::WC_CONFIRMATION_FAILED;
       }
     };
 
-    verify($sender->sendConfirmationEmail($this->subscriber, true))->true();
+    verify($sender->sendConfirmationEmail($this->subscriber, null, null, true))->true();
     $this->subscribersRepository->refresh($this->subscriber);
     verify($this->subscriber->getConfirmationsCount())->equals(2);
     verify($this->subscriber->getLastConfirmationEmailSentAt())->notNull();
@@ -408,14 +412,15 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     ) extends ConfirmationEmailMailer {
-      protected function sendWCConfirmationEmail(SubscriberEntity $subscriber): string {
+      protected function sendWCConfirmationEmail(SubscriberEntity $subscriber, ?int $confirmationPageId = null): string {
         return self::WC_CONFIRMATION_SENT;
       }
     };
 
-    verify($sender->sendConfirmationEmail($this->subscriber, true))->true();
+    verify($sender->sendConfirmationEmail($this->subscriber, null, null, true))->true();
     $this->subscribersRepository->refresh($this->subscriber);
     verify($this->subscriber->getConfirmationsCount())->equals(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
     verify($this->subscriber->getLastConfirmationEmailSentAt())->notNull();

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -87,7 +87,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $subscriptionUrlFactoryMock,
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     $segment = $this->segmentFactory->withName('Test segment')->create();
@@ -118,7 +119,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     $this->expectException(\Exception::class);
@@ -140,7 +142,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
     $exceptionMessage = '';
     try {
@@ -169,7 +172,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
     $exceptionMessage = '';
     try {
@@ -197,7 +201,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     $result = $sender->sendConfirmationEmail($this->subscriber);
@@ -222,7 +227,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     for ($i = 0; $i < $sender::MAX_CONFIRMATION_EMAILS; $i++) {
@@ -248,7 +254,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     for ($i = 0; $i < $sender::MAX_CONFIRMATION_EMAILS; $i++) {
@@ -469,7 +476,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $settings,
       $this->diContainer->get(SubscribersRepository::class),
       $subscriptionUrlFactoryMock,
-      $confirmationEmailCustomizer
+      $confirmationEmailCustomizer,
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     $confirmationNewsletter = $confirmationEmailCustomizer->getNewsletter();

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailResolverIntegrationTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailResolverIntegrationTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+
+class ConfirmationEmailResolverIntegrationTest extends \MailPoetTest {
+  /** @var ConfirmationEmailResolver */
+  private $resolver;
+
+  /** @var SegmentFactory */
+  private $segmentFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->resolver = $this->diContainer->get(ConfirmationEmailResolver::class);
+    $this->segmentFactory = new SegmentFactory();
+  }
+
+  public function testItResolvesFromPersistedSegments(): void {
+    $segment1 = $this->segmentFactory->withName('List A')->create();
+    $segment1->setConfirmationEmailId(42);
+    $this->entityManager->flush();
+
+    $segment2 = $this->segmentFactory->withName('List B')->create();
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->equals(42);
+    verify($pageId)->null();
+  }
+
+  public function testItFallsBackOnConflict(): void {
+    $segment1 = $this->segmentFactory->withName('List C')->create();
+    $segment1->setConfirmationEmailId(42);
+
+    $segment2 = $this->segmentFactory->withName('List D')->create();
+    $segment2->setConfirmationEmailId(43);
+
+    $this->entityManager->flush();
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->null();
+    verify($pageId)->null();
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -272,7 +272,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     $confirmationEmailMailer = $this->createMock(ConfirmationEmailMailer::class);
     $confirmationEmailMailer->expects($this->once())
       ->method('sendConfirmationEmailOnce')
-      ->with($this->isInstanceOf(SubscriberEntity::class), true)
+      ->with($this->isInstanceOf(SubscriberEntity::class), null, null, true)
       ->willReturn(false);
     $subscriberActions = $this->getServiceWithOverrides(SubscriberActions::class, [
       'confirmationEmailMailer' => $confirmationEmailMailer,
@@ -330,7 +330,7 @@ class SubscriberActionsTest extends \MailPoetTest {
     $confirmationEmailMailer = $this->createMock(ConfirmationEmailMailer::class);
     $confirmationEmailMailer->expects($this->once())
       ->method('sendConfirmationEmailOnce')
-      ->with($this->isInstanceOf(SubscriberEntity::class), true)
+      ->with($this->isInstanceOf(SubscriberEntity::class), null, null, true)
       ->willReturn(false);
     $subscriberActions = $this->getServiceWithOverrides(SubscriberActions::class, [
       'confirmationEmailMailer' => $confirmationEmailMailer,

--- a/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTest.php
@@ -183,7 +183,7 @@ class SubscriberSubscribeControllerTest extends \MailPoetTest {
     $confirmationEmailMailerMock = $this->createMock(ConfirmationEmailMailer::class);
     $confirmationEmailMailerMock->expects($this->once())
       ->method('sendConfirmationEmailOnce')
-      ->with($this->isInstanceOf(SubscriberEntity::class), true)
+      ->with($this->isInstanceOf(SubscriberEntity::class), null, null, true)
       ->willReturn(true);
     $subscriberActions = $this->getServiceWithOverrides(SubscriberActions::class, ['confirmationEmailMailer' => $confirmationEmailMailerMock]);
     $subscriberController = $this->getServiceWithOverrides(SubscriberSubscribeController::class, ['subscriberActions' => $subscriberActions]);

--- a/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
+++ b/mailpoet/tests/integration/WooCommerce/SubscriptionTest.php
@@ -234,7 +234,7 @@ class SubscriptionTest extends \MailPoetTest {
     $this->confirmationEmailMailer
       ->expects($this->once())
       ->method('sendConfirmationEmailOnce')
-      ->with($this->isInstanceOf(SubscriberEntity::class), true);
+      ->with($this->isInstanceOf(SubscriberEntity::class), null, null, true);
 
     $this->subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
     $this->subscribersRepository->flush();

--- a/mailpoet/tests/unit/Subscribers/ConfirmationEmailResolverTest.php
+++ b/mailpoet/tests/unit/Subscribers/ConfirmationEmailResolverTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Unit\Subscribers;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Subscribers\ConfirmationEmailResolver;
+
+class ConfirmationEmailResolverTest extends \MailPoetUnitTest {
+  /** @var ConfirmationEmailResolver */
+  private $resolver;
+
+  public function _before() {
+    parent::_before();
+    $this->resolver = new ConfirmationEmailResolver();
+  }
+
+  public function testItReturnsNullsWhenNoSegmentsHaveCustomSettings(): void {
+    $segment1 = $this->createSegment(null, null);
+    $segment2 = $this->createSegment(null, null);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->null();
+    verify($pageId)->null();
+  }
+
+  public function testItReturnsCustomEmailWhenOneSegmentHasIt(): void {
+    $segment1 = $this->createSegment(42, null);
+    $segment2 = $this->createSegment(null, null);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->equals(42);
+    verify($pageId)->null();
+  }
+
+  public function testItReturnsCustomPageWhenOneSegmentHasIt(): void {
+    $segment1 = $this->createSegment(null, null);
+    $segment2 = $this->createSegment(null, 99);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->null();
+    verify($pageId)->equals(99);
+  }
+
+  public function testItReturnsCustomSettingsWhenAllSegmentsAgree(): void {
+    $segment1 = $this->createSegment(42, 99);
+    $segment2 = $this->createSegment(42, 99);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->equals(42);
+    verify($pageId)->equals(99);
+  }
+
+  public function testItFallsBackToGlobalWhenSegmentsConflictOnEmail(): void {
+    $segment1 = $this->createSegment(42, null);
+    $segment2 = $this->createSegment(43, null);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->null();
+    verify($pageId)->null();
+  }
+
+  public function testItFallsBackToGlobalWhenSegmentsConflictOnPage(): void {
+    $segment1 = $this->createSegment(null, 99);
+    $segment2 = $this->createSegment(null, 100);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->null();
+    verify($pageId)->null();
+  }
+
+  public function testItHandlesEmptySegmentArray(): void {
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([]);
+
+    verify($emailId)->null();
+    verify($pageId)->null();
+  }
+
+  public function testItHandlesSingleSegmentWithBothSettings(): void {
+    $segment = $this->createSegment(42, 99);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment]);
+
+    verify($emailId)->equals(42);
+    verify($pageId)->equals(99);
+  }
+
+  public function testEmailAndPageResolveIndependently(): void {
+    $segment1 = $this->createSegment(42, 99);
+    $segment2 = $this->createSegment(42, 100);
+
+    [$emailId, $pageId] = $this->resolver->resolveFromSegments([$segment1, $segment2]);
+
+    verify($emailId)->equals(42);
+    verify($pageId)->null();
+  }
+
+  private function createSegment(?int $confirmationEmailId, ?int $confirmationPageId): SegmentEntity {
+    $segment = new SegmentEntity('Test', SegmentEntity::TYPE_DEFAULT, '');
+    $segment->setConfirmationEmailId($confirmationEmailId);
+    $segment->setConfirmationPageId($confirmationPageId);
+    return $segment;
+  }
+}

--- a/mailpoet/views/newsletter/editor.html
+++ b/mailpoet/views/newsletter/editor.html
@@ -1883,9 +1883,9 @@
         previewTypeLocalStorageKey: 'newsletter_editor.preview_type'
       },
       validation: {
-        validateUnsubscribeLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_template != true ? 'true' : 'false' %>,
-        validateReEngageLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_template != true ? 'true' : 'false' %>,
-        validateActivationLinkIsPresent: <%= is_confirmation_email_template ? 'true' : 'false' %>,
+        validateUnsubscribeLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
+        validateReEngageLinkPresent: <%= mss_active and is_wc_transactional_email != true and is_confirmation_email_type != true ? 'true' : 'false' %>,
+        validateActivationLinkIsPresent: <%= is_confirmation_email_type ? 'true' : 'false' %>,
       },
       urls: {
         send: '<%= admin_url('admin.php?page=mailpoet-newsletters#/send/' ~ (params('id') | intval)) %>',
@@ -1928,7 +1928,7 @@
       },
       hiddenWidgets: ['automatedLatestContentLayout', 'header', 'footer', 'posts', 'products'],
       <% endif %>
-      <% if is_confirmation_email_template %>
+      <% if is_confirmation_email_type %>
       hiddenWidgets: ['automatedLatestContentLayout', 'coupon', 'header', 'footer', 'posts', 'products', 'dynamicProducts'],
       <% endif %>
       coupon: <%= json_encode(woocommerce.coupon.config) %>,

--- a/mailpoet/views/segments/static.html
+++ b/mailpoet/views/segments/static.html
@@ -6,6 +6,8 @@
   <script type="text/javascript">
     var mailpoet_listing_per_page = <%= items_per_page %>;
     var mailpoet_segments_api = <%= json_encode(api) %>;
+    var mailpoet_confirmation_emails = <%= json_encode(confirmation_emails) %>;
+    var mailpoet_pages = <%= json_encode(pages) %>;
   </script>
 
   <% include 'segments/translations.html' %>


### PR DESCRIPTION
## Description

Refactors confirmation email/page settings from **per-form** to **per-list (segment)**, following the p1764871181226819-slack-C01GH764202 where we agreed this approach better covers all subscription sources (forms, API, third-party integrations).

Each list can now optionally specify a custom confirmation email and confirmation page, overriding the global defaults. When a subscriber joins multiple lists:
- If exactly one unique custom setting exists → use it
- If different custom settings conflict → fall back to the global default
- Email and page are resolved independently

### What changed from the original PR

The original implementation added per-form settings in the form editor sidebar. This has been **replaced** with per-list settings accessible from the list edit form (`Lists > Edit`). This approach:
- Covers API-based subscriptions and third-party integrations (not just MailPoet forms)
- Follows the Klaviyo model of list-level settings
- Is more universal and less surprising for users

### Key changes

**Backend:**
- **SegmentEntity**: New nullable `confirmation_email_id` and `confirmation_page_id` columns
- **DB migration**: Adds both columns to the `segments` table (idempotent)
- **ConfirmationEmailResolver**: New service that resolves which email/page to use from target segments, with conflict resolution logic
- **SegmentSaveController / SegmentsRepository**: Pass confirmation settings through the segment save pipeline
- **SegmentsResponseBuilder**: Exposes both fields in API responses
- **SubscriberActions + public API (`MP\v1\Subscribers`)**: Resolve per-list settings from segments before sending confirmation emails
- **DI container**: `ConfirmationEmailResolver` registered for autowiring
- **Newsletters API**: `getConfirmationEmails` and `createConfirmationEmail` endpoints for managing confirmation email templates

**Frontend (list edit form):**
- **Confirmation email field**: Custom React component with select dropdown, "Create new" button (creates via API, shows success notice with edit link), and "Edit" button (opens newsletter editor)
- **Confirmation page field**: Standard select dropdown populated with published WordPress pages
- Both fields use "Use global default" as the default option (value `0` → `null` in backend)
- Uses MailPoet's `Button` component and `tip` field property for consistent styling with other form fields

**Admin page (`StaticSegments.php`):**
- Passes `confirmation_emails` and `pages` data to the Twig template for React consumption via JS globals

**Other paths (documented with comments):**
- WooCommerce checkout, WP Users sync, admin-created users, and manual resend all use global defaults — each has a comment explaining why per-list resolution doesn't apply

## Code review notes

- The `ConfirmationEmailResolver` has full unit test coverage (9 test cases covering all conflict scenarios)
- Integration test verifies the resolver works with persisted entities
- Secondary subscription paths (WooCommerce, WP Users, admin-created users, manual resend) use global defaults — documented with comments explaining why
- The existing `ConfirmationEmailMailer` API is backward-compatible (nullable params with defaults)

## QA notes

1. Go to `Lists > Edit list` — verify "Confirmation email" and "Confirmation page" dropdowns appear with tips
2. Click "Create new" on the confirmation email field — verify a new email is created, selected, and a success notice with "Edit it now" link appears
3. Select a custom email — verify the "Edit" button appears and opens the newsletter editor in a new tab
4. Set a custom confirmation email on a list, subscribe via a form to that list — verify the custom email is sent
5. Subscribe to two lists with different custom emails — verify global default is used (conflict resolution)
6. Subscribe to two lists where only one has a custom email — verify the custom email is used
7. Verify existing global confirmation settings still work when no per-list overrides are set
8. Test via the public API (`$mailpoet_api->subscribeToLists()`) — verify per-list resolution works

## Linked PRs

_N/A_

## Linked tickets

https://feedback.mailpoet.com/feature-requests/p/multiple-confirmation-email-for-each-list-type

## Screenshots

<img width="1115" height="756" alt="Screenshot 2026-05-13 at 14 19 59" src="https://github.com/user-attachments/assets/d45046c0-e661-4821-a606-818b187b327b" />

## After-merge notes

- A database migration adds two columns to the segments table
- No breaking changes — all existing behavior is preserved when no per-list overrides are set

## Tasks

- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:multiple-confirmation-emails)

_The latest successful build from `multiple-confirmation-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**3 issues found**

## Issues by Category

**Bug:**
1. **Missing json_encode() error handling in createConfirmationEmail()** (Medium severity)
   - Location: mailpoet/lib/API/JSON/v1/Newsletters.php::createConfirmationEmail()
   - The method JSON-encodes the default newsletter body and passes the result to the save controller without validating json_encode()'s result. If json_encode() fails (returns false) invalid data may be persisted or cause silent failures.
   - Recommendation: Validate the json_encode() result (or use JSON_THROW_ON_ERROR) and handle errors before calling save().

2. **No validation that referenced confirmation email/page IDs exist before saving to segments** (Medium severity)
   - Location: mailpoet/lib/Segments/SegmentSaveController.php and mailpoet/lib/Segments/SegmentsRepository.php
   - Inputs confirmation_email_id and confirmation_page_id are normalized (<=0 → null) but not checked against the newsletters/pages store. This can produce orphaned references or invalid configuration.
   - Recommendation: Verify IDs refer to existing newsletters/pages (e.g., via NewslettersRepository::findOneById() and WP page checks) and return validation errors if not found.

**Suggestion:**
3. **Missing test coverage for invalid confirmation email/page ID references** (Low severity)
   - Tests cover resolver logic and persistence happy paths but do not assert behavior when segments reference non-existent or deleted confirmation email/page IDs.
   - Recommendation: Add unit/integration tests to validate graceful handling (validation errors or normalization) when confirmationEmailId or confirmationPageId reference missing resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->