### PR TITLE
Fix acceptance tests for WordPress 7.0 compatibility

### DIFF
--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -98,6 +98,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->see('Active');
 
     $i->wantTo('Test editing existing automation email with block editor');
+    $i->waitForText('Edit', 10, '.mailpoet-automation-listing');
     $i->click('Edit', '.mailpoet-automation-listing');
     $i->waitForText('Active');
     $i->click('Send email');

--- a/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
+++ b/mailpoet/tests/acceptance/Automation/CreateAutomationEmailWithBlockEditorCest.php
@@ -60,7 +60,7 @@ class CreateAutomationEmailWithBlockEditorCest {
     $i->switchToIFrame('[name="editor-canvas"]');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
-    $i->waitForElementVisible('[aria-label="Block: Heading"]');
+    $i->waitForElementVisible('[aria-label^="Block: Heading"]');
 
     $i->wantTo('Add content to the email using block editor');
     $i->click('[aria-label="Block: Paragraph"]');

--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -31,7 +31,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->switchToIFrame('[name="editor-canvas"]');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
-    $i->waitForElementVisible('[aria-label="Block: Heading"]');
+    $i->waitForElementVisible('[aria-label^="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');
     $i->type('Sample text');
     $i->switchToIFrame();
@@ -104,7 +104,7 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->switchToIFrame('[name="editor-canvas"]');
     $i->waitForElementVisible('.is-root-container', 20);
     $i->waitForElementVisible('[aria-label="Block: Image"]');
-    $i->waitForElementVisible('[aria-label="Block: Heading"]');
+    $i->waitForElementVisible('[aria-label^="Block: Heading"]');
     $i->click('[aria-label="Block: Paragraph"]');
     $i->type('Sample text');
     $i->switchToIFrame();

--- a/mailpoet/tests/acceptance/Newsletters/EditorLineHeightCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/EditorLineHeightCest.php
@@ -43,6 +43,7 @@ class EditorLineHeightCest {
     $this->checkLineHeightInEditor($i, $h3Size, $headingLineHeight, 'h3');
 
     // check rendered Preview
+    $i->scrollTo('.mailpoet_show_preview', 0, -50);
     $i->click('.mailpoet_show_preview');
     $i->waitForElement('#mailpoet_browser_preview_iframe');
     $i->switchToIframe('#mailpoet_browser_preview_iframe');


### PR DESCRIPTION
## Description

Fix three acceptance test failures caused by WordPress 7.0 changes:

1. **Heading block aria-label change**: WP 7.0 introduces heading level variations in Gutenberg, changing `aria-label="Block: Heading"` to `aria-label="Block: Heading 2"` (or other levels). Updated selectors to use prefix match `[aria-label^="Block: Heading"]`.

2. **Admin bar overlapping preview button**: WP 7.0's admin bar overlaps the `.mailpoet_show_preview` button in the newsletter editor, causing `ElementClickInterceptedException`. Added `scrollTo` before the click.

3. **Automation listing Edit button timing**: The Edit button in the automation listing may render after the row data. Added explicit `waitForText` before clicking.

## Code review notes

- All changes are in test files only — no production code changes
- The prefix selector `[aria-label^="Block: Heading"]` is backward-compatible with older WP versions
- Verified tests pass on both latest stable WP and WP 7.0-beta1

## QA notes

Can be skipped— test-only changes
[Here](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/22355/workflows/0104e4a4-7624-469f-8e2e-43a99e604291) is a passing build containing acceptance tests with WordPress 7.0-beta1

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->