### PR TITLE
Fix fatal error getSibling in pQuery

### DIFF
--- a/mailpoet/lib-3rd-party/pquery/gan_node_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_node_html.php
@@ -753,6 +753,9 @@ class DomNode implements IQuery {
 	 * @return DomNode Null if not found
 	 */
 	function getSibling($offset = 1) {
+		if (!$this->parent) {
+			return null;
+		}
 		$index = $this->index() + $offset;
 		if (($index >= 0) && ($index < $this->parent->childCount())) {
 			return $this->parent->getChild($index);

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -220,4 +220,22 @@ class TextTest extends \MailPoetUnitTest {
     $output = (new Text())->render($this->block);
     verify($output)->stringContainsString('<a href="https://example.com">Link</a>');
   }
+
+  public function testGetSiblingReturnsNullForRemovedNode(): void {
+    $html = '<p>First</p><p>Second</p>';
+    $dom = $this->parser->parseStr($html);
+    $paragraphs = $dom->query('p');
+    $this->assertInstanceOf(pQuery::class, $paragraphs);
+    $firstParagraph = $paragraphs[0];
+    $this->assertInstanceOf(DomNode::class, $firstParagraph);
+
+    // Remove the node (this sets parent to null)
+    $firstParagraph->remove();
+
+    // Without the fix in gan_node_html.php, this would crash:
+    // "Call to a member function childCount() on null"
+    $result = $firstParagraph->getNextSibling();
+
+    verify($result)->null();
+  }
 }


### PR DESCRIPTION
## Description

I found this in Grafana quite a few times:

```
PHP Fatal error:  Uncaught Error: Call to a member function childCount() on null in /wordpress/plugins/mailpoet/5.18.0/lib-3rd-party/pquery/gan_node_html.php:760
Stack trace:
#0 /wordpress/plugins/mailpoet/5.18.0/lib-3rd-party/pquery/gan_node_html.php(776): MailPoetVendor\pQuery\DomNode->getSibling(1)
#1 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Blocks/Text.php(85): MailPoetVendor\pQuery\DomNode->getNextSibling()
#2 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Blocks/Text.php(20): MailPoet\Newsletter\Renderer\Blocks\Text->convertParagraphsToTables('<h3><span>Hva e...')
#3 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Blocks/Renderer.php(136): MailPoet\Newsletter\Renderer\Blocks\Text->render(Array)
#4 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Blocks/Renderer.php(98): MailPoet\Newsletter\Renderer\Blocks\Renderer->createElementFromBlockType(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Array, 330)
#5 [internal function]: MailPoet\Newsletter\Renderer\Blocks\Renderer->MailPoet\Newsletter\Renderer\Blocks\{closure}(Array)
#6 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Blocks/Renderer.php(97): array_map(Object(Closure), Array)
#7 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Blocks/Renderer.php(87): MailPoet\Newsletter\Renderer\Blocks\Renderer->renderBlocksInColumn(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Array, 330)
#8 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/BodyRenderer.php(37): MailPoet\Newsletter\Renderer\Blocks\Renderer->render(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Array)
#9 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Renderer.php(142): MailPoet\Newsletter\Renderer\BodyRenderer->renderBody(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Array)
#10 /wordpress/plugins/mailpoet/5.18.0/lib/Newsletter/Renderer/Renderer.php(75): MailPoet\Newsletter\Renderer\Renderer->_render(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Object(MailPoetntities\SendingQueueEntity), false)
#11 /wordpress/plugins/mailpoet/5.18.0/lib/Cron/Workers/SendingQueue/Tasks/Newsletter.php(183): MailPoet\Newsletter\Renderer\Renderer->render(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Object(MailPoetntities\SendingQueueEntity))
#12 /wordpress/plugins/mailpoet/5.18.0/lib/Cron/Workers/SendingQueue/SendingQueue.php(188): MailPoet\Cron\Workers\SendingQueue\Tasks\Newsletter->preProcessNewsletter(Object(MailPoetDoctrineProxies\__CG__\MailPoetntities\NewsletterEntity), Object(MailPoetntities\ScheduledTaskEntity))
#13 /wordpress/plugins/mailpoet/5.18.0/lib/Cron/Workers/SendingQueue/SendingQueue.php(161): MailPoet\Cron\Workers\SendingQueue\SendingQueue->processSending(Object(MailPoetntities\ScheduledTaskEntity), 1768999161)
#14 /wordpress/plugins/mailpoet/5.18.0/lib/Cron/Daemon.php(65): MailPoet\Cron\Workers\SendingQueue\SendingQueue->process(1768999161.9973)
#15 /wordpress/plugins/mailpoet/5.18.0/lib/Cron/DaemonHttpRunner.php(85): MailPoet\Cron\Daemon->run(Array)
#16 /wordpress/plugins/mailpoet/5.18.0/lib/Router/Endpoints/CronDaemon.php(42): MailPoet\Cron\DaemonHttpRunner->run(Array)
#17 [internal function]: MailPoet\Routerndpoints\CronDaemon->run(Array)
#18 /wordpress/plugins/mailpoet/5.18.0/lib/Router/Router.php(74): call_user_func(Array, Array)
#19 /wordpress/plugins/mailpoet/5.18.0/lib/Config/Initializer.php(488): MailPoet\Router\Router->init()
#20 /wordpress/core/6.9/wp-includes/class-wp-hook.php(341): MailPoet\Config\Initializer->postInitialize('')
#21 /wordpress/core/6.9/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters(NULL, Array)
#22 /wordpress/core/6.9/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#23 /wordpress/core/6.9/wp-settings.php(764): do_action('wp_loaded')
#24 /srv/htdocs/wp-config.php(83): require_once('/wordpress/core...')
#25 /wordpress/core/6.9/wp-load.php(55): require_once('/srv/htdocs/wp-...')
#26 /wordpress/core/6.9/wp-blog-header.php(13): require_once('/wordpress/core...')
#27 /wordpress/core/6.9/index.php(17): require('/wordpress/core...')
#28 {main}
  thrown in /wordpress/plugins/mailpoet/5.18.0/lib-3rd-party/pquery/gan_node_html.php on line 760
```

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7753

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7753-php-fatal-error-in-pquery-getsibling-when-parent-is-null)

_The latest successful build from `stomail-7753-php-fatal-error-in-pquery-getsibling-when-parent-is-null` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness by preventing potential crashes when handling detached nodes.

* **Tests**
  * Added test coverage for text rendering with multiple empty paragraphs to ensure stability without crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->