### PR TITLE
Fix untranslatable greeting in marketing confirmation email templates

### DIFF
--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
@@ -28,8 +28,12 @@ do_action('woocommerce_email_header', $email_heading, $email); ?>
 
 <p>
 <?php
+if ($subscriber_firstname) {
   /* translators: %s: Subscriber first name */
-  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: _x('there', 'subscriber name placeholder', 'mailpoet')));
+  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname));
+} else {
+  echo esc_html(__('Hello there,', 'mailpoet'));
+}
 ?>
 </p>
 

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
@@ -23,8 +23,12 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html($email_heading);
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/* translators: %s: Subscriber first name */
-echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: __('there', 'mailpoet')));
+if ($subscriber_firstname) {
+  /* translators: %s: Subscriber first name */
+  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname));
+} else {
+  echo esc_html(__('Hello there,', 'mailpoet'));
+}
 echo "\n\n";
 
 /* translators: %s: Site name */


### PR DESCRIPTION
## Summary

Fixes `STOMAIL-7746` — the `sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: __('there', 'mailpoet'))` pattern forced translators to translate "there" as a standalone word, which has no correct equivalent in Romanian and many other languages.

**Before:** A single translatable string `"Hello %s,"` with either the subscriber name or the word "there" substituted in — impossible to translate correctly as a phrase in most locales.

**After:** Two separate translatable strings — `"Hello %s,"` (when name is known) and `"Hello there,"` (when name is unknown) — so translators can translate each full phrase independently.

## Changes

- `emails/marketing-confirmation.php` — base HTML template fixed
- `emails/plain/marketing-confirmation.php` — plain text template fixed

## Not in this PR (follow-up needed)

The **block template** (`emails/block/marketing-confirmation.php`) uses a template-tag system (`<!--[mailpoet/subscriber-firstname default="..."]-->`) where the subscriber name is substituted at send time, not at render time. A PHP conditional can't be applied here without a new dedicated template tag (e.g. `<!--[mailpoet/subscriber-greeting]-->`). Raising a follow-up for that.

## Testing

1. Install MailPoet and WooCommerce on a local WordPress site
2. Switch site language to Romanian (or any language where "there" has no standalone greeting equivalent)
3. Go to **WooCommerce > Settings > Emails > Marketing Confirmation** and send a preview
4. Verify the greeting renders as `"Hello there,"` (or its translation) for subscribers without a first name
5. Add a subscriber with a first name and verify the greeting renders as `"Hello [Name],"` correctly

## References

- Linear: STOMAIL-7746
- Reported by FX Bénard in #mailpoet-translations on 2026-01-14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found

1 issue addressed:

**Bug** - The previous implementation of the greeting in marketing confirmation email templates required translators to translate the word "there" as a standalone word, which is incorrect for languages like Romanian where "there" is not a standalone greeting word. This issue (STOMAIL-7746) is fixed by replacing the single translatable string with a conditional fallback with two separate translatable strings: one for greetings with the subscriber's first name ("Hello %s,") and another for greetings without a name ("Hello there,").

## Changes Summary

Modified the greeting logic in two email template files:
- `emails/marketing-confirmation.php` (HTML template)
- `emails/plain/marketing-confirmation.php` (plain text template)

Both files now use explicit if-else blocks instead of inline ternary operators to handle the greeting based on whether the subscriber's first name is present.

**Note:** The block template (`emails/block/marketing-confirmation.php`) uses a send-time template-tag system and requires a follow-up to address the same translation issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->