### PR TITLE
Add reviewing-code and starting-branch skills

### DIFF
--- a/.ai/skills/reviewing-code/SKILL.md
+++ b/.ai/skills/reviewing-code/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: reviewing-code
+description: Use when reviewing pull requests or local code changes. Use when asked to review a PR, review code, test changes, verify implementation quality, or do a code review.
+---
+
+# Reviewing Code
+
+## Overview
+
+This skill handles two review modes:
+
+| Mode         | Trigger                             | Input                          |
+| ------------ | ----------------------------------- | ------------------------------ |
+| PR Review    | User provides a GitHub PR URL       | PR diff, description, CI, etc. |
+| Local Review | User asks to review current changes | git diff, branch state         |
+
+## Step 1: Determine Review Mode
+
+- If the user provides a GitHub PR URL (e.g. `https://github.com/.../pull/123`) --> **PR Review mode**
+- If the user asks to review current branch, uncommitted changes, or staged changes --> **Local Review mode**
+- If ambiguous, ask the user which mode they want.
+
+## Step 2: Gather Context
+
+### PR Review Mode
+
+1. **Read the PR** using `gh pr view <number> --json title,body,state,baseRefName,headRefName,files,reviews,statusCheckRollup,labels`
+2. **Get the full diff** using `gh pr diff <number>`
+3. **Check CI status** using `gh pr checks <number>`
+4. **Read linked PRs** -- if the PR description contains links to other PRs (in the "Linked PRs" section), fetch and read those too with `gh pr view`
+5. **Read the changed files in full** -- for each significantly changed file, read the complete file (not just the diff) to understand context
+
+### Local Review Mode
+
+1. **Check branch state** using `git status`, `git branch --show-current`
+2. **Get the diff** using `git diff trunk...HEAD` for committed changes and `git diff` / `git diff --cached` for uncommitted changes
+3. **Read the changed files in full** for context
+4. **Ask the user** what they intended to implement (if not already clear)
+
+### Both Modes
+
+5. **Find the Linear ticket** -- look for a Linear ticket ID in:
+   - PR description (PR mode)
+   - Commit messages (`git log trunk..HEAD --oneline`)
+   - Branch name
+
+   If found, fetch the Linear ticket using the Linear MCP tool (`get_issue`). **Always load the ticket's comments and attachments.** Verify the changes actually address the ticket requirements. If no Linear ticket is found, skip this step but note it in the output.
+
+6. **Identify the change type** -- classify what the diff primarily touches:
+   - PHP backend changes
+   - React/TypeScript frontend changes
+   - SCSS/CSS styling changes
+   - Test-only changes
+   - Mixed changes
+
+   This classification determines how to tailor the sub-agent prompts in Step 3.
+
+## Step 3: Parallel Sub-Agent Code Review
+
+Launch multiple sub-agents in parallel using the Agent tool. Each agent receives the full diff and relevant context, but has a specific review focus. Determine the exact count of sub-agents based on the complexity and scope of changes.
+
+**IMPORTANT:** Tailor each agent's prompt based on the change type identified in Step 2. For PHP-heavy changes, emphasize PHP patterns, Doctrine, WordPress conventions. For frontend changes, emphasize React patterns, TypeScript, accessibility. For mixed changes, cover both.
+
+### What should be verified
+
+- Scope & Completeness - Do the changes fully address the Linear ticket requirements? List any gaps.
+- Are there user-facing changes missing a changelog entry? (Check for files in `mailpoet/changelog/` on the branch.)
+- Are there missing test files for the changes? (Compare changed source files to test directories.)
+- Do the changes follow existing patterns in the codebase?
+- **PHP:** Is DI used correctly? Are WordPress functions called via `WP\Functions`? Are entities/repositories following Doctrine patterns?
+- **Frontend:** Are components well-structured? Is state management appropriate? Are named exports used?
+- **Other file types:** Are they written properly, named according the correct standards?
+- Is the code well-organized -- right files, right namespaces, right directories?
+- Are there any design concerns?
+- Security & Safety - is the code safe to be shipped? Are all user inputs sanitized and validated properly? Are all security standards used?
+- Backward Compatibility - if the code is changed what happens to the users who already used the previous versions?
+- Is the code using only supported PHP versions?
+- API changes: Do changes to the public API break existing integrations?
+- Are any WordPress hooks (actions/filters) added, removed, or changed in signature?
+- WooCommerce compatibility: If WooCommerce integration code changed, is it guarded with existence checks?
+- Test Coverage: Is there a regression test that reproduces the original bug and verifies the fix?
+- Is there sufficient test coverage for the new behavior? Are happy paths, error paths, and edge cases covered?
+- Are the right test types used? Unit tests vs Integration tests vs Acceptance tests
+- Are there tests that test implementation details rather than behavior?
+- Do the test properly check the code or blindly verify the mocks?
+- Did all the checks in the GitHub Pull Request passed?
+
+### Devil's Advocate – always spin up this sub-agent
+
+- What are the missing pieces? What is the implementation missing? What is the plan overlooking?
+- What edge cases are not handled?
+- What happens when this code fails? Are errors handled gracefully?
+- What assumptions does this code make that might not always hold?
+- Could this cause performance issues at scale (large subscriber lists, many newsletters, high-traffic sites)?
+- What would a hostile reviewer point out?
+- Are there any "it works but..." concerns -- code that is technically correct but fragile, hard to maintain, or surprising?
+- If tests were added, are they actually testing the right things? Are there missing test cases?
+
+## Step 4: Manual Testing
+
+### Decide Whether to Test
+
+Skip manual testing if ALL of the following are true:
+- Changes are test-only, documentation-only, or CI/build configuration only
+- No user-facing behavior was changed
+- No UI components were modified
+
+If user-facing changes exist, proceed with testing.
+
+### Get Testing Steps
+
+- **PR mode:** Extract testing steps from the "QA notes" section of the PR description.
+- **Local mode:** Create testing steps based on the changes. Describe what to test and expected outcomes.
+- If the PR's QA notes say `_N/A_` but there are clearly user-facing changes, flag this as a concern.
+
+### Execute Browser Testing
+
+1. **Check for testing tools** -- verify the Playwright browser tools or Chrome available. If not, inform the user and explain what should they do and how to enable those.
+2. **Navigate to the local dev environment** – if there are any issues with the environment fix them
+3. **Follow the testing steps** one by one:
+   - Navigate to the relevant page
+   - Perform the described actions
+   - Take a screenshot documenting that the required behaviour has been fixed or improved
+   - Verify expected outcomes match actual behavior
+4. **Document results** -- for each step, note: pass/fail, screenshot path, and any unexpected behavior.
+
+## Step 5: Output
+
+### PR Review Mode
+
+Present the review as structured output the user can post as PR comments.
+
+Do NOT post the review to GitHub automatically. Print it for the user to review and post themselves.
+
+### Local Review Mode
+
+Ask the user what they want to do with the findings:
+- Fix the issues now
+- Get a summary to review later
+- Proceed to create a PR (invoke the `creating-pull-requests` skill)
+
+## Common Mistakes
+
+| Mistake                                    | Fix                                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Reviewing only the diff, not full files    | Always read the complete changed files for context                                   |
+| Skipping the Linear ticket                 | The ticket has acceptance criteria that may not be in the PR description             |
+| Not loading ticket comments/attachments    | Comments and attachments often contain clarifications and design mockups             |
+| Generic security review                    | Tailor findings to the actual code -- do not list OWASP items with no code evidence  |
+| Posting review to GitHub automatically     | Always print for the user to post themselves                                         |
+| Skipping linked PRs                        | Linked PRs need to be reviewed together                                              |
+| Not reading PR CI status                   | CI failures are important context for the review                                     |
+| Missing regression test for bug fix        | Bug fixes without a test that reproduces the bug are incomplete -- always flag       |

