### PR TITLE
Fetch total recipients count in the email editor from the API

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -49,6 +49,11 @@
     color: $gray-700;
     font-size: $font-size-small;
   }
+
+  &__recipients-total-count &__recipients-loader {
+    margin: 0;
+    vertical-align: middle;
+  }
 }
 
 .mailpoet-content-settings-panel {

--- a/mailpoet/changelog/2026-01-12-13-27-35-fixed-fix-the-total-recipients-count-in-the-email-editor.md
+++ b/mailpoet/changelog/2026-01-12-13-27-35-fixed-fix-the-total-recipients-count-in-the-email-editor.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix the total recipients count in the email editor


### PR DESCRIPTION
## Description

Fixes an issue in the email editor where **Total Recipients** shows all subscribers (including Unsubscribed/Unconfirmed) and can overcount due to duplicates.

Now uses the segments admin AJAX `subscriberCount` endpoint to return an accurate, de-duplicated count of **subscribed** recipients only.

#### Screenshot:
<img width="598" height="723" alt="Qjr9MMhAOruKgywb" src="https://github.com/user-attachments/assets/b56f4cfb-e720-4905-8de6-41026d12a271" />

## Code review notes

_N/A_

## QA notes

* Create a new email using the email editor from MailPoet → Emails → Add new email → **Create using the new email editor (Alpha)**.
* Open the **Recipients** dropdown from the sidebar and select lists/segments with mixed subscriber statuses.
* Verify **Total recipients** matches actual send count.
* Save the email and navigate to the `Review & schedule` to verify the `Estimated recipients:` count is matching.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7685: In new block-based email editor, "total recipients" count shows all statuses](https://linear.app/a8c/issue/STOMAIL-7685/in-new-block-based-email-editor-total-recipients-count-shows-all)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7685-in-new-block-based-email-editor-total-recipients-count-shows)

_The latest successful build from `stomail-7685-in-new-block-based-email-editor-total-recipients-count-shows` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed total recipients count in the email editor — count now updates dynamically for selected segments and displays a loading spinner while fetching.

* **Style**
  * Adjusted recipient loader alignment so the loading indicator displays correctly next to the total count.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->