### PR TITLE
Add regression tests for WordPress password-protected pages STOMAIL-7664

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -762,6 +762,18 @@ class AcceptanceTester extends \Codeception\Actor {
     return $postData['url'];
   }
 
+  /**
+   * Creates a password-protected post or page and returns its URL
+   */
+  public function createPasswordProtectedPost(string $title, string $body, string $password, string $type = 'post'): string {
+    $post = $this->cliToString(['post', 'create', '--format=json', '--porcelain', '--post_status=publish', '--post_type=' . $type, '--post_title="' . $title . '"', '--post_content="' . $body . '"', '--post_password="' . $password . '"']);
+    $postData = $this->cliToString(['post', 'get', $post, '--format=json']);
+    $postData = json_decode($postData, true);
+    Assert::assertIsArray($postData);
+    Assert::assertIsString($postData['url']);
+    return $postData['url'];
+  }
+
   public function addFromBlockInEditor($name, $context = null) {
     $i = $this;
     $appender = '[data-automation-id="form_inserter_open"]';

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -762,15 +762,27 @@ class AcceptanceTester extends \Codeception\Actor {
     return $postData['url'];
   }
 
-  /**
-   * Creates a password-protected post or page and returns its URL
-   */
   public function createPasswordProtectedPost(string $title, string $body, string $password, string $type = 'post'): string {
-    $post = $this->cliToString(['post', 'create', '--format=json', '--porcelain', '--post_status=publish', '--post_type=' . $type, '--post_title="' . $title . '"', '--post_content="' . $body . '"', '--post_password="' . $password . '"']);
-    $postData = $this->cliToString(['post', 'get', $post, '--format=json']);
-    $postData = json_decode($postData, true);
+    $createArgs = [
+      'post',
+      'create',
+      '--format=json',
+      '--porcelain',
+      '--post_status=publish',
+      '--post_type="' . $type . '"',
+      '--post_title="' . $title . '"',
+      '--post_content="' . $body . '"',
+      '--post_password="' . $password . '"',
+    ];
+
+    $postId = $this->cliToString($createArgs);
+
+    $postJson = $this->cliToString(['post', 'get', $postId, '--format=json']);
+    $postData = json_decode($postJson, true);
+
     Assert::assertIsArray($postData);
     Assert::assertIsString($postData['url']);
+
     return $postData['url'];
   }
 

--- a/mailpoet/tests/acceptance/Misc/PasswordProtectedPagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/PasswordProtectedPagesCest.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Acceptance;
+
+/**
+ * @group frontend
+ * Ensures password-protected pages do not expose content when MailPoet is active
+ */
+class PasswordProtectedPagesCest {
+
+  private const PASSWORD = 'testpassword123';
+  private const PROTECTED_CONTENT = 'This is secret protected content that should not be visible without password.';
+
+  public function passwordProtectedPostContentIsNotExposed(\AcceptanceTester $i) {
+    $i->wantTo('Test that password-protected post content is not exposed');
+
+    $i->login();
+
+    $postTitle = 'Protected Post Test';
+    $postUrl = $i->createPasswordProtectedPost($postTitle, self::PROTECTED_CONTENT, self::PASSWORD, 'post');
+
+    $i->wantTo('Log out to test as anonymous user');
+    $i->logOut();
+
+    $i->wantTo('Visit the password-protected post as an anonymous user');
+    $i->amOnUrl($postUrl);
+
+    $i->wantTo('Verify the password form is displayed');
+    $i->waitForText('Protected:', 10);
+    $i->seeElement('input[name="post_password"]');
+
+    $i->wantTo('Verify the protected content is NOT visible');
+    $i->dontSee(self::PROTECTED_CONTENT);
+
+    $i->wantTo('Enter the password and verify content becomes visible');
+    $i->fillField('input[name="post_password"]', self::PASSWORD);
+    $i->click('input[type="submit"]');
+    $i->waitForText(self::PROTECTED_CONTENT, 10);
+    $i->see(self::PROTECTED_CONTENT);
+  }
+
+  public function passwordProtectedPageContentIsNotExposed(\AcceptanceTester $i) {
+    $i->wantTo('Test that password-protected page content is not exposed');
+
+    $i->login();
+
+    $pageTitle = 'Protected Page Test';
+    $pageUrl = $i->createPasswordProtectedPost($pageTitle, self::PROTECTED_CONTENT, self::PASSWORD, 'page');
+
+    $i->wantTo('Log out to test as anonymous user');
+    $i->logOut();
+
+    $i->wantTo('Visit the password-protected page as an anonymous user');
+    $i->amOnUrl($pageUrl);
+
+    $i->wantTo('Verify the password form is displayed');
+    $i->waitForText('Protected:', 10);
+    $i->seeElement('input[name="post_password"]');
+
+    $i->wantTo('Verify the protected content is NOT visible');
+    $i->dontSee(self::PROTECTED_CONTENT);
+  }
+
+  public function passwordProtectionWorksWithWooCommerceActive(\AcceptanceTester $i) {
+    $i->wantTo('Test that password protection works when WooCommerce is active');
+
+    $i->login();
+
+    $i->wantTo('Activate WooCommerce plugin');
+    $i->activateWooCommerce();
+
+    $postTitle = 'Protected Post With WooCommerce';
+    $protectedContent = 'Secret content with WooCommerce active, this should not be visible.';
+    $postUrl = $i->createPasswordProtectedPost($postTitle, $protectedContent, self::PASSWORD, 'post');
+
+    $i->wantTo('Log out to test as anonymous user');
+    $i->logOut();
+
+    $i->wantTo('Visit the password-protected post as an anonymous user');
+    $i->amOnUrl($postUrl);
+
+    $i->wantTo('Verify the password form is displayed');
+    $i->waitForText('Protected:', 10);
+    $i->seeElement('input[name="post_password"]');
+
+    $i->wantTo('Verify the protected content is NOT visible');
+    $i->dontSee($protectedContent);
+
+    $i->wantTo('Enter the password and verify content becomes visible');
+    $i->fillField('input[name="post_password"]', self::PASSWORD);
+    $i->click('input[type="submit"]');
+    $i->waitForText($protectedContent, 10);
+    $i->see($protectedContent);
+
+    $i->wantTo('Deactivate WooCommerce plugin');
+    $i->deactivateWooCommerce();
+  }
+
+  public function multiplePasswordProtectedPostsDontLeakContent(\AcceptanceTester $i) {
+    $i->wantTo('Test that visiting multiple password-protected posts does not leak content');
+
+    $i->login();
+
+    $posts = [];
+    for ($j = 1; $j <= 3; $j++) {
+      $title = "Protected Post $j";
+      $content = "Secret content for post $j, this must remain hidden.";
+      $posts[] = [
+        'title' => $title,
+        'content' => $content,
+        'url' => $i->createPasswordProtectedPost($title, $content, self::PASSWORD, 'post'),
+      ];
+    }
+
+    $i->wantTo('Log out to test as anonymous user');
+    $i->logOut();
+
+    $i->wantTo('Visit each password-protected post and verify content is not exposed');
+    foreach ($posts as $post) {
+      $i->amOnUrl($post['url']);
+      $i->waitForText('Protected:', 10);
+      $i->seeElement('input[name="post_password"]');
+      $i->dontSee($post['content']);
+    }
+
+    $i->wantTo('Visit them again in reverse order to ensure no caching issues');
+    foreach (array_reverse($posts) as $post) {
+      $i->amOnUrl($post['url']);
+      $i->waitForText('Protected:', 10);
+      $i->dontSee($post['content']);
+    }
+  }
+}

--- a/mailpoet/tests/acceptance/Misc/PasswordProtectedPagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/PasswordProtectedPagesCest.php
@@ -11,6 +11,10 @@ class PasswordProtectedPagesCest {
   private const PASSWORD = 'testpassword123';
   private const PROTECTED_CONTENT = 'This is secret protected content that should not be visible without password.';
 
+  public function _after(\AcceptanceTester $i) {
+    $i->deactivateWooCommerce();
+  }
+
   public function passwordProtectedPostContentIsNotExposed(\AcceptanceTester $i) {
     $i->wantTo('Test that password-protected post content is not exposed');
 
@@ -91,9 +95,6 @@ class PasswordProtectedPagesCest {
     $i->click('input[type="submit"]');
     $i->waitForText($protectedContent, 10);
     $i->see($protectedContent);
-
-    $i->wantTo('Deactivate WooCommerce plugin');
-    $i->deactivateWooCommerce();
   }
 
   public function multiplePasswordProtectedPostsDontLeakContent(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

Add regression tests for WordPress password-protected pages to prevent recurrence of the issue where MailPoet + WooCommerce exposed protected content (STOMAIL-7662). 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7664

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7664-add-regression-tests-for-wordpress-password-protected-pages)

_The latest successful build from `stomail-7664-add-regression-tests-for-wordpress-password-protected-pages` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive acceptance tests for password-protected posts and pages, validating content protection, password form behavior, WooCommerce interaction, and caching scenarios across multiple protected items.
* **Chores**
  * Added a test helper to create password-protected content to support the new acceptance tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->