### PR TITLE
Update email editor packages

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.1.0"
+    "woocommerce/email-editor": "2.1.1"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb2d44e3d30962ec48179c3ba635dcd4",
+    "content-hash": "c96770a1f4a82ce1742e6808957fef29",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "3f36b4a494950eeb57fa6439a50f1a45cdcb001f"
+                "reference": "f6e51e65d0b1cbf1f903719eede8bc2580a2cd51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/3f36b4a494950eeb57fa6439a50f1a45cdcb001f",
-                "reference": "3f36b4a494950eeb57fa6439a50f1a45cdcb001f",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/f6e51e65d0b1cbf1f903719eede8bc2580a2cd51",
+                "reference": "f6e51e65d0b1cbf1f903719eede8bc2580a2cd51",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.1.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.1.1"
             },
-            "time": "2025-11-30T12:26:38+00:00"
+            "time": "2025-12-12T12:14:07+00:00"
         }
     ],
     "packages-dev": [

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -31,7 +31,7 @@
     "@woocommerce/components": "^12.3.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "1.4.2",
+    "@woocommerce/email-editor": "1.4.3",
     "@wordpress/a11y": "^4.0.0",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^13.0.0",

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -565,9 +565,23 @@ const emailEditorIntegration = Object.assign({}, wpScriptConfig, {
     ...wpScriptConfig.resolve,
     modules: ['node_modules', 'assets/js/src'],
   },
-  plugins: PRODUCTION_ENV
-    ? wpScriptConfig.plugins
-    : [...wpScriptConfig.plugins, new ForkTsCheckerWebpackPlugin()],
+  plugins: [
+    // Filter out the default DependencyExtractionWebpackPlugin
+    ...wpScriptConfig.plugins.filter(
+      (plugin) =>
+        plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
+    ),
+    // Add our custom DependencyExtractionWebpackPlugin that forces bundling of @wordpress/global-styles-engine
+    new DependencyExtractionWebpackPlugin({
+      requestToExternal: (request) => {
+        if (request === '@wordpress/global-styles-engine') {
+          return false;
+        }
+        return;
+      },
+    }),
+    ...(PRODUCTION_ENV ? [] : [new ForkTsCheckerWebpackPlugin()]),
+  ],
 });
 
 const configs = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.17.21)
       '@woocommerce/email-editor':
-        specifier: 1.4.2
-        version: 1.4.2(@types/react-dom@18.3.0)(@types/react@18.3.3)
+        specifier: 1.4.3
+        version: 1.4.3(@types/react-dom@18.3.0)(@types/react@18.3.3)
       '@wordpress/a11y':
         specifier: ^4.0.0
         version: 4.0.0
@@ -5464,39 +5464,40 @@ packages:
       qs: 6.12.1
     dev: false
 
-  /@woocommerce/email-editor@1.4.2(@types/react-dom@18.3.0)(@types/react@18.3.3):
-    resolution: {integrity: sha512-Rgewax8qGu7/B3pZhGP4NDiEeizEe5n3rtiiWoL2pIM6JauoneNSlyyqg8Pql1mWeVOm1lS4DGYrUeif+1s0QQ==}
+  /@woocommerce/email-editor@1.4.3(@types/react-dom@18.3.0)(@types/react@18.3.3):
+    resolution: {integrity: sha512-ZvLeR0YPQZsYQr5DekZVX/WnK7GIlDYbvinp0ZR52Xp7PgJD0mi8YF3RBbkjVryaeJ76rfQ9hOdJqzUuK63hlw==}
     dependencies:
       '@wordpress/api-fetch': 7.0.0
-      '@wordpress/base-styles': 5.0.0
+      '@wordpress/base-styles': 5.23.0
       '@wordpress/block-editor': 13.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/block-library': 9.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/blocks': 13.0.0(react@18.3.1)
       '@wordpress/commands': 1.36.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/components': 28.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/compose': 7.0.0(react@18.3.1)
+      '@wordpress/components': 28.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/compose': 7.36.0(react@18.3.1)
       '@wordpress/core-data': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/data': 10.0.0(react@18.3.1)
+      '@wordpress/data': 10.36.0(react@18.3.1)
       '@wordpress/data-controls': 4.0.0(react@18.3.1)
       '@wordpress/dom-ready': 4.36.0
       '@wordpress/editor': 14.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/element': 6.0.0
+      '@wordpress/element': 6.36.0
       '@wordpress/format-library': 5.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/hooks': 4.0.0
-      '@wordpress/html-entities': 4.0.0
-      '@wordpress/i18n': 5.0.0
-      '@wordpress/icons': 10.0.0
-      '@wordpress/interface': 6.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.0.0
-      '@wordpress/keyboard-shortcuts': 5.0.0(react@18.3.1)
-      '@wordpress/keycodes': 4.0.0
+      '@wordpress/global-styles-engine': 1.3.0(react@18.3.1)
+      '@wordpress/hooks': 4.36.0
+      '@wordpress/html-entities': 4.36.0
+      '@wordpress/i18n': 5.26.0
+      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/interface': 6.9.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.36.0
+      '@wordpress/keyboard-shortcuts': 5.36.0(react@18.3.1)
+      '@wordpress/keycodes': 4.36.0
       '@wordpress/notices': 5.0.0(react@18.3.1)
