### PR TITLE
Add booking triggers to transactional triggers

### DIFF
--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -82,6 +82,8 @@ class SendEmailAction implements Action {
     'woocommerce:buys-from-a-tag',
     'woocommerce:buys-from-a-category',
     'woocommerce:buys-a-product',
+    'woocommerce-bookings:booking-created',
+    'woocommerce-bookings:booking-status-changed',
   ];
 
   private AutomationController $automationController;


### PR DESCRIPTION
## Description

Add WooCommerce Bookings triggers to the `TRANSACTIONAL_TRIGGERS` list in `SendEmailAction`.

This allows booking confirmation emails to be sent to unconfirmed subscribers, similar to how WooCommerce order triggers work.

## Code review notes

Simple addition of two trigger keys to the existing constant array.

## QA notes

See the linked premium plugin PR for full QA instructions.

## Linked PRs

- Premium plugin: https://github.com/mailpoet/mailpoet-premium/pull/999

## Linked tickets

- [STOMAIL-7576](https://linear.app/a8c/issue/STOMAIL-7576)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7576-support-guest-customers-in-bookings-automation-triggers)

_The latest successful build from `stomail-7576-support-guest-customers-in-bookings-automation-triggers` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for WooCommerce Bookings automation, enabling automated emails to trigger when bookings are created or their status changes. These events are treated as transactional, ensuring proper email scheduling and opt-in logic handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->