### PR TITLE
Add filter to modify email editor patterns before registration

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -6,14 +6,18 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPat
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewsletterPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeEmailPattern;
 use MailPoet\Util\CdnAssetUrl;
+use MailPoet\WP\Functions as WPFunctions;
 
 class PatternsController {
   private CdnAssetUrl $cdnAssetUrl;
+  private WPFunctions $wp;
 
   public function __construct(
-    CdnAssetUrl $cdnAssetUrl
+    CdnAssetUrl $cdnAssetUrl,
+    WPFunctions $wp
   ) {
     $this->cdnAssetUrl = $cdnAssetUrl;
+    $this->wp = $wp;
   }
 
   public function registerPatterns(): void {
@@ -23,8 +27,26 @@ class PatternsController {
     $patterns[] = new NewsletterPattern($this->cdnAssetUrl);
     $patterns[] = new WelcomeEmailPattern($this->cdnAssetUrl);
     $patterns[] = new AbandonedCartPattern($this->cdnAssetUrl);
+
     foreach ($patterns as $pattern) {
-      register_block_pattern($pattern->get_namespace() . '/' . $pattern->get_name(), $pattern->get_properties());
+      $patternName = $pattern->get_namespace() . '/' . $pattern->get_name();
+      $patternProperties = $pattern->get_properties();
+
+      /**
+       * Filters pattern data before it is registered as a block pattern.
+       *
+       * @param array{name: string, properties: array} $patternData Pattern name and properties.
+       * @param Pattern $pattern The original Pattern object.
+       * @return array|null Return modified data or null/false to skip registration.
+       */
+      $patternData = $this->wp->applyFilters('mailpoet_email_editor_register_pattern', [
+        'name' => $patternName,
+        'properties' => $patternProperties,
+      ], $pattern);
+
+      if (is_array($patternData) && isset($patternData['name']) && isset($patternData['properties'])) {
+        register_block_pattern($patternData['name'], $patternData['properties']);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Introduce `mailpoet_email_editor_register_pattern` filter that allows modifying pattern name and properties before they are registered as block patterns. Returning null/false skips registration entirely.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[WOOPRD-1010: Allow WooCommerce Personalization Tags in marketing emails](https://linear.app/a8c/issue/WOOPRD-1010/allow-woocommerce-personalization-tags-in-marketing-emails)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wooprd-1010-add-email-editor-register-pattern-hook)

_The latest successful build from `wooprd-1010-add-email-editor-register-pattern-hook` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced pattern registration system to support external customization of email patterns through filtering mechanisms, improving extensibility for plugin developers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->