### PR TITLE
Add filter to hide sender details in Send email step

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/email-panel.tsx
@@ -34,13 +34,14 @@ function SingleLineTextareaControl(
 }
 
 export function EmailPanel(): JSX.Element {
-  const { selectedStep, errors } = useSelect(
+  const { selectedStep, errors, isGarden } = useSelect(
     (select) => ({
       selectedStep: select(storeName).getSelectedStep(),
       selectedStepType: select(storeName).getSelectedStepType(),
       errors: select(storeName).getStepError(
         select(storeName).getSelectedStep().id,
       ),
+      isGarden: select(storeName).getContext('is_garden') === true,
     }),
     [],
   );
@@ -49,6 +50,8 @@ export function EmailPanel(): JSX.Element {
   const senderNameErrorMessage = errorFields?.sender_name ?? '';
   const senderAddressErrorMessage = errorFields?.sender_address ?? '';
   const subjectErrorMessage = errorFields?.subject ?? '';
+  const showSenderDetailsFields = !isGarden;
+
   return (
     <PanelBody opened>
       <StepName
@@ -62,55 +65,63 @@ export function EmailPanel(): JSX.Element {
           );
         }}
       />
-      <TextControl
-        className={
-          senderNameErrorMessage ? 'mailpoet-automation-field__error' : ''
-        }
-        help={senderNameErrorMessage}
-        label={__('"From" name', 'mailpoet')}
-        placeholder={
-          // translators: A placeholder for a person's name
-          __('John Doe', 'mailpoet')
-        }
-        value={(selectedStep.args.sender_name as string) ?? ''}
-        onChange={(value) =>
-          dispatch(storeName).updateStepArgs(
-            selectedStep.id,
-            'sender_name',
-            value,
-          )
-        }
-      />
-      <TextControl
-        className={
-          senderAddressErrorMessage ? 'mailpoet-automation-field__error' : ''
-        }
-        help={
-          <>
-            {senderAddressErrorMessage}
-            {window.mailpoet_mss_active &&
-              isEmail((selectedStep.args.sender_address as string) ?? '') && (
-                <SenderDomainNotice
-                  email={(selectedStep.args.sender_address as string) ?? ''}
-                />
-              )}
-          </>
-        }
-        type="email"
-        label={__('"From" email address', 'mailpoet')}
-        placeholder={
-          // translators: A placeholder for an email
-          __('you@domain.com', 'mailpoet')
-        }
-        value={(selectedStep.args.sender_address as string) ?? ''}
-        onChange={(value) =>
-          dispatch(storeName).updateStepArgs(
-            selectedStep.id,
-            'sender_address',
-            value,
-          )
-        }
-      />
+      {showSenderDetailsFields && (
+        <>
+          <TextControl
+            className={
+              senderNameErrorMessage ? 'mailpoet-automation-field__error' : ''
+            }
+            help={senderNameErrorMessage}
+            label={__('"From" name', 'mailpoet')}
+            placeholder={
+              // translators: A placeholder for a person's name
+              __('John Doe', 'mailpoet')
+            }
+            value={(selectedStep.args.sender_name as string) ?? ''}
+            onChange={(value) =>
+              dispatch(storeName).updateStepArgs(
+                selectedStep.id,
+                'sender_name',
+                value,
+              )
+            }
+          />
+          <TextControl
+            className={
+              senderAddressErrorMessage
+                ? 'mailpoet-automation-field__error'
+                : ''
+            }
+            help={
+              <>
+                {senderAddressErrorMessage}
+                {window.mailpoet_mss_active &&
+                  isEmail(
+                    (selectedStep.args.sender_address as string) ?? '',
+                  ) && (
+                    <SenderDomainNotice
+                      email={(selectedStep.args.sender_address as string) ?? ''}
+                    />
+                  )}
+              </>
+            }
+            type="email"
+            label={__('"From" email address', 'mailpoet')}
+            placeholder={
+              // translators: A placeholder for an email
+              __('you@domain.com', 'mailpoet')
+            }
+            value={(selectedStep.args.sender_address as string) ?? ''}
+            onChange={(value) =>
+              dispatch(storeName).updateStepArgs(
+                selectedStep.id,
+                'sender_address',
+                value,
+              )
+            }
+          />
+        </>
+      )}
       <SingleLineTextareaControl
         className={
           subjectErrorMessage ? 'mailpoet-automation-field__error' : ''
@@ -141,7 +152,6 @@ export function EmailPanel(): JSX.Element {
         }
         help={<ShortcodeHelpText />}
       />
-
       <div className="mailpoet-automation-email-content-separator" />
       <PlainBodyTitle title={__('Email', 'mailpoet')} />
       <EditNewsletter />


### PR DESCRIPTION
## Description

Hides the sender name and sender address fields in the MailPoet automation "Send email" step when the site runs in the Garden environment.

| Before | After |
| -- | -- |
| <img width="280" height="735" alt="kk4rKIzccug4l5hz" src="https://github.com/user-attachments/assets/3238c4c9-7e38-4ada-899d-a475e80e6abd" /> | <img width="280" height="735" alt="kk4rKIzccug4l5hz" src="https://github.com/user-attachments/assets/4ac02a48-c9c1-4804-b361-df19fbf28995" /> |

## Code review notes

_N/A_

## QA notes

1. Navigate to MailPoet → Automations → Edit an existing automation or create a new one.
2. Focus the Send email action step.
3. Confirm the `"From" name` and `"From" email address` are present and can be edited normally.
4. To simulate Garden environment, apply the following change locally:
```diff
--- a/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/AutomationEditor.php
@@ -166,7 +166,7 @@ class AutomationEditor {
       $data[$key] = $factory();
     }

-    $data['is_garden'] = $this->dotcomHelperFunctions->isGarden();
+    $data['is_garden'] = true;

     return $data;
   }
```
5. Focus the Send email action step and confirm the sender details fields are no longer showing.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7799: Email automation FROM should not be customizable](https://linear.app/a8c/issue/STOMAIL-7799/email-automation-from-should-not-be-customizable)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7799-email-automation-from-should-not-be-customizable)

_The latest successful build from `stomail-7799-email-automation-from-should-not-be-customizable` will be used. If none is available, the link won't work._