### PR TITLE
Add filter for manage subscription preview email

### DIFF
--- a/mailpoet/changelog/2026-04-13-12-00-00-added-filter-for-manage-subscription-preview-email.md
+++ b/mailpoet/changelog/2026-04-13-12-00-00-added-filter-for-manage-subscription-preview-email.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add `mailpoet_manage_subscription_preview_subscriber_email` filter to allow overriding the demo email on the manage subscription preview page

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -414,7 +414,8 @@ class Pages {
   public function getManageContent() {
     if ($this->isPreview()) {
       $subscriber = new SubscriberEntity();
-      $subscriber->setEmail(self::DEMO_EMAIL);
+      $previewEmail = $this->wp->applyFilters('mailpoet_manage_subscription_preview_subscriber_email', self::DEMO_EMAIL);
+      $subscriber->setEmail(is_string($previewEmail) ? $previewEmail : self::DEMO_EMAIL);
       $subscriber->setFirstName('John');
       $subscriber->setLastName('Doe');
       $subscriber->setLinkToken('bfd0889dbc7f081e171fa0cee7401df2');

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -415,7 +415,7 @@ class Pages {
     if ($this->isPreview()) {
       $subscriber = new SubscriberEntity();
       $previewEmail = $this->wp->applyFilters('mailpoet_manage_subscription_preview_subscriber_email', self::DEMO_EMAIL);
-      $subscriber->setEmail(is_string($previewEmail) ? $previewEmail : self::DEMO_EMAIL);
+      $subscriber->setEmail(is_string($previewEmail) && $previewEmail !== '' ? $previewEmail : self::DEMO_EMAIL);
       $subscriber->setFirstName('John');
       $subscriber->setLastName('Doe');
       $subscriber->setLinkToken('bfd0889dbc7f081e171fa0cee7401df2');


### PR DESCRIPTION
## Description

Add `mailpoet_manage_subscription_preview_subscriber_email` filter to allow overriding the hardcoded `demo@mailpoet.com` email shown on the manage subscription page in preview mode.

When previewing the manage subscription page, `getManageContent()` creates a dummy subscriber with `DEMO_EMAIL` (`demo@mailpoet.com`). This filter lets integrations replace it with a more meaningful value (e.g., the current user's email).

## Code review notes

- The filter is applied in `Subscription/Pages.php:getManageContent()` only in the preview branch (`isPreview()`)
- A runtime `is_string()` check ensures the filter return is valid, falling back to `DEMO_EMAIL` if not
- Backward compatible — without any filter, behavior is unchanged

## QA notes

1. Visit the manage subscription page in preview mode without any filter — should still show `demo@mailpoet.com`
2. Add a filter returning a custom email — preview should show the custom email
3. Add a filter returning a non-string value — should fall back to `demo@mailpoet.com`

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7935](https://linear.app/a8c/issue/STOMAIL-7935/sender-email-hardcoded-to-demomailpoetcom)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/manage-subscription-preview-email-filter)

_The latest successful build from `fix/manage-subscription-preview-email-filter` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

3 issues found:

**Suggestion (3)**
1. Validation — The `is_string()` check is too loose as it allows empty strings. Reviewer recommends a stricter check: `is_string($previewEmail) && $previewEmail !== ''`, or preferably using `$this->wp->isEmail($previewEmail)` to enforce email format validation.
2. Architecture — Reviewer suggests reconsidering the approach of exposing a new public filter. Alternative proposal: use the current user's email when previewing (when available) and fall back to `DEMO_EMAIL`, which would benefit all users without introducing a new public API to maintain.
3. Process — Changelog entry is missing. The PR checklist shows this task unchecked; reviewer requests adding a changelog entry via `./do changelog:add --type=fix --description=…`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->