### PR TITLE
Trigger postMessage when inside an iframe

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx
@@ -66,7 +66,14 @@ function PostStep({ onClose }): JSX.Element {
   );
 
   const goToListings = () => {
-    window.location.href = MailPoet.urls.automationListing;
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(
+        { type: 'mailpoet-navigate-to-automation-listing' },
+        window.location.origin,
+      );
+    } else {
+      window.location.href = MailPoet.urls.automationListing;
+    }
   };
 
   return (

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -216,10 +216,21 @@ export function* trash(onTrashed: () => void = undefined) {
   onTrashed?.();
 
   if (data?.data?.status === AutomationStatus.TRASH) {
-    window.location.href = addQueryArgs(MailPoet.urls.automationListing, {
-      notice: LISTING_NOTICES.automationDeleted,
-      'notice-args': [automation.name],
-    });
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(
+        {
+          type: 'mailpoet-navigate-to-automation-listing',
+          notice: LISTING_NOTICES.automationDeleted,
+          'notice-args': [automation.name],
+        },
+        window.location.origin,
+      );
+    } else {
+      window.location.href = addQueryArgs(MailPoet.urls.automationListing, {
+        notice: LISTING_NOTICES.automationDeleted,
+        'notice-args': [automation.name],
+      });
+    }
   }
 
   return {


### PR DESCRIPTION
## Description

If the Automation editor is running inside an iframe, we want to trigger an event rather than redirect directly somewhere. This PR shouldn’t change anything if the editor is running in the usual circumstances within the MailPoet plugin.

## Code review notes

_N/A_

## QA notes

There is no change, so verify that the "View all automations" redirects to the user without any issues.

<img width="1916" height="1045" alt="image" src="https://github.com/user-attachments/assets/c3ef74fd-6bdf-4cd5-beb5-ab6e6a97bd12" />

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7767

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`) - no changes visible to the users
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7767-the-view-all-automations-redirects-to-the-old-ui)

_The latest successful build from `stomail-7767-the-view-all-automations-redirects-to-the-old-ui` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation when returning to the automation listing after deleting an automation; works correctly when the editor is embedded or running standalone.
  * Fixed navigation when activating an automation from the editor so it reliably returns users to the automation listing in both embedded and standalone contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->