### PR TITLE
Add Automation Flow Embed for rendering in a iframe

### DIFF
--- a/mailpoet/assets/js/src/automation/flow-embed.tsx
+++ b/mailpoet/assets/js/src/automation/flow-embed.tsx
@@ -1,0 +1,97 @@
+/**
+ * Automation Flow Embed Entry Point
+ *
+ * This is a minimal entry point for rendering the automation flow diagram
+ * with statistics in an iframe.
+ */
+import { createRoot } from 'react-dom/client';
+import { dispatch, select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { registerTranslations } from 'common';
+import { initializeApi } from './api';
+import { initializeIntegrations } from './editor/integrations';
+import { createStore as editorStoreCreate } from './editor/store';
+import {
+  createStore as analyticsStoreCreate,
+  Section,
+  storeName as analyticsStoreName,
+} from './integrations/mailpoet/analytics/store';
+import { initializeApi as initializeAnalyticsApi } from './integrations/mailpoet/analytics/api';
+import { AutomationFlow } from './integrations/mailpoet/analytics/components/tabs/automation-flow';
+
+declare global {
+  interface Window {
+    mailpoet_automation_id?: number;
+    mailpoet_automation_api: {
+      root: string;
+      nonce: string;
+    };
+  }
+}
+
+function FlowEmbed(): JSX.Element {
+  const automationId = window.mailpoet_automation_id;
+
+  if (!automationId) {
+    return (
+      <div className="flow-embed-error">
+        {__('No automation specified', 'mailpoet')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mailpoet-automation-flow-embed">
+      <AutomationFlow />
+    </div>
+  );
+}
+
+function boot() {
+  initializeAnalyticsApi();
+  select(analyticsStoreName)
+    .getSections()
+    .forEach((section: Section) => {
+      void dispatch(analyticsStoreName).updateSection(section);
+    });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('mailpoet_automation_flow_embed');
+  if (!container) {
+    return;
+  }
+
+  registerTranslations();
+  initializeApi();
+  editorStoreCreate();
+  analyticsStoreCreate();
+  initializeIntegrations();
+  boot();
+
+  const root = createRoot(container);
+  root.render(<FlowEmbed />);
+
+  // Height communication for iframe embedding
+  if (window.parent !== window) {
+    let lastHeight = 0;
+
+    const sendHeightToParent = () => {
+      const height = document.body.scrollHeight;
+      if (height > 0 && height !== lastHeight) {
+        lastHeight = height;
+        window.parent.postMessage(
+          { type: 'mailpoet-flow-embed-height', height },
+          '*',
+        );
+      }
+    };
+
+    // Poll for height changes during initial load
+    const interval = setInterval(sendHeightToParent, 300);
+    setTimeout(() => clearInterval(interval), 5000);
+
+    // Also send on window load
+    window.addEventListener('load', sendHeightToParent);
+  }
+});

--- a/mailpoet/assets/js/src/automation/flow-embed.tsx
+++ b/mailpoet/assets/js/src/automation/flow-embed.tsx
@@ -87,9 +87,9 @@ window.addEventListener('DOMContentLoaded', () => {
       }
     };
 
-    // Poll for height changes during initial load
-    const interval = setInterval(sendHeightToParent, 300);
-    setTimeout(() => clearInterval(interval), 5000);
+    // Use ResizeObserver to detect height changes
+    const resizeObserver = new ResizeObserver(sendHeightToParent);
+    resizeObserver.observe(document.body);
 
     // Also send on window load
     window.addEventListener('load', sendHeightToParent);

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -74,6 +74,11 @@ class AssetsController {
     $this->wp->wpEnqueueStyle('mailpoet_automation_templates', $this->getCssUrl('mailpoet-automation-templates.css'));
   }
 
+  public function setupAutomationFlowEmbedDependencies(): void {
+    $this->enqueueJsEntrypoint('automation_flow_embed');
+    $this->wp->wpEnqueueStyle('mailpoet_automation_analytics', $this->getCssUrl('mailpoet-automation-analytics.css'));
+  }
+
   private function enqueueJsEntrypoint(string $asset, array $dependencies = []): void {
     $this->registerAdminDeps();
 

--- a/mailpoet/lib/AdminPages/Pages/AbstractAutomationEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AbstractAutomationEmbed.php
@@ -1,0 +1,203 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\AssetsController;
+use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Engine\Integration\Trigger;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Config\Renderer;
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptionsHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+abstract class AbstractAutomationEmbed {
+  protected AssetsController $assetsController;
+  protected Registry $registry;
+  protected Renderer $renderer;
+  protected TrackingConfig $trackingConfig;
+  protected WPFunctions $wp;
+  protected SubscribersFeature $subscribersFeature;
+  protected CapabilitiesManager $capabilitiesManager;
+  protected ServicesChecker $servicesChecker;
+  protected WooCommerceHelper $wooCommerceHelper;
+  protected WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper;
+  protected WooCommerceBookingsHelper $wooCommerceBookingsHelper;
+  protected SubjectTransformerHandler $subjectTransformerHandler;
+
+  public function __construct(
+    AssetsController $assetsController,
+    Registry $registry,
+    Renderer $renderer,
+    TrackingConfig $trackingConfig,
+    WPFunctions $wp,
+    SubscribersFeature $subscribersFeature,
+    CapabilitiesManager $capabilitiesManager,
+    ServicesChecker $servicesChecker,
+    WooCommerceHelper $wooCommerceHelper,
+    WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper,
+    WooCommerceBookingsHelper $wooCommerceBookingsHelper,
+    SubjectTransformerHandler $subjectTransformerHandler
+  ) {
+    $this->assetsController = $assetsController;
+    $this->registry = $registry;
+    $this->renderer = $renderer;
+    $this->trackingConfig = $trackingConfig;
+    $this->wp = $wp;
+    $this->subscribersFeature = $subscribersFeature;
+    $this->capabilitiesManager = $capabilitiesManager;
+    $this->servicesChecker = $servicesChecker;
+    $this->wooCommerceHelper = $wooCommerceHelper;
+    $this->wooCommerceSubscriptionsHelper = $wooCommerceSubscriptionsHelper;
+    $this->wooCommerceBookingsHelper = $wooCommerceBookingsHelper;
+    $this->subjectTransformerHandler = $subjectTransformerHandler;
+  }
+
+  abstract public function render(): void;
+
+  abstract protected function setupDependencies(): void;
+
+  abstract protected function getTemplateName(): string;
+
+  abstract protected function getCustomData(): array;
+
+  protected function renderEmbed(): void {
+    $this->disableAdminBarAndEmojis();
+    $this->setupDependencies();
+
+    $headContent = $this->captureHead();
+    $footerContent = $this->captureFooter();
+
+    $data = array_merge(
+      $this->getBaseData(),
+      $this->getCustomData(),
+      [
+        'head_content' => $headContent,
+        'footer_content' => $footerContent,
+      ]
+    );
+
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo $this->renderer->render($this->getTemplateName(), $data);
+    exit;
+  }
+
+  protected function disableAdminBarAndEmojis(): void {
+    // Disable admin bar for embed (intentional for iframe display)
+    // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+    add_filter('show_admin_bar', '__return_false');
+
+    // Disable WordPress emoji handling (prevents deprecation warning)
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('admin_print_styles', 'print_emoji_styles');
+  }
+
+  protected function captureHead(): string {
+    ob_start();
+    wp_head();
+    return (string)ob_get_clean();
+  }
+
+  protected function captureFooter(): string {
+    ob_start();
+    wp_footer();
+    return (string)ob_get_clean();
+  }
+
+  protected function getBaseData(): array {
+    return [
+      'locale' => $this->wp->getLocale(),
+      'api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
+      'registry' => $this->buildRegistry(),
+      'context' => $this->buildContext(),
+      'tracking_config' => $this->trackingConfig->getConfig(),
+      'has_valid_premium_key' => $this->subscribersFeature->hasValidPremiumKey(),
+      'subscribers_limit_reached' => $this->subscribersFeature->check(),
+      'premium_active' => $this->servicesChecker->isPremiumPluginActive(),
+      'capabilities' => $this->capabilitiesManager->getCapabilities(),
+      'woocommerce_active' => $this->wooCommerceHelper->isWooCommerceActive(),
+      'woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
+      'woocommerce_bookings_active' => $this->wooCommerceBookingsHelper->isWooCommerceBookingsActive(),
+    ];
+  }
+
+  protected function buildRegistry(): array {
+    $steps = [];
+    foreach ($this->registry->getSteps() as $key => $step) {
+      $steps[$key] = [
+        'key' => $step->getKey(),
+        'name' => $step->getName(),
+        'subject_keys' => $step instanceof Trigger ? $this->subjectTransformerHandler->getSubjectKeysForTrigger($step) : $step->getSubjectKeys(),
+        'args_schema' => $step->getArgsSchema()->toArray(),
+      ];
+    }
+
+    $subjects = [];
+    foreach ($this->registry->getSubjects() as $key => $subject) {
+      $subjectFields = $subject->getFields();
+      usort($subjectFields, function (Field $a, Field $b) {
+        return $a->getName() <=> $b->getName();
+      });
+
+      $subjects[$key] = [
+        'key' => $subject->getKey(),
+        'name' => $subject->getName(),
+        'args_schema' => $subject->getArgsSchema()->toArray(),
+        'field_keys' => array_map(function ($field) {
+          return $field->getKey();
+        }, $subjectFields),
+      ];
+    }
+
+    $fields = [];
+    foreach ($this->registry->getFields() as $key => $field) {
+      $fields[$key] = [
+        'key' => $field->getKey(),
+        'type' => $field->getType(),
+        'name' => $field->getName(),
+        'args' => $field->getArgs(),
+      ];
+    }
+
+    $filters = [];
+    foreach ($this->registry->getFilters() as $fieldType => $filter) {
+      $conditions = [];
+      foreach ($filter->getConditions() as $key => $label) {
+        $conditions[] = [
+          'key' => $key,
+          'label' => $label,
+        ];
+      }
+      $filters[$fieldType] = [
+        'field_type' => $filter->getFieldType(),
+        'conditions' => $conditions,
+      ];
+    }
+
+    return [
+      'steps' => $steps,
+      'subjects' => $subjects,
+      'fields' => $fields,
+      'filters' => $filters,
+    ];
+  }
+
+  protected function buildContext(): array {
+    $data = [];
+    foreach ($this->registry->getContextFactories() as $key => $factory) {
+      $data[$key] = $factory();
+    }
+    return $data;
+  }
+}

--- a/mailpoet/lib/AdminPages/Pages/AutomationFlowEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationFlowEmbed.php
@@ -4,8 +4,6 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\AssetsController;
 use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
-use MailPoet\Automation\Engine\Data\Field;
-use MailPoet\Automation\Engine\Integration\Trigger;
 use MailPoet\Automation\Engine\Mappers\AutomationMapper;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
@@ -19,19 +17,7 @@ use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper
 use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptionsHelper;
 use MailPoet\WP\Functions as WPFunctions;
 
-class AutomationFlowEmbed {
-  private AssetsController $assetsController;
-  private Registry $registry;
-  private Renderer $renderer;
-  private TrackingConfig $trackingConfig;
-  private WPFunctions $wp;
-  private SubscribersFeature $subscribersFeature;
-  private CapabilitiesManager $capabilitiesManager;
-  private ServicesChecker $servicesChecker;
-  private WooCommerceHelper $wooCommerceHelper;
-  private WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper;
-  private WooCommerceBookingsHelper $wooCommerceBookingsHelper;
-  private SubjectTransformerHandler $subjectTransformerHandler;
+class AutomationFlowEmbed extends AbstractAutomationEmbed {
   private AutomationStorage $automationStorage;
   private AutomationMapper $automationMapper;
 
@@ -51,146 +37,46 @@ class AutomationFlowEmbed {
     AutomationStorage $automationStorage,
     AutomationMapper $automationMapper
   ) {
-    $this->assetsController = $assetsController;
-    $this->registry = $registry;
-    $this->renderer = $renderer;
-    $this->trackingConfig = $trackingConfig;
-    $this->wp = $wp;
-    $this->subscribersFeature = $subscribersFeature;
-    $this->capabilitiesManager = $capabilitiesManager;
-    $this->servicesChecker = $servicesChecker;
-    $this->wooCommerceHelper = $wooCommerceHelper;
-    $this->wooCommerceSubscriptionsHelper = $wooCommerceSubscriptionsHelper;
-    $this->wooCommerceBookingsHelper = $wooCommerceBookingsHelper;
-    $this->subjectTransformerHandler = $subjectTransformerHandler;
+    parent::__construct(
+      $assetsController,
+      $registry,
+      $renderer,
+      $trackingConfig,
+      $wp,
+      $subscribersFeature,
+      $capabilitiesManager,
+      $servicesChecker,
+      $wooCommerceHelper,
+      $wooCommerceSubscriptionsHelper,
+      $wooCommerceBookingsHelper,
+      $subjectTransformerHandler
+    );
     $this->automationStorage = $automationStorage;
     $this->automationMapper = $automationMapper;
   }
 
   public function render(): void {
+    $this->renderEmbed();
+  }
+
+  protected function setupDependencies(): void {
+    $this->assetsController->setupAutomationFlowEmbedDependencies();
+  }
+
+  protected function getTemplateName(): string {
+    return 'automation/flow-embed.html';
+  }
+
+  protected function getCustomData(): array {
     // phpcs:ignore WordPress.Security.NonceVerification.Recommended
     $id = isset($_GET['id']) ? (int)$_GET['id'] : null;
 
-    // Disable admin bar for embed (intentional for iframe display)
-    // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
-    add_filter('show_admin_bar', '__return_false');
-
-    // Disable WordPress emoji handling (prevents deprecation warning)
-    remove_action('wp_head', 'print_emoji_detection_script', 7);
-    remove_action('wp_print_styles', 'print_emoji_styles');
-    remove_action('admin_print_scripts', 'print_emoji_detection_script');
-    remove_action('admin_print_styles', 'print_emoji_styles');
-
-    // Load flow embed dependencies
-    $this->assetsController->setupAutomationFlowEmbedDependencies();
-
-    ob_start();
-    wp_head();
-    $headContent = ob_get_clean();
-
-    // Capture wp_footer() output
-    ob_start();
-    wp_footer();
-    $footerContent = ob_get_clean();
-
-    // Get automation data
     $automation = $id ? $this->automationStorage->getAutomation($id) : null;
     $automationData = $automation ? $this->automationMapper->buildAutomation($automation) : null;
 
-    // Build template data
-    $data = [
-      'locale' => $this->wp->getLocale(),
+    return [
       'automation_id' => $id,
       'automation' => $automationData,
-      'api' => [
-        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
-        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
-      ],
-      'registry' => $this->buildRegistry(),
-      'context' => $this->buildContext(),
-      'tracking_config' => $this->trackingConfig->getConfig(),
-      'has_valid_premium_key' => $this->subscribersFeature->hasValidPremiumKey(),
-      'subscribers_limit_reached' => $this->subscribersFeature->check(),
-      'premium_active' => $this->servicesChecker->isPremiumPluginActive(),
-      'capabilities' => $this->capabilitiesManager->getCapabilities(),
-      'woocommerce_active' => $this->wooCommerceHelper->isWooCommerceActive(),
-      'woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
-      'woocommerce_bookings_active' => $this->wooCommerceBookingsHelper->isWooCommerceBookingsActive(),
-      'head_content' => $headContent,
-      'footer_content' => $footerContent,
     ];
-
-    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    echo $this->renderer->render('automation/flow-embed.html', $data);
-    exit;
-  }
-
-  private function buildRegistry(): array {
-    $steps = [];
-    foreach ($this->registry->getSteps() as $key => $step) {
-      $steps[$key] = [
-        'key' => $step->getKey(),
-        'name' => $step->getName(),
-        'subject_keys' => $step instanceof Trigger ? $this->subjectTransformerHandler->getSubjectKeysForTrigger($step) : $step->getSubjectKeys(),
-        'args_schema' => $step->getArgsSchema()->toArray(),
-      ];
-    }
-
-    $subjects = [];
-    foreach ($this->registry->getSubjects() as $key => $subject) {
-      $subjectFields = $subject->getFields();
-      usort($subjectFields, function (Field $a, Field $b) {
-        return $a->getName() <=> $b->getName();
-      });
-
-      $subjects[$key] = [
-        'key' => $subject->getKey(),
-        'name' => $subject->getName(),
-        'args_schema' => $subject->getArgsSchema()->toArray(),
-        'field_keys' => array_map(function ($field) {
-          return $field->getKey();
-        }, $subjectFields),
-      ];
-    }
-
-    $fields = [];
-    foreach ($this->registry->getFields() as $key => $field) {
-      $fields[$key] = [
-        'key' => $field->getKey(),
-        'type' => $field->getType(),
-        'name' => $field->getName(),
-        'args' => $field->getArgs(),
-      ];
-    }
-
-    $filters = [];
-    foreach ($this->registry->getFilters() as $fieldType => $filter) {
-      $conditions = [];
-      foreach ($filter->getConditions() as $key => $label) {
-        $conditions[] = [
-          'key' => $key,
-          'label' => $label,
-        ];
-      }
-      $filters[$fieldType] = [
-        'field_type' => $filter->getFieldType(),
-        'conditions' => $conditions,
-      ];
-    }
-
-    return [
-      'steps' => $steps,
-      'subjects' => $subjects,
-      'fields' => $fields,
-      'filters' => $filters,
-    ];
-  }
-
-  private function buildContext(): array {
-    $data = [];
-    foreach ($this->registry->getContextFactories() as $key => $factory) {
-      $data[$key] = $factory();
-    }
-    return $data;
   }
 }

--- a/mailpoet/lib/AdminPages/Pages/AutomationFlowEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationFlowEmbed.php
@@ -69,7 +69,9 @@ class AutomationFlowEmbed extends AbstractAutomationEmbed {
 
   protected function getCustomData(): array {
     // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-    $id = isset($_GET['id']) ? (int)$_GET['id'] : null;
+    $id = isset($_GET['id']) && is_numeric($_GET['id']) && (int)$_GET['id'] > 0
+      ? (int)$_GET['id']
+      : null;
 
     $automation = $id ? $this->automationStorage->getAutomation($id) : null;
     $automationData = $automation ? $this->automationMapper->buildAutomation($automation) : null;

--- a/mailpoet/lib/AdminPages/Pages/AutomationFlowEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationFlowEmbed.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\AssetsController;
+use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
+use MailPoet\Automation\Engine\Data\Field;
+use MailPoet\Automation\Engine\Integration\Trigger;
+use MailPoet\Automation\Engine\Mappers\AutomationMapper;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Config\Renderer;
+use MailPoet\Config\ServicesChecker;
+use MailPoet\Settings\TrackingConfig;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WooCommerce\Helper as WooCommerceHelper;
+use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
+use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptionsHelper;
+use MailPoet\WP\Functions as WPFunctions;
+
+class AutomationFlowEmbed {
+  private AssetsController $assetsController;
+  private Registry $registry;
+  private Renderer $renderer;
+  private TrackingConfig $trackingConfig;
+  private WPFunctions $wp;
+  private SubscribersFeature $subscribersFeature;
+  private CapabilitiesManager $capabilitiesManager;
+  private ServicesChecker $servicesChecker;
+  private WooCommerceHelper $wooCommerceHelper;
+  private WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper;
+  private WooCommerceBookingsHelper $wooCommerceBookingsHelper;
+  private SubjectTransformerHandler $subjectTransformerHandler;
+  private AutomationStorage $automationStorage;
+  private AutomationMapper $automationMapper;
+
+  public function __construct(
+    AssetsController $assetsController,
+    Registry $registry,
+    Renderer $renderer,
+    TrackingConfig $trackingConfig,
+    WPFunctions $wp,
+    SubscribersFeature $subscribersFeature,
+    CapabilitiesManager $capabilitiesManager,
+    ServicesChecker $servicesChecker,
+    WooCommerceHelper $wooCommerceHelper,
+    WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper,
+    WooCommerceBookingsHelper $wooCommerceBookingsHelper,
+    SubjectTransformerHandler $subjectTransformerHandler,
+    AutomationStorage $automationStorage,
+    AutomationMapper $automationMapper
+  ) {
+    $this->assetsController = $assetsController;
+    $this->registry = $registry;
+    $this->renderer = $renderer;
+    $this->trackingConfig = $trackingConfig;
+    $this->wp = $wp;
+    $this->subscribersFeature = $subscribersFeature;
+    $this->capabilitiesManager = $capabilitiesManager;
+    $this->servicesChecker = $servicesChecker;
+    $this->wooCommerceHelper = $wooCommerceHelper;
+    $this->wooCommerceSubscriptionsHelper = $wooCommerceSubscriptionsHelper;
+    $this->wooCommerceBookingsHelper = $wooCommerceBookingsHelper;
+    $this->subjectTransformerHandler = $subjectTransformerHandler;
+    $this->automationStorage = $automationStorage;
+    $this->automationMapper = $automationMapper;
+  }
+
+  public function render(): void {
+    // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $id = isset($_GET['id']) ? (int)$_GET['id'] : null;
+
+    // Disable admin bar for embed (intentional for iframe display)
+    // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+    add_filter('show_admin_bar', '__return_false');
+
+    // Disable WordPress emoji handling (prevents deprecation warning)
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('admin_print_styles', 'print_emoji_styles');
+
+    // Load flow embed dependencies
+    $this->assetsController->setupAutomationFlowEmbedDependencies();
+
+    ob_start();
+    wp_head();
+    $headContent = ob_get_clean();
+
+    // Capture wp_footer() output
+    ob_start();
+    wp_footer();
+    $footerContent = ob_get_clean();
+
+    // Get automation data
+    $automation = $id ? $this->automationStorage->getAutomation($id) : null;
+    $automationData = $automation ? $this->automationMapper->buildAutomation($automation) : null;
+
+    // Build template data
+    $data = [
+      'locale' => $this->wp->getLocale(),
+      'automation_id' => $id,
+      'automation' => $automationData,
+      'api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
+      'registry' => $this->buildRegistry(),
+      'context' => $this->buildContext(),
+      'tracking_config' => $this->trackingConfig->getConfig(),
+      'has_valid_premium_key' => $this->subscribersFeature->hasValidPremiumKey(),
+      'subscribers_limit_reached' => $this->subscribersFeature->check(),
+      'premium_active' => $this->servicesChecker->isPremiumPluginActive(),
+      'capabilities' => $this->capabilitiesManager->getCapabilities(),
+      'woocommerce_active' => $this->wooCommerceHelper->isWooCommerceActive(),
+      'woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
+      'woocommerce_bookings_active' => $this->wooCommerceBookingsHelper->isWooCommerceBookingsActive(),
+      'head_content' => $headContent,
+      'footer_content' => $footerContent,
+    ];
+
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo $this->renderer->render('automation/flow-embed.html', $data);
+    exit;
+  }
+
+  private function buildRegistry(): array {
+    $steps = [];
+    foreach ($this->registry->getSteps() as $key => $step) {
+      $steps[$key] = [
+        'key' => $step->getKey(),
+        'name' => $step->getName(),
+        'subject_keys' => $step instanceof Trigger ? $this->subjectTransformerHandler->getSubjectKeysForTrigger($step) : $step->getSubjectKeys(),
+        'args_schema' => $step->getArgsSchema()->toArray(),
+      ];
+    }
+
+    $subjects = [];
+    foreach ($this->registry->getSubjects() as $key => $subject) {
+      $subjectFields = $subject->getFields();
+      usort($subjectFields, function (Field $a, Field $b) {
+        return $a->getName() <=> $b->getName();
+      });
+
+      $subjects[$key] = [
+        'key' => $subject->getKey(),
+        'name' => $subject->getName(),
+        'args_schema' => $subject->getArgsSchema()->toArray(),
+        'field_keys' => array_map(function ($field) {
+          return $field->getKey();
+        }, $subjectFields),
+      ];
+    }
+
+    $fields = [];
+    foreach ($this->registry->getFields() as $key => $field) {
+      $fields[$key] = [
+        'key' => $field->getKey(),
+        'type' => $field->getType(),
+        'name' => $field->getName(),
+        'args' => $field->getArgs(),
+      ];
+    }
+
+    $filters = [];
+    foreach ($this->registry->getFilters() as $fieldType => $filter) {
+      $conditions = [];
+      foreach ($filter->getConditions() as $key => $label) {
+        $conditions[] = [
+          'key' => $key,
+          'label' => $label,
+        ];
+      }
+      $filters[$fieldType] = [
+        'field_type' => $filter->getFieldType(),
+        'conditions' => $conditions,
+      ];
+    }
+
+    return [
+      'steps' => $steps,
+      'subjects' => $subjects,
+      'fields' => $fields,
+      'filters' => $filters,
+    ];
+  }
+
+  private function buildContext(): array {
+    $data = [];
+    foreach ($this->registry->getContextFactories() as $key => $factory) {
+      $data[$key] = $factory();
+    }
+    return $data;
+  }
+}

--- a/mailpoet/lib/AdminPages/Pages/AutomationPreviewEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationPreviewEmbed.php
@@ -2,182 +2,25 @@
 
 namespace MailPoet\AdminPages\Pages;
 
-use MailPoet\AdminPages\AssetsController;
-use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
-use MailPoet\Automation\Engine\Data\Field;
-use MailPoet\Automation\Engine\Integration\Trigger;
-use MailPoet\Automation\Engine\Registry;
-use MailPoet\Config\Renderer;
-use MailPoet\Config\ServicesChecker;
-use MailPoet\Settings\TrackingConfig;
-use MailPoet\Util\License\Features\CapabilitiesManager;
-use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
-use MailPoet\WooCommerce\Helper as WooCommerceHelper;
-use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
-use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptionsHelper;
-use MailPoet\WP\Functions as WPFunctions;
-
-class AutomationPreviewEmbed {
-  private AssetsController $assetsController;
-  private Registry $registry;
-  private Renderer $renderer;
-  private TrackingConfig $trackingConfig;
-  private WPFunctions $wp;
-  private SubscribersFeature $subscribersFeature;
-  private CapabilitiesManager $capabilitiesManager;
-  private ServicesChecker $servicesChecker;
-  private WooCommerceHelper $wooCommerceHelper;
-  private WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper;
-  private WooCommerceBookingsHelper $wooCommerceBookingsHelper;
-  private SubjectTransformerHandler $subjectTransformerHandler;
-
-  public function __construct(
-    AssetsController $assetsController,
-    Registry $registry,
-    Renderer $renderer,
-    TrackingConfig $trackingConfig,
-    WPFunctions $wp,
-    SubscribersFeature $subscribersFeature,
-    CapabilitiesManager $capabilitiesManager,
-    ServicesChecker $servicesChecker,
-    WooCommerceHelper $wooCommerceHelper,
-    WooCommerceSubscriptionsHelper $wooCommerceSubscriptionsHelper,
-    WooCommerceBookingsHelper $wooCommerceBookingsHelper,
-    SubjectTransformerHandler $subjectTransformerHandler
-  ) {
-    $this->assetsController = $assetsController;
-    $this->registry = $registry;
-    $this->renderer = $renderer;
-    $this->trackingConfig = $trackingConfig;
-    $this->wp = $wp;
-    $this->subscribersFeature = $subscribersFeature;
-    $this->capabilitiesManager = $capabilitiesManager;
-    $this->servicesChecker = $servicesChecker;
-    $this->wooCommerceHelper = $wooCommerceHelper;
-    $this->wooCommerceSubscriptionsHelper = $wooCommerceSubscriptionsHelper;
-    $this->wooCommerceBookingsHelper = $wooCommerceBookingsHelper;
-    $this->subjectTransformerHandler = $subjectTransformerHandler;
+class AutomationPreviewEmbed extends AbstractAutomationEmbed {
+  public function render(): void {
+    $this->renderEmbed();
   }
 
-  public function render(): void {
+  protected function setupDependencies(): void {
+    $this->assetsController->setupAutomationPreviewEmbedDependencies();
+  }
+
+  protected function getTemplateName(): string {
+    return 'automation/preview-embed.html';
+  }
+
+  protected function getCustomData(): array {
     // phpcs:ignore WordPress.Security.NonceVerification.Recommended
     $templateSlug = isset($_GET['template']) ? sanitize_key(wp_unslash($_GET['template'])) : '';
 
-    // Disable admin bar for embed preview (intentional for iframe display)
-    // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
-    add_filter('show_admin_bar', '__return_false');
-
-    // Disable WordPress emoji handling (prevents deprecation warning)
-    remove_action('wp_head', 'print_emoji_detection_script', 7);
-    remove_action('wp_print_styles', 'print_emoji_styles');
-    remove_action('admin_print_scripts', 'print_emoji_detection_script');
-    remove_action('admin_print_styles', 'print_emoji_styles');
-
-    // Load preview embed dependencies (lighter setup without full admin bundle)
-    $this->assetsController->setupAutomationPreviewEmbedDependencies();
-
-    ob_start();
-    wp_head();
-    $headContent = ob_get_clean();
-
-    // Capture wp_footer() output
-    ob_start();
-    wp_footer();
-    $footerContent = ob_get_clean();
-
-    // Build template data
-    $data = [
-      'locale' => $this->wp->getLocale(),
-      'template_slug' => $templateSlug,
-      'api' => [
-        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
-        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
-      ],
-      'registry' => $this->buildRegistry(),
-      'context' => $this->buildContext(),
-      'tracking_config' => $this->trackingConfig->getConfig(),
-      'has_valid_premium_key' => $this->subscribersFeature->hasValidPremiumKey(),
-      'subscribers_limit_reached' => $this->subscribersFeature->check(),
-      'premium_active' => $this->servicesChecker->isPremiumPluginActive(),
-      'capabilities' => $this->capabilitiesManager->getCapabilities(),
-      'woocommerce_active' => $this->wooCommerceHelper->isWooCommerceActive(),
-      'woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
-      'woocommerce_bookings_active' => $this->wooCommerceBookingsHelper->isWooCommerceBookingsActive(),
-      'head_content' => $headContent,
-      'footer_content' => $footerContent,
-    ];
-
-    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    echo $this->renderer->render('automation/preview-embed.html', $data);
-    exit;
-  }
-
-  private function buildRegistry(): array {
-    $steps = [];
-    foreach ($this->registry->getSteps() as $key => $step) {
-      $steps[$key] = [
-        'key' => $step->getKey(),
-        'name' => $step->getName(),
-        'subject_keys' => $step instanceof Trigger ? $this->subjectTransformerHandler->getSubjectKeysForTrigger($step) : $step->getSubjectKeys(),
-        'args_schema' => $step->getArgsSchema()->toArray(),
-      ];
-    }
-
-    $subjects = [];
-    foreach ($this->registry->getSubjects() as $key => $subject) {
-      $subjectFields = $subject->getFields();
-      usort($subjectFields, function (Field $a, Field $b) {
-        return $a->getName() <=> $b->getName();
-      });
-
-      $subjects[$key] = [
-        'key' => $subject->getKey(),
-        'name' => $subject->getName(),
-        'args_schema' => $subject->getArgsSchema()->toArray(),
-        'field_keys' => array_map(function ($field) {
-          return $field->getKey();
-        }, $subjectFields),
-      ];
-    }
-
-    $fields = [];
-    foreach ($this->registry->getFields() as $key => $field) {
-      $fields[$key] = [
-        'key' => $field->getKey(),
-        'type' => $field->getType(),
-        'name' => $field->getName(),
-        'args' => $field->getArgs(),
-      ];
-    }
-
-    $filters = [];
-    foreach ($this->registry->getFilters() as $fieldType => $filter) {
-      $conditions = [];
-      foreach ($filter->getConditions() as $key => $label) {
-        $conditions[] = [
-          'key' => $key,
-          'label' => $label,
-        ];
-      }
-      $filters[$fieldType] = [
-        'field_type' => $filter->getFieldType(),
-        'conditions' => $conditions,
-      ];
-    }
-
     return [
-      'steps' => $steps,
-      'subjects' => $subjects,
-      'fields' => $fields,
-      'filters' => $filters,
+      'template_slug' => $templateSlug,
     ];
-  }
-
-  private function buildContext(): array {
-    $data = [];
-    foreach ($this->registry->getContextFactories() as $key => $factory) {
-      $data[$key] = $factory();
-    }
-    return $data;
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -37,6 +37,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\AutomationEditor::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\AutomationAnalytics::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\AutomationPreviewEmbed::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\AutomationFlowEmbed::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\DynamicSegments::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\ExperimentalFeatures::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\FormEditor::class)->setPublic(true);

--- a/mailpoet/views/automation/flow-embed.html
+++ b/mailpoet/views/automation/flow-embed.html
@@ -20,6 +20,17 @@
       text-align: center;
       color: #cc1818;
     }
+    /* Disable clickable links in embed mode */
+    #mailpoet_automation_flow_embed a {
+      pointer-events: none;
+      cursor: default;
+      text-decoration: none;
+      color: inherit;
+    }
+    /* Hide step more menu in embed mode */
+    .mailpoet-automation-step-more-menu {
+      display: none;
+    }
   </style>
   <script type="text/javascript">
     // Global config needed by admin bundle

--- a/mailpoet/views/automation/flow-embed.html
+++ b/mailpoet/views/automation/flow-embed.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="<%= locale %>">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Automation Flow</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: #fff;
+      font-size: 13px;
+    }
+    #mailpoet_automation_flow_embed {
+      background: #fff;
+      min-height: 100vh;
+    }
+    .flow-embed-error {
+      padding: 20px;
+      text-align: center;
+      color: #cc1818;
+    }
+  </style>
+  <script type="text/javascript">
+    // Global config needed by admin bundle
+    var mailpoet_tracking_config = <%= json_encode(tracking_config) %>;
+    // Premium-related variables needed for step type registration
+    var mailpoet_has_valid_premium_key = <%= json_encode(has_valid_premium_key) %>;
+    var mailpoet_subscribers_limit_reached = <%= json_encode(subscribers_limit_reached) %>;
+    var mailpoet_premium_active = <%= json_encode(premium_active) %>;
+    var mailpoet_capabilities = <%= json_encode(capabilities) %>;
+    // WooCommerce-related variables needed for WooCommerce step types
+    var mailpoet_woocommerce_active = <%= json_encode(woocommerce_active) %>;
+    var mailpoet_woocommerce_subscriptions_active = <%= json_encode(woocommerce_subscriptions_active) %>;
+    var mailpoet_woocommerce_bookings_active = <%= json_encode(woocommerce_bookings_active) %>;
+    // Flow embed-specific variables
+    var mailpoet_automation_id = <%= json_encode(automation_id) %>;
+    var mailpoet_automation_api = <%= json_encode(api) %>;
+    var mailpoet_automation_registry = <%= json_encode(registry) %>;
+    var mailpoet_automation_context = <%= json_encode(context) %>;
+    var mailpoet_automation = <%= json_encode(automation) %>;
+  </script>
+  <%= head_content | raw %>
+</head>
+<body>
+  <div id="mailpoet_automation_flow_embed"></div>
+  <%= footer_content | raw %>
+</body>
+</html>

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -240,6 +240,7 @@ const adminConfig = {
       'automation/integrations/mailpoet/analytics/index.tsx',
     automation_templates: 'automation/templates/index.tsx',
     automation_preview_embed: 'automation/preview-embed.tsx',
+    automation_flow_embed: 'automation/flow-embed.tsx',
     newsletter_editor: 'newsletter-editor/webpack-index.jsx',
     form_editor: 'form-editor/form-editor.jsx',
     settings: 'settings/index.tsx',


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Related STOMAIL-7564

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7564)

_The latest successful build from `stomail-7564` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation Flow Embed: view automation flow diagrams inside embedded iframes with responsive height syncing to the parent frame
  * New hidden admin embed page for direct access to flow embeds with appropriate assets and translations
  * Embedded context now provides automation data, analytics, editor/store integrations and runtime configuration for richer in-embed experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->