### PR TITLE
Fix open tracking for new email editor (Alpha)

### DIFF
--- a/mailpoet/changelog/2026-02-13-10-31-26-fixed-fix-open-tracking-for-emails-created-with-the-new-.md
+++ b/mailpoet/changelog/2026-02-13-10-31-26-fixed-fix-open-tracking-for-emails-created-with-the-new-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix open tracking for emails created with the new email editor (Alpha)

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -115,6 +115,11 @@ class Renderer {
       if ($filterCallback) {
         $this->wp->removeFilter('woocommerce_email_editor_rendering_email_context', $filterCallback);
       }
+
+      $renderedNewsletter['html'] = $this->wp->applyFilters(
+        self::FILTER_POST_PROCESS,
+        $renderedNewsletter['html']
+      );
     } else {
       $body = (is_array($newsletter->getBody()))
         ? $newsletter->getBody()


### PR DESCRIPTION
## Description

This PR fixes open tracking for the new email editor (Alpha).

Emails created with the new email editor (Alpha) were sent without the open tracking pixel, causing open rates to drop to near zero. The small percentage still reported was actually the click rate, since click tracking also records an open event.

## Code review notes

Did not reuse `postProcessTemplate()` because it also contains TinyMCE-specific DOM fixes (image URL space encoding, `&amp;` handling) that are irrelevant to Gutenberg output. Not quite sure if this is the right approach. If there's a better direction, please let me know.

## QA notes

1. Create a newsletter using the new email editor (Alpha)
2. Send the newsletter
3. Inspect the received email HTML source
5. Verify the email contains an open tracking code by searching `mailpoet_router&endpoint=track&action=open`

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7816

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="528" height="476" alt="image" src="https://github.com/user-attachments/assets/83b070e5-acc2-47a4-9487-bde0a2b31108" /> | <img width="780" height="487" alt="image" src="https://github.com/user-attachments/assets/e47508a7-f2f2-46d4-9cb0-7cf2ab81ada9" /> |

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:STOMAIL-7816/fix-alpha-email-editor-open-rate)

_The latest successful build from `STOMAIL-7816/fix-alpha-email-editor-open-rate` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR correctly implements open tracking for Gutenberg-rendered emails by applying the `FILTER_POST_PROCESS` filter to the HTML output from the new email editor. The implementation:

- Properly applies the post-processing filter (`mailpoet_rendering_post_process`) to Gutenberg-rendered emails, ensuring the open tracking pixel is injected
- Maintains backward compatibility with the existing TinyMCE rendering path, which continues to use `postProcessTemplate()`
- Includes a comprehensive integration test that verifies the tracking pixel is correctly added to Gutenberg-rendered newsletters
- Uses proper cleanup in the test (filter removal and post deletion)

The test method appears only once in the file (contrary to the raw summary's claim of duplication), and all assertions are correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->