### PR TITLE
Fix block validation warnings in email patterns and unsubscribe link insertion

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/validate-email-content.ts
@@ -15,10 +15,10 @@ type EmailEditorSelectors = {
   getCurrentTemplate(): EmailTemplate;
 };
 
-const contentLink = `<a data-link-href='[mailpoet/subscription-unsubscribe-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${__(
+const contentLink = `<a data-link-href="[mailpoet/subscription-unsubscribe-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">${__(
   'Unsubscribe',
   'mailpoet',
-)}</a> | <a data-link-href='[mailpoet/subscription-manage-url]' contenteditable='false' style='text-decoration: underline;' class='mailpoet-email-editor__personalization-tags-link'>${__(
+)}</a> | <a data-link-href="[mailpoet/subscription-manage-url]" contenteditable="false" style="text-decoration: underline;" class="mailpoet-email-editor__personalization-tags-link">${__(
   'Manage subscription',
   'mailpoet',
 )}</a>`;
@@ -89,7 +89,7 @@ export const emailValidationRule: EmailContentValidationRule = {
               content: `
                 ${editedTemplateContent}
                 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-                ${contentLink}
+                <p class="has-text-align-center has-small-font-size">${contentLink}</p>
                 <!-- /wp:paragraph -->
               `,
             },

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbandonedCartWithDiscountPattern.php
@@ -31,7 +31,7 @@ class AbandonedCartWithDiscountPattern extends AbstractAbandonedCartPattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Finish checkout', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Finish checkout', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbstractAbandonedCartPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/AbstractAbandonedCartPattern.php
@@ -18,18 +18,22 @@ abstract class AbstractAbandonedCartPattern extends Pattern {
    * Get Product Collection block configured for cart contents.
    */
   protected function getProductCollectionBlock(): string {
-    return '<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"perPage":10,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":1,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/cart-contents","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"],"queryContextIncludes":["cart"]} -->
+    return '
+      <!-- wp:woocommerce/product-collection {"queryId":2,"query":{"perPage":10,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":1,"shrinkColumns":true},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/cart-contents","hideControls":["inherit","attributes","keyword","order","default-order","featured","on-sale","stock-status","hand-picked","taxonomy","filterable","created","price-range"],"queryContextIncludes":["cart"],"__privatePreviewState":{"isPreview":false,"previewMessage":"Actual products will vary depending on the page being viewed."}} -->
       <div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
-      <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+      <!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
       <!-- wp:woocommerce/product-sale-badge {"align":"right"} /-->
       <!-- /wp:woocommerce/product-image -->
 
-      <!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"lineHeight":"1.4"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+      <!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}},"typography":{"fontSize":"24px"}},"__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","style":{"typography":{"fontSize":"14px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->
 
-      <!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
-      <!-- /wp:woocommerce/product-template --></div>
-      <!-- /wp:woocommerce/product-collection -->';
+      <!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"style":{"typography":{"fontSize":"16px"}}} /-->
+      <!-- /wp:woocommerce/product-template -->
+      </div>
+      <!-- /wp:woocommerce/product-collection -->
+    ';
+
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
@@ -128,7 +128,7 @@ class EducationalCampaignPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Read the guide', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Read the guide', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
@@ -50,7 +50,7 @@ class EventInvitationPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('RSVP now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('RSVP now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
@@ -49,7 +49,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop the collection', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop the collection', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -76,7 +76,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -99,7 +99,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -126,7 +126,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->
@@ -149,7 +149,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"width":100,"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} -->
-      <div class="wp-block-button has-custom-width wp-block-button__width-100 has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
@@ -48,7 +48,7 @@ class NewProductsAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Discover now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Discover now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewsletterPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewsletterPattern.php
@@ -55,7 +55,7 @@ class NewsletterPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Visit our store', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Visit our store', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
@@ -48,7 +48,7 @@ class ProductRestockNotificationPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
@@ -50,7 +50,7 @@ class SaleAnnouncementPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeEmailPattern.php
@@ -49,7 +49,7 @@ class WelcomeEmailPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Shop now', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/WelcomeWithDiscountEmailPattern.php
@@ -49,7 +49,7 @@ class WelcomeWithDiscountEmailPattern extends Pattern {
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->
       <div class="wp-block-buttons">
       <!-- wp:button {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
-      <div class="wp-block-button has-custom-font-size" style="font-size:16px"><a class="wp-block-button__link wp-element-button" style="padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Start shopping', 'mailpoet') . '</a></div>
+      <div class="wp-block-button"><a class="wp-block-button__link wp-element-button has-custom-font-size" style="font-size:16px;padding-top:var(--wp--preset--spacing--10);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20)" href="[mailpoet/site-homepage-url]">' . __('Start shopping', 'mailpoet') . '</a></div>
       <!-- /wp:button -->
       </div>
       <!-- /wp:buttons -->


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                       
  Fix block validation warnings in email content patterns and fix the "Insert link" action from the unsubscribe validation warning.                                                                                                                    
                                                                                                                                                                                                                                                       
  **Changes:**                                                                                                                                                                                                                                         
  1. **Button block markup (10 pattern files):** Moved `has-custom-font-size` class and `font-size` style from wrapper `<div>` to inner `<a>` element to match Gutenberg's expected block output                                                       
  2. **Unsubscribe link insertion (validate-email-content.ts):** Rewrote insertion logic to detect editing mode (template vs post) and use appropriate method - `insertBlock` for templates, `resetEditorBlocks` for posts                             
  3. **HTML attributes:** Changed single quotes to double quotes in contentLink to match Gutenberg's save function output                                                                                                                              
                                                                                                                                                                                                                                                       
  ## Code review notes                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                       
  - The button markup fix is a consistent pattern across all affected files - moving styles/classes from the wrapper div to the inner anchor element                                                                                                   
  - The TypeScript changes simplify the code by removing the unused `getEditorContext` function and related imports                                                                                                                                    
                                                                                                                                                                                                                                                       
  ## QA notes                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                       
  ### Test 1: Block validation warnings in patterns                                                                                                                                                                                                    
  1. Open browser developer console (F12 → Console tab)                                                                                                                                                                                                
  2. Go to MailPoet → Emails → Add New → Block Email                                                                                                                                                                                                   
  3. In the pattern selection modal, browse through patterns                                                                                                                                                                                           
  4. **Expected:** No "Block successfully updated for `core/button`" warnings in console                                                                                                                                                               
                                                                                                                                                                                                                                                       
  ### Test 2: Insert unsubscribe link in email (post mode)                                                                                                                                                                                             
  1. Create a new block email or edit an existing one                                                                                                                                                                                                  
  2. Delete the unsubscribe/manage subscription links from the email content                                                                                                                                                                           
  3. Try to send/save - validation warning "All emails must include an Unsubscribe link" should appear                                                                                                                                                 
  4. Click "Insert link" button in the warning                                                                                                                                                                                                         
  5. **Expected:** A paragraph with "Unsubscribe | Manage subscription" links is added at the end of the email content                                                                                                                                 
                                                                                                                                                                                                                                                       
  ### Test 3: Insert unsubscribe link in template (template mode)                                                                                                                                                                                      
  1. Open email editor                                                                                                                                                                                                                                 
  2. Click on "Edit template" to switch to template editing mode                                                                                                                                                                                       
  3. Delete the unsubscribe/manage subscription links from the template                                                                                                                                                                                
  4. Validation warning should appear                                                                                                                                                                                                                  
  5. Click "Insert link" button                                                                                                                                                                                                                        
  6. **Expected:** A paragraph with "Unsubscribe | Manage subscription" links is added to the template                                                                                                                                                 
                                                                                                                                                                                                                                                       
  ### Test 4: Verify inserted block has correct markup                                                                                                                                                                                                 
  1. After inserting the link (in either mode), check browser console                                                                                                                                                                                  
  2. **Expected:** No block validation warnings about the newly inserted paragraph block  
                                                                                                                                                                                                                                                       
  ## Linked PRs                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                       
  _N/A_                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                       
  ## Linked tickets                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                       
  STOMAIL-7774                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                       
  ## After-merge notes                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                       
  _N/A_                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                       
  ## Tasks                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                       
  - [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)                                                                                                                                                
  - [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations                                                                                                                                        
  - [ ] I added sufficient test coverage                                                                                                                                                                                                               
  - [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7774-incorrect-block-markup-for-buttons-in-email-content-patterns)

_The latest successful build from `stomail-7774-incorrect-block-markup-for-buttons-in-email-content-patterns` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed insertion of unsubscribe and Manage Preferences links to properly handle both template and post editing modes.
  * Corrected button styling structure across multiple email template patterns for consistent rendering.

* **Improvements**
  * Enhanced Abandoned Cart email pattern with improved product display formatting and styling options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->