### PR TITLE
Fix colour in automation editor running in the Garden environment  STOMAIL-7795

### DIFF
--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -31,6 +31,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\Form\Util\CustomFonts;
 use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 class Menu {
   const MAIN_PAGE_SLUG = self::HOMEPAGE_PAGE_SLUG;
@@ -91,6 +92,8 @@ class Menu {
 
   private CapabilitiesManager $capabilitiesManager;
 
+  private DotcomHelperFunctions $dotcomHelperFunctions;
+
   public function __construct(
     AccessControl $accessControl,
     WPFunctions $wp,
@@ -99,7 +102,8 @@ class Menu {
     Router $router,
     CustomFonts $customFonts,
     CapabilitiesManager $capabilitiesManager,
-    EmailEditor $emailEditor
+    EmailEditor $emailEditor,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->accessControl = $accessControl;
     $this->wp = $wp;
@@ -109,6 +113,7 @@ class Menu {
     $this->customFonts = $customFonts;
     $this->capabilitiesManager = $capabilitiesManager;
     $this->emailEditor = $emailEditor;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function init() {
@@ -570,7 +575,11 @@ class Menu {
     });
     $this->wp->addAction('load-' . $automationEditorPage, function() {
       $this->wp->addFilter('admin_body_class', function ($classes) {
-        return ltrim($classes . ' site-editor-php');
+        $classes .= ' site-editor-php';
+        if ($this->dotcomHelperFunctions->isGarden()) {
+          $classes .= ' admin-color-modern';
+        }
+        return ltrim($classes);
       });
     });
   }


### PR DESCRIPTION
## Description

When running inside the Garden environment, the automation editor uses `#007cba` (WordPress default blue) instead of the correct colour. The change is scoped to the automation editor page only and uses `DotcomHelperFunctions::isGarden()` to conditionally apply. Standalone MailPoet is unaffected.

## Code review notes

- The `admin-color-modern` body class is added alongside the existing `site-editor-php` class in the `admin_body_class` filter
- This automatically fixes all 5 components in `components-automation-editor/` that use `var(--wp-admin-theme-color)`

## QA notes

1. **CIAB:** Open automation editor via CIAB, edit an automation — verify buttons, focus rings, links use `#3858e9`. Inspect `<body>` — should have `admin-color-modern` class.
2. **Standalone:** Open automation editor directly (`/wp-admin/admin.php?page=mailpoet-automation-editor`) — verify colors remain `#007cba` and `<body>` does NOT have `admin-color-modern`.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7795

## After-merge notes

_N/A_

## Screenshots or screencast

### Garden environment Before

<img width="470" height="197" alt="CIAB-before" src="https://github.com/user-attachments/assets/a16b4233-494c-41df-a7b4-712a771dabfe" />


### Garden environment After

<img width="365" height="112" alt="CIAB-after" src="https://github.com/user-attachments/assets/f82c3828-a4b5-493b-84c0-6e9aa44eceed" />

### MailPoet after

<img width="656" height="904" alt="MailPoet" src="https://github.com/user-attachments/assets/324f4ca5-15e2-46fa-b813-d4288dba2aa5" />

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7795-automation-editor-fix-wrong-blue-color)

_The latest successful build from `stomail-7795-automation-editor-fix-wrong-blue-color` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR successfully implements a targeted fix to resolve incorrect color rendering in the automation editor when running in the Garden environment. The implementation demonstrates good engineering practices:

- **Dependency Management**: DotcomHelperFunctions is properly registered in the DI container (ContainerConfigurator.php line 683) and correctly injected into the Menu class constructor
- **Scope Control**: The CSS class addition is appropriately scoped to the automation editor page only via the `load-{$automationEditorPage}` hook, preventing unintended side effects
- **Conditional Logic**: The `isGarden()` check ensures the fix only applies to Garden/CIAB environments, leaving standalone MailPoet installations unaffected
- **Code Quality**: The change follows existing codebase patterns and WordPress conventions
- **Backward Compatibility**: No breaking changes; the modification is additive and environment-specific

<!-- end of auto-generated comment: release notes by coderabbit.ai -->