### PR TITLE
Fix wp_title fatal error on subscription confirmation STOMAIL-7754

### DIFF
--- a/mailpoet/changelog/2026-01-23-08-49-18-fixed-fix-wptitle-fatal-error-when-confirming-subscripti.md
+++ b/mailpoet/changelog/2026-01-23-08-49-18-fixed-fix-wptitle-fatal-error-when-confirming-subscripti.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix wp_title fatal error when confirming subscription

--- a/mailpoet/lib/Captcha/PageRenderer.php
+++ b/mailpoet/lib/Captcha/PageRenderer.php
@@ -33,7 +33,11 @@ class PageRenderer {
     $this->wp->addFilter('the_content', [$this, 'setPageContent']);
   }
 
-  public function setWindowTitle($title, $separator, $separatorLocation = 'right') {
+  public function setWindowTitle($title, $separator = '', $separatorLocation = 'right') {
+    // If no separator is provided, just modify the entire title
+    if (empty($separator)) {
+      return $this->getPageTitle();
+    }
     $titleParts = explode(" $separator ", $title);
     if (!is_array($titleParts)) {
       return $title;

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -340,7 +340,11 @@ class Pages {
     }
   }
 
-  public function setWindowTitle($title, $separator, $separatorLocation = 'right') {
+  public function setWindowTitle($title, $separator = '', $separatorLocation = 'right') {
+    // If no separator is provided, just modify the entire title
+    if (empty($separator)) {
+      return $this->setPageTitle($title);
+    }
     $titleParts = explode(" $separator ", $title);
     if (!is_array($titleParts)) {
       return $title;

--- a/mailpoet/tests/integration/Captcha/PageRendererTitleTest.php
+++ b/mailpoet/tests/integration/Captcha/PageRendererTitleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Captcha;
+
+use MailPoet\Captcha\CaptchaFormRenderer;
+use MailPoet\Captcha\PageRenderer;
+use MailPoet\Form\AssetsController;
+use MailPoet\WP\Functions as WPFunctions;
+
+class PageRendererTitleTest extends \MailPoetTest {
+  private PageRenderer $pageRenderer;
+
+  public function _before() {
+    parent::_before();
+    $container = $this->diContainer;
+    $this->pageRenderer = new PageRenderer(
+      $container->get(WPFunctions::class),
+      $container->get(CaptchaFormRenderer::class),
+      $container->get(AssetsController::class)
+    );
+  }
+
+  public function testWindowTitleCanBeCalledWithSingleArgument(): void {
+    $result = $this->pageRenderer->setWindowTitle('MailPoet Page');
+
+    $this->assertIsString($result);
+    $this->assertNotSame('', $result);
+  }
+
+  public function testWindowTitleStillWorksWithThreeArguments(): void {
+    $result = $this->pageRenderer->setWindowTitle('MailPoet Page | Example', '|', 'right');
+
+    $this->assertIsString($result);
+    $this->assertStringContainsString('Confirm', $result);
+  }
+}

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -294,6 +294,24 @@ class PagesTest extends \MailPoetTest {
     verify($clickStat)->arrayCount(1);
   }
 
+  public function testWindowTitleCanBeCalledWithSingleArgument() {
+    $pages = $this->getPages();
+
+    $result = $pages->setWindowTitle('MailPoet Page');
+
+    $this->assertIsString($result);
+    $this->assertNotSame('', $result);
+  }
+
+  public function testWindowTitleStillWorksWithThreeArguments() {
+    $pages = $this->getPages();
+
+    $result = $pages->setWindowTitle('MailPoet Page | Example', '|', 'right');
+
+    $this->assertIsString($result);
+    $this->assertStringContainsString('MailPoet', $result);
+  }
+
   private function getPages(
     ?NewSubscriberNotificationMailer $newSubscriberNotificationsMock = null,
     ?Unsubscribes $unsubscribesMock = null


### PR DESCRIPTION
## Description

Fixes a fatal `ArgumentCountError` when WordPress calls the `wp_title` filter with a single argument, and our subscription/captcha page title hooks expect more. This ensures confirmation and captcha pages render correctly instead of showing a critical error.

## Code review notes

_N/A_

## QA notes

- Confirm that clicking the "Confirm your subscription" link now loads the confirmation page without a fatal error.
- Verify the browser tab title is still correct for MailPoet subscription pages and the captcha verification page.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7754

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7754-fatal-error-argumentcounterror-in-setwindowtitle-on)

_The latest successful build from `stomail-7754-fatal-error-argumentcounterror-in-setwindowtitle-on` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a fatal error that occurred during the subscription confirmation process on certain website configurations
  * Improved page title handling to enhance the reliability of subscription confirmations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->