### PR TITLE
Fix GH Action plugin version checks for private repos

### DIFF
--- a/.github/workflows/scripts/check_woocommerce_versions.php
+++ b/.github/workflows/scripts/check_woocommerce_versions.php
@@ -15,7 +15,8 @@ function getWooCommerceVersions(): array {
   $data = json_decode($response, true);
 
   if (!isset($data['versions'])) {
-    die("Failed to fetch WooCommerce versions.");
+    fwrite(STDERR, "Failed to fetch WooCommerce versions.\n");
+    exit(1);
   }
 
   return array_keys($data['versions']);

--- a/.github/workflows/scripts/helpers.php
+++ b/.github/workflows/scripts/helpers.php
@@ -7,7 +7,8 @@ function replaceVersionInFile(string $filePath, string $pattern, string $replace
   $content = file_get_contents($filePath);
 
   if ($content === false) {
-    die("Failed to read the file at $filePath.");
+    fwrite(STDERR, "Failed to read the file at $filePath.\n");
+    exit(1);
   }
 
   $updatedContent = preg_replace($pattern, $replacement, $content);
@@ -18,7 +19,8 @@ function replaceVersionInFile(string $filePath, string $pattern, string $replace
   }
 
   if (file_put_contents($filePath, $updatedContent) === false) {
-    die("Failed to write the updated file at $filePath.");
+    fwrite(STDERR, "Failed to write the updated file at $filePath.\n");
+    exit(1);
   }
 }
 
@@ -60,11 +62,14 @@ function getMinorMajorVersion(string $version): string {
  */
 function fetchGitHubTags(string $repo, int $page = 1, int $limit = 50): array {
   $apiPath = sprintf('repos/%s/tags', $repo);
+  $ghToken = getenv('GH_TOKEN');
+  if ($ghToken) {
+    putenv('GH_TOKEN=' . $ghToken); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv -- needed to authenticate gh CLI for private repos
+  }
+  $url = sprintf('%s?per_page=%d&page=%d', $apiPath, $limit, $page);
   $command = sprintf(
-    'gh api %s -F per_page=%d -F page=%d --jq %s 2>&1',
-    escapeshellarg($apiPath),
-    $limit,
-    $page,
+    'gh api %s --jq %s 2>&1',
+    escapeshellarg($url),
     escapeshellarg('.[].name')
   );
   $output = [];
@@ -72,7 +77,8 @@ function fetchGitHubTags(string $repo, int $page = 1, int $limit = 50): array {
   exec($command, $output, $exitCode);
 
   if ($exitCode !== 0) {
-    die("Failed to fetch tags from GitHub: " . implode("\n", $output));
+    fwrite(STDERR, "Failed to fetch tags for '$repo' (page $page): " . implode("\n", $output) . "\n");
+    exit(1);
   }
 
   return array_filter($output, function ($line) {


### PR DESCRIPTION
## Description

The "Check new versions of plugins and WordPress" GH Action was silently failing for all three private WooCommerce plugins (AutomateWoo, Subscriptions, Memberships).

### Bugs fixed

1. **`gh api -F` sends POST instead of GET** — the `-F` flag causes `gh api` to use POST method, which returns 404 on the tags endpoint. Fixed by passing pagination as URL query parameters instead.

2. **`GH_TOKEN` not reaching `gh` CLI from PHP `exec()`** — the token set in the workflow env wasn't propagated to the `gh` subprocess. Fixed by explicitly reading `GH_TOKEN` via `getenv()` and setting it with `putenv()` before calling `exec()`.

3. **`die()` exits with code 0** — all error paths used `die("message")` which exits with code 0 in PHP, making workflow steps silently succeed. Changed to `fwrite(STDERR, ...) + exit(1)` so failures are properly reported.

## Code review notes

- The `-F` to query params fix is the main bug — `-F` makes `gh api` send POST, causing 404 on GET-only endpoints
- `putenv()` has a `phpcs:ignore` since it's needed to propagate the token to `gh` subprocess
- All `die()` calls in the scripts have been replaced with `exit(1)`
- Error messages now include the repo name and page number for easier debugging

## QA notes

Test locally:
```bash
GH_TOKEN=<woocommerce-token> php .github/workflows/scripts/check_automate_woo_versions.php
GH_TOKEN=<woocommerce-token> php .github/workflows/scripts/check_woocommerce_subscriptions_versions.php
GH_TOKEN=<woocommerce-token> php .github/workflows/scripts/check_woocommerce_memberships_versions.php
```

Each should print latest/previous versions and update `.circleci/config.yml` if needed.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

After merging, trigger the workflow manually to verify: Actions → "Check new versions of plugins and WordPress" → Run workflow

## Tasks

- [x] I have added a changelog entry — N/A, CI tooling
- [x] I followed best practices for translations — N/A
- [ ] I added sufficient test coverage — CI script, not unit-testable
- [x] I embraced TypeScript — N/A, PHP only