### PR TITLE
Update the email categories

### DIFF
--- a/mailpoet/changelog/2026-03-30-match-prd-template-categories.md
+++ b/mailpoet/changelog/2026-03-30-match-prd-template-categories.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Register new email pattern categories (Sales announcements, Educational campaign, Events) and reassign patterns to match the PRD template categories for CIAB

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EducationalCampaignPattern.php
@@ -12,7 +12,7 @@ class EducationalCampaignPattern extends Pattern {
   protected $name = 'educational-campaign';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['newsletter'];
+  protected $categories = ['educational-campaign'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/EventInvitationPattern.php
@@ -12,7 +12,7 @@ class EventInvitationPattern extends Pattern {
   protected $name = 'event-invitation';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['newsletter'];
+  protected $categories = ['event'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewArrivalsAnnouncementPattern.php
@@ -12,7 +12,7 @@ class NewArrivalsAnnouncementPattern extends Pattern {
   protected $name = 'new-arrivals-announcement';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['newsletter'];
+  protected $categories = ['sales-announcement'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/NewProductsAnnouncementPattern.php
@@ -12,7 +12,7 @@ class NewProductsAnnouncementPattern extends Pattern {
   protected $name = 'new-products-announcement';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['newsletter'];
+  protected $categories = ['sales-announcement'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/Library/SaleAnnouncementPattern.php
@@ -12,7 +12,7 @@ class SaleAnnouncementPattern extends Pattern {
   protected $name = 'sale-announcement';
   protected $block_types = ['core/post-content']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
   protected $template_types = ['email-template']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-  protected $categories = ['newsletter'];
+  protected $categories = ['sales-announcement'];
   protected $post_types = [EmailEditor::MAILPOET_EMAIL_POST_TYPE]; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Patterns/PatternsController.php
@@ -199,6 +199,21 @@ class PatternsController {
   private function registerPatternCategories(): void {
     $categories = [
       [
+        'name' => 'sales-announcement',
+        'label' => _x('Sales announcements', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of sales announcement email layouts.', 'mailpoet'),
+      ],
+      [
+        'name' => 'educational-campaign',
+        'label' => _x('Educational campaign', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of educational campaign email layouts.', 'mailpoet'),
+      ],
+      [
+        'name' => 'event',
+        'label' => _x('Events', 'Block pattern category', 'mailpoet'),
+        'description' => __('A collection of event email layouts.', 'mailpoet'),
+      ],
+      [
         'name' => 'newsletter',
         'label' => _x('Newsletter', 'Block pattern category', 'mailpoet'),
         'description' => __('A collection of newsletter email layouts.', 'mailpoet'),

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/Patterns/PatternsControllerTest.php
@@ -66,6 +66,21 @@ class PatternsControllerTest extends \MailPoetTest {
     $patterns->registerPatterns();
     $registry = \WP_Block_Pattern_Categories_Registry::get_instance();
 
+    $salesAnnouncementCategory = $registry->get_registered('sales-announcement');
+    $this->assertIsArray($salesAnnouncementCategory);
+    $this->assertEquals('sales-announcement', $salesAnnouncementCategory['name']);
+    $this->assertNotEmpty($salesAnnouncementCategory['label']);
+
+    $educationalCampaignCategory = $registry->get_registered('educational-campaign');
+    $this->assertIsArray($educationalCampaignCategory);
+    $this->assertEquals('educational-campaign', $educationalCampaignCategory['name']);
+    $this->assertNotEmpty($educationalCampaignCategory['label']);
+
+    $eventCategory = $registry->get_registered('event');
+    $this->assertIsArray($eventCategory);
+    $this->assertEquals('event', $eventCategory['name']);
+    $this->assertNotEmpty($eventCategory['label']);
+
     $newsletterCategory = $registry->get_registered('newsletter');
     $this->assertIsArray($newsletterCategory);
     $this->assertEquals('newsletter', $newsletterCategory['name']);
@@ -203,11 +218,11 @@ class PatternsControllerTest extends \MailPoetTest {
     $registry = \WP_Block_Pattern_Categories_Registry::get_instance();
 
     // Should include non-WooCommerce categories
-    $newsletterCategory = $registry->get_registered('newsletter');
-    $this->assertIsArray($newsletterCategory);
-
-    $welcomeCategory = $registry->get_registered('welcome');
-    $this->assertIsArray($welcomeCategory);
+    $this->assertIsArray($registry->get_registered('sales-announcement'));
+    $this->assertIsArray($registry->get_registered('educational-campaign'));
+    $this->assertIsArray($registry->get_registered('event'));
+    $this->assertIsArray($registry->get_registered('newsletter'));
+    $this->assertIsArray($registry->get_registered('welcome'));
 
     // Should NOT include WooCommerce-dependent categories
     $purchaseCategory = $registry->get_registered('purchase');


### PR DESCRIPTION
## Description

In a certain environment, we want to update the email categories; we could make it so that the change is done only in the environment. But I guess that categories make sense, so I updated it in MailPoet as well.

Registers three new block pattern categories (`sales-announcement`, `educational-campaign`, `event`) and reassigns email patterns from the `newsletter` catch-all to their proper categories. 

**Pattern reassignments:**
- `SaleAnnouncementPattern`, `NewArrivalsAnnouncementPattern`, `NewProductsAnnouncementPattern` → `sales-announcement`
- `EducationalCampaignPattern` → `educational-campaign`
- `EventInvitationPattern` → `event`
- `NewsletterPattern`, `ProductRestockNotificationPattern` → remain in `newsletter`

## Code review notes

Straightforward category registration + pattern reassignment. The new categories use `_x()` with the existing `'Block pattern category'` context for translations.

## QA notes

1. Open the MailPoet email editor template picker
2. Verify the new categories appear: "Sales announcements", "Educational campaign", "Events"
3. Verify patterns are assigned to the correct categories

## Linked PRs

- https://github.a8c.com/Automattic/ciab-admin/pull/4168

## Linked tickets

- https://linear.app/a8c/issue/WOOPRD-3005/reduced-templates-in-garden-site-didnt-match-the-design

## After-merge notes

_N/A_

## Screenshots or screencast

<img width="783" height="570" alt="After-MailPoet" src="https://github.com/user-attachments/assets/cf59c9cc-813a-49ac-b2ba-121fc39a5fda" />


## Tasks

- [x] I have added a changelog entry
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->