### PR TITLE
Improve stability of EditorUpdateNewForm test

### DIFF
--- a/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
+++ b/mailpoet/tests/acceptance/Forms/EditorUpdateNewFormCest.php
@@ -51,7 +51,7 @@ class EditorUpdateNewFormCest {
     $i->waitForElement('[data-automation-id="template_selection_list"]');
     $i->click('[data-automation-id="select_template_template_1_popup"]');
     $i->waitForElement('[data-automation-id="form_title_input"]');
-    $i->clearField('[data-automation-id="form_title_input"]'); // Clear field due to flakiness
+    $i->clearFormField('[data-automation-id="form_title_input"]');
     $i->fillField('[data-automation-id="form_title_input"]', $formName);
 
     $i->wantTo('Try saving form without selected list');
@@ -71,6 +71,7 @@ class EditorUpdateNewFormCest {
     $i->seeNoJSErrors();
 
     $i->wantTo('Update form name and confirmation message');
+    $i->clearFormField('[data-automation-id="form_title_input"]');
     $i->fillField('[data-automation-id="form_title_input"]', $updatedFormName);
     $i->fillField('.components-textarea-control__input', $newConfMessage);
 


### PR DESCRIPTION


## Description

### Summary                                                                                                                                                                                                     
                                                                                                                                                                                                              
  - Replace clearField with clearFormField when clearing the form title input in the form editor acceptance test
  - Add missing clearFormField call before updating the form name

### Problem

  The test was flaky because clearField (WebDriver's native clear()) doesn't trigger React's onChange events. React re-renders the input with its stale state ("Join the Club" from the template), causing
  fillField to append rather than replace, resulting in "Join the ClubMy awesome form".

### Fix

  clearFormField presses Backspace for each character, which properly fires React key events and updates React's internal state. This is the same pattern used in other form editor tests
  (EditorTextInputStylesCest, EditorAddDividerCest, EditorButtonStylesCest, etc.).

### Test plan

  - Run ./do test:acceptance --skip-deps --skip-plugins --file ./tests/acceptance/Forms/EditorUpdateNewFormCest.php

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7802-flaky-update-form-acceptance-test)

_The latest successful build from `stomail-7802-flaky-update-form-acceptance-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved form field clearing mechanism in acceptance tests for the form editor to enhance test reliability and consistency when handling form inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->