### PR TITLE
Exclude guest orders from registered customers sync query

### DIFF
--- a/mailpoet/changelog/2026-01-21-09-11-32-fixed-exclude-guest-orders-from-registered-customers-syn.md
+++ b/mailpoet/changelog/2026-01-21-09-11-32-fixed-exclude-guest-orders-from-registered-customers-syn.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Exclude guest orders from registered customers sync query

--- a/mailpoet/lib/Segments/WooCommerce.php
+++ b/mailpoet/lib/Segments/WooCommerce.php
@@ -518,12 +518,14 @@ class WooCommerce {
     // Registered users with orders
     if ($this->woocommerceHelper->isWooCommerceCustomOrdersTableEnabled()) {
       $ordersTable = $this->woocommerceHelper->getOrdersTableName();
-      $registeredCustomersSubQuery = "SELECT DISTINCT customer_id AS id FROM `{$ordersTable}` WHERE type = 'shop_order'";
+      // Exclude guest orders (customer_id = 0) as they are not registered users
+      $registeredCustomersSubQuery = "SELECT DISTINCT customer_id AS id FROM `{$ordersTable}` WHERE type = 'shop_order' AND customer_id > 0";
     } else {
+      // Exclude guest orders (meta_value = 0 or empty) as they are not registered users
       $registeredCustomersSubQuery = "SELECT DISTINCT wppm.meta_value AS id FROM {$wpdb->postmeta} wppm
         JOIN {$wpdb->posts} wpp ON wppm.post_id = wpp.ID
         AND wpp.post_type = 'shop_order'
-        WHERE wppm.meta_key = '_customer_user'";
+        WHERE wppm.meta_key = '_customer_user' AND wppm.meta_value > 0";
     }
 
     $this->connection->executeQuery("


### PR DESCRIPTION
## Description

Fixes "Duplicate entry '0' for key 'PRIMARY'" error during WooCommerceSync cron job.

When a WooCommerce store has guest checkout orders with a mix of `customer_id = NULL` and `customer_id = 0` in the `wc_orders` table, the sync creates a temporary table with a `NOT NULL` constraint. MySQL converts NULL values to 0, resulting in a duplicate-key conflict with existing 0 values.

The fix adds `AND customer_id > 0` to exclude guest orders from the registered customers query in both HPOS and legacy postmeta paths. This is correct because guest orders don't correspond to registered WordPress users.

## Code review notes

_N/A_

## QA notes

1. On a site with WooCommerce and guest checkout enabled, verify WooCommerceSync cron runs without errors
2. Verify registered customers with orders are still synced to the WooCommerce Customers segment

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7750

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Guest orders are now excluded from the registered-customer synchronization for WooCommerce segments, improving segment accuracy and avoiding incorrect subscriber classification.

* **Tests**
  * Added integration tests to verify synchronization behavior with mixed guest and registered orders, ensuring correct inclusion of registered customers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7750-woocommercesync-fails-with-duplicate-entry-0-for-key-primary)

_The latest successful build from `stomail-7750-woocommercesync-fails-with-duplicate-entry-0-for-key-primary` will be used. If none is available, the link won't work._