### PR TITLE
Fix subscription form block breaking Site Editor

### DIFF
--- a/mailpoet/assets/css/src/components-post-editor-block/_post-editor-block.scss
+++ b/mailpoet/assets/css/src/components-post-editor-block/_post-editor-block.scss
@@ -1,5 +1,10 @@
 .mailpoet-block-div {
   padding: 20px;
+
+  .mailpoet_form_image img {
+    height: auto;
+    max-width: 100%;
+  }
 }
 
 .mailpoet-block-create-new-content {

--- a/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/subscription-form/edit.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Icon } from './icon.jsx';
 
 const wp = window.wp;
-const { Placeholder, PanelBody } = wp.components;
+const { Placeholder, PanelBody, Disabled } = wp.components;
 const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const ServerSideRender = wp.serverSideRender;
 
@@ -42,10 +42,12 @@ function Edit({ attributes, setAttributes }) {
 
   function renderForm() {
     return (
-      <ServerSideRender
-        block="mailpoet/subscription-form-block-render"
-        attributes={{ formId: attributes.formId }}
-      />
+      <Disabled>
+        <ServerSideRender
+          block="mailpoet/subscription-form-block-render"
+          attributes={{ formId: attributes.formId }}
+        />
+      </Disabled>
     );
   }
 

--- a/mailpoet/changelog/2026-03-05-09-45-37-fixed-fix-subscription-form-block-breaking-the-site-edit.md
+++ b/mailpoet/changelog/2026-03-05-09-45-37-fixed-fix-subscription-form-block-breaking-the-site-edit.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix subscription form block breaking the Site Editor when submit button is clicked


### PR DESCRIPTION
## Description

The MailPoet Subscription Form block breaks the Site Editor when the submit button is clicked. The block uses `ServerSideRender` to display a real `<form>` with `target="_self"` and `action="admin-post.php?..."` in the editor iframe. Clicking submit triggers native form submission, navigating the iframe away from the editor to the frontend.

The fix wraps the `ServerSideRender` output with WordPress's `Disabled` component, which adds the `inert` HTML attribute and `pointer-events: none` CSS. This is the standard WordPress pattern for non-interactive block previews.

## Code review notes

_N/A_

## QA notes

1. Open the Post Editor or Site Editor
2. Add a MailPoet Subscription Form block and select a form
3. Click the submit button in the form preview — it should do nothing (no iframe navigation)
4. Verify the form selection dropdown in the sidebar still works
5. Verify the form renders and submits correctly on the actual frontend

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7875](https://linear.app/a8c/issue/STOMAIL-7875/mailpoet-subscription-form-block-reloads-site-editor-iframe-to)

## After-merge notes

_N/A_

## Screenshots or screencast

<img width="1200" height="1278" alt="form-block-disabled-in-editor" src="https://github.com/user-attachments/assets/e2fa3a3c-92da-4750-87a4-11f6431a548b" />

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7875-mailpoet-subscription-form-block-reloads-site-editor-iframe)

_The latest successful build from `stomail-7875-mailpoet-subscription-form-block-reloads-site-editor-iframe` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->