### PR TITLE
Ensure that RC is not returned when the final version is released

### DIFF
--- a/.circleci/check_woocommerce_beta.sh
+++ b/.circleci/check_woocommerce_beta.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
 
-# Fetch the versions of WooCommerce from the WordPress API
+# Fetch the latest version of WooCommerce from the WordPress API
+# Sorting: -dev < -alpha < -beta < -rc < final (no suffix)
 LATEST_VERSION=$(
   curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | \
   jq -r '.versions | keys_unsorted | .[]' | \
   grep -v 'trunk' | \
-  sort -V | \
-  tail -n 1
+  awk '{
+    orig = $0
+    v = $0
+    if (v ~ /-dev/) { gsub(/-dev/, "~0dev", v) }
+    else if (v ~ /-alpha/) { gsub(/-alpha/, "~1alpha", v) }
+    else if (v ~ /-beta/) { gsub(/-beta/, "~2beta", v) }
+    else if (v ~ /-rc/) { gsub(/-rc/, "~3rc", v) }
+    else { v = v "~4" }
+    print v "\t" orig
+  }' | \
+  sort -V -k1,1 | \
+  tail -n 1 | \
+  cut -f2
 )
 
 # Check if the latest version is a beta/RC version


### PR DESCRIPTION
## Description

**Before:**
```bash
╰─± ./.circleci/check_woocommerce_beta.sh
Latest WooCommerce beta/RC version: 10.4.0-rc.1
LATEST_BETA=10.4.0-rc.1
```

**After:**
```bash
╰─± ./.circleci/check_woocommerce_beta.sh 
No WooCommerce beta/RC version found.
LATEST_BETA=
```

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7660

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7660-adjust-woocommerce-beta-check-script-to-skip-rc-after-final)

_The latest successful build from `stomail-7660-adjust-woocommerce-beta-check-script-to-skip-rc-after-final` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-release version handling and ordering logic for more accurate version selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->