### PR TITLE
Fix default scheduled time to use site local timezone

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -13,7 +13,8 @@ import { Field } from 'form/types';
 import { SendToFieldWithCount } from './send-to-field';
 
 const tomorrowLocalDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
-const tomorrowDateTime = MailPoet.Date.toGmtDatetimeString(tomorrowLocalDateTime);
+const tomorrowDateTime =
+  MailPoet.Date.toGmtDatetimeString(tomorrowLocalDateTime);
 const timeOfDayItems = window.mailpoet_schedule_time_of_day as unknown as {
   [key: string]: string;
 };

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -12,7 +12,8 @@ import { NewsLetter, NewsletterStatus } from 'common/newsletter';
 import { Field } from 'form/types';
 import { SendToFieldWithCount } from './send-to-field';
 
-const tomorrowDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
+const tomorrowLocalDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
+const tomorrowDateTime = MailPoet.Date.toGmtDatetimeString(tomorrowLocalDateTime);
 const timeOfDayItems = window.mailpoet_schedule_time_of_day as unknown as {
   [key: string]: string;
 };

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -13,8 +13,9 @@ import { Field } from 'form/types';
 import { SendToFieldWithCount } from './send-to-field';
 
 const tomorrowLocalDateTime = `${window.mailpoet_tomorrow_date} 08:00:00`;
-const tomorrowDateTime =
-  MailPoet.Date.toGmtDatetimeString(tomorrowLocalDateTime);
+const tomorrowDateTime = MailPoet.Date.toGmtDatetimeString(
+  tomorrowLocalDateTime,
+);
 const timeOfDayItems = window.mailpoet_schedule_time_of_day as unknown as {
   [key: string]: string;
 };

--- a/mailpoet/changelog/2026-03-29-13-10-04-fixed-default-scheduled-send-time-now-shows-800-am-in-th.md
+++ b/mailpoet/changelog/2026-03-29-13-10-04-fixed-default-scheduled-send-time-now-shows-800-am-in-th.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Default scheduled send time now shows 8:00 AM in the site's local timezone instead of 8:00 AM UTC


### PR DESCRIPTION
## Description

When creating a newsletter and choosing the "Schedule" sending option, the default date/time was auto-filled with "tomorrow at 8:00 AM" — but calculated in UTC. On a UTC-5 site, this rendered as 3:00 AM instead of 8:00 AM.

The fix converts the naive local-time string to its UTC equivalent via `MailPoet.Date.toGmtDatetimeString()` before passing it to `MailPoet.Date.datetimeString()`, which round-trips it back to the site's local time correctly for all offsets.

## Code review notes

_N/A_

## QA notes

1. Go to Newsletters → New newsletter → Standard newsletter
2. On the sending step, select "Schedule"
3. Verify the default time shown is 8:00 AM local time (not offset from UTC)
4. Repeat on a site with a non-UTC timezone (e.g. UTC-5, UTC+12) to confirm it always shows 8:00 AM

## Linked PRs

Supersedes https://github.com/mailpoet/mailpoet/pull/6582 (fork draft, can be closed)

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7358/fix-default-scheduled-time-to-consider-local-time-zone

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7358-default-scheduled-time-local-timezone)

_The latest successful build from `fix/stomail-7358-default-scheduled-time-local-timezone` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

The change correctly implements the timezone conversion fix by:
1. Creating a local datetime string combining `window.mailpoet_tomorrow_date` with `08:00:00`
2. Converting this local time to UTC via `MailPoet.Date.toGmtDatetimeString()`
3. Using this GMT datetime as the default, which is then round-tripped back to local time for display

The implementation properly addresses the stated bug where default scheduled times were computed in UTC instead of the site's local timezone. The code pattern is consistent with existing MailPoet date handling utilities and the scope is minimal (4 lines added, 1 removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->