### PR TITLE
Add is_automation_newsletter flag to the mailpoet_data payload

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -57,6 +57,7 @@ class EmailApiController {
    */
   public function getEmailData($postEmailData): array {
     $newsletter = $this->newsletterRepository->findOneBy(['wpPost' => $postEmailData['id']]);
+    $isAutomationNewsletter = $newsletter && ($newsletter->isAutomation() || $newsletter->isAutomationTransactional());
     return [
       'id' => $newsletter ? $newsletter->getId() : null,
       'subject' => $newsletter ? $newsletter->getSubject() : '',
@@ -66,6 +67,7 @@ class EmailApiController {
       'scheduled_at' => $newsletter ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT) : null,
       'utm_campaign' => $newsletter ? $newsletter->getGaCampaign() : '',
       'segment_ids' => $newsletter ? $newsletter->getSegmentIds() : [],
+      'is_automation_newsletter' => $isAutomationNewsletter,
     ];
   }
 
@@ -225,6 +227,7 @@ class EmailApiController {
       'scheduled_at' => Builder::string()->nullable(),
       'utm_campaign' => Builder::string(),
       'segment_ids' => Builder::array(),
+      'is_automation_newsletter' => Builder::boolean(),
     ])->toArray();
   }
 }


### PR DESCRIPTION
## Description

Add a `is_automation_newsletter` field to the `mailpoet_data` object appended to the `mailpoet_email` post type response.

## Code review notes

Inspect the API response for the `mailpoet_email` post type and confirm it includes the `is_automation_newsletter` field.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email API responses now include an is_automation_newsletter flag indicating whether an email belongs to an automation or automation transactional flow.

* **Documentation**
  * Public API schema updated to include the is_automation_newsletter boolean field, reflecting its presence in responses and expected type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->