### PR TITLE
Add GitHub Actions workflow for creating trunk snapshot builds

### DIFF
--- a/.github/workflows/create-trunk-snapshot-build.yml
+++ b/.github/workflows/create-trunk-snapshot-build.yml
@@ -1,0 +1,179 @@
+name: 'Create Trunk Snapshot Build'
+
+on:
+  workflow_dispatch:
+
+env:
+  SOURCE_REF: trunk
+  TARGET_REF: trunk-snapshot
+
+permissions: {}
+
+jobs:
+  build:
+    if: github.repository_owner == 'mailpoet'
+    name: 'Create Trunk Snapshot Build'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: 'Update trunk-snapshot tag'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sourceRef = process.env.SOURCE_REF;
+            const targetRef = process.env.TARGET_REF;
+
+            const branchData = await github.rest.repos.getBranch({
+              ...context.repo,
+              branch: sourceRef,
+            });
+
+            try {
+              await github.rest.git.updateRef({
+                ...context.repo,
+                ref: `tags/${targetRef}`,
+                sha: branchData.data.commit.sha,
+              });
+              core.info(`Updated tag '${targetRef}' to ${branchData.data.commit.sha}`);
+            } catch (e) {
+              await github.rest.git.createRef({
+                ...context.repo,
+                ref: `refs/tags/${targetRef}`,
+                sha: branchData.data.commit.sha,
+              });
+              core.info(`Created tag '${targetRef}' at ${branchData.data.commit.sha}`);
+            }
+
+      - name: 'Checkout ref'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_REF }}
+
+      - name: 'Setup PHP'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, mysql, gd, zip, intl
+          tools: wp-cli
+
+      - name: 'Setup pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
+
+      - name: 'Setup Node.js'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: 'Install system dependencies'
+        run: sudo apt-get update && sudo apt-get install -y gettext
+
+      - name: 'Setup WordPress'
+        run: |
+          wp core download --path=wordpress
+          wp config create \
+            --dbname=wordpress \
+            --dbuser=root \
+            --dbpass=root \
+            --dbhost=127.0.0.1 \
+            --dbprefix=mp_ \
+            --path=wordpress
+          wp core install \
+            --admin_name=admin \
+            --admin_password=admin \
+            --admin_email=admin@example.com \
+            --url=http://localhost \
+            --title="WordPress" \
+            --path=wordpress \
+            --skip-email
+
+      - name: 'Configure build environment'
+        working-directory: mailpoet
+        run: echo "WP_ROOT=${{ github.workspace }}/wordpress" > .env
+
+      - name: 'Build zip'
+        working-directory: mailpoet
+        run: bash build.sh
+
+      - name: 'Set build variables'
+        id: build_vars
+        shell: bash
+        run: |
+          echo "BUILD_DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_OUTPUT
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: 'Upload trunk snapshot build'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const targetRef = process.env.TARGET_REF;
+            const buildDate = '${{ steps.build_vars.outputs.BUILD_DATE }}';
+            const shortSha = '${{ steps.build_vars.outputs.SHORT_SHA }}';
+            const assetName = `mailpoet-${buildDate}-${shortSha}-trunk-snapshot.zip`;
+            const assetPath = `${{ github.workspace }}/mailpoet/mailpoet.zip`;
+
+            let release;
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({
+                ...context.repo,
+                tag: targetRef,
+              });
+              release = data;
+              core.info(`Found existing release: ${release.html_url}`);
+            } catch (e) {
+              const { data } = await github.rest.repos.createRelease({
+                ...context.repo,
+                tag_name: targetRef,
+                name: 'Trunk Snapshot Build',
+                body: 'Latest trunk snapshot build of the MailPoet plugin. This release is automatically updated on each workflow run.',
+                prerelease: true,
+              });
+              release = data;
+              core.info(`Created new release: ${release.html_url}`);
+            }
+
+            // Remove existing assets to keep only the latest snapshot
+            for (const asset of release.assets) {
+              core.info(`Deleting old asset: ${asset.name}`);
+              await github.rest.repos.deleteReleaseAsset({
+                ...context.repo,
+                asset_id: asset.id,
+              });
+            }
+
+            // Upload the new snapshot zip
+            const fileContent = fs.readFileSync(assetPath);
+            const uploadResponse = await github.rest.repos.uploadReleaseAsset({
+              ...context.repo,
+              release_id: release.id,
+              name: assetName,
+              data: fileContent,
+              headers: {
+                'content-type': 'application/zip',
+                'content-length': fileContent.length,
+              },
+            });
+
+            core.info(`Uploaded ${assetName} to ${release.html_url}`);
+            core.info(`Direct download: ${uploadResponse.data.browser_download_url}`);


### PR DESCRIPTION

## Description

Add GitHub Actions workflow for creating trunk snapshot builds

Key adaptations for MailPoet:
* MySQL service -- The MailPoet build requires a WordPress installation (for DI container dump via containerDump()), which needs a real database. A MySQL 8.0 service container is provisioned.

* WordPress setup -- Downloads WP core, creates wp-config.php, and installs WP using wp-cli. This mirrors what the CircleCI build_release_zip job does via setup.bash.

* .env configuration -- Sets WP_ROOT to point to the WordPress installation, which build.sh needs for the ./do container:dump step.

* Dynamic release management -- Instead of WooCommerce's hardcoded RELEASE_ID, the workflow finds or creates the release by tag name, deletes old assets, and uploads the new zip. This means no manual release setup is needed.

* pnpm caching -- Uses actions/setup-node with cache: 'pnpm' for faster subsequent runs.

* The output zip is named mailpoet-{DATE}-{SHORT_SHA}-trunk-snapshot.zip and uploaded to a pre-release tagged trunk-snapshot.


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:trunk-snapshot)

_The latest successful build from `trunk-snapshot` will be used. If none is available, the link won't work._