### PR TITLE
Fix /dev/shm/ permission issue in local acceptance tests docker config

### DIFF
--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -133,7 +133,7 @@ services:
     environment:
       - DBUS_SESSION_BUS_ADDRESS=/dev/null
     tmpfs:
-      - /dev/shm
+      - /dev/shm:rw,nosuid,nodev,exec,size=2g,mode=1777
     image: selenium/standalone-chrome:107.0-20221104
     ports:
       - 4444

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -91,7 +91,8 @@ services:
       - ../../mailpoet-premium:/project/mailpoet-premium
       - ../../mailpoet-premium:/var/www/html/wp-content/plugins/mailpoet-premium
     tmpfs:
-      - /var/www/html/wp-content/uploads/mailpoet/
+      - /var/www/html/wp-content/uploads/mailpoet/:rw,nosuid,nodev,noexec,mode=1777
+      - /var/www/html/wp-content/languages/plugins/:rw,nosuid,nodev,noexec,mode=1777
     environment:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_USER: wordpress


### PR DESCRIPTION
## Description

This PR fixes error:
```
Creating shared memory in /dev/shm/.org.chromium.Chromium.FhlueH failed: Permission denied (13)
Unable to access(W_OK|X_OK) /dev/shm: Permission denied (13)
```

## Code review notes

Verify you can run the acceptance tests locally. You may need to reset docker containers for tests. `./do reset:test-docker`
## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix-acceptance-tests-locally)

_The latest successful build from `fix-acceptance-tests-locally` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment Docker configuration to enhance Chrome service resource management with improved mount permissions and memory allocation settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->