### PR TITLE
Fix fatal error from MAX_JOIN_SIZE on restrictive hosts

### DIFF
--- a/mailpoet/changelog/2026-03-26-07-37-30-fixed-prevent-fatal-error-on-hosts-with-strict-maxjoinsi.md
+++ b/mailpoet/changelog/2026-03-26-07-37-30-fixed-prevent-fatal-error-on-hosts-with-strict-maxjoinsi.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent fatal error on hosts with strict MAX_JOIN_SIZE database limits when loading pages with segment subscriber counts

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -18,6 +18,7 @@ use MailPoetVendor\Doctrine\DBAL\Result;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder as ORMQueryBuilder;
+use Throwable;
 
 class SegmentSubscribersRepository {
   /** @var EntityManager */
@@ -467,6 +468,11 @@ class SegmentSubscribersRepository {
   }
 
   private function executeQuery(QueryBuilder $queryBuilder): Result {
+    try {
+      $this->entityManager->getConnection()->executeStatement('SET SESSION SQL_BIG_SELECTS=1');
+    } catch (Throwable $e) {
+      // Best-effort: some hosts may not allow SET SESSION, continue without it
+    }
     $result = $queryBuilder->execute();
     // Execute for select always returns statement but PHP Stan doesn't know that :(
     if (!$result instanceof Result) {
@@ -523,6 +529,18 @@ class SegmentSubscribersRepository {
       'query' => $queryBuilder->getSQL(),
     ]);
 
+    return $this->emptyStatisticsResult();
+  }
+
+  private function logQueryException(?SegmentEntity $segment, Throwable $e): void {
+    $logger = LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_SEGMENTS);
+    $logger->error('Failed to execute segment subscribers query: ' . $e->getMessage(), [
+      'segment_id' => $segment ? $segment->getId() : null,
+      'error' => $e->getMessage(),
+    ]);
+  }
+
+  private function emptyStatisticsResult(): array {
     return [
       'all' => 0,
       'trash' => 0,

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -55,40 +55,40 @@ class SegmentSubscribersRepository {
   }
 
   public function getSubscribersCountBySegmentIds(array $segmentIds, ?string $status = null, ?int $filterSegmentId = null): int {
-    try {
-      $segments = $this->segmentsRepository->findByIds($segmentIds);
-      $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-      $queryBuilder = $this->createCountQueryBuilder();
+    $segments = $this->segmentsRepository->findByIds($segmentIds);
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $queryBuilder = $this->createCountQueryBuilder();
 
-      $subQueries = [];
-      foreach ($segments as $segment) {
-        $segmentQb = $this->createCountQueryBuilder();
-        $segmentQb->select("{$subscribersTable}.id AS inner_id");
+    $subQueries = [];
+    foreach ($segments as $segment) {
+      $segmentQb = $this->createCountQueryBuilder();
+      $segmentQb->select("{$subscribersTable}.id AS inner_id");
 
-        if ($segment->isStatic()) {
-          $segmentQb = $this->filterSubscribersInStaticSegment($segmentQb, $segment, $status);
-        } else {
-          $segmentQb = $this->filterSubscribersInDynamicSegment($segmentQb, $segment, $status);
-        }
-
-        // inner parameters and types have to be merged to outer queryBuilder
-        $queryBuilder->setParameters(array_merge(
-          $segmentQb->getParameters(),
-          $queryBuilder->getParameters()
-        ), array_merge(
-          $segmentQb->getParameterTypes(),
-          $queryBuilder->getParameterTypes()
-        ));
-        $subQueries[] = $segmentQb->getSQL();
+      if ($segment->isStatic()) {
+        $segmentQb = $this->filterSubscribersInStaticSegment($segmentQb, $segment, $status);
+      } else {
+        $segmentQb = $this->filterSubscribersInDynamicSegment($segmentQb, $segment, $status);
       }
 
-      $queryBuilder->innerJoin(
-        $subscribersTable,
-        sprintf('(%s)', join(' UNION ', $subQueries)),
-        'inner_subscribers',
-        "inner_subscribers.inner_id = {$subscribersTable}.id"
-      );
+      // inner parameters and types have to be merged to outer queryBuilder
+      $queryBuilder->setParameters(array_merge(
+        $segmentQb->getParameters(),
+        $queryBuilder->getParameters()
+      ), array_merge(
+        $segmentQb->getParameterTypes(),
+        $queryBuilder->getParameterTypes()
+      ));
+      $subQueries[] = $segmentQb->getSQL();
+    }
 
+    $queryBuilder->innerJoin(
+      $subscribersTable,
+      sprintf('(%s)', join(' UNION ', $subQueries)),
+      'inner_subscribers',
+      "inner_subscribers.inner_id = {$subscribersTable}.id"
+    );
+
+    try {
       if (is_int($filterSegmentId)) {
         $filterSegment = $this->segmentsRepository->verifyDynamicSegmentExists($filterSegmentId);
         $filterSegmentQb = $this->createCountQueryBuilder();
@@ -102,7 +102,11 @@ class SegmentSubscribersRepository {
           "filter_segment.filter_segment_subscriber_id = {$subscribersTable}.id"
         );
       }
+    } catch (InvalidStateException $exception) {
+      return 0;
+    }
 
+    try {
       $statement = $this->executeQuery($queryBuilder);
       /** @var string $result */
       $result = $statement->fetchOne();

--- a/mailpoet/lib/Segments/SegmentSubscribersRepository.php
+++ b/mailpoet/lib/Segments/SegmentSubscribersRepository.php
@@ -55,40 +55,40 @@ class SegmentSubscribersRepository {
   }
 
   public function getSubscribersCountBySegmentIds(array $segmentIds, ?string $status = null, ?int $filterSegmentId = null): int {
-    $segments = $this->segmentsRepository->findByIds($segmentIds);
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $queryBuilder = $this->createCountQueryBuilder();
+    try {
+      $segments = $this->segmentsRepository->findByIds($segmentIds);
+      $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+      $queryBuilder = $this->createCountQueryBuilder();
 
-    $subQueries = [];
-    foreach ($segments as $segment) {
-      $segmentQb = $this->createCountQueryBuilder();
-      $segmentQb->select("{$subscribersTable}.id AS inner_id");
+      $subQueries = [];
+      foreach ($segments as $segment) {
+        $segmentQb = $this->createCountQueryBuilder();
+        $segmentQb->select("{$subscribersTable}.id AS inner_id");
 
-      if ($segment->isStatic()) {
-        $segmentQb = $this->filterSubscribersInStaticSegment($segmentQb, $segment, $status);
-      } else {
-        $segmentQb = $this->filterSubscribersInDynamicSegment($segmentQb, $segment, $status);
+        if ($segment->isStatic()) {
+          $segmentQb = $this->filterSubscribersInStaticSegment($segmentQb, $segment, $status);
+        } else {
+          $segmentQb = $this->filterSubscribersInDynamicSegment($segmentQb, $segment, $status);
+        }
+
+        // inner parameters and types have to be merged to outer queryBuilder
+        $queryBuilder->setParameters(array_merge(
+          $segmentQb->getParameters(),
+          $queryBuilder->getParameters()
+        ), array_merge(
+          $segmentQb->getParameterTypes(),
+          $queryBuilder->getParameterTypes()
+        ));
+        $subQueries[] = $segmentQb->getSQL();
       }
 
-      // inner parameters and types have to be merged to outer queryBuilder
-      $queryBuilder->setParameters(array_merge(
-        $segmentQb->getParameters(),
-        $queryBuilder->getParameters()
-      ), array_merge(
-        $segmentQb->getParameterTypes(),
-        $queryBuilder->getParameterTypes()
-      ));
-      $subQueries[] = $segmentQb->getSQL();
-    }
+      $queryBuilder->innerJoin(
+        $subscribersTable,
+        sprintf('(%s)', join(' UNION ', $subQueries)),
+        'inner_subscribers',
+        "inner_subscribers.inner_id = {$subscribersTable}.id"
+      );
 
-    $queryBuilder->innerJoin(
-      $subscribersTable,
-      sprintf('(%s)', join(' UNION ', $subQueries)),
-      'inner_subscribers',
-      "inner_subscribers.inner_id = {$subscribersTable}.id"
-    );
-
-    try {
       if (is_int($filterSegmentId)) {
         $filterSegment = $this->segmentsRepository->verifyDynamicSegmentExists($filterSegmentId);
         $filterSegmentQb = $this->createCountQueryBuilder();
@@ -102,14 +102,15 @@ class SegmentSubscribersRepository {
           "filter_segment.filter_segment_subscriber_id = {$subscribersTable}.id"
         );
       }
-    } catch (InvalidStateException $exception) {
+
+      $statement = $this->executeQuery($queryBuilder);
+      /** @var string $result */
+      $result = $statement->fetchOne();
+      return (int)$result;
+    } catch (Throwable $e) {
+      $this->logQueryException(null, $e);
       return 0;
     }
-
-    $statement = $this->executeQuery($queryBuilder);
-    /** @var string $result */
-    $result = $statement->fetchOne();
-    return (int)$result;
   }
 
   /**
@@ -118,20 +119,25 @@ class SegmentSubscribersRepository {
    * @throws InvalidStateException
    */
   public function getDynamicSubscribersCount(array $filters): int {
-    $segment = new SegmentEntity('temporary segment', SegmentEntity::TYPE_DYNAMIC, '');
-    foreach ($filters as $filter) {
-      $segment->addDynamicFilter(new DynamicSegmentFilterEntity($segment, $filter));
-    }
-    $queryBuilder = $this->createDynamicStatisticsQueryBuilder();
-    $queryBuilder = $this->filterSubscribersInDynamicSegment($queryBuilder, $segment, null);
-    $statement = $this->executeQuery($queryBuilder);
-    $result = $statement->fetch();
+    try {
+      $segment = new SegmentEntity('temporary segment', SegmentEntity::TYPE_DYNAMIC, '');
+      foreach ($filters as $filter) {
+        $segment->addDynamicFilter(new DynamicSegmentFilterEntity($segment, $filter));
+      }
+      $queryBuilder = $this->createDynamicStatisticsQueryBuilder();
+      $queryBuilder = $this->filterSubscribersInDynamicSegment($queryBuilder, $segment, null);
+      $statement = $this->executeQuery($queryBuilder);
+      $result = $statement->fetch();
 
-    if (!is_array($result)) {
-      $result = $this->logErrorAndReturnEmptyResult(null, $queryBuilder, $result);
-    }
+      if (!is_array($result)) {
+        $result = $this->logErrorAndReturnEmptyResult(null, $queryBuilder, $result);
+      }
 
-    return (int)$result['all'];
+      return (int)$result['all'];
+    } catch (Throwable $e) {
+      $this->logQueryException(null, $e);
+      return 0;
+    }
   }
 
   private function createCountQueryBuilder(): QueryBuilder {
@@ -284,55 +290,60 @@ class SegmentSubscribersRepository {
   }
 
   public function getSubscribersWithoutSegmentStatisticsCount(): array {
-    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $queryBuilder = $this->entityManager
-      ->getConnection()
-      ->createQueryBuilder();
-    $queryBuilder
-      ->addSelect('IFNULL(SUM(
-          CASE WHEN s.deleted_at IS NULL
+    try {
+      $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+      $queryBuilder = $this->entityManager
+        ->getConnection()
+        ->createQueryBuilder();
+      $queryBuilder
+        ->addSelect('IFNULL(SUM(
+            CASE WHEN s.deleted_at IS NULL
+              THEN 1 ELSE 0 END
+        ), 0) as `all`')
+        ->addSelect('IFNULL(SUM(
+            CASE WHEN s.deleted_at IS NOT NULL
+              THEN 1 ELSE 0 END
+        ), 0) as trash')
+        ->addSelect('IFNULL(SUM(
+            CASE WHEN s.status = :status_subscribed AND s.deleted_at IS NULL
+              THEN 1 ELSE 0 END
+        ), 0) as :status_subscribed')
+        ->addSelect('IFNULL(SUM(
+          CASE WHEN s.status = :status_unsubscribed AND s.deleted_at IS NULL
             THEN 1 ELSE 0 END
-      ), 0) as `all`')
-      ->addSelect('IFNULL(SUM(
-          CASE WHEN s.deleted_at IS NOT NULL
+        ), 0) as :status_unsubscribed')
+        ->addSelect('IFNULL(SUM(
+          CASE WHEN s.status = :status_inactive AND s.deleted_at IS NULL
             THEN 1 ELSE 0 END
-      ), 0) as trash')
-      ->addSelect('IFNULL(SUM(
-          CASE WHEN s.status = :status_subscribed AND s.deleted_at IS NULL
+        ), 0) as :status_inactive')
+        ->addSelect('IFNULL(SUM(
+          CASE WHEN s.status = :status_unconfirmed AND s.deleted_at IS NULL
             THEN 1 ELSE 0 END
-      ), 0) as :status_subscribed')
-      ->addSelect('IFNULL(SUM(
-        CASE WHEN s.status = :status_unsubscribed AND s.deleted_at IS NULL
-          THEN 1 ELSE 0 END
-      ), 0) as :status_unsubscribed')
-      ->addSelect('IFNULL(SUM(
-        CASE WHEN s.status = :status_inactive AND s.deleted_at IS NULL
-          THEN 1 ELSE 0 END
-      ), 0) as :status_inactive')
-      ->addSelect('IFNULL(SUM(
-        CASE WHEN s.status = :status_unconfirmed AND s.deleted_at IS NULL
-          THEN 1 ELSE 0 END
-      ), 0) as :status_unconfirmed')
-      ->addSelect('IFNULL(SUM(
-        CASE WHEN s.status = :status_bounced AND s.deleted_at IS NULL
-          THEN 1 ELSE 0 END
-      ), 0) as :status_bounced')
-      ->from($subscribersTable, 's')
-      ->setParameter('status_subscribed', SubscriberEntity::STATUS_SUBSCRIBED)
-      ->setParameter('status_unsubscribed', SubscriberEntity::STATUS_UNSUBSCRIBED)
-      ->setParameter('status_inactive', SubscriberEntity::STATUS_INACTIVE)
-      ->setParameter('status_unconfirmed', SubscriberEntity::STATUS_UNCONFIRMED)
-      ->setParameter('status_bounced', SubscriberEntity::STATUS_BOUNCED);
+        ), 0) as :status_unconfirmed')
+        ->addSelect('IFNULL(SUM(
+          CASE WHEN s.status = :status_bounced AND s.deleted_at IS NULL
+            THEN 1 ELSE 0 END
+        ), 0) as :status_bounced')
+        ->from($subscribersTable, 's')
+        ->setParameter('status_subscribed', SubscriberEntity::STATUS_SUBSCRIBED)
+        ->setParameter('status_unsubscribed', SubscriberEntity::STATUS_UNSUBSCRIBED)
+        ->setParameter('status_inactive', SubscriberEntity::STATUS_INACTIVE)
+        ->setParameter('status_unconfirmed', SubscriberEntity::STATUS_UNCONFIRMED)
+        ->setParameter('status_bounced', SubscriberEntity::STATUS_BOUNCED);
 
