### PR TITLE
Send monthly stats through all the day, switch to WordPress timezone

### DIFF
--- a/mailpoet/changelog/2026-01-06-10-41-44-improved-send-monthly-stats-emails-throughout-the-day-using.md
+++ b/mailpoet/changelog/2026-01-06-10-41-44-improved-send-monthly-stats-emails-throughout-the-day-using.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Send monthly stats emails throughout the day using site timezone


### PR DESCRIPTION
## Description
It used to be that the monthly stats emails is send out at the first Monday of a month at 12:00. We switched to a bigger time window in #6452.

Now we decided to extend the time range in which we send the emails to the whole day. Additionally we switch to the WordPress timezone.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:mpi-171-randomize-mailpoet-monthly-stats-send-window)

_The latest successful build from `mpi-171-randomize-mailpoet-monthly-stats-send-window` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Monthly stats emails are now scheduled throughout the entire day using the site timezone, improving delivery distribution and randomness.
* **Tests**
  * Time-handling tests updated to reflect timezone-aware scheduling and the expanded full-day randomization window.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->