### PR TITLE
Fix silent failure in release:publish and release:prepare

### DIFF
--- a/.ai/skills/reviewing-code/SKILL.md
+++ b/.ai/skills/reviewing-code/SKILL.md
@@ -63,6 +63,15 @@ Launch multiple sub-agents in parallel using the Agent tool. Each agent receives
 
 **IMPORTANT:** Tailor each agent's prompt based on the change type identified in Step 2. For PHP-heavy changes, emphasize PHP patterns, Doctrine, WordPress conventions. For frontend changes, emphasize React patterns, TypeScript, accessibility. For mixed changes, cover both.
 
+### Important rules
+
+- Only report issues you are CERTAIN about after reading the actual code. If you are unsure, say so explicitly rather than presenting speculation as fact.
+- Do NOT flag standard WordPress/WooCommerce patterns as issues (e.g. $wpdb->posts interpolation, get_posts() with posts_per_page => -1 for bounded queries).
+- Focus on real bugs, logic errors, security vulnerabilities, and missing edge cases — not stylistic preferences.
+- If you find no real issues, say "No issues found" — do not invent problems to fill the review.
+- Keep it concise. No filler praise or emoji headers.
+- Categorize findings as: Bug, Security, Performance, or Suggestion.
+
 ### What should be verified
 
 - Scope & Completeness - Do the changes fully address the Linear ticket requirements? List any gaps.

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -993,7 +993,7 @@ class RoboFile extends \Robo\Tasks {
         return $callback();
       } catch (\Exception $e) {
         $this->yell($e->getMessage(), 40, 'red');
-        throw $e;
+        return \Robo\Result::error($this, $e->getMessage(), ['exception' => $e]);
       }
     };
   }
@@ -1102,13 +1102,19 @@ class RoboFile extends \Robo\Tasks {
     $this->say('Translations check passed');
   }
 
