### PR TITLE
Fix: include automation emails in 'Subscriber Clicks a Link in Email' trigger

### DIFF
--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -456,6 +456,25 @@ class NewslettersRepository extends Repository {
   }
 
   /**
+   * Returns standard and automation newsletters ordered by sentAt
+   * @return NewsletterEntity[]
+   */
+  public function getStandardAndAutomationNewsletterList(): array {
+    return $this->entityManager->createQueryBuilder()
+      ->select('PARTIAL n.{id,subject,sentAt}, PARTIAL wpPost.{id, postTitle}')
+      ->addSelect('CASE WHEN n.sentAt IS NULL THEN 1 ELSE 0 END as HIDDEN sent_at_is_null')
+      ->from(NewsletterEntity::class, 'n')
+      ->leftJoin('n.wpPost', 'wpPost')
+      ->where('n.type IN (:types)')
+      ->andWhere('n.deletedAt IS NULL')
+      ->orderBy('sent_at_is_null', 'DESC')
+      ->addOrderBy('n.sentAt', 'DESC')
+      ->setParameter('types', [NewsletterEntity::TYPE_STANDARD, NewsletterEntity::TYPE_AUTOMATION])
+      ->getQuery()
+      ->getResult();
+  }
+
+  /**
    * Returns standard newsletters ordered by sentAt
    * filter by status STATUS_SCHEDULED, STATUS_SENDING, STATUS_SENT
    * @return NewsletterEntity[]


### PR DESCRIPTION
## Summary

- Adds `getStandardAndAutomationNewsletterList()` to `NewslettersRepository`, returning both `TYPE_STANDARD` and `TYPE_AUTOMATION` newsletters ordered by `sentAt`
- The corresponding change to use this method in `ContextFactory` (mailpoet-premium) is part of a separate PR in the premium repo

## Problem

The "Subscriber Clicks a Link in Email" automation trigger only showed links from standard newsletters. Automation emails were excluded because `ContextFactory::getContextData()` called `getStandardNewsletterList()`, which filters to `TYPE_STANDARD` only.

## Fix

New method `getStandardAndAutomationNewsletterList()` queries for both newsletter types, allowing automation emails to appear in the trigger's newsletter dropdown.

## Test plan

- [ ] Create an automation with a "Send Email" step
- [ ] Trigger the automation for a subscriber so the email gets sent
- [ ] Open the "Subscriber Clicks a Link in Email" trigger settings
- [ ] Confirm the automation email appears in the newsletter dropdown
- [ ] Confirm links from the automation email are selectable

Fixes: STOMAIL-7626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7626-automation-email-link-trigger)

_The latest successful build from `fix/stomail-7626-automation-email-link-trigger` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Review Findings

**1 issue found**

### Bug
The new getStandardAndAutomationNewsletterList() method passes an array literal directly to setParameter('types', [...]) without specifying an ArrayParameterType. For consistency and to match similar patterns in this file (e.g., getCountOfActiveAutomaticEmailsForEvent()), use ArrayParameterType::STRING:

Suggested change:
```php
->setParameter('types', [NewsletterEntity::TYPE_STANDARD, NewsletterEntity::TYPE_AUTOMATION], ArrayParameterType::STRING)
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->