### PR TITLE
Disable real-time collaboration in the email editor

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -131,6 +131,16 @@ addFilter(
   },
 );
 
+/**
+ * Disables real-time collaboration by removing all sync providers.
+ * This forces the editor to fall back to traditional single-user post locking.
+ */
+addFilter(
+  'sync.providers',
+  'mailpoet/email-editor-integration-disable-rtc',
+  () => [],
+);
+
 initStripPostStatusOnSaveMiddleware();
 
 initializeEditor('mailpoet-email-editor');


### PR DESCRIPTION
## Description

Fixes the failing `acceptance_tests_wordpress_beta` nightly test by disabling WordPress 7.0's new real-time collaboration (RTC) feature in the MailPoet email editor.

WordPress 7.0 beta introduces real-time collaboration in the block editor via an HTTP polling sync provider. When the MailPoet email editor loads in the test environment, the RTC polling starts but loses its authenticated session during the multi-step template editing flow (the HTML snapshot shows a "Session expired" state). This causes the polling to fail, triggering a `SyncConnectionModal` overlay ("Connection lost — The connection to real-time collaboration was interrupted") that blocks all UI interactions. Specifically, `EmailTemplatesCest::selectEditSwapAndResetEmailTemplate` fails because the modal intercepts clicks on the `.editor-all-actions-button`.

The fix uses the official `sync.providers` filter ([dev note](https://make.wordpress.org/core/2026/03/10/real-time-collaboration-in-the-block-editor/)) to return an empty array, which disables collaboration entirely and falls back to traditional single-user post locking. This is appropriate because the email editor intends to disable the mode as well https://linear.app/a8c/issue/STOMAIL-7892/turn-off-real-time-collaboration-in-email-editor


## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes