### PR TITLE
Replace bracket placeholders with uppercase text in email templates

### DIFF
--- a/mailpoet/changelog/2026-02-19-07-54-16-updated-replace-bracket-placeholders-with-uppercase-text-i.md
+++ b/mailpoet/changelog/2026-02-19-07-54-16-updated-replace-bracket-placeholders-with-uppercase-text-i.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Replace bracket placeholders with uppercase text in email patterns

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
@@ -26,11 +26,13 @@ class EducationalCampaignPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
+      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
       __('How to Get the Most from PRODUCT NAME', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
+      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
       __('Our latest guide walks you through expert tips to make the most out of your PRODUCT NAME.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
@@ -56,6 +58,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
+      /* translators: Placeholder text that merchants replace with their own content. */
       __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
@@ -77,6 +80,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
+      /* translators: Placeholder text that merchants replace with their own content. */
       __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
@@ -113,6 +117,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
+      /* translators: Placeholder text that merchants replace with their own content. */
       __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
@@ -26,14 +26,12 @@ class EducationalCampaignPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product Name] is the product name placeholder to translate */
-      __('How to Get the Most from [Product Name]', 'mailpoet') . '</h1>
+      __('How to Get the Most from PRODUCT NAME', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [product] is the product name placeholder to translate */
-      __('Our latest guide walks you through expert tips to make the most out of your [product].', 'mailpoet') . '</p>
+      __('Our latest guide walks you through expert tips to make the most out of your PRODUCT NAME.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:heading -->
@@ -58,8 +56,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: [Brief description] is the step description placeholder to translate */
-      __('[Brief description]', 'mailpoet') . '</p>
+      __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
       <!-- /wp:column -->
@@ -80,8 +77,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: [Brief description] is the step description placeholder to translate */
-      __('[Brief description]', 'mailpoet') . '</p>
+      __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
       <!-- /wp:column -->
@@ -117,8 +113,7 @@ class EducationalCampaignPattern extends Pattern {
 
       <!-- wp:paragraph -->
       <p>' .
-      /* translators: [Brief description] is the step description placeholder to translate */
-      __('[Brief description]', 'mailpoet') . '</p>
+      __('BRIEF DESCRIPTION', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
       </div>
       <!-- /wp:column -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
@@ -25,14 +25,12 @@ class EventInvitationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Event Name] is the event name placeholder to translate */
-      __('Join us for [Event Name]', 'mailpoet') . '</h1>
+      __('Join us for EVENT NAME', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [brief description] is the event description placeholder to translate */
-      __("You're invited 🎉 Join us for [brief description] and be part of our exclusive event series.", 'mailpoet') . '</p>
+      __("You're invited 🎉 Join us for A BRIEF DESCRIPTION OF THE EVENT and be part of our exclusive event series.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:image -->
@@ -40,11 +38,11 @@ class EventInvitationPattern extends Pattern {
       <!-- /wp:image -->
 
       <!-- wp:heading {"textAlign":"center","fontSize":"large"} -->
-      <h2 class="wp-block-heading has-text-align-center has-large-font-size">' . __('October 31, at 6PM', 'mailpoet') . '</h2>
+      <h2 class="wp-block-heading has-text-align-center has-large-font-size">' . __('MONTH DAY, at TIME', 'mailpoet') . '</h2>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"16px"}}} -->
-      <p class="has-text-align-center" style="font-size:16px">' . __('123 Event Address, City', 'mailpoet') . '</p>
+      <p class="has-text-align-center" style="font-size:16px">' . __('BUILDING STREET, CITY', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
@@ -25,11 +25,13 @@ class EventInvitationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
+      /* translators: EVENT NAME is placeholder text that merchants replace with their own content. */
       __('Join us for EVENT NAME', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
+      /* translators: A BRIEF DESCRIPTION OF THE EVENT is placeholder text that merchants replace with their own content. */
       __("You're invited 🎉 Join us for A BRIEF DESCRIPTION OF THE EVENT and be part of our exclusive event series.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
@@ -38,11 +40,15 @@ class EventInvitationPattern extends Pattern {
       <!-- /wp:image -->
 
       <!-- wp:heading {"textAlign":"center","fontSize":"large"} -->
-      <h2 class="wp-block-heading has-text-align-center has-large-font-size">' . __('MONTH DAY, at TIME', 'mailpoet') . '</h2>
+      <h2 class="wp-block-heading has-text-align-center has-large-font-size">' .
+      /* translators: Placeholder text that merchants replace with their own content. */
+      __('MONTH DAY, at TIME', 'mailpoet') . '</h2>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"16px"}}} -->
-      <p class="has-text-align-center" style="font-size:16px">' . __('BUILDING STREET, CITY', 'mailpoet') . '</p>
+      <p class="has-text-align-center" style="font-size:16px">' .
+      /* translators: Placeholder text that merchants replace with their own content. */
+      __('BUILDING STREET, CITY', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
@@ -30,6 +30,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
+      /* translators: PRODUCT CATEGORY is placeholder text that merchants replace with their own content. */
       __("Explore our latest collection featuring PRODUCT CATEGORY. It's designed to inspire and elevate.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
@@ -30,8 +30,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [product category] is the product category placeholder to translate */
-      __("Explore our latest collection featuring [product category]. It's designed to inspire and elevate.", 'mailpoet') . '</p>
+      __("Explore our latest collection featuring PRODUCT CATEGORY. It's designed to inspire and elevate.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:image -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
@@ -25,6 +25,7 @@ class NewProductsAnnouncementPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
+      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
       __('Introducing PRODUCT NAME', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
@@ -25,8 +25,7 @@ class NewProductsAnnouncementPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product Name] is the product name placeholder to translate */
-      __('Introducing [Product Name]', 'mailpoet') . '</h1>
+      __('Introducing PRODUCT NAME', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
@@ -26,6 +26,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
+      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
       __('Loving your PRODUCT NAME? Make it even better', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductPurchaseFollowUpPattern.php
@@ -26,8 +26,7 @@ class ProductPurchaseFollowUpPattern extends Pattern {
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
       <!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product] is the product category placeholder to translate */
-      __('Loving your [Product]? Make it even better', 'mailpoet') . '</h1>
+      __('Loving your PRODUCT NAME? Make it even better', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"},"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|30"}}}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
@@ -25,6 +25,7 @@ class ProductRestockNotificationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
+      /* translators: PRODUCT NAME is placeholder text that merchants replace with their own content. */
       __('PRODUCT NAME is back in stock!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
@@ -25,8 +25,7 @@ class ProductRestockNotificationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [Product Name] is the product name placeholder to translate */
-      __('[Product Name] Is back in stock!', 'mailpoet') . '</h1>
+      __('PRODUCT NAME Is back in stock!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/ProductRestockNotificationPattern.php
@@ -25,7 +25,7 @@ class ProductRestockNotificationPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      __('PRODUCT NAME Is back in stock!', 'mailpoet') . '</h1>
+      __('PRODUCT NAME is back in stock!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
@@ -25,6 +25,7 @@ class SaleAnnouncementPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
+      /* translators: XX% is placeholder text that merchants replace with their own content. */
       __('XX% off sitewide!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
@@ -38,6 +39,7 @@ class SaleAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
+      /* translators: XX% OFF EVERYTHING is placeholder text that merchants replace with their own content. */
       __('Get XX% OFF EVERYTHING in the store for a limited time.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
@@ -55,6 +57,7 @@ class SaleAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"fontSize":"medium"} -->
       <p class="has-medium-font-size">' .
+      /* translators: MONTH DAY is placeholder text that merchants replace with their own content. */
       __("Don't wait too long – this offer ends on MONTH DAY.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
     </div>

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
@@ -25,8 +25,7 @@ class SaleAnnouncementPattern extends Pattern {
     <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":1} -->
       <h1 class="wp-block-heading">' .
-      /* translators: [X]% is the discount percentage placeholder to translate */
-      __('[X]% off sitewide!', 'mailpoet') . '</h1>
+      __('XX% off sitewide!', 'mailpoet') . '</h1>
       <!-- /wp:heading -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
@@ -39,8 +38,7 @@ class SaleAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
       <p style="font-size:16px">' .
-      /* translators: [X]% is the discount percentage placeholder to translate */
-      __('Get [X]% OFF EVERYTHING in the store for a limited time.', 'mailpoet') . '</p>
+      __('Get XX% OFF EVERYTHING in the store for a limited time.', 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
 
       <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
@@ -57,8 +55,7 @@ class SaleAnnouncementPattern extends Pattern {
 
       <!-- wp:paragraph {"fontSize":"medium"} -->
       <p class="has-medium-font-size">' .
-      /* translators: [End Date] is the sale end date placeholder to translate */
-      __("Don't wait too long – this offer ends on [End Date].", 'mailpoet') . '</p>
+      __("Don't wait too long – this offer ends on MONTH DAY.", 'mailpoet') . '</p>
       <!-- /wp:paragraph -->
     </div>
     <!-- /wp:group -->


### PR DESCRIPTION
## Description

Replace confusing bracket-style placeholders (e.g. `[X]`, `[Product Name]`, `[End Date]`) in CIAB email templates with human-readable uppercase text (e.g. `PRODUCT NAME`, `MONTH DAY`).

The bracket syntax was visually identical to MailPoet merge tags like `[mailpoet/site-homepage-url]`, making it unclear to merchants which text they should edit vs. which are dynamic tags resolved at send time.

## Code review notes

Pure copy changes across 7 email template pattern files under `mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/`. No logic changes. Translator comments for the old bracket placeholders were removed since they are no longer needed.

**Templates changed:**
- SaleAnnouncementPattern — `[X]` percentage → uppercase placeholder, `[End Date]` → `MONTH DAY`
- NewProductsAnnouncementPattern — `[Product Name]` → `PRODUCT NAME`
- EducationalCampaignPattern — `[Product Name]`/`[product]` → `PRODUCT NAME`, `[Brief description]` → `BRIEF DESCRIPTION`
- EventInvitationPattern — `[Event Name]` → `EVENT NAME`, `[brief description]` → descriptive uppercase text, `October 31, at 6PM` → `MONTH DAY, at TIME`, `123 Event Address, City` → `BUILDING STREET, CITY`
- ProductRestockNotificationPattern — `[Product Name]` → `PRODUCT NAME`
- NewArrivalsAnnouncementPattern — `[product category]` → `PRODUCT CATEGORY`
- ProductPurchaseFollowUpPattern — `[Product]` → `PRODUCT NAME`

## QA notes

1. Create a new email campaign using each of the CIAB templates (Sale Announcement, Product Announcement, Educational Campaign, Event Invitation, Product Restock Notification, New Arrivals Announcement, Product Purchase Follow-Up)
2. Verify that placeholder text appears as uppercase words instead of bracket syntax
3. Verify that MailPoet merge tags like `[mailpoet/site-homepage-url]` still work correctly and are not affected

## Linked PRs

_N/A_

## Linked tickets

[WOOPRD-2173](https://linear.app/a8c/issue/WOOPRD-2173/the-x-for-editing-and-the-ciabstore-name-unsure-what-to-edit)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wooprd-2173-the-x-for-editing-and-the-ciabstore-name-unsure-what-to-edit)

_The latest successful build from `wooprd-2173-the-x-for-editing-and-the-ciabstore-name-unsure-what-to-edit` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->