### PR TITLE
Clarify sending frequency in System Status for MSS

### DIFF
--- a/mailpoet/changelog/2026-03-26-09-45-23-fixed-sending-frequency-in-system-info-showing-misleadin.md
+++ b/mailpoet/changelog/2026-03-26-09-45-23-fixed-sending-frequency-in-system-info-showing-misleadin.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Sending frequency in System Info showing misleading values when using MailPoet Sending Service

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -3,6 +3,7 @@
 namespace MailPoet\SystemReport;
 
 use MailPoet\Cron\CronHelper;
+use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Router\Endpoints\CronDaemon;
 use MailPoet\Services\Bridge;
@@ -141,11 +142,13 @@ class SystemReportCollector {
         'API key state' => $ApiKeyState ?? 'Unset',
         'Premium key state' => $premiumKeyState ?? 'Unset',
       ]),
-      'Sending Frequency' => sprintf(
-        '%d emails every %d minutes',
-        $mta['frequency']['emails'],
-        $mta['frequency']['interval']
-      ),
+      'Sending Frequency' => ($mta['method'] === Mailer::METHOD_MAILPOET)
+        ? __('Managed by MailPoet Sending Service', 'mailpoet')
+        : sprintf(
+          '%d emails every %d minutes',
+          $mta['frequency']['emails'],
+          $mta['frequency']['interval']
+        ),
       'MailPoet sending info' => $this->formatCompositeField([
         "Send all site's emails with" => ($this->settings->get('send_transactional_emails') ? 'current sending method' : 'default WordPress sending method'),
         'Task Scheduler method' => $this->settings->get('cron_trigger.method'),

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Test\SystemReport;
 
 use MailPoet\Cron\CronHelper;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Mailer\Mailer;
 use MailPoet\Mailer\MailerLog;
 use MailPoet\Services\Bridge;
 use MailPoet\Settings\SettingsController;
@@ -118,6 +119,16 @@ class SystemReportCollectorTest extends \MailPoetTest {
     verify($this->systemInfoData['Sending Method'])->equals($mta['method']);
     verify($this->systemInfoData['Sending Frequency'])->stringContainsString($mta['frequency']['emails'] . ' emails');
     verify($this->systemInfoData['Sending Frequency'])->stringContainsString($mta['frequency']['interval'] . ' minutes');
+  }
+
+  public function testItReturnsManagedLabelForSendingFrequencyWhenMssIsEnabled() {
+    $this->settings->set('mta.method', Mailer::METHOD_MAILPOET);
+    $bridge = $this->createMock(Bridge::class);
+    $bridge->method('pingBridge')->willReturn(new \WP_Error('error', 'test'));
+    $bridge->method('validateBridgePingResponse')->willReturn(false);
+    $systemReporter = $this->createSystemReporterWithMockedBridge($bridge);
+    $systemInfoData = $systemReporter->getData();
+    verify($systemInfoData['Sending Frequency'])->equals('Managed by MailPoet Sending Service');
   }
 
   public function testItReturnsSomeSettings() {


### PR DESCRIPTION
## Description

When MailPoet Sending Service (MSS) is the active sending method, System Info displays "Sending Frequency: 25 emails every 5 minutes" — a value from the "Other" sending method settings. This is misleading because MSS handles sending internally and has no user-configurable frequency. It also caused Odie AI to give incorrect guidance about changing a setting that doesn't exist for MSS.

Now, when MSS is active, the field shows "Managed by MailPoet Sending Service" instead. The numeric frequency continues to display for non-MSS sending methods.

## Code review notes

_N/A_

## QA notes

1. Set the sending method to MailPoet Sending Service
2. Go to MailPoet → Help → System Info
3. Verify "Sending Frequency" shows "Managed by MailPoet Sending Service"
4. Switch to a non-MSS sending method (e.g., "Other")
5. Verify "Sending Frequency" shows the numeric format (e.g., "25 emails every 5 minutes")

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7902](https://linear.app/a8c/issue/STOMAIL-7902/clarify-sending-frequency-in-system-status-for-mss)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7902-clarify-sending-frequency-in-system-status-for-mss)

_The latest successful build from `fix/stomail-7902-clarify-sending-frequency-in-system-status-for-mss` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->