### PR TITLE
Move built in captcha to the subscription form

### DIFF
--- a/mailpoet/assets/css/src/components-public/captcha.scss
+++ b/mailpoet/assets/css/src/components-public/captcha.scss
@@ -11,6 +11,52 @@
   }
 }
 
+// Inline captcha displayed within MailPoet forms
+.mailpoet_captcha_container {
+  margin-bottom: 20px;
+
+  .mailpoet_captcha {
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  .mailpoet_icon_button {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    padding: 5px;
+    vertical-align: middle;
+
+    img {
+      height: 20px;
+      width: 20px;
+    }
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
+  .mailpoet_captcha_player {
+    display: none;
+  }
+
+  .mailpoet_captcha_label {
+    display: block;
+    margin-top: 10px;
+
+    .mailpoet_text_label {
+      display: block;
+      margin-bottom: 5px;
+    }
+
+    .mailpoet_text {
+      max-width: 220px;
+      width: 100%;
+    }
+  }
+}
+
 // WP registration form
 form#registerform .g-recaptcha:not([data-size='invisible']) {
   scale: 0.9;

--- a/mailpoet/assets/css/src/components-public/captcha.scss
+++ b/mailpoet/assets/css/src/components-public/captcha.scss
@@ -13,11 +13,17 @@
 
 // Inline captcha displayed within MailPoet forms
 .mailpoet_captcha_container {
-  margin-bottom: 20px;
+  margin: 0 auto 20px;
+  max-width: 300px;
+  text-align: center;
+
+  .mailpoet_captcha_image_wrapper {
+    margin-bottom: 10px;
+  }
 
   .mailpoet_captcha {
     display: block;
-    margin-bottom: 10px;
+    margin: 0 auto;
   }
 
   .mailpoet_icon_button {
@@ -44,6 +50,7 @@
   .mailpoet_captcha_label {
     display: block;
     margin-top: 10px;
+    text-align: left;
 
     .mailpoet_text_label {
       display: block;
@@ -55,6 +62,15 @@
       width: 100%;
     }
   }
+
+  .mailpoet_captcha_submit {
+    margin-top: 15px;
+  }
+}
+
+// Elements hidden by JavaScript when captcha is active
+.mailpoet_captcha_hidden {
+  display: none !important;
 }
 
 // WP registration form

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -173,6 +173,11 @@ interface Window {
   MailPoetForm?: {
     ajax_url: string;
     ajax_common_error_message: string;
+    is_rtl?: boolean;
+    captcha_input_label?: string;
+    captcha_reload_title?: string;
+    captcha_audio_title?: string;
+    assets_url?: string;
   };
   mailpoet_authorized_emails?: string[];
   mailpoet_verified_sender_domains?: string[];

--- a/mailpoet/changelog/2026-01-13-16-48-56-improved-built-in-captcha-now-appears-inline-within-subscri.md
+++ b/mailpoet/changelog/2026-01-13-16-48-56-improved-built-in-captcha-now-appears-inline-within-subscri.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Built-in captcha now appears inline within subscription forms

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -96,6 +96,10 @@ class AssetsController {
       'ajax_url' => $this->wp->adminUrl('admin-ajax.php'),
       'is_rtl' => (function_exists('is_rtl') ? (bool)is_rtl() : false),
       'ajax_common_error_message' => esc_js($ajaxFailedErrorMessage),
+      'captcha_input_label' => esc_js(__('Type in the characters you see in the picture above:', 'mailpoet')),
+      'captcha_reload_title' => esc_js(__('Reload CAPTCHA', 'mailpoet')),
+      'captcha_audio_title' => esc_js(__('Play CAPTCHA', 'mailpoet')),
+      'assets_url' => Env::$assetsUrl,
     ]);
   }
 

--- a/mailpoet/tests/acceptance/Settings/CaptchaSubscriptionCest.php
+++ b/mailpoet/tests/acceptance/Settings/CaptchaSubscriptionCest.php
@@ -63,6 +63,7 @@ class CaptchaSubscriptionCest {
     $i->seeElement('.mailpoet_captcha_container input[name="data[captcha]"]');
     $i->seeElement('.mailpoet_captcha_container .mailpoet_captcha_update');
     $i->seeElement('.mailpoet_captcha_container .mailpoet_captcha_audio');
+    $i->seeElement('.mailpoet_captcha_container .mailpoet_captcha_submit');
     $i->see('Please fill in the CAPTCHA', '.mailpoet_validate_error');
     $i->seeNoJSErrors();
   }
@@ -94,9 +95,9 @@ class CaptchaSubscriptionCest {
     $i->click('.mailpoet_submit');
     $i->waitForElement('.mailpoet_captcha_container', 10);
 
-    // Enter wrong captcha
+    // Enter wrong captcha and submit using the button inside captcha container
     $i->fillField('.mailpoet_captcha_container input[name="data[captcha]"]', 'wrongcode');
-    $i->click('.mailpoet_submit');
+    $i->click('.mailpoet_captcha_container .mailpoet_captcha_submit input[type="submit"], .mailpoet_captcha_container .mailpoet_captcha_submit button[type="submit"]');
     $i->waitForText('The characters entered do not match with the previous CAPTCHA.', 10, '.mailpoet_validate_error');
     $i->seeNoJSErrors();
   }

--- a/mailpoet/tests/integration/Captcha/Validator/CaptchaValidatorTest.php
+++ b/mailpoet/tests/integration/Captcha/Validator/CaptchaValidatorTest.php
@@ -42,6 +42,8 @@ class CaptchaValidatorTest extends \MailPoetTest {
   }
 
   public function testWrongCaptchaThrowsError() {
+    $this->diContainer->get(Populator::class)->up();
+
     $sessionId = '123';
     $this->session->setCaptchaHash($sessionId, ['phrase' => 'abc']);
     try {
@@ -49,6 +51,7 @@ class CaptchaValidatorTest extends \MailPoetTest {
     } catch (ValidationError $error) {
       $meta = $error->getMeta();
       $this->assertEquals('The characters entered do not match with the previous CAPTCHA.', $meta['error']);
+      $this->assertTrue(array_key_exists('redirect_url', $meta));
     }
   }
 

--- a/mailpoet/tests/unit/Captcha/Validator/CaptchaValidatorTest.php
+++ b/mailpoet/tests/unit/Captcha/Validator/CaptchaValidatorTest.php
@@ -207,7 +207,9 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
     $captchaController = Stub::make(
       CaptchaUrlFactory::class,
       [
-        'getCaptchaUrl' => $newUrl,
+        'getCaptchaUrlForMPForm' => $newUrl,
+        'getCaptchaImageUrl' => 'https://example.com/image',
+        'getCaptchaAudioUrl' => 'https://example.com/audio',
       ],
       $this
     );
@@ -216,6 +218,7 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       CaptchaPhrase::class,
       [
         'getPhrase' => null,
+        'createPhrase' => 'new_phrase',
       ],
       $this
     );
@@ -249,7 +252,14 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
 
   public function testCaptchaMissmatch() {
     $phrase = 'abc';
-    $urlFactory = Stub::makeEmpty(CaptchaUrlFactory::class);
+    $redirectUrl = 'https://example.com/captcha';
+    $urlFactory = Stub::make(
+      CaptchaUrlFactory::class,
+      [
+        'getCaptchaUrlForMPForm' => $redirectUrl,
+      ],
+      $this
+    );
     $captchaPhrase = Stub::make(
       CaptchaPhrase::class,
       [
@@ -280,6 +290,7 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
     } catch (ValidationError $error) {
       verify($error->getMessage())->equals('The characters entered do not match with the previous CAPTCHA.');
       verify($error->getMeta()['refresh_captcha'])->true();
+      verify($error->getMeta()['redirect_url'])->equals($redirectUrl);
     }
 
     verify($error)->instanceOf(ValidationError::class);
@@ -291,7 +302,9 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
     $captchaController = Stub::make(
       CaptchaUrlFactory::class,
       [
-        'getCaptchaUrl' => $newUrl,
+        'getCaptchaUrlForMPForm' => $newUrl,
+        'getCaptchaImageUrl' => 'https://example.com/image',
+        'getCaptchaAudioUrl' => 'https://example.com/audio',
       ],
       $this
     );
@@ -300,6 +313,7 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       CaptchaPhrase::class,
       [
         'getPhrase' => $phrase,
+        'createPhrase' => 'new_phrase',
       ],
       $this
     );


### PR DESCRIPTION
## Description

  Show the built-in captcha inline within subscription forms instead of redirecting users to a separate captcha page. This improves UX by keeping users on the same page and maintaining visual consistency with the site's design.

  **Changes:**
  - Backend (`CaptchaValidator.php`): Return inline captcha data (`show_captcha`, `captcha_session_id`, `captcha_image_url`, `captcha_audio_url`) instead of just `redirect_url`
  - Frontend (`public.tsx`): Add `showInlineCaptcha()` function to inject captcha HTML into the form, with refresh and audio playback support
  - Frontend (`AssetsController.php`): Pass captcha labels and assets URL to JavaScript
  - CSS: Add styles for inline captcha container

  The redirect to the captcha page is kept as a fallback for non-JavaScript form submissions.

 ## Code review notes

  - The error handling flow in `public.tsx` now checks `show_captcha` first (initial captcha display), then `refresh_captcha` (wrong code), then `redirect_url` (non-JS fallback)
  - Captcha phrase is created before returning URLs to ensure the image/audio are ready

 ## QA notes

  1. Enable built-in captcha in MailPoet Settings → Advanced → CAPTCHA
  2. Create a form and add it to a page
  3. Submit the form with an email that triggers captcha (e.g., one that already subscribed)
  4. Verify captcha appears inline within the form
  5. Test refresh button - captcha image should change
  6. Test audio button - should play audio captcha
  7. Test wrong captcha - should show error and refresh image
  8. Test with JavaScript disabled - should redirect to captcha page (fallback)
  9. Test as logged-in admin/editor - captcha should be bypassed

  ## Linked PRs

  _N/A_

  ## Linked tickets

  STOMAIL-7677, closes #3081

  ## After-merge notes

  _N/A_

  ## Tasks

  - [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
  - [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
  - [x] I added sufficient test coverage
  - [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7677-move-built-in-captcha-to-the-subscription-form)

_The latest successful build from `stomail-7677-move-built-in-captcha-to-the-subscription-form` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * Built-in CAPTCHA now appears inline within subscription forms with image, audio, refresh controls, inline error display, focus behavior, and smoother JS-enabled submission flows.
* **New Features**
  * Added frontend styling, localized labels/titles, RTL support and asset URL for inline CAPTCHA.
  * Backend now returns structured inline CAPTCHA payloads to support in-form rendering, refresh and redirect metadata.
* **Tests**
  * Acceptance, integration and unit tests updated to cover inline display, refresh, errors and redirect behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->