### PR TITLE
Use fixed dimensions for captcha image rendering

### DIFF
--- a/mailpoet/changelog/2026-03-17-08-23-34-fixed-fix-captcha-image-endpoint.md
+++ b/mailpoet/changelog/2026-03-17-08-23-34-fixed-fix-captcha-image-endpoint.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix captcha image- use fixed dimensions for captcha image rendering

--- a/mailpoet/lib/Captcha/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaFormRenderer.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Captcha;
 
+use MailPoet\Captcha\CaptchaRenderer;
 use MailPoet\Config\Env;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Form\FormsRepository;
@@ -187,9 +188,9 @@ class CaptchaFormRenderer {
     $formHtml = '<form method="POST" action="' . $this->wp->escUrl($actionUrl) . '" class="' . $this->wp->escAttr($classes) . '" id="mailpoet_captcha_form" novalidate>';
     $formHtml .= $hiddenFields;
 
-    $width = 220;
-    $height = 60;
-    $captchaUrl = $this->captchaUrlFactory->getCaptchaImageUrl($width, $height, $sessionId);
+    $width = CaptchaRenderer::DEFAULT_WIDTH;
+    $height = CaptchaRenderer::DEFAULT_HEIGHT;
+    $captchaUrl = $this->captchaUrlFactory->getCaptchaImageUrl($sessionId);
     $mp3CaptchaUrl = $this->captchaUrlFactory->getCaptchaAudioUrl($sessionId);
     $reloadIcon = Env::$assetsUrl . '/img/icons/image-rotate.svg';
     $playIcon = Env::$assetsUrl . '/img/icons/controls-volumeon.svg';

--- a/mailpoet/lib/Captcha/CaptchaFormRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaFormRenderer.php
@@ -2,7 +2,6 @@
 
 namespace MailPoet\Captcha;
 
-use MailPoet\Captcha\CaptchaRenderer;
 use MailPoet\Config\Env;
 use MailPoet\Entities\FormEntity;
 use MailPoet\Form\FormsRepository;

--- a/mailpoet/lib/Captcha/CaptchaRenderer.php
+++ b/mailpoet/lib/Captcha/CaptchaRenderer.php
@@ -42,13 +42,13 @@ class CaptchaRenderer {
     }
   }
 
-  public function renderImage(string $sessionId, $width = null, $height = null): void {
+  public function renderImage(string $sessionId): void {
     if (!$this->isSupported()) {
       return;
     }
 
-    $width = (isset($width) && $width > 0) ? intval($width) : self::DEFAULT_WIDTH;
-    $height = (isset($height) && $height > 0) ? intval($height) : self::DEFAULT_HEIGHT;
+    $width = self::DEFAULT_WIDTH;
+    $height = self::DEFAULT_HEIGHT;
 
     $fontNumbers = array_merge(range(0, 3), [5]); // skip font #4
     $fontNumber = $fontNumbers[mt_rand(0, count($fontNumbers) - 1)];

--- a/mailpoet/lib/Captcha/CaptchaUrlFactory.php
+++ b/mailpoet/lib/Captcha/CaptchaUrlFactory.php
@@ -36,12 +36,10 @@ class CaptchaUrlFactory {
     return $this->getCaptchaUrl($data);
   }
 
-  public function getCaptchaImageUrl(int $width, int $height, string $sessionId) {
+  public function getCaptchaImageUrl(string $sessionId) {
     return $this->getUrl(
       CaptchaEndpoint::ACTION_IMAGE,
       [
-        'width' => $width,
-        'height' => $height,
         'captcha_session_id' => $sessionId,
       ]
     );

--- a/mailpoet/lib/Captcha/Validator/CaptchaValidator.php
+++ b/mailpoet/lib/Captcha/Validator/CaptchaValidator.php
@@ -141,7 +141,7 @@ class CaptchaValidator {
     return [
       'show_captcha' => true,
       'captcha_session_id' => $sessionId,
-      'captcha_image_url' => $this->captchaUrlFactory->getCaptchaImageUrl(220, 60, $sessionId),
+      'captcha_image_url' => $this->captchaUrlFactory->getCaptchaImageUrl($sessionId),
       'captcha_audio_url' => $this->captchaUrlFactory->getCaptchaAudioUrl($sessionId),
       // Keep redirect_url for non-JavaScript form submissions
       'redirect_url' => $this->captchaUrlFactory->getCaptchaUrlForMPForm($sessionId),

--- a/mailpoet/lib/Router/Endpoints/Captcha.php
+++ b/mailpoet/lib/Router/Endpoints/Captcha.php
@@ -40,14 +40,12 @@ class Captcha {
   }
 
   public function image($data) {
-    $width = !empty($data['width']) ? (int)$data['width'] : null;
-    $height = !empty($data['height']) ? (int)$data['height'] : null;
     $sessionId = $data['captcha_session_id'] ?? null;
     if (!$sessionId) {
       return;
     }
 
-    $this->captchaRenderer->renderImage($sessionId, $width, $height);
+    $this->captchaRenderer->renderImage($sessionId);
     exit;
   }
 

--- a/mailpoet/tests/integration/Captcha/CaptchaUrlFactoryTest.php
+++ b/mailpoet/tests/integration/Captcha/CaptchaUrlFactoryTest.php
@@ -33,7 +33,7 @@ class CaptchaUrlFactoryTest extends \MailPoetTest {
   }
 
   public function testItReturnsCaptchaImageUrl() {
-    $url = $this->urlFactory->getCaptchaImageUrl(100, 200, 'abc');
+    $url = $this->urlFactory->getCaptchaImageUrl('abc');
 
     verify($url)->notNull();
     verify($url)->stringContainsString(Router::NAME);


### PR DESCRIPTION
## Description

The captcha image renderer previously accepted `width` and `height` parameters from the request URL data, but these were unnecessary since the only caller (`CaptchaFormRenderer`) always uses the fixed 220×60 defaults. This change removes the unused parameters and uses the constants directly.

**Changes:**
- `CaptchaRenderer::renderImage()` no longer accepts `$width`/`$height` parameters — always uses `DEFAULT_WIDTH` (220) and `DEFAULT_HEIGHT` (60)
- `CaptchaUrlFactory::getCaptchaImageUrl()` simplified to only accept `$sessionId`
- `Captcha::image()` endpoint no longer extracts `width`/`height` from request data
- `CaptchaFormRenderer` now references `CaptchaRenderer::DEFAULT_WIDTH` and `DEFAULT_HEIGHT` constants instead of hardcoded values
- `CaptchaValidator::getInlineCaptchaData()` updated to match new `getCaptchaImageUrl()` signature

## Code review notes

_N/A_

## QA notes

1. Enable the built-in CAPTCHA (Settings → Advanced → CAPTCHA → Built-in)
2. Open a subscription form that triggers the CAPTCHA (submit multiple times quickly to hit the rate limit)
3. Verify the CAPTCHA image renders correctly at its normal size
4. Verify the CAPTCHA reload button works
5. Verify the CAPTCHA audio playback works
6. Verify submitting the correct CAPTCHA text completes the subscription

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7897](https://linear.app/a8c/issue/STOMAIL-7897)

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7897-fix-captcha-image)

_The latest successful build from `stomail-7897-fix-captcha-image` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->