### PR TITLE
Update maximum PHP version for WordPress images in the update workflow

### DIFF
--- a/.github/workflows/update-wordpress-and-plugins.yml
+++ b/.github/workflows/update-wordpress-and-plugins.yml
@@ -9,7 +9,7 @@ jobs:
   check-versions:
     runs-on: ubuntu-latest
     env:
-      MAX_PHP_VERSION: '8.3' # Maximum PHP version to use for WordPress Docker images
+      MAX_PHP_VERSION: '8.4' # Maximum PHP version to use for WordPress Docker images
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

After we updated the PHP version used for acceptance and integration tests, we can increase the restriction for the maximum PHP version for WordPress images used by the automatic update workflow.

This will prevent the workflow from downgrading[ the PHP version for tests](https://github.com/mailpoet/mailpoet/pull/6474/changes/09c86c9d6ce32bb66d6a29b9c8dbf4a398d6947e) in CI.

Note: Currently, the WP's PHP version and the test runner's PHP versions must match for acceptance tests. Different PHP versions cause issues with restoring login snapshots.

Related to: STOMAIL-7697

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing environment configuration to support PHP 8.4 for WordPress Docker images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->