### PR TITLE
Fix tag autocomplete on repeated subscriber imports

### DIFF
--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-results.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-results.jsx
@@ -165,7 +165,9 @@ export function StepResults({
           <Button
             variant="secondary"
             type="button"
-            onClick={() => navigate('/step_method_selection')}
+            onClick={() => {
+              window.location.href = `${window.location.pathname}${window.location.search}#/step_method_selection`;
+            }}
           >
             {MailPoet.I18n.t('importAgain')}
           </Button>

--- a/mailpoet/changelog/2026-04-13-18-30-33-fixed-newly-created-tags-are-now-available-for-autocompl.md
+++ b/mailpoet/changelog/2026-04-13-18-30-33-fixed-newly-created-tags-are-now-available-for-autocompl.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Newly created tags are now available for autocomplete when importing subscribers multiple times without reloading the page


### PR DESCRIPTION
## Description

When a user creates a new tag during a subscriber import and then clicks "Import again", the new tag doesn't appear in the autocomplete on the next import — a page reload is needed to see it.

The root cause: the "Import again" button used React Router's `navigate()`, a client-side transition that keeps all in-memory state alive (including the tag list fetched at page load). Switching to a full page reload via `window.location.href` resets the React app, so the tag list is fetched fresh from the server.

## Code review notes

_N/A_

## QA notes

1. On the subscriber import page, complete an import while creating a new tag
2. Click "Import again"
3. On the final step, type the newly created tag — it should now appear in autocomplete without needing a manual page reload

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7290

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7290-tag-autocomplete-on-import-page)

_The latest successful build from `fix/stomail-7290-tag-autocomplete-on-import-page` will be used. If none is available, the link won't work._