### PR TITLE
Fix npm security vulnerabilities for locutus and babel-traverse

### DIFF
--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -158,7 +158,6 @@
     "grunt-cli": "^1.4.3",
     "husky": "^9.0.11",
     "imports-loader": "^5.0.0",
-    "inject-loader": "^4.0.1",
     "install": "^0.13.0",
     "js-yaml": "^4.1.1",
     "jsdom": "^24.1.0",

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/automated-latest-content-layout.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/automated-latest-content-layout.spec.js
@@ -2,7 +2,6 @@ import { App } from 'newsletter-editor/app';
 import { AutomatedLatestContentBlock } from 'newsletter-editor/blocks/automated-latest-content-layout';
 import { ContainerBlock } from 'newsletter-editor/blocks/container';
 import { CommunicationComponent } from 'newsletter-editor/components/communication';
-import AutomatedLatestContentInjector from 'inject-loader!newsletter-editor/blocks/automated-latest-content-layout';
 
 const expect = global.expect;
 const sinon = global.sinon;
@@ -14,7 +13,6 @@ var EditorApplication = App;
 describe('Automated Latest Content Layout Supervisor', function () {
   var model;
   var mock;
-  var module;
   beforeEach(function () {
     model = new AutomatedLatestContentBlock.ALCLayoutSupervisor();
   });
@@ -26,23 +24,14 @@ describe('Automated Latest Content Layout Supervisor', function () {
       .returns([new Backbone.SuperModel()]);
 
     mock = sinon
-      .mock({ getBulkTransformedPosts: function () {} })
-      .expects('getBulkTransformedPosts')
-      .once()
+      .stub(CommunicationComponent, 'getBulkTransformedPosts')
       .returns(jQuery.Deferred());
 
-    module = AutomatedLatestContentInjector({
-      'newsletter-editor/components/communication': {
-        CommunicationComponent: {
-          getBulkTransformedPosts: mock,
-        },
-      },
-    }).AutomatedLatestContentBlock;
-
-    model = new module.ALCLayoutSupervisor();
+    model = new AutomatedLatestContentBlock.ALCLayoutSupervisor();
     model.refresh();
 
-    mock.verify();
+    expect(mock.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions
+    mock.restore();
   });
 
   it('refreshes posts for given blocks', function () {
@@ -66,12 +55,7 @@ describe('Automated Latest Content Layout Supervisor', function () {
 describe('Automated latest content layout', function () {
   describe('model', function () {
     var model;
-    var module;
     var sandbox;
-
-    before(function () {
-      module = AutomatedLatestContentBlock;
-    });
 
     beforeEach(function () {
       global.stubChannel(EditorApplication);
@@ -79,7 +63,8 @@ describe('Automated latest content layout', function () {
       EditorApplication.getBlockTypeModel = sinon
         .stub()
         .returns(Backbone.SuperModel);
-      model = new module.AutomatedLatestContentLayoutBlockModel();
+      model =
+        new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
       sandbox = sinon.createSandbox();
     });
 
@@ -230,7 +215,8 @@ describe('Automated latest content layout', function () {
           },
         },
       });
-      model = new module.AutomatedLatestContentLayoutBlockModel();
+      model =
+        new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
 
       expect(model.get('amount')).to.equal('17');
       expect(model.get('contentType')).to.equal('mailpoet_page');
@@ -286,7 +272,8 @@ describe('Automated latest content layout', function () {
       EditorApplication.getBlockTypeModel = sinon
         .stub()
         .returns(ContainerBlock.ContainerBlockModel);
-      model = new module.AutomatedLatestContentLayoutBlockModel();
+      model =
+        new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
 
       model.updatePosts([
         {
@@ -343,7 +330,8 @@ describe('Automated latest content layout', function () {
         .stub()
         .returns(Backbone.Model);
       EditorApplication.getBlockTypeView = sinon.stub().returns(Backbone.View);
-      model = new module.AutomatedLatestContentLayoutBlockModel();
+      model =
+        new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
       view = new module.AutomatedLatestContentLayoutBlockView({ model: model });
     });
 
@@ -403,45 +391,35 @@ describe('Automated latest content layout', function () {
   describe('block settings view', function () {
     var model;
     var view;
-    var module;
+    var getPostTypesStub;
 
     before(function () {
-      module = AutomatedLatestContentInjector({
-        'newsletter-editor/components/communication': {
-          CommunicationComponent: {
-            getPostTypes: function () {
-              return jQuery.Deferred();
+      getPostTypesStub = sinon
+        .stub(CommunicationComponent, 'getPostTypes')
+        .callsFake(function () {
+          var deferred = jQuery.Deferred();
+          deferred.resolve([
+            {
+              name: 'post',
+              labels: {
+                singular_name: 'Post',
+              },
             },
-          },
-        },
-      }).AutomatedLatestContentBlock;
-    });
-
-    before(function () {
-      CommunicationComponent.getPostTypes = function () {
-        var deferred = jQuery.Deferred();
-        deferred.resolve([
-          {
-            name: 'post',
-            labels: {
-              singular_name: 'Post',
+            {
+              name: 'page',
+              labels: {
+                singular_name: 'Page',
+              },
             },
-          },
-          {
-            name: 'page',
-            labels: {
-              singular_name: 'Page',
+            {
+              name: 'mailpoet_page',
+              labels: {
+                singular_name: 'Mailpoet page',
+              },
             },
-          },
-          {
-            name: 'mailpoet_page',
-            labels: {
-              singular_name: 'Mailpoet page',
-            },
-          },
-        ]);
-        return deferred;
-      };
+          ]);
+          return deferred;
+        });
 
       global.stubChannel(EditorApplication);
       global.stubConfig(EditorApplication, {
@@ -453,11 +431,19 @@ describe('Automated latest content layout', function () {
       EditorApplication.getBlockTypeView = sinon.stub().returns(Backbone.View);
     });
 
+    after(function () {
+      getPostTypesStub.restore();
+    });
+
     beforeEach(function () {
-      model = new module.AutomatedLatestContentLayoutBlockModel();
-      view = new module.AutomatedLatestContentLayoutBlockSettingsView({
-        model: model,
-      });
+      model =
+        new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
+      view =
+        new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockSettingsView(
+          {
+            model: model,
+          },
+        );
     });
 
     after(function () {
@@ -470,10 +456,14 @@ describe('Automated latest content layout', function () {
 
     describe('once rendered', function () {
       beforeEach(function () {
-        model = new module.AutomatedLatestContentLayoutBlockModel();
-        view = new module.AutomatedLatestContentLayoutBlockSettingsView({
-          model: model,
-        });
+        model =
+          new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
+        view =
+          new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockSettingsView(
+            {
+              model: model,
+            },
+          );
         view.render();
       });
 
@@ -654,10 +644,14 @@ describe('Automated latest content layout', function () {
 
       describe('when "title only" display type is selected', function () {
         beforeEach(function () {
-          model = new module.AutomatedLatestContentLayoutBlockModel();
-          view = new module.AutomatedLatestContentLayoutBlockSettingsView({
-            model: model,
-          });
+          model =
+            new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
+          view =
+            new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockSettingsView(
+              {
+                model: model,
+              },
+            );
           view.render();
           view
             .$('.mailpoet_automated_latest_content_display_type')
@@ -673,10 +667,14 @@ describe('Automated latest content layout', function () {
 
         describe('when "title as list" is selected', function () {
           beforeEach(function () {
-            model = new module.AutomatedLatestContentLayoutBlockModel();
-            view = new module.AutomatedLatestContentLayoutBlockSettingsView({
-              model: model,
-            });
+            model =
+              new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockModel();
+            view =
+              new AutomatedLatestContentBlock.AutomatedLatestContentLayoutBlockSettingsView(
+                {
+                  model: model,
+                },
+              );
             view.render();
             view
               .$('.mailpoet_automated_latest_content_display_type')

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/dynamic-products.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/blocks/dynamic-products.spec.js
@@ -2,7 +2,6 @@ import { App } from 'newsletter-editor/app';
 import { DynamicProductsBlock } from 'newsletter-editor/blocks/dynamic-products';
 import { ContainerBlock } from 'newsletter-editor/blocks/container';
 import { CommunicationComponent } from 'newsletter-editor/components/communication';
-import DynamicProductsInjector from 'inject-loader!newsletter-editor/blocks/dynamic-products';
 
 const expect = global.expect;
 const sinon = global.sinon;
@@ -14,7 +13,6 @@ var EditorApplication = App;
 describe('Dynamic Products Supervisor', function () {
   var model;
   var mock;
-  var module;
   beforeEach(function () {
     model = new DynamicProductsBlock.DynamicProductsSupervisor();
   });
@@ -26,23 +24,14 @@ describe('Dynamic Products Supervisor', function () {
       .returns([new Backbone.SuperModel()]);
 
     mock = sinon
-      .mock({ getBulkTransformedProducts: function () {} })
-      .expects('getBulkTransformedProducts')
-      .once()
+      .stub(CommunicationComponent, 'getBulkTransformedProducts')
       .returns(jQuery.Deferred());
 
-    module = DynamicProductsInjector({
-      'newsletter-editor/components/communication': {
-        CommunicationComponent: {
-          getBulkTransformedProducts: mock,
-        },
-      },
-    }).DynamicProductsBlock;
-
-    model = new module.DynamicProductsSupervisor();
+    model = new DynamicProductsBlock.DynamicProductsSupervisor();
     model.refresh();
 
-    mock.verify();
+    expect(mock.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions
+    mock.restore();
   });
 
   it('refreshes products for given blocks', function () {
@@ -66,12 +55,7 @@ describe('Dynamic Products Supervisor', function () {
 describe('Dynamic Products', function () {
   describe('model', function () {
     var model;
-    var module;
     var sandbox;
-
-    before(function () {
-      module = DynamicProductsBlock;
-    });
 
     beforeEach(function () {
       global.stubChannel(EditorApplication);
@@ -79,7 +63,7 @@ describe('Dynamic Products', function () {
       EditorApplication.getBlockTypeModel = sinon
         .stub()
         .returns(Backbone.SuperModel);
-      model = new module.DynamicProductsBlockModel();
+      model = new DynamicProductsBlock.DynamicProductsBlockModel();
       sandbox = sinon.createSandbox();
     });
 
@@ -220,7 +204,7 @@ describe('Dynamic Products', function () {
           },
         },
       });
-      model = new module.DynamicProductsBlockModel();
+      model = new DynamicProductsBlock.DynamicProductsBlockModel();
 
       expect(model.get('amount')).to.equal('17');
       expect(model.get('contentType')).to.equal('product');
@@ -270,7 +254,7 @@ describe('Dynamic Products', function () {
       EditorApplication.getBlockTypeModel = sinon
         .stub()
         .returns(ContainerBlock.ContainerBlockModel);
-      model = new module.DynamicProductsBlockModel();
+      model = new DynamicProductsBlock.DynamicProductsBlockModel();
 
       model.updatePosts([
         {
@@ -321,7 +305,7 @@ describe('Dynamic Products', function () {
         .stub()
         .returns(Backbone.Model);
       EditorApplication.getBlockTypeView = sinon.stub().returns(Backbone.View);
-      model = new module.DynamicProductsBlockModel();
+      model = new DynamicProductsBlock.DynamicProductsBlockModel();
       view = new module.DynamicProductsBlockView({ model: model });
     });
 
@@ -380,33 +364,23 @@ describe('Dynamic Products', function () {
   describe('block settings view', function () {
     var model;
     var view;
-    var module;
+    var getPostTypesStub;
 
     before(function () {
-      module = DynamicProductsInjector({
-        'newsletter-editor/components/communication': {
-          CommunicationComponent: {
-            getPostTypes: function () {
-              return jQuery.Deferred();
+      getPostTypesStub = sinon
+        .stub(CommunicationComponent, 'getPostTypes')
+        .callsFake(function () {
+          var deferred = jQuery.Deferred();
+          deferred.resolve([
+            {
+              name: 'product',
+              labels: {
+                singular_name: 'Product',
+              },
             },
-          },
-        },
-      }).DynamicProductsBlock;
-    });
-
-    before(function () {
-      CommunicationComponent.getPostTypes = function () {
-        var deferred = jQuery.Deferred();
-        deferred.resolve([
-          {
-            name: 'product',
-            labels: {
-              singular_name: 'Product',
-            },
-          },
-        ]);
-        return deferred;
-      };
+          ]);
+          return deferred;
+        });
 
       global.stubChannel(EditorApplication);
       global.stubConfig(EditorApplication, {
@@ -418,9 +392,13 @@ describe('Dynamic Products', function () {
       EditorApplication.getBlockTypeView = sinon.stub().returns(Backbone.View);
     });
 
+    after(function () {
+      getPostTypesStub.restore();
+    });
+
     beforeEach(function () {
-      model = new module.DynamicProductsBlockModel();
-      view = new module.DynamicProductsBlockSettingsView({
+      model = new DynamicProductsBlock.DynamicProductsBlockModel();
+      view = new DynamicProductsBlock.DynamicProductsBlockSettingsView({
         model: model,
       });
     });
@@ -435,8 +413,8 @@ describe('Dynamic Products', function () {
 
     describe('once rendered', function () {
       beforeEach(function () {
-        model = new module.DynamicProductsBlockModel();
-        view = new module.DynamicProductsBlockSettingsView({
+        model = new DynamicProductsBlock.DynamicProductsBlockModel();
+        view = new DynamicProductsBlock.DynamicProductsBlockSettingsView({
           model: model,
         });
         view.render();
@@ -572,8 +550,8 @@ describe('Dynamic Products', function () {
 
       describe('when "title only" display type is selected', function () {
         beforeEach(function () {
-          model = new module.DynamicProductsBlockModel();
-          view = new module.DynamicProductsBlockSettingsView({
+          model = new DynamicProductsBlock.DynamicProductsBlockModel();
+          view = new DynamicProductsBlock.DynamicProductsBlockSettingsView({
             model: model,
           });
           view.render();
@@ -591,8 +569,8 @@ describe('Dynamic Products', function () {
 
         describe('when "title as list" is selected', function () {
           beforeEach(function () {
-            model = new module.DynamicProductsBlockModel();
-            view = new module.DynamicProductsBlockSettingsView({
+            model = new DynamicProductsBlock.DynamicProductsBlockModel();
+            view = new DynamicProductsBlock.DynamicProductsBlockSettingsView({
               model: model,
             });
             view.render();

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/communication.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/communication.spec.js
@@ -1,32 +1,33 @@
-import CommunicationInjector from 'inject-loader!newsletter-editor/components/communication';
+import { CommunicationComponent } from 'newsletter-editor/components/communication';
+import { MailPoet } from 'mailpoet';
 
 const expect = global.expect;
 const jQuery = global.jQuery;
 const sinon = global.sinon;
 
 describe('getPostTypes', function () {
+  var originalPost;
+
+  beforeEach(function () {
+    CommunicationComponent._cachedQuery.cache = {};
+  });
+
   it('fetches post types from the server', function () {
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: function () {
-              var deferred = jQuery.Deferred();
-              deferred.resolve({
-                data: {
-                  post: 'val1',
-                  page: 'val2',
-                },
-              });
-              return deferred;
-            },
-          },
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = function () {
+      var deferred = jQuery.Deferred();
+      deferred.resolve({
+        data: {
+          post: 'val1',
+          page: 'val2',
         },
-      },
-    }).CommunicationComponent;
-    module.getPostTypes().done(function (types) {
+      });
+      return deferred;
+    };
+    CommunicationComponent.getPostTypes().done(function (types) {
       expect(types).to.eql(['val1', 'val2']);
     });
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('caches results', function () {
@@ -36,27 +37,27 @@ describe('getPostTypes', function () {
       .expects('post')
       .once()
       .returns(deferred);
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: mock,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = mock;
     deferred.resolve({
       post: 'val1',
       page: 'val2',
     });
-    module.getPostTypes();
-    module.getPostTypes();
+    CommunicationComponent.getPostTypes();
+    CommunicationComponent.getPostTypes();
 
     mock.verify();
+    MailPoet.Ajax.post = originalPost;
   });
 });
 
 describe('getTaxonomies', function () {
+  var originalPost;
+
+  beforeEach(function () {
+    CommunicationComponent._cachedQuery.cache = {};
+  });
+
   it('sends post type to endpoint', function () {
     var spy;
     var post = function () {
@@ -67,43 +68,30 @@ describe('getTaxonomies', function () {
       });
       return deferred;
     };
-    var module;
     spy = sinon.spy(post);
-    module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: spy,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = spy;
 
-    module.getTaxonomies('post');
+    CommunicationComponent.getTaxonomies('post');
     expect(spy.args[0][0].data.postType).to.equal('post');
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('fetches taxonomies from the server', function () {
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: function () {
-              var deferred = jQuery.Deferred();
-              deferred.resolve({
-                data: {
-                  category: 'val1',
-                },
-              });
-              return deferred;
-            },
-          },
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = function () {
+      var deferred = jQuery.Deferred();
+      deferred.resolve({
+        data: {
+          category: 'val1',
         },
-      },
-    }).CommunicationComponent;
-    module.getTaxonomies('page').done(function (types) {
+      });
+      return deferred;
+    };
+    CommunicationComponent.getTaxonomies('page').done(function (types) {
       expect(types).to.eql({ category: 'val1' });
     });
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('caches results', function () {
@@ -113,24 +101,24 @@ describe('getTaxonomies', function () {
       .expects('post')
       .once()
       .returns(deferred);
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: mock,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = mock;
     deferred.resolve({ category: 'val1' });
-    module.getTaxonomies('page');
-    module.getTaxonomies('page');
+    CommunicationComponent.getTaxonomies('page');
+    CommunicationComponent.getTaxonomies('page');
 
     mock.verify();
+    MailPoet.Ajax.post = originalPost;
   });
 });
 
 describe('getTerms', function () {
+  var originalPost;
+
+  beforeEach(function () {
+    CommunicationComponent._cachedQuery.cache = {};
+  });
+
   it('sends terms to endpoint', function () {
     var spy;
     var post = function () {
@@ -138,46 +126,35 @@ describe('getTerms', function () {
       deferred.resolve({});
       return deferred;
     };
-    var module;
     spy = sinon.spy(post);
-    module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: spy,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = spy;
 
-    module.getTerms({
+    CommunicationComponent.getTerms({
       taxonomies: ['category', 'post_tag'],
     });
     expect(spy.args[0][0].data.taxonomies).to.eql(['category', 'post_tag']);
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('fetches terms from the server', function () {
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: function () {
-              var deferred = jQuery.Deferred();
-              deferred.resolve({
-                data: {
-                  term1: 'term1val1',
-                  term2: 'term2val2',
-                },
-              });
-              return deferred;
-            },
-          },
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = function () {
+      var deferred = jQuery.Deferred();
+      deferred.resolve({
+        data: {
+          term1: 'term1val1',
+          term2: 'term2val2',
         },
+      });
+      return deferred;
+    };
+    CommunicationComponent.getTerms({ taxonomies: ['category'] }).done(
+      function (types) {
+        expect(types).to.eql({ term1: 'term1val1', term2: 'term2val2' });
       },
-    }).CommunicationComponent;
-    module.getTerms({ taxonomies: ['category'] }).done(function (types) {
-      expect(types).to.eql({ term1: 'term1val1', term2: 'term2val2' });
-    });
+    );
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('caches results', function () {
@@ -187,24 +164,24 @@ describe('getTerms', function () {
       .expects('post')
       .once()
       .returns(deferred);
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: mock,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = mock;
     deferred.resolve({ term1: 'term1val1', term2: 'term2val2' });
-    module.getTerms({ taxonomies: ['category'] });
-    module.getTerms({ taxonomies: ['category'] });
+    CommunicationComponent.getTerms({ taxonomies: ['category'] });
+    CommunicationComponent.getTerms({ taxonomies: ['category'] });
 
     mock.verify();
+    MailPoet.Ajax.post = originalPost;
   });
 });
 
 describe('getPosts', function () {
+  var originalPost;
+
+  beforeEach(function () {
+    CommunicationComponent._cachedQuery.cache = {};
+  });
+
   it('sends options to endpoint', function () {
     var spy;
     var post = function () {
@@ -212,19 +189,11 @@ describe('getPosts', function () {
       deferred.resolve({});
       return deferred;
     };
-    var module;
     spy = sinon.spy(post);
-    module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: spy,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = spy;
 
-    module.getPosts({
+    CommunicationComponent.getPosts({
       type: 'posts',
       search: 'some search term',
     });
@@ -232,33 +201,25 @@ describe('getPosts', function () {
       type: 'posts',
       search: 'some search term',
     });
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('fetches posts from the server', function () {
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: function () {
-              var deferred = jQuery.Deferred();
-              deferred.resolve({
-                data: [
-                  { post_title: 'title 1' },
-                  { post_title: 'post title 2' },
-                ],
-              });
-              return deferred;
-            },
-          },
-        },
-      },
-    }).CommunicationComponent;
-    module.getPosts().done(function (posts) {
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = function () {
+      var deferred = jQuery.Deferred();
+      deferred.resolve({
+        data: [{ post_title: 'title 1' }, { post_title: 'post title 2' }],
+      });
+      return deferred;
+    };
+    CommunicationComponent.getPosts().done(function (posts) {
       expect(posts).to.eql([
         { post_title: 'title 1' },
         { post_title: 'post title 2' },
       ]);
     });
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('caches results', function () {
@@ -268,27 +229,27 @@ describe('getPosts', function () {
       .expects('post')
       .once()
       .returns(deferred);
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: mock,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = mock;
     deferred.resolve({
       type: 'posts',
       search: 'some search term',
     });
-    module.getPosts({});
-    module.getPosts({});
+    CommunicationComponent.getPosts({});
+    CommunicationComponent.getPosts({});
 
     mock.verify();
+    MailPoet.Ajax.post = originalPost;
   });
 });
 
 describe('getTransformedPosts', function () {
+  var originalPost;
+
+  beforeEach(function () {
+    CommunicationComponent._cachedQuery.cache = {};
+  });
+
   it('sends options to endpoint', function () {
     var spy;
     var post = function () {
@@ -296,19 +257,11 @@ describe('getTransformedPosts', function () {
       deferred.resolve({});
       return deferred;
     };
-    var module;
     spy = sinon.spy(post);
-    module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: spy,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = spy;
 
-    module.getTransformedPosts({
+    CommunicationComponent.getTransformedPosts({
       type: 'posts',
       posts: [1, 2],
     });
@@ -316,33 +269,28 @@ describe('getTransformedPosts', function () {
       type: 'posts',
       posts: [1, 2],
     });
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('fetches transformed posts from the server', function () {
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: function () {
-              var deferred = jQuery.Deferred();
-              deferred.resolve({
-                data: [
-                  { type: 'text', text: 'something' },
-                  { type: 'text', text: 'something else' },
-                ],
-              });
-              return deferred;
-            },
-          },
-        },
-      },
-    }).CommunicationComponent;
-    module.getTransformedPosts().done(function (posts) {
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = function () {
+      var deferred = jQuery.Deferred();
+      deferred.resolve({
+        data: [
+          { type: 'text', text: 'something' },
+          { type: 'text', text: 'something else' },
+        ],
+      });
+      return deferred;
+    };
+    CommunicationComponent.getTransformedPosts().done(function (posts) {
       expect(posts).to.eql([
         { type: 'text', text: 'something' },
         { type: 'text', text: 'something else' },
       ]);
     });
+    MailPoet.Ajax.post = originalPost;
   });
 
   it('caches results', function () {
@@ -352,22 +300,16 @@ describe('getTransformedPosts', function () {
       .expects('post')
       .once()
       .returns(deferred);
-    var module = CommunicationInjector({
-      mailpoet: {
-        MailPoet: {
-          Ajax: {
-            post: mock,
-          },
-        },
-      },
-    }).CommunicationComponent;
+    originalPost = MailPoet.Ajax.post;
+    MailPoet.Ajax.post = mock;
     deferred.resolve({
       type: 'posts',
       posts: [1, 3],
     });
-    module.getTransformedPosts({});
-    module.getTransformedPosts({});
+    CommunicationComponent.getTransformedPosts({});
+    CommunicationComponent.getTransformedPosts({});
 
     mock.verify();
+    MailPoet.Ajax.post = originalPost;
   });
 });

--- a/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
+++ b/mailpoet/tests/javascript-newsletter-editor/newsletter-editor/components/save.spec.js
@@ -1,7 +1,8 @@
 import { App } from 'newsletter-editor/app';
 import { SaveComponent } from 'newsletter-editor/components/save';
+import { CommunicationComponent } from 'newsletter-editor/components/communication';
+import { MailPoet } from 'mailpoet';
 import jQuery from 'jquery';
-import SaveInjector from 'inject-loader!newsletter-editor/components/save';
 
 const expect = global.expect;
 const sinon = global.sinon;
@@ -9,17 +10,16 @@ const Backbone = global.Backbone;
 
 describe('Save', function () {
   describe('save method', function () {
-    var module;
+    var saveNewsletterStub;
+
     before(function () {
-      module = SaveInjector({
-        'newsletter-editor/components/communication': {
-          CommunicationComponent: {
-            saveNewsletter: function () {
-              return jQuery.Deferred();
-            },
-          },
-        },
-      }).SaveComponent;
+      saveNewsletterStub = sinon
+        .stub(CommunicationComponent, 'saveNewsletter')
+        .returns(jQuery.Deferred());
+    });
+
+    after(function () {
+      saveNewsletterStub.restore();
     });
 
     it('triggers beforeEditorSave event', function () {
@@ -32,13 +32,12 @@ describe('Save', function () {
           type: 'container',
         },
       });
-      module.save();
+      SaveComponent.save();
       expect(spy).to.have.callCount(1);
       expect(spy).to.have.been.calledWith('beforeEditorSave');
     });
 
     it('triggers afterEditorSave event', function () {
-      var innerModule;
       var spy = sinon.spy();
       var promise = jQuery.Deferred();
       global.stubChannel(App, {
@@ -49,40 +48,36 @@ describe('Save', function () {
           type: 'container',
         },
       });
-      innerModule = SaveInjector({
-        'newsletter-editor/components/communication': {
-          CommunicationComponent: {
-            saveNewsletter: sinon.stub().returns(promise),
-          },
-        },
-      }).SaveComponent;
+      saveNewsletterStub.returns(promise);
       promise.resolve({ success: true });
-      innerModule.save();
+      SaveComponent.save();
       expect(spy.withArgs('afterEditorSave').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions
     });
 
     it('sends newsletter json to server for saving', function () {
-      var mock = sinon.mock().once().returns(jQuery.Deferred());
-      var innerModule = SaveInjector({
-        'newsletter-editor/components/communication': {
-          CommunicationComponent: {
-            saveNewsletter: mock,
-          },
-        },
-      }).SaveComponent;
+      var mock;
+      saveNewsletterStub.restore();
+      mock = sinon.mock(CommunicationComponent);
+      mock.expects('saveNewsletter').once().returns(jQuery.Deferred());
       global.stubChannel(App);
 
       App.toJSON = sinon.stub().returns({});
-      innerModule.save();
+      SaveComponent.save();
 
       mock.verify();
+      mock.restore();
+      saveNewsletterStub = sinon
+        .stub(CommunicationComponent, 'saveNewsletter')
+        .returns(jQuery.Deferred());
     });
 
     it('encodes newsletter body in JSON format', function () {
-      var innerModule;
       var body = { type: 'testType' };
-      var mock = sinon
-        .mock()
+      var mock;
+      saveNewsletterStub.restore();
+      mock = sinon.mock(CommunicationComponent);
+      mock
+        .expects('saveNewsletter')
         .once()
         .withArgs({
           body: JSON.stringify(body),
@@ -93,16 +88,13 @@ describe('Save', function () {
       App.toJSON = sinon.stub().returns({
         body: body,
       });
-      innerModule = SaveInjector({
-        'newsletter-editor/components/communication': {
-          CommunicationComponent: {
-            saveNewsletter: mock,
-          },
-        },
-      }).SaveComponent;
-      innerModule.save();
+      SaveComponent.save();
 
       mock.verify();
+      mock.restore();
+      saveNewsletterStub = sinon
+        .stub(CommunicationComponent, 'saveNewsletter')
+        .returns(jQuery.Deferred());
     });
   });
 
@@ -234,13 +226,11 @@ describe('Save', function () {
       });
 
       it('triggers template saving when clicked on "save as template" button', function () {
-        var mock = sinon
-          .mock({ post: function () {} })
-          .expects('post')
-          .once()
-          .returns(jQuery.Deferred());
+        var ajaxPostStub;
         var promiseMock = {};
-        var module;
+        var originalI18n = MailPoet.I18n;
+        var originalNotice = MailPoet.Notice;
+        var originalTrackEvent = MailPoet.trackEvent;
 
         promiseMock.then = function (cb) {
           cb();
@@ -256,31 +246,18 @@ describe('Save', function () {
             },
           };
         };
-        module = SaveInjector({
-          mailpoet: {
-            MailPoet: {
-              Ajax: {
-                post: mock,
-              },
-              I18n: {
-                t: function () {
-                  return '';
-                },
-              },
-              Notice: {
-                success: function () {},
-                error: function () {},
-              },
-              trackEvent: function () {},
-            },
+
+        ajaxPostStub = sinon
+          .stub(MailPoet.Ajax, 'post')
+          .returns(jQuery.Deferred());
+        MailPoet.I18n = {
+          t: function () {
+            return '';
           },
-          'newsletter-editor/app': { App },
-          common: {
-            fromNewsletter: function () {
-              return promiseMock;
-            },
-          },
-        }).SaveComponent;
+        };
+        MailPoet.Notice = { success: function () {}, error: function () {} };
+        MailPoet.trackEvent = function () {};
+
         model = new Backbone.SuperModel({});
         model.isWoocommerceTransactional = function () {
           return false;
@@ -291,7 +268,7 @@ describe('Save', function () {
         model.isConfirmationEmailTemplate = function () {
           return false;
         };
-        view = new module.SaveView({ model: model });
+        view = new SaveComponent.SaveView({ model: model });
         view.render();
 
         view.$('.mailpoet_save_as_template_name').val('A sample template');
@@ -300,20 +277,19 @@ describe('Save', function () {
           .val('Sample template description');
         view.$('.mailpoet_save_as_template').trigger('click');
 
-        mock.verify();
+        expect(ajaxPostStub.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions
+
+        ajaxPostStub.restore();
+        MailPoet.I18n = originalI18n;
+        MailPoet.Notice = originalNotice;
+        MailPoet.trackEvent = originalTrackEvent;
       });
 
       it('saves newsletter when clicked on "next" button', function () {
         var spy = sinon.spy();
-        var module = SaveInjector({
-          'newsletter-editor/components/communication': {
-            CommunicationComponent: {
-              saveNewsletter: function () {
-                return jQuery.Deferred();
-              },
-            },
-          },
-        }).SaveComponent;
+        var saveNewsletterStub = sinon
+          .stub(CommunicationComponent, 'saveNewsletter')
+          .returns(jQuery.Deferred());
         global.stubChannel(App, {
           trigger: spy,
         });
@@ -327,12 +303,13 @@ describe('Save', function () {
         model.isConfirmationEmailTemplate = function () {
           return false;
         };
-        view = new module.SaveView({ model: model });
+        view = new SaveComponent.SaveView({ model: model });
         view.render();
 
         view.$('.mailpoet_save_next').trigger('click');
         expect(spy).to.have.callCount(1);
         expect(spy).to.have.been.calledWith('beforeEditorSave');
+        saveNewsletterStub.restore();
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "@woocommerce/components@13.1.0": "patches/@woocommerce__components@13.1.0.patch",
       "backbone.supermodel@1.2.0": "patches/backbone.supermodel@1.2.0.patch",
       "parsleyjs@2.9.2": "patches/parsleyjs@2.9.2.patch",
-      "spectrum-colorpicker@1.8.1": "patches/spectrum-colorpicker@1.8.1.patch"
+      "spectrum-colorpicker@1.8.1": "patches/spectrum-colorpicker@1.8.1.patch",
+      "@woocommerce/number@2.5.0": "patches/@woocommerce__number@2.5.0.patch"
     },
     "overrides": {
       "@babel/runtime": ">=7.26.10",
@@ -73,6 +74,7 @@
       "immutable@>=4.0.0-rc.1 <4.3.8": ">=4.3.8 <5.0.0",
       "flatted@<3.4.2": ">=3.4.2 <4.0.0",
       "dompurify@<3.3.3": ">=3.3.3 <4.0.0",
+      "locutus@<3.0.25": ">=3.0.25 <4.0.0",
       "lodash@<4.18.1": ">=4.18.1 <5.0.0",
       "react-router@>=6.0.0 <6.30.2": ">=6.30.2 <7.0.0",
       "webpack-dev-server@<=5.2.0": ">=5.2.1 <6.0.0",

--- a/patches/@woocommerce__number@2.5.0.patch
+++ b/patches/@woocommerce__number@2.5.0.patch
@@ -1,0 +1,26 @@
+diff --git a/build/index.js b/build/index.js
+index e7212335ad59514756936474eac6c70c4452ff68..09ed6f7decd38ad5ba240dfaece6f42712142e82 100644
+--- a/build/index.js
++++ b/build/index.js
+@@ -7,7 +7,7 @@ exports.parseNumber = exports.calculateDelta = exports.formatValue = exports.num
+ /**
+  * External dependencies
+  */
+-const number_format_1 = __importDefault(require("locutus/php/strings/number_format"));
++const number_format_1 = { default: require("locutus/php/strings/number_format").number_format };
+ /**
+  * Formats a number using site's current locale
+  *
+diff --git a/build-module/index.js b/build-module/index.js
+index dfd612f20cdd8bfc5ad322822bc469e6d3a8df2d..a56a416d23db7d7ff12de12c8d0d72d2c4eb3d0b 100644
+--- a/build-module/index.js
++++ b/build-module/index.js
+@@ -1,7 +1,7 @@
+ /**
+  * External dependencies
+  */
+-import numberFormatter from 'locutus/php/strings/number_format';
++import { number_format as numberFormatter } from 'locutus/php/strings/number_format';
+ /**
+  * Formats a number using site's current locale
+  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,7 @@ overrides:
   immutable@>=4.0.0-rc.1 <4.3.8: '>=4.3.8 <5.0.0'
   flatted@<3.4.2: '>=3.4.2 <4.0.0'
   dompurify@<3.3.3: '>=3.3.3 <4.0.0'
+  locutus@<3.0.25: '>=3.0.25 <4.0.0'
   lodash@<4.18.1: '>=4.18.1 <5.0.0'
   react-router@>=6.0.0 <6.30.2: '>=6.30.2 <7.0.0'
   webpack-dev-server@<=5.2.0: '>=5.2.1 <6.0.0'
@@ -73,6 +74,9 @@ patchedDependencies:
   '@woocommerce/components@13.1.0':
     hash: txpzaxxaiic57erltohxpswt5i
     path: patches/@woocommerce__components@13.1.0.patch
+  '@woocommerce/number@2.5.0':
+    hash: lyssmpdajz4xlerzv73ts2g46a
+    path: patches/@woocommerce__number@2.5.0.patch
   backbone.supermodel@1.2.0:
     hash: hhsvgimsfhfs4itf7ipk47fane
     path: patches/backbone.supermodel@1.2.0.patch
@@ -511,9 +515,6 @@ importers:
       imports-loader:
         specifier: ^5.0.0
         version: 5.0.0(webpack@5.105.4)
-      inject-loader:
-        specifier: ^4.0.1
-        version: 4.0.1(webpack@5.105.4)
       install:
         specifier: ^0.13.0
         version: 0.13.0
@@ -4080,10 +4081,6 @@ packages:
     resolution: {integrity: sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==}
     engines: {node: '>=0.10.0'}
 
-  ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-
   ansi-regex@4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
     engines: {node: '>=6'}
@@ -4095,10 +4092,6 @@ packages:
   ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-
-  ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -4258,18 +4251,6 @@ packages:
   b4a@1.6.6:
     resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
 
-  babel-code-frame@6.26.0:
-    resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==}
-
-  babel-core@6.26.3:
-    resolution: {integrity: sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==}
-
-  babel-generator@6.26.1:
-    resolution: {integrity: sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==}
-
-  babel-helpers@6.24.1:
-    resolution: {integrity: sha512-n7pFrqQm44TCYvrCDb0MqabAF+JUBq+ijBvNMUxpkLjJaAu32faIexewMumrH5KLLJ1HDyT0PTEqRyAe/GwwuQ==}
-
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4289,9 +4270,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
       webpack: '>=5'
-
-  babel-messages@6.23.0:
-    resolution: {integrity: sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==}
 
   babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
@@ -4331,27 +4309,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  babel-register@6.26.0:
-    resolution: {integrity: sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==}
-
   babel-runtime@6.25.0:
     resolution: {integrity: sha512-zeCYxDePWYAT/DfmQWIHsMSFW2vv45UIwIAMjGvQVsTd47RwsiRH0uK1yzyWZ7LDBKdhnGDPM6NYEO5CZyhPrg==}
-
-  babel-runtime@6.26.0:
-    resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==}
-
-  babel-template@6.26.0:
-    resolution: {integrity: sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==}
-
-  babel-traverse@6.26.0:
-    resolution: {integrity: sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==}
-
-  babel-types@6.26.0:
-    resolution: {integrity: sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==}
-
-  babylon@6.18.0:
-    resolution: {integrity: sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==}
-    hasBin: true
 
   backbone.marionette@3.2.0:
     resolution: {integrity: sha512-S4KW9AuRVo4oV3kALIdnnqqznrEc7kbSDPCbkkgxFlGRTI9XLRE4a2auhXoL5DE16LXF59hZ9p860JRNl4e24A==}
@@ -4585,10 +4544,6 @@ packages:
   chai@5.1.1:
     resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
     engines: {node: '>=12'}
-
-  chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -5288,10 +5243,6 @@ packages:
 
   detect-file@1.0.0:
     resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
-    engines: {node: '>=0.10.0'}
-
-  detect-indent@4.0.0:
-    resolution: {integrity: sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==}
     engines: {node: '>=0.10.0'}
 
   detect-newline@3.1.0:
@@ -6220,10 +6171,6 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
-  globals@9.18.0:
-    resolution: {integrity: sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==}
-    engines: {node: '>=0.10.0'}
-
   globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
@@ -6309,10 +6256,6 @@ packages:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
 
-  has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
-
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -6375,10 +6318,6 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
-
-  home-or-tmp@2.0.0:
-    resolution: {integrity: sha512-ycURW7oUxE2sNiPVw1HVEFsW+ecOpJ5zaj7eC0RlwhibhRBod20muUN8qu/gzx956YrLolVvs1MTXwKgC2rVEg==}
-    engines: {node: '>=0.10.0'}
 
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -6567,11 +6506,6 @@ packages:
     resolution: {integrity: sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
-  inject-loader@4.0.1:
-    resolution: {integrity: sha512-fUFtHkso2AnzQyyJjuGuDYL0mW2EIQUlS4MgXXmCIRjVLyDk3oXGJqNcSTUg6DGs1q4gvqVIWsxfmPKxF44xfw==}
-    peerDependencies:
-      webpack: ^1 || ^2 || ^3 || ^4
-
   install@0.13.0:
     resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
     engines: {node: '>= 0.10'}
@@ -6601,9 +6535,6 @@ packages:
 
   intl-messageformat@4.4.0:
     resolution: {integrity: sha512-z+Bj2rS3LZSYU4+sNitdHrwnBhr0wO80ZJSW8EzKDBowwUe3Q/UsvgCGjrwa+HPzoGCLEb9HAjfJgo4j2Sac8w==}
-
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -6681,10 +6612,6 @@ packages:
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-finite@1.0.2:
-    resolution: {integrity: sha512-e+gU0KGrlbqjEcV80SAqg4g7PQYOm3/IrdwAJ+kPwHqGhLKhtuTJGGxGtrsc8RXlHt2A8Vlnv+79Vq2B1GQasg==}
     engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@2.0.0:
@@ -7052,9 +6979,6 @@ packages:
   js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
 
-  js-tokens@3.0.2:
-    resolution: {integrity: sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -7089,10 +7013,6 @@ packages:
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
-    hasBin: true
-
-  jsesc@1.3.0:
-    resolution: {integrity: sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==}
     hasBin: true
 
   jsesc@2.5.2:
@@ -7281,9 +7201,9 @@ packages:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  locutus@2.0.39:
-    resolution: {integrity: sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww==}
-    engines: {node: '>= 10', yarn: '>= 1'}
+  locutus@3.0.34:
+    resolution: {integrity: sha512-q8sKVNKHc9g5nv3g1cHf5H1Nw2ciRYrv0Zl5SnCauX9mvkKG1RxWnB5JhYDlfxUJcRDcZ7IoeqjMLVSW+uwLAA==}
+    engines: {node: '>= 22', yarn: '>= 1'}
 
   lodash._basecallback@3.3.1:
     resolution: {integrity: sha512-LQffghuO63ufDY33KKO1ezGKbcFZK3ngYV7JpxaUomoM5acf0YeXU3Pm8csVE0girVs50TXzfNibl69Co3ggJA==}
@@ -7740,10 +7660,6 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  number-is-nan@1.0.1:
-    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
-    engines: {node: '>=0.10.0'}
 
   nwsapi@2.2.10:
     resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
@@ -8380,10 +8296,6 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
-  private@0.1.8:
-    resolution: {integrity: sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==}
-    engines: {node: '>= 0.6'}
-
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -8813,9 +8725,6 @@ packages:
   regenerator-runtime@0.10.5:
     resolution: {integrity: sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==}
 
-  regenerator-runtime@0.11.1:
-    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
-
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -8842,10 +8751,6 @@ packages:
 
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
-
-  repeating@2.0.1:
-    resolution: {integrity: sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==}
-    engines: {node: '>=0.10.0'}
 
   requestidlecallback@0.3.0:
     resolution: {integrity: sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==}
@@ -9259,9 +9164,6 @@ packages:
     resolution: {integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==}
     deprecated: See https://github.com/lydell/source-map-resolve#deprecated
 
-  source-map-support@0.4.18:
-    resolution: {integrity: sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==}
-
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
@@ -9391,10 +9293,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
@@ -9485,10 +9383,6 @@ packages:
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
-
-  supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -9659,10 +9553,6 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
-  to-fast-properties@1.0.3:
-    resolution: {integrity: sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==}
-    engines: {node: '>=0.10.0'}
-
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -9710,10 +9600,6 @@ packages:
 
   trim-repeated@1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
-    engines: {node: '>=0.10.0'}
-
-  trim-right@1.0.1:
-    resolution: {integrity: sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==}
     engines: {node: '>=0.10.0'}
 
   ts-api-utils@1.3.0:
@@ -13667,7 +13553,7 @@ snapshots:
 
   '@woocommerce/currency@4.3.0':
     dependencies:
-      '@woocommerce/number': 2.5.0
+      '@woocommerce/number': 2.5.0(patch_hash=lyssmpdajz4xlerzv73ts2g46a)
       '@wordpress/deprecated': 4.0.0
       '@wordpress/element': 6.0.0
       '@wordpress/hooks': 4.0.0
@@ -13676,7 +13562,7 @@ snapshots:
 
   '@woocommerce/currency@5.0.0':
     dependencies:
-      '@woocommerce/number': 2.5.0
+      '@woocommerce/number': 2.5.0(patch_hash=lyssmpdajz4xlerzv73ts2g46a)
       '@wordpress/deprecated': 4.39.0
       '@wordpress/element': 6.39.0
       '@wordpress/hooks': 4.39.0
@@ -13789,9 +13675,9 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@woocommerce/number@2.5.0':
+  '@woocommerce/number@2.5.0(patch_hash=lyssmpdajz4xlerzv73ts2g46a)':
     dependencies:
-      locutus: 2.0.39
+      locutus: 3.0.34
 
   '@woocommerce/sanitize@1.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16093,15 +15979,11 @@ snapshots:
 
   ansi-regex@1.1.1: {}
 
-  ansi-regex@2.1.1: {}
-
   ansi-regex@4.1.1: {}
 
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.0.1: {}
-
-  ansi-styles@2.2.1: {}
 
   ansi-styles@3.2.1:
     dependencies:
@@ -16265,54 +16147,6 @@ snapshots:
 
   b4a@1.6.6: {}
 
-  babel-code-frame@6.26.0:
-    dependencies:
-      chalk: 1.1.3
-      esutils: 2.0.3
-      js-tokens: 3.0.2
-
-  babel-core@6.26.3:
-    dependencies:
-      babel-code-frame: 6.26.0
-      babel-generator: 6.26.1
-      babel-helpers: 6.24.1
-      babel-messages: 6.23.0
-      babel-register: 6.26.0
-      babel-runtime: 6.26.0
-      babel-template: 6.26.0
-      babel-traverse: 6.26.0
-      babel-types: 6.26.0
-      babylon: 6.18.0
-      convert-source-map: 1.9.0
-      debug: 2.6.9
-      json5: 2.2.3
-      lodash: 4.18.1
-      minimatch: 3.1.5
-      path-is-absolute: 1.0.1
-      private: 0.1.8
-      slash: 1.0.0
-      source-map: 0.5.7
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-generator@6.26.1:
-    dependencies:
-      babel-messages: 6.23.0
-      babel-runtime: 6.26.0
-      babel-types: 6.26.0
-      detect-indent: 4.0.0
-      jsesc: 1.3.0
-      lodash: 4.18.1
-      source-map: 0.5.7
-      trim-right: 1.0.1
-
-  babel-helpers@6.24.1:
-    dependencies:
-      babel-runtime: 6.26.0
-      babel-template: 6.26.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-jest@29.7.0(@babel/core@7.24.7):
     dependencies:
       '@babel/core': 7.24.7
@@ -16341,10 +16175,6 @@ snapshots:
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
       webpack: 5.105.4(webpack-cli@5.1.4)
-
-  babel-messages@6.23.0:
-    dependencies:
-      babel-runtime: 6.26.0
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -16418,60 +16248,10 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.24.7)
 
-  babel-register@6.26.0:
-    dependencies:
-      babel-core: 6.26.3
-      babel-runtime: 6.26.0
-      core-js: 2.6.12
-      home-or-tmp: 2.0.0
-      lodash: 4.18.1
-      mkdirp: 0.5.5
-      source-map-support: 0.4.18
-    transitivePeerDependencies:
-      - supports-color
-
   babel-runtime@6.25.0:
     dependencies:
       core-js: 2.6.12
       regenerator-runtime: 0.10.5
-
-  babel-runtime@6.26.0:
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.11.1
-
-  babel-template@6.26.0:
-    dependencies:
-      babel-runtime: 6.26.0
-      babel-traverse: 6.26.0
-      babel-types: 6.26.0
-      babylon: 6.18.0
-      lodash: 4.18.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-traverse@6.26.0:
-    dependencies:
-      babel-code-frame: 6.26.0
-      babel-messages: 6.23.0
-      babel-runtime: 6.26.0
-      babel-types: 6.26.0
-      babylon: 6.18.0
-      debug: 2.6.9
-      globals: 9.18.0
-      invariant: 2.2.4
-      lodash: 4.18.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-types@6.26.0:
-    dependencies:
-      babel-runtime: 6.26.0
-      esutils: 2.0.3
-      lodash: 4.18.1
-      to-fast-properties: 1.0.3
-
-  babylon@6.18.0: {}
 
   backbone.marionette@3.2.0(backbone@1.3.3)(underscore@1.13.8):
     dependencies:
@@ -16723,14 +16503,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.1.1
       pathval: 2.0.0
-
-  chalk@1.1.3:
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
 
   chalk@2.4.2:
     dependencies:
@@ -17471,10 +17243,6 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-file@1.0.0: {}
-
-  detect-indent@4.0.0:
-    dependencies:
-      repeating: 2.0.1
 
   detect-newline@3.1.0: {}
 
@@ -18622,8 +18390,6 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
-  globals@9.18.0: {}
-
   globalthis@1.0.3:
     dependencies:
       define-properties: 1.2.1
@@ -18724,10 +18490,6 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  has-ansi@2.0.0:
-    dependencies:
-      ansi-regex: 2.1.1
-
   has-bigints@1.0.2: {}
 
   has-flag@3.0.0: {}
@@ -18788,11 +18550,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  home-or-tmp@2.0.0:
-    dependencies:
-      os-homedir: 1.0.2
-      os-tmpdir: 1.0.2
 
   homedir-polyfill@1.0.3:
     dependencies:
@@ -18998,13 +18755,6 @@ snapshots:
 
   ini@3.0.1: {}
 
-  inject-loader@4.0.1(webpack@5.105.4):
-    dependencies:
-      babel-core: 6.26.3
-      webpack: 5.105.4(webpack-cli@5.1.4)
-    transitivePeerDependencies:
-      - supports-color
-
   install@0.13.0: {}
 
   interact.js@1.2.8: {}
@@ -19026,10 +18776,6 @@ snapshots:
   intl-messageformat@4.4.0:
     dependencies:
       intl-messageformat-parser: 1.8.1
-
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
 
   ip-address@9.0.5:
     dependencies:
@@ -19095,10 +18841,6 @@ snapshots:
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
-
-  is-finite@1.0.2:
-    dependencies:
-      number-is-nan: 1.0.1
 
   is-fullwidth-code-point@2.0.0: {}
 
@@ -19661,8 +19403,6 @@ snapshots:
 
   js-sdsl@4.4.0: {}
 
-  js-tokens@3.0.2: {}
-
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -19735,8 +19475,6 @@ snapshots:
       - utf-8-validate
 
   jsesc@0.5.0: {}
-
-  jsesc@1.3.0: {}
 
   jsesc@2.5.2: {}
 
@@ -19956,7 +19694,7 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
-  locutus@2.0.39: {}
+  locutus@3.0.34: {}
 
   lodash._basecallback@3.3.1:
     dependencies:
@@ -20441,8 +20179,6 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
-
-  number-is-nan@1.0.1: {}
 
   nwsapi@2.2.10: {}
 
@@ -21043,8 +20779,6 @@ snapshots:
 
   prismjs@1.30.0: {}
 
-  private@0.1.8: {}
-
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
@@ -21571,8 +21305,6 @@ snapshots:
 
   regenerator-runtime@0.10.5: {}
 
-  regenerator-runtime@0.11.1: {}
-
   regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.2:
@@ -21604,10 +21336,6 @@ snapshots:
   remove-accents@0.4.4: {}
 
   remove-accents@0.5.0: {}
-
-  repeating@2.0.1:
-    dependencies:
-      is-finite: 1.0.2
 
   requestidlecallback@0.3.0: {}
 
@@ -22057,10 +21785,6 @@ snapshots:
       atob: 2.1.2
       decode-uri-component: 0.4.1
 
-  source-map-support@0.4.18:
-    dependencies:
-      source-map: 0.5.7
-
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -22230,10 +21954,6 @@ snapshots:
     dependencies:
       ansi-regex: 1.1.1
 
-  strip-ansi@3.0.1:
-    dependencies:
-      ansi-regex: 2.1.1
-
   strip-ansi@5.2.0:
     dependencies:
       ansi-regex: 4.1.1
@@ -22399,8 +22119,6 @@ snapshots:
       - typescript
 
   stylis@4.2.0: {}
-
-  supports-color@2.0.0: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -22572,8 +22290,6 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  to-fast-properties@1.0.3: {}
-
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -22612,8 +22328,6 @@ snapshots:
   trim-repeated@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
-
-  trim-right@1.0.1: {}
 
   ts-api-utils@1.3.0(typescript@5.0.2):
     dependencies:


### PR DESCRIPTION
## Description

Fix all open Dependabot alerts and `pnpm audit` findings:

- **locutus** (3 Dependabot alerts + 1 additional `pnpm audit` finding): Override locutus from 2.0.39 to 3.x via pnpm overrides. Patch `@woocommerce/number` to use named import compatible with locutus 3.x's changed export format.
- **babel-traverse** (1 `pnpm audit` critical): Remove `inject-loader` devDependency which pulled in `babel-core@6` → `babel-traverse@6` (no patched version exists). Refactor 4 newsletter editor test files to use sinon stubs instead.

After this change, `pnpm audit` reports 0 vulnerabilities.

## Code review notes

The `@woocommerce/number` patch is needed because locutus 3.x changed from default export to named export for `number_format`. Without the patch, `@woocommerce/number`'s ESM build (`import numberFormatter from '...'`) would resolve to `undefined`.

## QA notes

_N/A_ — only dev dependencies and test infrastructure changes. No production code modified.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/dependabot-security-alerts-locutus-inject-loader)

_The latest successful build from `fix/dependabot-security-alerts-locutus-inject-loader` will be used. If none is available, the link won't work._