### PR TITLE
Allow non-delay actions before transactional emails

### DIFF
--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: creating-pull-requests
-description: Use when asked to create a pull request, open a PR, or submit changes for review
+description: 'ALWAYS use when asked to: create a PR, open a PR, make a PR, push and create PR, submit changes for review. Do NOT use gh pr create directly.'
 ---
 
 # Creating Pull Requests
+
+## ⚠️ CRITICAL
+
+**NEVER run `gh pr create` directly.** ALWAYS follow this skill's workflow.
 
 ## Overview
 
@@ -11,30 +15,18 @@ Always create pull requests as **drafts** and follow the repository's PR templat
 
 ## Workflow
 
-1. **Read the PR template first** - Check `.github/pull_request_template.md`
-2. **Create as draft** - Use `gh pr create --draft`
-3. **Follow template sections exactly** - Fill in all sections, use `_N/A_` for non-applicable ones
-
-## Quick Reference
-
-```bash
-# Read template
-cat .github/pull_request_template.md
-
-# Create draft PR with template format
-gh pr create --draft --title "Short title" --body "$(cat <<'EOF'
-## Description
-...
-## Code review notes
-...
-EOF
-)"
-```
+1. **Read the PR template first** refer .github/pull_request_template.md
+2. **Gather context**
+3. **Create as draft**
+4. **Follow template sections exactly** - Not all sections are mandatory, use `_N/A_` for non-applicable ones
+5. There are some checkboxes on the bottom of the template, only check the ones that are applicable.
 
 ## Common Mistakes
 
-| Mistake               | Fix                                                          |
-| --------------------- | ------------------------------------------------------------ |
-| Creating non-draft PR | Always use `--draft` flag                                    |
-| Custom PR format      | Read and follow `.github/pull_request_template.md`           |
-| Missing sections      | Include all template sections, use `_N/A_` if not applicable |
+| Mistake                       | Fix                                                          |
+| ----------------------------- | ------------------------------------------------------------ |
+| Using `gh pr create` directly | ALWAYS use this skill workflow first                         |
+| Creating non-draft PR         | Always use `--draft` flag                                    |
+| Custom PR format              | Read and follow `.github/pull_request_template.md`           |
+| Missing sections              | Include all template sections, use `_N/A_` if not applicable |
+| Skipping template read        | ALWAYS read the template first, it may have changed          |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,14 @@ _N/A_
 
 _N/A_
 
