### PR TITLE
Fix free plan subscriber limit

### DIFF
--- a/mailpoet/assets/js/src/newsletters/send/congratulate/success-pitch-mss.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/congratulate/success-pitch-mss.tsx
@@ -82,9 +82,9 @@ export function PitchMss(props: Props): JSX.Element {
             )}
           </Heading>
           <p>
-            {props.subscribersCount < 1000
+            {props.subscribersCount < 500
               ? _x(
-                  'Did you know? Users with 1,000 subscribers or less get the Starter plan for free.',
+                  'Did you know? Users with 500 subscribers or less get the Starter plan for free.',
                   'Promotion for our email sending service: Paragraph',
                   'mailpoet',
                 )

--- a/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
+++ b/mailpoet/assets/js/src/wizard/steps/pitch-mss-step/first-part.tsx
@@ -42,7 +42,7 @@ function MSSStepFirstPart(): JSX.Element {
         <List>
           <li>{MailPoet.I18n.t('welcomeWizardMSSList1')}</li>
           <li>{MailPoet.I18n.t('welcomeWizardMSSList2')}</li>
-          {MailPoet.subscribersCount < 1000 ? (
+          {MailPoet.subscribersCount < 500 ? (
             <li>{MailPoet.I18n.t('welcomeWizardMSSList3Free')}</li>
           ) : (
             <li>{MailPoet.I18n.t('welcomeWizardMSSList3Paid')}</li>

--- a/mailpoet/changelog/2026-04-07-07-04-06-fixed-free-plan-subscriber-limit-shown-in-settings-send-.md
+++ b/mailpoet/changelog/2026-04-07-07-04-06-fixed-free-plan-subscriber-limit-shown-in-settings-send-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Free plan subscriber limit shown in Settings > Send with now reflects the correct limit of 500 subscribers

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -169,7 +169,7 @@
   'seeVideo': __('See video guide'),
   'activate': __('Activate'),
   'activated': __('Activated'),
-  'freeUpto': __('Free up to 1,000 subscribers'),
+  'freeUpto': __('Free up to 500 subscribers'),
   'or': __('or'),
   'enterYourKey': __("[link]enter your key[/link]"),
   'otherTitle': __('Other'),


### PR DESCRIPTION
## Description

Updates the label on the MailPoet Sending Service button in Settings > Send with from "Free up to 1,000 subscribers" to "Free up to 500 subscribers" to reflect the current free plan limit, as well as when pitching MSS feature.

## Code review notes

_N/A_

## QA notes

Navigate to MailPoet > Settings > Send with. The MailPoet Sending Service button should display "Free up to 500 subscribers".

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7918

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7918-free-sending-plan-subscriber-limit-text)

_The latest successful build from `fix/stomail-7918-free-sending-plan-subscriber-limit-text` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
1 issue found:

**Bug**: Inconsistent free plan subscriber limit messaging. The PR updates Settings > Send with and success pitch copy to "Free up to 500 subscribers", but the FAQ landing page still references "1,000 subscribers" (mailpoet/assets/js/src/landingpage/faq.tsx), causing inconsistent customer-facing messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->