### PR TITLE
MailPoet TranslationUpdater returns null causing fatal error

### DIFF
--- a/mailpoet/changelog/2025-12-16-12-52-39-fixed-translations-api-response-validation-was-not-check.md
+++ b/mailpoet/changelog/2025-12-16-12-52-39-fixed-translations-api-response-validation-was-not-check.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Translations API response validation was not checking data format

--- a/mailpoet/lib/Config/TranslationUpdater.php
+++ b/mailpoet/lib/Config/TranslationUpdater.php
@@ -116,7 +116,12 @@ class TranslationUpdater {
       $this->wpFunctions->setTransient($cacheKey, $rawResponse, self::TRANSIENT_EXPIRATION);
     }
     $response = json_decode($this->wpFunctions->wpRemoteRetrieveBody($rawResponse), true);
-    if (!is_array($response) || (array_key_exists('success', $response) && $response['success'] === false)) {
+    if (
+      !is_array($response)
+      || (array_key_exists('success', $response) && $response['success'] === false)
+      || !array_key_exists('data', $response)
+      || !is_array($response['data'])
+    ) {
       $this->logError("MailPoet: Failed to fetch translations from WordPress.com API with code 200 and response: " . json_encode($response));
       return [];
     }

--- a/mailpoet/lib/Config/TranslationUpdater.php
+++ b/mailpoet/lib/Config/TranslationUpdater.php
@@ -178,7 +178,7 @@ class TranslationUpdater {
     });
   }
 
