### PR TITLE
Add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,33 @@
+language: en-US
+tone_instructions: 'Keep reviews concise. No filler praise or emoji. Focus on real issues only; if no issues, say so briefly.'
+
+reviews:
+  profile: chill
+  path_filters:
+    - 'mailpoet/lib/**/*.php'
+    - 'mailpoet/tests/**/*.php'
+    - 'mailpoet/views/**/*.html'
+    - 'mailpoet/assets/js/src/**/*.js'
+    - 'mailpoet/assets/js/src/**/*.jsx'
+    - 'mailpoet/assets/js/src/**/*.ts'
+    - 'mailpoet/assets/js/src/**/*.tsx'
+  path_instructions:
+    - path: 'mailpoet/**/*.{php,html,js,jsx,ts,tsx}'
+      instructions: |
+        - Consider full file context before commenting; do not rely only on the diff.
+        - Use line numbers from the actual file, not from the diff.
+        - Only report issues you are certain about; if unsure, say so explicitly.
+        - Do not flag standard WordPress/WooCommerce patterns (e.g. $wpdb->posts interpolation, get_posts() with posts_per_page => -1 for bounded queries).
+        - Focus on real bugs, logic errors, security vulnerabilities, and missing edge cases — not stylistic preferences.
+        - Categorize each finding as: Bug, Security, Performance, or Suggestion.
+        - For each finding: give file path, line number, brief explanation of why it is a problem, and a concrete fix.
+        - If there are no real issues, say "No issues found"; do not invent problems to fill the review.
+  poem: false
+  in_progress_fortune: false
+  high_level_summary_instructions: "Write a brief summary listing the number of issues found and their categories (Bug, Security, Performance, Suggestion). If no issues, state 'No issues found.'"
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - '.claude/CLAUDE.md'


### PR DESCRIPTION
## Description

This PR adds CodeRabbit configuration so that PR reviews are more concise and easier to read. It limits reviews to the MailPoet plugin code (`mailpoet/**`), adds instructions for full file context and real issues only feedback, aligns tone with our review preferences, and wires in .claude/CLAUDE.md as code guidelines.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/coderabbitai-config)

_The latest successful build from `add/coderabbitai-config` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a code-review configuration that standardizes automated review behavior: sets language and concise tone, applies a chill review profile, scopes which asset types are reviewed, requires per-issue details (file path, line, explanation, concrete fix) or an explicit "No issues found" response, disables poetic/in-progress flags, and enables a code-guidelines knowledge base reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->