### PR TITLE
Update translators comments in Email patterns STOMAIL-7775

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
@@ -26,13 +26,13 @@ class EducationalCampaignPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product Name] is a placeholder for the product name */
+      /* translators: [Product Name] is the product name placeholder to translate */
       __('How to Get the Most from [Product Name]', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [product] is a placeholder for the product name */
+      /* translators: [product] is the product name placeholder to translate */
       __('Our latest guide walks you through expert tips to make the most out of your [product].', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
@@ -58,7 +58,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: Placeholder text for a brief step description */
+      /* translators: [Brief description] is the step description placeholder to translate */
       __('[Brief description]', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
@@ -80,7 +80,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: Placeholder text for a brief step description */
+      /* translators: [Brief description] is the step description placeholder to translate */
       __('[Brief description]', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
@@ -117,7 +117,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: Placeholder text for a brief step description */
+      /* translators: [Brief description] is the step description placeholder to translate */
       __('[Brief description]', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
@@ -25,13 +25,13 @@ class EventInvitationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Event Name] is a placeholder for the event name */
+      /* translators: [Event Name] is the event name placeholder to translate */
       __('Join us for [Event Name]', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [brief description] is a placeholder for the event description */
+      /* translators: [brief description] is the event description placeholder to translate */
       __("You're invited 🎉 Join us for [brief description] and be part of our exclusive event series.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
@@ -30,7 +30,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [product category] is a placeholder for the product category */
+      /* translators: [product category] is the product category placeholder to translate */
       __("Explore our latest collection featuring [product category]. It's designed to inspire and elevate.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
@@ -25,7 +25,7 @@ class NewProductsAnnouncementPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product Name] is a placeholder for the product name */
+      /* translators: [Product Name] is the product name placeholder to translate */
       __('Introducing [Product Name]', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
@@ -26,7 +26,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product] is a placeholder for the product category */
+      /* translators: [Product] is the product category placeholder to translate */
       __('Loving your [Product]? Make it even better', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
@@ -25,7 +25,7 @@ class ProductRestockNotificationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product Name] is a placeholder for the product name */
+      /* translators: [Product Name] is the product name placeholder to translate */
       __('[Product Name] Is back in stock!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
@@ -25,7 +25,7 @@ class SaleAnnouncementPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [X]% is a placeholder for the discount percentage */
+      /* translators: [X]% is the discount percentage placeholder to translate */
       __('[X]% off sitewide!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
@@ -39,7 +39,7 @@ class SaleAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [X]% is a placeholder for the discount percentage */
+      /* translators: [X]% is the discount percentage placeholder to translate */
       __('Get [X]% OFF EVERYTHING in the store for a limited time.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
@@ -57,7 +57,7 @@ class SaleAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"fontSize":"medium"} -->
       <p class="has-medium-font-size">' .
-      /* translators: [End Date] is a placeholder for the sale end date */
+      /* translators: [End Date] is the sale end date placeholder to translate */
       __("Don't wait too long – this offer ends on [End Date].", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
     </div>


### PR DESCRIPTION
## Description

New email patterns contain placeholders that should be translated, but the comment can be confusing.

Expectation

Translation strings with placeholders that should be translated have a correct comment.

For example, replace this translator's comment:

/* translators: [Product Name] is a placeholder for the product name */
__('[Product Name] Is back in stock!', 'mailpoet')

With

/* translators: [Product Name] is the product name placeholder to translate */
## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7775

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7775-update-translators-comments-in-email-patterns)

_The latest successful build from `stomail-7775-update-translators-comments-in-email-patterns` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced translator comments in email pattern templates for clearer guidance on placeholder text requiring translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->