### PR TITLE
Update Automatewoo for oldest supported versions tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1194,7 +1194,7 @@ workflows:
           name: acceptance_oldest
           woo_core_version: 10.3.6
           woo_subscriptions_version: 8.1.0
-          automate_woo_version: 6.0.33
+          automate_woo_version: 6.1.3
           mysql_command: --max_allowed_packet=100M
           mysql_image: mysql:5.6
           codeception_image_version: 7.4-cli_20220605.0
@@ -1234,7 +1234,7 @@ workflows:
           name: integration_oldest
           woo_core_version: 10.3.6
           woo_subscriptions_version: 8.1.0
-          automate_woo_version: 6.0.33
+          automate_woo_version: 6.1.3
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.8.3
@@ -1296,7 +1296,7 @@ workflows:
           name: acceptance_with_premium_oldest
           woo_core_version: 10.3.6
           woo_subscriptions_version: 8.1.0
-          automate_woo_version: 6.0.33
+          automate_woo_version: 6.1.3
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.8.3
@@ -1307,7 +1307,7 @@ workflows:
           name: integration_with_premium_oldest
           woo_core_version: 10.3.6
           woo_subscriptions_version: 8.1.0
-          automate_woo_version: 6.0.33
+          automate_woo_version: 6.1.3
           codeception_image_version: 7.4-cli_20220605.0
           wordpress_image_version: 6.1.1-php7.4 # We use image with PHP 7.4 and install required WordPress version via CLI
           wordpress_version: 6.8.3


### PR DESCRIPTION
## Description

This PR updates Automatewoo used in the oldest supported versions tests to a version that is compatible with WP 6.8.

We released Automatewoo 6.2.0 so the next week the update action should update Automatewoo to the proper 6.1 version.

## Code review notes

Here is a testing build for oldest versions https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21953/workflows/5bc56e46-4ebe-4319-bcf8-cb567fe9b8fc

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7667

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7667-failing-nightly-tests)

_The latest successful build from `stomail-7667-failing-nightly-tests` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure tooling to improve automated test reliability across acceptance and integration test workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->