### PR TITLE
Release 5.21.0

### DIFF
--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 5.21.0 - 2026-02-10 =
+* Added: Provide automation subject fields as tags in email block editor;
+* Added: New email patterns for post-purchase automations: First Purchase Thank You, Post Purchase Thank You, Product Purchase Follow-Up, and Win Back Customer;
+* Fixed: Fix negative date errors when using large days values in segment filters;
+* Fixed: Rare fatal error in rendering text blocks in emails.
+
 = 5.20.0 - 2026-02-02 =
 * Added: Filter mailpoet_is_cookie_tracking_enabled allowing control of cookie tracking;
 * Added: Add Welcome with Discount email pattern;

--- a/mailpoet/changelog/2025-11-14-07-06-45-added-provide-automation-subject-fields-as-tags-in-email.md
+++ b/mailpoet/changelog/2025-11-14-07-06-45-added-provide-automation-subject-fields-as-tags-in-email.md
@@ -1,5 +1,0 @@
-# Type: Added
-
-# Description
-
-Provide automation subject fields as tags in email block editor

--- a/mailpoet/changelog/2026-01-29-08-19-41-added-new-email-patterns-for-post-purchase-automations-f.md
+++ b/mailpoet/changelog/2026-01-29-08-19-41-added-new-email-patterns-for-post-purchase-automations-f.md
@@ -1,5 +1,0 @@
-# Type: Added
-
-# Description
-
-New email patterns for post-purchase automations: First Purchase Thank You, Post Purchase Thank You, Product Purchase Follow-Up, and Win Back Customer

--- a/mailpoet/changelog/2026-01-30-12-27-55-fixed-fix-negative-date-errors-when-using-large-days-val.md
+++ b/mailpoet/changelog/2026-01-30-12-27-55-fixed-fix-negative-date-errors-when-using-large-days-val.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Fix negative date errors when using large days values in segment filters

--- a/mailpoet/changelog/2026-02-04-14-42-05-fixed-rare-fatal-error-in-rendering-text-blocks-in-email.md
+++ b/mailpoet/changelog/2026-02-04-14-42-05-fixed-rare-fatal-error-in-rendering-text-blocks-in-email.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Rare fatal error in rendering text blocks in emails

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.20.0
+ * Version: 5.21.0
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.20.0',
+  'version' => '5.21.0',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 5.20.0
+Stable tag: 5.21.0
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,11 +227,10 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.20.0 - 2026-02-02 =
-* Added: Filter mailpoet_is_cookie_tracking_enabled allowing control of cookie tracking;
-* Added: Add Welcome with Discount email pattern;
-* Added: "Abandoned Cart" and "Abandoned Cart with Discount" email patterns using WooCommerce Product Collection block;
-* Updated: Block email editor version;
-* Changed: Rename automation status "Draft" to "Inactive" in UI.
+= 5.21.0 - 2026-02-10 =
+* Added: Provide automation subject fields as tags in email block editor;
+* Added: New email patterns for post-purchase automations: First Purchase Thank You, Post Purchase Thank You, Product Purchase Follow-Up, and Win Back Customer;
+* Fixed: Fix negative date errors when using large days values in segment filters;
+* Fixed: Rare fatal error in rendering text blocks in emails.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 5.21.0 Release Notes

* **New Features**
  * Automation subject fields now available as tags in email block editor
  * New post-purchase automation email patterns: First Purchase Thank You, Post Purchase Thank You, Product Purchase Follow-Up, and Win Back Customer

* **Bug Fixes**
  * Fixed negative date errors with large days values in segment filters
  * Fixed rare fatal error in rendering text blocks in emails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->