### PR TITLE
Add "Abandoned Cart" email patterns using WooCommerce Product Collection block

### DIFF
--- a/mailpoet/changelog/2026-01-28-12-44-45-added-abandoned-cart-and-abandoned-cart-with-discount-em.md
+++ b/mailpoet/changelog/2026-01-28-12-44-45-added-abandoned-cart-and-abandoned-cart-with-discount-em.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+"Abandoned Cart" and "Abandoned Cart with Discount" email patterns using WooCommerce Product Collection block

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartPattern.php
@@ -2,18 +2,11 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
-use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
-use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
-
 /**
  * Abandoned cart email pattern for cart recovery.
  */
-class AbandonedCartPattern extends Pattern {
+class AbandonedCartPattern extends AbstractAbandonedCartPattern {
   protected $name = 'abandoned-cart-content';
-  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['abandoned-cart'];
-  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '
@@ -27,25 +20,7 @@ class AbandonedCartPattern extends Pattern {
       <p>' . __('You’ve already done the hard part: finding something great. Now’s the time to make it yours.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:image -->
-      <figure class="wp-block-image"><img alt=""/></figure>
-      <!-- /wp:image -->
-
-      <!-- wp:heading {"textAlign":"center"} -->
-      <h2 class="wp-block-heading has-text-align-center">' . __('Product name', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"16px"}}} -->
-      <p class="has-text-align-center" style="font-size:16px">$99.90</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-      <div class="wp-block-buttons">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Finish checkout', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
+      ' . $this->getProductCollectionBlock() . '
     </div>
     <!-- /wp:group -->
     ';

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
@@ -2,18 +2,11 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
 
-use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
-use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
-
 /**
- * Abandoned cart email pattern for cart recovery.
+ * Abandoned cart with discount email pattern for cart recovery.
  */
-class AbandonedCartWithDiscountPattern extends Pattern {
+class AbandonedCartWithDiscountPattern extends AbstractAbandonedCartPattern {
   protected $name = 'abandoned-cart-with-discount-content';
-  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['abandoned-cart'];
-  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     return '
@@ -47,25 +40,7 @@ class AbandonedCartWithDiscountPattern extends Pattern {
       <h3 class="wp-block-heading has-text-align-left" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">' . __('These items are waiting in your cart', 'mailpoet') . '</h3>
       <!-- /wp:heading -->
 
-      <!-- wp:image -->
-      <figure class="wp-block-image"><img alt=""/></figure>
-      <!-- /wp:image -->
-
-      <!-- wp:heading {"textAlign":"center"} -->
-      <h2 class="wp-block-heading has-text-align-center">' . __('Product name', 'mailpoet') . '</h2>
-      <!-- /wp:heading -->
-
-      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"16px"}}} -->
-      <p class="has-text-align-center" style="font-size:16px">$99.90</p>
-      <!-- /wp:paragraph -->
-
-      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-      <div class="wp-block-buttons">
-      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Buy now', 'mailpoet') . '</a></div>
-      <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
+      ' . $this->getProductCollectionBlock() . '
     </div>
     <!-- /wp:group -->
     ';

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * Abandoned cart email pattern for cart recovery.
+ */
+class AbandonedCartWithDiscountPattern extends Pattern {
+  protected $name = 'abandoned-cart-with-discount-content';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['abandoned-cart'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading ">' . __('We Saved Your Cart + Little Surprise', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph -->
+      <p>' . __('Good news — your cart is still here! Even better? You can get 10% off if you check out in the next 24 hours.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph -->
+      <p>' . __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:woocommerce/coupon-code {"align":"left"} -->
+      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
+      <!-- /wp:woocommerce/coupon-code -->
+
+      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Finish checkout', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:heading {"textAlign":"left","level":3,"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+      <h3 class="wp-block-heading has-text-align-left" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">' . __('These items are waiting in your cart', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"textAlign":"center"} -->
+      <h2 class="wp-block-heading has-text-align-center">' . __('Product name', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"16px"}}} -->
+      <p class="has-text-align-center" style="font-size:16px">$99.90</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Buy now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Abandoned Cart with Discount', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbstractAbandonedCartPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbstractAbandonedCartPattern.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * Base class for abandoned cart email patterns.
+ */
+abstract class AbstractAbandonedCartPattern extends Pattern {
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['abandoned-cart'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /**
+   * Get Product Collection block configured for cart contents.
+   */
+  protected function getProductCollectionBlock(): string {
+    return '<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":10,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":1,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/cart-contents","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"],"queryContextIncludes":["cart"]} -->
+      <div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
+      <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+      <!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->
+      <!-- /wp:woocommerce/product-image -->
+
+      <!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+      <!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+      <!-- /wp:woocommerce/product-template --></div>
+      <!-- /wp:woocommerce/product-collection -->';
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbstractAbandonedCartPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbstractAbandonedCartPattern.php
@@ -18,18 +18,22 @@ abstract class AbstractAbandonedCartPattern extends Pattern {
    * Get Product Collection block configured for cart contents.
    */
   protected function getProductCollectionBlock(): string {
-    return '<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":10,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":1,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/cart-contents","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"],"queryContextIncludes":["cart"]} -->
+    return '
+      <!-- wp:woocommerce/product-collection {"queryId":2,"query":{"perPage":10,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":1,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/cart-contents","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"],"queryContextIncludes":["cart"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."}} -->
       <div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
-      <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+      <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
       <!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->
       <!-- /wp:woocommerce/product-image -->
 
-      <!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+      <!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}},"typography":{"fontSize":"24px"}},"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","style":{"typography":{"fontSize":"14px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->
 
-      <!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
-      <!-- /wp:woocommerce/product-template --></div>
-      <!-- /wp:woocommerce/product-collection -->';
+      <!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"style":{"typography":{"fontSize":"16px"}}} /-->
+      <!-- /wp:woocommerce/product-template -->
+      </div>
+      <!-- /wp:woocommerce/product-collection -->
+    ';
+
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -3,6 +3,7 @@
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns;
 
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EventInvitationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewArrivalsAnnouncementPattern;
@@ -73,6 +74,7 @@ class PatternsController {
       new WelcomeEmailPattern($this->cdnAssetUrl),
       new WelcomeWithDiscountEmailPattern($this->cdnAssetUrl),
       new AbandonedCartPattern($this->cdnAssetUrl),
+      new AbandonedCartWithDiscountPattern($this->cdnAssetUrl),
     ];
   }
 

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -16,6 +16,17 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->patterns->registerPatterns();
     $blockPatterns = \WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 
+    $abandonedCartWithDiscount = array_pop($blockPatterns);
+    $this->assertIsArray($abandonedCartWithDiscount);
+    $this->assertArrayHasKey('name', $abandonedCartWithDiscount);
+    $this->assertArrayHasKey('content', $abandonedCartWithDiscount);
+    $this->assertArrayHasKey('title', $abandonedCartWithDiscount);
+    $this->assertArrayHasKey('categories', $abandonedCartWithDiscount);
+    $this->assertEquals('mailpoet/abandoned-cart-with-discount-content', $abandonedCartWithDiscount['name']);
+    $this->assertStringContainsString('We Saved Your Cart + Little Surprise', $abandonedCartWithDiscount['content']);
+    $this->assertEquals('Abandoned Cart with Discount', $abandonedCartWithDiscount['title']);
+    $this->assertEquals(['abandoned-cart'], $abandonedCartWithDiscount['categories']);
+
     $abandonedCart = array_pop($blockPatterns);
     $this->assertIsArray($abandonedCart);
     $this->assertArrayHasKey('name', $abandonedCart);


### PR DESCRIPTION
  ## Description                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                           
  Add two new email patterns for abandoned cart recovery:                                                                                                                                                                                                  
  - **Abandoned Cart** - Basic cart recovery email with Product Collection block                                                                                                                                                                           
  - **Abandoned Cart with Discount** - Cart recovery email with coupon code and Product Collection block                                                                                                                                                   
                                                                                                                                                                                                                                                           
  Both patterns use the WooCommerce Product Collection block with `cart-contents` collection to display items left in the customer's cart.                                                                                                                 
                                                                                                                                                                                                                                                           
  ## Code review notes                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                           
  - Created `AbstractAbandonedCartPattern` base class to share common configuration between patterns                                                                                                                                                       
  - Patterns are registered under the `abandoned-cart` category                                                                                                                                                                                            
  - Product Collection block is configured with `isPreview: false` for production use                                                                                                                                                                      
                                                                                                                                                                                                                                                           
  ## QA notes                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                           
  1. Open email editor and create a new automation email                                                                                                                                                                                                   
  2. In the pattern picker, verify "Abandoned Cart" and "Abandoned Cart with Discount" patterns appear                                                                                                                                                     
  3. Insert each pattern and verify the Product Collection block is present                                                                                                                                                                                
  4. In automation flow, verify emails show actual cart items                                                                                                                                                                                              
                                                                                                                                                                                                                                                           
  ## Linked PRs                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                           
  _N/A_                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                           
  ## Linked tickets                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                           
  STOMAIL-7492                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                           
  ## After-merge notes                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                           
  _N/A_                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                           
  ## Tasks                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                           
  - [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)                                                                                                                                                    
  - [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations                                                                                                                                            
  - [ ] I added sufficient test coverage                                                                                                                                                                                                                   
  - [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes                                                                                                                       
                                                                                                                                                                                                                                                           
  Note: You may want to add test coverage for the new patterns. You can adjust the linked ticket number based on your actual ticket.       

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7492)

_The latest successful build from `stomail-7492` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Abandoned Cart" and "Abandoned Cart with Discount" email patterns for WooCommerce stores.
  * Patterns dynamically render product-collection blocks to display customers' cart contents.
  * "Abandoned Cart with Discount" adds a coupon-code section and messaging to encourage checkout completion.

* **Chores**
  * Updated pattern registration and related tests to include the new patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->