### PR TITLE
Fix the scroll-to-bottom detection on zoomed browsers for the Posts block

### DIFF
--- a/mailpoet/assets/js/src/newsletter-editor/blocks/posts.js
+++ b/mailpoet/assets/js/src/newsletter-editor/blocks/posts.js
@@ -404,9 +404,12 @@ PostsSelectionCollectionView = Marionette.CollectionView.extend({
   },
   onPostsScroll: function (event) {
     var $postsBox = jQuery(event.target);
+
+    // The 1px tolerance accounts for potential decimal inaccuracies in DOM's
+    // `scrollTop` after the browser zooms the page.
     if (
       $postsBox.scrollTop() + $postsBox.innerHeight() >=
-      $postsBox[0].scrollHeight
+      $postsBox[0].scrollHeight - 1
     ) {
       // Load more posts if scrolled to bottom
       this.blockModel.trigger('loadMorePosts');

--- a/mailpoet/changelog/2025-12-25-10-47-07-fixed-fix-the-scroll-to-bottom-detection-on-zoomed-brows.md
+++ b/mailpoet/changelog/2025-12-25-10-47-07-fixed-fix-the-scroll-to-bottom-detection-on-zoomed-brows.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix the scroll-to-bottom detection on zoomed browsers for the Posts block


### PR DESCRIPTION
## Description

This PR fixes the scroll-to-bottom detection on zoomed browsers for the Posts block.

https://github.com/user-attachments/assets/25198fd6-1dfa-4a32-8e52-864d205de11a

## Code review notes

_N/A_

## QA notes

Steps for reproducing can be found in the related Linear ticket.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7687

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:STOMAIL-7687/fix-scroll-issue-for-posts-block)

_The latest successful build from `STOMAIL-7687/fix-scroll-issue-for-posts-block` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll-to-bottom detection in the Posts block for zoomed browsers to ensure content loads correctly at any zoom level.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->