### PR TITLE
Fix subscriber displayname shortcode returning username instead of display name

### DIFF
--- a/mailpoet/changelog/2026-04-08-10-00-00-fixed-subscriber-displayname-shortcode-returning-username-instead-of-display-name.md
+++ b/mailpoet/changelog/2026-04-08-10-00-00-fixed-subscriber-displayname-shortcode-returning-username-instead-of-display-name.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix subscriber displayname shortcode returning WordPress username instead of display name

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -50,7 +50,7 @@ class Subscriber implements CategoryInterface {
       case 'displayname':
         if ($subscriber->getWpUserId()) {
           $wpUser = WPFunctions::get()->getUserdata($subscriber->getWpUserId());
-          return $wpUser->user_login; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+          return $wpUser->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         }
         return $defaultValue;
       case 'count':

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -239,7 +239,7 @@ class ShortcodesTest extends \MailPoetTest {
     verify($result[0])->equals($this->subscriber->getLastName());
     $result =
       $shortcodesObject->process(['[subscriber:displayname]']);
-    verify($result[0])->equals($this->wPUser->user_login);
+    verify($result[0])->equals($this->wPUser->display_name);
 
     $subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
     $subscriberCount = $subscribersRepository->countBy(


### PR DESCRIPTION
## Problem
The `[subscriber:displayname]` shortcode was returning `user_login` (the WordPress **username**) instead of `display_name` (the WordPress **display name**) for subscribers linked to a WP user account.

This means emails were showing e.g. `chrism245` instead of `Christian Moreira`.

## Solution
Changed `$wpUser->user_login` to `$wpUser->display_name` in the `displayname` case of the shortcode processor. Also updated the test assertion to match the correct expected value.

## Changes
- `mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php` — one-line fix
- `mailpoet/tests/integration/Newsletter/ShortcodesTest.php` — updated test assertion

## Testing
1. Set a WordPress Display Name different from the username (WP Admin → Profile)
2. Create a newsletter with `[subscriber:displayname]` in a text block
3. Preview the email — it now shows the Display Name instead of the username ✅

## Notes
- Linear: STOMAIL-7295
- Part of the Woo Extensions Bug Blitz: https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->