### PR TITLE
Bump minimum WooCommerce to 10.4, tested up to 10.5

### DIFF
--- a/mailpoet/changelog/2026-02-10-00-00-00-updated-bump-the-minimum-required-woocommerce-version-to-10-4.md
+++ b/mailpoet/changelog/2026-02-10-00-00-00-updated-bump-the-minimum-required-woocommerce-version-to-10-4.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Bump the minimum required WooCommerce version to 10.4 and tested up to version to 10.5

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 10.3
- * WC tested up to: 10.4
+ * WC requires at least: 10.4
+ * WC tested up to: 10.5
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.8'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.3'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.4'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
## Description

This PR bumps the minimum required WooCommerce to 10.4 to align with the L-1 of the released WooCommerce 10.5.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wc-10-5)

_The latest successful build from `wc-10-5` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Minimum required WooCommerce version updated to 10.4
  * Plugin compatibility confirmed through WooCommerce 10.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->