### PR TITLE
Fix performance test selector for renamed automation tab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1166,6 +1166,14 @@ workflows:
           <<: *slack-fail-post-step
           requires:
             - build_release_zip
+      - performance_tests:
+          name: performance_latest
+          url: https://mpperftesting.com
+          us: $WP_TEST_PERFORMANCE_US
+          pw: $WP_TEST_PERFORMANCE_PW
+          scenario: nightlytests
+          requires:
+            - build
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1166,14 +1166,6 @@ workflows:
           <<: *slack-fail-post-step
           requires:
             - build_release_zip
-      - performance_tests:
-          name: performance_latest
-          url: https://mpperftesting.com
-          us: $WP_TEST_PERFORMANCE_US
-          pw: $WP_TEST_PERFORMANCE_PW
-          scenario: nightlytests
-          requires:
-            - build
 
   nightly:
     triggers:

--- a/mailpoet/tests/performance/tests/automation-create-woocommerce.js
+++ b/mailpoet/tests/performance/tests/automation-create-woocommerce.js
@@ -51,8 +51,8 @@ export async function automationCreateWooCommerce() {
       fullPage: fullPageSet,
     });
 
-    // Click on the WooCommerce tab and then choose the first template
-    await page.locator('#tab-panel-0-woocommerce').click();
+    // Click on the Post-purchase tab and then choose the first template
+    await page.locator('#tab-panel-0-purchase').click();
     await page.waitForLoadState('networkidle');
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');


### PR DESCRIPTION
## Description

The automation template category was renamed from `woocommerce` to `purchase` (display name "Post-purchase") in 05bdce71, but the performance test selector was not updated.

This PR updates `#tab-panel-0-woocommerce` to `#tab-panel-0-purchase` in `automation-create-woocommerce.js`

<img width="1334" height="741" alt="image" src="https://github.com/user-attachments/assets/8b369204-cccc-4bb0-937d-776a3410eb48" />

## Code review notes

Skip

## QA notes

Skip

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

Applicable if all automated tests pass.

The `performance_tests` job was temporarily added to the `build_and_test` workflow to verify the fix on CircleCI, since it normally only runs in the nightly workflow on trunk. This temporary config change will be reverted before merging.

- Revision: 104646bef0ba9a99326dbafc30f4d707640f666b (reverted by 6521c3d080e8fa2330aa50ce1d9791da8dbe9af2)
- CI: https://app.circleci.com/pipelines/github/mailpoet/mailpoet/22256/workflows/77273082-7f85-4ab2-b02f-e61882eb8528/jobs/387420

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/perf-test-woocommerce-tab-selector)

_The latest successful build from `fix/perf-test-woocommerce-tab-selector` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated WooCommerce automation performance test flow to validate interaction with the Post-purchase tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->