### PR TITLE
Fix automation emails post status

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/components/automation-save-button.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/components/automation-save-button.tsx
@@ -1,0 +1,103 @@
+import { useRef, useEffect, useCallback, useState } from '@wordpress/element';
+import { check, cloud, Icon } from '@wordpress/icons';
+import { createPortal } from 'react-dom';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * A "Save draft" button for automation emails that appears as a link-style button
+ * on the left side of the header toolbar.
+ *
+ * This is needed because automation emails use 'private' post status,
+ * which WordPress treats as published. The standard "Save Draft" button
+ * is not shown for published posts, leaving no way to save changes.
+ */
+export function AutomationSaveButton() {
+  const portalRef = useRef<HTMLSpanElement>(document.createElement('span'));
+  const [isMounted, setIsMounted] = useState(false);
+
+  const { isDirty, isSaving } = useSelect(
+    (select) => ({
+      isDirty: select(editorStore).isEditedPostDirty(),
+      isSaving: select(editorStore).isSavingPost(),
+    }),
+    [],
+  );
+
+  const { savePost } = useDispatch(editorStore);
+
+  const handleSave = useCallback(async () => {
+    await savePost();
+  }, [savePost]);
+
+  // Mount the portal element as the first child of the header settings area
+  useEffect(() => {
+    const portalElement = portalRef.current;
+    let observer: MutationObserver | null = null;
+
+    const findAndMount = () => {
+      // Find the header settings container (right side of header toolbar)
+      const headerSettings = document.querySelector('.editor-header__settings');
+
+      if (headerSettings) {
+        headerSettings.insertBefore(portalElement, headerSettings.firstChild);
+        setIsMounted(true);
+        return true;
+      }
+      return false;
+    };
+
+    // Try to mount immediately
+    if (!findAndMount()) {
+      // If not found, wait for the editor to fully load
+      observer = new MutationObserver(() => {
+        if (findAndMount()) {
+          observer?.disconnect();
+        }
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    return () => {
+      observer?.disconnect();
+      portalElement.remove();
+      setIsMounted(false);
+    };
+  }, []);
+
+  // Don't render if not mounted
+  if (!isMounted) {
+    return null;
+  }
+
+  // Show different states based on dirty/saving status
+  let buttonLabel: string;
+  if (isSaving) {
+    buttonLabel = __('Saving', 'mailpoet');
+  } else if (isDirty) {
+    buttonLabel = __('Save draft', 'mailpoet');
+  } else {
+    buttonLabel = __('Saved', 'mailpoet');
+  }
+
+  return createPortal(
+    <Button
+      variant="tertiary"
+      onClick={handleSave}
+      disabled={isSaving || !isDirty}
+      className="editor-post-saved-state"
+      data-automation-id="email_editor_save_draft_button"
+    >
+      {isSaving && <Icon icon={cloud} />}
+      {!isSaving && !isDirty && <Icon icon={check} />}
+      {buttonLabel}
+    </Button>,
+    portalRef.current,
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -13,6 +13,7 @@ import { initializeEditor } from '@woocommerce/email-editor';
 import { EmailContentValidationRule } from '@woocommerce/email-editor/build-types/store';
 import { withSatismeterSurvey } from './satismeter-survey';
 import { EmailSidebarExtension } from './email-sidebar-extension';
+import { AutomationSaveButton } from './components/automation-save-button';
 import './index.scss';
 import { emailValidationRule } from './validate-email-content';
 import { initStripPostStatusOnSaveMiddleware } from './middleware/strip-post-status-on-save';
@@ -105,6 +106,16 @@ addFilter(
 if (!isAutomationNewsletter) {
   registerPlugin('mailpoet-settings-sidebar', {
     render: EmailSidebarExtension,
+    scope: 'woocommerce-email-editor',
+  });
+}
+
+// Register save button for automation emails
+// Automation emails use 'private' post status, which WordPress treats as published.
+// The standard "Save Draft" button is not shown for published posts, so we add our own.
+if (isAutomationNewsletter) {
+  registerPlugin('mailpoet-automation-save-button', {
+    render: AutomationSaveButton,
     scope: 'woocommerce-email-editor',
   });
 }

--- a/mailpoet/changelog/2026-02-06-07-10-21-fixed-ensure-automation-emails-consistently-use-private-.md
+++ b/mailpoet/changelog/2026-02-06-07-10-21-fixed-ensure-automation-emails-consistently-use-private-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Ensure automation emails consistently use 'private' post status and prevent duplicate newsletter records

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/EmailFactory.php
@@ -126,10 +126,11 @@ class EmailFactory {
 
     // Create a WordPress post with the pattern content
     // The meta_input flag prevents other plugins from creating duplicate newsletters
+    // Automation emails use 'private' status to prevent them from appearing in public queries
     $postId = $this->wpFunctions->wpInsertPost([
       'post_content' => $patternContent,
       'post_type' => EmailEditor::MAILPOET_EMAIL_POST_TYPE,
-      'post_status' => 'draft',
+      'post_status' => 'private',
       'post_author' => $this->wpFunctions->getCurrentUserId(),
       'post_title' => $data['subject'] ?? __('New Email', 'mailpoet'),
       'meta_input' => ['_mailpoet_is_automation_email' => '1'],

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Templates/EmailFactoryTest.php
@@ -541,6 +541,9 @@ class EmailFactoryTest extends MailPoetTest {
     $this->assertNotNull($wpPost);
     $this->assertNotEmpty($wpPost->post_content); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
+    // Verify the automation email post status is 'private'
+    $this->assertEquals('private', $wpPost->post_status); // @phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
     // Verify the email template is set
     $templateSlug = get_post_meta($wpPostId, '_wp_page_template', true);
     $this->assertEquals('newsletter', $templateSlug);


### PR DESCRIPTION
## Description

This PR ensures all automation emails consistently use `post_status = 'private'` instead of 'draft'.

  **Changes:**

  1. **Set 'private' post status for automation emails** (`NewsletterSaveController.php`)
     - Modified `ensureWpPost()` to set `post_status = 'private'` for automation emails
     - Updated `duplicate()` method to preserve 'private' status for duplicated automation emails

  2. **Preserve 'private' status during REST API updates** (`EmailEditor.php`)
     - Added `rest_pre_insert_mailpoet_email` filter that prevents the block editor from changing automation email status to  'draft' during autosave
     - This fixes an issue where leaving the editor without saving would change the post status

  The 'private' status prevents automation emails from appearing in public WordPress queries while still allowing admin access.

## Code review notes

_N/A_

## QA notes

- Make sure that the block email editor is enabled for automations.

  1. **Test automation email creation:**
     - Create a new automation with a "Send Email" step
     - Verify the email's `wp_posts.post_status` is 'private' (not 'draft')

  2. **Test editor autosave behavior:**
     - Open an automation email in the block editor
     - Make changes but don't save
     - Leave the editor (click back/close)
     - Verify the post status remains 'private'

  3. **Test step duplication:**
     - Duplicate an automation email step
     - Verify the duplicated email has 'private' status

  4. **Test email duplication:**
     - Duplicate an automation email via the duplicate action
     - Verify the duplicated email also has 'private' status

## Linked PRs

STOMAIL-7797

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7797-fix-automation-emails-post_status)

_The latest successful build from `stomail-7797-fix-automation-emails-post_status` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Save Draft" button in the email editor for automation emails to improve saving UX.

* **Bug Fixes**
  * Automation emails now consistently use a private post status, preventing them from appearing in public queries and avoiding duplicate newsletter records.

* **Tests**
  * Added tests for automation newsletter duplication and block-editor creation ensuring private post status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->