--- a/.ai/skills/reviewing-code/SKILL.md
+++ b/.ai/skills/reviewing-code/SKILL.md
@@ -40,6 +40,7 @@ This skill handles two review modes:
 ### Both Modes
 
 5. **Find the Linear ticket** -- look for a Linear ticket ID in:
+
    - PR description (PR mode)
    - Commit messages (`git log trunk..HEAD --oneline`)
    - Branch name
@@ -47,6 +48,7 @@ This skill handles two review modes:
    If found, fetch the Linear ticket using the Linear MCP tool (`get_issue`). **Always load the ticket's comments and attachments.** Verify the changes actually address the ticket requirements. If no Linear ticket is found, skip this step but note it in the output.
 
 6. **Identify the change type** -- classify what the diff primarily touches:
+
    - PHP backend changes
    - React/TypeScript frontend changes
    - SCSS/CSS styling changes
@@ -101,6 +103,7 @@ Launch multiple sub-agents in parallel using the Agent tool. Each agent receives
 ### Decide Whether to Test
 
 Skip manual testing if ALL of the following are true:
+
 - Changes are test-only, documentation-only, or CI/build configuration only
 - No user-facing behavior was changed
 - No UI components were modified
@@ -135,19 +138,20 @@ Do NOT post the review to GitHub automatically. Print it for the user to review 
 ### Local Review Mode
 
 Ask the user what they want to do with the findings:
+
 - Fix the issues now
 - Get a summary to review later
 - Proceed to create a PR (invoke the `creating-pull-requests` skill)
 
 ## Common Mistakes
 
