### PR TITLE
Fix subscription confirmation email not using store email template in Garden environment

### DIFF
--- a/mailpoet/changelog/2026-02-27-18-36-59-fixed-fix-subscription-confirmation-email-not-using-stor.md
+++ b/mailpoet/changelog/2026-02-27-18-36-59-fixed-fix-subscription-confirmation-email-not-using-stor.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix subscription confirmation email not using store email template in Garden environment

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -289,6 +289,11 @@ class Initializer {
       'setupEmailEditorIntegrations',
     ]);
 
+    $this->wpFunctions->addAction('woocommerce_init', [
+      $this,
+      'setupMarketingConfirmationEmail',
+    ]);
+
     WPFunctions::get()->addAction(AutomationHooks::INITIALIZE, [
       $this->automationMailPoetIntegration,
       'register',
@@ -326,7 +331,6 @@ class Initializer {
       $this->renderer = $this->rendererFactory->getRenderer();
       $this->setupWidget();
       $this->setupWoocommerceTransactionalEmails();
-      $this->setupMarketingConfirmationEmail();
       $this->assetsLoader->loadStyles();
       $this->emailEditorLogger->set_logger(new Logger());
     } catch (\Exception $e) {
@@ -567,7 +571,7 @@ class Initializer {
     }
   }
 
-  private function setupMarketingConfirmationEmail() {
+  public function setupMarketingConfirmationEmail() {
     $wcEnabled = $this->wcHelper->isWooCommerceActive();
     if ($wcEnabled) {
       $emails = new \MailPoet\WooCommerce\Emails();


### PR DESCRIPTION
## Description

In the Garden environment, the subscription confirmation email was sent via the MailPoet email system rather than the WooCommerce email template system. The root cause is a hook timing issue: `setupMarketingConfirmationEmail()` was called during `preInitialize()`, but in Garden, the WooCommerce init hook fires before MailPoet's preInitialize, so the woocommerce_email_classes filter was registered too late for WC to pick up the MarketingConfirmation email class.

This fix moves the registration to the `woocommerce_init` action hook, ensuring the email is registered at the correct time in WC's lifecycle.

<img width="911" height="351" alt="Screenshot 2026-02-27 at 5 51 58 PM" src="https://github.com/user-attachments/assets/daa36ba8-a221-4b52-aa1e-0f26525cbf04" />


## Code review notes

_N/A_

## QA notes

Environment: Garden only (the MarketingConfirmation email is gated by `DotcomHelperFunctions::isGarden()` in `Emails::init()`).

1. Set up a Garden environment (or simulate with `IS_COMMERCE_GARDEN` constant)
2. Ensure WooCommerce is active
3. Subscribe to a MailPoet list using a subscription form with double opt-in enabled OR Add a product to cart and checkout, on checkout, select the checkbox "I would like to receive exclusive emails with discounts and product information"
4. Verify the confirmation email uses the WooCommerce email template (header, footer, store styling) instead of the plain text version
5. Verify the email appears in WooCommerce Settings > Notifications > Customer notifications 

## Linked PRs

_N/A_

## Linked tickets

Closes https://linear.app/a8c/issue/WOOPRD-1959/align-subscription-confirmation-email-template-with-store-emails
Closes https://linear.app/a8c/issue/WOOPRD-1958/subscription-confirmation-email-sender-details-look-incorrect

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1533" height="433" alt="Screenshot 2026-02-27 at 7 36 36 PM" src="https://github.com/user-attachments/assets/3bd3e454-4ef3-42fd-af05-8d2259673f88" />


## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wooprd-1959-align-subscription-confirmation-email-template-with-store)

_The latest successful build from `wooprd-1959-align-subscription-confirmation-email-template-with-store` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR implements a straightforward and correct solution to the hook timing issue. The implementation shows:

- **Proper hook registration**: The `setupMarketingConfirmationEmail()` method is registered exactly once on the `woocommerce_init` hook, ensuring it fires at the correct time in WooCommerce's initialization lifecycle.
- **Appropriate visibility change**: The method visibility change from `private` to `public` is necessary and follows WordPress conventions for hook callbacks.
- **Adequate error handling**: The method includes a WooCommerce active check via `$this->wcHelper->isWooCommerceActive()` before proceeding, and the called `Emails::init()` method further guards with an `isGarden()` check, preventing execution outside the intended environment.
- **Safe dependency injection**: The `$wcHelper` dependency is properly injected through constructor with appropriate type hints.
- **No duplicate registrations**: Confirmed the method is registered only once with no conflicting registrations found in the codebase.

The fix correctly addresses the reported issue where the subscription confirmation email wasn't using the store email template in Garden environments due to the hook firing too late.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->