-      '@wordpress/plugins': 7.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
-      '@wordpress/preferences': 4.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/plugins': 7.13.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@wordpress/preferences': 4.30.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@wordpress/priority-queue': 3.36.0
-      '@wordpress/private-apis': 1.0.0
-      '@wordpress/rich-text': 7.0.0(react@18.3.1)
-      '@wordpress/url': 4.0.0
+      '@wordpress/private-apis': 1.36.0
+      '@wordpress/rich-text': 7.36.0(react@18.3.1)
+      '@wordpress/url': 4.34.0
       clsx: 2.1.1
       deepmerge: 4.3.1
       lodash: 4.17.21
@@ -5622,6 +5623,11 @@ packages:
       '@babel/runtime': 7.26.10
     dev: false
 
+  /@wordpress/autop@4.36.0:
+    resolution: {integrity: sha512-hmmknzXVOS5/zxkmjtEH1ONeXV/hWGV/MUrj1KhcOoskbyErYjE2hiEDlgpxJofyT/EcH6bawCoAHlVSnH7txw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dev: false
+
   /@wordpress/babel-plugin-import-jsx-pragma@4.41.0(@babel/core@7.24.7):
     resolution: {integrity: sha512-hYxj2Uobxk86ctlfaJou9v13XqXZ30yx4ZwRNu5cH5/LWXe2MIXBTPv7dUk6wqN/qFOjsFvP9jCB0NsW6MnkrA==}
     engines: {node: '>=14'}
@@ -5699,6 +5705,11 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.26.10
+    dev: false
+
+  /@wordpress/blob@4.36.0:
+    resolution: {integrity: sha512-lctZHSmDgysObyBUPeruG6HhkPcLlAms8kTkwLa76ZS2K2qwG9BbaXeFopZnt10Ti91hOVfwitu+d796lfnNkw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dev: false
 
   /@wordpress/block-editor@12.26.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
@@ -5899,6 +5910,11 @@ packages:
       '@babel/runtime': 7.26.10
     dev: false
 
+  /@wordpress/block-serialization-default-parser@5.36.0:
+    resolution: {integrity: sha512-bRJZZUhQkPrV0BL9upamwzkhmEzUDzleqCrIl5bT+GjSO5R1C14oBkeOtJvp7gsMAF+n7QZz/qRaEyxxNRQvIg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dev: false
+
   /@wordpress/blocks@11.21.0(react@18.3.1):
     resolution: {integrity: sha512-FlOrF0VMugW7wW9LAAF3ixUp2t1HsEGTBjqERYr7dYQIJI8yIII7/Zh2Opuzq0baWaA7kqexUQeD6sYSOcu8lA==}
     engines: {node: '>=12'}
@@ -5997,6 +6013,41 @@ packages:
       hpq: 1.4.0
       is-plain-object: 5.0.0
       memize: 2.1.0
+      react: 18.3.1
+      react-is: 18.3.1
+      remove-accents: 0.5.0
+      showdown: 1.9.1
+      simple-html-tokenizer: 0.5.11
+      uuid: 9.0.1
+    dev: false
+
+  /@wordpress/blocks@15.9.0(react@18.3.1):
+    resolution: {integrity: sha512-3y0SzLS/AOVwDdvbHNjbS2YNQb9670ojNq3YYbm6qxfGUzzfitSjKUsREtU2seCiomYygBRLM0cTzgSHQELHpg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      '@wordpress/autop': 4.36.0
+      '@wordpress/blob': 4.36.0
+      '@wordpress/block-serialization-default-parser': 5.36.0
+      '@wordpress/data': 10.36.0(react@18.3.1)
+      '@wordpress/deprecated': 4.36.0
+      '@wordpress/dom': 4.36.0
+      '@wordpress/element': 6.36.0
+      '@wordpress/hooks': 4.36.0
+      '@wordpress/html-entities': 4.36.0
+      '@wordpress/i18n': 6.9.0
+      '@wordpress/is-shallow-equal': 5.36.0
+      '@wordpress/private-apis': 1.36.0
+      '@wordpress/rich-text': 7.36.0(react@18.3.1)
+      '@wordpress/shortcode': 4.36.0
+      '@wordpress/warning': 3.36.0
+      change-case: 4.1.2
+      colord: 2.9.3
+      fast-deep-equal: 3.1.3
+      hpq: 1.4.0
+      is-plain-object: 5.0.0
+      memize: 2.1.1
       react: 18.3.1
       react-is: 18.3.1
       remove-accents: 0.5.0
@@ -6221,7 +6272,7 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
     dependencies:
-      '@ariakit/react': 0.4.19(react-dom@18.3.1)(react@18.3.1)
+      '@ariakit/react': 0.4.20(react-dom@18.3.1)(react@18.3.1)
       '@babel/runtime': 7.26.10
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -6233,23 +6284,23 @@ packages:
       '@types/gradient-parser': 0.1.3
       '@types/highlight-words-core': 1.2.1
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.34.0
-      '@wordpress/compose': 7.34.0(react@18.3.1)
-      '@wordpress/date': 5.34.0
-      '@wordpress/deprecated': 4.34.0
-      '@wordpress/dom': 4.34.0
-      '@wordpress/element': 6.34.0
-      '@wordpress/escape-html': 3.34.0
-      '@wordpress/hooks': 4.34.0
-      '@wordpress/html-entities': 4.34.0
+      '@wordpress/a11y': 4.36.0
+      '@wordpress/compose': 7.36.0(react@18.3.1)
+      '@wordpress/date': 5.36.0
+      '@wordpress/deprecated': 4.36.0
+      '@wordpress/dom': 4.36.0
+      '@wordpress/element': 6.36.0
+      '@wordpress/escape-html': 3.36.0
+      '@wordpress/hooks': 4.36.0
+      '@wordpress/html-entities': 4.36.0
       '@wordpress/i18n': 5.26.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.34.0
-      '@wordpress/keycodes': 4.34.0
-      '@wordpress/primitives': 4.34.0(react@18.3.1)
-      '@wordpress/private-apis': 1.34.0
-      '@wordpress/rich-text': 7.34.0(react@18.3.1)
-      '@wordpress/warning': 3.34.0
+      '@wordpress/is-shallow-equal': 5.36.0
+      '@wordpress/keycodes': 4.36.0
+      '@wordpress/primitives': 4.36.0(react@18.3.1)
+      '@wordpress/private-apis': 1.36.0
+      '@wordpress/rich-text': 7.36.0(react@18.3.1)
+      '@wordpress/warning': 3.36.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -7465,6 +7516,23 @@ packages:
       - supports-color
     dev: false
 
+  /@wordpress/global-styles-engine@1.3.0(react@18.3.1):
+    resolution: {integrity: sha512-6wfOjSRNVaVOeFcbvRb5HOaDQOtvMvi+mvj0moEDAaXzFz+ENnFOeAYLkthROfmVWudO9UI0epOeYMDGIa6/qA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      '@wordpress/blocks': 15.9.0(react@18.3.1)
+      '@wordpress/data': 10.36.0(react@18.3.1)
+      '@wordpress/i18n': 6.9.0
+      '@wordpress/style-engine': 2.36.0
+      colord: 2.9.3
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+    transitivePeerDependencies:
+      - react
+    dev: false
+
   /@wordpress/hooks@3.58.0:
     resolution: {integrity: sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==}
     engines: {node: '>=12'}
@@ -8560,6 +8628,13 @@ packages:
       memize: 2.1.0
     dev: false
 
+  /@wordpress/shortcode@4.36.0:
+    resolution: {integrity: sha512-MhSlWzQ8t9oMTB7S04C/M+mejzzo8Rv5JDYVtLpAAbkP7U0I5VpY7lk5C7BIHRGXkIPYwQMs+yos6u3qDap7rw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
+      memize: 2.1.1
+    dev: false
+
   /@wordpress/style-engine@1.41.0:
     resolution: {integrity: sha512-aM5bbJn6m8SHRotCoh/fSGuIB0MQJoVFBjpzIDoUDQ1KlO7CbY+fj9daDV1FZPMNv0h0ZEFWZ+y7Gv/CERypMA==}
     engines: {node: '>=12'}
@@ -8573,6 +8648,13 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     dependencies:
       '@babel/runtime': 7.26.10
+      change-case: 4.1.2
+    dev: false
+
+  /@wordpress/style-engine@2.36.0:
+    resolution: {integrity: sha512-vJcdpvccMQxLjpwmoShlpRzX1MDN9wSENTymCWeah5OE4gkGgO9sb1yi4Xo9RWfknUs4ZlqY4zfD6w7WE2sSvw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    dependencies:
       change-case: 4.1.2
     dev: false
 
@@ -9636,6 +9718,8 @@ packages:
       bare-stream: 2.6.5(bare-events@2.5.4)
       bare-url: 2.2.2
       fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
     dev: true
     optional: true
 
@@ -9668,6 +9752,8 @@ packages:
     dependencies:
       bare-events: 2.5.4
       streamx: 2.22.1
+    transitivePeerDependencies:
+      - bare-abort-controller
     dev: true
     optional: true
 
@@ -18585,7 +18671,9 @@ packages:
       fast-fifo: 1.3.2
       text-decoder: 1.1.1
     optionalDependencies:
-      bare-events: 2.5.4
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
     dev: true
     optional: true
 


### PR DESCRIPTION
## Description

This PR updates email editor PHP and JS package to 2.1.1 and 1.4.3.

## Code review notes

- the 1.4.3 JS package requires change in webpack to ensure `@wordpress/global-styles-engine` package is properly bundled

## QA notes

- please do basic smoke tests of the email editor

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-email-editor-packages)

_The latest successful build from `update-email-editor-packages` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WooCommerce email editor dependencies to the latest patch versions
  * Enhanced webpack build configuration for improved email editor integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->