### PR TITLE
Fix race condition causing cron action to persist after deactivation

### DIFF
--- a/mailpoet/changelog/2025-12-10-14-13-53-fixed-race-condition-causing-cron-action-to-persist-afte.md
+++ b/mailpoet/changelog/2025-12-10-14-13-53-fixed-race-condition-causing-cron-action-to-persist-afte.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Race condition causing cron action to persist after deactivation

--- a/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonTrigger.php
+++ b/mailpoet/lib/Cron/ActionScheduler/Actions/DaemonTrigger.php
@@ -4,6 +4,7 @@ namespace MailPoet\Cron\ActionScheduler\Actions;
 
 use MailPoet\Cron\ActionScheduler\ActionScheduler;
 use MailPoet\Cron\ActionScheduler\RemoteExecutorHandler;
+use MailPoet\Cron\DaemonActionSchedulerRunner;
 use MailPoet\Cron\Triggers\WordPress;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -37,6 +38,12 @@ class DaemonTrigger {
 
   public function init() {
     $this->wp->addAction(self::NAME, [$this, 'process']);
+
+    // Don't schedule if plugin is being deactivated (prevents race condition)
+    if ($this->wp->getOption(DaemonActionSchedulerRunner::DEACTIVATION_FLAG_OPTION, false)) {
+      return;
+    }
+
     if (!$this->actionScheduler->hasScheduledAction(self::NAME)) {
       $this->actionScheduler->scheduleRecurringAction($this->wp->currentTime('timestamp', true), self::TRIGGER_RUN_INTERVAL, self::NAME);
     }

--- a/mailpoet/lib/Cron/DaemonActionSchedulerRunner.php
+++ b/mailpoet/lib/Cron/DaemonActionSchedulerRunner.php
@@ -9,6 +9,8 @@ use MailPoet\Cron\ActionScheduler\RemoteExecutorHandler;
 use MailPoet\WP\Functions as WPFunctions;
 
 class DaemonActionSchedulerRunner {
+  public const DEACTIVATION_FLAG_OPTION = 'mailpoet_cron_deactivating';
+
   /** @var ActionScheduler */
   private $actionScheduler;
 
@@ -49,7 +51,17 @@ class DaemonActionSchedulerRunner {
   }
 
   public function deactivate(): void {
+    // Set flag BEFORE unscheduling to prevent race condition with parallel requests
+    $this->wp->updateOption(self::DEACTIVATION_FLAG_OPTION, true);
     $this->actionScheduler->unscheduleAllCronActions();
+  }
+
+  public function clearDeactivationFlag(): void {
+    $this->wp->deleteOption(self::DEACTIVATION_FLAG_OPTION);
+  }
+
+  public function isDeactivating(): bool {
+    return (bool)$this->wp->getOption(self::DEACTIVATION_FLAG_OPTION, false);
   }
 
   /**

--- a/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SetupTest.php
@@ -11,6 +11,7 @@ use MailPoet\Captcha\CaptchaRenderer;
 use MailPoet\Config\Activator;
 use MailPoet\Config\Populator;
 use MailPoet\Cron\ActionScheduler\ActionScheduler;
+use MailPoet\Cron\DaemonActionSchedulerRunner;
 use MailPoet\Migrator\Migrator;
 use MailPoet\Referrals\ReferralDetector;
 use MailPoet\Settings\SettingsController;
@@ -34,7 +35,8 @@ class SetupTest extends \MailPoetTest {
     $captchaRenderer = $this->diContainer->get(CaptchaRenderer::class);
     $migrator = $this->diContainer->get(Migrator::class);
     $cronActionScheduler = $this->diContainer->get(ActionScheduler::class);
-    $router = new Setup($wpStub, new Activator($this->connection, $settings, $populator, $wpStub, $migrator, $cronActionScheduler), $settings);
+    $daemonActionSchedulerRunner = $this->diContainer->get(DaemonActionSchedulerRunner::class);
+    $router = new Setup($wpStub, new Activator($this->connection, $settings, $populator, $wpStub, $migrator, $cronActionScheduler, $daemonActionSchedulerRunner), $settings);
     $response = $router->reset();
     verify($response->status)->equals(APIResponse::STATUS_OK);
 

--- a/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonActionSchedulerRunnerTest.php
@@ -24,6 +24,7 @@ class DaemonActionSchedulerRunnerTest extends \MailPoetTest {
     $this->actionSchedulerRunner = $this->diContainer->get(DaemonActionSchedulerRunner::class);
     $this->actionScheduler = $this->diContainer->get(ActionScheduler::class);
     $this->cleanup();
+    $this->actionSchedulerRunner->clearDeactivationFlag();
     $this->actionSchedulerHelper = new ActionSchedulerTestHelper();
   }
 
@@ -59,6 +60,24 @@ class DaemonActionSchedulerRunnerTest extends \MailPoetTest {
 
     $actions = $this->actionSchedulerHelper->getMailPoetScheduledActions();
     verify($actions)->arrayCount(0);
+  }
+
+  public function testDeactivateSetsDeactivationFlag(): void {
+    verify($this->actionSchedulerRunner->isDeactivating())->false();
+
+    $this->actionSchedulerRunner->deactivate();
+    verify($this->actionSchedulerRunner->isDeactivating())->true();
+
+    // Cleanup
+    $this->actionSchedulerRunner->clearDeactivationFlag();
+  }
+
+  public function testClearDeactivationFlagRemovesFlag(): void {
+    $this->actionSchedulerRunner->deactivate();
+    verify($this->actionSchedulerRunner->isDeactivating())->true();
+
+    $this->actionSchedulerRunner->clearDeactivationFlag();
+    verify($this->actionSchedulerRunner->isDeactivating())->false();
   }
 
   private function cleanup(): void {


### PR DESCRIPTION
## Description

Fix race condition where the `mailpoet/cron/daemon-trigger` Action Scheduler action can persist after plugin deactivation. 

**Problem:** When the MailPoet plugin is deactivated, a parallel request (e.g., opening the MailPoet emails page right before clicking deactivate) can re-initialise the daemon trigger action after unscheduleAllCronActions() has run. This keeps the action in a pending state and causes it to fail repeatedly because the plugin is no longer active. 

**Solution:** Introduce a deactivation flag 

## QA notes

Please verify the fix prevents orphaned cron actions

1. Activate the MailPoet plugin and set the cron method to "WordPress built-in cron (recommended)" in MailPoet > Settings > Advanced
2. Open the installed plugins page
3. Open the MailPoet Emails page in a new tab (from the sidebar menu) and immediately click deactivate MailPoet plugin
4. Go to Tools > Scheduled Actions and check for mailpoet/cron/daemon-trigger
5. Activate MailPoet plugin
6. Ensure cron method is set to "WordPress built-in cron (recommended)" in MailPoet > Settings > Advanced
7. Go to Tools > Scheduled Actions and verify mailpoet/cron/daemon-trigger is scheduled (status: pending)

Also do some smoke tests around scheduled newsletters and automations, that nothing is broken

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7283

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7283-action-scheduler-action-mailpoetcrondaemon-trigger-may)

_The latest successful build from `stomail-7283-action-scheduler-action-mailpoetcrondaemon-trigger-may` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could leave a scheduled daemon action active during plugin deactivation, improving reliability during deactivate/reactivate cycles.
* **New Features**
  * Added a deactivation flag mechanism to prevent scheduling while deactivation is in progress and a way to clear that flag.
* **Tests**
  * Added integration tests verifying the deactivation flag lifecycle and that triggers are not scheduled when deactivating.
* **Changelog**
  * Added an entry documenting the race‑condition fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->