### PR TITLE
Add Garden-aware stats notification emails

### DIFF
--- a/mailpoet/changelog/2026-02-27-18-16-13-improved-neutralize-mailpoet-branding-in-stats-and-subscrib.md
+++ b/mailpoet/changelog/2026-02-27-18-16-13-improved-neutralize-mailpoet-branding-in-stats-and-subscrib.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Neutralize MailPoet branding in stats and subscriber notification emails for Garden environments

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -142,7 +142,10 @@ class AutomatedEmails extends SimpleWorker {
    */
   private function prepareContext(array $newsletters): array {
     $context = [
-      'linkSettings' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings#basics'),
+      'linkSettings' => WPFunctions::get()->applyFilters(
+        'mailpoet_stats_notification_link_settings',
+        WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings#basics')
+      ),
       'newsletters' => [],
     ];
     foreach ($newsletters as $row) {
@@ -154,7 +157,11 @@ class AutomatedEmails extends SimpleWorker {
       $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $statistics->getTotalSentCount();
       $bounced = ($statistics->getBounceCount() * 100) / $statistics->getTotalSentCount();
       $context['newsletters'][] = [
-        'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters#/stats/' . $newsletter->getId()),
+        'linkStats' => WPFunctions::get()->applyFilters(
+          'mailpoet_stats_notification_link_stats',
+          WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters#/stats/' . $newsletter->getId()),
+          $newsletter->getId()
+        ),
         'clicked' => $clicked,
         'opened' => $opened,
         'machineOpened' => $machineOpened,

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -162,8 +162,15 @@ class Worker {
         number_format($unsubscribed, 2)
       ),
       'topLinkClicks' => 0,
-      'linkSettings' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings#basics'),
-      'linkStats' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters&stats=' . $newsletter->getId()),
+      'linkSettings' => WPFunctions::get()->applyFilters(
+        'mailpoet_stats_notification_link_settings',
+        WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings#basics')
+      ),
+      'linkStats' => WPFunctions::get()->applyFilters(
+        'mailpoet_stats_notification_link_stats',
+        WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-newsletters&stats=' . $newsletter->getId()),
+        $newsletter->getId()
+      ),
       'clicked' => $clicked,
       'opened' => $opened,
       'machineOpened' => $machineOpened,

--- a/mailpoet/lib/Services/CongratulatoryMssEmailController.php
+++ b/mailpoet/lib/Services/CongratulatoryMssEmailController.php
@@ -5,6 +5,7 @@ namespace MailPoet\Services;
 use MailPoet\Config\Renderer;
 use MailPoet\Mailer\MailerFactory;
 use MailPoet\Mailer\MetaInfo;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 
 class CongratulatoryMssEmailController {
   /** @var MailerFactory */
@@ -16,19 +17,27 @@ class CongratulatoryMssEmailController {
   /** @var Renderer */
   private $renderer;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     MailerFactory $mailerFactory,
     MetaInfo $mailerMetaInfo,
-    Renderer $renderer
+    Renderer $renderer,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->mailerFactory = $mailerFactory;
     $this->mailerMetaInfo = $mailerMetaInfo;
     $this->renderer = $renderer;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   public function sendCongratulatoryEmail(string $toEmailAddress) {
+    $subject = $this->dotcomHelperFunctions->isGarden()
+      ? _x('Your email sending is set up!', 'Subject of an email confirming that the email sending service works', 'mailpoet')
+      : _x('Sending with MailPoet works!', 'Subject of an email confirming that MailPoet Sending Service works', 'mailpoet');
     $renderedNewsletter = [
-      'subject' => _x('Sending with MailPoet works!', 'Subject of an email confirming that MailPoet Sending Service works', 'mailpoet'),
+      'subject' => $subject,
       'body' => [
         'html' => $this->renderer->render('emails/congratulatoryMssEmail.html'),
         'text' => $this->renderer->render('emails/congratulatoryMssEmail.txt'),

--- a/mailpoet/lib/Subscribers/NewSubscriberNotificationMailer.php
+++ b/mailpoet/lib/Subscribers/NewSubscriberNotificationMailer.php
@@ -87,7 +87,10 @@ class NewSubscriberNotificationMailer {
     $context = [
       'subscriber_email' => $subscriber->getEmail(),
       'segments_names' => $segmentNames,
-      'link_settings' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings'),
+      'link_settings' => WPFunctions::get()->applyFilters(
+        'mailpoet_new_subscriber_notification_link_settings',
+        WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings')
+      ),
       'link_premium' => WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-upgrade'),
     ];
     return [

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -218,6 +218,11 @@ class Functions extends AbstractExtension {
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
+        'is_garden',
+        [$this, 'isGarden'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
         'pending_approval_message',
         [$this, 'pendingApprovalMessage'],
         ['is_safe' => ['html']]
@@ -391,6 +396,10 @@ class Functions extends AbstractExtension {
 
   public function isDotcom(): bool {
     return $this->getDotcomHelperFunctions()->isDotcom();
+  }
+
+  public function isGarden(): bool {
+    return $this->getDotcomHelperFunctions()->isGarden();
   }
 
   public function pendingApprovalMessage(): string {

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -283,18 +283,20 @@ class WorkerTest extends \MailPoetTest {
       return 'https://example.com/custom-settings';
     });
 
-    $this->renderer->expects($this->exactly(2))
-      ->method('render')
-      ->with(
-        $this->anything(),
-        $this->callback(function ($context) {
-          return $context['linkSettings'] === 'https://example.com/custom-settings';
-        })
-      );
+    try {
+      $this->renderer->expects($this->exactly(2))
+        ->method('render')
+        ->with(
+          $this->anything(),
+          $this->callback(function ($context) {
+            return $context['linkSettings'] === 'https://example.com/custom-settings';
+          })
+        );
 
-    $this->statsNotifications->process();
-
-    $wp->removeAllFilters('mailpoet_stats_notification_link_settings');
+      $this->statsNotifications->process();
+    } finally {
+      $wp->removeAllFilters('mailpoet_stats_notification_link_settings');
+    }
   }
 
   public function testItAppliesFilterToLinkStats() {
@@ -303,18 +305,20 @@ class WorkerTest extends \MailPoetTest {
       return 'https://example.com/stats/' . $newsletterId;
     }, 10, 2);
 
-    $this->renderer->expects($this->exactly(2))
-      ->method('render')
-      ->with(
-        $this->anything(),
-        $this->callback(function ($context) {
-          return strpos($context['linkStats'], 'https://example.com/stats/') === 0;
-        })
-      );
+    try {
+      $this->renderer->expects($this->exactly(2))
+        ->method('render')
+        ->with(
+          $this->anything(),
+          $this->callback(function ($context) {
+            return strpos($context['linkStats'], 'https://example.com/stats/') === 0;
+          })
+        );
 
-    $this->statsNotifications->process();
-
-    $wp->removeAllFilters('mailpoet_stats_notification_link_stats');
+      $this->statsNotifications->process();
+    } finally {
+      $wp->removeAllFilters('mailpoet_stats_notification_link_stats');
+    }
   }
 
   private function createStatisticsUnsubscribe($data): StatisticsUnsubscribeEntity {

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -26,6 +26,7 @@ use MailPoet\Test\DataFactories\StatisticsClicks as StatisticsClicksFactory;
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -274,6 +275,46 @@ class WorkerTest extends \MailPoetTest {
       ->method('send');
 
     $this->statsNotifications->process();
+  }
+
+  public function testItAppliesFilterToLinkSettings() {
+    $wp = WPFunctions::get();
+    $wp->addFilter('mailpoet_stats_notification_link_settings', function () {
+      return 'https://example.com/custom-settings';
+    });
+
+    $this->renderer->expects($this->exactly(2))
+      ->method('render')
+      ->with(
+        $this->anything(),
+        $this->callback(function ($context) {
+          return $context['linkSettings'] === 'https://example.com/custom-settings';
+        })
+      );
+
+    $this->statsNotifications->process();
+
+    $wp->removeAllFilters('mailpoet_stats_notification_link_settings');
+  }
+
+  public function testItAppliesFilterToLinkStats() {
+    $wp = WPFunctions::get();
+    $wp->addFilter('mailpoet_stats_notification_link_stats', function ($url, $newsletterId) {
+      return 'https://example.com/stats/' . $newsletterId;
+    }, 10, 2);
+
+    $this->renderer->expects($this->exactly(2))
+      ->method('render')
+      ->with(
+        $this->anything(),
+        $this->callback(function ($context) {
+          return strpos($context['linkStats'], 'https://example.com/stats/') === 0;
+        })
+      );
+
+    $this->statsNotifications->process();
+
+    $wp->removeAllFilters('mailpoet_stats_notification_link_stats');
   }
 
   private function createStatisticsUnsubscribe($data): StatisticsUnsubscribeEntity {

--- a/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
@@ -108,20 +108,22 @@ class NewSubscriberNotificationMailerTest extends \MailPoetTest {
       return 'https://example.com/custom-settings';
     });
 
-    $mailer = Stub::makeEmpty(Mailer::class, [
-      'send' =>
-        Expected::once(function($newsletter) {
-          verify($newsletter['body']['html'])->stringContainsString('https://example.com/custom-settings');
-          verify($newsletter['body']['text'])->stringContainsString('https://example.com/custom-settings');
-        }),
-    ], $this);
+    try {
+      $mailer = Stub::makeEmpty(Mailer::class, [
+        'send' =>
+          Expected::once(function($newsletter) {
+            verify($newsletter['body']['html'])->stringContainsString('https://example.com/custom-settings');
+            verify($newsletter['body']['text'])->stringContainsString('https://example.com/custom-settings');
+          }),
+      ], $this);
 
-    $mailerFactory = $this->createMock(MailerFactory::class);
-    $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
-    $service = new NewSubscriberNotificationMailer($mailerFactory, $this->diContainer->get(Renderer::class), $this->diContainer->get(SettingsController::class));
-    $service->send($this->subscriber, $this->segments);
-
-    $wp->removeAllFilters('mailpoet_new_subscriber_notification_link_settings');
+      $mailerFactory = $this->createMock(MailerFactory::class);
+      $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
+      $service = new NewSubscriberNotificationMailer($mailerFactory, $this->diContainer->get(Renderer::class), $this->diContainer->get(SettingsController::class));
+      $service->send($this->subscriber, $this->segments);
+    } finally {
+      $wp->removeAllFilters('mailpoet_new_subscriber_notification_link_settings');
+    }
   }
 
   public function testItSendsWithSubscriberEntity() {

--- a/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/NewSubscriberNotificationMailerTest.php
@@ -12,6 +12,7 @@ use MailPoet\Mailer\MailerFactory;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class NewSubscriberNotificationMailerTest extends \MailPoetTest {
 
@@ -97,6 +98,30 @@ class NewSubscriberNotificationMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $service = new NewSubscriberNotificationMailer($mailerFactory, $this->diContainer->get(Renderer::class), $this->diContainer->get(SettingsController::class));
     $service->send($this->subscriber, $this->segments);
+  }
+
+  public function testItAppliesFilterToSettingsLink() {
+    $this->settings->set(NewSubscriberNotificationMailer::SETTINGS_KEY, ['enabled' => true, 'address' => 'a@b.c']);
+
+    $wp = WPFunctions::get();
+    $wp->addFilter('mailpoet_new_subscriber_notification_link_settings', function () {
+      return 'https://example.com/custom-settings';
+    });
+
+    $mailer = Stub::makeEmpty(Mailer::class, [
+      'send' =>
+        Expected::once(function($newsletter) {
+          verify($newsletter['body']['html'])->stringContainsString('https://example.com/custom-settings');
+          verify($newsletter['body']['text'])->stringContainsString('https://example.com/custom-settings');
+        }),
+    ], $this);
+
+    $mailerFactory = $this->createMock(MailerFactory::class);
+    $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
+    $service = new NewSubscriberNotificationMailer($mailerFactory, $this->diContainer->get(Renderer::class), $this->diContainer->get(SettingsController::class));
+    $service->send($this->subscriber, $this->segments);
+
+    $wp->removeAllFilters('mailpoet_new_subscriber_notification_link_settings');
   }
 
   public function testItSendsWithSubscriberEntity() {

--- a/mailpoet/tests/unit/Services/CongratulatoryMssEmailControllerTest.php
+++ b/mailpoet/tests/unit/Services/CongratulatoryMssEmailControllerTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Services;
+
+use MailPoet\Config\Renderer;
+use MailPoet\Mailer\Mailer;
+use MailPoet\Mailer\MailerFactory;
+use MailPoet\Mailer\MetaInfo;
+use MailPoet\WPCOM\DotcomHelperFunctions;
+
+class CongratulatoryMssEmailControllerTest extends \MailPoetUnitTest {
+  /** @var Mailer&\PHPUnit\Framework\MockObject\MockObject */
+  private $mailer;
+
+  /** @var Renderer&\PHPUnit\Framework\MockObject\MockObject */
+  private $renderer;
+
+  /** @var DotcomHelperFunctions&\PHPUnit\Framework\MockObject\MockObject */
+  private $dotcomHelperFunctions;
+
+  public function _before() {
+    parent::_before();
+    $this->mailer = $this->createMock(Mailer::class);
+    $this->renderer = $this->createMock(Renderer::class);
+    $this->dotcomHelperFunctions = $this->createMock(DotcomHelperFunctions::class);
+  }
+
+  private function createController(): CongratulatoryMssEmailController {
+    $mailerFactory = $this->createMock(MailerFactory::class);
+    $mailerFactory->method('getDefaultMailer')->willReturn($this->mailer);
+    return new CongratulatoryMssEmailController(
+      $mailerFactory,
+      new MetaInfo(),
+      $this->renderer,
+      $this->dotcomHelperFunctions
+    );
+  }
+
+  public function testItUsesMailPoetSubjectWhenNotGarden() {
+    $this->dotcomHelperFunctions->method('isGarden')->willReturn(false);
+    $this->mailer->expects($this->once())
+      ->method('send')
+      ->with(
+        $this->callback(function ($newsletter) {
+          return strpos($newsletter['subject'], 'MailPoet') !== false;
+        }),
+        $this->anything(),
+        $this->anything()
+      );
+    $this->createController()->sendCongratulatoryEmail('test@example.com');
+  }
+
+  public function testItUsesNeutralSubjectWhenGarden() {
+    $this->dotcomHelperFunctions->method('isGarden')->willReturn(true);
+    $this->mailer->expects($this->once())
+      ->method('send')
+      ->with(
+        $this->callback(function ($newsletter) {
+          return strpos($newsletter['subject'], 'MailPoet') === false
+            && strpos($newsletter['subject'], 'email sending') !== false;
+        }),
+        $this->anything(),
+        $this->anything()
+      );
+    $this->createController()->sendCongratulatoryEmail('test@example.com');
+  }
+
+  public function testItRendersHtmlAndTxtTemplates() {
+    $this->dotcomHelperFunctions->method('isGarden')->willReturn(false);
+    $this->renderer->expects($this->exactly(2))
+      ->method('render')
+      ->withConsecutive(
+        ['emails/congratulatoryMssEmail.html'],
+        ['emails/congratulatoryMssEmail.txt']
+      );
+    $this->mailer->expects($this->once())->method('send');
+    $this->createController()->sendCongratulatoryEmail('test@example.com');
+  }
+}

--- a/mailpoet/views/emails/congratulatoryMssEmail.html
+++ b/mailpoet/views/emails/congratulatoryMssEmail.html
@@ -37,17 +37,25 @@
                     <tr>
                       <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
                     </tr>
+                    <% if not is_garden() %>
                     <tr>
                       <td class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="center" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px">
                         <img src="<%= cdn_url('logo-orange-400x122.png') %>" width="80" alt="new_logo_orange" style="height:auto;max-width:100%;-ms-interpolation-mode:bicubic;border:0;display:block;outline:none;text-align:center" />
                       </td>
                     </tr>
+                    <% endif %>
                     <tr>
                       <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
                     </tr>
                     <tr>
                       <td class="mailpoet_text mailpoet_padded_vertical mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-top:10px;padding-bottom:10px;padding-left:20px;padding-right:20px;word-break:break-word;word-wrap:break-word">
-                        <h1 style="margin:0 0 12px;color:#111111;font-family:'Trebuchet MS','Lucida Grande','Lucida Sans Unicode','Lucida Sans',Tahoma,sans-serif;font-size:40px;line-height:64px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal"><strong><%= __('Congrats!') %><br /><%= __('MailPoet is now sending your emails') %></strong></h1>
+                        <h1 style="margin:0 0 12px;color:#111111;font-family:'Trebuchet MS','Lucida Grande','Lucida Sans Unicode','Lucida Sans',Tahoma,sans-serif;font-size:40px;line-height:64px;margin-bottom:0;text-align:center;padding:0;font-style:normal;font-weight:normal"><strong><%= __('Congrats!') %><br />
+                        <% if is_garden() %>
+                          <%= __('Your emails are now being sent') %>
+                        <% else %>
+                          <%= __('MailPoet is now sending your emails') %>
+                        <% endif %>
+                        </strong></h1>
                       </td>
                     </tr>
                     <tr>
@@ -58,7 +66,11 @@
                         <table style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0" width="100%" cellpadding="0">
                           <tr>
                             <td class="mailpoet_paragraph" style="border-collapse:collapse;color:#000000;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:25.6px;word-break:break-word;word-wrap:break-word;text-align:center">
+                              <% if is_garden() %>
+                              <%= __('This email was sent automatically after you activated your email sending key in your settings.') %>
+                              <% else %>
                               <%= __('This email was sent automatically with the MailPoet Sending Service after you activated your key in your MailPoet settings.') %>
+                              <% endif %>
                             </td>
                           </tr></table>
                       </td>
@@ -74,6 +86,7 @@
             </table>
           </td>
         </tr>
+        <% if not is_garden() %>
         <tr>
           <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse;background-color:#fe5301!important" bgcolor="#fe5301">
             <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
@@ -127,6 +140,7 @@
             </table>
           </td>
         </tr>
+        <% endif %>
         </tbody>
       </table><!--[if mso]>
       </td>

--- a/mailpoet/views/emails/congratulatoryMssEmail.txt
+++ b/mailpoet/views/emails/congratulatoryMssEmail.txt
@@ -1,5 +1,11 @@
 <%= __('Congrats!') %>
 
+<% if is_garden() %>
+<%= __('Your emails are now being sent') %>
+
+<%= __('This email was sent automatically after you activated your email sending key in your settings.') %>
+<% else %>
 <%= __('MailPoet is now sending your emails') %>
 
 <%= __('This email was sent automatically with the MailPoet Sending Service after you activated your key in your MailPoet settings.') %>
+<% endif %>

--- a/mailpoet/views/emails/newSubscriberNotification.html
+++ b/mailpoet/views/emails/newSubscriberNotification.html
@@ -7,7 +7,7 @@
 <p><%= __('Cheers,') %>
 
 <% if is_garden() %>
-<p><%= get_option('blogname') %>
+<p><%= get_option('blogname')|e('html') %>
 <% else %>
 <p><%= __('The MailPoet Plugin') %>
 <% endif %>

--- a/mailpoet/views/emails/newSubscriberNotification.html
+++ b/mailpoet/views/emails/newSubscriberNotification.html
@@ -6,11 +6,21 @@
 
 <p><%= __('Cheers,') %>
 
+<% if is_garden() %>
+<p><%= get_option('blogname') %>
+<% else %>
 <p><%= __('The MailPoet Plugin') %>
+<% endif %>
 
+<% if is_garden() %>
+<p><small><%= __('You can disable these emails in your [link]Email settings.[/link]'
+  |replaceLinkTags(link_settings)
+  ) %></small>
+<% else %>
 <p><small><%= __('You can disable these emails in your [link]MailPoet Settings.[/link]'
   |replaceLinkTags(link_settings)
   ) %></small>
+<% endif %>
 
 <% if 'now'|date('Y-m-d') < '2018-11-30'|date('Y-m-d') %>
   <p>

--- a/mailpoet/views/emails/newSubscriberNotification.html
+++ b/mailpoet/views/emails/newSubscriberNotification.html
@@ -13,7 +13,7 @@
 <% endif %>
 
 <% if is_garden() %>
-<p><small><%= __('You can disable these emails in your [link]Email settings.[/link]'
+<p><small><%= __('You can disable these emails in your [link]email settings.[/link]'
   |replaceLinkTags(link_settings)
   ) %></small>
 <% else %>

--- a/mailpoet/views/emails/newSubscriberNotification.txt
+++ b/mailpoet/views/emails/newSubscriberNotification.txt
@@ -12,7 +12,7 @@
 <% endif %>
 
 <% if is_garden() %>
-<%= __('You can disable these emails in your Email settings.') %>
+<%= __('You can disable these emails in your email settings.') %>
 <% else %>
 <%= __('You can disable these emails in your MailPoet Settings.') %>
 <% endif %>

--- a/mailpoet/views/emails/newSubscriberNotification.txt
+++ b/mailpoet/views/emails/newSubscriberNotification.txt
@@ -16,10 +16,10 @@
 <% else %>
 <%= __('You can disable these emails in your MailPoet Settings.') %>
 <% endif %>
-<%= link_settings %>
+<%= link_settings|raw %>
 
 <% if 'now'|date('Y-m-d') < '2018-11-30'|date('Y-m-d') %>
     <%= __('PS. MailPoet annual plans are nearly half price for a limited time. Find out more in the Premium page in your admin.') %>
-    <%= link_premium %>
+    <%= link_premium|raw %>
 <% endif %>
 

--- a/mailpoet/views/emails/newSubscriberNotification.txt
+++ b/mailpoet/views/emails/newSubscriberNotification.txt
@@ -5,9 +5,17 @@
 %>
 
 <%= __('Cheers,') %>
+<% if is_garden() %>
+<%= get_option('blogname') %>
+<% else %>
 <%= __('The MailPoet Plugin') %>
+<% endif %>
 
+<% if is_garden() %>
+<%= __('You can disable these emails in your Email settings.') %>
+<% else %>
 <%= __('You can disable these emails in your MailPoet Settings.') %>
+<% endif %>
 <%= link_settings %>
 
 <% if 'now'|date('Y-m-d') < '2018-11-30'|date('Y-m-d') %>

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -12,11 +12,13 @@
               <tr>
                 <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
               </tr>
+              <% if not is_garden() %>
               <tr>
                 <td class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="center" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
                   <img src="<%= cdn_url('logo-orange-400x122.png') %>" width="80" alt="new_logo_orange" style="height:auto;max-width:100%;-ms-interpolation-mode:bicubic;border:0;display:block;outline:none;text-align:center"/>
                 </td>
               </tr>
+              <% endif %>
               <tr>
                 <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
               </tr>
@@ -474,7 +476,7 @@
                     <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                       <tr>
                         <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
-                          <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#fe5301 ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:288px ;line-height:50px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:20px ;font-weight:normal ">
+                          <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= is_garden() ? '#333333' : '#fe5301' %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:288px ;line-height:50px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:20px ;font-weight:normal ">
                             <%= __('View all stats') %>
                           </a>
                         </td>

--- a/mailpoet/views/emails/statsNotification.txt
+++ b/mailpoet/views/emails/statsNotification.txt
@@ -16,7 +16,7 @@
 <%= __('You need to upgrade now to be able to continue using MailPoet.') %>
 
 <%= __('Upgrade Now') %>
-  <%= upgradeNowLink %>
+  <%= upgradeNowLink|raw %>
 <% endif %>
 
 <%= stats_number_format_i18n(clicked) %>% <%= __('clicked') %>
@@ -38,6 +38,6 @@
 <% endif %>
 
 <%= __('View all stats') %>
-  <%= linkStats %>
+  <%= linkStats|raw %>
 
 <% endblock %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -13,11 +13,13 @@
             <tr>
               <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
             </tr>
+            <% if not is_garden() %>
             <tr>
               <td class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="center" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
                 <img src="<%= cdn_url('logo-orange-400x122.png') %>" width="80" alt="new_logo_orange" style="height:auto;max-width:100%;-ms-interpolation-mode:bicubic;border:0;display:block;outline:none;text-align:center" />
               </td>
             </tr>
+            <% endif %>
             <tr>
               <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
             </tr>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
@@ -13,7 +13,7 @@
   <%= stats_number_format_i18n(newsletter.unsubscribed) %>% <%= __('unsubscribed') %>
   <%= stats_number_format_i18n(newsletter.bounced) %>% <%= __('bounced') %>
   <%= __('View all stats') %>
-    <%= newsletter.linkStats %>
+    <%= newsletter.linkStats|raw %>
 <% endfor %>
 ------------------------------------------
 <% endblock %>

--- a/mailpoet/views/emails/statsNotificationLayout.html
+++ b/mailpoet/views/emails/statsNotificationLayout.html
@@ -45,6 +45,7 @@
 
         <% block content %><% endblock %>
 
+        <% if not is_garden() %>
         <tr>
           <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse;background-color:#fe5301" bgcolor="#fe5301">
             <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
@@ -120,6 +121,32 @@
             </table>
           </td>
         </tr>
+        <% else %>
+        <tr>
+          <td class="mailpoet_content" align="center" style="border-collapse:collapse;background-color:#ffffff" bgcolor="#ffffff">
+            <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td style="padding:20px;border-collapse:collapse">
+                  <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                    <tr>
+                      <td class="mailpoet_divider-cell" style="border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8;border-collapse:collapse"></td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:0 20px 20px;text-align:center;border-collapse:collapse;color:#999999;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px">
+                  <a href="<%= linkSettings %>" style="color:#999999;text-decoration:underline">
+                    <%= __('Disable these emails') %>
+                  </a>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <% endif %>
         </tbody>
       </table><!--[if mso]>
       </td>

--- a/mailpoet/views/emails/statsNotificationLayout.txt
+++ b/mailpoet/views/emails/statsNotificationLayout.txt
@@ -1,5 +1,7 @@
 <% block content %><% endblock %>
 
+<% if not is_garden() %>
 <%= __('How to improve my open rate?') %> https://www.mailpoet.com/how-to-improve-open-rates/
 <%= __('And my click rate?') %> https://www.mailpoet.com/how-to-improve-click-rates/
+<% endif %>
 <%= __('Disable these emails') %> <%= linkSettings %>

--- a/mailpoet/views/emails/statsNotificationLayout.txt
+++ b/mailpoet/views/emails/statsNotificationLayout.txt
@@ -4,4 +4,4 @@
 <%= __('How to improve my open rate?') %> https://www.mailpoet.com/how-to-improve-open-rates/
 <%= __('And my click rate?') %> https://www.mailpoet.com/how-to-improve-click-rates/
 <% endif %>
-<%= __('Disable these emails') %> <%= linkSettings %>
+<%= __('Disable these emails') %> <%= linkSettings|raw %>


### PR DESCRIPTION
## Description

When a campaign is sent in Garden environments, MailPoet sends system emails that use MailPoet's orange branding, logo, KB links, and wp-admin URLs. These should be neutralized for Garden environments.

This PR updates all system emails in `mailpoet/views/emails/`:

### Stats Notification & Stats Notification Automated Emails
- Add `is_garden()` Twig function (delegates to `DotcomHelperFunctions::isGarden()`)
- Add WP filters for notification URLs (`mailpoet_stats_notification_link_settings`, `mailpoet_stats_notification_link_stats`, `mailpoet_new_subscriber_notification_link_settings`)
- Hide MailPoet logo, use neutral `#333333` button color, replace orange footer with minimal footer
- Updated both HTML and TXT templates

### New Subscriber Notification
- Use site name instead of "The MailPoet Plugin"
- Use "Email settings" instead of "MailPoet Settings"
- Add filter for settings URL
- Updated both HTML and TXT templates

### Congratulatory MSS Email
- Hide MailPoet logo and orange branded footer
- Neutralize MailPoet-specific copy (heading, body text, subject line)
- Updated both HTML and TXT templates

### TXT URL escaping fix
- Add `|raw` filter to all URL variables in TXT templates to prevent Twig's HTML autoescape from encoding `&` as `&amp;` in plain text emails, which broke URLs with query parameters (e.g. filtered Garden admin URLs)

## Code review notes

_N/A_

## QA notes

1. Set up a Garden environment (define `IS_COMMERCE_GARDEN` constant)
2. Trigger a stats notification email (send a campaign, then run the stats notification cron)
3. Verify: no MailPoet logo, neutral button color, minimal footer, filtered URLs
4. Trigger a new subscriber notification
5. Verify: site name signoff, "Email settings" link text, filtered URL
6. Activate an MSS key to trigger the congratulatory email
7. Verify: no MailPoet logo, neutral copy, no orange footer
8. Verify both HTML and TXT versions of all emails are consistent
9. Verify URLs in TXT emails don't contain `&amp;` — they should have plain `&`
10. Verify non-Garden environments are unchanged

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7849/email-stats-report-uses-mailpoets-orange-template

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/garden-aware-stats-notification-emails)

_The latest successful build from `add/garden-aware-stats-notification-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->