### PR TITLE
Fix flaky FormWithColumnsCest by retrying on stale element

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -366,7 +366,7 @@ class AcceptanceTester extends \Codeception\Actor {
   }
 
   public function click($link, $context = null) {
-    // retry click in case of "element click intercepted... Other element would receive the click" error
+    // retry click in case of transient WebDriver errors (intercepted click, not interactable, stale element)
     $retries = 3;
     while (true) {
       try {
@@ -374,7 +374,7 @@ class AcceptanceTester extends \Codeception\Actor {
         $this->_click($link, $context);
         break;
       } catch (WebDriverException $e) {
-        if ($retries > 0 && preg_match('(element click intercepted|element not interactable)', $e->getMessage()) === 1) {
+        if ($retries > 0 && preg_match('(element click intercepted|element not interactable|stale element reference)', $e->getMessage()) === 1) {
           $this->wait(0.2);
           continue;
         }

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -374,7 +374,11 @@ class AcceptanceTester extends \Codeception\Actor {
         $this->_click($link, $context);
         break;
       } catch (WebDriverException $e) {
-        if ($retries > 0 && preg_match('(element click intercepted|element not interactable|stale element reference)', $e->getMessage()) === 1) {
+        $message = $e->getMessage();
+        $isTransient = strpos($message, 'element click intercepted') !== false
+          || strpos($message, 'element not interactable') !== false
+          || strpos($message, 'stale element reference') !== false;
+        if ($retries > 0 && $isTransient) {
           $this->wait(0.2);
           continue;
         }


### PR DESCRIPTION
## Description

Fix flaky `FormWithColumnsCest::createAndTestFormWithColumns` acceptance test. The test fails intermittently with `StaleElementReferenceException` when clicking the "Columns" block in the Gutenberg block inserter — React re-renders the search results between `waitForText` and `click`, leaving a stale DOM reference.

The fix adds `stale element reference` to the existing click retry logic in `AcceptanceTester::click()`. Since `_click()` re-locates elements from selectors on each retry, this handles the race condition globally for all click operations.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/flaky-form-columns-stale-element)

_The latest successful build from `fix/flaky-form-columns-stale-element` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**1 issue found**

**Category: Suggestion**

**Issue: Misleading commit message**

The commit message "Replace preg_match with strpos checks for readability" is inaccurate. The git log shows this is a new file creation (the entire `AcceptanceTester.php` file is being added), not a replacement of existing code. There is no prior `preg_match()` usage to replace in this context. The commit message should more accurately describe the change as "Add stale element reference handling to click retry logic in AcceptanceTester" to reflect that this is new code implementing enhanced error handling for WebDriver click operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->