### PR TITLE
Update `woocommerce/email-editor` dependency to version 2.9.0

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.8.0"
+    "woocommerce/email-editor": "2.9.0"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e764e02ffa0b68ee8f25b4ee66fa5d28",
+    "content-hash": "bae19fda0f3f16eda8a8c0809132a8d7",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "1d0b5f59572b59d669411991bcc0f1f68eb70e4f"
+                "reference": "f9f320f03710191c79c55e929194ba3023b04025"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/1d0b5f59572b59d669411991bcc0f1f68eb70e4f",
-                "reference": "1d0b5f59572b59d669411991bcc0f1f68eb70e4f",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/f9f320f03710191c79c55e929194ba3023b04025",
+                "reference": "f9f320f03710191c79c55e929194ba3023b04025",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.8.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.9.0"
             },
-            "time": "2026-02-17T11:14:35+00:00"
+            "time": "2026-02-23T19:48:14+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Description

Update `woocommerce/email-editor` dependency to version 2.9.0

## Code review notes

_N/A_

## QA notes

Do some smoke testing of the email editor.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/email-editor-package-2.9.0)

_The latest successful build from `update/email-editor-package-2.9.0` will be used. If none is available, the link won't work._