### PR TITLE
Supress Debug Code Detection Warning

### DIFF
--- a/mailpoet/lib-3rd-party/pquery/gan_node_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_node_html.php
@@ -1311,6 +1311,7 @@ class DomNode implements IQuery {
 			} elseif ($compare === 'name') {
 				return ((isset($t[$attr])) ? $t[$attr] : false);
 			} else {
+				// phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
 				trigger_error('Unknown comparison mode');
 			}
 		}
@@ -1741,6 +1742,7 @@ class DomNode implements IQuery {
 								if ($res) break 1; else break 2;
 
 							default:
+								// phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
 								trigger_error('Unknown operator "'.esc_html($match['operator_value']).'" to match attributes!');
 								return false;
 						}
@@ -1775,6 +1777,7 @@ class DomNode implements IQuery {
 					return false;
 				}
 			} else {
+				// phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
 				trigger_error('Unknown filter "'.esc_html($c['filter']).'"!');
 				return false;
 			}

--- a/mailpoet/lib-3rd-party/pquery/gan_selector_html.php
+++ b/mailpoet/lib-3rd-party/pquery/gan_selector_html.php
@@ -389,6 +389,7 @@ class HtmlSelector {
 			$error
 		), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
 
+		// phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
 		trigger_error(esc_html($error));
 	}
 

