### PR TITLE
Add more information to key check error logging

### DIFF
--- a/mailpoet/changelog/2026-01-14-10-02-45-improved-more-information-logged-when-key-validation-fails.md
+++ b/mailpoet/changelog/2026-01-14-10-02-45-improved-more-information-logged-when-key-validation-fails.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+More information logged when key validation fails

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -93,11 +93,19 @@ class Services extends APIEndpoint {
 
   public function checkMSSKey($data = []) {
     $key = isset($data['key']) ? trim($data['key']) : null;
+    $meta = [
+      'key' => $key,
+      'home_url' => $this->wp->homeUrl(),
+      'site_url' => $this->wp->siteUrl(),
+    ];
 
     if (!$key) {
-      return $this->badRequest([
-        APIError::BAD_REQUEST => __('Please specify a key.', 'mailpoet'),
-      ]);
+      return $this->badRequest(
+        [
+          APIError::BAD_REQUEST => __('Please specify a key.', 'mailpoet'),
+        ],
+        $meta
+      );
     }
 
     $wasPendingApproval = $this->servicesChecker->isMailPoetAPIKeyPendingApproval();
@@ -106,9 +114,12 @@ class Services extends APIEndpoint {
       $result = $this->bridge->checkMSSKey($key);
       $this->bridge->storeMSSKeyAndState($key, $result);
     } catch (\Exception $e) {
-      return $this->errorResponse([
-        $e->getCode() => $e->getMessage(),
-      ]);
+      return $this->errorResponse(
+        [
+          $e->getCode() => $e->getMessage(),
+        ],
+        $meta
+      );
     }
 
     // pause sending when key is pending approval, resume when not pending anymore
@@ -164,25 +175,39 @@ class Services extends APIEndpoint {
         break;
     }
 
-    return $this->errorResponse([APIError::BAD_REQUEST => $error]);
+    return $this->errorResponse(
+      [APIError::BAD_REQUEST => $error],
+      $meta
+    );
   }
 
   public function checkPremiumKey($data = []) {
     $key = isset($data['key']) ? trim($data['key']) : null;
+    $meta = [
+      'key' => $key,
+      'home_url' => $this->wp->homeUrl(),
+      'site_url' => $this->wp->siteUrl(),
+    ];
 
     if (!$key) {
-      return $this->badRequest([
-        APIError::BAD_REQUEST => __('Please specify a key.', 'mailpoet'),
-      ]);
+      return $this->badRequest(
+        [
+          APIError::BAD_REQUEST => __('Please specify a key.', 'mailpoet'),
+        ],
+        $meta
+      );
     }
 
     try {
       $result = $this->bridge->checkPremiumKey($key);
       $this->bridge->storePremiumKeyAndState($key, $result);
     } catch (\Exception $e) {
-      return $this->errorResponse([
-        $e->getCode() => $e->getMessage(),
-      ]);
+      return $this->errorResponse(
+        [
+          $e->getCode() => $e->getMessage(),
+        ],
+        $meta
+      );
     }
 
     $state = !empty($result['state']) ? $result['state'] : null;
@@ -229,8 +254,13 @@ class Services extends APIEndpoint {
     }
 
     return $this->errorResponse(
-      [APIError::BAD_REQUEST => $error],
-      ['code' => $result['code'] ?? null]
+      [
+        APIError::BAD_REQUEST => $error,
+      ],
+      array_merge(
+        $meta,
+        ['code' => $result['code'] ?? null]
+      )
     );
   }
 

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -93,18 +93,13 @@ class Services extends APIEndpoint {
 
   public function checkMSSKey($data = []) {
     $key = isset($data['key']) ? trim($data['key']) : null;
-    $meta = [
-      'key' => $key,
-      'home_url' => $this->wp->homeUrl(),
-      'site_url' => $this->wp->siteUrl(),
-    ];
 
     if (!$key) {
       return $this->badRequest(
         [
           APIError::BAD_REQUEST => __('Please specify a key.', 'mailpoet'),
         ],
-        $meta
+        $this->getMetaForLogging($key)
       );
     }
 
@@ -118,7 +113,7 @@ class Services extends APIEndpoint {
         [
           $e->getCode() => $e->getMessage(),
         ],
-        $meta
+        $this->getMetaForLogging($key)
       );
     }
 
@@ -177,24 +172,19 @@ class Services extends APIEndpoint {
 
     return $this->errorResponse(
       [APIError::BAD_REQUEST => $error],
-      $meta
+      $this->getMetaForLogging($key)
     );
   }
 
   public function checkPremiumKey($data = []) {
     $key = isset($data['key']) ? trim($data['key']) : null;
-    $meta = [
-      'key' => $key,
-      'home_url' => $this->wp->homeUrl(),
-      'site_url' => $this->wp->siteUrl(),
-    ];
 
     if (!$key) {
       return $this->badRequest(
         [
           APIError::BAD_REQUEST => __('Please specify a key.', 'mailpoet'),
         ],
-        $meta
+        $this->getMetaForLogging($key)
       );
     }
 
@@ -206,7 +196,7 @@ class Services extends APIEndpoint {
         [
           $e->getCode() => $e->getMessage(),
         ],
-        $meta
+        $this->getMetaForLogging($key)
       );
     }
 
@@ -258,10 +248,19 @@ class Services extends APIEndpoint {
         APIError::BAD_REQUEST => $error,
       ],
       array_merge(
-        $meta,
+        $this->getMetaForLogging($key),
         ['code' => $result['code'] ?? null]
       )
     );
+  }
+
+  private function getMetaForLogging(?string $key): array {
+    $obfuscatedKey = $key ? substr($key, 0, 4) . str_repeat('*', strlen($key) - 8) . substr($key, -4) : '';
+    return [
+      'key' => $obfuscatedKey,
+      'home_url' => $this->wp->homeUrl(),
+      'site_url' => $this->wp->siteUrl(),
+    ];
   }
 
   public function recheckKeys() {

--- a/mailpoet/lib/API/JSON/v1/Services.php
+++ b/mailpoet/lib/API/JSON/v1/Services.php
@@ -255,7 +255,7 @@ class Services extends APIEndpoint {
   }
 
   private function getMetaForLogging(?string $key): array {
-    $obfuscatedKey = $key ? substr($key, 0, 4) . str_repeat('*', strlen($key) - 8) . substr($key, -4) : '';
+    $obfuscatedKey = $key ? substr($key, 0, 4) . "..." . substr($key, -4) : '';
     return [
       'key' => $obfuscatedKey,
       'home_url' => $this->wp->homeUrl(),


### PR DESCRIPTION
## Description

Improves debugging of key validation errors by adding more info to the logs

[Related:](https://a8c.slack.com/archives/C0313FPUG74/p1768379060949709?thread_ts=1768374157.489289&cid=C0313FPUG74)
> Shame we don’t log the site we use for the validation 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add-more-logging-info)

_The latest successful build from `add-more-logging-info` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved**
  * Error handling and logging for key validation failures now record sanitized key details plus site context, giving clearer diagnostic information while keeping sensitive data obfuscated.

* **Documentation**
  * Added a changelog entry documenting the improved logging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->