### PR TITLE
Fix step name popover not closing on outside click

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/panel/step-name.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/panel/step-name.tsx
@@ -32,12 +32,14 @@ function StepNameContent({
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
+      if (event.button !== 0) return;
+
       const target = event.target as Node;
-      const popoverEl = contentRef.current?.closest('.components-popover');
+      const contentEl = contentRef.current;
       const dropdownEl = dropdownRef.current;
 
       if (
-        (!popoverEl || !popoverEl.contains(target)) &&
+        (!contentEl || !contentEl.contains(target)) &&
         (!dropdownEl || !dropdownEl.contains(target))
       ) {
         onClose();

--- a/mailpoet/assets/js/src/automation/editor/components/panel/step-name.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/panel/step-name.tsx
@@ -1,4 +1,5 @@
 import { Dropdown, TextControl } from '@wordpress/components';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { edit, Icon } from '@wordpress/icons';
 import { PlainBodyTitle } from './plain-body-title';
@@ -9,44 +10,102 @@ type Props = {
   defaultName: string;
   update: (value: string) => void;
 };
+
+type ContentProps = Props & {
+  onClose: () => void;
+  dropdownRef: React.RefObject<HTMLDivElement>;
+};
+
+/**
+ * WordPress Popover intentionally skips closing when activeElement is
+ * document.body (happens when clicking non-focusable areas like the canvas
+ * background). This component adds a mousedown listener to cover that gap.
+ */
+function StepNameContent({
+  currentName,
+  defaultName,
+  update,
+  onClose,
+  dropdownRef,
+}: ContentProps): JSX.Element {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as Node;
+      const popoverEl = contentRef.current?.closest('.components-popover');
+      const dropdownEl = dropdownRef.current;
+
+      if (
+        (!popoverEl || !popoverEl.contains(target)) &&
+        (!dropdownEl || !dropdownEl.contains(target))
+      ) {
+        onClose();
+      }
+    },
+    [onClose, dropdownRef],
+  );
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [handleClickOutside]);
+
+  return (
+    <div ref={contentRef}>
+      <TextControl
+        label={__('Step name', 'mailpoet')}
+        className="mailpoet-step-name-input"
+        placeholder={defaultName}
+        value={currentName}
+        onChange={update}
+        help={__(
+          'Give the automation step a name that indicates its purpose. E.g "Abandoned cart recovery". This name will be displayed only to you and not to the clients.',
+          'mailpoet',
+        )}
+      />
+    </div>
+  );
+}
+
 export function StepName({
   currentName,
   defaultName,
   update,
 }: Props): JSX.Element {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
   return (
-    <Dropdown
-      className="mailpoet-step-name-dropdown"
-      contentClassName="mailpoet-step-name-popover"
-      popoverProps={{
-        placement: 'bottom-end',
-      }}
-      renderToggle={({ isOpen, onToggle }) => (
-        <PlainBodyTitle
-          title={currentName.length > 0 ? currentName : defaultName}
-        >
-          <TitleActionButton
-            onClick={onToggle}
-            aria-expanded={isOpen}
-            aria-label={__('Edit step name', 'mailpoet')}
+    <div ref={dropdownRef}>
+      <Dropdown
+        className="mailpoet-step-name-dropdown"
+        contentClassName="mailpoet-step-name-popover"
+        popoverProps={{
+          placement: 'bottom-end',
+        }}
+        renderToggle={({ isOpen, onToggle }) => (
+          <PlainBodyTitle
+            title={currentName.length > 0 ? currentName : defaultName}
           >
-            <Icon icon={edit} size={16} />
-          </TitleActionButton>
-        </PlainBodyTitle>
-      )}
-      renderContent={() => (
-        <TextControl
-          label={__('Step name', 'mailpoet')}
-          className="mailpoet-step-name-input"
-          placeholder={defaultName}
-          value={currentName}
-          onChange={update}
-          help={__(
-            'Give the automation step a name that indicates its purpose. E.g "Abandoned cart recovery". This name will be displayed only to you and not to the clients.',
-            'mailpoet',
-          )}
-        />
-      )}
-    />
+            <TitleActionButton
+              onClick={onToggle}
+              aria-expanded={isOpen}
+              aria-label={__('Edit step name', 'mailpoet')}
+            >
+              <Icon icon={edit} size={16} />
+            </TitleActionButton>
+          </PlainBodyTitle>
+        )}
+        renderContent={({ onClose }) => (
+          <StepNameContent
+            currentName={currentName}
+            defaultName={defaultName}
+            update={update}
+            onClose={onClose}
+            dropdownRef={dropdownRef}
+          />
+        )}
+      />
+    </div>
   );
 }

--- a/mailpoet/changelog/2026-03-10-14-20-46-fixed-fix-automation-step-name-popover-not-closing-when-.md
+++ b/mailpoet/changelog/2026-03-10-14-20-46-fixed-fix-automation-step-name-popover-not-closing-when-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix automation step name popover not closing when clicking outside


### PR DESCRIPTION
## Description

Fix the automation step name popover not dismissing when clicking outside of it (e.g. on the canvas background). The WordPress `Popover` component intentionally skips closing when `activeElement` is `document.body`, which happens when clicking non-focusable areas. Added a supplementary `mousedown` listener on the document to cover that gap.

## Code review notes

The WordPress Popover's `onDialogClose` handler has a guard: `if (activeElement === document.body) return;` — this prevents closing when clicking non-focusable areas. Since we can't modify core, the fix adds a document-level `mousedown` listener inside the dropdown content that explicitly calls `onClose()` when the click target is outside both the popover and the dropdown toggle.

## QA notes

1. Go to the Automation Editor and select a step that has a "Step name" field (e.g. "Send email")
2. Click the pencil icon next to the step name to open the rename popover
3. **Without typing anything**, click on the canvas background area
4. Verify the popover closes
5. Re-open the popover, type something, then click outside — verify it still closes
6. Re-open the popover and click inside the text input — verify it stays open
7. Re-open the popover and click the pencil icon again — verify it toggles closed

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7884](https://linear.app/a8c/issue/STOMAIL-7884/cant-dismiss-automation-step-popover-by-clicking-outside)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

Before:
https://github.com/user-attachments/assets/621a56db-84d0-4e7d-b4d6-1062434f3f86

After:
https://github.com/user-attachments/assets/5eb32af7-4929-4a86-9830-dceedcc0ff8b




## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes



## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7884-cant-dismiss-automation-step-popover-by-clicking-outside)

_The latest successful build from `stomail-7884-cant-dismiss-automation-step-popover-by-clicking-outside` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**1 issue found:**

**Performance**: The `handleClickOutside` callback includes `dropdownRef` in its dependency array (line 48), but since `dropdownRef` is a stable ref object, this inclusion is unnecessary. More significantly, if `onClose` changes on each render (which is likely given it comes from the Dropdown component's renderContent prop), the callback is recreated frequently, causing the useEffect (line 54) to repeatedly remove and re-add the document's mousedown event listener. This unnecessary setup/teardown cycle on every render impacts performance. Consider removing `dropdownRef` from the dependency array since refs maintain stable identity, or refactoring to reduce callback recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->