### PR TITLE
Remove WC version comparison when checking if email improvements are enabled

### DIFF
--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -349,11 +349,6 @@ class Helper {
     if (!class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
       return false;
     }
-    // By this point, the feature should be enabled by default for everyone
-    $wcVersion = $this->getWooCommerceVersion();
-    if (version_compare($wcVersion, '10.0.0', '>')) {
-      return true;
-    }
     return \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled('email_improvements');
   }
 


### PR DESCRIPTION
## Description

The rollout in WooCommerce was paused and is opt-in only, so the check was incorrect in the first place. 

Additionally, it was causing issues when `$wcVersion` was `null`, which was throwing deprecation notice causing syntax error in JS script.

<img width="1494" height="92" alt="Screenshot 2025-12-16 at 12 00 47" src="https://github.com/user-attachments/assets/fd383f75-3b43-4592-9b8d-f3b1bca60577" />

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7670

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated WooCommerce email improvements feature control to exclusively rely on the feature flag system, removing version-based automatic activation. This ensures the feature is only enabled when explicitly configured, providing more consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->