### PR TITLE
Add Automation Preview Embed for rendering templates in a iframe

### DIFF
--- a/mailpoet/assets/js/src/automation/preview-embed.tsx
+++ b/mailpoet/assets/js/src/automation/preview-embed.tsx
@@ -5,13 +5,14 @@
  * in an iframe.
  */
 import { createRoot } from 'react-dom/client';
+import { __ } from '@wordpress/i18n';
 import { registerTranslations } from 'common';
 import { initializeApi } from './api';
 import { TemplatePreview } from './templates/components/template-preview';
 
 declare global {
   interface Window {
-    mailpoet_template_slug: string;
+    mailpoet_template_slug?: string;
   }
 }
 
@@ -19,7 +20,11 @@ function PreviewEmbed(): JSX.Element {
   const templateSlug = window.mailpoet_template_slug;
 
   if (!templateSlug) {
-    return <div className="preview-error">No template specified</div>;
+    return (
+      <div className="preview-error">
+        {__('No template specified', 'mailpoet')}
+      </div>
+    );
   }
 
   return (

--- a/mailpoet/assets/js/src/automation/preview-embed.tsx
+++ b/mailpoet/assets/js/src/automation/preview-embed.tsx
@@ -1,0 +1,50 @@
+/**
+ * Automation Preview Embed Entry Point
+ *
+ * This is a minimal entry point for rendering automation template previews
+ * in an iframe.
+ */
+import { createRoot } from 'react-dom/client';
+import { registerTranslations } from 'common';
+import { initializeApi } from './api';
+import { TemplatePreview } from './templates/components/template-preview';
+
+declare global {
+  interface Window {
+    mailpoet_template_slug: string;
+  }
+}
+
+function PreviewEmbed(): JSX.Element {
+  const templateSlug = window.mailpoet_template_slug;
+
+  if (!templateSlug) {
+    return <div className="preview-error">No template specified</div>;
+  }
+
+  return (
+    <TemplatePreview
+      template={{
+        slug: templateSlug,
+        name: '',
+        description: '',
+        category: 'custom',
+        type: 'default',
+        required_capabilities: {},
+      }}
+    />
+  );
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('mailpoet_automation_preview');
+  if (!container) {
+    return;
+  }
+
+  registerTranslations();
+  initializeApi();
+
+  const root = createRoot(container);
+  root.render(<PreviewEmbed />);
+});

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -69,6 +69,11 @@ class AssetsController {
     $this->wp->wpEnqueueStyle('mailpoet_automation_analytics', $this->getCssUrl('mailpoet-automation-analytics.css'));
   }
 
+  public function setupAutomationPreviewEmbedDependencies(): void {
+    $this->enqueueJsEntrypoint('automation_preview_embed');
+    $this->wp->wpEnqueueStyle('mailpoet_automation_templates', $this->getCssUrl('mailpoet-automation-templates.css'));
+  }
+
   private function enqueueJsEntrypoint(string $asset, array $dependencies = []): void {
     $this->registerAdminDeps();
 

--- a/mailpoet/lib/AdminPages/Pages/AutomationPreviewEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationPreviewEmbed.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\AssetsController;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Config\Renderer;
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptionsHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+class AutomationPreviewEmbed {
+  private AssetsController $assetsController;
+  private Registry $registry;
+  private Renderer $renderer;
+  private TrackingConfig $trackingConfig;
+  private WPFunctions $wp;
+  private SubscribersFeature $subscribersFeature;
+  private CapabilitiesManager $capabilitiesManager;
+  private ServicesChecker $servicesChecker;
+  private WooCommerceHelper $wooCommerceHelper;
+  private WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper;
+  private WooCommerceBookingsHelper $wooCommerceBookingsHelper;
+
+  public function __construct(
+    AssetsController $assetsController,
+    Registry $registry,
+    Renderer $renderer,
+    TrackingConfig $trackingConfig,
+    WPFunctions $wp,
+    SubscribersFeature $subscribersFeature,
+    CapabilitiesManager $capabilitiesManager,
+    ServicesChecker $servicesChecker,
+    WooCommerceHelper $wooCommerceHelper,
+    WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper,
+    WooCommerceBookingsHelper $wooCommerceBookingsHelper
+  ) {
+    $this->assetsController = $assetsController;
+    $this->registry = $registry;
+    $this->renderer = $renderer;
+    $this->trackingConfig = $trackingConfig;
+    $this->wp = $wp;
+    $this->subscribersFeature = $subscribersFeature;
+    $this->capabilitiesManager = $capabilitiesManager;
+    $this->servicesChecker = $servicesChecker;
+    $this->wooCommerceHelper = $wooCommerceHelper;
+    $this->wooCommerceSubscriptionsHelper = $wooCommerceSubscriptionsHelper;
+    $this->wooCommerceBookingsHelper = $wooCommerceBookingsHelper;
+  }
+
+  public function render(): void {
+    $templateSlug = isset($_GET['template']) ? sanitize_key($_GET['template']) : '';
+
+    // Disable admin bar for embed preview (intentional for iframe display)
+    // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+    add_filter('show_admin_bar', '__return_false');
+
+    // Disable WordPress emoji handling (prevents deprecation warning)
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('admin_print_styles', 'print_emoji_styles');
+
+    // Load preview embed dependencies (lighter setup without full admin bundle)
+    $this->assetsController->setupAutomationPreviewEmbedDependencies();
+
+    ob_start();
+    wp_head();
+    $headContent = ob_get_clean();
+
+    // Capture wp_footer() output
+    ob_start();
+    wp_footer();
+    $footerContent = ob_get_clean();
+
+    // Build template data
+    $data = [
+      'locale' => $this->wp->getLocale(),
+      'template_slug' => $templateSlug,
+      'api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
+      'registry' => $this->buildRegistry(),
+      'context' => $this->buildContext(),
+      'tracking_config' => $this->trackingConfig->getConfig(),
+      'has_valid_premium_key' => $this->subscribersFeature->hasValidPremiumKey(),
+      'subscribers_limit_reached' => $this->subscribersFeature->check(),
+      'premium_active' => $this->servicesChecker->isPremiumPluginActive(),
+      'capabilities' => $this->capabilitiesManager->getCapabilities(),
+      'woocommerce_active' => $this->wooCommerceHelper->isWooCommerceActive(),
+      'woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
+      'woocommerce_bookings_active' => $this->wooCommerceBookingsHelper->isWooCommerceBookingsActive(),
+      'head_content' => $headContent,
+      'footer_content' => $footerContent,
+    ];
+
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo $this->renderer->render('automation/preview-embed.html', $data);
+    exit;
+  }
+
+  private function buildRegistry(): array {
+    $steps = [];
+    foreach ($this->registry->getSteps() as $key => $step) {
+      $steps[$key] = [
+        'key' => $step->getKey(),
+        'name' => $step->getName(),
+        'args_schema' => $step->getArgsSchema()->toArray(),
+      ];
+    }
+
+    $subjects = [];
+    foreach ($this->registry->getSubjects() as $key => $subject) {
+      $subjects[$key] = [
+        'key' => $subject->getKey(),
+        'name' => $subject->getName(),
+        'args_schema' => $subject->getArgsSchema()->toArray(),
+        'field_keys' => array_map(function ($field) {
+          return $field->getKey();
+        }, $subject->getFields()),
+      ];
+    }
+
+    return [
+      'steps' => $steps,
+      'subjects' => $subjects,
+    ];
+  }
+
+  private function buildContext(): array {
+    $data = [];
+    foreach ($this->registry->getContextFactories() as $key => $factory) {
+      $data[$key] = $factory();
+    }
+    return $data;
+  }
+}

--- a/mailpoet/lib/AdminPages/Pages/AutomationPreviewEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationPreviewEmbed.php
@@ -54,7 +54,8 @@ class AutomationPreviewEmbed {
   }
 
   public function render(): void {
-    $templateSlug = isset($_GET['template']) ? sanitize_key($_GET['template']) : '';
+    // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $templateSlug = isset($_GET['template']) ? sanitize_key(wp_unslash($_GET['template'])) : '';
 
     // Disable admin bar for embed preview (intentional for iframe display)
     // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -36,6 +36,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\AutomationTemplates::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\AutomationEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\AutomationAnalytics::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\AutomationPreviewEmbed::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\DynamicSegments::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class)->setPublic(true);

--- a/mailpoet/views/automation/preview-embed.html
+++ b/mailpoet/views/automation/preview-embed.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="<%= locale %>">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Automation Preview</title>
+  <style>
+    html, body {
+      margin: 20px;
+      padding: 0;
+      background: #fbfbfb;
+      font-size: 12px;
+    }
+    #mailpoet_automation_preview {
+      zoom: 0.7;
+      background: #fbfbfb;
+      text-align: center;
+    }
+  </style>
+  <script type="text/javascript">
+    // Global config needed by admin bundle
+    var mailpoet_tracking_config = <%= json_encode(tracking_config) %>;
+    // Premium-related variables needed for step type registration
+    var mailpoet_has_valid_premium_key = <%= json_encode(has_valid_premium_key) %>;
+    var mailpoet_subscribers_limit_reached = <%= json_encode(subscribers_limit_reached) %>;
+    var mailpoet_premium_active = <%= json_encode(premium_active) %>;
+    var mailpoet_capabilities = <%= json_encode(capabilities) %>;
+    // WooCommerce-related variables needed for WooCommerce step types
+    var mailpoet_woocommerce_active = <%= json_encode(woocommerce_active) %>;
+    var mailpoet_woocommerce_subscriptions_active = <%= json_encode(woocommerce_subscriptions_active) %>;
+    var mailpoet_woocommerce_bookings_active = <%= json_encode(woocommerce_bookings_active) %>;
+    // Preview-specific variables
+    var mailpoet_template_slug = <%= json_encode(template_slug) %>;
+    var mailpoet_automation_api = <%= json_encode(api) %>;
+    var mailpoet_automation_registry = <%= json_encode(registry) %>;
+    var mailpoet_automation_context = <%= json_encode(context) %>;
+  </script>
+  <%= head_content | raw %>
+</head>
+<body>
+  <div id="mailpoet_automation_preview"></div>
+  <%= footer_content | raw %>
+</body>
+</html>

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -239,6 +239,7 @@ const adminConfig = {
     automation_analytics:
       'automation/integrations/mailpoet/analytics/index.tsx',
     automation_templates: 'automation/templates/index.tsx',
+    automation_preview_embed: 'automation/preview-embed.tsx',
     newsletter_editor: 'newsletter-editor/webpack-index.jsx',
     form_editor: 'form-editor/form-editor.jsx',
     settings: 'settings/index.tsx',


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7597-add-automation-preview-to-template-modal)

_The latest successful build from `stomail-7597-add-automation-preview-to-template-modal` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automation template preview view for admins that renders inside an isolated iframe, showing a template preview or a clear "no template specified" message and respecting locale, tracking and WooCommerce context.
  * The preview page mounts a client-side renderer to display templates.

* **Chores**
  * Registered and bundled new admin assets and lightweight styles required for the embed; added a hidden admin preview page and early render hook.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->