### PR TITLE
Fix untranslatable greeting in marketing confirmation email templates

### DIFF
--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/marketing-confirmation.php
@@ -28,8 +28,12 @@ do_action('woocommerce_email_header', $email_heading, $email); ?>
 
 <p>
 <?php
+if ($subscriber_firstname) {
   /* translators: %s: Subscriber first name */
-  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: _x('there', 'subscriber name placeholder', 'mailpoet')));
+  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname));
+} else {
+  echo esc_html(__('Hello there,', 'mailpoet'));
+}
 ?>
 </p>
 

--- a/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
+++ b/mailpoet/lib/WooCommerce/Emails/Templates/emails/plain/marketing-confirmation.php
@@ -23,8 +23,12 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html($email_heading);
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/* translators: %s: Subscriber first name */
-echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname ?: __('there', 'mailpoet')));
+if ($subscriber_firstname) {
+  /* translators: %s: Subscriber first name */
+  echo esc_html(sprintf(__('Hello %s,', 'mailpoet'), $subscriber_firstname));
+} else {
+  echo esc_html(__('Hello there,', 'mailpoet'));
+}
 echo "\n\n";
 
 /* translators: %s: Site name */


### PR DESCRIPTION
Copy of #6567 (from fork by @chrism245) — pushed to our repo to trigger CircleCI.

---

## Summary

Fixes `STOMAIL-7746` — the `sprintf(__('Hello ,', 'mailpoet'), $subscriber_firstname ?: __('there', 'mailpoet'))` pattern forced translators to translate "there" as a standalone word, which has no correct equivalent in Romanian and many other languages.

**Before:** A single translatable string `"Hello ,"` with either the subscriber name or the word "there" substituted in — impossible to translate correctly as a phrase in most locales.

**After:** Two separate translatable strings — `"Hello ,"` (when name is known) and `"Hello there,"` (when name is unknown) — so translators can translate each full phrase independently.

## Changes

- `emails/marketing-confirmation.php` — base HTML template fixed
- `emails/plain/marketing-confirmation.php` — plain text template fixed

## Not in this PR (follow-up needed)

The **block template** (`emails/block/marketing-confirmation.php`) uses a template-tag system (`<!--[mailpoet/subscriber-firstname default="..."]-->`) where the subscriber name is substituted at send time, not at render time. A PHP conditional can't be applied here without a new dedicated template tag (e.g. `<!--[mailpoet/subscriber-greeting]-->`). Raising a follow-up for that.

## Testing

1. Install MailPoet and WooCommerce on a local WordPress site
2. Switch site language to Romanian (or any language where "there" has no standalone greeting equivalent)
3. Go to **WooCommerce > Settings > Emails > Marketing Confirmation** and send a preview
4. Verify the greeting renders as `"Hello there,"` (or its translation) for subscribers without a first name
5. Add a subscriber with a first name and verify the greeting renders as `"Hello [Name],"` correctly

## References

- Linear: STOMAIL-7746
- Original PR: #6567 by @chrism245

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7746-marketing-confirmation-email-label-not-translatable)

_The latest successful build from `stomail-7746-marketing-confirmation-email-label-not-translatable` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->