### PR TITLE
Hide Reply-to panel in automations for Garden

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/index.tsx
@@ -1,12 +1,18 @@
+import { useSelect } from '@wordpress/data';
 import { EmailPanel } from './email-panel';
 import { GoogleAnalyticsPanel } from './google-analytics-panel';
 import { ReplyToPanel } from './reply-to-panel';
+import { storeName } from '../../../../../editor/store';
 
 export function Edit(): JSX.Element {
+  const isGarden = useSelect(
+    (select) => select(storeName).getContext('is_garden') === true,
+    [],
+  );
   return (
     <>
       <EmailPanel />
-      <ReplyToPanel />
+      {!isGarden && <ReplyToPanel />}
       <GoogleAnalyticsPanel />
     </>
   );


### PR DESCRIPTION
## Description

Hide the Reply-to section in email automation steps when running in the Garden environment. The Reply-to settings should use defaults from Settings > Email instead of being editable per-automation.

## Code review notes

Uses the existing `isGarden` gating pattern (same as sender fields in `email-panel.tsx`). The `ReplyToPanel` is conditionally rendered in the parent `Edit` component.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7862](https://linear.app/a8c/issue/STOMAIL-7862/reply-to-field-editable-in-email-automations)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/STOMAIL-7862-hide-reply-to-in-automations)

_The latest successful build from `fix/STOMAIL-7862-hide-reply-to-in-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The implementation correctly:
- Uses `useSelect` hook with proper imports from '@wordpress/data' and the correct store name
- Implements conditional rendering with strict equality check (`=== true`) to safely determine Garden environment
- Applies an empty dependency array appropriate for this static context value
- Uses correct negation logic (`!isGarden`) to hide ReplyToPanel in Garden environments
- Follows the existing pattern described for sender field gating in email-panel.tsx

<!-- end of auto-generated comment: release notes by coderabbit.ai -->