### PR TITLE
Fix flaky SubscriberCountShortcodeCest acceptance test

### DIFF
--- a/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
+++ b/mailpoet/tests/acceptance/Settings/SubscriberCountShortcodeCest.php
@@ -66,7 +66,8 @@ class SubscriberCountShortcodeCest {
     $i->click('[data-automation-id="action-trash"]');
     $i->waitForListingItemsToLoad();
     $i->waitForNoticeAndClose('11 subscribers were moved to the trash.');
-    $i->waitForText('No items found.');
+    $i->selectOption('[data-automation-id="listing_filter_segment"]', '');
+    $i->waitForListingItemsToLoad();
     $i->waitForElement('[data-automation-id="filters_trash"]');
     $i->click('[data-automation-id="filters_trash"]');
     $i->waitForListingItemsToLoad();


### PR DESCRIPTION
## Description

Fix a race condition in `SubscriberCountShortcodeCest::verifySubscribersShortcodeAllCounts` that caused flaky failures.

After trashing all subscribers in a segment, the segment disappears from the filter dropdown, causing an auto-reset to "All Lists" which triggers a cascading listing reload. If the test clicks the Trash tab during this reload, the reload overwrites the navigation and the test lands back on the "All" tab, failing to find the `empty_trash` button.

The fix explicitly resets the segment filter to "All Lists" and waits for the listing to stabilize before clicking the Trash tab.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry — N/A, test-only change
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/flaky-subscriber-count-shortcode-acceptance-test)

_The latest successful build from `fix/flaky-subscriber-count-shortcode-acceptance-test` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

This pull request is a test-only fix that addresses a race condition in the SubscriberCountShortcodeCest acceptance test. The change appropriately stabilizes the test by:
1. Explicitly resetting the segment filter to "All Lists" (by selecting an empty option)
2. Waiting for the listing to stabilize before proceeding to access the trash filter

This eliminates the flaky behavior caused by the implicit filter reset that could race with the test's navigation steps. The modification is a sound defensive programming practice for acceptance tests and introduces no bugs, security concerns, or performance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->