### PR TITLE
Add WooCommerce Bookings automation template stubs [STOMAIL-7497]

### DIFF
--- a/mailpoet/changelog/2026-03-31-12-38-31-added-automation-templates-for-woocommerce-bookings.md
+++ b/mailpoet/changelog/2026-03-31-12-38-31-added-automation-templates-for-woocommerce-bookings.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Automation templates for WooCommerce Bookings

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\AutomationTemplate;
 use MailPoet\Automation\Engine\Templates\AutomationBuilder;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
 use MailPoet\Config\Env;
+use MailPoet\WooCommerce\WooCommerceBookings\Helper as WooCommerceBookingsHelper;
 use MailPoet\WooCommerce\WooCommerceSubscriptions\Helper as WooCommerceSubscriptions;
 
 class TemplatesFactory {
@@ -23,16 +24,21 @@ class TemplatesFactory {
   /** @phpstan-ignore-next-line Property is reserved for future use */
   private $emailFactory;
 
+  /** @var WooCommerceBookingsHelper */
+  private $woocommerceBookingsHelper;
+
   public function __construct(
     AutomationBuilder $builder,
     WooCommerce $woocommerce,
     WooCommerceSubscriptions $woocommerceSubscriptions,
-    EmailFactory $emailFactory
+    EmailFactory $emailFactory,
+    WooCommerceBookingsHelper $woocommerceBookingsHelper
   ) {
     $this->builder = $builder;
     $this->woocommerce = $woocommerce;
     $this->woocommerceSubscriptions = $woocommerceSubscriptions;
     $this->emailFactory = $emailFactory;
+    $this->woocommerceBookingsHelper = $woocommerceBookingsHelper;
   }
 
   public function createTemplates(): array {
@@ -62,6 +68,14 @@ class TemplatesFactory {
         $templates[] = $this->createFollowUpOnChurnedSubscriptionTemplate();
         $templates[] = $this->createFollowUpWhenTrialEndsTemplate();
         $templates[] = $this->createWinBackChurnedSubscribersTemplate();
+      }
+      if ($this->woocommerceBookingsHelper->isWooCommerceBookingsActive()) {
+        $templates[] = $this->createWcBookingAbandonedSpotTemplate();
+        $templates[] = $this->createWcBookingNewBookingFollowUpTemplate();
+        $templates[] = $this->createWcBookingPreVisitReminderTemplate();
+        $templates[] = $this->createWcBookingPreVisitDripTemplate();
+        $templates[] = $this->createWcBookingPostVisitReviewTemplate();
+        $templates[] = $this->createWcBookingNextBookingNudgeTemplate();
       }
     }
 
@@ -636,6 +650,144 @@ class TemplatesFactory {
       ],
       AutomationTemplate::TYPE_PREMIUM,
       'payment'
+    );
+  }
+
+  private function createWcBookingAbandonedSpotTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'wc-booking-abandoned-spot',
+      'bookings',
+      __('Abandoned booking reminder', 'mailpoet'),
+      __(
+        'Remind customers who left a booking in their cart to complete their reservation.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Abandoned booking reminder', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'calendar'
+    );
+  }
+
+  private function createWcBookingNewBookingFollowUpTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'wc-booking-new-booking-follow-up',
+      'bookings',
+      __('Follow-up after a new booking', 'mailpoet'),
+      __(
+        'Send a confirmation email after a new booking is created.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Follow-up after a new booking', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'calendar'
+    );
+  }
+
+  private function createWcBookingPreVisitReminderTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'wc-booking-pre-visit-reminder',
+      'bookings',
+      __('Pre-visit reminder', 'mailpoet'),
+      __(
+        'Send a reminder before a booking starts. Customize the timing in the trigger settings.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Pre-visit reminder', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'calendar'
+    );
+  }
+
+  private function createWcBookingPreVisitDripTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'wc-booking-pre-visit-drip',
+      'bookings',
+      __('Educational drip after booking', 'mailpoet'),
+      __(
+        'Send a series of emails after a booking is created to help customers prepare for their visit.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Educational drip after booking', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 2, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'calendar'
+    );
+  }
+
+  private function createWcBookingPostVisitReviewTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'wc-booking-post-visit-review',
+      'bookings',
+      __('Post-booking review request', 'mailpoet'),
+      __(
+        'Ask for feedback after a booking is completed.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Post-booking review request', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'calendar'
+    );
+  }
+
+  private function createWcBookingNextBookingNudgeTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'wc-booking-next-booking-nudge',
+      'bookings',
+      __('Next booking nudge', 'mailpoet'),
+      __(
+        'Encourage customers to rebook after their booking is completed.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Next booking nudge', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1, // trigger and all delay steps are excluded
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'calendar'
     );
   }
 }


### PR DESCRIPTION
## Description

Add 6 automation template stubs for WooCommerce Bookings in the free plugin, gated behind `isWooCommerceBookingsActive()`:

1. **Abandoned booking reminder** — triggers on booking status change to `was-in-cart`
2. **Follow-up after a new booking** — triggers on booking created
3. **Pre-visit reminder** — triggers before booking starts
4. **Educational drip after booking** — 2-email drip series after booking created
5. **Post-booking review request** — triggers on booking status change to `complete`
6. **Next booking nudge** — triggers 30 days after booking completes

These are `TYPE_PREMIUM` stubs with empty sequences for upsell display. Full template implementations are in the linked premium PR.

## Code review notes

Templates follow the exact same pattern as the existing WooCommerce Subscriptions stubs. The `bookings` category was already registered in `Registry::setupTemplateCategories()`.

## QA notes

1. Enable WooCommerce Bookings plugin
2. Go to MailPoet → Automations → Create Automation
3. Verify 6 new templates appear under the "Bookings" category
4. Deactivate WooCommerce Bookings
5. Verify no bookings templates appear

## Linked PRs

Premium PR: https://github.com/mailpoet/mailpoet-premium/pull/1019

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7497/template-wc-bookings-automations

## After-merge notes

_N/A_

## Screenshots or screencast

<img width="1206" height="618" alt="After" src="https://github.com/user-attachments/assets/d9708375-4a20-448a-b123-25a4033e813f" />


## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-7497-wc-bookings-automation-templates)

_The latest successful build from `add/stomail-7497-wc-bookings-automation-templates` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->