### PR TITLE
Fix negative date errors when using large days values in segment filters

### DIFF
--- a/mailpoet/changelog/2026-01-30-12-27-55-fixed-fix-negative-date-errors-when-using-large-days-val.md
+++ b/mailpoet/changelog/2026-01-30-12-27-55-fixed-fix-negative-date-errors-when-using-large-days-val.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix negative date errors when using large days values in segment filters

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
@@ -16,6 +16,15 @@ class DateFilterHelper {
   const IN_THE_LAST = 'inTheLast';
   const NOT_IN_THE_LAST = 'notInTheLast';
 
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  public function __construct(
+    FilterHelper $filterHelper
+  ) {
+    $this->filterHelper = $filterHelper;
+  }
+
   public function getValidOperators(): array {
     return array_merge(
       $this->getAbsoluteDateOperators(),
@@ -48,7 +57,7 @@ class DateFilterHelper {
         throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
       }
     } else if (in_array($operator, self::getRelativeDateOperators())) {
-      $carbon = CarbonImmutable::now()->subDays(intval($value) - 1);
+      $carbon = $this->filterHelper->getDateNDaysAgoImmutable(intval($value) - 1);
     } else {
       throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailsReceived.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailsReceived.php
@@ -5,7 +5,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\StatisticsNewsletterEntity;
-use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -40,7 +39,7 @@ class EmailsReceived implements Filter {
       $days = $filterData->getIntParam('days');
       $dateParam = $this->filterHelper->getUniqueParameterName('days');
       $queryBuilder->leftJoin($subscribersTable, $statsTable, 'emails', "{$subscribersTable}.id = emails.subscriber_id AND emails.sent_at >= :$dateParam");
-      $queryBuilder->setParameter($dateParam, CarbonImmutable::now()->subDays($days)->startOfDay());
+      $queryBuilder->setParameter($dateParam, $this->filterHelper->getDateNDaysAgoImmutable($days)->startOfDay());
     }
 
     $queryBuilder->groupBy("$subscribersTable.id");

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -6,10 +6,18 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\Security;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class FilterHelper {
+  /**
+   * Minimum valid year for MySQL DATE/DATETIME fields.
+   * Used to clamp dates when subtracting large day values to prevent negative dates.
+   */
+  private const MIN_DATE_YEAR = 1000;
+
   /** @var EntityManager */
   private $entityManager;
 
@@ -80,5 +88,29 @@ class FilterHelper {
     if ($days < 1) {
       throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
     }
+  }
+
+  /**
+   * Get a date by subtracting days from now, clamped to a minimum valid date.
+   * This prevents negative dates when users set very large day values,
+   * which can cause errors on some database engines like MySQL.
+   *
+   * @param int $days Number of days to subtract from current date
+   * @return Carbon The calculated date, clamped to minimum 1000-01-01
+   */
+  public function getDateNDaysAgo(int $days): Carbon {
+    return Carbon::now()->subDays($days)->max(Carbon::createFromDate(self::MIN_DATE_YEAR, 1, 1));
+  }
+
+  /**
+   * Get an immutable date by subtracting days from now, clamped to a minimum valid date.
+   * This prevents negative dates when users set very large day values,
+   * which can cause errors on some database engines like MySQL.
+   *
+   * @param int $days Number of days to subtract from current date
+   * @return CarbonImmutable The calculated date, clamped to minimum 1000-01-01
+   */
+  public function getDateNDaysAgoImmutable(int $days): CarbonImmutable {
+    return CarbonImmutable::now()->subDays($days)->max(CarbonImmutable::createFromDate(self::MIN_DATE_YEAR, 1, 1));
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/NumberOfClicks.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/NumberOfClicks.php
@@ -5,7 +5,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\StatisticsClickEntity;
-use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -40,7 +39,7 @@ class NumberOfClicks implements Filter {
       $days = $filterData->getIntParam('days');
       $dateParam = $this->filterHelper->getUniqueParameterName('days');
       $queryBuilder->leftJoin($subscribersTable, $statsTable, 'clicks', "{$subscribersTable}.id = clicks.subscriber_id AND clicks.created_at >= :$dateParam");
-      $queryBuilder->setParameter($dateParam, CarbonImmutable::now()->subDays($days)->startOfDay());
+      $queryBuilder->setParameter($dateParam, $this->filterHelper->getDateNDaysAgoImmutable($days)->startOfDay());
     }
 
     $queryBuilder->groupBy("$subscribersTable.id");

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -4,7 +4,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class WooCommerceAverageSpent implements Filter {
@@ -36,7 +35,7 @@ class WooCommerceAverageSpent implements Filter {
       /** @var int $days */
       $days = $filterData->getParam('days');
       $days = intval($days);
-      $date = Carbon::now()->subDays($days);
+      $date = $this->filterHelper->getDateNDaysAgo($days);
       $dateParam = $this->filterHelper->getUniqueParameterName('date');
       $queryBuilder
         ->andWhere("$orderStatsAlias.date_created >= :$dateParam")

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -7,7 +7,6 @@ use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Util\DBCollationChecker;
 use MailPoet\Util\Security;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -30,14 +29,19 @@ class WooCommerceNumberOfOrders implements Filter {
   /** @var WooFilterHelper */
   private $wooFilterHelper;
 
+  /** @var FilterHelper */
+  private $filterHelper;
+
   public function __construct(
     EntityManager $entityManager,
     DBCollationChecker $collationChecker,
-    WooFilterHelper $wooFilterHelper
+    WooFilterHelper $wooFilterHelper,
+    FilterHelper $filterHelper
   ) {
     $this->entityManager = $entityManager;
     $this->collationChecker = $collationChecker;
     $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -59,8 +63,9 @@ class WooCommerceNumberOfOrders implements Filter {
       'email'
     );
 
+    /** @var int $days - for PHPStan because intval() doesn't accept a value of mixed */
     $days = $filterData->getParam('days');
-    $date = Carbon::now()->subDays($days);
+    $date = $this->filterHelper->getDateNDaysAgo(intval($days));
 
     $joinCondition = $isAllTime
       ? 'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN (:excludedStatuses' . $parameterSuffix . ')'

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
@@ -6,7 +6,6 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Util\DBCollationChecker;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class WooCommerceNumberOfReviews implements Filter {
@@ -57,7 +56,7 @@ class WooCommerceNumberOfReviews implements Filter {
       AND comments.comment_type = 'review'";
 
     if (!$isAllTime) {
-      $date = Carbon::now()->subDays($days);
+      $date = $this->filterHelper->getDateNDaysAgo($days);
       $dateParam = $this->filterHelper->getUniqueParameterName('date');
       $joinCondition .= " AND comments.comment_date >= :$dateParam";
       $queryBuilder->setParameter($dateParam, $date->toDateTimeString());

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
@@ -5,7 +5,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Util\Security;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class WooCommerceSingleOrderValue implements Filter {
@@ -14,10 +13,15 @@ class WooCommerceSingleOrderValue implements Filter {
   /** @var WooFilterHelper */
   private $wooFilterHelper;
 
+  /** @var FilterHelper */
+  private $filterHelper;
+
   public function __construct(
-    WooFilterHelper $wooFilterHelper
+    WooFilterHelper $wooFilterHelper,
+    FilterHelper $filterHelper
   ) {
     $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -34,7 +38,7 @@ class WooCommerceSingleOrderValue implements Filter {
       if (!is_string($days)) {
         $days = '1'; // Default to last day
       }
-      $date = Carbon::now()->subDays((int)$days);
+      $date = $this->filterHelper->getDateNDaysAgo(intval($days));
       $dateParam = "date_$parameterSuffix";
       $queryBuilder
         ->andWhere("$orderStatsAlias.date_created >= :$dateParam")

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -5,7 +5,6 @@ namespace MailPoet\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Util\Security;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
 class WooCommerceTotalSpent implements Filter {
@@ -14,10 +13,15 @@ class WooCommerceTotalSpent implements Filter {
   /** @var WooFilterHelper */
   private $wooFilterHelper;
 
+  /** @var FilterHelper */
+  private $filterHelper;
+
   public function __construct(
-    WooFilterHelper $wooFilterHelper
+    WooFilterHelper $wooFilterHelper,
+    FilterHelper $filterHelper
   ) {
     $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
   }
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
@@ -30,8 +34,9 @@ class WooCommerceTotalSpent implements Filter {
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
 
     if (!$isAllTime) {
+      /** @var int $days - for PHPStan because intval() doesn't accept a value of mixed */
       $days = $filterData->getParam('days');
-      $date = Carbon::now()->subDays($days);
+      $date = $this->filterHelper->getDateNDaysAgo(intval($days));
       $dateParam = "date_$parameterSuffix";
       $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
         ->setParameter($dateParam, $date->toDateTimeString());

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
@@ -6,7 +6,6 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\WooCommerce\Helper;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -68,7 +67,7 @@ class WooCommerceUsedCouponCode implements Filter {
     if (!$isAllTime) {
       /** @var int $days */
       $days = $filterData->getParam('days');
-      $date = Carbon::now()->subDays($days);
+      $date = $this->filterHelper->getDateNDaysAgo(intval($days));
       $dateParam = $this->filterHelper->getUniqueParameterName('date');
       $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
         ->setParameter($dateParam, $date->toDateTimeString());

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -58,7 +58,7 @@ class WooCommerceUsedPaymentMethod implements Filter {
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
     $excludedStatuses = $this->wooFilterHelper->defaultExcludedStatuses();
-    $date = is_int($days) ? Carbon::now()->subDays($days) : Carbon::now();
+    $date = is_int($days) ? $this->filterHelper->getDateNDaysAgo($days) : Carbon::now();
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -58,7 +58,7 @@ class WooCommerceUsedShippingMethod implements Filter {
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
     $excludedStatuses = $this->wooFilterHelper->defaultExcludedStatuses();
-    $date = is_int($days) ? Carbon::now()->subDays($days) : Carbon::now();
+    $date = is_int($days) ? $this->filterHelper->getDateNDaysAgo($days) : Carbon::now();
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:

--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -326,11 +326,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/EmailAction.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method MailPoetVendor\\\\Carbon\\\\CarbonImmutable\\:\\:subDays\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
-
-		-
 			message: "#^Parameter \\#2 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\MailPoetCustomFields\\:\\:applyForDateEqual\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
@@ -366,11 +361,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceCountry.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method MailPoetVendor\\\\Carbon\\\\Carbon\\:\\:subDays\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
-
-		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -379,11 +369,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of method MailPoetVendor\\\\Carbon\\\\Carbon\\:\\:subDays\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -301,11 +301,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/EmailAction.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method MailPoetVendor\\\\Carbon\\\\CarbonImmutable\\:\\:subDays\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
-
-		-
 			message: "#^Parameter \\#2 \\$operator of method MailPoet\\\\Segments\\\\DynamicSegments\\\\Filters\\\\MailPoetCustomFields\\:\\:applyForDateEqual\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
@@ -341,11 +336,6 @@ parameters:
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceCountry.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method MailPoetVendor\\\\Carbon\\\\Carbon\\:\\:subDays\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -354,11 +344,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceSubscription.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of method MailPoetVendor\\\\Carbon\\\\Carbon\\:\\:subDays\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: ../../lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
 
 		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -137,6 +137,16 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['customer-with-coupon-order@example.com'], $emails);
   }
 
+  public function testItWorksWithVeryLargeDaysValue(): void {
+    $customerId = $this->tester->createCustomer('customer@example.com');
+    $this->createOrder($customerId, Carbon::now()->subDays(5));
+
+    $segmentFilterData = $this->getSegmentFilterData('>', 0, 999999999);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->numberOfOrdersFilter);
+
+    $this->assertEqualsCanonicalizing(['customer@example.com'], $emails);
+  }
+
   private function getSegmentFilterData(string $comparisonType, int $ordersCount, int $days, $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, $action = WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, $action, [
       'number_of_orders_type' => $comparisonType,


### PR DESCRIPTION
## Description

When users set the `days` parameter to a very large number in dynamic segment filters, `Carbon::now()->subDays()` produces negative dates (e.g., year -1000). Depending on the database engine and the SQL mode, using negative dates in the queries can be rejected with errors.

This fix adds `getDateNDaysAgo()` and `getDateNDaysAgoImmutable()` helper methods to `FilterHelper` that clamp dates to a minimum of 1000-01-01 (MySQL's minimum valid DATE/DATETIME value).

Updated 12 filter files to use the new helper:
- WooCommerceNumberOfOrders
- WooCommerceUsedCouponCode
- WooCommerceTotalSpent
- WooCommerceSingleOrderValue
- WooCommerceNumberOfReviews
- WooCommerceAverageSpent
- WooCommerceUsedShippingMethod
- WooCommerceUsedPaymentMethod
- NumberOfClicks
- EmailsReceived
- EmailOpensAbsoluteCountAction
- DateFilterHelper

## Code review notes

To reproduce this error locally, I switched my local container to use `mysql:8.0` in `docker-compose.override.yml`:

```yml
services:
  db:
    image: mysql:8.0
    command: --sql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,ANSI,ONLY_FULL_GROUP_BY
    volumes:
      - mysql8-datavolume:/var/lib/mysql

volumes:
  mysql8-datavolume:
```

On creating a dynamic segment, e.g. `Repeat Buyers`, setting the `number of orders` to `in the last 999999` days, it is expected to get an error due to using an Invalid date in the query.

## QA notes

1. Navigate to MailPoet → Segments → Add new segment
2. Select any of the updated filters for the condition and confirm that after updating the number of days, the request to update the subscribers count is successful and updates the count as expected.
3. Set the `days` parameter to a large number, e.g. `999999`, and confirm the request doesn't throw any errors.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7773-date-error-after-updating-to-recent-version-of-the-plugin)

_The latest successful build from `stomail-7773-date-error-after-updating-to-recent-version-of-the-plugin` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed negative date errors when using very large day values in segment filters.

* **Tests**
  * Added tests to verify correct behavior and clamping for very large day values in date-based segment filters.

* **Refactor**
  * Centralized date calculation logic to make time-based filters more robust and consistent.

* **Changelog**
  * Added a release note entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->