### PR TITLE
Bump minimum WooCommerce to 10.6, tested up to 10.7

### DIFF
--- a/mailpoet/changelog/2026-04-14-15-25-45-updated-bump-the-minimum-required-woocommerce-version-to-1.md
+++ b/mailpoet/changelog/2026-04-14-15-25-45-updated-bump-the-minimum-required-woocommerce-version-to-1.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Bump the minimum required WooCommerce version to 10.6 and tested up to version to 10.7

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -11,8 +11,8 @@
  * Text Domain: mailpoet
  * Domain Path: /lang
  *
- * WC requires at least: 10.5
- * WC tested up to: 10.6
+ * WC requires at least: 10.6
+ * WC tested up to: 10.7
  *
  * @package WordPress
  * @author MailPoet
@@ -28,7 +28,7 @@ $mailpoetPlugin = [
 ];
 
 const MAILPOET_MINIMUM_REQUIRED_WP_VERSION = '6.8'; // L-1 version, not the latest
-const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.5'; // L-1 version, not the latest
+const MAILPOET_MINIMUM_REQUIRED_WOOCOMMERCE_VERSION = '10.6'; // L-1 version, not the latest
 
 
 // Display WP version error notice


### PR DESCRIPTION
## Description

This PR bumps the minimum required WooCommerce to 10.6 to align with the L-1 of the released WooCommerce 10.7.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed best practices for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

Made with [Cursor](https://cursor.com)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:wc-10-7)

_The latest successful build from `wc-10-7` will be used. If none is available, the link won't work._