### PR TITLE
Fix default scheduled time to use site local timezone

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -12,7 +12,8 @@ import { NewsLetter, NewsletterStatus } from 'common/newsletter';
 import { Field } from 'form/types';
 import { SendToFieldWithCount } from './send-to-field';
 
-const tomorrowDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
+const tomorrowLocalDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
+const tomorrowDateTime = MailPoet.Date.toGmtDatetimeString(tomorrowLocalDateTime);
 const timeOfDayItems = window.mailpoet_schedule_time_of_day as unknown as {
   [key: string]: string;
 };

--- a/mailpoet/changelog/2026-03-29-13-10-04-fixed-default-scheduled-send-time-now-shows-800-am-in-th.md
+++ b/mailpoet/changelog/2026-03-29-13-10-04-fixed-default-scheduled-send-time-now-shows-800-am-in-th.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Default scheduled send time now shows 8:00 AM in the site's local timezone instead of 8:00 AM UTC


### PR DESCRIPTION
## Description

When scheduling a newsletter, the default send time was constructed as a naive local-time string (`"tomorrow 08:00:00"`) but was passed through `MailPoet.Date.datetimeString()`, which treats its input as UTC and applies the site's GMT offset for display. For a UTC−5 site this meant the picker defaulted to 3:00 AM instead of 8:00 AM.

The fix converts the naive local-time string to its UTC equivalent via `MailPoet.Date.toGmtDatetimeString()` before using it as the default. The round-trip through `datetimeString()` then correctly renders 8:00 AM in the site's local timezone for all offsets, including cases where the UTC time crosses a day boundary (e.g. UTC+12).

## Code review notes

_N/A_

## QA notes

1. Go to **Newsletters → New newsletter → Standard newsletter**
2. On the sending step, select **"Schedule"**
3. Verify the default time shown is **8:00 AM** (not offset from UTC)
4. Repeat on a site configured with a non-UTC timezone (e.g. UTC−5, UTC+12) to confirm it always shows 8:00 AM local time

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7358

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=Fixed --description="..."`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes