### PR TITLE
Include automation emails in authorized sender validation

### DIFF
--- a/mailpoet/changelog/2026-03-29-14-46-13-fixed-changing-the-default-from-email-address-now-also-u.md
+++ b/mailpoet/changelog/2026-03-29-14-46-13-fixed-changing-the-default-from-email-address-now-also-u.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Changing the default 'from' email address now also updates existing automation emails with an unauthorized sender

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -42,6 +42,8 @@ class AuthorizedEmailsController {
     NewsletterEntity::TYPE_WELCOME,
     NewsletterEntity::TYPE_NOTIFICATION,
     NewsletterEntity::TYPE_AUTOMATIC,
+    NewsletterEntity::TYPE_AUTOMATION,
+    NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
   ];
 
   public function __construct(

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -146,6 +146,14 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::STATUS_ACTIVE);
   }
 
+  public function testItSetErrorForAutomationEmailUnauthorizedSender() {
+    $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+  }
+
+  public function testItSetErrorForAutomationTransactionalEmailUnauthorizedSender() {
+    $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_ACTIVE);
+  }
+
   public function testItResetErrorWhenAllSendersAreCorrect() {
     $this->newsletterFactory
       ->withSenderAddress('auth@email.com')


### PR DESCRIPTION
## Description

`TYPE_AUTOMATION` and `TYPE_AUTOMATION_TRANSACTIONAL` were missing from `$automaticEmailTypes` in `AuthorizedEmailsController`. This caused two problems:

1. `checkAuthorizedEmailAddresses()` never detected or reported authorization errors for automation emails
2. `setFromEmailAddress()` never updated automation newsletter entities when their sender became unauthorized

The fix adds the two missing types to `$automaticEmailTypes`, which is the same array used by both the validation check and the update loop.

## Code review notes

**Known limitation:** automation step args (the `sender_address` key in the step's JSON args) are not updated by this fix. If the user opens an automation in the editor and re-saves after a sender address change, `saveEmailSettings()` will copy the stale step args back to the newsletter entity, reverting the update. Fixing that would require injecting `AutomationStorage` and iterating all active automations — out of scope for this low-priority ticket. This matches the note in the original Linear issue: "I guess we need to clarify the specs here a bit."

## QA notes

1. Set up a MailPoet site using the MailPoet sending service
2. Create an automation with a "Send email" step using a specific from address
3. In MailPoet settings, change the default from address to a new authorized address, making the old one unauthorized
4. Verify that the automation's newsletter entity now uses the new sender address (previously it would remain on the old, unauthorized one)
5. Verify that `checkAuthorizedEmailAddresses()` now correctly reports unauthorized sender errors for automation emails

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7313

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=Fixed --description="..."`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Fixed:** 2

**Categories:**
- **Bug:** 2 issues
  - Authorization validation not detecting unauthorized senders in automation emails
  - Automation newsletter entities not updating when sender addresses become unauthorized

<!-- end of auto-generated comment: release notes by coderabbit.ai -->