### PR TITLE
Sanitize sort_by in listing handler

### DIFF
--- a/mailpoet/lib/Listing/Handler.php
+++ b/mailpoet/lib/Listing/Handler.php
@@ -18,13 +18,18 @@ class Handler {
     );
   }
 
-  /**
-   * Polyfill for deprecated FILTER_SANITIZE_STRING which was used to sanitize
-   * $data['sort_by'].
-   */
-  private function filterString(string $string): string {
-    $str = (string)preg_replace('/\x00|<[^>]*>?/', '', $string);
-    return str_replace(["'", '"'], ['&#39;', '&#34;'], $str);
+  private function sanitizeSortBy(string $sortBy): string {
+    $sortBy = trim($sortBy);
+    if ($sortBy === '') {
+      return 'id';
+    }
+
+    // Fallback to `id` when there is at least one non-identifier character.
+    if (strspn($sortBy, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_') !== strlen($sortBy)) {
+      return 'id';
+    }
+
+    return $sortBy;
   }
 
   private function processData(array $data) {
@@ -35,7 +40,7 @@ class Handler {
 
     // sanitize sort by
     $sortBy = (!empty($data['sort_by']))
-      ? $this->filterString($data['sort_by'])
+      ? $this->sanitizeSortBy((string)$data['sort_by'])
       : '';
 
     if (empty($sortBy)) {

--- a/mailpoet/tests/unit/Listing/HandlerTest.php
+++ b/mailpoet/tests/unit/Listing/HandlerTest.php
@@ -40,4 +40,18 @@ class HandlerTest extends \MailPoetUnitTest {
     ]);
     verify($definition->getSelection())->equals([1, 2]);
   }
+
+  public function testItFallbacksSortByToIdForDisallowedValue() {
+    $listingData = $this->listingData;
+    $listingData['sort_by'] = "id, extractvalue(1, concat('a'))";
+    $definition = $this->handler->getListingDefinition($listingData);
+    verify($definition->getSortBy())->equals('id');
+  }
+
+  public function testItKeepsValidUnderscoreSortByValue() {
+    $listingData = $this->listingData;
+    $listingData['sort_by'] = 'last_subscribed_at';
+    $definition = $this->handler->getListingDefinition($listingData);
+    verify($definition->getSortBy())->equals('last_subscribed_at');
+  }
 }


### PR DESCRIPTION
## Description

Add sanitization for `sort_by` parameter on listings pages.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7911

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7911)

_The latest successful build from `stomail-7911` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The implementation properly sanitizes the `sort_by` parameter by:
- Validating that the string contains only identifier-safe characters (a-z, A-Z, 0-9, _) using `strspn()`
- Returning a safe default value ('id') for invalid input, including SQL injection attempts
- Handling edge cases like empty strings and whitespace

The test coverage adequately validates both malicious input (SQL injection attempts) and legitimate values with underscores. The security implementation is sound and follows best practices for column name validation in SQL query contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->