### PR TITLE
Re-schedule daemon-trigger action during activation

### DIFF
--- a/mailpoet/changelog/2026-02-10-14-09-15-fixed-cron-heartbeat-action-not-being-rescheduled-after-.md
+++ b/mailpoet/changelog/2026-02-10-14-09-15-fixed-cron-heartbeat-action-not-being-rescheduled-after-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Cron heartbeat action not being rescheduled after plugin updates

--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -119,12 +119,11 @@ class Activator {
   }
 
   private function reactivateCronActions(): void {
+    $this->daemonActionSchedulerRunner->clearDeactivationFlag();
     $currentMethod = $this->settings->get(CronTrigger::SETTING_NAME . '.method');
     if ($currentMethod !== CronTrigger::METHOD_ACTION_SCHEDULER) {
-      $this->daemonActionSchedulerRunner->clearDeactivationFlag();
       return;
     }
-    $this->daemonActionSchedulerRunner->clearDeactivationFlag();
     if (!$this->cronActionSchedulerRunner->hasScheduledAction(DaemonTrigger::NAME)) {
       $this->cronActionSchedulerRunner->scheduleRecurringAction(
         $this->wp->currentTime('timestamp', true),

--- a/mailpoet/tests/integration/Config/ActivatorCronTest.php
+++ b/mailpoet/tests/integration/Config/ActivatorCronTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\Cron\ActionScheduler\Actions\DaemonTrigger;
+use MailPoet\Cron\ActionScheduler\ActionSchedulerTestHelper;
+use MailPoet\Cron\CronTrigger;
+use MailPoet\Cron\DaemonActionSchedulerRunner;
+use MailPoet\Settings\SettingsController;
+
+require_once __DIR__ . '/../Cron/ActionScheduler/ActionSchedulerTestHelper.php';
+
+class ActivatorCronTest extends \MailPoetTest {
+
+  /** @var Activator */
+  private $activator;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var DaemonActionSchedulerRunner */
+  private $daemonActionSchedulerRunner;
+
+  /** @var ActionSchedulerTestHelper */
+  private $actionSchedulerHelper;
+
+  public function _before(): void {
+    $this->activator = $this->diContainer->get(Activator::class);
+    $this->settings = $this->diContainer->get(SettingsController::class);
+    $this->daemonActionSchedulerRunner = $this->diContainer->get(DaemonActionSchedulerRunner::class);
+    $this->actionSchedulerHelper = new ActionSchedulerTestHelper();
+    $this->cleanup();
+    $this->daemonActionSchedulerRunner->clearDeactivationFlag();
+  }
+
+  public function testProcessActivateReschedulesDaemonTrigger(): void {
+    $this->settings->set(CronTrigger::SETTING_CURRENT_METHOD, CronTrigger::METHOD_ACTION_SCHEDULER);
+
+    $actions = $this->actionSchedulerHelper->getMailPoetScheduledActions();
+    verify($actions)->arrayCount(0);
+
+    $this->activator->activate();
+
+    $actions = $this->actionSchedulerHelper->getMailPoetScheduledActions();
+    verify($actions)->arrayCount(1);
+    $action = reset($actions);
+    $this->assertInstanceOf(\ActionScheduler_Action::class, $action);
+    verify($action->get_hook())->equals(DaemonTrigger::NAME);
+  }
+
+  public function testProcessActivateDoesNotScheduleWhenMethodIsNotActionScheduler(): void {
+    $this->settings->set(CronTrigger::SETTING_CURRENT_METHOD, CronTrigger::METHOD_WORDPRESS);
+
+    $this->activator->activate();
+
+    $actions = $this->actionSchedulerHelper->getMailPoetScheduledActions();
+    verify($actions)->arrayCount(0);
+  }
+
+  public function testDeactivationFlagIsClearedAfterActivation(): void {
+    $this->settings->set(CronTrigger::SETTING_CURRENT_METHOD, CronTrigger::METHOD_ACTION_SCHEDULER);
+    update_option(DaemonActionSchedulerRunner::DEACTIVATION_FLAG_OPTION, true);
+    verify($this->daemonActionSchedulerRunner->isDeactivating())->true();
+
+    $this->activator->activate();
+
+    verify($this->daemonActionSchedulerRunner->isDeactivating())->false();
+  }
+
+  private function cleanup(): void {
+    global $wpdb;
+    $actionsTable = $wpdb->prefix . 'actionscheduler_actions';
+    $wpdb->query($wpdb->prepare('TRUNCATE %i', $actionsTable));
+  }
+}


### PR DESCRIPTION
## Description

During plugin updates, `Activator::processActivate()` unschedules all cron actions via `deactivateCronActions()` to prevent them from running during migrations, but relied on `Initializer::initialize()` → `setupCronTrigger()` to re-schedule them.

If `initialize()` threw before reaching `setupCronTrigger()`, the `mailpoet/cron/daemon-trigger` Action Scheduler action was permanently lost because `updateDbVersion()` already ran, so `maybeRunActivator()` would not retry.

Secondary fix: `clearDeactivationFlag()` previously ran BEFORE `deactivateCronActions()`, opening a race window where parallel requests could schedule an action that immediately got removed. It now runs after unscheduling.

## Code review notes

_N/A_

## QA notes

1. Set cron method to Action Scheduler (default)
2. Trigger plugin activation (deactivate + reactivate MailPoet)
3. Verify the `mailpoet/cron/daemon-trigger` recurring action exists in Tools → Scheduled Actions
4. Verify scheduled emails continue to send

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7815

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Issues found: 1
  - Bug: 1 (cron heartbeat action could be permanently unscheduled during activation; now re-scheduled and deactivation race window fixed)
  - Security: 0
  - Performance: 0
  - Suggestion: 0

- Tests: Integration tests added to verify cron rescheduling and deactivation-flag clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/reschedule-daemon-trigger-on-activation)

_The latest successful build from `fix/reschedule-daemon-trigger-on-activation` will be used. If none is available, the link won't work._