### PR TITLE
Add post-purchase email patterns

### DIFF
--- a/mailpoet/changelog/2026-01-29-08-19-41-added-new-email-patterns-for-post-purchase-automations-f.md
+++ b/mailpoet/changelog/2026-01-29-08-19-41-added-new-email-patterns-for-post-purchase-automations-f.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+New email patterns for post-purchase automations: First Purchase Thank You, Post Purchase Thank You, Product Purchase Follow-Up, and Win Back Customer

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/FirstPurchaseThankYouPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/FirstPurchaseThankYouPattern.php
@@ -1,0 +1,166 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * First purchase thank you email pattern.
+ */
+class FirstPurchaseThankYouPattern extends Pattern {
+  protected $name = 'first-purchase-thank-you';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['purchase'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /**
+   * Get pattern content.
+   *
+   * @return string Pattern HTML content.
+   */
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('Thank You for Your First Order', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      /* translators: %s is a placeholder for the shop name */
+      sprintf(__('We’re thrilled you chose %s. Your order is being processed, and we can’t wait for you to receive it.', 'mailpoet'), '<!--[woocommerce/store-name]-->') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">
+      ' . __('While you wait, check out other items that pair perfectly with your order.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:spacer {"height":"30px"} -->
+      <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+      <!-- /wp:spacer -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('Happy shopping!', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('First Purchase Thank You', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/FirstPurchaseThankYouPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/FirstPurchaseThankYouPattern.php
@@ -61,7 +61,7 @@ class FirstPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -84,7 +84,7 @@ class FirstPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -111,7 +111,7 @@ class FirstPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -134,7 +134,7 @@ class FirstPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * Post purchase thank you email pattern.
+ */
+class PostPurchaseThankYouPattern extends Pattern {
+  protected $name = 'post-purchase-thank-you';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['purchase'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /**
+   * Get pattern content.
+   *
+   * @return string Pattern HTML content.
+   */
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' .
+      /* translators: %s is a placeholder for the customer first name */
+      sprintf(__('%s, thank you for your order', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      __('Thanks for shopping with us. Your order is being processed, and we can’t wait for you to receive it.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">
+      ' . __('While you wait, check out other items that pair perfectly with your order.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:spacer {"height":"30px"} -->
+      <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+      <!-- /wp:spacer -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('Happy shopping!', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Post Purchase Thank You', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/PostPurchaseThankYouPattern.php
@@ -62,7 +62,7 @@ class PostPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -85,7 +85,7 @@ class PostPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -112,7 +112,7 @@ class PostPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -135,7 +135,7 @@ class PostPurchaseThankYouPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
@@ -50,7 +50,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -77,7 +77,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -100,7 +100,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -127,7 +127,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -150,7 +150,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
@@ -1,0 +1,182 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * Product purchase follow-up email pattern.
+ */
+class ProductPurchaseFollowUpPattern extends Pattern {
+  protected $name = 'product-purchase-follow-up';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['purchase'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /**
+   * Get pattern content.
+   *
+   * @return string Pattern HTML content.
+   */
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' .
+      /* translators: [Product] is a placeholder for the product category */
+      __('Loving your [Product]? Make it even better', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      __('Here are a few essentials that pair perfectly.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"textAlign":"center"} -->
+      <h2 class="wp-block-heading has-text-align-center">' . __('Product name', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"16px"}}} -->
+      <p class="has-text-align-center" style="font-size:16px">$99.90</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:spacer {"height":"30px"} -->
+      <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+      <!-- /wp:spacer -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('Happy shopping!', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Product Purchase Follow-Up', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -34,7 +34,7 @@ class WinBackCustomerPattern extends Pattern {
       sprintf(__('Hi %s, come see what’s new — we’ve added fresh arrivals and exclusive deals just for you.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
       <!-- /wp:paragraph -->
 
-      <!-- wp:paragraph -->
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
       /* translators: %s: Site description personalization tag */
       __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
@@ -47,7 +47,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
       <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Start shopping', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Start shopping', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -79,7 +79,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -102,7 +102,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -129,7 +129,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -152,7 +152,7 @@ class WinBackCustomerPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-custom-font-size wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);font-size:16px" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WinBackCustomerPattern.php
@@ -1,0 +1,184 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Pattern;
+
+/**
+ * Win Back Customer email pattern.
+ */
+class WinBackCustomerPattern extends Pattern {
+  protected $name = 'win-back-customer';
+  protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+  protected $categories = ['purchase'];
+  protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+  /**
+   * Get pattern content.
+   *
+   * @return string Pattern HTML content.
+   */
+  protected function get_content(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    return '
+    <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+      <!-- wp:heading {"level":1} -->
+      <h1 class="wp-block-heading">' . __('We Miss You! Here’s 15% Off ', 'mailpoet') . '</h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">' .
+      /* translators: %s is a placeholder for the first name */
+      sprintf(__('Hi %s, come see what’s new — we’ve added fresh arrivals and exclusive deals just for you.', 'mailpoet'), '<!--[woocommerce/customer-first-name]-->') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph -->
+      <p style="font-size:16px">' .
+      /* translators: %s: Site description personalization tag */
+      __('Use this code at checkout to redeem your discount:', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:woocommerce/coupon-code {"align":"left"} -->
+      <div class="wp-block-woocommerce-coupon-code alignleft"></div>
+      <!-- /wp:woocommerce/coupon-code -->
+
+      <!-- wp:buttons {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","justifyContent":"left"}} -->
+      <div class="wp-block-buttons" style="padding-bottom:var(--wp--preset--spacing--30)">
+      <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Start shopping', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+
+      <!-- wp:heading {"style":{"border":{"top":{"color":"var:preset|color|cyan-bluish-gray"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}},"typography":{"fontSize":"24px"}}} -->
+      <h2 class="wp-block-heading" style="border-top-color:var(--wp--preset--color--cyan-bluish-gray);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);font-size:24px">' . __('You might also like', 'mailpoet') . '</h2>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->
+      <p style="padding-top:0;padding-bottom:var(--wp--preset--spacing--30);font-size:16px">
+      ' . __('While you wait, check out other items that pair perfectly with your order.', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:columns -->
+      <div class="wp-block-columns">
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"var:preset|spacing|20","left":"0"}}}} -->
+      <div class="wp-block-column" style="padding-right:var(--wp--preset--spacing--20);padding-left:0"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column {"style":{"spacing":{"padding":{"right":"0","left":"var:preset|spacing|20"}}}} -->
+      <div class="wp-block-column" style="padding-right:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:image -->
+      <figure class="wp-block-image"><img alt=""/></figure>
+      <!-- /wp:image -->
+
+      <!-- wp:heading {"level":3} -->
+      <h3 class="wp-block-heading">' . __('Product', 'mailpoet') . '</h3>
+      <!-- /wp:heading -->
+
+      <!-- wp:heading {"level":4} -->
+      <h4 class="wp-block-heading">$99.90</h4>
+      <!-- /wp:heading -->
+
+      <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
+      <div class="wp-block-buttons">
+      <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
+      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+
+      <!-- wp:spacer {"height":"30px"} -->
+      <div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
+      <!-- /wp:spacer -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">' . __('Happy shopping!', 'mailpoet') . '</p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:paragraph {"fontSize":"medium"} -->
+      <p class="has-medium-font-size">–<!--[woocommerce/site-title]--></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+    ';
+  }
+
+  protected function get_title(): string { // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    /* translators: Name of a content pattern used as starting content of an email */
+    return __('Win Back Customer', 'mailpoet');
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -6,13 +6,16 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartPat
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\AbandonedCartWithDiscountPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EducationalCampaignPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\EventInvitationPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\FirstPurchaseThankYouPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewArrivalsAnnouncementPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewProductsAnnouncementPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewsletterPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\PostPurchaseThankYouPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductRestockNotificationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\SaleAnnouncementPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeEmailPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeWithDiscountEmailPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WinBackCustomerPattern;
 use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -73,6 +76,9 @@ class PatternsController {
       new NewArrivalsAnnouncementPattern($this->cdnAssetUrl),
       new WelcomeEmailPattern($this->cdnAssetUrl),
       new WelcomeWithDiscountEmailPattern($this->cdnAssetUrl),
+      new FirstPurchaseThankYouPattern($this->cdnAssetUrl),
+      new PostPurchaseThankYouPattern($this->cdnAssetUrl),
+      new WinBackCustomerPattern($this->cdnAssetUrl),
       new AbandonedCartPattern($this->cdnAssetUrl),
       new AbandonedCartWithDiscountPattern($this->cdnAssetUrl),
     ];
@@ -115,6 +121,11 @@ class PatternsController {
         'name' => 'welcome',
         'label' => _x('Welcome', 'Block pattern category', 'mailpoet'),
         'description' => __('A collection of welcome email layouts.', 'mailpoet'),
+      ],
+      [
+        'name' => 'purchase',
+        'label' => _x('Post-purchase', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of post-purchase email layouts.', 'mailpoet'),
       ],
       [
         'name' => 'abandoned-cart',

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -11,6 +11,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewArrivalsAnnou
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewProductsAnnouncementPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\NewsletterPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\PostPurchaseThankYouPattern;
+use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductPurchaseFollowUpPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\ProductRestockNotificationPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\SaleAnnouncementPattern;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\Library\WelcomeEmailPattern;
@@ -78,6 +79,7 @@ class PatternsController {
       new WelcomeWithDiscountEmailPattern($this->cdnAssetUrl),
       new FirstPurchaseThankYouPattern($this->cdnAssetUrl),
       new PostPurchaseThankYouPattern($this->cdnAssetUrl),
+      new ProductPurchaseFollowUpPattern($this->cdnAssetUrl),
       new WinBackCustomerPattern($this->cdnAssetUrl),
       new AbandonedCartPattern($this->cdnAssetUrl),
       new AbandonedCartWithDiscountPattern($this->cdnAssetUrl),

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -38,6 +38,39 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertEquals('Abandoned Cart', $abandonedCart['title']);
     $this->assertEquals(['abandoned-cart'], $abandonedCart['categories']);
 
+    $winBackCustomer = array_pop($blockPatterns);
+    $this->assertIsArray($winBackCustomer);
+    $this->assertArrayHasKey('name', $winBackCustomer);
+    $this->assertArrayHasKey('content', $winBackCustomer);
+    $this->assertArrayHasKey('title', $winBackCustomer);
+    $this->assertArrayHasKey('categories', $winBackCustomer);
+    $this->assertEquals('mailpoet/win-back-customer', $winBackCustomer['name']);
+    $this->assertStringContainsString('We Miss You', $winBackCustomer['content']);
+    $this->assertEquals('Win Back Customer', $winBackCustomer['title']);
+    $this->assertEquals(['purchase'], $winBackCustomer['categories']);
+
+    $postPurchaseThankYou = array_pop($blockPatterns);
+    $this->assertIsArray($postPurchaseThankYou);
+    $this->assertArrayHasKey('name', $postPurchaseThankYou);
+    $this->assertArrayHasKey('content', $postPurchaseThankYou);
+    $this->assertArrayHasKey('title', $postPurchaseThankYou);
+    $this->assertArrayHasKey('categories', $postPurchaseThankYou);
+    $this->assertEquals('mailpoet/post-purchase-thank-you', $postPurchaseThankYou['name']);
+    $this->assertStringContainsString('thank you for your order', $postPurchaseThankYou['content']);
+    $this->assertEquals('Post Purchase Thank You', $postPurchaseThankYou['title']);
+    $this->assertEquals(['purchase'], $postPurchaseThankYou['categories']);
+
+    $firstPurchaseThankYou = array_pop($blockPatterns);
+    $this->assertIsArray($firstPurchaseThankYou);
+    $this->assertArrayHasKey('name', $firstPurchaseThankYou);
+    $this->assertArrayHasKey('content', $firstPurchaseThankYou);
+    $this->assertArrayHasKey('title', $firstPurchaseThankYou);
+    $this->assertArrayHasKey('categories', $firstPurchaseThankYou);
+    $this->assertEquals('mailpoet/first-purchase-thank-you', $firstPurchaseThankYou['name']);
+    $this->assertStringContainsString('Thank You for Your First Order', $firstPurchaseThankYou['content']);
+    $this->assertEquals('First Purchase Thank You', $firstPurchaseThankYou['title']);
+    $this->assertEquals(['purchase'], $firstPurchaseThankYou['categories']);
+
     $welcomeWithDiscountEmail = array_pop($blockPatterns);
     $this->assertIsArray($welcomeWithDiscountEmail);
     $this->assertArrayHasKey('name', $welcomeWithDiscountEmail);
@@ -151,6 +184,11 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertIsArray($welcomeCategory);
     $this->assertEquals('welcome', $welcomeCategory['name']);
     $this->assertNotEmpty($welcomeCategory['label']);
+
+    $purchaseCategory = $registry->get_registered('purchase');
+    $this->assertIsArray($purchaseCategory);
+    $this->assertEquals('purchase', $purchaseCategory['name']);
+    $this->assertNotEmpty($purchaseCategory['label']);
 
     $abandonedCartCategory = $registry->get_registered('abandoned-cart');
     $this->assertIsArray($abandonedCartCategory);

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -49,6 +49,17 @@ class PatternsControllerTest extends \MailPoetTest {
     $this->assertEquals('Win Back Customer', $winBackCustomer['title']);
     $this->assertEquals(['purchase'], $winBackCustomer['categories']);
 
+    $productPurchaseFollowUp = array_pop($blockPatterns);
+    $this->assertIsArray($productPurchaseFollowUp);
+    $this->assertArrayHasKey('name', $productPurchaseFollowUp);
+    $this->assertArrayHasKey('content', $productPurchaseFollowUp);
+    $this->assertArrayHasKey('title', $productPurchaseFollowUp);
+    $this->assertArrayHasKey('categories', $productPurchaseFollowUp);
+    $this->assertEquals('mailpoet/product-purchase-follow-up', $productPurchaseFollowUp['name']);
+    $this->assertStringContainsString('Loving your [Product]', $productPurchaseFollowUp['content']);
+    $this->assertEquals('Product Purchase Follow-Up', $productPurchaseFollowUp['title']);
+    $this->assertEquals(['purchase'], $productPurchaseFollowUp['categories']);
+
     $postPurchaseThankYou = array_pop($blockPatterns);
     $this->assertIsArray($postPurchaseThankYou);
     $this->assertArrayHasKey('name', $postPurchaseThankYou);


### PR DESCRIPTION
## Description

- Introduced `FirstPurchaseThankYouPattern`, `PostPurchaseThankYouPattern`, and `WinBackCustomerPattern` for enhanced email customization.
- Updated `PatternsController` and integration tests to register and validate the new patterns.
- Added "purchase" category to the pattern registry.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Related STOMAIL-7493

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7493)

_The latest successful build from `stomail-7493` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four post-purchase email templates: First Purchase Thank You, Post Purchase Thank You, Product Purchase Follow-Up, and Win Back Customer.
  * Templates include dynamic placeholders, product recommendations, coupon support and customizable layouts.
  * Templates and a new "purchase" category are conditionally available when WooCommerce is active; coupon templates are version-gated.

* **Tests**
  * Expanded tests for WooCommerce active/inactive scenarios, version gating, and template/category registration.

* **New**
  * Added programmatic retrieval of pattern content for previewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->