### PR TITLE
Add new email design for stats notification emails (WOOPRD-3160)

### DIFF
--- a/mailpoet/changelog/2026-03-31-08-40-02-fixed-automation-stats-notification-email-not-including-.md
+++ b/mailpoet/changelog/2026-03-31-08-40-02-fixed-automation-stats-notification-email-not-including-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Automation stats notification email not including automation-type newsletters

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -15,6 +15,7 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\WP\DateTime as WpDateTime;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class AutomatedEmails extends SimpleWorker {
@@ -44,6 +45,9 @@ class AutomatedEmails extends SimpleWorker {
   /** @var WpDateTime */
   private $wpDateTime;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     MailerFactory $mailerFactory,
     Renderer $renderer,
@@ -51,7 +55,8 @@ class AutomatedEmails extends SimpleWorker {
     NewslettersRepository $repository,
     NewsletterStatisticsRepository $newsletterStatisticsRepository,
     MetaInfo $mailerMetaInfo,
-    TrackingConfig $trackingConfig
+    TrackingConfig $trackingConfig,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     parent::__construct();
     $this->mailerFactory = $mailerFactory;
@@ -61,6 +66,7 @@ class AutomatedEmails extends SimpleWorker {
     $this->repository = $repository;
     $this->newsletterStatisticsRepository = $newsletterStatisticsRepository;
     $this->trackingConfig = $trackingConfig;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
     $this->wpDateTime = new WpDateTime();
   }
 
@@ -92,7 +98,7 @@ class AutomatedEmails extends SimpleWorker {
         $extraParams = [
           'meta' => $this->mailerMetaInfo->getStatsNotificationMetaInfo(),
         ];
-        $this->mailerFactory->getDefaultMailer()->send($this->constructNewsletter($newsletters), $settings['address'], $extraParams);
+        $this->mailerFactory->getDefaultMailer()->send($this->constructNewsletter($newsletters, $settings), $settings['address'], $extraParams);
       }
     } catch (\Exception $e) {
       if (WP_DEBUG) {
@@ -105,10 +111,15 @@ class AutomatedEmails extends SimpleWorker {
   /**
    * @param array<int, array{newsletter: NewsletterEntity, statistics: NewsletterStatistics}> $newsletters
    */
-  private function constructNewsletter(array $newsletters): array {
-    $context = $this->prepareContext($newsletters);
+  private function constructNewsletter(array $newsletters, array $settings): array {
+    $context = $this->prepareContext($newsletters, $settings);
+    if ($this->dotcomHelperFunctions->isGarden()) {
+      $subject = __('Your monthly automation stats are in!', 'mailpoet');
+    } else {
+      $subject = __('Your monthly stats are in!', 'mailpoet');
+    }
     return [
-      'subject' => __('Your monthly stats are in!', 'mailpoet'),
+      'subject' => $subject,
       'body' => [
         'html' => $this->renderer->render('emails/statsNotificationAutomatedEmails.html', $context),
         'text' => $this->renderer->render('emails/statsNotificationAutomatedEmails.txt', $context),
@@ -122,7 +133,7 @@ class AutomatedEmails extends SimpleWorker {
   protected function getNewsletters(): array {
     $result = [];
     $newsletters = $this->repository->findActiveByTypes(
-      [NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::TYPE_WELCOME]
+      [NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::TYPE_WELCOME, NewsletterEntity::TYPE_AUTOMATION]
     );
     foreach ($newsletters as $newsletter) {
       $statistics = $this->newsletterStatisticsRepository->getStatistics($newsletter);
@@ -140,22 +151,25 @@ class AutomatedEmails extends SimpleWorker {
    * @param array<int, array{newsletter: NewsletterEntity, statistics: NewsletterStatistics}> $newsletters
    * @return array
    */
-  private function prepareContext(array $newsletters): array {
+  private function prepareContext(array $newsletters, array $settings = []): array {
     $context = [
       'linkSettings' => WPFunctions::get()->applyFilters(
         'mailpoet_stats_notification_link_settings',
         WPFunctions::get()->getSiteUrl(null, '/wp-admin/admin.php?page=mailpoet-settings#basics')
       ),
+      'blogName' => WPFunctions::get()->getBloginfo('name'),
+      'recipientFirstName' => $this->getRecipientFirstName($settings['address'] ?? ''),
       'newsletters' => [],
     ];
     foreach ($newsletters as $row) {
       $statistics = $row['statistics'];
       $newsletter = $row['newsletter'];
-      $clicked = ($statistics->getClickCount() * 100) / $statistics->getTotalSentCount();
-      $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();
-      $machineOpened = ($statistics->getMachineOpenCount() * 100) / $statistics->getTotalSentCount();
-      $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $statistics->getTotalSentCount();
-      $bounced = ($statistics->getBounceCount() * 100) / $statistics->getTotalSentCount();
+      $totalSentCount = $statistics->getTotalSentCount() ?: 1;
+      $clicked = ($statistics->getClickCount() * 100) / $totalSentCount;
+      $opened = ($statistics->getOpenCount() * 100) / $totalSentCount;
+      $machineOpened = ($statistics->getMachineOpenCount() * 100) / $totalSentCount;
+      $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $totalSentCount;
+      $bounced = ($statistics->getBounceCount() * 100) / $totalSentCount;
       $context['newsletters'][] = [
         'linkStats' => WPFunctions::get()->applyFilters(
           'mailpoet_stats_notification_link_stats',
@@ -171,6 +185,22 @@ class AutomatedEmails extends SimpleWorker {
       ];
     }
     return $context;
+  }
+
+  private function getRecipientFirstName(string $email): string {
+    if (empty($email)) {
+      return '';
+    }
+    $user = WPFunctions::get()->getUserBy('email', $email);
+    if (!$user) {
+      return '';
+    }
+    $firstName = $user->first_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    if (!empty($firstName)) {
+      return $firstName;
+    }
+    $displayName = $user->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    return !empty($displayName) ? $displayName : '';
   }
 
   public function getNextRunDate() {

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/AutomatedEmails.php
@@ -2,6 +2,9 @@
 
 namespace MailPoet\Cron\Workers\StatsNotifications;
 
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
 use MailPoet\Config\Renderer;
 use MailPoet\Cron\Workers\SimpleWorker;
 use MailPoet\Entities\NewsletterEntity;
@@ -48,6 +51,9 @@ class AutomatedEmails extends SimpleWorker {
   /** @var DotcomHelperFunctions */
   private $dotcomHelperFunctions;
 
+  /** @var AutomationStorage */
+  private $automationStorage;
+
   public function __construct(
     MailerFactory $mailerFactory,
     Renderer $renderer,
@@ -56,7 +62,8 @@ class AutomatedEmails extends SimpleWorker {
     NewsletterStatisticsRepository $newsletterStatisticsRepository,
     MetaInfo $mailerMetaInfo,
     TrackingConfig $trackingConfig,
-    DotcomHelperFunctions $dotcomHelperFunctions
+    DotcomHelperFunctions $dotcomHelperFunctions,
+    AutomationStorage $automationStorage
   ) {
     parent::__construct();
     $this->mailerFactory = $mailerFactory;
@@ -67,6 +74,7 @@ class AutomatedEmails extends SimpleWorker {
     $this->newsletterStatisticsRepository = $newsletterStatisticsRepository;
     $this->trackingConfig = $trackingConfig;
     $this->dotcomHelperFunctions = $dotcomHelperFunctions;
+    $this->automationStorage = $automationStorage;
     $this->wpDateTime = new WpDateTime();
   }
 
@@ -135,7 +143,14 @@ class AutomatedEmails extends SimpleWorker {
     $newsletters = $this->repository->findActiveByTypes(
       [NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::TYPE_WELCOME, NewsletterEntity::TYPE_AUTOMATION]
     );
+    $activeAutomationNewsletterIds = $this->getActiveAutomationNewsletterIds();
     foreach ($newsletters as $newsletter) {
+      if (
+        $newsletter->getType() === NewsletterEntity::TYPE_AUTOMATION
+        && !in_array($newsletter->getId(), $activeAutomationNewsletterIds, true)
+      ) {
+        continue;
+      }
       $statistics = $this->newsletterStatisticsRepository->getStatistics($newsletter);
       if ($statistics->getTotalSentCount()) {
         $result[] = [
@@ -145,6 +160,23 @@ class AutomatedEmails extends SimpleWorker {
       }
     }
     return $result;
+  }
+
+  /** @return int[] */
+  private function getActiveAutomationNewsletterIds(): array {
+    $ids = [];
+    $automations = $this->automationStorage->getAutomations([Automation::STATUS_ACTIVE]);
+    foreach ($automations as $automation) {
+      foreach ($automation->getSteps() as $step) {
+        if ($step->getKey() === SendEmailAction::KEY) {
+          $args = $step->getArgs();
+          if (isset($args['email_id'])) {
+            $ids[] = (int)$args['email_id'];
+          }
+        }
+      }
+    }
+    return $ids;
   }
 
   /**

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/Worker.php
@@ -17,6 +17,7 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
@@ -62,6 +63,9 @@ class Worker {
   /** @var ServicesChecker */
   private $servicesChecker;
 
+  /** @var DotcomHelperFunctions */
+  private $dotcomHelperFunctions;
+
   public function __construct(
     MailerFactory $mailerFactory,
     Renderer $renderer,
@@ -74,7 +78,8 @@ class Worker {
     EntityManager $entityManager,
     SubscribersFeature $subscribersFeature,
     SubscribersRepository $subscribersRepository,
-    ServicesChecker $servicesChecker
+    ServicesChecker $servicesChecker,
+    DotcomHelperFunctions $dotcomHelperFunctions
   ) {
     $this->renderer = $renderer;
     $this->mailerFactory = $mailerFactory;
@@ -88,6 +93,7 @@ class Worker {
     $this->subscribersFeature = $subscribersFeature;
     $this->subscribersRepository = $subscribersRepository;
     $this->servicesChecker = $servicesChecker;
+    $this->dotcomHelperFunctions = $dotcomHelperFunctions;
   }
 
   /** @throws \Exception */
@@ -101,7 +107,7 @@ class Worker {
         $extraParams = [
           'meta' => $this->mailerMetaInfo->getStatsNotificationMetaInfo(),
         ];
-        $this->mailerFactory->getDefaultMailer()->send($this->constructNewsletter($statsNotificationEntity), $settings['address'], $extraParams);
+        $this->mailerFactory->getDefaultMailer()->send($this->constructNewsletter($statsNotificationEntity, $settings), $settings['address'], $extraParams);
       } catch (\Exception $e) {
         if (WP_DEBUG) {
           throw $e;
@@ -116,7 +122,7 @@ class Worker {
     }
   }
 
-  private function constructNewsletter(StatsNotificationEntity $statsNotificationEntity) {
+  private function constructNewsletter(StatsNotificationEntity $statsNotificationEntity, array $settings) {
     $newsletter = $statsNotificationEntity->getNewsletter();
     if (!$newsletter instanceof NewsletterEntity) {
       throw new \RuntimeException('Missing newsletter entity for statistic notification.');
@@ -126,11 +132,17 @@ class Worker {
     if (!$sendingQueue instanceof SendingQueueEntity) {
       throw new \RuntimeException('Missing sending queue entity for statistic notification.');
     }
-    $context = $this->prepareContext($newsletter, $sendingQueue, $link);
+    $context = $this->prepareContext($newsletter, $sendingQueue, $link, $settings);
     $subject = $sendingQueue->getNewsletterRenderedSubject();
-    return [
+    if ($this->dotcomHelperFunctions->isGarden()) {
+      // translators: %s is the name of the email campaign.
+      $emailSubject = sprintf(__('Campaign performance summary: %s', 'mailpoet'), $subject);
+    } else {
       // translators: %s is the subject of the email.
-      'subject' => sprintf(_x('Stats for email %s', 'title of an automatic email containing statistics (newsletter open rate, click rate, etc)', 'mailpoet'), $subject),
+      $emailSubject = sprintf(_x('Stats for email %s', 'title of an automatic email containing statistics (newsletter open rate, click rate, etc)', 'mailpoet'), $subject);
+    }
+    return [
+      'subject' => $emailSubject,
       'body' => [
         'html' => $this->renderer->render('emails/statsNotification.html', $context),
         'text' => $this->renderer->render('emails/statsNotification.txt', $context),
@@ -138,13 +150,14 @@ class Worker {
     ];
   }
 
-  private function prepareContext(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue, ?NewsletterLinkEntity $link = null) {
+  private function prepareContext(NewsletterEntity $newsletter, SendingQueueEntity $sendingQueue, ?NewsletterLinkEntity $link = null, array $settings = []) {
     $statistics = $this->newsletterStatisticsRepository->getStatistics($newsletter);
-    $clicked = ($statistics->getClickCount() * 100) / $statistics->getTotalSentCount();
-    $opened = ($statistics->getOpenCount() * 100) / $statistics->getTotalSentCount();
-    $machineOpened = ($statistics->getMachineOpenCount() * 100) / $statistics->getTotalSentCount();
-    $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $statistics->getTotalSentCount();
-    $bounced = ($statistics->getBounceCount() * 100) / $statistics->getTotalSentCount();
+    $totalSentCount = $statistics->getTotalSentCount() ?: 1;
+    $clicked = ($statistics->getClickCount() * 100) / $totalSentCount;
+    $opened = ($statistics->getOpenCount() * 100) / $totalSentCount;
+    $machineOpened = ($statistics->getMachineOpenCount() * 100) / $totalSentCount;
+    $unsubscribed = ($statistics->getUnsubscribeCount() * 100) / $totalSentCount;
+    $bounced = ($statistics->getBounceCount() * 100) / $totalSentCount;
     $subject = $sendingQueue->getNewsletterRenderedSubject();
     $subscribersCount = $this->subscribersRepository->getTotalSubscribers();
     $hasValidApiKey = $this->subscribersFeature->hasValidApiKey();
@@ -188,7 +201,25 @@ class Worker {
       $mappings = self::getShortcodeLinksMapping();
       $context['topLink'] = isset($mappings[$link->getUrl()]) ? $mappings[$link->getUrl()] : $link->getUrl();
     }
+    $context['blogName'] = WPFunctions::get()->getBloginfo('name');
+    $context['recipientFirstName'] = $this->getRecipientFirstName($settings['address'] ?? '');
     return $context;
+  }
+
+  private function getRecipientFirstName(string $email): string {
+    if (empty($email)) {
+      return '';
+    }
+    $user = WPFunctions::get()->getUserBy('email', $email);
+    if (!$user) {
+      return '';
+    }
+    $firstName = $user->first_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    if (!empty($firstName)) {
+      return $firstName;
+    }
+    $displayName = $user->display_name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    return !empty($displayName) ? $displayName : '';
   }
 
   private function markTaskAsFinished(ScheduledTaskEntity $task) {

--- a/mailpoet/lib/Twig/Functions.php
+++ b/mailpoet/lib/Twig/Functions.php
@@ -198,6 +198,16 @@ class Functions extends AbstractExtension {
         ['is_safe' => ['all']]
       ),
       new TwigFunction(
+        'clicked_stats_text_garden',
+        [$this, 'clickedStatsTextGarden'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
+        'clicked_stats_badge_color',
+        [$this, 'clickedStatsBadgeColor'],
+        ['is_safe' => ['all']]
+      ),
+      new TwigFunction(
         'add_referral_id',
         [$this, 'addReferralId'],
         ['is_safe' => ['all']]
@@ -357,6 +367,30 @@ class Functions extends AbstractExtension {
       return __('Good', 'mailpoet');
     } else {
       return __('Average', 'mailpoet');
+    }
+  }
+
+  public function clickedStatsTextGarden($clicked) {
+    if ($clicked > 3) {
+      return __('Excellent', 'mailpoet');
+    } elseif ($clicked > 1) {
+      return __('Good', 'mailpoet');
+    } elseif ($clicked > 0) {
+      return __('Average', 'mailpoet');
+    } else {
+      return __('Poor', 'mailpoet');
+    }
+  }
+
+  public function clickedStatsBadgeColor($clicked) {
+    if ($clicked > 3) {
+      return '#C6E1C6'; // Stable (green) — Excellent
+    } elseif ($clicked > 1) {
+      return '#B5D4EF'; // Informational (blue) — Good
+    } elseif ($clicked > 0) {
+      return '#DCDCDE'; // Draft (gray) — Average
+    } else {
+      return '#F5E6AB'; // Medium (yellow) — Poor
     }
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -14,6 +14,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterLink as NewsletterLinkFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
@@ -217,6 +218,56 @@ class AutomatedEmailsTest extends \MailPoetTest {
 
     $this->createClicks($newsletter, 5);
     $this->createOpens($newsletter, 2);
+  }
+
+  public function testItIncludesAutomationNewsletterLinkedToActiveAutomation() {
+    $newsletter = $this->newsletterFactory
+      ->withSubject('Automation Email')
+      ->withAutomationType()
+      ->withActiveStatus()
+      ->withSendingQueue(['count_processed' => 10])
+      ->create();
+
+    (new AutomationFactory())
+      ->withStatusActive()
+      ->withSendEmailStep($newsletter)
+      ->create();
+
+    $this->createClicks($newsletter, 3);
+    $this->createOpens($newsletter, 2);
+
+    $this->renderer->expects($this->exactly(2))
+      ->method('render');
+
+    $this->mailer->expects($this->once())
+      ->method('send');
+
+    $result = $this->cronWorkerRunner->run($this->statsNotifications);
+
+    verify($result)->equals(true);
+  }
+
+  public function testItExcludesOrphanedAutomationNewsletter() {
+    // TYPE_AUTOMATION newsletter that is not referenced by any active automation
+    $newsletter = $this->newsletterFactory
+      ->withSubject('Orphaned Automation Email')
+      ->withAutomationType()
+      ->withActiveStatus()
+      ->withSendingQueue(['count_processed' => 10])
+      ->create();
+
+    $this->createClicks($newsletter, 3);
+    $this->createOpens($newsletter, 2);
+
+    $this->renderer->expects($this->never())
+      ->method('render');
+
+    $this->mailer->expects($this->never())
+      ->method('send');
+
+    $result = $this->cronWorkerRunner->run($this->statsNotifications);
+
+    verify($result)->equals(true);
   }
 
   public function testItGeneratesRandomNextRunDate() {

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/AutomatedEmailsTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Cron\Workers\StatsNotifications;
 
 use Codeception\Stub;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Config\Renderer;
 use MailPoet\Cron\CronWorkerRunner;
 use MailPoet\Entities\NewsletterEntity;
@@ -19,6 +20,7 @@ use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\StatisticsClicks as StatisticsClicksFactory;
 use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -65,7 +67,9 @@ class AutomatedEmailsTest extends \MailPoetTest {
       $this->diContainer->get(NewslettersRepository::class),
       $this->diContainer->get(NewsletterStatisticsRepository::class),
       new MetaInfo,
-      $this->diContainer->get(TrackingConfig::class)
+      $this->diContainer->get(TrackingConfig::class),
+      $this->diContainer->get(DotcomHelperFunctions::class),
+      $this->diContainer->get(AutomationStorage::class)
     );
     $this->cronWorkerRunner = Stub::copy($this->diContainer->get(CronWorkerRunner::class), [
       'timer' => microtime(true), // reset timer to avoid timeout during full test suite run

--- a/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatsNotifications/WorkerTest.php
@@ -27,6 +27,7 @@ use MailPoet\Test\DataFactories\StatisticsOpens as StatisticsOpensFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WPCOM\DotcomHelperFunctions;
 use MailPoetVendor\Carbon\Carbon;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -100,7 +101,8 @@ class WorkerTest extends \MailPoetTest {
       $this->entityManager,
       $this->diContainer->get(SubscribersFeature::class),
       $this->diContainer->get(SubscribersRepository::class),
-      $this->diContainer->get(ServicesChecker::class)
+      $this->diContainer->get(ServicesChecker::class),
+      $this->diContainer->get(DotcomHelperFunctions::class)
     );
     $this->settings->set(Worker::SETTINGS_KEY, [
       'enabled' => true,

--- a/mailpoet/tests/unit/Twig/FunctionsTest.php
+++ b/mailpoet/tests/unit/Twig/FunctionsTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Twig;
+
+use MailPoet\Twig\Functions;
+
+class FunctionsTest extends \MailPoetUnitTest {
+
+  /** @var Functions */
+  private $functions;
+
+  public function _before() {
+    parent::_before();
+    $this->functions = new Functions();
+  }
+
+  // clickedStatsTextGarden
+
+  public function testClickedStatsTextGardenReturnsPoorForZero() {
+    verify($this->functions->clickedStatsTextGarden(0))->equals('Poor');
+  }
+
+  public function testClickedStatsTextGardenReturnsPoorForNegative() {
+    verify($this->functions->clickedStatsTextGarden(-1))->equals('Poor');
+  }
+
+  public function testClickedStatsTextGardenReturnsAverageForAboveZero() {
+    verify($this->functions->clickedStatsTextGarden(0.1))->equals('Average');
+  }
+
+  public function testClickedStatsTextGardenReturnsAverageAtOneBoundary() {
+    verify($this->functions->clickedStatsTextGarden(1))->equals('Average');
+  }
+
+  public function testClickedStatsTextGardenReturnsGoodAboveOne() {
+    verify($this->functions->clickedStatsTextGarden(1.1))->equals('Good');
+  }
+
+  public function testClickedStatsTextGardenReturnsGoodAtThreeBoundary() {
+    verify($this->functions->clickedStatsTextGarden(3))->equals('Good');
+  }
+
+  public function testClickedStatsTextGardenReturnsExcellentAboveThree() {
+    verify($this->functions->clickedStatsTextGarden(3.1))->equals('Excellent');
+  }
+
+  // clickedStatsBadgeColor
+
+  public function testClickedStatsBadgeColorReturnsPoorColorForZero() {
+    verify($this->functions->clickedStatsBadgeColor(0))->equals('#F5E6AB');
+  }
+
+  public function testClickedStatsBadgeColorReturnsPoorColorForNegative() {
+    verify($this->functions->clickedStatsBadgeColor(-5))->equals('#F5E6AB');
+  }
+
+  public function testClickedStatsBadgeColorReturnsAverageColorForAboveZero() {
+    verify($this->functions->clickedStatsBadgeColor(0.5))->equals('#DCDCDE');
+  }
+
+  public function testClickedStatsBadgeColorReturnsAverageColorAtOneBoundary() {
+    verify($this->functions->clickedStatsBadgeColor(1))->equals('#DCDCDE');
+  }
+
+  public function testClickedStatsBadgeColorReturnsGoodColorAboveOne() {
+    verify($this->functions->clickedStatsBadgeColor(2))->equals('#B5D4EF');
+  }
+
+  public function testClickedStatsBadgeColorReturnsGoodColorAtThreeBoundary() {
+    verify($this->functions->clickedStatsBadgeColor(3))->equals('#B5D4EF');
+  }
+
+  public function testClickedStatsBadgeColorReturnsExcellentColorAboveThree() {
+    verify($this->functions->clickedStatsBadgeColor(4))->equals('#C6E1C6');
+  }
+}

--- a/mailpoet/views/emails/statsNotification.html
+++ b/mailpoet/views/emails/statsNotification.html
@@ -1,6 +1,9 @@
 <% extends 'emails/statsNotificationLayout.html' %>
 
 <% block content %>
+<% if is_garden() %>
+  <%- include 'emails/statsNotificationGarden.html' -%>
+<% else %>
   <tr>
     <td class="mailpoet_content" align="center" style="border-collapse:collapse">
       <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
@@ -12,13 +15,11 @@
               <tr>
                 <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
               </tr>
-              <% if not is_garden() %>
               <tr>
                 <td class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="center" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:20px;padding-right:20px">
                   <img src="<%= cdn_url('logo-orange-400x122.png') %>" width="80" alt="new_logo_orange" style="height:auto;max-width:100%;-ms-interpolation-mode:bicubic;border:0;display:block;outline:none;text-align:center"/>
                 </td>
               </tr>
-              <% endif %>
               <tr>
                 <td class="mailpoet_spacer" height="26" valign="top" style="border-collapse:collapse"></td>
               </tr>
@@ -476,7 +477,7 @@
                     <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                       <tr>
                         <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
-                          <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:<%= is_garden() ? '#333333' : '#fe5301' %> ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:288px ;line-height:50px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:20px ;font-weight:normal ">
+                          <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#fe5301 ;border-color:#0074a2 ;border-width:0px ;border-radius:3px ;border-style:solid ;width:288px ;line-height:50px ;color:#ffffff ;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif ;font-size:20px ;font-weight:normal ">
                             <%= __('View all stats') %>
                           </a>
                         </td>
@@ -496,4 +497,5 @@
       </table>
     </td>
   </tr>
+<% endif %>
 <% endblock %>

--- a/mailpoet/views/emails/statsNotification.txt
+++ b/mailpoet/views/emails/statsNotification.txt
@@ -1,6 +1,25 @@
 <% extends 'emails/statsNotificationLayout.txt' %>
 
 <% block content %>
+<% if is_garden() %>
+<%= blogName %>
+
+<%= __('Your campaign stats') %>
+
+<% if recipientFirstName %><%= __('Hi %s,')|replace({'%s': recipientFirstName}) %>
+
+<% endif %>
+<%= __('Here\'s how your campaign "%s" performed in the first 24 hours.')|replace({'%s': subject}) %>
+
+<%= __('Clicked') %>: <%= stats_number_format_i18n(clicked) %>% (<%= clicked_stats_text_garden(clicked) %>)
+<%= __('Opened') %>: <%= stats_number_format_i18n(opened) %>%
+<%= __('Machine-opened') %>: <%= stats_number_format_i18n(machineOpened) %>%
+<%= __('Unsubscribed') %>: <%= stats_number_format_i18n(unsubscribed) %>%
+<%= __('Bounced') %>: <%= stats_number_format_i18n(bounced) %>%
+
+<%= __('View full campaign report') %>
+  <%= linkStats|raw %>
+<% else %>
 <%= __('Your stats are in!') %>
 
 <%= subject %>
@@ -39,5 +58,5 @@
 
 <%= __('View all stats') %>
   <%= linkStats|raw %>
-
+<% endif %>
 <% endblock %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.html
@@ -1,7 +1,9 @@
 <% extends 'emails/statsNotificationLayout.html' %>
 
 <% block content %>
-
+<% if is_garden() %>
+  <%- include 'emails/statsNotificationAutomatedEmailsGarden.html' -%>
+<% else %>
 <tr>
   <td class="mailpoet_content" align="center" style="border-collapse:collapse">
     <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
@@ -282,5 +284,5 @@
 <tr>
   <td class="mailpoet_spacer" height="55" valign="top" style="border-collapse:collapse"></td>
 </tr>
-
+<% endif %>
 <% endblock %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmails.txt
@@ -1,7 +1,31 @@
 <% extends 'emails/statsNotificationLayout.txt' %>
 
 <% block content %>
+<% if is_garden() %>
+<%= blogName %>
 
+<%= __('Your monthly automation stats') %>
+
+<% if recipientFirstName %><%= __('Hi %s,')|replace({'%s': recipientFirstName}) %>
+
+<% endif %>
+<%= __('Here\'s a summary of how your active automations performed this month.') %>
+
+<% for newsletter in newsletters %>
+------------------------------------------
+<%= newsletter.subject %>
+
+<%= __('Clicked') %>: <%= stats_number_format_i18n(newsletter.clicked) %>% (<%= clicked_stats_text_garden(newsletter.clicked) %>)
+<%= __('Opened') %>: <%= stats_number_format_i18n(newsletter.opened) %>%
+<%= __('Machine-opened') %>: <%= stats_number_format_i18n(newsletter.machineOpened) %>%
+<%= __('Unsubscribed') %>: <%= stats_number_format_i18n(newsletter.unsubscribed) %>%
+<%= __('Bounced') %>: <%= stats_number_format_i18n(newsletter.bounced) %>%
+
+<%= __('View automation report') %>
+  <%= newsletter.linkStats|raw %>
+<% endfor %>
+------------------------------------------
+<% else %>
 <%= __('Your monthly stats are in!') %>
 
 <% for newsletter in newsletters %>
@@ -16,4 +40,5 @@
     <%= newsletter.linkStats|raw %>
 <% endfor %>
 ------------------------------------------
+<% endif %>
 <% endblock %>

--- a/mailpoet/views/emails/statsNotificationAutomatedEmailsGarden.html
+++ b/mailpoet/views/emails/statsNotificationAutomatedEmailsGarden.html
@@ -1,0 +1,335 @@
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:12px;line-height:16px;text-transform:uppercase;letter-spacing:0.5px">
+                  <%= blogName %>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <h1 style="text-align:left;padding:0;font-style:normal;font-weight:bold;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:28px;line-height:36px">
+                  <%= __('Your monthly automation stats') %>
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <% if recipientFirstName %>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px;padding-bottom:24px;">
+                <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                  <%= __('Hi %s,')|replace({'%s': recipientFirstName}) %>
+                </p>
+              </td>
+            </tr>
+            <% endif %>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                  <%= __('Here\'s a summary of how your active automations performed this month.') %>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="32" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+
+<% for newsletter in newsletters %>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_divider" valign="top" style="border-collapse:collapse;padding:0 48px 24px 48px">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                  <tr>
+                    <td class="mailpoet_divider-cell" style="border-collapse:collapse;border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8"></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <h2 style="text-align:left;padding:0;font-style:normal;font-weight:bold;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:22px;line-height:28px">
+                  <%= newsletter.subject %>
+                </h2>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                  <%= __('Clicked') %>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <table cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                  <tr>
+                    <td valign="middle" style="border-collapse:collapse;padding-right:8px">
+                      <span style="font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;color:#1e1e1e;line-height:32px">
+                        <%= stats_number_format_i18n(newsletter.clicked) %>%
+                      </span>
+                    </td>
+                    <td valign="middle" style="border-collapse:collapse">
+                      <span style="display:inline-block;background-color:<%= clicked_stats_badge_color(newsletter.clicked) %>;border-radius:4px;padding:2px 10px;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;color:#1e1e1e">
+                        <%= clicked_stats_text_garden(newsletter.clicked) %>
+                      </span>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td align="center" style="font-size:0;border-collapse:collapse">
+          <!--[if mso]>
+          <table border="0" width="100%" cellpadding="0" cellspacing="0">
+            <tbody>
+            <tr>
+              <td width="330" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+            <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Opened') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(newsletter.opened) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          <td width="330" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+            <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Machine-opened') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(newsletter.machineOpened) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          </tr>
+          </tbody>
+          </table>
+          <![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+</tr>
+<tr>
+  <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td align="center" style="font-size:0;border-collapse:collapse">
+          <!--[if mso]>
+          <table border="0" width="100%" cellpadding="0" cellspacing="0">
+            <tbody>
+            <tr>
+              <td width="330" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+            <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Unsubscribed') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(newsletter.unsubscribed) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          <td width="330" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:330px; vertical-align:top; width:100%;">
+            <table width="330" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:330px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Bounced') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(newsletter.bounced) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          </tr>
+          </tbody>
+          </table>
+          <![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+</tr>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:48px;padding-right:48px">
+                <div>
+                  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                    <tr>
+                      <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
+                        <a class="mailpoet_button" href="<%= newsletter.linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#1e1e1e;border-width:0px;border-radius:4px;border-style:solid;width:100%;max-width:564px;line-height:42px;color:#ffffff;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:16px;font-weight:normal;box-sizing:border-box">
+                          <%= __('View automation report') %>
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="10" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<% endfor %>
+
+<tr>
+  <td class="mailpoet_spacer" height="20" valign="top" style="border-collapse:collapse"></td>
+</tr>

--- a/mailpoet/views/emails/statsNotificationGarden.html
+++ b/mailpoet/views/emails/statsNotificationGarden.html
@@ -1,0 +1,291 @@
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:12px;line-height:16px;text-transform:uppercase;letter-spacing:0.5px">
+                  <%= blogName %>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="36" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <h1 style="text-align:left;padding:0;font-style:normal;font-weight:bold;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:28px;line-height:36px">
+                  <%= __('Your campaign stats') %>
+                </h1>
+              </td>
+            </tr>
+
+            <% if recipientFirstName %>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px;padding-bottom:24px;padding-top:12px;">
+                <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                  <%= __('Hi %s,')|replace({'%s': recipientFirstName}) %>
+                </p>
+              </td>
+            </tr>
+            <% endif %>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px;">
+                <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                  <%= __('Here\'s how your campaign "%s" performed in the first 24 hours.')|replace({'%s': subject}) %>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="32" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                  <%= __('Clicked') %>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;padding-left:48px;padding-right:48px">
+                <table cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                  <tr>
+                    <td valign="middle" style="border-collapse:collapse;padding-right:8px">
+                      <span style="font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;color:#1e1e1e;line-height:32px">
+                        <%= stats_number_format_i18n(clicked) %>%
+                      </span>
+                    </td>
+                    <td valign="middle" style="border-collapse:collapse">
+                      <span style="display:inline-block;background-color:<%= clicked_stats_badge_color(clicked) %>;border-radius:4px;padding:2px 10px;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px;color:#1e1e1e">
+                        <%= clicked_stats_text_garden(clicked) %>
+                      </span>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td align="center" style="font-size:0;border-collapse:collapse">
+          <!--[if mso]>
+          <table border="0" width="100%" cellpadding="0" cellspacing="0">
+            <tbody>
+            <tr>
+              <td width="282" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:282px; vertical-align:top; width:100%;">
+            <table width="282" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:282px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Opened') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(opened) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          <td width="282" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:282px; vertical-align:top; width:100%;">
+            <table width="282" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:282px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Machine-opened') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(machineOpened) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          </tr>
+          </tbody>
+          </table>
+          <![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+</tr>
+<tr>
+  <td class="mailpoet_content-cols-two" align="left" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td align="center" style="font-size:0;border-collapse:collapse">
+          <!--[if mso]>
+          <table border="0" width="100%" cellpadding="0" cellspacing="0">
+            <tbody>
+            <tr>
+              <td width="282" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:282px; vertical-align:top; width:100%;">
+            <table width="282" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:282px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Unsubscribed') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(unsubscribed) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          <td width="282" valign="top">
+          <![endif]-->
+          <div style="display:inline-block; max-width:282px; vertical-align:top; width:100%;">
+            <table width="282" class="mailpoet_cols-two" border="0" cellpadding="0" cellspacing="0" align="left" style="width:100%;max-width:282px;border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+              <tbody>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#666666;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:16px;line-height:24px">
+                    <%= __('Bounced') %>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td class="mailpoet_spacer" height="8" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td class="mailpoet_text mailpoet_padded_side" valign="top" style="word-break:break-word;word-wrap:break-word;border-collapse:collapse;">
+                  <p style="text-align:left;padding:0;margin:0;color:#1e1e1e;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:24px;font-weight:bold;line-height:32px">
+                    <%= stats_number_format_i18n(bounced) %>%
+                  </p>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso]>
+          </td>
+          </tr>
+          </tbody>
+          </table>
+          <![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
+<tr>
+  <td class="mailpoet_content" align="center" style="border-collapse:collapse">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+      <tbody>
+      <tr>
+        <td style="padding-left:0;padding-right:0;border-collapse:collapse">
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" class="mailpoet_cols-one" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;table-layout:fixed;margin-left:auto;margin-right:auto;padding-left:0;padding-right:0;border-collapse:collapse">
+            <tbody>
+            <tr>
+              <td class="mailpoet_spacer" height="48" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            <tr>
+              <td class="mailpoet_padded_side" valign="top" style="border-collapse:collapse;padding-bottom:20px;padding-left:48px;padding-right:48px">
+                <div>
+                  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
+                    <tr>
+                      <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
+                        <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#1e1e1e;border-width:0px;border-radius:4px;border-style:solid;width:100%;max-width:564px;line-height:50px;color:#ffffff;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:16px;font-weight:normal;box-sizing:border-box">
+                          <%= __('View full campaign report') %>
+                        </a>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td class="mailpoet_spacer" height="10" valign="top" style="border-collapse:collapse"></td>
+            </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>

--- a/mailpoet/views/emails/statsNotificationGarden.html
+++ b/mailpoet/views/emails/statsNotificationGarden.html
@@ -269,7 +269,7 @@
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
                     <tr>
                       <td class="mailpoet_button-container" style="text-align:center;border-collapse:collapse">
-                        <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#1e1e1e;border-width:0px;border-radius:4px;border-style:solid;width:100%;max-width:564px;line-height:50px;color:#ffffff;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:16px;font-weight:normal;box-sizing:border-box">
+                        <a class="mailpoet_button" href="<%= linkStats %>" style="display:inline-block;-webkit-text-size-adjust:none;mso-hide:all;text-decoration:none;text-align:center;background-color:#1e1e1e;border-width:0px;border-radius:4px;border-style:solid;width:100%;max-width:564px;line-height:42px;color:#ffffff;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;font-size:16px;font-weight:normal;box-sizing:border-box">
                           <%= __('View full campaign report') %>
                         </a>
                       </td>

--- a/mailpoet/views/emails/statsNotificationLayout.html
+++ b/mailpoet/views/emails/statsNotificationLayout.html
@@ -35,12 +35,12 @@
     <% endif %>
   </tr>
   <tr>
-    <td align="center" class="mailpoet-wrapper" valign="top" style="border-collapse:collapse;background-color:#f0f0f0"><!--[if mso]>
+    <td align="center" class="mailpoet-wrapper" valign="top" style="border-collapse:collapse;background-color:#f0f0f0<% if is_garden() %>;padding-top:24px;padding-bottom:24px<% endif %>"><!--[if mso]>
       <table align="center" border="0" cellspacing="0" cellpadding="0"
              width="660">
         <tr>
           <td class="mailpoet_content-wrapper" align="center" valign="top" width="660">
-      <![endif]--><table class="mailpoet_content-wrapper" border="0" width="660" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;max-width:660px;width:100%;border-collapse:collapse;background-color:#ffffff">
+      <![endif]--><table class="mailpoet_content-wrapper" border="0" width="660" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;max-width:660px;width:100%;border-collapse:collapse;background-color:#ffffff<% if is_garden() %>;border-radius:8px;overflow:hidden<% endif %>">
         <tbody>
 
         <% block content %><% endblock %>
@@ -127,18 +127,17 @@
             <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
               <tbody>
               <tr>
-                <td style="padding:20px;border-collapse:collapse">
-                  <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0;border-collapse:collapse">
-                    <tr>
-                      <td class="mailpoet_divider-cell" style="border-top-width:1px;border-top-style:solid;border-top-color:#e8e8e8;border-collapse:collapse"></td>
-                    </tr>
-                  </table>
+                <td class="mailpoet_spacer" height="20" valign="top" style="border-collapse:collapse"></td>
+              </tr>
+              <tr>
+                <td style="padding:0 20px;text-align:center;border-collapse:collapse;color:#999999;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px">
+                  &copy; <%= blogName %>. <%= __('All Rights Reserved.') %>
                 </td>
               </tr>
               <tr>
-                <td style="padding:0 20px 20px;text-align:center;border-collapse:collapse;color:#999999;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px">
-                  <a href="<%= linkSettings %>" style="color:#999999;text-decoration:underline">
-                    <%= __('Disable these emails') %>
+                <td style="padding:4px 20px 20px;text-align:center;border-collapse:collapse;color:#999999;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:13px;line-height:20px">
+                  <a href="<%= linkSettings %>" style="color:#1e1e1e;text-decoration:underline">
+                    <%= __('Manage email preference') %>
                   </a>
                 </td>
               </tr>

--- a/mailpoet/views/emails/statsNotificationLayout.txt
+++ b/mailpoet/views/emails/statsNotificationLayout.txt
@@ -1,7 +1,10 @@
 <% block content %><% endblock %>
 
-<% if not is_garden() %>
+<% if is_garden() %>
+&copy; <%= blogName %>. <%= __('All Rights Reserved.') %>
+<%= __('Manage email preference') %> <%= linkSettings|raw %>
+<% else %>
 <%= __('How to improve my open rate?') %> https://www.mailpoet.com/how-to-improve-open-rates/
 <%= __('And my click rate?') %> https://www.mailpoet.com/how-to-improve-click-rates/
-<% endif %>
 <%= __('Disable these emails') %> <%= linkSettings|raw %>
+<% endif %>


### PR DESCRIPTION
## Description

Adds a new email design for campaign and automation stats notification emails shown in a specific environment, gated by an environment flag (existing templates are untouched for all other environments).

Also fixes two automation stats email bugs:
- `TYPE_AUTOMATION` newsletters were excluded from the stats query — the worker only queried legacy `TYPE_AUTOMATIC` and `TYPE_WELCOME`
- Orphaned `TYPE_AUTOMATION` newsletters (parent automation deleted, email still in DB) appeared in stats — now only newsletters actively referenced in an active automation's send-email step are included
- Division-by-zero guard added to both workers when `getTotalSentCount()` is 0

## Code review notes

`AutomationStorage` is injected into `AutomatedEmails` to walk active automation steps and collect valid newsletter IDs; the filter runs in `getNewsletters()` after the DB query.

## QA notes

### Campaign stats email

1. Create a newsletter, add at least one subscriber to its list, and send it.
2. Open the sent email in Mailhog and click a link to generate open/click stats.
3. Force the scheduled task to run:
   ```sql
   UPDATE wp_mailpoet_scheduled_tasks
   SET scheduled_at = '2020-01-01 00:00:00', status = NULL
   WHERE type = 'stats_notification';
   ```
4. Verify the new layout: store name header, left-aligned stats, Clicked badge, "View full campaign report" button, merchant footer.

### Automation stats email

1. Go to **MailPoet → Automations → New**, add a **Send Email** step with a newsletter, and activate the automation.
2. Trigger the automation for at least one subscriber so stats are recorded.
3. Force the scheduled task to run:
   ```sql
   UPDATE wp_mailpoet_scheduled_tasks
   SET scheduled_at = '2020-01-01 00:00:00', status = NULL
   WHERE type = 'stats_notification_automated_emails';
   ```
4. Verify: per-automation sections with name, left-aligned stats, Clicked badge, individual "View automation report" buttons, merchant footer.

## Linked PRs

_N/A_

## Linked tickets

closes WOOPRD-3160

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/wooprd-3160-ciab-stats-email-templates)

_The latest successful build from `update/wooprd-3160-ciab-stats-email-templates` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->