### PR TITLE
Fix orphaned subscriber_segment rows when a WP user is deleted

### DIFF
--- a/mailpoet/changelog/2026-04-01-10-27-57-fixed-subscriber-list-membership-entries-are-now-correct.md
+++ b/mailpoet/changelog/2026-04-01-10-27-57-fixed-subscriber-list-membership-entries-are-now-correct.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Subscriber list membership entries are now correctly removed when a WordPress user is deleted

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -38,6 +38,7 @@ class WP {
   /** @var SubscriberChangesNotifier */
   private $subscriberChangesNotifier;
 
+  /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
   /** @var Validator */
@@ -104,6 +105,7 @@ class WP {
   }
 
   private function deleteSubscriber(SubscriberEntity $subscriber): void {
+    $this->subscriberSegmentRepository->deleteAllBySubscriber($subscriber);
     $this->subscribersRepository->remove($subscriber);
     $this->subscribersRepository->flush();
   }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -105,9 +105,11 @@ class WP {
   }
 
   private function deleteSubscriber(SubscriberEntity $subscriber): void {
-    $this->subscriberSegmentRepository->deleteAllBySubscriber($subscriber);
-    $this->subscribersRepository->remove($subscriber);
-    $this->subscribersRepository->flush();
+    $this->entityManager->wrapInTransaction(function() use ($subscriber): void {
+      $this->subscriberSegmentRepository->deleteAllBySubscriber($subscriber);
+      $this->subscribersRepository->remove($subscriber);
+      $this->subscribersRepository->flush();
+    });
   }
 
   /**

--- a/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberSegmentRepository.php
@@ -43,6 +43,15 @@ class SubscriberSegmentRepository extends Repository {
       ->getResult();
   }
 
+  public function deleteAllBySubscriber(SubscriberEntity $subscriber): void {
+    $this->entityManager->createQueryBuilder()
+      ->delete(SubscriberSegmentEntity::class, 'ss')
+      ->where('ss.subscriber = :subscriber')
+      ->setParameter('subscriber', $subscriber)
+      ->getQuery()
+      ->execute();
+  }
+
   /**
    * @param SegmentEntity[] $segments
    */

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -346,6 +346,44 @@ class WPTest extends \MailPoetTest {
     verify($subscribersCount)->equals(1);
   }
 
+  public function testItDeletesSubscriberSegmentEntriesWhenWPUserIsDeleted(): void {
+    // Insert a user directly (no hooks) and sync to MailPoet tables.
+    $id = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    // Confirm the subscriber and its segment entry were created.
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    $subscriberSegmentTable = $this->entityManager
+      ->getClassMetadata(SubscriberSegmentEntity::class)
+      ->getTableName();
+    $segmentCount = (int)$this->entityManager->getConnection()
+      ->executeQuery(
+        "SELECT COUNT(*) FROM $subscriberSegmentTable WHERE subscriber_id = :id",
+        ['id' => $subscriberId]
+      )->fetchOne();
+    $this->assertEquals(1, $segmentCount);
+
+    // Delete the WP user — this fires delete_user → synchronizeUser → deleteSubscriber.
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    // The subscriber row must be gone.
+    $deletedSubscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertNull($deletedSubscriber);
+
+    // The subscriber_segment row must also be gone (this is what the bug was about).
+    $orphanedCount = (int)$this->entityManager->getConnection()
+      ->executeQuery(
+        "SELECT COUNT(*) FROM $subscriberSegmentTable WHERE subscriber_id = :id",
+        ['id' => $subscriberId]
+      )->fetchOne();
+    $this->assertEquals(0, $orphanedCount, 'wp_mailpoet_subscriber_segment row was not deleted when WP user was deleted');
+  }
+
   public function testItSynchronizesNewUsersToDisabledWPSegmentAsUnconfirmedAndTrashed(): void {
     $this->disableWpSegment();
     $this->settings->set('signup_confirmation.enabled', '1');

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -360,12 +360,12 @@ class WPTest extends \MailPoetTest {
     $subscriberSegmentTable = $this->entityManager
       ->getClassMetadata(SubscriberSegmentEntity::class)
       ->getTableName();
-    $segmentCount = (int)$this->entityManager->getConnection()
+    $segmentCountRaw = $this->entityManager->getConnection()
       ->executeQuery(
         "SELECT COUNT(*) FROM $subscriberSegmentTable WHERE subscriber_id = :id",
         ['id' => $subscriberId]
       )->fetchOne();
-    $this->assertEquals(1, $segmentCount);
+    $this->assertEquals(1, is_numeric($segmentCountRaw) ? (int)$segmentCountRaw : 0);
 
     // Delete the WP user — this fires delete_user → synchronizeUser → deleteSubscriber.
     wp_delete_user((int)$id);
@@ -376,12 +376,12 @@ class WPTest extends \MailPoetTest {
     $this->assertNull($deletedSubscriber);
 
     // The subscriber_segment row must also be gone (this is what the bug was about).
-    $orphanedCount = (int)$this->entityManager->getConnection()
+    $orphanedCountRaw = $this->entityManager->getConnection()
       ->executeQuery(
         "SELECT COUNT(*) FROM $subscriberSegmentTable WHERE subscriber_id = :id",
         ['id' => $subscriberId]
       )->fetchOne();
-    $this->assertEquals(0, $orphanedCount, $subscriberSegmentTable . ' row was not deleted when WP user was deleted');
+    $this->assertEquals(0, is_numeric($orphanedCountRaw) ? (int)$orphanedCountRaw : 0, $subscriberSegmentTable . ' row was not deleted when WP user was deleted');
   }
 
   public function testItSynchronizesNewUsersToDisabledWPSegmentAsUnconfirmedAndTrashed(): void {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -381,7 +381,7 @@ class WPTest extends \MailPoetTest {
         "SELECT COUNT(*) FROM $subscriberSegmentTable WHERE subscriber_id = :id",
         ['id' => $subscriberId]
       )->fetchOne();
-    $this->assertEquals(0, $orphanedCount, 'wp_mailpoet_subscriber_segment row was not deleted when WP user was deleted');
+    $this->assertEquals(0, $orphanedCount, $subscriberSegmentTable . ' row was not deleted when WP user was deleted');
   }
 
   public function testItSynchronizesNewUsersToDisabledWPSegmentAsUnconfirmedAndTrashed(): void {


### PR DESCRIPTION
## Description

When a WordPress user was deleted, MailPoet's `delete_user` hook handler removed the subscriber row from `wp_mailpoet_subscribers` but left the corresponding `wp_mailpoet_subscriber_segment` rows behind. These orphaned rows caused intermittent integration test failures when the full test suite ran (the `APITest` class creates and deletes WP users in `_before`/`_after`, leaving entries that interfered with subsequent tests).

The fix adds an explicit `SubscriberSegmentRepository::deleteAllBySubscriber()` call at the top of `WP::deleteSubscriber()`, before the ORM `remove()`. Although Doctrine's `orphanRemoval=true` annotation on `SubscriberEntity::$subscriberSegments` sets `isCascadeRemove=true` in the ORM metadata, the explicit deletion makes the behaviour unconditionally reliable regardless of whether the segment collection has been loaded into Doctrine's identity map.

Fixes STOMAIL-7265

## Code review notes

The key ordering decision: `deleteAllBySubscriber()` (DQL bulk DELETE, immediate) runs before `remove()` + `flush()` (ORM, deferred). This ensures the child rows are gone before the parent row is deleted, avoiding any FK constraint edge cases.

## QA notes

_N/A_ — backend-only change, no UI surface.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7265/entry-in-wp-mailpoet-subscriber-segment-is-not-deleted-when-a-wp-user

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7265-delete-subscriber-segment-entries-when-wp-user-deleted)

_The latest successful build from `fix/stomail-7265-delete-subscriber-segment-entries-when-wp-user-deleted` will be used. If none is available, the link won't work._