### PR TITLE
Send monthly stats email between 9am and 3pm [mpi-171]

### DIFF
--- a/mailpoet/changelog/2026-01-05-13-15-05-improved-randomize-monthly-stats-email-send-time-to-reduce-.md
+++ b/mailpoet/changelog/2026-01-05-13-15-05-improved-randomize-monthly-stats-email-send-time-to-reduce-.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Randomize monthly stats email send time to reduce server load spikes

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -163,6 +163,12 @@ class AutomatedEmails extends SimpleWorker {
 
   public function getNextRunDate() {
     $date = Carbon::now()->millisecond(0);
-    return $date->endOfMonth()->next(Carbon::MONDAY)->midDay();
+    // Get first Monday of next month at 09:00
+    $nextMonday = $date->endOfMonth()->next(Carbon::MONDAY)->setTime(9, 0, 0);
+    // Add random time between 0 and 6 hours (09:00 to 14:59:59)
+    return $nextMonday
+      ->addHours(rand(0, 5))
+      ->addMinutes(rand(0, 59))
+      ->addSeconds(rand(0, 59));
   }
 }


### PR DESCRIPTION
## Description

The monthly sending stats are currently send once a month from all plugin instances at the same time. This PR will spread this a bit out.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

mpi-171

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:mpi-171-randomize-mailpoet-monthly-stats-send-window)

_The latest successful build from `mpi-171-randomize-mailpoet-monthly-stats-send-window` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * Monthly stats emails now send at a randomized time between 09:00–15:00 on the first Monday of each month to reduce server load spikes.

* **Documentation**
  * Changelog entry added describing the randomized scheduling change.

* **Tests**
  * Integration test added to verify the randomized scheduling produces valid first-Monday dates and varying send times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->