### PR TITLE
Clarify automation run-once toggle label and add helper text

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run-automation-once.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run-automation-once.tsx
@@ -34,7 +34,11 @@ export function RunAutomationOnce(): JSX.Element {
   return (
     <ToggleControl
       className="mailpoet-automation-run-only-once"
-      label={__('Run this automation only once per subscriber.', 'mailpoet')}
+      label={__('Run automation once per subscriber', 'mailpoet')}
+      help={__(
+        'Use this for automations that should only run once, like a welcome email. Turn it off for automations that should run every time, like abandoned cart reminders.',
+        'mailpoet',
+      )}
       checked={checked}
       onChange={(value) => {
         void dispatch(storeName).updateAutomationMeta(

--- a/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
+++ b/mailpoet/tests/acceptance/Automation/RunAutomationOnlyOnceSettingCest.php
@@ -69,7 +69,8 @@ class RunAutomationOnlyOnceSettingCest {
     $i->see('Entered 0'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
     $i->click($this->automation->getName());
     $i->waitForText('Automation settings');
-    $i->waitForText('Run this automation only once per subscriber.');
+    $i->waitForText('Run automation once per subscriber');
+    $i->see('Use this for automations that should only run once, like a welcome email. Turn it off for automations that should run every time, like abandoned cart reminders.');
     $i->click('.mailpoet-automation-run-only-once label');
 
     $i->click('Trigger');
@@ -127,9 +128,9 @@ class RunAutomationOnlyOnceSettingCest {
     $i->dontSee('Entered 2');
     $i->see('Entered 0'); //Actually I see "0 Entered", but this CSS switch is not caught by the test
     $i->click($this->automation->getName());
-    $i->waitForText('Run this automation only once per subscriber.');
-    $i->click('.mailpoet-automation-run-only-once'); //yes
-    $i->click('.mailpoet-automation-run-only-once'); //no
+    $i->waitForText('Run automation once per subscriber');
+    $i->click('.mailpoet-automation-run-only-once label'); //yes
+    $i->click('.mailpoet-automation-run-only-once label'); //no
 
     $i->click('Trigger');
     $i->fillField('When someone subscribes to the following lists:', $this->segment->getName());


### PR DESCRIPTION
## Description

Clarifies the automation "run once per subscriber" setting by updating the toggle label and adding helper text, as specified in [STOMAIL-7784](https://linear.app/a8c/issue/STOMAIL-7784).

Changes:
- Toggle label changed from "Run this automation only once per subscriber." to "Run automation once per subscriber"
- Added helper text: "Use this for automations that should only run once, like a welcome email. Turn it off for automations that should run every time, like abandoned cart reminders."

## Code review notes

Small UI copy change in `run-automation-once.tsx`. Uses the existing `help` prop on WordPress `ToggleControl` component.

## QA notes

1. Open an automation in the editor
2. Check the "Automation settings" sidebar
3. Verify the toggle now reads "Run automation once per subscriber"
4. Verify the helper text appears below the toggle

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7784](https://linear.app/a8c/issue/STOMAIL-7784/clarify-automation-settingsmeaning-any-subscriber-etc)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7784-clarify-automation-settingsmeaning-any-subscriber-etc)

_The latest successful build from `stomail-7784-clarify-automation-settingsmeaning-any-subscriber-etc` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 1

### Bug
**Inconsistent meta key in test file**: In `RunAutomationOnlyOnceSettingCest.php`, the two test methods use different meta keys:
- Line 55 (`runAutomationOnlyOnce` test): Uses `'mailpoet:run-once-per-subscriber'`
- Line 118 (`runAutomationMultipleTimes` test): Uses `'run_only_once'`

The meta key should be consistent between both tests to match the actual component implementation which uses `'mailpoet:run-once-per-subscriber'`. The second test method appears to have the incorrect legacy key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->