+## Screenshots or screencast <!-- if applicable -->
+
+<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
+
+| Before                          | After                          |
+| ------------------------------- | ------------------------------ |
+| <!-- Before screenshot here --> | <!-- After screenshot here --> |
+
 ## Tasks
 
 - [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/context.ts
@@ -19,6 +19,8 @@ export type Context = {
   segments?: Segment[];
   userRoles?: FormTokenItem[];
   senderDomainsConfig?: SenderDomainsConfig;
+  transactional_triggers?: string[];
+  delay_action_key?: string;
 };
 
 export const getContext = (): Context =>

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/helper/is-transactional.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/helper/is-transactional.ts
@@ -19,39 +19,76 @@ const transactionalTriggers = [
   'woocommerce:buys-from-a-tag',
   'woocommerce:buys-from-a-category',
   'woocommerce:buys-a-product',
+  'woocommerce-bookings:booking-created',
+  'woocommerce-bookings:booking-status-changed',
 ];
+
+// Only the delay action converts an email from transactional to marketing.
+// Other actions (if/else, tagging, adding to list) do not affect transactional nature.
+const delayActionKey = 'core:delay';
+
+/**
+ * Checks if there exists at least one path from the 'from' step to the 'to' step
+ * that doesn't contain a delay action.
+ */
+function hasDelayFreePathToStep(
+  from: Step,
+  to: Step,
+  steps: Record<string, Step>,
+): boolean {
+  const stack: Array<[Step, boolean]> = [[from, false]]; // [step, hasDelayOnPath]
+  const visited: Record<string, boolean> = {};
+
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item) {
+      break;
+    }
+    const [current, hasDelayOnPath] = item;
+    const currentHasDelay = current.key === delayActionKey || hasDelayOnPath;
+
+    const stateKey = `${current.id}:${currentHasDelay ? '1' : '0'}`;
+    if (visited[stateKey]) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    visited[stateKey] = true;
+
+    if (current.id === to.id && !currentHasDelay) {
+      return true;
+    }
+
+    if (current.id !== to.id) {
+      current.next_steps.forEach((nextStep) => {
+        const nextStepObj = steps[nextStep.id];
+        if (nextStepObj) {
+          stack.push([nextStepObj, currentHasDelay]);
+        }
+      });
+    }
+  }
+  return false;
+}
 
 export function isTransactional(step: Step): boolean {
   const automation = select(storeName).getAutomationData();
-  const triggers = Object.values(automation.steps).filter(
-    (s) => s.type === 'trigger',
+  const { steps } = automation;
+  const allSteps: Step[] = Object.values(steps);
+  const triggers = allSteps.filter((s) => s.type === 'trigger');
+
+  // All triggers must be transactional triggers
+  const transactionalTriggersOnly = triggers.every((trigger) =>
+    transactionalTriggers.includes(trigger.key),
   );
 
-  let triggersAllowTransactionals = null;
-  triggers.forEach((trigger) => {
-    if (
-      triggersAllowTransactionals === true &&
-      !transactionalTriggers.includes(trigger.key)
-    ) {
-      triggersAllowTransactionals = false;
-    }
-    if (
-      triggersAllowTransactionals === null &&
-      transactionalTriggers.includes(trigger.key)
-    ) {
-      triggersAllowTransactionals = true;
-    }
-  });
-
-  if (!triggersAllowTransactionals) {
+  if (!triggers.length || !transactionalTriggersOnly) {
     return false;
   }
 
-  let stepPositionIsUnderNeathTransactionalTrigger = false;
-  triggers.forEach((trigger) => {
-    if (trigger.next_steps.map((next) => next.id).includes(step.id)) {
-      stepPositionIsUnderNeathTransactionalTrigger = true;
-    }
-  });
-  return stepPositionIsUnderNeathTransactionalTrigger;
+  // Every transactional trigger must have at least one delay-free path to the email step
+  const allTriggersHaveDelayFreePath = triggers.every((trigger) =>
+    hasDelayFreePathToStep(trigger, step, steps as Record<string, Step>),
+  );
+
+  return allTriggersHaveDelayFreePath;
 }

--- a/mailpoet/changelog/2026-02-05-10-08-58-changed-automation-emails-after-non-delay-actions-add-tag-.md
+++ b/mailpoet/changelog/2026-02-05-10-08-58-changed-automation-emails-after-non-delay-actions-add-tag-.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Automation emails after non-delay actions (add tag, if/else, add to list) are now treated as transactional when using transactional triggers. Only the delay action converts emails to marketing

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -13,6 +13,7 @@ use MailPoet\Automation\Engine\Exceptions\NotFoundException;
 use MailPoet\Automation\Engine\Integration\Action;
 use MailPoet\Automation\Engine\Integration\ValidationException;
 use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SegmentPayload;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\WooCommerce\Payloads\AbandonedCartPayload;
@@ -492,8 +493,8 @@ class SendEmailAction implements Action {
     $triggers = $automation->getTriggers();
     $transactionalTriggers = array_filter(
       $triggers,
-      function(Step $step): bool {
-        return in_array($step->getKey(), self::TRANSACTIONAL_TRIGGERS, true);
+      function(Step $triggerStep): bool {
+        return in_array($triggerStep->getKey(), self::TRANSACTIONAL_TRIGGERS, true);
       }
     );
 
@@ -502,11 +503,53 @@ class SendEmailAction implements Action {
     }
 
     foreach ($transactionalTriggers as $trigger) {
-      if (!in_array($step->getId(), $trigger->getNextStepIds(), true)) {
+      if (!$this->hasDelayFreePathToStep($trigger, $step, $automation)) {
         return false;
       }
     }
     return true;
+  }
+
+  /**
+   * Checks if there exists at least one path from $from step to $to step
+   * that doesn't contain a delay action.
+   */
+  private function hasDelayFreePathToStep(Step $from, Step $to, Automation $automation): bool {
+    $steps = $automation->getSteps();
+    $stack = [[$from, false]]; // [step, hasDelayOnPath]
+    $visited = [];
+
+    while (!empty($stack)) {
+      [$current, $hasDelayOnPath] = array_pop($stack);
+
+      $stateKey = $current->getId() . ':' . ($hasDelayOnPath ? '1' : '0');
+      if (isset($visited[$stateKey])) {
+        continue;
+      }
+      $visited[$stateKey] = true;
+
+      // Only delay actions convert transactional emails to marketing, as they introduce
+      // a significant time gap between the trigger event and email delivery.
+      // If new delay-like actions are added (e.g., "wait until date"), they should also be checked here.
+      if ($current->getKey() === DelayAction::KEY) {
+        $hasDelayOnPath = true;
+      }
+
+      if ($current->getId() === $to->getId()) {
+        if (!$hasDelayOnPath) {
+          return true;
+        }
+        continue;
+      }
+
+      foreach ($current->getNextStepIds() as $nextStepId) {
+        $nextStep = $steps[$nextStepId] ?? null;
+        if ($nextStep !== null) {
+          $stack[] = [$nextStep, $hasDelayOnPath];
+        }
+      }
+    }
+    return false;
   }
 
   private function automationHasWooCommerceTrigger(Automation $automation): bool {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -66,7 +66,7 @@ class SendEmailAction implements Action {
   private const WAIT_OPTIN = 'wait_optin';
   private const OPTIN_RETRIES = 'optin_retries';
 
-  private const TRANSACTIONAL_TRIGGERS = [
+  public const TRANSACTIONAL_TRIGGERS = [
     'mailpoet:custom-trigger',
     'woocommerce:order-status-changed',
     'woocommerce:order-created',

--- a/mailpoet/lib/Automation/Integrations/MailPoet/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/ContextFactory.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\Automation\Integrations\MailPoet;
 
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Services\AuthorizedEmailsController;
@@ -43,6 +45,8 @@ class ContextFactory {
     $data = [
       'segments' => $this->getSegments(),
       'userRoles' => $this->getUserRoles(),
+      'transactional_triggers' => SendEmailAction::TRANSACTIONAL_TRIGGERS,
+      'delay_action_key' => DelayAction::KEY,
     ];
 
     if ($this->isMSSEnabled()) {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Actions/SendEmailActionTest.php
@@ -687,6 +687,21 @@ class SendEmailActionTest extends \MailPoetTest {
       'expected_type' => NewsletterEntity::TYPE_AUTOMATION,
     ];
 
+    // Booking triggers should be transactional
+    $bookingCreatedTrigger = new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce-bookings:booking-created', [], [new NextStep('emailstep')]);
+
+    $isTransactionalWithBookingCreated = [
+      'steps' => [$root, $bookingCreatedTrigger, $emailStep],
+      'expected_type' => NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+    ];
+
+    $bookingStatusChangedTrigger = new Step('trigger', Step::TYPE_TRIGGER, 'woocommerce-bookings:booking-status-changed', [], [new NextStep('emailstep')]);
+
+    $isTransactionalWithBookingStatusChanged = [
+      'steps' => [$root, $bookingStatusChangedTrigger, $emailStep],
+      'expected_type' => NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+    ];
+
     return [
       'is_transactional' => $isTransactional,
       'is_not_transactional_because_of_trigger' => $isNotTransactionalBecauseOfTrigger,
@@ -696,6 +711,8 @@ class SendEmailActionTest extends \MailPoetTest {
       'is_marketing_with_non_delay_then_delay' => $isMarketingWithNonDelayThenDelay,
       'is_transactional_with_if_else' => $isTransactionalWithIfElse,
       'is_marketing_with_delay_in_branch' => $isMarketingWithDelayInBranch,
+      'is_transactional_with_booking_created' => $isTransactionalWithBookingCreated,
+      'is_transactional_with_booking_status_changed' => $isTransactionalWithBookingStatusChanged,
     ];
   }
 


### PR DESCRIPTION
## Description

Modified transactional email detection so only `core:delay` action converts an email from transactional to marketing. Non-delay actions (add tag, if/else, add to list) no longer affect transactional status.

**New Behavior:**

| Automation Flow | Before | After |
|-----------------|--------|-------|
| Trigger → Send Email | Transactional | Transactional |
| Trigger → Add Tag → Send Email | Marketing | **Transactional** |
| Trigger → If/Else → Send Email | Marketing | **Transactional** |
| Trigger → Delay → Send Email | Marketing | Marketing |

## Code review notes

_N/A_

## QA notes

1. Create automation with WooCommerce trigger (e.g., Order completed)
2. Add "Add tag" action before "Send email"
3. Verify sidebar shows "This is a transactional email"
4. Add "Delay" action before "Send email" - verify it changes to "This is a marketing email"

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7472

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
|  <img width="1155" height="676" alt="ScreenshotBefore" src="https://github.com/user-attachments/assets/3e12f6dd-5f99-4317-b4b2-f9d59426bc62" />  |  <img width="1106" height="695" alt="ScreenshotAfter" src="https://github.com/user-attachments/assets/4d802196-f29e-4e2f-b298-1f2a2246c189" /> |

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7472-allow-non-delay-automation-actions-before-transactional)

_The latest successful build from `stomail-7472-allow-non-delay-automation-actions-before-transactional` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking-related events added as transactional triggers.

* **Bug Fixes**
  * Emails after non-delay actions (add tag, if/else, add to list) are now treated as transactional when initiated by transactional triggers; only delay actions convert emails to marketing.

* **Tests**
  * Expanded test coverage across delay, non-delay, branching, and multiple-action scenarios to validate transactional vs. marketing outcomes.

* **Documentation**
  * Updated changelog and PR template; internal workflow guidance refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->