### PR TITLE
Prevent a fatal error from Text block

### DIFF
--- a/mailpoet/changelog/2026-02-04-14-42-05-fixed-rare-fatal-error-in-rendering-text-blocks-in-email.md
+++ b/mailpoet/changelog/2026-02-04-14-42-05-fixed-rare-fatal-error-in-rendering-text-blocks-in-email.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Rare fatal error in rendering text blocks in emails

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -173,6 +173,7 @@ class Text {
   }
 
   public function insertLineBreak($element) {
+    if (!$element->parent) return $element;
     $element->parent->insertChild(
       [
         'tag_name' => 'br',

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -238,4 +238,24 @@ class TextTest extends \MailPoetUnitTest {
 
     verify($result)->null();
   }
+
+  public function testInsertLineBreakHandlesElementWithoutParent(): void {
+    $html = '<p>Test paragraph</p>';
+    $dom = $this->parser->parseStr($html);
+    $paragraphs = $dom->query('p');
+    $this->assertInstanceOf(pQuery::class, $paragraphs);
+    $paragraph = $paragraphs[0];
+    $this->assertInstanceOf(DomNode::class, $paragraph);
+
+    // Remove the node (this sets parent to null)
+    $paragraph->remove();
+
+    // "Call to a member function insertChild() on null"
+    $textRenderer = new Text();
+    $result = $textRenderer->insertLineBreak($paragraph);
+
+    // Should return the element unchanged without crashing
+    verify($result)->equals($paragraph);
+    verify($result->parent)->null();
+  }
 }


### PR DESCRIPTION
## Description

This PR prevents a fatal error triggered when the Text block render attempts to add a line break to an element without a parent.

## Code review notes

Testing data attached in the ticket STOMAIL-7777

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7777

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare fatal error when rendering text blocks in emails.

* **Tests**
  * Added test coverage for text block rendering edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7777-call-to-a-member-function-insertchild-on-null)

_The latest successful build from `stomail-7777-call-to-a-member-function-insertchild-on-null` will be used. If none is available, the link won't work._