### PR TITLE
Fix: keep Trash tab visible and selected when search yields no results

### DIFF
--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -196,8 +196,13 @@ class ListingComponent extends Component {
             meta: _.omit(response.meta, ['filters', 'groups', 'count']),
           },
           () => {
-            // if viewing an empty trash
-            if (this.state.group === 'trash' && response.meta.count === 0) {
+            // if viewing an empty trash (not just a search/filter with no results)
+            if (
+              this.state.group === 'trash' &&
+              response.meta.count === 0 &&
+              !this.state.search &&
+              Object.keys(this.state.filter).length === 0
+            ) {
               // redirect to default group
               this.handleGroup('all');
             }

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -617,7 +617,12 @@ class ListingComponent extends Component {
         }),
       )
       .filter(
-        (category) => !(category.name === 'trash' && category.count === 0),
+        (category) =>
+          !(
+            category.name === 'trash' &&
+            category.count === 0 &&
+            this.state.group !== 'trash'
+          ),
       );
 
     // groups

--- a/mailpoet/changelog/2026-03-27-16-02-24-fixed-searching-in-subscribers-trash-with-no-results-no-.md
+++ b/mailpoet/changelog/2026-03-27-16-02-24-fixed-searching-in-subscribers-trash-with-no-results-no-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Searching in Subscribers Trash with no results no longer redirects to the All tab or hides the Trash tab

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Acceptance;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoet\Test\DataFactories\Tag;
+use DateTime;
 
 class SubscribersListingCest {
   public function subscribersListing(\AcceptanceTester $i) {
@@ -134,5 +135,29 @@ class SubscribersListingCest {
     $i->waitForText('Subscribed', 10, "[data-automation-id='listing_item_{$subscriber4->getId()}']");
     $i->dontSee('Unsubscribed', "[data-automation-id='listing_item_{$subscriber3->getId()}']");
     $i->dontSee('Unsubscribed', "[data-automation-id='listing_item_{$subscriber4->getId()}']");
+  }
+
+  public function searchInTrashWithNoResultsStaysInTrash(\AcceptanceTester $i) {
+    $i->wantTo('Verify that searching in Trash with no results does not redirect to All');
+
+    // Create a trashed subscriber
+    (new Subscriber())
+      ->withEmail('trashed@example.com')
+      ->withDeletedAt(new DateTime())
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+
+    // Navigate to the Trash group
+    $i->changeGroupInListingFilter('trash');
+    $i->waitForText('trashed@example.com');
+
+    // Search for something that won't match any trashed subscriber
+    $i->searchFor('noresultsexpected_xyz');
+
+    // Should stay in trash — not redirect to All
+    $i->waitForText('No items found.');
+    $i->seeInCurrentURL(urlencode('group[trash]'));
   }
 }

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -2,10 +2,10 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use DateTime;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoet\Test\DataFactories\Tag;
-use DateTime;
 
 class SubscribersListingCest {
   public function subscribersListing(\AcceptanceTester $i) {


### PR DESCRIPTION
## Description

When a user searched in **Subscribers → Trash** with a term that matched nothing, two bugs fired together:

1. **Redirect bug** — the empty-trash redirect in `listing.jsx` fired whenever `getItems()` returned `count=0` for the trash group, without checking whether the zero was caused by an active search. The user got silently kicked to the All tab.
2. **Tab disappears bug** — the tab-visibility filter hid the Trash tab whenever its count was 0, even while the user was actively viewing that tab. So even after fixing the redirect, the Trash tab vanished from the nav.

**Fix:**
- Guard the redirect with `!this.state.search` (and empty-filter check) so it only fires when trash is genuinely empty with no active search or filter.
- Keep the Trash tab visible whenever `this.state.group === 'trash'`, regardless of count.

## Code review notes

The two conditions are related but distinct. The redirect guard and the tab-visibility filter are separate code paths — both need the same "am I currently on trash?" awareness. Worth verifying both independently in review.

## QA notes

1. Go to **MailPoet → Subscribers → Trash** (must have at least one trashed subscriber)
2. Type a search term that matches nothing (e.g. `zzz`)
3. **Expected:** Trash tab stays visible and selected, table shows "No items found."
4. **Before fix:** redirect to All tab (bug 1) or Trash tab disappears (bug 2)
5. Clear the search → trashed subscribers reappear

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7241

## After-merge notes

_N/A_

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| Searching in Trash with no results redirected to All tab and hid the Trash tab | Trash tab stays visible and selected, "No items found." is shown |

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=Fixed --description=...`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7241-trash-search-redirect)

_The latest successful build from `fix/stomail-7241-trash-search-redirect` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Issues found: 2**

**Category: Bug**

1. **Redirect bug**: Searching in Trash with no matches caused listing.jsx to redirect to the All tab whenever `getItems()` returned `count = 0` for the trash group, without checking for an active search or filter.

2. **Tab visibility bug**: The Trash tab was hidden when its count was 0, even while the user was actively viewing that tab.

This PR fixes both issues by:
- Guarding the empty-trash redirect so it only triggers when there is no active search (`!this.state.search`) and the filter is empty (`Object.keys(this.state.filter).length === 0`).
- Keeping the Trash tab visible whenever `this.state.group === 'trash'`, regardless of item count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->