### PR TITLE
Only run Playground GH action on PRs whose branch lives in main repo

### DIFF
--- a/.github/workflows/wordpress-playground-preview.yml
+++ b/.github/workflows/wordpress-playground-preview.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   add-wp-playground-link:
+    if: github.event.pull_request.head.repo.full_name == 'mailpoet/mailpoet'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

The reason is, that the action would otherwise fail to update the PR description

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7909

## After-merge notes

_N/A_

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7909-only-run-playground-action-for-main-repo-pr-branches)

_The latest successful build from `stomail-7909-only-run-playground-action-for-main-repo-pr-branches` will be used. If none is available, the link won't work._