-    $this->addConstraintsForSubscribersWithoutSegmentToDBAL($queryBuilder);
-    $statement = $this->executeQuery($queryBuilder);
-    $result = $statement->fetch();
+      $this->addConstraintsForSubscribersWithoutSegmentToDBAL($queryBuilder);
+      $statement = $this->executeQuery($queryBuilder);
+      $result = $statement->fetch();
 
-    if (is_array($result)) {
-      return $result;
+      if (is_array($result)) {
+        return $result;
+      }
+
+      return $this->logErrorAndReturnEmptyResult(null, $queryBuilder, $result);
+    } catch (Throwable $e) {
+      $this->logQueryException(null, $e);
+      return $this->emptyStatisticsResult();
     }
-
-    return $this->logErrorAndReturnEmptyResult(null, $queryBuilder, $result);
   }
 
   public function addConstraintsForSubscribersWithoutSegment(ORMQueryBuilder $queryBuilder): void {
@@ -482,37 +493,47 @@ class SegmentSubscribersRepository {
   }
 
   public function getSubscribersGlobalStatusStatisticsCount(SegmentEntity $segment): array {
-    if ($segment->isStatic()) {
-      $queryBuilder = $this->createStaticGlobalStatusStatisticsQueryBuilder($segment);
-    } else {
-      $queryBuilder = $this->createDynamicStatisticsQueryBuilder();
-      $this->filterSubscribersInDynamicSegment($queryBuilder, $segment);
-    }
+    try {
+      if ($segment->isStatic()) {
+        $queryBuilder = $this->createStaticGlobalStatusStatisticsQueryBuilder($segment);
+      } else {
+        $queryBuilder = $this->createDynamicStatisticsQueryBuilder();
+        $this->filterSubscribersInDynamicSegment($queryBuilder, $segment);
+      }
 
-    $statement = $this->executeQuery($queryBuilder);
-    $result = $statement->fetch();
-    if (is_array($result)) {
-      return $result;
-    }
+      $statement = $this->executeQuery($queryBuilder);
+      $result = $statement->fetch();
+      if (is_array($result)) {
+        return $result;
+      }
 
-    return $this->logErrorAndReturnEmptyResult($segment, $queryBuilder, $result);
+      return $this->logErrorAndReturnEmptyResult($segment, $queryBuilder, $result);
+    } catch (Throwable $e) {
+      $this->logQueryException($segment, $e);
+      return $this->emptyStatisticsResult();
+    }
   }
 
   public function getSubscribersStatisticsCount(SegmentEntity $segment): array {
-    if ($segment->isStatic()) {
-      $queryBuilder = $this->createStaticStatisticsQueryBuilder($segment);
-    } else {
-      $queryBuilder = $this->createDynamicStatisticsQueryBuilder();
-      $this->filterSubscribersInDynamicSegment($queryBuilder, $segment);
-    }
+    try {
+      if ($segment->isStatic()) {
+        $queryBuilder = $this->createStaticStatisticsQueryBuilder($segment);
+      } else {
+        $queryBuilder = $this->createDynamicStatisticsQueryBuilder();
+        $this->filterSubscribersInDynamicSegment($queryBuilder, $segment);
+      }
 
-    $statement = $this->executeQuery($queryBuilder);
-    $result = $statement->fetch();
-    if (is_array($result)) {
-      return $result;
-    }
+      $statement = $this->executeQuery($queryBuilder);
+      $result = $statement->fetch();
+      if (is_array($result)) {
+        return $result;
+      }
 
-    return $this->logErrorAndReturnEmptyResult($segment, $queryBuilder, $result);
+      return $this->logErrorAndReturnEmptyResult($segment, $queryBuilder, $result);
+    } catch (Throwable $e) {
+      $this->logQueryException($segment, $e);
+      return $this->emptyStatisticsResult();
+    }
   }
 
   /**

--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -255,10 +255,10 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
     $this->entityManager->flush();
 
     $result = $this->repository->getSubscribersStatisticsCount($segment);
-    $this->assertSame(0, $result['all']);
-    $this->assertSame(0, $result['subscribed']);
-    $this->assertSame(0, $result['unsubscribed']);
-    $this->assertSame(0, $result['trash']);
+    $this->assertEquals(0, $result['all']);
+    $this->assertEquals(0, $result['subscribed']);
+    $this->assertEquals(0, $result['unsubscribed']);
+    $this->assertEquals(0, $result['trash']);
   }
 
   public function testSubscriberCountIsZeroIfItHasAnInvalidFilter(): void {

--- a/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Segments/SegmentSubscribersRepositoryTest.php
@@ -229,6 +229,38 @@ class SegmentSubscribersRepositoryTest extends \MailPoetTest {
     verify($countWithFilter)->equals(2);
   }
 
+  public function testSqlBigSelectsIsSetBeforeSegmentQuery(): void {
+    global $wpdb;
+    $wpdb->query('SET SESSION SQL_BIG_SELECTS=0');
+
+    $segment = $this->segmentRepository->createOrUpdate('Segment' . rand(0, 10000));
+    $this->entityManager->flush();
+
+    $this->repository->getSubscribersStatisticsCount($segment);
+
+    $result = $wpdb->get_var('SELECT @@SESSION.SQL_BIG_SELECTS');
+    $this->assertSame('1', $result);
+  }
+
+  public function testStatisticsCountReturnsZerosOnQueryError(): void {
+    $segment = new SegmentEntity('Segment' . rand(0, 10000), SegmentEntity::TYPE_DYNAMIC, 'Segment description');
+    $filterData = new DynamicSegmentFilterData(
+      'typeThatDefinitelyDoesNotExist',
+      'theActionDoesNotExistEither'
+    );
+    $dynamicFilter = new DynamicSegmentFilterEntity($segment, $filterData);
+    $segment->getDynamicFilters()->add($dynamicFilter);
+    $this->entityManager->persist($segment);
+    $this->entityManager->persist($dynamicFilter);
+    $this->entityManager->flush();
+
+    $result = $this->repository->getSubscribersStatisticsCount($segment);
+    $this->assertSame(0, $result['all']);
+    $this->assertSame(0, $result['subscribed']);
+    $this->assertSame(0, $result['unsubscribed']);
+    $this->assertSame(0, $result['trash']);
+  }
+
   public function testSubscriberCountIsZeroIfItHasAnInvalidFilter(): void {
     $segment = new SegmentEntity('Segment' . rand(0, 10000), SegmentEntity::TYPE_DYNAMIC, 'Segment description');
     $filterData = new DynamicSegmentFilterData(


### PR DESCRIPTION
## Description

On shared hosts with strict `MAX_JOIN_SIZE` limits (e.g. 64 MB), dynamic segments with many AND-combined filters produce queries with excessive JOINs that exceed the limit, causing an unhandled fatal error that crashes the entire admin page.

This PR:
1. Sets `SET SESSION SQL_BIG_SELECTS=1` before segment subscriber queries (best-effort, silently ignored if the host blocks it) — the same approach WooCommerce uses
2. Wraps all public segment count query methods in `try/catch(Throwable)` so failures return zero counts instead of crashing
3. Logs query errors for debugging

## Code review notes

The `SQL_BIG_SELECTS=1` is applied only in `SegmentSubscribersRepository::executeQuery()`, not globally at the connection level. This limits the scope to segment queries only.

## QA notes

Hard to reproduce without a host that enforces `MAX_JOIN_SIZE`. The graceful degradation can be verified by checking that pages with segment counts don't crash when a segment query fails — counts show as 0 instead.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7899](https://linear.app/a8c/issue/STOMAIL-7899/queries-exceeding-max-join-size-rows)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7899-queries-exceeding-max-join-size)

_The latest successful build from `fix/stomail-7899-queries-exceeding-max-join-size` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 3

### Bug
1. **Overly broad exception catching**: The PR catches `Throwable` in multiple methods instead of specific exception types. This will catch fatal errors like `OutOfMemoryError`, `StackOverflowError`, and `TypeError` that indicate serious infrastructure problems and should not be silently converted to zero counts. This approach masks critical failures that require investigation. The codebase pattern elsewhere shows catching specific exceptions (e.g., `InvalidStateException`, `InvalidFilterException`, `\Exception`), not `Throwable`.

2. **Questionable session variable test logic**: The test `testSqlBigSelectsIsSetBeforeSegmentQuery()` verifies that `@@SESSION.SQL_BIG_SELECTS` equals `'1'` after calling `getSubscribersStatisticsCount()`, but this test doesn't validate that the setting actually took effect for the query execution—only that the variable exists afterward. Session variables set within a method may not reliably persist beyond execution in WordPress's connection handling context.

### Suggestion
3. **Inconsistent error handling patterns**: The code mixes two different logging approaches—some exception handlers call `logQueryException()` while other error cases call `logErrorAndReturnEmptyResult()`. This inconsistency could lead to different logging behaviors for different failure modes and makes the error handling strategy harder to maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->