### PR TITLE
Stop using custom rich text in email editor

### DIFF
--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -104,17 +104,6 @@ class EditorPageRenderer {
       $editorIntegrationAssetsParams['version']
     );
 
-    // Email editor rich text JS - Because we Personalization Tags depend on Gutenberg 19.8.0 and higher
-    // the following code replaces used Rich Text for the version containing the necessary changes.
-    $assetsParams = require Env::$assetsPath . '/dist/js/email-editor/assets/rich-text.asset.php';
-    $this->wp->wpDeregisterScript('wp-rich-text');
-    $this->wp->wpEnqueueScript(
-      'wp-rich-text',
-      Env::$assetsUrl . '/dist/js/email-editor/assets/rich-text.js',
-      $assetsParams['dependencies'],
-      $assetsParams['version'],
-      true
-    );
     // End of replacing Rich Text package.
     $styleParams = require Env::$assetsPath . '/dist/js/email-editor/style/style.asset.php';
     $this->wp->wpEnqueueStyle(

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -104,7 +104,6 @@ class EditorPageRenderer {
       $editorIntegrationAssetsParams['version']
     );
 
-    // End of replacing Rich Text package.
     $styleParams = require Env::$assetsPath . '/dist/js/email-editor/style/style.asset.php';
     $this->wp->wpEnqueueStyle(
       'mailpoet_email_editor',

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -258,10 +258,6 @@ const adminConfig = {
           from: 'node_modules/@woocommerce/email-editor/build-style',
           to: 'email-editor/style',
         },
-        {
-          from: 'node_modules/@woocommerce/email-editor/assets',
-          to: 'email-editor/assets',
-        },
       ],
     }),
     new DirectCopyPlugin({


### PR DESCRIPTION
## Description

We added a custom RichText package for the email editor to support Personalization tags in WordPress 6.7.
The most recent changes in Gutenberg (https://github.com/WordPress/gutenberg/pull/75387) are incompatible with our old custom package. We support WordPress 6.8+, so we can remove the custom package and use the package directly from core.

## Code review notes

Verify that RichText in email editor works as expected and that you can insert Personalization tags

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

WOOPRD-2309

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:remove-custom-richtext)

_The latest successful build from `remove-custom-richtext` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR removes custom RichText package deregistration and asset enqueuing from EditorPageRenderer.php, allowing WordPress core's RichText package to be used instead. This is a straightforward code removal with no new functionality introduced. The change:

- Eliminates the deprecated custom RichText handling that would break with future Gutenberg releases
- Maintains all other email editor integration logic intact
- Relies on WordPress core RichText (available in WordPress 6.8+, which is the minimum supported version)
- Does not introduce new dependencies, error handling, or code paths that could introduce bugs

The remaining RichText usage in other components (form-editor, marketing-optin-block) are unaffected by this change since they import from `@wordpress/block-editor` or `@wordpress/rich-text`, not from the custom package being removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->