### PR TITLE
Fix WordPress beta version detection in CI

### DIFF
--- a/.circleci/check_wordpress_beta.sh
+++ b/.circleci/check_wordpress_beta.sh
@@ -8,17 +8,15 @@ LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed
 
 # Check if a beta or RC version is found
 if [[ $LAST_VERSION == *'beta'* ]]; then
-  # Extract titles containing beta versions from the feed
-  VERSION_LINE=$(echo "$RSS_FEED" | grep -o '<code>wp core update [^<]*</code>' | sed -E 's/<\/?code>//g' | head -n 1 | grep 'beta')
-  LATEST_BETA=$(echo "$VERSION_LINE" | sed -E 's/.*--version=([0-9\.]+-beta[0-9]+).*/\1/')
+  # Extract version from the direct download zip link (e.g. wordpress-7.0-beta3.zip)
+  LATEST_BETA=$(echo "$RSS_FEED" | grep -o 'wordpress-[0-9\.]*-beta[0-9]*\.zip' | head -n 1 | sed -E 's/wordpress-([0-9\.]+-beta[0-9]*)\.zip/\1/')
 
   echo "Latest WordPress beta version: $LATEST_BETA"
   echo "LATEST_BETA=$LATEST_BETA"
 
 elif [[ $LAST_VERSION == *'release candidate'* ]]; then
-  # Extract titles containing RC versions from the feed
-  VERSION_LINE=$(echo "$RSS_FEED" | grep -o '<code>wp core update [^<]*</code>' | sed -E 's/<\/?code>//g' | head -n 1 | grep 'RC')
-  LATEST_BETA=$(echo "$VERSION_LINE" | sed -E 's/.*--version=([0-9\.]+-RC[0-9]+).*/\1/')
+  # Extract version from the direct download zip link (e.g. wordpress-7.0-RC3.zip)
+  LATEST_BETA=$(echo "$RSS_FEED" | grep -o 'wordpress-[0-9\.]*-RC[0-9]*\.zip' | head -n 1 | sed -E 's/wordpress-([0-9\.]+-RC[0-9]*)\.zip/\1/')
 
   echo "Latest WordPress RC version: $LATEST_BETA"
   echo "LATEST_BETA=$LATEST_BETA"


### PR DESCRIPTION
## Description

The `check_wordpress_beta.sh` is currently reading the latest WordPress Beta release version from the [releases feed](https://wordpress.org/news/category/releases/feed/) and is trying to extract it from the `<code>wp core update --version=7.0-beta2</code>` block.

However, the last two beta releases had some small issues in the markup (`<code>wp core update --version=7.0-beta</code>3` and `<code>wp core update --version=7.0-beta</code>4` - the beta version number is outside of the code block) which resulted in incorrectly extracting the versing and breaking the [CI builds with WordPress Beta](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/22457/workflows/5939b91f-c5ae-44b6-b3e8-ad20ef01569f/jobs/391369).

This PR updates the script to use the direct download link for extracting the version identifier which should be a bit more reliable.

## Code review notes

The changes can be tested by running the script locally `.circleci/check_wordpress_beta.sh`.

Unfortunately, at the moment of creating this PR, the latest released version is a non-beta and non-RC release, and thus the script will return `No WordPress beta/RC version found.`

In order to test the version extraction, you can replace the following like locally in order to make the script check the post before the last one, which at the moment of creating this PR is the post with the WordPress 7.0 Beta 4 release:

```diff
--- a/.circleci/check_wordpress_beta.sh
+++ b/.circleci/check_wordpress_beta.sh
@@ -4,7 +4,7 @@
 RSS_FEED=$(curl -s https://wordpress.org/news/category/releases/feed/)

 # Extract the latest version from the feed and convert it to lowercase
-LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed -E 's/<\/?title>//g' | head -n 1 | tr [:upper:] [:lower:])
+LAST_VERSION=$(echo "$RSS_FEED" | grep -o '<title>WordPress [^<]*</title>' | sed -E 's/<\/?title>//g' | sed -n '2p' | tr [:upper:] [:lower:])

 # Check if a beta or RC version is found
 if [[ $LAST_VERSION == *'beta'* ]]; then
```

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

N/A

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/check-wordpress-beta-script)

_The latest successful build from `fix/check-wordpress-beta-script` will be used. If none is available, the link won't work._