-  private function logError(string $message): void {
+  protected function logError(string $message): void {
     if (class_exists(Debugger::class)) {
       Debugger::log($message, ILogger::ERROR);
     }

--- a/mailpoet/tests/integration/Config/TranslationUpdaterTest.php
+++ b/mailpoet/tests/integration/Config/TranslationUpdaterTest.php
@@ -415,6 +415,207 @@ class TranslationUpdaterTest extends \MailPoetTest {
     verify($freeTranslation['package'])->equals('https:\/\/translate.files.wordpress.com\/2021\/08\/mailpoet-free-0_1-fr_fr.zip');
   }
 
+  public function testItReturnsEmptyArrayWhenResponseMissingDataKey(): void {
+    $responseBody = json_encode([
+      'success' => true,
+      // Missing 'data' key
+    ]);
+    $wpFunctions = Stub::construct(
+      $this->wp,
+      [],
+      [
+        'wpRemotePost' => function() use ($responseBody) {
+          return [
+            'response' => [
+              'code' => 200,
+              'message' => 'OK',
+            ],
+            'body' => $responseBody,
+          ];
+        },
+        'wpRemoteRetrieveResponseCode' => function() {
+          return 200;
+        },
+        'wpRemoteRetrieveBody' => function() use ($responseBody) {
+          return $responseBody;
+        },
+        'getAvailableLanguages' => function() {
+          return ['fr_FR'];
+        },
+      ],
+      $this
+    );
+
+    $updateTransient = new \stdClass;
+    $updateTransient->translations = [];
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $wpFunctions,
+        $this->freeSlug,
+        $this->freeVersion,
+        $this->premiumSlug,
+        $this->premiumVersion,
+      ],
+      [
+        'logError' => Expected::once(),
+      ],
+      $this
+    );
+    $result = $updater->checkForTranslations($updateTransient);
+    verify($result->translations)->empty();
+  }
+
+  public function testItReturnsEmptyArrayWhenResponseDataIsNotArray(): void {
+    $responseBody = json_encode([
+      'success' => true,
+      'data' => 'not an array',
+    ]);
+    $wpFunctions = Stub::construct(
+      $this->wp,
+      [],
+      [
+        'wpRemotePost' => function() use ($responseBody) {
+          return [
+            'response' => [
+              'code' => 200,
+              'message' => 'OK',
+            ],
+            'body' => $responseBody,
+          ];
+        },
+        'wpRemoteRetrieveResponseCode' => function() {
+          return 200;
+        },
+        'wpRemoteRetrieveBody' => function() use ($responseBody) {
+          return $responseBody;
+        },
+        'getAvailableLanguages' => function() {
+          return ['fr_FR'];
+        },
+      ],
+      $this
+    );
+
+    $updateTransient = new \stdClass;
+    $updateTransient->translations = [];
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $wpFunctions,
+        $this->freeSlug,
+        $this->freeVersion,
+        $this->premiumSlug,
+        $this->premiumVersion,
+      ],
+      [
+        'logError' => Expected::once(),
+      ],
+      $this
+    );
+    $result = $updater->checkForTranslations($updateTransient);
+    verify($result->translations)->empty();
+  }
+
+  public function testItReturnsEmptyArrayWhenResponseIsNotArray(): void {
+    $responseBody = json_encode('not an array');
+    $wpFunctions = Stub::construct(
+      $this->wp,
+      [],
+      [
+        'wpRemotePost' => function() use ($responseBody) {
+          return [
+            'response' => [
+              'code' => 200,
+              'message' => 'OK',
+            ],
+            'body' => $responseBody,
+          ];
+        },
+        'wpRemoteRetrieveResponseCode' => function() {
+          return 200;
+        },
+        'wpRemoteRetrieveBody' => function() use ($responseBody) {
+          return $responseBody;
+        },
+        'getAvailableLanguages' => function() {
+          return ['fr_FR'];
+        },
+      ],
+      $this
+    );
+
+    $updateTransient = new \stdClass;
+    $updateTransient->translations = [];
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $wpFunctions,
+        $this->freeSlug,
+        $this->freeVersion,
+        $this->premiumSlug,
+        $this->premiumVersion,
+      ],
+      [
+        'logError' => Expected::once(),
+      ],
+      $this
+    );
+    $result = $updater->checkForTranslations($updateTransient);
+    verify($result->translations)->empty();
+  }
+
+  public function testItReturnsEmptyArrayWhenResponseSuccessIsFalse(): void {
+    $responseBody = json_encode([
+      'success' => false,
+      'data' => $this->getResponseData(),
+    ]);
+    $wpFunctions = Stub::construct(
+      $this->wp,
+      [],
+      [
+        'wpRemotePost' => function() use ($responseBody) {
+          return [
+            'response' => [
+              'code' => 200,
+              'message' => 'OK',
+            ],
+            'body' => $responseBody,
+          ];
+        },
+        'wpRemoteRetrieveResponseCode' => function() {
+          return 200;
+        },
+        'wpRemoteRetrieveBody' => function() use ($responseBody) {
+          return $responseBody;
+        },
+        'getAvailableLanguages' => function() {
+          return ['fr_FR'];
+        },
+      ],
+      $this
+    );
+
+    $updateTransient = new \stdClass;
+    $updateTransient->translations = [];
+    $updater = Stub::construct(
+      $this->updater,
+      [
+        $wpFunctions,
+        $this->freeSlug,
+        $this->freeVersion,
+        $this->premiumSlug,
+        $this->premiumVersion,
+      ],
+      [
+        'logError' => Expected::once(),
+      ],
+      $this
+    );
+    $result = $updater->checkForTranslations($updateTransient);
+    verify($result->translations)->empty();
+  }
+
   private function getResponseData(): array {
     return [
       $this->freeSlug => [


### PR DESCRIPTION
## Description

This PR fixes an issue that TranslationUpdated may return `null` and is expected to an array.

### Fix
Add two additional validation checks to ensure the translation API response contains a valid `data` array before processing:

- Check that `data` key exists in the response
- Check that `data` value is an array

These checks prevent potential errors when the API returns malformed responses and ensure consistent error handling with appropriate logging.


## Code review notes

_N/A_

## QA notes

Test that plugin translations are installed for new languages added in WP settings and work as expected.

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7671

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7671-mailpoet-translationupdater-returns-null)

_The latest successful build from `stomail-7671-mailpoet-translationupdater-returns-null` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translations API response validation to properly verify data format and structure, improving reliability when fetching translation updates and preventing errors from malformed responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->