--- a/mailpoet/lib-3rd-party/pquery/ganon.php
+++ b/mailpoet/lib-3rd-party/pquery/ganon.php
@@ -33,8 +33,10 @@ function file_get_dom($file, $return_root = true, $use_include_path = false, $co
 	if (version_compare(PHP_VERSION, '5.0.0', '>='))
 		$f = file_get_contents($file, $use_include_path, $context);
 	else {
-		if ($context !== null)
+		if ($context !== null) {
+			// phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
 			trigger_error('Context parameter not supported in this PHP version');
+		}
 		$f = file_get_contents($file, $use_include_path);
 	}
 

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -297,7 +297,9 @@ class API {
   private function logError(Throwable $e): void {
     // logging to the php log
     if (function_exists('error_log')) {
+      // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
       error_log((string)$e); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+      // phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
     }
     // logging to the MailPoet table
     $this->loggerFactory->getLogger(LoggerFactory::TOPIC_API)->warning($e->getMessage(), [

--- a/mailpoet/lib/API/REST/API.php
+++ b/mailpoet/lib/API/REST/API.php
@@ -84,7 +84,9 @@ class API {
       : new ErrorResponse(500, __('An unknown error occurred.', 'mailpoet'), 'mailpoet_automation_unknown_error');
 
     if ($response->get_status() >= 500 && function_exists('error_log')) {
+      // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
       error_log((string)$e); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+      // phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
     }
     return $response;
   }

--- a/mailpoet/lib/Config/TranslationUpdater.php
+++ b/mailpoet/lib/Config/TranslationUpdater.php
@@ -183,7 +183,9 @@ class TranslationUpdater {
       Debugger::log($message, ILogger::ERROR);
     }
     if (function_exists('error_log')) {
+      // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
       error_log($message); // phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+      // phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
     }
   }
 

--- a/mailpoet/lib/Entities/NewsletterEntity.php
+++ b/mailpoet/lib/Entities/NewsletterEntity.php
@@ -213,12 +213,14 @@ class NewsletterEntity {
     $getterName = 'get' . Helpers::underscoreToCamelCase($key, $capitaliseFirstChar = true);
     $callable = [$this, $getterName];
     if (is_callable($callable)) {
-      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      // phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
       trigger_error(
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- if the function is callable, it's safe to output
         "Direct access to \$newsletter->{$key} is deprecated and will be removed after 2026-01-01. Use \$newsletter->{$getterName}() instead.",
         E_USER_DEPRECATED
       );
+      // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
       return call_user_func($callable);
     }
   }

--- a/mailpoet/lib/Entities/SendingQueueEntity.php
+++ b/mailpoet/lib/Entities/SendingQueueEntity.php
@@ -92,12 +92,14 @@ class SendingQueueEntity {
     $getterName = 'get' . Helpers::underscoreToCamelCase($key, $capitaliseFirstChar = true);
     $callable = [$this, $getterName];
     if (is_callable($callable)) {
-      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      // phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
       trigger_error(
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- if the function is callable, it's safe to output
         "Direct access to \$sendingQueue->{$key} is deprecated and will be removed after 2026-01-01. Use \$sendingQueue->{$getterName}() instead.",
         E_USER_DEPRECATED
       );
+      // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
       return call_user_func($callable);
     }
   }

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -238,12 +238,14 @@ class SubscriberEntity {
     $getterName = 'get' . Helpers::underscoreToCamelCase($key, $capitaliseFirstChar = true);
     $callable = [$this, $getterName];
     if (is_callable($callable)) {
-      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Intended for deprecation warnings
+      // phpcs:ignore QITStandard.PHP.DebugCode.DebugFunctionFound
       trigger_error(
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- if the function is callable, it's safe to output
         "Direct access to \$subscriber->{$key} is deprecated and will be removed after 2026-01-01. Use \$subscriber->{$getterName}() instead.",
         E_USER_DEPRECATED
       );
+      // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
       return call_user_func($callable);
     }
   }

--- a/mailpoet/lib/Util/Helpers.php
+++ b/mailpoet/lib/Util/Helpers.php
@@ -133,7 +133,9 @@ class Helpers {
       );
       // logging to the php log
       if (function_exists('error_log')) {
+        // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
         error_log($customErrorMessage); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+        // phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
       }
 
       return $customErrorMessage;

--- a/mailpoet/mailpoet-cron.php
+++ b/mailpoet/mailpoet-cron.php
@@ -8,9 +8,11 @@
  * prevents MailPoet from functioning. To work around this problem, this script loads only MailPoet and WordPress,
  * without any other plugins. That is why it needs to require wp-load.php directly.
  */
+// phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
+ini_set("display_errors", "1"); // phpcs:ignore QITStandard.PHP.DebugCode.DangerousIniSet
+error_reporting(E_ALL); // phpcs:ignore QITStandard.PHP.DebugCode.ErrorReportingMaximum
+// phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
 
-ini_set("display_errors", "1");
-error_reporting(E_ALL);
 
 if (!isset($argv[1]) || !$argv[1]) {
   echo 'You need to pass a WordPress root as an argument.';

--- a/mailpoet/tests/DataGenerator/DataGenerator.php
+++ b/mailpoet/tests/DataGenerator/DataGenerator.php
@@ -20,7 +20,7 @@ class DataGenerator {
 
   public function run($generatorName) {
     if (!$generatorName) $generatorName = self::PAST_REVENUES_GENERATOR;
-    ini_set('memory_limit', '1024M');
+    ini_set('memory_limit', '1024M'); // phpcs:ignore QITStandard.PHP.DebugCode.DangerousIniSet
     $timer = time();
     try {
       $generator = $this->createGenerator($generatorName);

--- a/mailpoet/tests/acceptance/_bootstrap.php
+++ b/mailpoet/tests/acceptance/_bootstrap.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-ini_set('max_execution_time', '900');
+ini_set('max_execution_time', '900'); // phpcs:ignore QITStandard.PHP.DebugCode.DangerousIniSet
 
 $dotenv = Dotenv\Dotenv::createUnsafeImmutable(__DIR__ . '/../..');
 $dotenv->load();


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:supress-debug-warning)

_The latest successful build from `supress-debug-warning` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added non-functional linting directives across the codebase to suppress static-analysis warnings.
  * Scoped PHPCS enable/disable and ignore pragmas around logging and deprecation notices for coding-standard alignment.
  * No runtime, behavior, public API, or control-flow changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->