### PR TITLE
Add telemetry bridge for automation editor

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/actions/trash-button.tsx
@@ -6,6 +6,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
 
 export function TrashButton({
   performActionAfterDelete = () => {},
@@ -49,7 +50,13 @@ export function TrashButton({
         isBusy={isBusy}
         variant="secondary"
         isDestructive
-        onClick={() => setShowConfirmDialog(true)}
+        onClick={() => {
+          sendTelemetryEvent('button_click', {
+            button_label: 'move_to_trash',
+            automation_id: automation.id,
+          });
+          setShowConfirmDialog(true);
+        }}
       >
         {__('Move to Trash', 'mailpoet')}
       </Button>

--- a/mailpoet/assets/js/src/automation/editor/components/automation/add-trigger.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/add-trigger.tsx
@@ -2,10 +2,11 @@ import { useContext } from 'react';
 import { __unstableCompositeItem as CompositeItem } from '@wordpress/components';
 import { Icon, plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { AutomationContext, AutomationCompositeContext } from './context';
 import { Step } from './types';
 import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
 
 type Props = {
   step: Step;
@@ -16,6 +17,10 @@ export function AddTrigger({ step, index }: Props): JSX.Element {
   const { context } = useContext(AutomationContext);
   const compositeState = useContext(AutomationCompositeContext);
   const { setInserterPopover } = useDispatch(storeName);
+  const { automationId } = useSelect(
+    (s) => ({ automationId: s(storeName).getAutomationData().id }),
+    [],
+  );
 
   return (
     <CompositeItem
@@ -29,6 +34,10 @@ export function AddTrigger({ step, index }: Props): JSX.Element {
         context === 'edit'
           ? (event) => {
               event.stopPropagation();
+              sendTelemetryEvent('button_click', {
+                button_label: 'add_trigger',
+                automation_id: automationId,
+              });
               void setInserterPopover({
                 anchor: (event.target as HTMLElement).closest('button'),
                 type: 'triggers',

--- a/mailpoet/assets/js/src/automation/editor/components/automation/separator.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/separator.tsx
@@ -2,6 +2,7 @@ import { dispatch, useSelect } from '@wordpress/data';
 import { AddStepButton } from './add-step-button';
 import { Step } from './types';
 import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
 
 type Props = {
   previousStep: Step;
@@ -10,8 +11,11 @@ type Props = {
 
 export function Separator({ previousStep, index }: Props): JSX.Element {
   const { setInserterPopover } = dispatch(storeName);
-  const stepType = useSelect(
-    (select) => select(storeName).getStepType(previousStep.key),
+  const { stepType, automationId } = useSelect(
+    (select) => ({
+      stepType: select(storeName).getStepType(previousStep.key),
+      automationId: select(storeName).getAutomationData().id,
+    }),
     [],
   );
 
@@ -26,9 +30,13 @@ export function Separator({ previousStep, index }: Props): JSX.Element {
       )}
       <div className="mailpoet-automation-editor-separator">
         <AddStepButton
-          onClick={(button) =>
-            setInserterPopover({ anchor: button, type: 'steps' })
-          }
+          onClick={(button) => {
+            sendTelemetryEvent('button_click', {
+              button_label: 'add_step',
+              automation_id: automationId,
+            });
+            void setInserterPopover({ anchor: button, type: 'steps' });
+          }}
           previousStepId={previousStep.id}
           index={index}
         />

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
 import { DropdownMenu } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { moreVertical, trash, copy } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Hooks } from 'wp-js-hooks';
@@ -7,6 +8,8 @@ import { PremiumModal } from 'common/premium-modal';
 import { AutomationContext } from './context';
 import { Step as StepData } from './types';
 import { StepMoreControlsType } from '../../../types/filters';
+import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
 
 type Props = {
   step: StepData;
@@ -16,6 +19,10 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
   const { context } = useContext(AutomationContext);
   const [showModal, setShowModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+  const { automationId } = useSelect(
+    (s) => ({ automationId: s(storeName).getAutomationData().id }),
+    [],
+  );
 
   const canDuplicate = step.key !== 'core:if-else' && step.type !== 'trigger';
   const moreControls: StepMoreControlsType = Hooks.applyFilters(
@@ -57,7 +64,13 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
         control: {
           title: __('Delete step', 'mailpoet'),
           icon: trash,
-          onClick: () => setShowModal(true),
+          onClick: () => {
+            sendTelemetryEvent('step_delete', {
+              step_type: step.type === 'trigger' ? 'trigger' : step.key,
+              automation_id: automationId,
+            });
+            setShowModal(true);
+          },
         },
         slot: () => {
           if (!showModal) {

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step-more-menu.tsx
@@ -65,7 +65,7 @@ export function StepMoreMenu({ step }: Props): JSX.Element {
           title: __('Delete step', 'mailpoet'),
           icon: trash,
           onClick: () => {
-            sendTelemetryEvent('step_delete', {
+            sendTelemetryEvent('step_delete_click', {
               step_type: step.type === 'trigger' ? 'trigger' : step.key,
               automation_id: automationId,
             });

--- a/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/automation/step.tsx
@@ -15,6 +15,7 @@ import { stepSidebarKey, storeName } from '../../store';
 import { StepType } from '../../store/types';
 import { RenderStepFooterType, StepMoreType } from '../../../types/filters';
 import { triggerFilterStrings } from './trigger-filters';
+import { sendTelemetryEvent } from '../../telemetry';
 
 const getUnknownStepType = (step: StepData): StepType => {
   const isTrigger = step.type === 'trigger';
@@ -47,10 +48,11 @@ type Props = {
 };
 
 export function Step({ step, isSelected }: Props): JSX.Element {
-  const { stepType, error } = useSelect(
+  const { stepType, error, automationId } = useSelect(
     (select) => ({
       stepType: select(storeName).getStepType(step.key),
       error: select(storeName).getStepError(step.id),
+      automationId: select(storeName).getAutomationData().id,
     }),
     [step],
   );
@@ -105,9 +107,12 @@ export function Step({ step, isSelected }: Props): JSX.Element {
               context === 'edit'
                 ? () => {
                     if (typeof htmlProps.onClick === 'function') {
-                      // Preserve CompositeItem's internal click behavior.
                       htmlProps.onClick();
                     }
+                    sendTelemetryEvent('step_click', {
+                      step_type: step.type === 'trigger' ? 'trigger' : step.key,
+                      automation_id: automationId,
+                    });
                     batch(() => {
                       void openSidebar(stepSidebarKey);
                       void selectStep(step);

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -22,18 +22,20 @@ import {
   DeactivateImmediatelyModal,
   DeactivateModal,
 } from '../modals/deactivate-modal';
+import { sendTelemetryEvent } from '../../telemetry';
 
 // See:
 //   https://github.com/WordPress/gutenberg/blob/9601a33e30ba41bac98579c8d822af63dd961488/packages/edit-post/src/components/header/index.js
 //   https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/header/index.js
 
 export function ActivateButton({ label }): JSX.Element {
-  const { errors, isDeactivating } = useSelect(
+  const { errors, isDeactivating, automationId } = useSelect(
     (select) => ({
       errors: select(storeName).getErrors(),
       isDeactivating:
         select(storeName).getAutomationData().status ===
         AutomationStatus.DEACTIVATING,
+      automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
@@ -43,7 +45,13 @@ export function ActivateButton({ label }): JSX.Element {
     <Button
       variant="primary"
       className="editor-post-publish-button"
-      onClick={openActivationPanel}
+      onClick={() => {
+        sendTelemetryEvent('button_click', {
+          button_label: 'activate',
+          automation_id: automationId,
+        });
+        void openActivationPanel();
+      }}
       disabled={isDeactivating || !!errors}
     >
       {label}
@@ -169,28 +177,38 @@ function SaveDraftButton(): JSX.Element {
 export function DeactivateButton(): JSX.Element {
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
-  const { hasUsersInProgress } = useSelect(
+  const { hasUsersInProgress, automationId } = useSelect(
     (select) => ({
       hasUsersInProgress:
         select(storeName).getAutomationData().stats.totals.in_progress > 0,
+      automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
 
   const deactivateOrShowModal = () => {
+    sendTelemetryEvent('button_click', {
+      button_label: 'deactivate',
+      automation_id: automationId,
+    });
     if (hasUsersInProgress) {
       setShowDeactivateModal(true);
       return;
     }
     setIsBusy(true);
-    void dispatch(storeName).deactivate();
+    void dispatch(storeName).deactivate(true, { source: 'header' });
   };
 
   return (
     <>
       {showDeactivateModal && (
         <DeactivateModal
-          onClose={() => {
+          onClose={() => setShowDeactivateModal(false)}
+          onRequestClose={() => {
+            sendTelemetryEvent('modal_close', {
+              modal_title: 'deactivate_automation',
+              automation_id: automationId,
+            });
             setShowDeactivateModal(false);
           }}
         />
@@ -209,28 +227,38 @@ export function DeactivateButton(): JSX.Element {
 export function DeactivateNowButton(): JSX.Element {
   const [showDeactivateModal, setShowDeactivateModal] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
-  const { hasUsersInProgress } = useSelect(
+  const { hasUsersInProgress, automationId } = useSelect(
     (select) => ({
       hasUsersInProgress:
         select(storeName).getAutomationData().stats.totals.in_progress > 0,
+      automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
 
   const deactivateOrShowModal = () => {
+    sendTelemetryEvent('button_click', {
+      button_label: 'deactivate_now',
+      automation_id: automationId,
+    });
     if (hasUsersInProgress) {
       setShowDeactivateModal(true);
       return;
     }
     setIsBusy(true);
-    void dispatch(storeName).deactivate();
+    void dispatch(storeName).deactivate(true, { source: 'header' });
   };
 
   return (
     <>
       {showDeactivateModal && (
         <DeactivateImmediatelyModal
-          onClose={() => {
+          onClose={() => setShowDeactivateModal(false)}
+          onRequestClose={() => {
+            sendTelemetryEvent('modal_close', {
+              modal_title: 'deactivate_automation',
+              automation_id: automationId,
+            });
             setShowDeactivateModal(false);
           }}
         />

--- a/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter-popover/index.tsx
@@ -8,27 +8,37 @@ import { Inserter } from '../inserter';
 import { Item } from '../inserter/item';
 import { storeName } from '../../store';
 import { AddStepCallbackType } from '../../../types/filters';
+import { sendTelemetryEvent } from '../../telemetry';
 
 export function InserterPopover(): JSX.Element | null {
   const popoverRef = useRef<HTMLDivElement>();
   const [showModal, setShowModal] = useState(false);
-  const { inserterPopover } = useSelect(
+  const { inserterPopover, automationId } = useSelect(
     (select) => ({
       inserterPopover: select(storeName).getInserterPopover(),
+      automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
   const { setInserterPopover } = useDispatch(storeName);
 
-  const onInsert = useCallback((item: Item) => {
-    const addStepCallback: AddStepCallbackType = Hooks.applyFilters(
-      'mailpoet.automation.add_step_callback',
-      () => {
-        setShowModal(true);
-      },
-    );
-    addStepCallback(item);
-  }, []);
+  const onInsert = useCallback(
+    (item: Item) => {
+      const isTrigger = inserterPopover?.type === 'triggers';
+      sendTelemetryEvent(isTrigger ? 'trigger_select' : 'step_select', {
+        [isTrigger ? 'trigger_type' : 'step_type']: item.key,
+        automation_id: automationId,
+      });
+      const addStepCallback: AddStepCallbackType = Hooks.applyFilters(
+        'mailpoet.automation.add_step_callback',
+        () => {
+          setShowModal(true);
+        },
+      );
+      addStepCallback(item);
+    },
+    [automationId, inserterPopover?.type],
+  );
 
   if (!inserterPopover) {
     return null;

--- a/mailpoet/assets/js/src/automation/editor/components/inserter/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Fragment, useCallback, useMemo } from 'react';
+import { forwardRef, Fragment, useCallback, useEffect, useMemo } from 'react';
 import { SearchControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useRef, useImperativeHandle, useState } from '@wordpress/element';
@@ -10,6 +10,7 @@ import { StepInfoPanel } from './step-info-panel';
 import { StepList } from './step-list';
 import { InserterListbox } from '../inserter-listbox';
 import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
 
 // See: https://github.com/WordPress/gutenberg/blob/628ae68152f572d0b395bb15c0f71b8821e7f130/packages/block-editor/src/components/inserter/menu.js
 
@@ -85,6 +86,23 @@ export const Inserter = forwardRef(
         searchRef.current?.focus();
       },
     }));
+
+    const searchTimerRef = useRef<ReturnType<typeof setTimeout>>();
+    useEffect(() => {
+      if (!filterValue.trim()) return undefined;
+      searchTimerRef.current = setTimeout(() => {
+        const resultCount = groups.reduce(
+          (sum, group) => sum + filterItems(filterValue, group.items).length,
+          0,
+        );
+        sendTelemetryEvent('picker_search_submit', {
+          picker_type: type,
+          result_count: resultCount,
+          automation_id: null,
+        });
+      }, 300);
+      return () => clearTimeout(searchTimerRef.current);
+    }, [filterValue, groups, type]);
 
     const filteredGroups = useMemo(
       () =>

--- a/mailpoet/assets/js/src/automation/editor/components/inserter/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/inserter/index.tsx
@@ -32,10 +32,11 @@ export const Inserter = forwardRef(
     const [filterValue, setFilterValue] = useState('');
     const [hoveredItem, setHoveredItem] = useState(null);
 
-    const { steps, type } = useSelect(
+    const { steps, type, automationId } = useSelect(
       (select) => ({
         steps: select(storeName).getSteps(),
         type: select(storeName).getInserterPopover().type,
+        automationId: select(storeName).getAutomationData().id,
       }),
       [],
     );
@@ -98,11 +99,11 @@ export const Inserter = forwardRef(
         sendTelemetryEvent('picker_search_submit', {
           picker_type: type,
           result_count: resultCount,
-          automation_id: null,
+          automation_id: automationId,
         });
       }, 300);
       return () => clearTimeout(searchTimerRef.current);
-    }, [filterValue, groups, type]);
+    }, [filterValue, groups, type, automationId]);
 
     const filteredGroups = useMemo(
       () =>

--- a/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/deactivate-modal.tsx
@@ -1,22 +1,39 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Modal } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { dispatch, useSelect } from '@wordpress/data';
 import { storeName } from '../../store';
 import { AutomationStatus } from '../../../listing/automation';
+import { sendTelemetryEvent } from '../../telemetry';
 
 type DeactivateImmediatelyModalProps = {
   onClose: () => void;
+  onRequestClose?: () => void;
 };
 export function DeactivateImmediatelyModal({
   onClose,
+  onRequestClose,
 }: DeactivateImmediatelyModalProps): JSX.Element {
   const [isBusy, setIsBusy] = useState<boolean>(false);
+  const { automationId } = useSelect(
+    (s) => ({
+      automationId: s(storeName).getAutomationData().id,
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    sendTelemetryEvent('modal_view', {
+      modal_title: 'deactivate_automation',
+      automation_id: automationId,
+    });
+  }, [automationId]);
+
   return (
     <Modal
       className="mailpoet-automation-deactivate-modal"
       title={__('Stop automation for all subscribers?', 'mailpoet')}
-      onRequestClose={onClose}
+      onRequestClose={onRequestClose ?? onClose}
     >
       <p>
         {__(
@@ -29,14 +46,33 @@ export function DeactivateImmediatelyModal({
         isBusy={isBusy}
         variant="primary"
         onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'deactivate_automation',
+            button_label: 'deactivate_now',
+            automation_id: automationId,
+          });
           setIsBusy(true);
-          void dispatch(storeName).deactivate(true);
+          void dispatch(storeName).deactivate(true, {
+            source: 'modal',
+            selected_option: 'stop_all_subscribers',
+          });
         }}
       >
         {__('Deactivate now', 'mailpoet')}
       </Button>
 
-      <Button disabled={isBusy} variant="tertiary" onClick={onClose}>
+      <Button
+        disabled={isBusy}
+        variant="tertiary"
+        onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'deactivate_automation',
+            button_label: 'cancel',
+            automation_id: automationId,
+          });
+          onClose();
+        }}
+      >
         {__('Cancel', 'mailpoet')}
       </Button>
     </Modal>
@@ -45,13 +81,16 @@ export function DeactivateImmediatelyModal({
 
 type DeactivateModalProps = {
   onClose: () => void;
+  onRequestClose?: () => void;
 };
 export function DeactivateModal({
   onClose,
+  onRequestClose,
 }: DeactivateModalProps): JSX.Element {
-  const { automationName } = useSelect(
-    (select) => ({
-      automationName: select(storeName).getAutomationData().name,
+  const { automationName, automationId } = useSelect(
+    (s) => ({
+      automationName: s(storeName).getAutomationData().name,
+      automationId: s(storeName).getAutomationData().id,
     }),
     [],
   );
@@ -59,17 +98,30 @@ export function DeactivateModal({
     AutomationStatus.DRAFT | AutomationStatus.DEACTIVATING
   >(AutomationStatus.DEACTIVATING);
   const [isBusy, setIsBusy] = useState<boolean>(false);
+
+  useEffect(() => {
+    sendTelemetryEvent('modal_view', {
+      modal_title: 'deactivate_automation',
+      automation_id: automationId,
+    });
+  }, [automationId]);
+
   // translators: %s is the name of the automation.
   const title = sprintf(
     __('Deactivate the "%s" automation?', 'mailpoet'),
     automationName,
   );
 
+  const selectedOption =
+    selected === AutomationStatus.DEACTIVATING
+      ? 'let_existing_finish'
+      : 'stop_all_subscribers';
+
   return (
     <Modal
       className="mailpoet-automation-deactivate-modal"
       title={title}
-      onRequestClose={onClose}
+      onRequestClose={onRequestClose ?? onClose}
     >
       {__(
         "Some subscribers entered but have not finished the flow. Let's decide what to do in this case.",
@@ -90,7 +142,14 @@ export function DeactivateModal({
                 disabled={isBusy}
                 name="deactivation-method"
                 checked={selected === AutomationStatus.DEACTIVATING}
-                onChange={() => setSelected(AutomationStatus.DEACTIVATING)}
+                onChange={() => {
+                  sendTelemetryEvent('modal_option_select', {
+                    modal_title: 'deactivate_automation',
+                    selected_option: 'let_existing_finish',
+                    automation_id: automationId,
+                  });
+                  setSelected(AutomationStatus.DEACTIVATING);
+                }}
               />
             </span>
             <span>
@@ -118,7 +177,14 @@ export function DeactivateModal({
                 disabled={isBusy}
                 name="deactivation-method"
                 checked={selected === AutomationStatus.DRAFT}
-                onChange={() => setSelected(AutomationStatus.DRAFT)}
+                onChange={() => {
+                  sendTelemetryEvent('modal_option_select', {
+                    modal_title: 'deactivate_automation',
+                    selected_option: 'stop_all_subscribers',
+                    automation_id: automationId,
+                  });
+                  setSelected(AutomationStatus.DRAFT);
+                }}
               />
             </span>
             <span>
@@ -138,16 +204,34 @@ export function DeactivateModal({
         isBusy={isBusy}
         variant="primary"
         onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'deactivate_automation',
+            button_label: 'deactivate',
+            selected_option: selectedOption,
+            automation_id: automationId,
+          });
           setIsBusy(true);
           void dispatch(storeName).deactivate(
             selected !== AutomationStatus.DEACTIVATING,
+            { source: 'modal', selected_option: selectedOption },
           );
         }}
       >
         {__('Deactivate automation', 'mailpoet')}
       </Button>
 
-      <Button disabled={isBusy} variant="tertiary" onClick={onClose}>
+      <Button
+        disabled={isBusy}
+        variant="tertiary"
+        onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'deactivate_automation',
+            button_label: 'cancel',
+            automation_id: automationId,
+          });
+          onClose();
+        }}
+      >
         {__('Cancel', 'mailpoet')}
       </Button>
     </Modal>

--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/automation/index.tsx
@@ -6,8 +6,13 @@ import { TrashButton } from '../../actions/trash-button';
 import { locale } from '../../../../config';
 import { Hooks } from '../../../../../hooks';
 import { AutomationSettingElements } from '../../../../types/filters';
+import { sendTelemetryEvent } from '../../../telemetry';
 
 function AutomationSettings(): JSX.Element {
+  const { automationId } = useSelect(
+    (s) => ({ automationId: s(storeName).getAutomationData().id }),
+    [],
+  );
   const settings: AutomationSettingElements = Hooks.applyFilters(
     'mailpoet.automation.settings.render',
     {},
@@ -18,7 +23,16 @@ function AutomationSettings(): JSX.Element {
   }
 
   return (
-    <PanelBody title={__('Automation settings', 'mailpoet')} initialOpen>
+    <PanelBody
+      title={__('Automation settings', 'mailpoet')}
+      initialOpen
+      onToggle={(isOpen) =>
+        sendTelemetryEvent(isOpen ? 'section_expand' : 'section_collapse', {
+          card_section: 'automation_settings',
+          automation_id: automationId,
+        })
+      }
+    >
       {Object.keys(settings).map((key) => (
         <PanelRow key={key}>{settings[key]}</PanelRow>
       ))}
@@ -42,7 +56,16 @@ export function AutomationSidebar(): JSX.Element {
 
   return (
     <>
-      <PanelBody title={__('Automation details', 'mailpoet')} initialOpen>
+      <PanelBody
+        title={__('Automation details', 'mailpoet')}
+        initialOpen
+        onToggle={(isOpen) =>
+          sendTelemetryEvent(isOpen ? 'section_expand' : 'section_collapse', {
+            card_section: 'automation_details',
+            automation_id: automationData.id,
+          })
+        }
+      >
         <PanelRow>
           <strong>Date added</strong>{' '}
           {new Date(Date.parse(automationData.created_at)).toLocaleDateString(

--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/index.tsx
@@ -14,6 +14,7 @@ import { StepSidebar } from './step';
 import { AutomationSidebar } from './automation';
 import { stepSidebarKey, storeName, automationSidebarKey } from '../../store';
 import { unlock } from '../../../lock-unlock';
+import { sendTelemetryEvent } from '../../telemetry';
 
 const { Tabs } = unlock(componentsPrivateApis);
 
@@ -85,17 +86,29 @@ function SidebarContent(props: Props): JSX.Element {
 export function Sidebar(props: Props): JSX.Element {
   const { openSidebar } = useDispatch(storeName);
 
-  const { sidebarKey } = useSelect(
+  const { sidebarKey, automationId } = useSelect(
     (select) => ({
       sidebarKey:
         select(interfaceStore).getActiveComplementaryArea(storeName) ??
         automationSidebarKey,
+      automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
 
   return (
-    <Tabs selectedTabId={sidebarKey} onSelect={openSidebar}>
+    <Tabs
+      selectedTabId={sidebarKey}
+      onSelect={(tabId) => {
+        sendTelemetryEvent('tab_click', {
+          tab_name: sidebarKey === automationSidebarKey ? 'automation' : 'step',
+          selected_value:
+            tabId === automationSidebarKey ? 'automation' : 'step',
+          automation_id: automationId,
+        });
+        void openSidebar(tabId);
+      }}
+    >
       <SidebarContent {...props} />
     </Tabs>
   );

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { createRoot } from 'react-dom/client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Icon, SlotFillProvider } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 import { dispatch, select as globalSelect, useSelect } from '@wordpress/data';
@@ -31,6 +31,7 @@ import { registerApiErrorHandler } from './api-error-handler';
 import { ActivatePanel } from './components/panel/activate-panel';
 import { AutomationStatus } from '../listing/automation';
 import { initializeIntegrations } from './integrations';
+import { sendTelemetryEvent } from './telemetry';
 
 // See:
 //   https://github.com/WordPress/gutenberg/blob/9601a33e30ba41bac98579c8d822af63dd961488/packages/edit-post/src/components/layout/index.js
@@ -68,6 +69,11 @@ function updatingActiveAutomationNotPossible() {
 
 function onUnload(event) {
   if (globalSelect(storeName).getSavedState() !== 'saved') {
+    const automation = globalSelect(storeName).getAutomationData();
+    sendTelemetryEvent('page_abandon', {
+      automation_id: automation.id,
+      automation_status: automation.status,
+    });
     // eslint-disable-next-line no-param-reassign
     event.returnValue = __(
       'There are unsaved changes that will be lost. Do you want to continue?',
@@ -105,6 +111,7 @@ function Editor(): JSX.Element {
     [],
   );
   const [isBooting, setIsBooting] = useState(true);
+  const pageViewFiredRef = useRef(false);
 
   useConfirmUnsaved();
 
@@ -119,8 +126,22 @@ function Editor(): JSX.Element {
       });
     }
     updatingActiveAutomationNotPossible();
+    if (!pageViewFiredRef.current) {
+      pageViewFiredRef.current = true;
+      sendTelemetryEvent('page_view', {
+        automation_id: automation.id,
+        automation_status: automation.status,
+        is_new: automation.status === 'draft' && !automation.activated_at,
+      });
+    }
     setIsBooting(false);
-  }, [automation.name, automation.status, isBooting]);
+  }, [
+    automation.name,
+    automation.status,
+    automation.id,
+    automation.activated_at,
+    isBooting,
+  ]);
 
   if (automation.status === 'trash') {
     return null;

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -10,6 +10,7 @@ import { Feature, State } from './types';
 import { LISTING_NOTICES } from '../../listing/automation-listing-notices';
 import { MailPoet } from '../../../mailpoet';
 import { AutomationStatus } from '../../listing/automation';
+import { sendTelemetryEvent } from '../telemetry';
 
 const trackErrors = (errors) => {
   if (!errors?.steps) {
@@ -28,6 +29,13 @@ const trackErrors = (errors) => {
 
   MailPoet.trackEvent('Automations > Automation validation error', {
     errors: payload,
+  });
+  sendTelemetryEvent('validation_error', {
+    error_type:
+      Array.isArray(payload) && payload.length > 0
+        ? String(payload[0])
+        : 'unknown',
+    automation_id: select(storeName).getAutomationData()?.id ?? null,
   });
 };
 
@@ -119,14 +127,23 @@ export function* save() {
 
 export function* activate() {
   const automation = select(storeName).getAutomationData();
-  const data = yield apiFetch({
-    path: `/automations/${automation.id}`,
-    method: 'PUT',
-    data: {
-      ...automation,
-      status: AutomationStatus.ACTIVE,
-    },
-  });
+  let data;
+  try {
+    data = yield apiFetch({
+      path: `/automations/${automation.id}`,
+      method: 'PUT',
+      data: {
+        ...automation,
+        status: AutomationStatus.ACTIVE,
+      },
+    });
+  } catch {
+    sendTelemetryEvent('button_error', {
+      button_label: 'activate',
+      automation_id: automation.id,
+    });
+    throw new Error(__('Failed to activate automation.', 'mailpoet'));
+  }
 
   const { createNotice } = dispatch(noticesStore);
   if (data?.data.status === AutomationStatus.ACTIVE) {
@@ -138,6 +155,10 @@ export function* activate() {
       },
     );
     MailPoet.trackEvent('Automations > Automation activated');
+    sendTelemetryEvent('button_success', {
+      button_label: 'activate',
+      automation_id: automation.id,
+    });
   }
 
   return {
@@ -147,18 +168,52 @@ export function* activate() {
   } as const;
 }
 
-export function* deactivate(deactivateAutomationRuns = true) {
+export function* deactivate(
+  deactivateAutomationRuns = true,
+  telemetryContext?: { source: 'header' | 'modal'; selected_option?: string },
+) {
   const automation = select(storeName).getAutomationData();
-  const data = yield apiFetch({
-    path: `/automations/${automation.id}`,
-    method: 'PUT',
-    data: {
-      ...automation,
-      status: deactivateAutomationRuns
-        ? AutomationStatus.DRAFT
-        : AutomationStatus.DEACTIVATING,
-    },
-  });
+  let data;
+  try {
+    data = yield apiFetch({
+      path: `/automations/${automation.id}`,
+      method: 'PUT',
+      data: {
+        ...automation,
+        status: deactivateAutomationRuns
+          ? AutomationStatus.DRAFT
+          : AutomationStatus.DEACTIVATING,
+      },
+    });
+  } catch {
+    if (telemetryContext) {
+      sendTelemetryEvent('button_error', {
+        button_label: 'deactivate',
+        automation_id: automation.id,
+        ...(telemetryContext.source === 'modal' && {
+          modal_title: 'deactivate_automation',
+          selected_option: telemetryContext.selected_option ?? null,
+        }),
+      });
+    }
+    throw new Error(__('Failed to deactivate automation.', 'mailpoet'));
+  }
+
+  const emitSuccess = () => {
+    if (!telemetryContext) return;
+    const eventSuffix =
+      telemetryContext.source === 'modal'
+        ? 'modal_button_success'
+        : 'button_success';
+    sendTelemetryEvent(eventSuffix, {
+      button_label: 'deactivate',
+      automation_id: automation.id,
+      ...(telemetryContext.source === 'modal' && {
+        modal_title: 'deactivate_automation',
+        selected_option: telemetryContext.selected_option ?? null,
+      }),
+    });
+  };
 
   const { createNotice } = dispatch(noticesStore);
   if (
@@ -176,6 +231,7 @@ export function* deactivate(deactivateAutomationRuns = true) {
     MailPoet.trackEvent('Automations > Automation deactivated', {
       type: 'immediate',
     });
+    emitSuccess();
   }
   if (
     !deactivateAutomationRuns &&
@@ -194,6 +250,7 @@ export function* deactivate(deactivateAutomationRuns = true) {
     MailPoet.trackEvent('Automations > Automation deactivated', {
       type: 'continuous',
     });
+    emitSuccess();
   }
 
   return {
@@ -204,18 +261,31 @@ export function* deactivate(deactivateAutomationRuns = true) {
 
 export function* trash(onTrashed: () => void = undefined) {
   const automation = select(storeName).getAutomationData();
-  const data = yield apiFetch({
-    path: `/automations/${automation.id}`,
-    method: 'PUT',
-    data: {
-      ...automation,
-      status: AutomationStatus.TRASH,
-    },
-  });
+  let data;
+  try {
+    data = yield apiFetch({
+      path: `/automations/${automation.id}`,
+      method: 'PUT',
+      data: {
+        ...automation,
+        status: AutomationStatus.TRASH,
+      },
+    });
+  } catch {
+    sendTelemetryEvent('button_error', {
+      button_label: 'move_to_trash',
+      automation_id: automation.id,
+    });
+    throw new Error(__('Failed to move automation to trash.', 'mailpoet'));
+  }
 
   onTrashed?.();
 
   if (data?.data?.status === AutomationStatus.TRASH) {
+    sendTelemetryEvent('button_success', {
+      button_label: 'move_to_trash',
+      automation_id: automation.id,
+    });
     if (window.parent && window.parent !== window) {
       window.parent.postMessage(
         {

--- a/mailpoet/assets/js/src/automation/editor/telemetry.ts
+++ b/mailpoet/assets/js/src/automation/editor/telemetry.ts
@@ -1,0 +1,13 @@
+const CIAB_EVENT_TYPE = 'mailpoet-telemetry-event';
+
+export function sendTelemetryEvent(
+  eventSuffix: string,
+  properties?: Record<string, string | number | boolean | null>,
+): void {
+  if (window.parent && window.parent !== window) {
+    window.parent.postMessage(
+      { type: CIAB_EVENT_TYPE, eventSuffix, properties },
+      window.location.origin,
+    );
+  }
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run-automation-once.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/automation-sidebar/run-automation-once.tsx
@@ -2,6 +2,7 @@ import { ToggleControl } from '@wordpress/components';
 import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { storeName } from '../../../editor/store';
+import { sendTelemetryEvent } from '../../../editor/telemetry';
 
 export function showRunOnlyOnce(): boolean {
   const automation = select(storeName).getAutomationData();
@@ -41,6 +42,10 @@ export function RunAutomationOnce(): JSX.Element {
       )}
       checked={checked}
       onChange={(value) => {
+        sendTelemetryEvent(value ? 'toggle_enable' : 'toggle_disable', {
+          toggle_name: 'run_once_per_subscriber',
+          automation_id: automationData.id,
+        });
         void dispatch(storeName).updateAutomationMeta(
           'mailpoet:run-once-per-subscriber',
           value,

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx
@@ -6,6 +6,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { Button } from '../../../components/button';
 import { storeName } from '../../../../../editor/store';
 import { MailPoet } from '../../../../../../mailpoet';
+import { sendTelemetryEvent } from '../../../../../editor/telemetry';
 
 type HandleDuplicatedStepType = {
   newEmailId: number;
@@ -253,7 +254,13 @@ export function EditNewsletter(): JSX.Element {
       <Button
         variant="sidebar-primary"
         centered
-        onClick={handleEditContent}
+        onClick={() => {
+          sendTelemetryEvent('button_click', {
+            button_label: 'edit_content',
+            automation_id: automationId,
+          });
+          void handleEditContent();
+        }}
         isBusy={isHandlingDuplicatedStep}
         disabled={isHandlingDuplicatedStep}
       >


### PR DESCRIPTION
## Description

Adds telemetry event forwarding from the automation editor via postMessage. When the editor runs inside an iframe, user interactions are sent as structured messages.

A `sendTelemetryEvent()` helper is added that no-ops when the editor is not running inside an iframe, so standalone MailPoet is completely unaffected.

**Tracked interactions:**
- Page view on editor boot
- Activate/deactivate button clicks and success/error outcomes
- Deactivation modal lifecycle (view, option select, confirm, cancel)
- Step click, step delete, trigger/step selection from picker
- Add step/trigger button clicks
- Sidebar tab switches (automation/step)
- "Run once per subscriber" toggle enable/disable
- "Edit content" and "Move to trash" button clicks
- Validation errors

## Code review notes

- `sendTelemetryEvent()` in `telemetry.ts` is the only new file — a small helper that posts structured messages to the parent window
- All other changes add `sendTelemetryEvent()` calls alongside existing UI interactions
- The `MailPoet.trackEvent()` calls are preserved — both tracking systems fire independently
- The `activate()` generator in `store/actions.ts` now has a try/catch to track `button_error` on activation failure

## QA notes

This PR only has visible effects when the automation editor is loaded. To test:

1. Set up an environment with the companion PR applied
2. Enable telemetry debug logging: `localStorage.setItem('debug', 'wc-admin:*')` in browser console
3. Navigate to an automation editor 
4. Interact with the editor (activate, deactivate, click steps, add steps, switch sidebar tabs, etc.)
5. Verify events appear in the console prefixed with `email_marketing_automations_editor_`


## Linked PRs

- Companion PR: https://github.a8c.com/Automattic/ciab-admin/pull/3968

## Linked tickets

- https://linear.app/a8c/issue/STOMAIL-7711/telemetry-for-automations

## After-merge notes

_N/A_


## Tasks

- [ ] I have added a changelog entry
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-7711-telemetry-for-automations-editor)

_The latest successful build from `add/STOMAIL-7711-telemetry-for-automations-editor` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
2 issues found.

Security (1)
- Inconsistent postMessage usage: telemetry.ts correctly restricts target origin (window.location.origin), but other files (e.g., mailpoet/assets/js/src/automation/flow-embed.tsx, mailpoet/assets/js/src/automation/editor/components/panel/activate-panel.tsx, mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/edit-newsletter.tsx) call window.parent.postMessage without an explicit target origin — recommend standardizing to use the same origin-restricted pattern or validating event origin on the receiver.

Suggestion (1)
- TODO present in mailpoet/assets/js/src/automation/integrations/mailpoet/steps/send-email/edit/thumbnail.tsx indicating a missing backend implementation for thumbnails; consider addressing or tracking as a follow-up task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->