### PR TITLE
Rename Draft to Inactive in automation UI

### DIFF
--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: creating-pull-requests
+description: Use when asked to create a pull request, open a PR, or submit changes for review
+---
+
+# Creating Pull Requests
+
+## Overview
+
+Always create pull requests as **drafts** and follow the repository's PR template format.
+
+## Workflow
+
+1. **Read the PR template first** - Check `.github/pull_request_template.md`
+2. **Create as draft** - Use `gh pr create --draft`
+3. **Follow template sections exactly** - Fill in all sections, use `_N/A_` for non-applicable ones
+
+## Quick Reference
+
+```bash
+# Read template
+cat .github/pull_request_template.md
+
+# Create draft PR with template format
+gh pr create --draft --title "Short title" --body "$(cat <<'EOF'
+## Description
+...
+## Code review notes
+...
+EOF
+)"
+```
+
+## Common Mistakes
+
+| Mistake               | Fix                                                          |
+| --------------------- | ------------------------------------------------------------ |
+| Creating non-draft PR | Always use `--draft` flag                                    |
+| Custom PR format      | Read and follow `.github/pull_request_template.md`           |
+| Missing sections      | Include all template sections, use `_N/A_` if not applicable |

--- a/mailpoet/assets/js/src/automation/components/status/names.tsx
+++ b/mailpoet/assets/js/src/automation/components/status/names.tsx
@@ -8,7 +8,7 @@ type NamesProps = {
 export const automationStatusNames: NamesProps = {
   [AutomationStatus.ACTIVE]: __('Active', 'mailpoet'),
   [AutomationStatus.DEACTIVATING]: __('Deactivating', 'mailpoet'),
-  [AutomationStatus.DRAFT]: __('Draft', 'mailpoet'),
+  [AutomationStatus.DRAFT]: __('Inactive', 'mailpoet'),
   [AutomationStatus.TRASH]: __('In trash', 'mailpoet'),
 };
 

--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -100,7 +100,7 @@ export function AutomationListing(): JSX.Element {
       },
       {
         name: AutomationStatus.DRAFT,
-        title: _x('Draft', 'noun', 'mailpoet'),
+        title: _x('Inactive', 'noun', 'mailpoet'),
         className: 'mailpoet-tab-draft',
       },
       {

--- a/mailpoet/changelog/2026-01-30-14-23-57-changed-rename-automation-status-draft-to-inactive-in-ui.md
+++ b/mailpoet/changelog/2026-01-30-14-23-57-changed-rename-automation-status-draft-to-inactive-in-ui.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Rename automation status "Draft" to "Inactive" in UI

--- a/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
+++ b/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
@@ -42,7 +42,7 @@ class AutomationListingCest {
     $i->waitForText('Automations');
     $i->waitForText('All');
     $i->waitForText('Active');
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
     $i->waitForText('Trash');
     $i->waitForText('Test Automation 1');
     $i->waitForText('Test Automation 2');
@@ -56,7 +56,7 @@ class AutomationListingCest {
     $i->see('Entered 0', $automation1row);
     $i->see('Processing 0', $automation1row);
     $i->see('Exited 0', $automation1row);
-    $i->see('Draft', $automation1row);
+    $i->see('Inactive', $automation1row);
     $i->see('Analytics', $automation1row);
     $i->see('Edit', $automation1row);
 

--- a/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
+++ b/mailpoet/tests/acceptance/Automation/ConfirmLeaveWhenUnsavedChangesCest.php
@@ -33,7 +33,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
     $i->click('Start building');
 
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
     $i->click('Delay');
@@ -51,7 +51,7 @@ class ConfirmLeaveWhenUnsavedChangesCest {
     $i->amOnMailpoetPage('Automation');
     $i->waitForText('Automations');
     $i->amOnPage('wp-admin/admin.php?page=mailpoet-automation-editor&id=' . $automationId);
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
     $i->waitForText('Move to Trash');
     $i->waitForText('New email subscriber added');
     $i->waitForText('Wait for 5 minutes');

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -38,7 +38,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
     $i->click('Start building');
 
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
 
@@ -80,7 +80,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->click('[aria-label="Close Settings"]', '.editor-sidebar__panel-tabs'); // Close the side panel as it obstructs the view of the save and continue button.
     $i->see('Save and continue');
     $i->click('[data-automation-id="email_editor_send_button"]'); // Save and continue button.
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
 
     $i->wantTo('Activate the automation');
     $i->click('Activate');
@@ -129,7 +129,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
     $i->click('Start building');
 
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
 

--- a/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateEmailAutomationAndWalkThroughCest.php
@@ -35,7 +35,7 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->waitForElementVisible('.mailpoet-automation-editor-automation-flow');
     $i->click('Start building');
 
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', 'Newsletter mailing list');
     $i->click('Delay');
@@ -54,7 +54,7 @@ class CreateEmailAutomationAndWalkThroughCest {
     $i->waitForText('Design');
     $i->click('Save and continue');
 
-    $i->waitForText('Draft');
+    $i->waitForText('Inactive');
 
     $i->click('Send email');
     $i->click('Reply to');


### PR DESCRIPTION
## Description

Renames the UI text "Draft" to "Inactive" for automation status. The internal status value remains `draft` in code and database.

## Code review notes

- Only UI text changes, no logic changes
- Updated 2 source files and 4 acceptance test files

## QA notes

1. Navigate to Marketing → Automations
2. Confirm tabs show: All, Active, **Inactive**, Trash
3. Create a new automation - should show "Inactive" status
4. Deactivate an active automation - should show "Inactive" status

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7727](https://linear.app/a8c/issue/STOMAIL-7727)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7727-swap-draft-automations-state-to-inactive)

_The latest successful build from `stomail-7727-swap-draft-automations-state-to-inactive` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating pull requests as drafts with proper template adherence.

* **Changes**
  * Renamed automation status label from "Draft" to "Inactive" throughout the UI for clarity.

* **Tests**
  * Updated acceptance tests to reflect the new automation status label.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->