### PR TITLE
Fix broken link to create form in MailPoet Subscription Form block

### DIFF
--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
@@ -8,7 +8,7 @@ const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const ServerSideRender = wp.serverSideRender;
 
 const allForms = window.mailpoet_forms;
-const formEditUrl = window.mailpoet_form_edit_url;
+const formEditUrl = window.mailpoet_form_edit_url || '';
 
 function Edit({ attributes, setAttributes }) {
   const blockProps = useBlockProps();
@@ -52,17 +52,19 @@ function Edit({ attributes, setAttributes }) {
   function selectFormSettings() {
     return (
       <div className="mailpoet-block-create-new-content">
-        <a
-          href={formEditUrl}
-          rel="noopener noreferrer"
-          className="mailpoet-block-create-new-link"
-          onClick={(e) => {
-            e.preventDefault();
-            window.top.open(formEditUrl, '_blank', 'noopener noreferrer');
-          }}
-        >
-          {window.locale.createForm}
-        </a>
+        {formEditUrl && (
+          <a
+            href={formEditUrl}
+            rel="noopener noreferrer"
+            className="mailpoet-block-create-new-link"
+            onClick={(e) => {
+              e.preventDefault();
+              window.top.open(formEditUrl, '_blank', 'noopener noreferrer');
+            }}
+          >
+            {window.locale.createForm}
+          </a>
+        )}
         {displayFormsSelect()}
       </div>
     );

--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
@@ -8,6 +8,7 @@ const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const ServerSideRender = wp.serverSideRender;
 
 const allForms = window.mailpoet_forms;
+const formEditUrl = window.mailpoet_form_edit_url;
 
 function Edit({ attributes, setAttributes }) {
   const blockProps = useBlockProps();
@@ -52,7 +53,7 @@ function Edit({ attributes, setAttributes }) {
     return (
       <div className="mailpoet-block-create-new-content">
         <a
-          href="admin.php?page=mailpoet-form-editor-template-selection"
+          href={formEditUrl}
           target="_blank"
           className="mailpoet-block-create-new-link"
         >

--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
@@ -54,11 +54,11 @@ function Edit({ attributes, setAttributes }) {
       <div className="mailpoet-block-create-new-content">
         <a
           href={formEditUrl}
-          target="_blank"
+          rel="noopener noreferrer"
           className="mailpoet-block-create-new-link"
           onClick={(e) => {
             e.preventDefault();
-            window.top.open(formEditUrl, '_blank');
+            window.top.open(formEditUrl, '_blank', 'noopener noreferrer');
           }}
         >
           {window.locale.createForm}

--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
@@ -56,6 +56,10 @@ function Edit({ attributes, setAttributes }) {
           href={formEditUrl}
           target="_blank"
           className="mailpoet-block-create-new-link"
+          onClick={(e) => {
+            e.preventDefault();
+            window.top.open(formEditUrl, '_blank');
+          }}
         >
           {window.locale.createForm}
         </a>

--- a/mailpoet/changelog/2025-12-11-22-25-27-fixed-link-to-from-the-block-editor.md
+++ b/mailpoet/changelog/2025-12-11-22-25-27-fixed-link-to-from-the-block-editor.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Link to 'Create a new form' in the MailPoet subscription form block

--- a/mailpoet/lib/PostEditorBlocks/SubscriptionFormBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/SubscriptionFormBlock.php
@@ -55,6 +55,7 @@ class SubscriptionFormBlock {
       ?>
       <script type="text/javascript">
         window.mailpoet_forms = <?php echo $form_json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
+        window.mailpoet_form_edit_url = '<?php echo esc_js($this->wp->adminUrl('admin.php?page=mailpoet-form-editor-template-selection')); ?>';
         window.locale = {
           selectForm: '<?php echo esc_js(__('Select a MailPoet form', 'mailpoet')) ?>',
           createForm: '<?php echo esc_js(__('Create a new form', 'mailpoet')) ?>',


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7661

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7661-mailpoet-subscription-form-block-create-form-link-broken)

_The latest successful build from `stomail-7661-mailpoet-subscription-form-block-create-form-link-broken` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Create a new form" link in the subscription form block so it opens reliably in a new window and uses a dynamically configured URL, improving navigation and safety.

* **Documentation**
  * Added a changelog entry documenting the fixed link behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->