### PR TITLE
Include automation emails in authorized sender validation

### DIFF
--- a/mailpoet/changelog/2026-03-29-14-46-13-fixed-changing-the-default-from-email-address-now-also-u.md
+++ b/mailpoet/changelog/2026-03-29-14-46-13-fixed-changing-the-default-from-email-address-now-also-u.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Changing the default 'from' email address now also updates existing automation emails with an unauthorized sender

--- a/mailpoet/lib/Services/AuthorizedEmailsController.php
+++ b/mailpoet/lib/Services/AuthorizedEmailsController.php
@@ -42,6 +42,8 @@ class AuthorizedEmailsController {
     NewsletterEntity::TYPE_WELCOME,
     NewsletterEntity::TYPE_NOTIFICATION,
     NewsletterEntity::TYPE_AUTOMATIC,
+    NewsletterEntity::TYPE_AUTOMATION,
+    NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
   ];
 
   public function __construct(

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -150,6 +150,9 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
   }
 
+  /**
+   * @group woo
+   */
   public function testItSetErrorForAutomationTransactionalEmailUnauthorizedSender() {
     $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_ACTIVE);
   }

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -146,6 +146,14 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATIC, NewsletterEntity::STATUS_ACTIVE);
   }
 
+  public function testItSetErrorForAutomationEmailUnauthorizedSender() {
+    $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+  }
+
+  public function testItSetErrorForAutomationTransactionalEmailUnauthorizedSender() {
+    $this->checkUnauthorizedInNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_ACTIVE);
+  }
+
   public function testItResetErrorWhenAllSendersAreCorrect() {
     $this->newsletterFactory
       ->withSenderAddress('auth@email.com')


### PR DESCRIPTION
## Description

`TYPE_AUTOMATION` and `TYPE_AUTOMATION_TRANSACTIONAL` were missing from `$automaticEmailTypes` in `AuthorizedEmailsController`. This caused two problems:

1. `checkAuthorizedEmailAddresses()` never detected or reported authorization errors for automation emails
2. `setFromEmailAddress()` never updated automation newsletter entities when their sender became unauthorized

The fix adds the two missing types to `$automaticEmailTypes`, which is the same array used by both the validation check and the update loop.

## Code review notes

**Known limitation:** automation step args (the `sender_address` key in the step's JSON args) are not updated by this fix. If the user opens an automation in the editor and re-saves after a sender address change, `saveEmailSettings()` will copy the stale step args back to the newsletter entity, reverting the update. Fixing that would require injecting `AutomationStorage` and iterating all active automations — out of scope for this low-priority ticket. This matches the note in the original Linear issue: "I guess we need to clarify the specs here a bit."

## QA notes

1. Set up a MailPoet site using the MailPoet sending service
2. Create an automation with a "Send email" step using a specific from address
3. In MailPoet settings, change the default from address to a new authorized address, making the old one unauthorized
4. Verify that the automation's newsletter entity now uses the new sender address (previously it would remain on the old, unauthorized one)
5. Verify that `checkAuthorizedEmailAddresses()` now correctly reports unauthorized sender errors for automation emails

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7313

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=Fixed --description="..."`)
- [x] I added sufficient test coverage

---

_Replaces #6583 — branch moved from fork to main repo as requested by @NeosinneR._

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7313-from-email-change-not-updating-automations)

_The latest successful build from `fix/stomail-7313-from-email-change-not-updating-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found

**1 Bug:**
- An existing integration test started failing after the change (reported in PR comments). This indicates a regression that needs investigation/fix before merge.

**1 Suggestion / Known limitation:**
- Automation step args (the `sender_address` key in step JSON) are not updated by this change; re-opening and saving an automation can revert the update. Addressing this requires injecting `AutomationStorage` and iterating active automations (out of scope for this PR).

**Fix Applied (from PR):**
- Added `TYPE_AUTOMATION` and `TYPE_AUTOMATION_TRANSACTIONAL` to the `$automaticEmailTypes` array in `AuthorizedEmailsController` to include automation newsletters in authorized-sender validation and sender updates.

**Test Coverage:**
- Added two integration tests verifying unauthorized-sender detection for both automation email types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->