-  public function releasePublish($version = null) {
+  public function releasePublish($version = null, $opts = ['force' => false]) {
     $version = $this->releaseVersionGetNext($version);
+    $collection = $this->collectionBuilder();
 
-    return $this->collectionBuilder()
-      ->addCode($this->withErrorOutput(function () use ($version) {
+    if ($opts['force']) {
+      $this->yell('Skipping pull request check (--force)', 40, 'yellow');
+    } else {
+      $collection->addCode($this->withErrorOutput(function () use ($version) {
         $this->releaseCheckPullRequest($version);
-      }))
+      }));
+    }
+
+    return $collection
       ->addCode($this->withErrorOutput(function () use ($version) {
         $this->translationsCheckLanguagePacks($version);
       }))
@@ -1474,8 +1480,7 @@ class RoboFile extends \Robo\Tasks {
 
   protected function validateVersion($version) {
     if (!\MailPoetTasks\Release\VersionHelper::validateVersion($version)) {
-      $this->yell('Incorrect version format', 40, 'red');
-      exit(1);
+      throw new \Exception('Incorrect version format');
     }
   }
 
@@ -1521,12 +1526,11 @@ class RoboFile extends \Robo\Tasks {
   protected function getEnv($name, $help = null) {
     $env = getenv($name);
     if ($env === false || $env === '') {
-      $this->yell("Environment variable '$name' was not set.", 40, 'red');
+      $message = "Environment variable '$name' was not set.";
       if ($help !== null) {
-        $this->say('');
-        $this->say($help);
+        $message .= "\n\n" . $help;
       }
-      exit(1);
+      throw new \Exception($message);
     }
     return $env;
   }

--- a/mailpoet/RoboFile.php
+++ b/mailpoet/RoboFile.php
@@ -291,8 +291,7 @@ class RoboFile extends \Robo\Tasks {
     $potFilePath = 'lang/mailpoet.pot';
 
     if (!is_file(self::ZIP_BUILD_PATH)) {
-      $this->yell('mailpoet.zip file is missing. You must first download it using `./do release:download-zip`.', 40, 'red');
-      exit(1);
+      throw new \Exception('mailpoet.zip file is missing. You must first download it using `./do release:download-zip`.');
     }
 
     if (!file_exists(__DIR__ . '/lang')) {
@@ -307,12 +306,10 @@ class RoboFile extends \Robo\Tasks {
         file_put_contents($potFilePath, $potFileContent);
         $this->say('mailpoet.pot extracted from the zip file to ' . $potFilePath);
       } else {
-        $this->yell('Unable to find mailpoet.pot inside the zip file.', 40, 'red');
-        exit(1);
+        throw new \Exception('Unable to find mailpoet.pot inside the zip file.');
       }
     } else {
-      $this->yell('Unable to open the zip file.', 40, 'red');
-      exit(1);
+      throw new \Exception('Unable to open the zip file.');
     }
   }
 
@@ -990,28 +987,39 @@ class RoboFile extends \Robo\Tasks {
     return $result;
   }
 
+  private function withErrorOutput(callable $callback): \Closure {
+    return function () use ($callback) {
+      try {
+        return $callback();
+      } catch (\Exception $e) {
+        $this->yell($e->getMessage(), 40, 'red');
+        throw $e;
+      }
+    };
+  }
+
   public function releasePrepare($version = null) {
     $version = $this->releaseVersionGetNext($version);
 
     return $this->collectionBuilder()
-      ->addCode(function () {
+      ->addCode($this->withErrorOutput(function () {
         $this->releasePrepareGit();
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releaseVersionWrite($version);
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releaseChangelogWrite($version);
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releaseCreatePullRequest($version);
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         $this->releaseRerunCircleWorkflowForPremium();
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->translationsPrepareLanguagePacks($version);
-      })
+      }))
       ->run();
   }
 
@@ -1022,8 +1030,7 @@ class RoboFile extends \Robo\Tasks {
       ->exec('git status --porcelain')
       ->run();
     if (strlen(trim($gitStatus->getMessage())) > 0) {
-      $this->yell('Please make sure your working directory is clean before running release.', 40, 'red');
-      exit(1);
+      throw new \Exception('Please make sure your working directory is clean before running release.');
     }
     // checkout trunk and pull from remote
     $this->taskGitStack()
@@ -1037,8 +1044,7 @@ class RoboFile extends \Robo\Tasks {
       ->exec('git ls-remote --heads git@github.com:mailpoet/mailpoet.git release')
       ->run();
     if (strlen(trim($releaseBranchStatus->getMessage())) > 0) {
-      $this->yell('Delete old release branch before running release.', 40, 'red');
-      exit(1);
+      throw new \Exception('Delete old release branch before running release.');
     }
     // check if local branch with name "release" exists
     $gitStatus = $this->taskGitStack()
@@ -1078,8 +1084,7 @@ class RoboFile extends \Robo\Tasks {
     $translations = new \MailPoetTasks\Release\TranslationsController();
     $result = $translations->importTransifex($version);
     if (!$result['success']) {
-      $this->yell($result['data'], 40, 'red');
-      exit(1);
+      throw new \Exception($result['data']);
     }
     $this->say('Translations ' . $result['data']);
   }
@@ -1092,62 +1097,57 @@ class RoboFile extends \Robo\Tasks {
     $translations = new \MailPoetTasks\Release\TranslationsController();
     $result = $translations->checkIfTranslationsAreReady($version);
     if (!$result['success']) {
-      $this->yell('Translations are not ready yet on WordPress.com. ' . $result['data'], 40, 'red');
-      exit(1);
+      throw new \Exception('Translations are not ready yet on WordPress.com. ' . $result['data']);
     }
     $this->say('Translations check passed');
   }
 
   public function releasePublish($version = null) {
     $version = $this->releaseVersionGetNext($version);
+
     return $this->collectionBuilder()
-      ->addCode(function () use ($version) {
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releaseCheckPullRequest($version);
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->translationsCheckLanguagePacks($version);
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         $this->releaseDownloadZip();
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releaseVerifyDownloadedZip($version);
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         $this->translationsGetPotFileFromBuild();
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         return $this->translationsPush();
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         return $this->svnCheckout();
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         return $this->svnPublish($version);
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releasePublishGithub($version);
-      })
-      ->addCode(function () use ($version) {
+      }))
+      ->addCode($this->withErrorOutput(function () use ($version) {
         $this->releasePublishSlack($version);
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         $this->releaseMergePullRequest(\MailPoetTasks\Release\GitHubController::RELEASE_SOURCE_BRANCH);
-      })
-      ->addCode(function () {
+      }))
+      ->addCode($this->withErrorOutput(function () {
         $this->releaseDeleteDownloadedZip();
-      })
+      }))
       ->run();
   }
 
   public function releaseMergePullRequest(string $branch) {
-    try {
-      $this->createGitHubController()
-        ->mergePullRequest(\MailPoetTasks\Release\CircleCiController::PROJECT_MAILPOET, $branch);
-    } catch (\Exception $e) {
-      $this->yell($e->getMessage(), 40, 'red');
-      exit(1);
-    }
+    $this->createGitHubController()
+      ->mergePullRequest(\MailPoetTasks\Release\CircleCiController::PROJECT_MAILPOET, $branch);
     $this->say("Pull request for branch: '{$branch}' was successfully merged");
   }
 
@@ -1250,13 +1250,11 @@ class RoboFile extends \Robo\Tasks {
       }
       $zip->close();
     } else {
-      $this->yell('ZIP file could not be opened!', 40, 'red');
-      exit(1);
+      throw new \Exception('ZIP file could not be opened!');
     }
 
     if (!$versionFound) {
-      $this->yell('ZIP file does not contain required version: "' . $version . '" in readme.txt! ', 40, 'red');
-      exit(1);
+      throw new \Exception('ZIP file does not contain required version: "' . $version . '" in readme.txt!');
     }
     $this->say('ZIP file contains required version: "' . $version . '" in readme.txt.');
   }


### PR DESCRIPTION
## Description

When `release:publish` or `release:prepare` fails, it exits with code 1 but produces **no output**. This is because `collectionBuilder()->addCode()->run()` catches exceptions internally and returns a failed `Result` without displaying the error message. This makes it difficult for operators to diagnose failures.

This PR:
- Wraps each `addCode` callback in try/catch to surface error messages via `$this->yell()` before re-throwing
- Adds a `--force` flag to `release:publish` that skips the PR check step, allowing releases when CI has non-critical failures

## Code review notes

_N/A_

## QA notes

- Run `./do release:publish` where any step fails — error message should now be visible instead of silent exit code 1
- Run `./do release:publish --force` — should skip the PR check step and print a warning

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7868

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7868-fix-silent-failure-in-releasepublish-and-add-force-flag)

_The latest successful build from `stomail-7868-fix-silent-failure-in-releasepublish-and-add-force-flag` will be used. If none is available, the link won't work._