### PR TITLE
Preserve shortcodes in URLs processed for GA tracking

### DIFF
--- a/mailpoet/changelog/2025-12-16-12-18-50-fixed-shortcodes-in-urls-linking-the-sending-site-are-br.md
+++ b/mailpoet/changelog/2025-12-16-12-18-50-fixed-shortcodes-in-urls-linking-the-sending-site-are-br.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Shortcodes in URL parameters getting broken when GA tracking is enabled

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -138,23 +138,41 @@ class GATracking {
     $urlWithPlaceholders = $url;
     $index = 0;
 
-    // Process each parameter value
+    // Process each parameter value (recursively for arrays)
+    $this->processParamsForShortcodes($params, $urlWithPlaceholders, $shortcodeMap, $index);
+
+    return [$urlWithPlaceholders, $shortcodeMap];
+  }
+
+  /**
+   * Process parameter values recursively to find and replace shortcodes.
+   * Handles both string values and nested arrays.
+   *
+   * @param array $params Parameter values to process
+   * @param string $urlWithPlaceholders URL being modified (passed by reference)
+   * @param array $shortcodeMap Map of placeholders to shortcodes (passed by reference)
+   * @param int $index Current placeholder index (passed by reference)
+   */
+  private function processParamsForShortcodes(array $params, string &$urlWithPlaceholders, array &$shortcodeMap, int &$index): void {
     foreach ($params as $value) {
-      // Find shortcodes in this parameter's value
-      $pattern = '/\[([^\]]+)\]/';
-      if (preg_match_all($pattern, $value, $matches)) {
-        foreach ($matches[0] as $shortcode) {
-          // Create a unique placeholder
-          $placeholder = 'MPSHORTCODE' . $index . 'MPEND';
-          $shortcodeMap[$placeholder] = $shortcode;
-          // Replace shortcode with placeholder directly in the URL
-          $urlWithPlaceholders = str_replace($shortcode, $placeholder, $urlWithPlaceholders);
-          $index++;
+      if (is_array($value)) {
+        // Recursively process array values
+        $this->processParamsForShortcodes($value, $urlWithPlaceholders, $shortcodeMap, $index);
+      } elseif (is_string($value)) {
+        // Find shortcodes in string values
+        $pattern = '/\[([^\]]+)\]/';
+        if (preg_match_all($pattern, $value, $matches)) {
+          foreach ($matches[0] as $shortcode) {
+            // Create a unique placeholder
+            $placeholder = 'MPSHORTCODE' . $index . 'MPEND';
+            $shortcodeMap[$placeholder] = $shortcode;
+            // Replace shortcode with placeholder directly in the URL
+            $urlWithPlaceholders = str_replace($shortcode, $placeholder, $urlWithPlaceholders);
+            $index++;
+          }
         }
       }
     }
-
-    return [$urlWithPlaceholders, $shortcodeMap];
   }
 
   /**

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -162,10 +162,11 @@ class GATracking {
         // Find shortcodes in string values
         // Pattern matches MailPoet shortcodes in the format [name:value|option:value]
         // - \[ matches opening bracket
-        // - [^\]]+ matches one or more characters that are not a closing bracket
+        // - [^\]]{1,400} matches 1-400 characters that are not a closing bracket
+        //   (limit prevents ReDoS attacks from catastrophic backtracking)
         // - \] matches closing bracket
         // Examples: [subscriber:email], [subscriber:firstname|default:Guest]
-        $pattern = '/\[([^\]]+)\]/';
+        $pattern = '/\[[^\]]{1,400}\]/';
         if (preg_match_all($pattern, $value, $matches)) {
           foreach ($matches[0] as $shortcode) {
             // Create a unique placeholder

--- a/mailpoet/lib/Statistics/GATracking.php
+++ b/mailpoet/lib/Statistics/GATracking.php
@@ -160,6 +160,11 @@ class GATracking {
         $this->processParamsForShortcodes($value, $urlWithPlaceholders, $shortcodeMap, $index);
       } elseif (is_string($value)) {
         // Find shortcodes in string values
+        // Pattern matches MailPoet shortcodes in the format [name:value|option:value]
+        // - \[ matches opening bracket
+        // - [^\]]+ matches one or more characters that are not a closing bracket
+        // - \] matches closing bracket
+        // Examples: [subscriber:email], [subscriber:firstname|default:Guest]
         $pattern = '/\[([^\]]+)\]/';
         if (preg_match_all($pattern, $value, $matches)) {
           foreach ($matches[0] as $shortcode) {

--- a/mailpoet/tests/integration/Statistics/GATrackingTest.php
+++ b/mailpoet/tests/integration/Statistics/GATrackingTest.php
@@ -119,4 +119,48 @@ class GATrackingTest extends \MailPoetTest {
     verify($result['text'])->stringNotContainsString('utm_medium=email');
     verify($result['html'])->stringContainsString('utm_medium=another_medium');
   }
+
+  public function testItPreservesShortcodesInInternalLinks() {
+    $internalLink = 'http://newsletters.mailpoet.com/?email=[subscriber:email]&name=[subscriber:firstname|default:reader]';
+    $renderedNewsletter = [
+      'html' => '<p><a href="' . $internalLink . '">Click here</a></p>',
+      'text' => '[Click here](' . $internalLink . ')',
+    ];
+    $result = $this->tracking->applyGATracking($renderedNewsletter, $this->newsletter, $this->internalHost);
+    // Should contain GA tracking parameters
+    verify($result['text'])->stringContainsString('utm_source=mailpoet');
+    verify($result['html'])->stringContainsString('utm_source=mailpoet');
+    // Should preserve shortcodes without URL encoding
+    verify($result['text'])->stringContainsString('email=[subscriber:email]');
+    verify($result['html'])->stringContainsString('email=[subscriber:email]');
+    verify($result['text'])->stringContainsString('name=[subscriber:firstname|default:reader]');
+    verify($result['html'])->stringContainsString('name=[subscriber:firstname|default:reader]');
+    // Should NOT contain URL-encoded shortcodes
+    verify($result['text'])->stringNotContainsString('email=%5Bsubscriber%3Aemail%5D');
+    verify($result['html'])->stringNotContainsString('email=%5Bsubscriber%3Aemail%5D');
+  }
+
+  public function testItPreservesComplexShortcodesInInternalLinks() {
+    // Test with multiple complex shortcodes including various special characters
+    $internalLink = 'http://newsletters.mailpoet.com/?user=[subscriber:email]&first=[subscriber:firstname|default:Guest User]&last=[subscriber:lastname]&custom=[subscriber:cf_1:custom field|default:N/A]';
+    $renderedNewsletter = [
+      'html' => '<p><a href="' . $internalLink . '">Click here</a></p>',
+      'text' => '[Click here](' . $internalLink . ')',
+    ];
+    $result = $this->tracking->applyGATracking($renderedNewsletter, $this->newsletter, $this->internalHost);
+    // Should contain GA tracking parameters
+    verify($result['text'])->stringContainsString('utm_source=mailpoet');
+    verify($result['html'])->stringContainsString('utm_source=mailpoet');
+    verify($result['text'])->stringContainsString('utm_campaign=' . urlencode($this->gaCampaign));
+    verify($result['html'])->stringContainsString('utm_campaign=' . urlencode($this->gaCampaign));
+    // Should preserve all shortcodes exactly as they were
+    verify($result['text'])->stringContainsString('user=[subscriber:email]');
+    verify($result['html'])->stringContainsString('user=[subscriber:email]');
+    verify($result['text'])->stringContainsString('first=[subscriber:firstname|default:Guest User]');
+    verify($result['html'])->stringContainsString('first=[subscriber:firstname|default:Guest User]');
+    verify($result['text'])->stringContainsString('last=[subscriber:lastname]');
+    verify($result['html'])->stringContainsString('last=[subscriber:lastname]');
+    verify($result['text'])->stringContainsString('custom=[subscriber:cf_1:custom field|default:N/A]');
+    verify($result['html'])->stringContainsString('custom=[subscriber:cf_1:custom field|default:N/A]');
+  }
 }


### PR DESCRIPTION
## Description

### Problem
When GA tracking parameters were added to internal links containing shortcodes (e.g., [subscriber:email]), WordPress's add_query_arg() function would URL-encode the shortcodes, breaking them.

### Solution
Implemented a three-step process to preserve shortcodes:

1. Extract - Find all shortcodes in URL query parameters and replace them with safe placeholders
2. Add GA params - Use add_query_arg() to add tracking parameters (placeholders remain unencoded)
3. Restore - Replace placeholders with original shortcodes

The solution properly handles:

- Simple shortcodes: [subscriber:email]
- Complex shortcodes with defaults: [subscriber:firstname|default:Guest User]
- Shortcodes in array parameters: filters[email]=[subscriber:email]

## Code review notes
N/A

## QA notes

1. Add a link to an email paragraph. The link have to link to the site you're sending from http://yourtestsite.com/?email=[subscriber:email]&name=[subscriber:firstname|default:reader]
2. Send the email, with full tracking enabled. Use regular sending not preview
3. Verify that after clicking on the link in the url goes to something like http://yourtestsite.com/?email=admin@example.com&name=reader 

## Linked PRs
N/A

## Linked tickets
Closes STOMAIL-7665

## After-merge notes
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve shortcodes in URLs that link to the sending site when Google Analytics parameters are added, preventing them from being broken or encoded.

* **Tests**
  * Added tests covering preservation across internal links, complex shortcodes, array query parameters, and edge-case scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7665-shortcodes-in-urls-dont-work)

_The latest successful build from `stomail-7665-shortcodes-in-urls-dont-work` will be used. If none is available, the link won't work._