### PR TITLE
Switch integration tests to PHP 8.4 as default

### DIFF
--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -56,6 +56,9 @@ fi
 echo "WORDPRESS VERSION:"
 wp core version
 
+echo "TEST RUNNER PHP VERSION:"
+php --version
+
 # Load Composer dependencies
 # Set SKIP_DEPS environment flag to not download them. E.g. you have downloaded them yourself
 # Example: docker compose run -e SKIP_DEPS=1 codeception ...

--- a/tests_env/docker/docker-compose.yml
+++ b/tests_env/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       PHP_IDE_CONFIG: 'serverName=MailPoetTest'
 
   codeception_integration:
-    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.3-cli_20250304.1}
+    image: mailpoet/wordpress:${CODECEPTION_IMAGE_VERSION:-8.4-cli_20250729.1}
     depends_on:
       - smtp
       - wordpress


### PR DESCRIPTION
## Description

This is a follow-up of https://github.com/mailpoet/mailpoet/pull/6467 and switches integration tests in CI and locally to use PHP 8.4 as default container.

Closes STOMAIL-7697

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7697-integration-tests-php-84)

_The latest successful build from `stomail-7697-integration-tests-php-84` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing environment to use PHP 8.4 for integration tests.
  * Test runner now displays the PHP version during execution for clearer diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->