### PR TITLE
Remove MailPoet branding from automation UI in Garden

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
@@ -1,3 +1,4 @@
+import { getIsGarden } from 'common/functions';
 import { registerStepType } from '../../editor/store';
 import { step as SendEmailStep } from './steps/send-email';
 import { step as SomeoneSubscribesTrigger } from './steps/someone-subscribes';
@@ -20,9 +21,7 @@ import { step as WpUserRoleChangedTrigger } from './steps/wp-user-role-changed';
 // Insert new imports here
 
 export const initialize = (): void => {
-  const isGarden =
-    (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-      .mailpoet_automation_context?.is_garden === true;
+  const isGarden = getIsGarden();
 
   registerStepType(SendEmailStep);
   registerStepType(WpUserRegisteredTrigger);

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/shortcode-help-text.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/shortcode-help-text.tsx
@@ -1,8 +1,7 @@
 import { __ } from '@wordpress/i18n';
+import { getIsGarden } from 'common/functions';
 
-const isGarden =
-  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-    .mailpoet_automation_context?.is_garden === true;
+const isGarden = getIsGarden();
 
 export function ShortcodeHelpText(): JSX.Element {
   if (isGarden) {

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/shortcode-help-text.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/shortcode-help-text.tsx
@@ -1,6 +1,17 @@
 import { __ } from '@wordpress/i18n';
 
+const isGarden =
+  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+    .mailpoet_automation_context?.is_garden === true;
+
 export function ShortcodeHelpText(): JSX.Element {
+  if (isGarden) {
+    return (
+      <span className="mailpoet-shortcode-selector">
+        {__('You can use shortcodes.', 'mailpoet')}
+      </span>
+    );
+  }
   return (
     <span className="mailpoet-shortcode-selector">
       <a

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
@@ -9,6 +9,10 @@ import { SendMailIcon } from './icons/send-mail';
 import { TransactionalIcon } from './icons/transactional';
 import { MarketingIcon } from './icons/marketing';
 
+const isGarden =
+  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+    .mailpoet_automation_context?.is_garden === true;
+
 const keywords = [
   // translators: noun, used as a search keyword for "Send email" automation action
   __('email', 'mailpoet'),
@@ -40,23 +44,28 @@ export const step: StepType = {
       </span>
     );
     if (isTransactional(data)) {
-      const transactionalText = ReactStringReplace(
-        __(
-          "This is a transactional email. This type of email doesn't require marketing consent. Read more about [link]transactional emails[/link].",
-          'mailpoet',
-        ),
-        /\[link\](.*?)\[\/link\]/g,
-        (match, i) => (
-          <a
-            key={i}
-            rel="noreferrer"
-            href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
-            target="_blank"
-          >
-            {match}
-          </a>
-        ),
-      );
+      const transactionalText = isGarden
+        ? __(
+            "This is a transactional email. This type of email doesn't require marketing consent.",
+            'mailpoet',
+          )
+        : ReactStringReplace(
+            __(
+              "This is a transactional email. This type of email doesn't require marketing consent. Read more about [link]transactional emails[/link].",
+              'mailpoet',
+            ),
+            /\[link\](.*?)\[\/link\]/g,
+            (match, i) => (
+              <a
+                key={i}
+                rel="noreferrer"
+                href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
+                target="_blank"
+              >
+                {match}
+              </a>
+            ),
+          );
       return (
         <span className="mailpoet-sendmail-description">
           {text}
@@ -67,23 +76,28 @@ export const step: StepType = {
         </span>
       );
     }
-    const marketingText = ReactStringReplace(
-      __(
-        'This is a marketing email. This type of email does require marketing consent. Read more about [link]marketing emails[/link].',
-        'mailpoet',
-      ),
-      /\[link\](.*?)\[\/link\]/g,
-      (match, i) => (
-        <a
-          key={i}
-          rel="noreferrer"
-          href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
-          target="_blank"
-        >
-          {match}
-        </a>
-      ),
-    );
+    const marketingText = isGarden
+      ? __(
+          'This is a marketing email. This type of email does require marketing consent.',
+          'mailpoet',
+        )
+      : ReactStringReplace(
+          __(
+            'This is a marketing email. This type of email does require marketing consent. Read more about [link]marketing emails[/link].',
+            'mailpoet',
+          ),
+          /\[link\](.*?)\[\/link\]/g,
+          (match, i) => (
+            <a
+              key={i}
+              rel="noreferrer"
+              href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
+              target="_blank"
+            >
+              {match}
+            </a>
+          ),
+        );
     return (
       <span className="mailpoet-sendmail-description">
         {text}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/index.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
 import ReactStringReplace from 'react-string-replace';
+import { getIsGarden } from 'common/functions';
 import { Edit } from './edit';
 import { State, StepType } from '../../../../editor/store';
 import { Step } from '../../../../editor/components/automation/types';
@@ -9,9 +10,7 @@ import { SendMailIcon } from './icons/send-mail';
 import { TransactionalIcon } from './icons/transactional';
 import { MarketingIcon } from './icons/marketing';
 
-const isGarden =
-  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-    .mailpoet_automation_context?.is_garden === true;
+const isGarden = getIsGarden();
 
 const keywords = [
   // translators: noun, used as a search keyword for "Send email" automation action

--- a/mailpoet/assets/js/src/automation/listing/legacy-automations-notice.tsx
+++ b/mailpoet/assets/js/src/automation/listing/legacy-automations-notice.tsx
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getIsGarden } from 'common/functions';
 import { Notice } from 'notices/notice';
 import { legacyApiFetch } from './store/legacy-api';
 
-const isGarden =
-  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-    .mailpoet_automation_context?.is_garden === true;
+const isGarden = getIsGarden();
 
 export function LegacyAutomationsNotice(): JSX.Element {
   const saveNoticeDismissed = useCallback(() => {

--- a/mailpoet/assets/js/src/automation/listing/legacy-automations-notice.tsx
+++ b/mailpoet/assets/js/src/automation/listing/legacy-automations-notice.tsx
@@ -4,6 +4,10 @@ import { __ } from '@wordpress/i18n';
 import { Notice } from 'notices/notice';
 import { legacyApiFetch } from './store/legacy-api';
 
+const isGarden =
+  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+    .mailpoet_automation_context?.is_garden === true;
+
 export function LegacyAutomationsNotice(): JSX.Element {
   const saveNoticeDismissed = useCallback(() => {
     void legacyApiFetch({
@@ -22,22 +26,27 @@ export function LegacyAutomationsNotice(): JSX.Element {
       onClose={saveNoticeDismissed}
     >
       <p>
-        {createInterpolateElement(
-          __(
-            'Your existing automations are now listed here. You can also create new, more powerful automations with our new Automations editor. <link>Learn more</link>',
-            'mailpoet',
-          ),
-          {
-            link: (
-              // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-              <a
-                href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            ),
-          },
-        )}
+        {isGarden
+          ? __(
+              'Your existing automations are now listed here. You can also create new, more powerful automations with our new Automations editor.',
+              'mailpoet',
+            )
+          : createInterpolateElement(
+              __(
+                'Your existing automations are now listed here. You can also create new, more powerful automations with our new Automations editor. <link>Learn more</link>',
+                'mailpoet',
+              ),
+              {
+                link: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                  <a
+                    href="https://kb.mailpoet.com/article/397-how-to-set-up-an-automation"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                ),
+              },
+            )}
       </p>
     </Notice>
   );

--- a/mailpoet/assets/js/src/common/functions/get-is-garden.ts
+++ b/mailpoet/assets/js/src/common/functions/get-is-garden.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    mailpoet_automation_context?: { is_garden?: boolean };
+  }
+}
+
+export const getIsGarden = (): boolean =>
+  window.mailpoet_automation_context?.is_garden === true;

--- a/mailpoet/assets/js/src/common/functions/index.ts
+++ b/mailpoet/assets/js/src/common/functions/index.ts
@@ -5,3 +5,4 @@ export * from './set-lowercase-value';
 export * from './parsley-helper-functions';
 export * from './extract-email-domain';
 export * from './extract-page-name-from-url';
+export * from './get-is-garden';

--- a/mailpoet/assets/js/src/common/manage-sender-domain/manage-sender-domain.tsx
+++ b/mailpoet/assets/js/src/common/manage-sender-domain/manage-sender-domain.tsx
@@ -1,15 +1,14 @@
 import { Button, Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getIsGarden } from 'common/functions';
 import { Grid } from 'common/grid';
 import { SenderDomainEntity } from './manage-sender-domain-types';
 import { DomainKeyComponent } from './domain-key-component';
 import { DomainHostInfo, DomainValueInfo } from './domain-key-info';
 import { ErrorIcon } from './icons';
 
-const isGarden =
-  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-    .mailpoet_automation_context?.is_garden === true;
+const isGarden = getIsGarden();
 
 type Props = {
   rows: Array<SenderDomainEntity>;

--- a/mailpoet/assets/js/src/common/manage-sender-domain/manage-sender-domain.tsx
+++ b/mailpoet/assets/js/src/common/manage-sender-domain/manage-sender-domain.tsx
@@ -7,6 +7,10 @@ import { DomainKeyComponent } from './domain-key-component';
 import { DomainHostInfo, DomainValueInfo } from './domain-key-info';
 import { ErrorIcon } from './icons';
 
+const isGarden =
+  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+    .mailpoet_automation_context?.is_garden === true;
+
 type Props = {
   rows: Array<SenderDomainEntity>;
   loadingButton: boolean;
@@ -54,13 +58,15 @@ function ManageSenderDomain({
                 'Please add the following DNS records to your domain’s DNS settings.',
               )}{' '}
             </strong>
-            <a
-              href="https://kb.mailpoet.com/article/295-spf-dkim-dmarc#authenticating"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {__('Read the guide', 'mailpoet')}
-            </a>
+            {!isGarden && (
+              <a
+                href="https://kb.mailpoet.com/article/295-spf-dkim-dmarc#authenticating"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {__('Read the guide', 'mailpoet')}
+              </a>
+            )}
           </div>
 
           {error && (
@@ -70,22 +76,27 @@ function ManageSenderDomain({
                 <strong>
                   {__('Error authenticating your sender domain.', 'mailpoet')}
                 </strong>{' '}
-                {createInterpolateElement(
-                  __(
-                    'We detected different records from your domain. Please fix them by following the error messages below and reauthenticate your domain. For more help, <link>read our guide</link>.',
-                    'mailpoet',
-                  ),
-                  {
-                    link: (
-                      // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                      <a
-                        href="https://kb.mailpoet.com/article/295-spf-dkim-dmarc#authenticating"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      />
-                    ),
-                  },
-                )}
+                {isGarden
+                  ? __(
+                      'We detected different records from your domain. Please fix them by following the error messages below and reauthenticate your domain.',
+                      'mailpoet',
+                    )
+                  : createInterpolateElement(
+                      __(
+                        'We detected different records from your domain. Please fix them by following the error messages below and reauthenticate your domain. For more help, <link>read our guide</link>.',
+                        'mailpoet',
+                      ),
+                      {
+                        link: (
+                          // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
+                          <a
+                            href="https://kb.mailpoet.com/article/295-spf-dkim-dmarc#authenticating"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          />
+                        ),
+                      },
+                    )}
               </div>
             </div>
           )}
@@ -142,10 +153,15 @@ function ManageSenderDomain({
                 'mailpoet',
               )}
             </strong>{' '}
-            {__(
-              'MailPoet will verify your DNS records to ensure it matches. Do note that it may take up to 24 hours for DNS changes to propagate after you make the change.',
-              'mailpoet',
-            )}
+            {isGarden
+              ? __(
+                  'Your DNS records will be verified to ensure they match. Do note that it may take up to 24 hours for DNS changes to propagate after you make the change.',
+                  'mailpoet',
+                )
+              : __(
+                  'MailPoet will verify your DNS records to ensure it matches. Do note that it may take up to 24 hours for DNS changes to propagate after you make the change.',
+                  'mailpoet',
+                )}
           </div>
           <Button
             variant="primary"

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-actions.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-actions.tsx
@@ -1,9 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { getIsGarden } from 'common/functions';
 
-const isGarden =
-  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-    .mailpoet_automation_context?.is_garden === true;
+const isGarden = getIsGarden();
 
 function SenderActions({
   showAuthorizeButton,

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-actions.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-actions.tsx
@@ -1,6 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
+const isGarden =
+  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+    .mailpoet_automation_context?.is_garden === true;
+
 function SenderActions({
   showAuthorizeButton,
   authorizeAction,
@@ -23,14 +27,16 @@ function SenderActions({
           {authorizeButtonLabel}
         </Button>
       )}
-      <Button
-        variant="link"
-        target="_blank"
-        href={readMoreLink}
-        rel="noopener noreferrer"
-      >
-        {__('Learn more', 'mailpoet')}
-      </Button>
+      {!isGarden && (
+        <Button
+          variant="link"
+          target="_blank"
+          href={readMoreLink}
+          rel="noopener noreferrer"
+        >
+          {__('Learn more', 'mailpoet')}
+        </Button>
+      )}
     </>
   );
 }

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
@@ -1,10 +1,9 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __ } from '@wordpress/i18n';
+import { getIsGarden } from 'common/functions';
 
-const isGarden =
-  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
-    .mailpoet_automation_context?.is_garden === true;
+const isGarden = getIsGarden();
 
 function SenderDomainNoticeBody({
   emailAddressDomain,

--- a/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/sender-domain-notice-body.tsx
@@ -2,6 +2,10 @@ import { createInterpolateElement } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __ } from '@wordpress/i18n';
 
+const isGarden =
+  (window as { mailpoet_automation_context?: { is_garden?: boolean } })
+    .mailpoet_automation_context?.is_garden === true;
+
 function SenderDomainNoticeBody({
   emailAddressDomain,
   isFreeDomain,
@@ -17,14 +21,24 @@ function SenderDomainNoticeBody({
 }) {
   const renderMessage = (messageKey: string) => {
     const messages: { [key: string]: string } = {
-      freeSmall: __(
-        "Shared 3rd-party domains like <emailDomain/> will send from MailPoet's shared domain. We recommend that you use your site's branded domain instead.",
-        'mailpoet',
-      ),
-      free: __(
-        "MailPoet cannot send email campaigns from shared 3rd-party domains like <emailDomain/>. Please send from your site's branded domain instead.",
-        'mailpoet',
-      ),
+      freeSmall: isGarden
+        ? __(
+            "Shared 3rd-party domains like <emailDomain/> will send from a shared domain. We recommend that you use your site's branded domain instead.",
+            'mailpoet',
+          )
+        : __(
+            "Shared 3rd-party domains like <emailDomain/> will send from MailPoet's shared domain. We recommend that you use your site's branded domain instead.",
+            'mailpoet',
+          ),
+      free: isGarden
+        ? __(
+            "Email campaigns cannot be sent from shared 3rd-party domains like <emailDomain/>. Please send from your site's branded domain instead.",
+            'mailpoet',
+          )
+        : __(
+            "MailPoet cannot send email campaigns from shared 3rd-party domains like <emailDomain/>. Please send from your site's branded domain instead.",
+            'mailpoet',
+          ),
       partiallyVerified: __(
         'Update your domain settings to improve email deliverability and meet new sending requirements.',
         'mailpoet',

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SegmentSubject.php
@@ -11,6 +11,7 @@ use MailPoet\NotFoundException;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 /**
  * @implements Subject<SegmentPayload>
@@ -21,10 +22,15 @@ class SegmentSubject implements Subject {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
-    SegmentsRepository $segmentsRepository
+    SegmentsRepository $segmentsRepository,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->segmentsRepository = $segmentsRepository;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function getKey(): string {
@@ -32,6 +38,10 @@ class SegmentSubject implements Subject {
   }
 
   public function getName(): string {
+    if ($this->dotcomHelperFunctions->isGarden()) {
+      // translators: automation subject (entity entering automation) title
+      return __('Segment', 'mailpoet');
+    }
     // translators: automation subject (entity entering automation) title
     return __('MailPoet segment', 'mailpoet');
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SubscriberSubject.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Subjects/SubscriberSubject.php
@@ -12,6 +12,7 @@ use MailPoet\NotFoundException;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 /**
  * @implements Subject<SubscriberPayload>
@@ -25,12 +26,17 @@ class SubscriberSubject implements Subject {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     SubscriberFieldsFactory $subscriberFieldsFactory,
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->subscriberFieldsFactory = $subscriberFieldsFactory;
     $this->subscribersRepository = $subscribersRepository;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function getKey(): string {
@@ -38,6 +44,10 @@ class SubscriberSubject implements Subject {
   }
 
   public function getName(): string {
+    if ($this->dotcomHelperFunctions->isGarden()) {
+      // translators: automation subject (entity entering automation) title
+      return __('Subscriber', 'mailpoet');
+    }
     // translators: automation subject (entity entering automation) title
     return __('MailPoet subscriber', 'mailpoet');
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Subjects/CustomerSubject.php
@@ -11,6 +11,7 @@ use MailPoet\Automation\Integrations\WooCommerce\Payloads\CustomerPayload;
 use MailPoet\NotFoundException;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use WC_Customer;
 use WC_Order;
 
@@ -23,13 +24,22 @@ class CustomerSubject implements Subject {
   /** @var CustomerFieldsFactory */
   private $customerFieldsFactory;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
-    CustomerFieldsFactory $customerFieldsFactory
+    CustomerFieldsFactory $customerFieldsFactory,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->customerFieldsFactory = $customerFieldsFactory;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function getName(): string {
+    if ($this->dotcomHelperFunctions->isGarden()) {
+      // translators: automation subject (entity entering automation) title
+      return __('Customer', 'mailpoet');
+    }
     // translators: automation subject (entity entering automation) title
     return __('WooCommerce customer', 'mailpoet');
   }

--- a/mailpoet/lib/Automation/Integrations/WordPress/Subjects/UserSubject.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/Subjects/UserSubject.php
@@ -11,6 +11,7 @@ use MailPoet\Automation\Engine\WordPress;
 use MailPoet\Automation\Integrations\WordPress\Payloads\UserPayload;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema\ObjectSchema;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use WP_User;
 
 /**
@@ -22,13 +23,22 @@ class UserSubject implements Subject {
   /** @var WordPress */
   private $wordPress;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
-    WordPress $wordPress
+    WordPress $wordPress,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->wordPress = $wordPress;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function getName(): string {
+    if ($this->dotcomHelperFunctions->isGarden()) {
+      // translators: automation subject (entity entering automation) title
+      return __('User', 'mailpoet');
+    }
     // translators: automation subject (entity entering automation) title
     return __('WordPress user', 'mailpoet');
   }


### PR DESCRIPTION
## Description

In Garden mode, remove all MailPoet-specific branding, external links, and product mentions from the marketing automation section.

All changes are gated behind the `isGarden` check so non-Garden behaviour is unchanged.

## Code review notes

_N/A_

## QA notes

1. In a Garden environment, open Automations → create a new automation → add "New email subscriber added" trigger → open trigger filters → verify subject groups show "Subscriber", "Customer", "User" (not "MailPoet subscriber", etc.)
2. Add a "Send email" step → verify no "Read more about marketing/transactional emails" link appears
3. Check sender domain authentication flow → verify no "Learn more" or "Read the guide" links to kb.mailpoet.com
4. Verify all the above still work normally (with MailPoet branding) in a non-Garden environment

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7791](https://linear.app/a8c/issue/STOMAIL-7791/remove-all-mentions-of-mailpoet-in-marketing-automation-section)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7791-remove-all-mentions-of-mailpoet-in-marketing-automation)

_The latest successful build from `stomail-7791-remove-all-mentions-of-mailpoet-in-marketing-automation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 1

### 1. Bug: Incomplete is_garden Context Propagation (High Priority)
AutomationEditor.php sets is_garden in buildContext(), but other automation page classes with buildContext() do not (e.g., Automation.php, AutomationAnalytics.php, AutomationTemplates.php, AbstractAutomationEmbed-related pages). As a result, components rendered on those pages that rely on window.mailpoet_automation_context?.is_garden will fall back to non-Garden behavior (e.g., showing "Learn more" / kb.mailpoet.com links) even when Garden mode is active.

### Suggestion (Maintenance)
Add the is_garden flag to buildContext() in all Automation page classes to ensure consistent Garden-aware rendering across the automation UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->