### PR TITLE
Add block editor email creation with pattern support

### DIFF
--- a/mailpoet/changelog/2026-01-22-18-22-47-added-add-welcome-with-discount-email-pattern.md
+++ b/mailpoet/changelog/2026-01-22-18-22-47-added-add-welcome-with-discount-email-pattern.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add Welcome with Discount email pattern

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -201,7 +201,7 @@ class PageRenderer {
         'automationTemplates' => admin_url('admin.php?page=mailpoet-automation-templates'),
         'automationAnalytics' => admin_url('admin.php?page=mailpoet-automation-analytics'),
       ],
-      'woocommerce_store_config' => $this->wooCommerceHelper->isWooCommerceActive() ? $this->getWoocommerceStoreConfig() : null,
+      'woocommerce_store_config' => $this->wooCommerceHelper->isWooCommerceActive() ? $this->wooCommerceHelper->getWoocommerceStoreConfig() : null,
       'tags' => array_map(function (TagEntity $tag): array {
         return [
         'id' => $tag->getId(),
@@ -242,20 +242,6 @@ class PageRenderer {
       $notice = new WPNotice(WPNotice::TYPE_ERROR, $e->getMessage());
       $notice->displayWPNotice();
     }
-  }
-
-  private function getWoocommerceStoreConfig() {
-
-    return [
-      'precision' => $this->wooCommerceHelper->wcGetPriceDecimals(),
-      'decimalSeparator' => $this->wooCommerceHelper->wcGetPriceDecimalSeperator(),
-      'thousandSeparator' => $this->wooCommerceHelper->wcGetPriceThousandSeparator(),
-      'code' => $this->wooCommerceHelper->getWoocommerceCurrency(),
-      'symbol' => html_entity_decode($this->wooCommerceHelper->getWoocommerceCurrencySymbol(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),
-      'symbolPosition' => $this->wp->getOption('woocommerce_currency_pos'),
-      'priceFormat' => $this->wooCommerceHelper->getWoocommercePriceFormat(),
-
-    ];
   }
 
   public function displayChatBotWidget(): bool {

--- a/mailpoet/lib/AdminPages/Pages/AbstractAutomationEmbed.php
+++ b/mailpoet/lib/AdminPages/Pages/AbstractAutomationEmbed.php
@@ -129,6 +129,7 @@ abstract class AbstractAutomationEmbed {
       'woocommerce_active' => $this->wooCommerceHelper->isWooCommerceActive(),
       'woocommerce_subscriptions_active' => $this->wooCommerceSubscriptionsHelper->isWooCommerceSubscriptionsActive(),
       'woocommerce_bookings_active' => $this->wooCommerceBookingsHelper->isWooCommerceBookingsActive(),
+      'woocommerce_store_config' => $this->wooCommerceHelper->isWooCommerceActive() ? $this->wooCommerceHelper->getWoocommerceStoreConfig() : null,
     ];
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -6,14 +6,20 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Config\Env;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
+use MailPoet\EmailEditor\Integrations\MailPoet\Templates\TemplatesController;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\WpPostEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionFieldsRepository;
 use MailPoet\Newsletter\Options\NewsletterOptionsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class EmailFactory {
   /** @var NewslettersRepository */
@@ -34,18 +40,34 @@ class EmailFactory {
   /** @var NewsletterOptionFieldsRepository */
   private $newsletterOptionFieldsRepository;
 
+  private PatternsController $patternsController;
+
+  private TemplatesController $templatesController;
+
+  private EntityManager $entityManager;
+
+  private WPFunctions $wpFunctions;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
     SettingsController $settings,
     WordPress $wp,
     NewsletterOptionsRepository $newsletterOptionsRepository,
-    NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository
+    NewsletterOptionFieldsRepository $newsletterOptionFieldsRepository,
+    PatternsController $patternsController,
+    TemplatesController $templatesController,
+    WPFunctions $wpFunctions,
+    EntityManager $entityManager
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->settings = $settings;
     $this->wp = $wp;
     $this->newsletterOptionsRepository = $newsletterOptionsRepository;
     $this->newsletterOptionFieldsRepository = $newsletterOptionFieldsRepository;
+    $this->patternsController = $patternsController;
+    $this->templatesController = $templatesController;
+    $this->entityManager = $entityManager;
+    $this->wpFunctions = $wpFunctions;
   }
 
   /**
@@ -81,6 +103,75 @@ class EmailFactory {
 
     // Return the newsletter ID
     return $newsletter->getId();
+  }
+
+  /**
+   * Create a block editor email from a pattern and store it in the database.
+   *
+   * This method creates a WordPress post with the pattern content and links it
+   * to a NewsletterEntity for use with the block email editor.
+   *
+   * @param array $data Email data including:
+   *   - 'pattern' (string, required): The pattern name (e.g., 'welcome-email-content')
+   *   - 'subject' (string, optional): Email subject
+   *   - 'preheader' (string, optional): Email preheader
+   *   - 'sender_name' (string, optional): Sender name
+   *   - 'sender_address' (string, optional): Sender email address
+   * @param string|null $templateSlug The slug of the template to associate with the email.
+   * @return array{email_id: int, email_wp_post_id: int}|null The IDs of the created email and WP post, or null if creation failed
+   */
+  public function createBlockEditorEmail(array $data, ?string $templateSlug = null): ?array {
+    $patternName = $data['pattern'] ?? null;
+    if (!$patternName) {
+      return null;
+    }
+
+    // Get pattern content
+    $patternContent = $this->patternsController->getPatternContent($patternName);
+    if ($patternContent === null) {
+      return null;
+    }
+
+    // Create a WordPress post with the pattern content
+    $postId = $this->wpFunctions->wpInsertPost([
+      'post_content' => $patternContent,
+      'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
+      'post_status' => 'draft',
+      'post_author' => $this->wpFunctions->getCurrentUserId(),
+      'post_title' => $data['subject'] ?? __('New Email', 'mailpoet'),
+    ]);
+
+    if (!is_int($postId) || $postId <= 0) {
+      return null;
+    }
+
+    // Set the email template to associate the template wrapper (header, footer, unsubscribe links)
+    $templateSlug = $templateSlug ?: $this->templatesController->getDefaultTemplateSlug();
+    $this->wpFunctions->updatePostMeta($postId, '_wp_page_template', $templateSlug);
+
+    // Create a new newsletter entity
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+    $newsletter->setSubject($data['subject'] ?? '');
+    $newsletter->setPreheader($data['preheader'] ?? '');
+    $newsletter->setSenderName($data['sender_name'] ?? $this->getDefaultSenderName());
+    $newsletter->setSenderAddress($data['sender_address'] ?? $this->getDefaultSenderAddress());
+    $newsletter->setHash(Security::generateHash());
+    $newsletter->setWpPost($this->entityManager->getReference(WpPostEntity::class, $postId));
+
+    $this->newslettersRepository->persist($newsletter);
+    $this->newslettersRepository->flush();
+
+    $emailId = $newsletter->getId();
+    if ($emailId === null) {
+      return null;
+    }
+
+    return [
+      'email_id' => $emailId,
+      'email_wp_post_id' => $postId,
+    ];
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * Welcome email pattern for new subscribers.
+ */
+class WelcomeWithDiscountEmailPattern extends Pattern {
+  protected $name = 'welcome-with-discount-email-content';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['welcome'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /**
+   * Get pattern content.
+   *
+   * @return string Pattern HTML content.
+   */
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading ">' .
+      /* translators: %s: Store name personalization tag */
+      sprintf(__('Welcome to %s!', 'mailpoet'), '<!--[woocommerce/store-name]-->') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph -->
+      <p>' .
+      /* translators: %s: Customer full name personalization tag */
+      sprintf(__('Hi %s, we are so glad to have you onboard. As a thank you, here is a 10%% discount for your first purchase.', 'mailpoet'), '<!--[woocommerce/customer-full-name]-->') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph -->
+      <p>' .
+      /* translators: %s: Site description personalization tag */
+      __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:woocommerce/coupon-code {"align":"left"} -->
+      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
+      <!-- /wp:woocommerce/coupon-code -->
+
+      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Start shopping', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+
+      <!-- wp:paragraph -->
+      <p>' . __('Happy shopping!', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph -->
+      <p>–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Welcome with Discount', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -11,6 +11,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewsletterPatter
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductRestockNotificationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\SaleAnnouncementPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeEmailPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeWithDiscountEmailPattern;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -62,6 +63,7 @@ class PatternsController {
       new ProductRestockNotificationPattern($this->cdnAssetUrl),
       new NewArrivalsAnnouncementPattern($this->cdnAssetUrl),
       new WelcomeEmailPattern($this->cdnAssetUrl),
+      new WelcomeWithDiscountEmailPattern($this->cdnAssetUrl),
       new AbandonedCartPattern($this->cdnAssetUrl),
     ];
   }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -18,6 +18,9 @@ class PatternsController {
   private CdnAssetUrl $cdnAssetUrl;
   private WPFunctions $wp;
 
+  /** @var Pattern[] */
+  private array $patterns = [];
+
   public function __construct(
     CdnAssetUrl $cdnAssetUrl,
     WPFunctions $wp
@@ -26,21 +29,48 @@ class PatternsController {
     $this->wp = $wp;
   }
 
+  /**
+   * Get the content of a pattern by name.
+   *
+   * @param string $patternName The pattern name (e.g., 'welcome-email-content')
+   * @return string|null The pattern content or null if not found
+   */
+  public function getPatternContent(string $patternName): ?string {
+    $this->ensurePatternsInitialized();
+
+    foreach ($this->patterns as $pattern) {
+      if ($pattern->get_name() === $patternName) {
+        $properties = $pattern->get_properties();
+        return $properties['content'] ?? null;
+      }
+    }
+
+    return null;
+  }
+
+  private function ensurePatternsInitialized(): void {
+    if (!empty($this->patterns)) {
+      return;
+    }
+
+    $this->patterns = [
+      new NewsletterPattern($this->cdnAssetUrl),
+      new SaleAnnouncementPattern($this->cdnAssetUrl),
+      new NewProductsAnnouncementPattern($this->cdnAssetUrl),
+      new EducationalCampaignPattern($this->cdnAssetUrl),
+      new EventInvitationPattern($this->cdnAssetUrl),
+      new ProductRestockNotificationPattern($this->cdnAssetUrl),
+      new NewArrivalsAnnouncementPattern($this->cdnAssetUrl),
+      new WelcomeEmailPattern($this->cdnAssetUrl),
+      new AbandonedCartPattern($this->cdnAssetUrl),
+    ];
+  }
+
   public function registerPatterns(): void {
     $this->registerPatternCategories();
+    $this->ensurePatternsInitialized();
 
-    $patterns = [];
-    $patterns[] = new NewsletterPattern($this->cdnAssetUrl);
-    $patterns[] = new SaleAnnouncementPattern($this->cdnAssetUrl);
-    $patterns[] = new NewProductsAnnouncementPattern($this->cdnAssetUrl);
-    $patterns[] = new EducationalCampaignPattern($this->cdnAssetUrl);
-    $patterns[] = new EventInvitationPattern($this->cdnAssetUrl);
-    $patterns[] = new ProductRestockNotificationPattern($this->cdnAssetUrl);
-    $patterns[] = new NewArrivalsAnnouncementPattern($this->cdnAssetUrl);
-    $patterns[] = new WelcomeEmailPattern($this->cdnAssetUrl);
-    $patterns[] = new AbandonedCartPattern($this->cdnAssetUrl);
-
-    foreach ($patterns as $pattern) {
+    foreach ($this->patterns as $pattern) {
       $patternName = $pattern->get_namespace() . '/' . $pattern->get_name();
       $patternProperties = $pattern->get_properties();
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -42,7 +42,7 @@ class PatternsController {
     foreach ($this->patterns as $pattern) {
       if ($pattern->get_name() === $patternName) {
         // Apply the same filter used in registerPatterns for consistency
-        $patternData = $this->wp->applyFilters('mailpoet_email_editor_register_pattern', [
+        $patternData = $this->wp->applyFilters('mailpoet_email_editor_integration_register_pattern', [
           'name' => $pattern->get_namespace() . '/' . $pattern->get_name(),
           'properties' => $pattern->get_properties(),
         ], $pattern);
@@ -91,7 +91,7 @@ class PatternsController {
        * @param Pattern $pattern The original Pattern object.
        * @return array|null Return modified data or null/false to skip registration.
        */
-      $patternData = $this->wp->applyFilters('mailpoet_email_editor_register_pattern', [
+      $patternData = $this->wp->applyFilters('mailpoet_email_editor_integration_register_pattern', [
         'name' => $patternName,
         'properties' => $patternProperties,
       ], $pattern);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -41,8 +41,16 @@ class PatternsController {
 
     foreach ($this->patterns as $pattern) {
       if ($pattern->get_name() === $patternName) {
-        $properties = $pattern->get_properties();
-        return $properties['content'] ?? null;
+        // Apply the same filter used in registerPatterns for consistency
+        $patternData = $this->wp->applyFilters('mailpoet_email_editor_register_pattern', [
+          'name' => $pattern->get_namespace() . '/' . $pattern->get_name(),
+          'properties' => $pattern->get_properties(),
+        ], $pattern);
+
+        if (!is_array($patternData) || !isset($patternData['properties'])) {
+          return null;
+        }
+        return $patternData['properties']['content'] ?? null;
       }
     }
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
@@ -11,6 +11,7 @@ use MailPoet\WP\Functions as WPFunctions;
 
 class TemplatesController {
   private string $templatePrefix = 'mailpoet';
+  private ?string $defaultTemplateSlug = null;
   private WPFunctions $wp;
   private CdnAssetUrl $cdnAssetUrl;
 
@@ -39,6 +40,25 @@ class TemplatesController {
     );
     $templatesRegistry->register($template);
 
+    // Store the first registered template as the default
+    if ($this->defaultTemplateSlug === null) {
+      $this->defaultTemplateSlug = $newsletter->getSlug();
+    }
+
     return $templatesRegistry;
+  }
+
+  /**
+   * Get the default template slug for new emails.
+   *
+   * @return string The template slug (e.g., 'newsletter')
+   */
+  public function getDefaultTemplateSlug(): string {
+    // If templates haven't been registered yet, create the Newsletter to get its slug
+    if ($this->defaultTemplateSlug === null) {
+      $newsletter = new Newsletter($this->cdnAssetUrl);
+      $this->defaultTemplateSlug = $newsletter->getSlug();
+    }
+    return $this->defaultTemplateSlug;
   }
 }

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -313,6 +313,19 @@ class Helper {
     return wc_get_attribute_taxonomies();
   }
 
+  public function getWoocommerceStoreConfig(): array {
+    return [
+      'precision' => $this->wcGetPriceDecimals(),
+      'decimalSeparator' => $this->wcGetPriceDecimalSeperator(),
+      'thousandSeparator' => $this->wcGetPriceThousandSeparator(),
+      'code' => $this->getWoocommerceCurrency(),
+      'symbol' => html_entity_decode($this->getWoocommerceCurrencySymbol(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),
+      'symbolPosition' => $this->wp->getOption('woocommerce_currency_pos'),
+      'priceFormat' => $this->getWoocommercePriceFormat(),
+
+    ];
+  }
+
   protected function formatShippingMethods(array $shippingMethods, string $shippingZoneName): array {
     $formattedShippingMethods = [];
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -27,6 +27,17 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertEquals('Abandoned Cart', $abandonedCart['title']);
     $this->assertEquals(['abandoned-cart'], $abandonedCart['categories']);
 
+    $welcomeWithDiscountEmail = array_pop($blockPatterns);
+    $this->assertIsArray($welcomeWithDiscountEmail);
+    $this->assertArrayHasKey('name', $welcomeWithDiscountEmail);
+    $this->assertArrayHasKey('content', $welcomeWithDiscountEmail);
+    $this->assertArrayHasKey('title', $welcomeWithDiscountEmail);
+    $this->assertArrayHasKey('categories', $welcomeWithDiscountEmail);
+    $this->assertEquals('mailpoet/welcome-with-discount-email-content', $welcomeWithDiscountEmail['name']);
+    $this->assertStringContainsString('Welcome to', $welcomeWithDiscountEmail['content']);
+    $this->assertEquals('Welcome with Discount', $welcomeWithDiscountEmail['title']);
+    $this->assertEquals(['welcome'], $welcomeWithDiscountEmail['categories']);
+
     $welcomeEmail = array_pop($blockPatterns);
     $this->assertIsArray($welcomeEmail);
     $this->assertArrayHasKey('name', $welcomeEmail);

--- a/mailpoet/views/automation/flow-embed.html
+++ b/mailpoet/views/automation/flow-embed.html
@@ -50,6 +50,7 @@
     var mailpoet_automation_registry = <%= json_encode(registry) %>;
     var mailpoet_automation_context = <%= json_encode(context) %>;
     var mailpoet_automation = <%= json_encode(automation) %>;
+    var mailpoet_woocommerce_store_config = <%= json_encode(woocommerce_store_config) %>;
   </script>
   <%= head_content | raw %>
 </head>


### PR DESCRIPTION
## Description

  This PR adds the ability to create block editor emails from predefined patterns programmatically. It also introduces a new "Welcome with Discount" email pattern and exposes WooCommerce store configuration to the Automation Flow Embed
   context.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 

## Code review notes

  - The EmailFactory now has additional dependencies injected (PatternsController, TemplatesController, WPFunctions, EntityManager)                                                                                                        
  - Pattern initialization in PatternsController is lazy-loaded via ensurePatternsInitialized()                                                                                                                                            
  - The WooCommerce store config method was moved from PageRenderer to WooCommerce\Helper to allow reuse across different contexts      

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/997

## Linked tickets

STOMAIL-7491 

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7491)

_The latest successful build from `stomail-7491` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Welcome with Discount" email pattern (ready-made welcome email with coupon and personalization).
  * Added ability to create block-editor emails from patterns and apply templates for faster email creation.
  * Automation UI now receives WooCommerce store configuration via a JS global for storefront-aware personalization.

* **Tests**
  * Added tests for pattern registration and pattern-based email creation.

* **Documentation**
  * Added changelog entry documenting the new pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->