-| Mistake                                    | Fix                                                                                  |
-| ------------------------------------------ | ------------------------------------------------------------------------------------ |
-| Reviewing only the diff, not full files    | Always read the complete changed files for context                                   |
-| Skipping the Linear ticket                 | The ticket has acceptance criteria that may not be in the PR description             |
-| Not loading ticket comments/attachments    | Comments and attachments often contain clarifications and design mockups             |
-| Generic security review                    | Tailor findings to the actual code -- do not list OWASP items with no code evidence  |
-| Posting review to GitHub automatically     | Always print for the user to post themselves                                         |
-| Skipping linked PRs                        | Linked PRs need to be reviewed together                                              |
-| Not reading PR CI status                   | CI failures are important context for the review                                     |
-| Missing regression test for bug fix        | Bug fixes without a test that reproduces the bug are incomplete -- always flag       |
+| Mistake                                 | Fix                                                                                 |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| Reviewing only the diff, not full files | Always read the complete changed files for context                                  |
+| Skipping the Linear ticket              | The ticket has acceptance criteria that may not be in the PR description            |
+| Not loading ticket comments/attachments | Comments and attachments often contain clarifications and design mockups            |
+| Generic security review                 | Tailor findings to the actual code -- do not list OWASP items with no code evidence |
+| Posting review to GitHub automatically  | Always print for the user to post themselves                                        |
+| Skipping linked PRs                     | Linked PRs need to be reviewed together                                             |
+| Not reading PR CI status                | CI failures are important context for the review                                    |
+| Missing regression test for bug fix     | Bug fixes without a test that reproduces the bug are incomplete -- always flag      |

--- a/.ai/skills/starting-branch/SKILL.md
+++ b/.ai/skills/starting-branch/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: starting-branch
+description: ALWAYS use when creating a new branch, starting work on a task, or working on a Linear issue. Handles branch naming, Linear lookup, and branch creation. Do NOT run git switch -c or git checkout -b directly.
+---
+
+# Starting a Branch
+
+## Overview
+
+Creates a properly named Git branch for a Linear issue or task, following the company branch naming conventions.
+
+## Step 1: Determine the Branch Name
+
+### With a Linear Issue
+
+If the user provides a Linear issue ID (e.g. `STOMAIL-1234`):
+
+1. **Fetch the issue** using the Linear MCP tool (`get_issue`) to get the title and type
+2. **Pick the prefix** based on issue type: `add/`, `update/`, `fix/` or any other relevant prefix
+3. **Generate the branch name:** `<prefix><ISSUE-ID>-<short-description>`
+   - Issue ID in the branch name is **lowercase** (e.g. `stomail-1234`)
+   - Description is **kebab-case**, derived from the issue title
+   - Keep it short but descriptive
+   - Example: `fix/stomail-7875-mailpoet-subscription-form-block-reloads-site-editor-iframe`
+
+### Without a Linear Issue
+
+If no Linear issue is provided:
+1. Suggest a branch name based on what the user described
+2. Ask the user to confirm or provide their own name
+
+### Always Confirm
+
+**Always** present the generated branch name to the user and ask for confirmation before creating it.
+
+## Step 2: Create the Branch
+
+Once confirmed, ensure you are on `trunk` and up to date, then create the branch:
+
+```bash
+git switch trunk
+git pull
+git switch -c <branch-name>
+```

--- a/.ai/skills/starting-branch/SKILL.md
+++ b/.ai/skills/starting-branch/SKILL.md
@@ -26,6 +26,7 @@ If the user provides a Linear issue ID (e.g. `STOMAIL-1234`):
 ### Without a Linear Issue
 
 If no Linear issue is provided:
+
 1. Suggest a branch name based on what the user described
 2. Ask the user to confirm or provide their own name
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,8 @@ Skills are progressively-revealed instructions loaded on demand.
 - `mailpoet-dev-cycle` -- Linting and code quality workflows. Use when fixing code style or following the development workflow.
 - `code-quality.md` -- ESLint, Stylelint, Prettier commands and conventions
 - `php-coding-standards.md` -- PHP lint, PHPCS, PHPStan commands, ruleset details, naming conventions
+- **`starting-branch`** -- MUST use when creating any new branch. Handles branch naming, Linear lookup, and branch creation. Never run `git switch -c` or `git checkout -b` directly.
+- `reviewing-code.md` -- Reviewing pull requests or local code changes. Use when asked to review a PR, review code, test changes, verify implementation quality, or do a code review.
 - `writing-changelog` -- Use when adding a changelog entry for user-facing changes. Guides through analyzing branch changes, picking the right type, and writing a user-friendly description.
 
 ## Additional Resources


### PR DESCRIPTION
## Description

Add two new AI skills to standardize developer workflows:

- **`reviewing-code`** — Handles PR reviews (from GitHub URL) and local code reviews (current branch). Fetches Linear tickets with comments/attachments, launches parallel sub-agents for scope, architecture, security, backward compatibility, test coverage, and devil's advocate review. Includes Playwright-based manual testing with screenshots.
- **`starting-branch`** — Handles branch creation with proper naming conventions. Looks up Linear issues, picks the right prefix (`add/`, `update/`, `fix/`), generates kebab-case branch names, and confirms with the user before creating.

Both skills are referenced in `AGENTS.md` so they are discoverable.

## Code review notes

The `starting-branch` skill uses mandatory language ("ALWAYS use", "Do NOT run git switch -c directly") mirroring the pattern from `creating-pull-requests` — this is intentional to ensure the skill is reliably triggered rather than treated as optional.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/reviewing-code-and-starting-branch-skills)

_The latest successful build from `add/reviewing-code-and-starting-branch-skills` will be used. If none is available, the link won't work._