### PR TITLE
Mount .pnpmfile.cjs in Docker dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - './wordpress:/var/www/html'
       - './tsconfig.base.json:/var/www/html/wp-content/plugins/tsconfig.base.json:ro'
       - './.npmrc:/var/www/html/wp-content/plugins/.npmrc'
+      - './.pnpmfile.cjs:/var/www/html/wp-content/plugins/.pnpmfile.cjs:ro'
       - './package.json:/var/www/html/wp-content/plugins/package.json'
       - './pnpm-lock.yaml:/var/www/html/wp-content/plugins/pnpm-lock.yaml'
       - './pnpm-workspace.yaml:/var/www/html/wp-content/plugins/pnpm-workspace.yaml'


### PR DESCRIPTION
## Description

Mount `.pnpmfile.cjs` into the `wordpress` container at the workspace root plugins path.

We upgraded pnpm from 8.15.9 to 9.15.9 in https://github.com/mailpoet/mailpoet/pull/6594. In v9, [the checksum of the `.pnpmfile.cjs` is stored in the lockfile](https://github.com/pnpm/pnpm/pull/7662). As a result, the `./do setup` command began failing because it runs `pnpm install` inside the container, where `.pnpmfile.cjs` is missing, leading to frozen lockfile mismatch errors.

To resolve this problem, this PR mounts `.pnpmfile.cjs` to the plugins directory, which is the root for the mounted `mailpoet` and `mailpoet-premium` directories.

## Code review notes

* Run `./do setup`.
* Confirm frozen-lockfile mismatch no longer occurs during the setup.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/docker-mount-pnpmfile)

_The latest successful build from `fix/docker-mount-pnpmfile` will be used. If none is available, the link won't work._