### PR TITLE
Update @woocommerce/email-editor packages

### DIFF
--- a/mailpoet/changelog/2026-03-12-18-53-05-updated-update-email-editor-packages.md
+++ b/mailpoet/changelog/2026-03-12-18-53-05-updated-update-email-editor-packages.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Update email editor packages

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.9.0"
+    "woocommerce/email-editor": "2.9.2"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c0d7e264a9d7f0208bb951e822c03c5",
+    "content-hash": "13ec9dc4f0acceb81c184f4bbaa2b56c",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.9.0",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "f9f320f03710191c79c55e929194ba3023b04025"
+                "reference": "fd24335c605d7a52c5bf330fd3f12b0fadcad6b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/f9f320f03710191c79c55e929194ba3023b04025",
-                "reference": "f9f320f03710191c79c55e929194ba3023b04025",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/fd24335c605d7a52c5bf330fd3f12b0fadcad6b8",
+                "reference": "fd24335c605d7a52c5bf330fd3f12b0fadcad6b8",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.9.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.9.2"
             },
-            "time": "2026-02-23T19:48:14+00:00"
+            "time": "2026-03-12T17:34:21+00:00"
         }
     ],
     "packages-dev": [
@@ -8677,7 +8677,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {},
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
@@ -8694,5 +8694,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -31,7 +31,7 @@
     "@woocommerce/components": "^13.1.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "1.7.0",
+    "@woocommerce/email-editor": "1.9.0",
     "@wordpress/a11y": "^4.0.0",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.17.23)
       '@woocommerce/email-editor':
-        specifier: 1.7.0
-        version: 1.7.0(@types/react-dom@18.3.0)(@types/react@18.3.3)
+        specifier: 1.9.0
+        version: 1.9.0(@types/react-dom@18.3.0)(@types/react@18.3.3)
       '@wordpress/a11y':
         specifier: ^4.0.0
         version: 4.0.0
@@ -5391,8 +5391,8 @@ packages:
       qs: 6.15.0
     dev: false
 
-  /@woocommerce/email-editor@1.7.0(@types/react-dom@18.3.0)(@types/react@18.3.3):
-    resolution: {integrity: sha512-M3UAb10/4VyUcludbz3HvRVBJyH/TT6tLqAXscrKTTGCV8uW1t98YOzSNNeTkz4yEauk5k7u6B7yWh9UUfMpGQ==}
+  /@woocommerce/email-editor@1.9.0(@types/react-dom@18.3.0)(@types/react@18.3.3):
+    resolution: {integrity: sha512-8DIrSAyVq6MSGK3ucQ3fBchl+duwQilGcIe4jxHdZyISgjBnNqHebNwHQa1yJJTTs3Bf7dVx3RERuFX6zoLA/w==}
     dependencies:
       '@wordpress/api-fetch': 7.0.0
       '@wordpress/base-styles': 5.23.0


### PR DESCRIPTION
## Description

Update `@woocommerce/email-editor` packages:
- PHP package: 2.9.0 → 2.9.2
- JS package: 1.7.0 → 1.9.0

## Code review notes

_N/A_

## QA notes

Verify the email editor works correctly after the package update — create/edit an email, check rendering.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update-email-editor-packages)

_The latest successful build from `update-email-editor-packages` will be used. If none is available, the link won't work._