### PR TITLE
Add Dockerfile for PHP 8.5 for dev environment

### DIFF
--- a/dev/php80/Dockerfile
+++ b/dev/php80/Dockerfile
@@ -28,7 +28,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
 RUN git clone -b "3.3.1" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
-    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-configure xdebug --enable-xdebug \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug
 COPY dev/xdebug.ini /tmp/xdebug.ini

--- a/dev/php81/Dockerfile
+++ b/dev/php81/Dockerfile
@@ -28,7 +28,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
 RUN git clone -b "3.3.1" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
-    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-configure xdebug --enable-xdebug \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug
 COPY dev/xdebug.ini /tmp/xdebug.ini

--- a/dev/php82/Dockerfile
+++ b/dev/php82/Dockerfile
@@ -28,7 +28,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
 RUN git clone -b "3.4.2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
-    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-configure xdebug --enable-xdebug \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug
 COPY dev/xdebug.ini /tmp/xdebug.ini

--- a/dev/php83/Dockerfile
+++ b/dev/php83/Dockerfile
@@ -28,7 +28,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
 RUN git clone -b "3.4.2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
-    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-configure xdebug --enable-xdebug \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug
 COPY dev/xdebug.ini /tmp/xdebug.ini

--- a/dev/php84/Dockerfile
+++ b/dev/php84/Dockerfile
@@ -28,7 +28,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
 RUN git clone -b "3.4.5" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
-    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-configure xdebug --enable-xdebug \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug
 COPY dev/xdebug.ini /tmp/xdebug.ini

--- a/dev/php85/Dockerfile
+++ b/dev/php85/Dockerfile
@@ -1,0 +1,46 @@
+FROM wordpress:php8.5-apache
+
+ARG UID=1000
+ARG GID=1000
+
+# additinal extensions
+RUN apt-get update \
+	&& apt-get install -y git zlib1g-dev libzip-dev zip wget gnupg msmtp libpng-dev gettext subversion \
+	&& \
+    # Install NodeJS, enable Corepack
+    curl -sL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs build-essential && \
+    corepack enable && \
+	\
+	# Install WP-CLI
+	curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+	chmod +x /usr/local/bin/wp && \
+	\
+  # Clean up
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY dev/php.ini /usr/local/etc/php/conf.d/php_user.ini
+
+# msmtp config
+RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
+
+# xdebug build an config
+ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
+RUN git clone -b "3.5.0" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-install xdebug \
+    && mkdir /tmp/debug
+COPY dev/xdebug.ini /tmp/xdebug.ini
+RUN cat /tmp/xdebug.ini >> $XDEBUGINI_PATH
+
+# php extensions
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install mysqli
+
+# allow .htaccess files (between <Directory /var/www/> and </Directory>, which is WordPress installation)
+RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
+# ensure existing content in /var/www/html respects UID and GID, give Node permissions for Corepack
+RUN chown -R ${UID}:${GID} /var/www/html && \
+  mkdir -p /.node && chown -R ${UID}:${GID} /.node

--- a/dev/php85/Dockerfile
+++ b/dev/php85/Dockerfile
@@ -28,7 +28,7 @@ RUN printf "account default\nhost smtp\nport 1025" > /etc/msmtprc
 # xdebug build an config
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini
 RUN git clone -b "3.5.0" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
-    && docker-php-ext-configure xdebug --enable-xdebug-dev \
+    && docker-php-ext-configure xdebug --enable-xdebug \
     && docker-php-ext-install xdebug \
     && mkdir /tmp/debug
 COPY dev/xdebug.ini /tmp/xdebug.ini


### PR DESCRIPTION
## Description

This is a first step for PHP 8.5 support. It allows running the MailPoet dev site on PHP 8.5. It doesn't fix any warnings.

## Code review notes
Add 
```yml
 wordpress:
   build:
      dockerfile: dev/php85/Dockerfile
```      
into services in `docker-compose.override.yml`
      
Run `docker compose build wordpress` and then start the dev site as usual. It should run on PHP 8.5.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Related to STOMAIL-7698

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7698-add-dockerfile-php85)

_The latest successful build from `stomail-7698-add-dockerfile-php85` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an upgraded PHP 8.5 local development environment with Node.js 22.x, WP-CLI, PHP extensions, mail helper, and debugging support.
  * Improved Apache configuration and file ownership for smoother local workflows.
  * Standardized Xdebug build configuration across PHP 8.0–8.4 images to ensure consistent debugging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->