### PR TITLE
Add Bookings category to Automation Templates

### DIFF
--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -65,6 +65,7 @@ class Registry {
       'purchase' => new AutomationTemplateCategory('purchase', _x('Post-purchase', 'automation template category title', 'mailpoet')),
       'review' => new AutomationTemplateCategory('review', _x('Review', 'automation template category title', 'mailpoet')),
       'subscriptions' => new AutomationTemplateCategory('subscriptions', _x('Subscriptions', 'automation template category title', 'mailpoet')),
+      'bookings' => new AutomationTemplateCategory('bookings', _x('Bookings', 'automation template category title', 'mailpoet')),
     ];
   }
 


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7691-automation-bookings-category)

_The latest successful build from `stomail-7691-automation-bookings-category` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new bookings automation template category to enable booking-related automation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->