### PR TITLE
Fix accesibility issues in the Automation editor

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/automation/add-step-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/add-step-button.tsx
@@ -1,7 +1,10 @@
 import { useContext } from 'react';
+import type React from 'react';
 import { __unstableCompositeItem as CompositeItem } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { Icon, plus } from '@wordpress/icons';
 import { AutomationCompositeContext } from './context';
+import { storeName } from '../../store';
 
 type Props = {
   onClick?: (element: HTMLButtonElement) => void;
@@ -15,6 +18,7 @@ export function AddStepButton({
   index,
 }: Props): JSX.Element {
   const compositeState = useContext(AutomationCompositeContext);
+  const { selectStep } = useDispatch(storeName);
   return (
     <CompositeItem
       state={compositeState}
@@ -33,6 +37,12 @@ export function AddStepButton({
             if (onClick) {
               onClick(event.currentTarget);
             }
+          },
+          onFocus: (event: React.FocusEvent<HTMLButtonElement>) => {
+            if (typeof htmlProps.onFocus === 'function') {
+              htmlProps.onFocus(event);
+            }
+            void selectStep(undefined);
           },
         };
         return (

--- a/mailpoet/assets/js/src/automation/editor/components/automation/add-step-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/add-step-button.tsx
@@ -27,8 +27,7 @@ export function AddStepButton({
       focusable
       data-previous-step-id={previousStepId}
       data-index={index}
-    >
-      {(htmlProps) => {
+      render={(htmlProps) => {
         const propsWithTabIndex = {
           ...htmlProps,
           tabIndex: 0,
@@ -51,6 +50,6 @@ export function AddStepButton({
           </button>
         );
       }}
-    </CompositeItem>
+    />
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/automation/add-step-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/add-step-button.tsx
@@ -23,13 +23,24 @@ export function AddStepButton({
       focusable
       data-previous-step-id={previousStepId}
       data-index={index}
-      onClick={(event) => {
-        event.stopPropagation();
-        const button = (event.target as HTMLElement).closest('button');
-        onClick(button);
-      }}
     >
-      <Icon icon={plus} size={16} />
+      {(htmlProps) => {
+        const propsWithTabIndex = {
+          ...htmlProps,
+          tabIndex: 0,
+          onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+            event.stopPropagation();
+            if (onClick) {
+              onClick(event.currentTarget);
+            }
+          },
+        };
+        return (
+          <button {...propsWithTabIndex} type="button">
+            <Icon icon={plus} size={16} />
+          </button>
+        );
+      }}
     </CompositeItem>
   );
 }

--- a/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
@@ -57,26 +57,29 @@ export function Automation({
     <AutomationContext.Provider value={automationContext}>
       <AutomationCompositeContext.Provider value={compositeState}>
         <SlotFillProvider>
-          <Composite
+          <div
             ref={automationRef}
-            state={compositeState}
-            role="tree"
-            aria-label={__('Automation', 'mailpoet')}
-            aria-orientation="vertical"
             className="mailpoet-automation-editor-automation"
           >
-            {showStatistics && <Statistics />}
-            <div className="mailpoet-automation-editor-automation-wrapper">
-              <div className="mailpoet-automation-editor-automation-flow">
-                <Flow stepData={automationData.steps.root} row={0} />
+            <Composite
+              state={compositeState}
+              role="tree"
+              aria-label={__('Automation', 'mailpoet')}
+              aria-orientation="vertical"
+            >
+              {showStatistics && <Statistics />}
+              <div className="mailpoet-automation-editor-automation-wrapper">
+                <div className="mailpoet-automation-editor-automation-flow">
+                  <Flow stepData={automationData.steps.root} row={0} />
+                </div>
+                <div />
+                {/* Render popovers within the automation, so they work in modals and other contexts. */}
+                {/* @ts-expect-error Slot is not currently typed on Popover */}
+                <Popover.Slot />
               </div>
-              <div />
-              {/* Render popovers within the automation, so they work in modals and other contexts. */}
-              {/* @ts-expect-error Slot is not currently typed on Popover */}
-              <Popover.Slot />
-            </div>
-            <InserterPopover />
-          </Composite>
+              <InserterPopover />
+            </Composite>
+          </div>
         </SlotFillProvider>
       </AutomationCompositeContext.Provider>
     </AutomationContext.Provider>

--- a/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/index.tsx
@@ -72,7 +72,9 @@ export function Automation({
                 <div className="mailpoet-automation-editor-automation-flow">
                   <Flow stepData={automationData.steps.root} row={0} />
                 </div>
-                <div />
+                {/* Spacer element used to balance the grid layout columns; */}
+                {/* purely presentational and ignored by assistive technologies. */}
+                <div aria-hidden="true" />
                 {/* Render popovers within the automation, so they work in modals and other contexts. */}
                 {/* @ts-expect-error Slot is not currently typed on Popover */}
                 <Popover.Slot />

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
@@ -97,50 +97,72 @@ export function Step({ step, isSelected }: Props): JSX.Element {
         id={compositeItemId}
         key={step.id}
         focusable
-        onClick={
-          context === 'edit'
-            ? () =>
-                batch(() => {
-                  void openSidebar(stepSidebarKey);
-                  void selectStep(step);
-                })
-            : undefined
-        }
       >
-        <div className="mailpoet-automation-editor-step-icon">
-          <ColoredIcon
-            icon={stepTypeData.icon}
-            foreground={stepTypeData.foreground}
-            background={stepTypeData.background}
-            width="32px"
-            height="32px"
-          />
-        </div>
-        <div>
-          <label
-            htmlFor={compositeItemId}
-            className="mailpoet-automation-editor-step-title"
-          >
-            {step.type !== 'trigger'
-              ? stepTypeData.title(step, 'automation')
-              : _x('Trigger', 'noun', 'mailpoet')}
-          </label>
-          <div className="mailpoet-automation-editor-step-subtitle">
-            {step.type !== 'trigger'
-              ? stepTypeData.subtitle(step, 'automation')
-              : stepTypeData.title(step, 'automation')}
-          </div>
-        </div>
-        {
-          Hooks.applyFilters(
-            'mailpoet.automation.step.more',
-            null,
-            step,
-            context,
-            isSelected,
-          ) as StepMoreType
-        }
-        {footer}
+        {(htmlProps) => {
+          const propsWithTabIndex = {
+            ...htmlProps,
+            tabIndex: 0,
+            onClick:
+              context === 'edit'
+                ? () => {
+                    if (typeof htmlProps.onClick === 'function') {
+                      // Preserve CompositeItem's internal click behavior.
+                      htmlProps.onClick();
+                    }
+                    batch(() => {
+                      void openSidebar(stepSidebarKey);
+                      void selectStep(step);
+                    });
+                  }
+                : htmlProps.onClick,
+            onFocus: (event: React.FocusEvent<HTMLButtonElement>) => {
+              if (typeof htmlProps.onFocus === 'function') {
+                htmlProps.onFocus(event);
+              }
+              if (context === 'edit') {
+                void selectStep(step);
+              }
+            },
+          };
+          return (
+            <button {...propsWithTabIndex} type="button">
+              <div className="mailpoet-automation-editor-step-icon">
+                <ColoredIcon
+                  icon={stepTypeData.icon}
+                  foreground={stepTypeData.foreground}
+                  background={stepTypeData.background}
+                  width="32px"
+                  height="32px"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor={compositeItemId}
+                  className="mailpoet-automation-editor-step-title"
+                >
+                  {step.type !== 'trigger'
+                    ? stepTypeData.title(step, 'automation')
+                    : _x('Trigger', 'noun', 'mailpoet')}
+                </label>
+                <div className="mailpoet-automation-editor-step-subtitle">
+                  {step.type !== 'trigger'
+                    ? stepTypeData.subtitle(step, 'automation')
+                    : stepTypeData.title(step, 'automation')}
+                </div>
+              </div>
+              {
+                Hooks.applyFilters(
+                  'mailpoet.automation.step.more',
+                  null,
+                  step,
+                  context,
+                  isSelected,
+                ) as StepMoreType
+              }
+              {footer}
+            </button>
+          );
+        }}
       </CompositeItem>
     </div>
   );

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
@@ -97,8 +97,7 @@ export function Step({ step, isSelected }: Props): JSX.Element {
         id={compositeItemId}
         key={step.id}
         focusable
-      >
-        {(htmlProps) => {
+        render={(htmlProps) => {
           const propsWithTabIndex = {
             ...htmlProps,
             tabIndex: 0,
@@ -163,7 +162,7 @@ export function Step({ step, isSelected }: Props): JSX.Element {
             </button>
           );
         }}
-      </CompositeItem>
+      />
     </div>
   );
 }

--- a/mailpoet/changelog/2025-12-15-11-59-20-fixed-accessibility-issues-in-the-automation-editor.md
+++ b/mailpoet/changelog/2025-12-15-11-59-20-fixed-accessibility-issues-in-the-automation-editor.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Accessibility issues in the automation editor


### PR DESCRIPTION
## Description

Fix accessibility issues in the Automation editor. Before this change a user, couldn't use "Tab" to select the steps and the "+" button in the editor. This pull request fixes that. 

https://github.com/user-attachments/assets/46589d01-e945-4b71-b39e-ecfe7aa798cc



## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7270

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7270-a11y-automation-editor-not-really-usable-with-keyboard)

_The latest successful build from `stomail-7270-a11y-automation-editor-not-really-usable-with-keyboard` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed accessibility and focus/keyboard behavior in the automation editor so steps and controls respond correctly when navigating and editing.
* **Refactor**
  * Updated automation UI structure and button behaviors to improve reliability of popovers, spacing, and step selection during edit interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->