### PR TITLE
Fix checkbox custom field shortcode returning raw value instead of label

### DIFF
--- a/mailpoet/changelog/2026-04-07-10-00-00-fixed-checkbox-custom-field-shortcode-returns-label-instead-of-raw-value.md
+++ b/mailpoet/changelog/2026-04-07-10-00-00-fixed-checkbox-custom-field-shortcode-returns-label-instead-of-raw-value.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Fix checkbox custom field shortcode returning raw value (1) instead of the checkbox label

--- a/mailpoet/lib/Config/TranslationUpdater.php
+++ b/mailpoet/lib/Config/TranslationUpdater.php
@@ -179,7 +179,7 @@ class TranslationUpdater {
   }
 
   protected function logError(string $message): void {
-    if (class_exists(Debugger::class)) {
+    if (class_exists(Debugger::class) && Debugger::$logDirectory) {
       Debugger::log($message, ILogger::ERROR);
     }
     if (function_exists('error_log')) {

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -65,7 +65,7 @@ class Subscriber implements CategoryInterface {
             'subscriber' => $subscriber,
             'customField' => $customField[1],
           ]);
-          if (!($customField instanceof SubscriberCustomFieldEntity) || $customField->getValue() === '' || $customField->getValue() === null) {
+          if (!($customField instanceof SubscriberCustomFieldEntity) || empty($customField->getValue())) {
             return $defaultValue;
           }
           $customFieldDefinition = $customField->getCustomField();
@@ -75,7 +75,7 @@ class Subscriber implements CategoryInterface {
             $customField->getValue() === '1'
           ) {
             $params = $customFieldDefinition->getParams();
-            $label = $params['values'][0]['value'] ?? '';
+            $label = (is_array($params) && isset($params['values'][0]['value'])) ? (string)$params['values'][0]['value'] : '';
             return ($label !== '' && $label !== null) ? htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
           }
           return htmlspecialchars($customField->getValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -65,7 +65,7 @@ class Subscriber implements CategoryInterface {
             'subscriber' => $subscriber,
             'customField' => $customField[1],
           ]);
-          if (!($customField instanceof SubscriberCustomFieldEntity) || empty($customField->getValue())) {
+          if (!($customField instanceof SubscriberCustomFieldEntity) || $customField->getValue() === '' || $customField->getValue() === null) {
             return $defaultValue;
           }
           $customFieldDefinition = $customField->getCustomField();
@@ -76,7 +76,7 @@ class Subscriber implements CategoryInterface {
           ) {
             $params = $customFieldDefinition->getParams();
             $label = $params['values'][0]['value'] ?? '';
-            return $label ? htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
+            return ($label !== '' && $label !== null) ? htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
           }
           return htmlspecialchars($customField->getValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
         }

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Newsletter\Shortcodes\Categories;
 
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
@@ -64,9 +65,20 @@ class Subscriber implements CategoryInterface {
             'subscriber' => $subscriber,
             'customField' => $customField[1],
           ]);
-          return ($customField instanceof SubscriberCustomFieldEntity && !empty($customField->getValue()))
-            ? htmlspecialchars($customField->getValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401)
-            : $defaultValue;
+          if (!($customField instanceof SubscriberCustomFieldEntity) || empty($customField->getValue())) {
+            return $defaultValue;
+          }
+          $customFieldDefinition = $customField->getCustomField();
+          if (
+            $customFieldDefinition instanceof CustomFieldEntity &&
+            $customFieldDefinition->getType() === CustomFieldEntity::TYPE_CHECKBOX &&
+            $customField->getValue() === '1'
+          ) {
+            $params = $customFieldDefinition->getParams();
+            $label = $params['values'][0]['value'] ?? '';
+            return $label ? htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $defaultValue;
+          }
+          return htmlspecialchars($customField->getValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
         }
         return null;
     }

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -281,6 +281,41 @@ class ShortcodesTest extends \MailPoetTest {
     verify($result[0])->equals($subscriberCustomField->getValue());
   }
 
+  public function testItCanProcessCheckboxCustomFieldShortcodes() {
+    $shortcodesObject = $this->shortcodesObject;
+    $subscriber = $this->subscriber;
+
+    $customField = new CustomFieldEntity();
+    $customField->setName('terms_agreement');
+    $customField->setType(CustomFieldEntity::TYPE_CHECKBOX);
+    $customField->setParams(['values' => [['value' => 'I agree to the terms']]]);
+    $this->entityManager->persist($customField);
+    $this->entityManager->flush();
+
+    // No value set — should return empty string
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ']']
+    );
+    verify($result[0])->equals('');
+
+    // Checked (value = '1') — should return the checkbox label, not '1'
+    $subscriberCustomField = new SubscriberCustomFieldEntity($subscriber, $customField, '1');
+    $this->entityManager->persist($subscriberCustomField);
+    $this->entityManager->flush();
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ']']
+    );
+    verify($result[0])->equals('I agree to the terms');
+
+    // Unchecked (value = '') — should return empty string
+    $subscriberCustomField->setValue('');
+    $this->entityManager->flush();
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ']']
+    );
+    verify($result[0])->equals('');
+  }
+
   public function testItCanProcessLinkShortcodes() {
     $shortcodesObject = $this->shortcodesObject;
     $result =


### PR DESCRIPTION
## Problem

The `[subscriber:cf_X]` shortcode for checkbox custom fields was returning the raw stored value (`1`) instead of the human-readable checkbox label (e.g. `I agree to the terms`).

**Steps to reproduce:**
1. Create a checkbox custom field with label `I agree to the terms`
2. Use `[subscriber:cf_X]` in an email for a subscriber who has the checkbox checked
3. The rendered email shows `1` instead of `I agree to the terms`

## Solution

When resolving a custom field shortcode, the fix checks if the field type is `checkbox` and the value is `1`. If so, it fetches the label from the field's `params['values'][0]['value']` and returns that instead of the raw value.

All other field types (text, date, radio, select) are unaffected.

## Changes

- `mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php` — type-aware checkbox label resolution
- `mailpoet/tests/integration/Newsletter/ShortcodesTest.php` — regression test covering checked, unchecked, and empty states

## Bonus fix

Also fixes a `LogicException: Logging directory is not specified` Tracy error in local dev environments — `TranslationUpdater::logError()` was calling `Debugger::log()` without checking if `$logDirectory` was set, unlike `API.php` which already does this correctly.

## Testing

Verified locally:
- Checkbox checked → shortcode renders `I agree to the terms` ✅
- Checkbox unchecked → shortcode renders empty string ✅
- No value set → shortcode renders empty string ✅

## Notes

- Linear: STOMAIL-7309
- Part of the Woo Extensions Bug Blitz: https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->