### PR TITLE
Skip email auth for bundled subscription small senders

### DIFF
--- a/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
+++ b/mailpoet/assets/js/src/common/sender-domain-notice/index.tsx
@@ -11,6 +11,7 @@ export type SenderRestrictionsType = {
   isAuthorizedDomainRequiredForNewCampaigns?: boolean;
   campaignTypes?: string[];
   alwaysRewrite?: boolean;
+  skipAuthorization?: boolean;
 };
 
 type SenderDomainInlineNoticeProps = {

--- a/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
+++ b/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
@@ -36,7 +36,10 @@ function SenderEmailAddressWarning({
   onSuccessfulEmailOrDomainAuthorization = () => {},
 }: Props) {
   const [showAuthorizedEmailModal, setShowAuthorizedEmailModal] = useState(
-    showModal === 'authorizedEmailModal' ? ('sender_domain' as TabProps) : null,
+    showModal === 'authorizedEmailModal' &&
+      !senderRestrictions?.skipAuthorization
+      ? ('sender_domain' as TabProps)
+      : null,
   );
 
   const loadModal = (event, tab: TabProps) => {

--- a/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
+++ b/mailpoet/assets/js/src/common/sender-email-address-warning.tsx
@@ -56,7 +56,11 @@ function SenderEmailAddressWarning({
     MailPoet.freeMailDomains.indexOf(emailAddressDomain) > -1;
 
   if (mssActive) {
-    if (!isEmailAuthorized && emailAddress) {
+    if (
+      !isEmailAuthorized &&
+      emailAddress &&
+      !senderRestrictions?.skipAuthorization
+    ) {
       displayElements.push(
         <div key="authorizeMyEmail">
           <p className="sender_email_address_warning">
@@ -83,7 +87,11 @@ function SenderEmailAddressWarning({
         </div>,
       );
     }
-    if (showSenderDomainWarning && isEmailAuthorized) {
+    if (
+      showSenderDomainWarning &&
+      isEmailAuthorized &&
+      !senderRestrictions?.skipAuthorization
+    ) {
       displayElements.push(
         <div key="authorizeSenderDomain">
           <SenderDomainInlineNotice
@@ -106,8 +114,14 @@ function SenderEmailAddressWarning({
             onRequestClose={() => {
               setShowAuthorizedEmailModal(null);
             }}
-            showSenderEmailTab={!isEmailAuthorized}
-            showSenderDomainTab={showSenderDomainWarning && isEmailAuthorized}
+            showSenderEmailTab={
+              !isEmailAuthorized && !senderRestrictions?.skipAuthorization
+            }
+            showSenderDomainTab={
+              showSenderDomainWarning &&
+              isEmailAuthorized &&
+              !senderRestrictions?.skipAuthorization
+            }
             initialTab={showAuthorizedEmailModal}
             onSuccessAction={onSuccessfulEmailOrDomainAuthorization}
             autoSwitchTab={switchToNewTab}

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -186,6 +186,7 @@ interface Window {
     lowerLimit: number;
     isAuthorizedDomainRequiredForNewCampaigns?: boolean;
     campaignTypes?: string[];
+    skipAuthorization?: boolean;
   };
   mailpoet_all_sender_domains?: string[];
   mailpoet_mss_active: boolean;

--- a/mailpoet/assets/js/src/newsletters/send.tsx
+++ b/mailpoet/assets/js/src/newsletters/send.tsx
@@ -254,6 +254,9 @@ class NewsletterSendComponent extends Component<
     if (window.mailpoet_mta_method !== 'MailPoet') {
       return true;
     }
+    if (window.mailpoet_sender_restrictions?.skipAuthorization) {
+      return true;
+    }
     const verifiedDomains = await this.loadVerifiedSenderDomains();
     const senderDomain = extractEmailDomain(this.state.item.sender_address);
     if (verifiedDomains.indexOf(senderDomain) !== -1) {

--- a/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
@@ -99,6 +99,7 @@ class SenderField extends Component {
 
   validateEmailAddress() {
     if (!window.mailpoet_mss_active) return;
+    if (window.mailpoet_sender_restrictions?.skipAuthorization) return;
 
     const emailAddress = this.state.emailAddress;
 

--- a/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
+++ b/mailpoet/assets/js/src/newsletters/send/sender-address-field.jsx
@@ -19,6 +19,7 @@ class SenderField extends Component {
     this.state = {
       emailAddress: props.item.sender_address,
       showSenderDomainWarning:
+        !window.mailpoet_sender_restrictions?.skipAuthorization &&
         !window.mailpoet_verified_sender_domains.includes(emailDomain),
       isPartiallyVerifiedDomain:
         window.mailpoet_partially_verified_sender_domains.includes(emailDomain),

--- a/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
+++ b/mailpoet/assets/js/src/sending-paused-notices-resume-button.ts
@@ -31,6 +31,9 @@ const isValidFromAddress = async (fromAddress: string | null) => {
   if (MailPoet.mtaMethod !== 'MailPoet') {
     return true;
   }
+  if (window.mailpoet_sender_restrictions?.skipAuthorization) {
+    return true;
+  }
   const verifiedDomains = await loadVerifiedSenderDomains();
   const senderDomain = extractEmailDomain(fromAddress);
   if (verifiedDomains.indexOf(senderDomain) !== -1) {

--- a/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
@@ -62,13 +62,14 @@ export function DefaultSender({ showModal }) {
     setSenderEmail(email);
   };
 
+  const skipAuthorization =
+    window.mailpoet_sender_restrictions?.skipAuthorization;
+
   useEffect(() => {
     void setErrorFlag(
       invalidSenderEmail ||
         invalidReplyToEmail ||
-        (!isAuthorized &&
-          isMssActive &&
-          !window.mailpoet_sender_restrictions?.skipAuthorization),
+        (!isAuthorized && isMssActive && !skipAuthorization),
     );
   }, [
     invalidReplyToEmail,
@@ -76,6 +77,7 @@ export function DefaultSender({ showModal }) {
     setErrorFlag,
     isAuthorized,
     isMssActive,
+    skipAuthorization,
   ]);
   return (
     <>

--- a/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/default-sender.tsx
@@ -66,7 +66,9 @@ export function DefaultSender({ showModal }) {
     void setErrorFlag(
       invalidSenderEmail ||
         invalidReplyToEmail ||
-        (!isAuthorized && isMssActive),
+        (!isAuthorized &&
+          isMssActive &&
+          !window.mailpoet_sender_restrictions?.skipAuthorization),
     );
   }, [
     invalidReplyToEmail,

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -159,6 +159,7 @@ class Newsletters {
         'lowerLimit' => AuthorizedSenderDomainController::LOWER_LIMIT,
         'isAuthorizedDomainRequiredForNewCampaigns' => $this->senderDomainController->isAuthorizedDomainRequiredForNewCampaigns(),
         'campaignTypes' => NewsletterEntity::CAMPAIGN_TYPES,
+        'skipAuthorization' => $this->senderDomainController->shouldSkipAuthorization(),
       ];
     }
 

--- a/mailpoet/lib/AdminPages/Pages/Settings.php
+++ b/mailpoet/lib/AdminPages/Pages/Settings.php
@@ -112,6 +112,7 @@ class Settings {
       $data['all_sender_domains'] = $this->senderDomainController->getAllSenderDomains();
       $data['sender_restrictions'] = [
         'lowerLimit' => AuthorizedSenderDomainController::LOWER_LIMIT,
+        'skipAuthorization' => $this->senderDomainController->shouldSkipAuthorization(),
       ];
     }
 

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -59,6 +59,13 @@ class AuthorizedEmailsController {
   }
 
   public function setFromEmailAddress(string $address) {
+    // Bundled subscription users who are small senders skip authorization
+    if ($this->senderDomainController->shouldSkipAuthorization()) {
+      $this->settings->set('sender.address', $address);
+      $this->settings->set(self::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, null);
+      return;
+    }
+
     $authorizedEmails = $this->getAuthorizedEmailAddresses() ?: [];
     $verifiedDomains = $this->senderDomainController->getVerifiedSenderDomainsIgnoringCache();
     $isAuthorized = $this->validateAuthorizedEmail($authorizedEmails, $address);

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -135,6 +135,13 @@ class AuthorizedEmailsController {
       return null;
     }
 
+    // Bundled subscription users who are small senders skip authorization
+    if ($this->senderDomainController->shouldSkipAuthorization()) {
+      $this->settings->set(self::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, null);
+      $this->updateMailerLog();
+      return null;
+    }
+
     $authorizedEmails = $this->getAuthorizedEmailAddresses();
     // Keep previous check result for an invalid response from API
     if (!$authorizedEmails) {

--- a/mailpoet/lib/Services/AuthorizedSenderDomainController.php
+++ b/mailpoet/lib/Services/AuthorizedSenderDomainController.php
@@ -291,11 +291,29 @@ class AuthorizedSenderDomainController {
     return $this->subscribers->getSubscribersCount() > self::UPPER_LIMIT;
   }
 
+  public function isBundledSubscription(): bool {
+    return $this->settingsController->get(Bridge::SUBSCRIPTION_TYPE_SETTING_NAME) === Bridge::WPCOM_BUNDLE_SUBSCRIPTION_TYPE;
+  }
+
+  /**
+   * Bundled subscription users who are small senders
+   * can skip email/domain authorization requirements.
+   */
+  public function shouldSkipAuthorization(): bool {
+    return $this->isBundledSubscription() && $this->isSmallSender();
+  }
+
   public function isAuthorizedDomainRequiredForNewCampaigns(): bool {
+    if ($this->shouldSkipAuthorization()) {
+      return false;
+    }
     return $this->settingsController->get('mta.method') === Mailer::METHOD_MAILPOET && !$this->isSmallSender();
   }
 
   public function isAuthorizedDomainRequiredForExistingCampaigns(): bool {
+    if ($this->shouldSkipAuthorization()) {
+      return false;
+    }
     return $this->settingsController->get('mta.method') === Mailer::METHOD_MAILPOET && $this->isBigSender();
   }
 
@@ -307,6 +325,7 @@ class AuthorizedSenderDomainController {
       'senderRestrictions' => [
         'lowerLimit' => self::LOWER_LIMIT,
         'alwaysRewrite' => false,
+        'skipAuthorization' => $this->shouldSkipAuthorization(),
       ],
     ];
   }

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Mailer\MailerFactory;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -82,13 +83,14 @@ class PermanentNotices {
     SubscribersFeature $subscribersFeature,
     ServicesChecker $serviceChecker,
     MailerFactory $mailerFactory,
-    SenderDomainAuthenticationNotices $senderDomainAuthenticationNotices
+    SenderDomainAuthenticationNotices $senderDomainAuthenticationNotices,
+    AuthorizedSenderDomainController $senderDomainController
   ) {
     $this->wp = $wp;
     $this->phpVersionWarnings = new PHPVersionWarnings();
     $this->afterMigrationNotice = new AfterMigrationNotice();
-    $this->unauthorizedEmailsNotice = new UnauthorizedEmailNotice($wp, $settings);
-    $this->unauthorizedEmailsInNewslettersNotice = new UnauthorizedEmailInNewslettersNotice($settings, $wp);
+    $this->unauthorizedEmailsNotice = new UnauthorizedEmailNotice($wp, $settings, $senderDomainController);
+    $this->unauthorizedEmailsInNewslettersNotice = new UnauthorizedEmailInNewslettersNotice($settings, $wp, $senderDomainController);
     $this->inactiveSubscribersNotice = new InactiveSubscribersNotice($settings, $subscribersRepository, $wp);
     $this->blackFridayNotice = new BlackFridayNotice($serviceChecker, $subscribersFeature);
     $this->headersAlreadySentNotice = new HeadersAlreadySentNotice($settings, $trackingConfig, $wp);

--- a/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
+++ b/mailpoet/lib/Util/Notices/SenderDomainAuthenticationNotices.php
@@ -54,6 +54,7 @@ class SenderDomainAuthenticationNotices {
     if (
       !$shouldDisplay
       || !$this->bridge->isMailpoetSendingServiceEnabled()
+      || $this->authorizedSenderDomainController->shouldSkipAuthorization()
       || in_array($this->getDefaultFromDomain(), $this->authorizedSenderDomainController->getFullyVerifiedSenderDomains(true))
       || $this->authorizedSenderDomainController->isNewUser()
       || $this->isFreeMailUser() && $this->subscribersFeatures->getSubscribersCount() <= AuthorizedSenderDomainController::LOWER_LIMIT

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailInNewslettersNotice.php
@@ -7,6 +7,7 @@ use MailPoet\Mailer\MailerError;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Newsletter\Renderer\EscapeHelper;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Functions as WPFunctions;
@@ -21,15 +22,23 @@ class UnauthorizedEmailInNewslettersNotice {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var AuthorizedSenderDomainController|null */
+  private $senderDomainController;
+
   public function __construct(
     SettingsController $settings,
-    WPFunctions $wp
+    WPFunctions $wp,
+    ?AuthorizedSenderDomainController $senderDomainController = null
   ) {
     $this->settings = $settings;
     $this->wp = $wp;
+    $this->senderDomainController = $senderDomainController;
   }
 
   public function init($shouldDisplay) {
+    if ($this->senderDomainController && $this->senderDomainController->shouldSkipAuthorization()) {
+      return null;
+    }
     $validationError = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
     if ($shouldDisplay && isset($validationError['invalid_senders_in_newsletters'])) {
       return $this->display($validationError);

--- a/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
+++ b/mailpoet/lib/Util/Notices/UnauthorizedEmailNotice.php
@@ -4,6 +4,7 @@ namespace MailPoet\Util\Notices;
 
 use MailPoet\Newsletter\Renderer\EscapeHelper;
 use MailPoet\Services\AuthorizedEmailsController;
+use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice;
@@ -18,17 +19,25 @@ class UnauthorizedEmailNotice {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var AuthorizedSenderDomainController|null */
+  private $senderDomainController;
+
   public function __construct(
     WPFunctions $wp,
-    ?SettingsController $settings = null
+    ?SettingsController $settings = null,
+    ?AuthorizedSenderDomainController $senderDomainController = null
   ) {
     $this->settings = $settings;
     $this->wp = $wp;
+    $this->senderDomainController = $senderDomainController;
   }
 
   public function init($shouldDisplay) {
     if (!$this->settings instanceof SettingsController) {
       throw new \Exception('This method can only be called if SettingsController is provided');
+    }
+    if ($this->senderDomainController && $this->senderDomainController->shouldSkipAuthorization()) {
+      return null;
     }
     $validationError = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
     if ($shouldDisplay && isset($validationError['invalid_sender_address'])) {


### PR DESCRIPTION
## Description

Bundled subscription (garden environment) users who are small senders (≤100 subscribers) can now send newsletters without authorizing their email address. This simplifies the onboarding experience for new bundled subscription users by removing the email authorization requirement during their initial growth phase.

Big senders (>200 subscribers) still require email authorization, even if they are bundled subscription users. Non-bundled users are unaffected.

### Changes

**Backend:**
- Added `isBundledSubscription()` and `shouldSkipAuthorization()` to `AuthorizedSenderDomainController` as the central skip-auth check
- Added early return in `AuthorizedEmailsController::checkAuthorizedEmailAddresses()` to clear errors for bundled small senders
- Added early returns in `isAuthorizedDomainRequiredForNewCampaigns()` and `isAuthorizedDomainRequiredForExistingCampaigns()`
- Updated admin notices (`UnauthorizedEmailNotice`, `UnauthorizedEmailInNewslettersNotice`, `SenderDomainAuthenticationNotices`) to suppress for bundled small senders
- Passed `skipAuthorization` flag to frontend via `Settings.php`, `Newsletters.php`, and `getContextData()`

**Frontend:**
- Added `skipAuthorization` to `SenderRestrictionsType` and `global.d.ts`
- Guarded authorization warnings in `sender-email-address-warning.tsx`
- Skipped validation in `send.tsx`, `sender-address-field.jsx`, `default-sender.tsx`, and `sending-paused-notices-resume-button.ts`

## Code review notes

- The `shouldSkipAuthorization()` check is centralized in `AuthorizedSenderDomainController` and consumed by all backend callers
- `isSenderAddressValid()` (used by cron sending queue and Newsletter API) was not modified directly because it delegates to `isAuthorizedDomainRequired*()` methods which already have the skip check
- The `skipAuthorization` flag is passed to the frontend through existing `sender_restrictions` data structures
- Notice classes (`UnauthorizedEmailNotice`, `UnauthorizedEmailInNewslettersNotice`) use nullable `AuthorizedSenderDomainController` param to maintain backward compatibility

## QA notes

1. Set up a bundled subscription environment (subscription type = `WPCOM_BUNDLE`)
2. Ensure subscriber count is ≤100
3. Verify:
   - No "unauthorized email" notices appear in WP admin
   - Settings page allows saving any sender email without authorization errors
   - Newsletter send step does not block with authorization validation
   - Sender address field does not show red/error state
   - Resume sending button works without "Failed to resume" errors
4. Increase subscribers above 200 and verify authorization is required again
5. Test with non-bundled subscription to ensure existing behavior is unchanged

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7749](https://linear.app/a8c/issue/STOMAIL-7749)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7749)

_The latest successful build from `stomail-7749` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->