### PR TITLE
Improve System Status page: WooCommerce-style report with copy/download

### DIFF
--- a/.ai/skills/mailpoet-dev-cycle/code-quality.md
+++ b/.ai/skills/mailpoet-dev-cycle/code-quality.md
@@ -120,6 +120,25 @@ pnpm qa:fix
 
 Prettier runs from the repo root internally via `npx prettier`. It applies to JS, TS, JSX, TSX, SCSS, JSON, and other supported file types.
 
+### ⚠️ Docker vs CI Prettier Mismatch
+
+**Never use Docker's `./do run` to run Prettier write/check.** Docker's `npx` can resolve to a different Prettier version than what CI uses, causing the check to silently pass locally but fail in CI.
+
+The project uses **Prettier 2.6.2** with `singleQuote: true`. CI runs `node_modules/.bin/prettier` from the repo root, which enforces single quotes for all string literals in JS/JSX/TS/TSX files.
+
+**Always format changed files using Prettier directly on macOS** (not Docker):
+
+```bash
+# From the repo root — format only the files you've changed
+npx prettier@2.6.2 --write mailpoet/assets/js/src/path/to/file.jsx
+npx prettier@2.6.2 --write mailpoet/assets/css/src/path/to/file.scss
+
+# Verify both files pass
+npx prettier@2.6.2 --check mailpoet/assets/js/src/path/to/file.jsx
+```
+
+The most common symptom of this mismatch: CI fails with exactly the files you modified, while `./do qa:prettier-check` passes locally. This means Docker's Prettier formatted with double quotes (`"string"`) instead of the required single quotes (`'string'`).
+
 ### When to Run Prettier
 
 Always run `pnpm qa:fix` before committing. CI checks formatting via the underlying Robo Prettier check during the build step.

--- a/mailpoet/assets/css/src/components-plugin/_help.scss
+++ b/mailpoet/assets/css/src/components-plugin/_help.scss
@@ -1,0 +1,23 @@
+.mailpoet-system-status-report {
+  margin-bottom: 20px;
+
+  .submit {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    margin: 0;
+  }
+
+  .mailpoet-debug-report {
+    margin-top: 12px;
+  }
+
+  textarea {
+    background: #fff;
+    font-family: Menlo, Monaco, Consolas, monospace;
+    height: 240px;
+    margin-top: 8px;
+    white-space: pre;
+    width: 100%;
+  }
+}

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -1,49 +1,49 @@
 // Settings
 // Global variables, config switches. Not producing any CSS.
 
-@import "settings/breakpoints";
-@import "settings/grid";
-@import "settings/colors";
-@import "settings/form";
-@import "settings/legacy-modal";
-@import "settings/modal";
-@import "settings/newsletter";
-@import "settings/progress";
-@import "settings/typography";
+@import 'settings/breakpoints';
+@import 'settings/grid';
+@import 'settings/colors';
+@import 'settings/form';
+@import 'settings/legacy-modal';
+@import 'settings/modal';
+@import 'settings/newsletter';
+@import 'settings/progress';
+@import 'settings/typography';
 
 // Tools
 // Default mixins and functions. Still not producing any CSS.
 
-@import "mixins/breakpoints";
-@import "mixins/clearfix";
-@import "mixins/full-width-background";
+@import 'mixins/breakpoints';
+@import 'mixins/clearfix';
+@import 'mixins/full-width-background';
 
 // 3rd party styles
 
-@import "../../../node_modules/select2/dist/css/select2";
-@import "../../../node_modules/@wordpress/components/build-style/style";
+@import '../../../node_modules/select2/dist/css/select2';
+@import '../../../node_modules/@wordpress/components/build-style/style';
 
 // WordPress Admin Theme Color Variables
 // Needed for the WordPress Admin color scheme support for @wordpress/components.
-@import "../../../node_modules/@wordpress/base-styles/mixins";
+@import '../../../node_modules/@wordpress/base-styles/mixins';
 
 // Generic
-@import "generic/admin-colors"; // Has to be after @wordpress/components/build-style/style
-@import "generic/typography";
-@import "generic/buttons";
-@import "generic/buttons-spinners";
-@import "generic/forms";
-@import "generic/forms-checkbox";
-@import "generic/forms-input";
-@import "generic/forms-radio";
-@import "generic/forms-select";
-@import "generic/forms-select2";
-@import "generic/forms-textarea";
-@import "generic/forms-toggle";
-@import "generic/forms-token-field";
-@import "generic/forms-yesno";
-@import "generic/grid";
-@import "generic/helpers"; // must be the last
+@import 'generic/admin-colors'; // Has to be after @wordpress/components/build-style/style
+@import 'generic/typography';
+@import 'generic/buttons';
+@import 'generic/buttons-spinners';
+@import 'generic/forms';
+@import 'generic/forms-checkbox';
+@import 'generic/forms-input';
+@import 'generic/forms-radio';
+@import 'generic/forms-select';
+@import 'generic/forms-select2';
+@import 'generic/forms-textarea';
+@import 'generic/forms-toggle';
+@import 'generic/forms-token-field';
+@import 'generic/forms-yesno';
+@import 'generic/grid';
+@import 'generic/helpers'; // must be the last
 
 // Components
 // Actual UI components.

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -1,49 +1,49 @@
 // Settings
 // Global variables, config switches. Not producing any CSS.
 
-@import 'settings/breakpoints';
-@import 'settings/grid';
-@import 'settings/colors';
-@import 'settings/form';
-@import 'settings/legacy-modal';
-@import 'settings/modal';
-@import 'settings/newsletter';
-@import 'settings/progress';
-@import 'settings/typography';
+@import "settings/breakpoints";
+@import "settings/grid";
+@import "settings/colors";
+@import "settings/form";
+@import "settings/legacy-modal";
+@import "settings/modal";
+@import "settings/newsletter";
+@import "settings/progress";
+@import "settings/typography";
 
 // Tools
 // Default mixins and functions. Still not producing any CSS.
 
-@import 'mixins/breakpoints';
-@import 'mixins/clearfix';
-@import 'mixins/full-width-background';
+@import "mixins/breakpoints";
+@import "mixins/clearfix";
+@import "mixins/full-width-background";
 
 // 3rd party styles
 
-@import '../../../node_modules/select2/dist/css/select2';
-@import '../../../node_modules/@wordpress/components/build-style/style';
+@import "../../../node_modules/select2/dist/css/select2";
+@import "../../../node_modules/@wordpress/components/build-style/style";
 
 // WordPress Admin Theme Color Variables
 // Needed for the WordPress Admin color scheme support for @wordpress/components.
-@import '../../../node_modules/@wordpress/base-styles/mixins';
+@import "../../../node_modules/@wordpress/base-styles/mixins";
 
 // Generic
-@import 'generic/admin-colors'; // Has to be after @wordpress/components/build-style/style
-@import 'generic/typography';
-@import 'generic/buttons';
-@import 'generic/buttons-spinners';
-@import 'generic/forms';
-@import 'generic/forms-checkbox';
-@import 'generic/forms-input';
-@import 'generic/forms-radio';
-@import 'generic/forms-select';
-@import 'generic/forms-select2';
-@import 'generic/forms-textarea';
-@import 'generic/forms-toggle';
-@import 'generic/forms-token-field';
-@import 'generic/forms-yesno';
-@import 'generic/grid';
-@import 'generic/helpers'; // must be the last
+@import "generic/admin-colors"; // Has to be after @wordpress/components/build-style/style
+@import "generic/typography";
+@import "generic/buttons";
+@import "generic/buttons-spinners";
+@import "generic/forms";
+@import "generic/forms-checkbox";
+@import "generic/forms-input";
+@import "generic/forms-radio";
+@import "generic/forms-select";
+@import "generic/forms-select2";
+@import "generic/forms-textarea";
+@import "generic/forms-toggle";
+@import "generic/forms-token-field";
+@import "generic/forms-yesno";
+@import "generic/grid";
+@import "generic/helpers"; // must be the last
 
 // Components
 // Actual UI components.
@@ -71,6 +71,7 @@
 @import 'components-plugin/listing-newsletters';
 @import 'components-plugin/logs';
 @import 'components-plugin/forms';
+@import 'components-plugin/help';
 @import 'components-plugin/settings';
 @import 'components-plugin/segments';
 @import 'components-plugin/subscribers';

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -1,95 +1,96 @@
 // Settings
 // Global variables, config switches. Not producing any CSS.
 
-@import 'settings/breakpoints';
-@import 'settings/grid';
-@import 'settings/colors';
-@import 'settings/form';
-@import 'settings/legacy-modal';
-@import 'settings/modal';
-@import 'settings/newsletter';
-@import 'settings/progress';
-@import 'settings/typography';
+@import "settings/breakpoints";
+@import "settings/grid";
+@import "settings/colors";
+@import "settings/form";
+@import "settings/legacy-modal";
+@import "settings/modal";
+@import "settings/newsletter";
+@import "settings/progress";
+@import "settings/typography";
 
 // Tools
 // Default mixins and functions. Still not producing any CSS.
 
-@import 'mixins/breakpoints';
-@import 'mixins/clearfix';
-@import 'mixins/full-width-background';
+@import "mixins/breakpoints";
+@import "mixins/clearfix";
+@import "mixins/full-width-background";
 
 // 3rd party styles
 
-@import '../../../node_modules/select2/dist/css/select2';
-@import '../../../node_modules/@wordpress/components/build-style/style';
+@import "../../../node_modules/select2/dist/css/select2";
+@import "../../../node_modules/@wordpress/components/build-style/style";
 
 // WordPress Admin Theme Color Variables
 // Needed for the WordPress Admin color scheme support for @wordpress/components.
-@import '../../../node_modules/@wordpress/base-styles/mixins';
+@import "../../../node_modules/@wordpress/base-styles/mixins";
 
 // Generic
-@import 'generic/admin-colors'; // Has to be after @wordpress/components/build-style/style
-@import 'generic/typography';
-@import 'generic/buttons';
-@import 'generic/buttons-spinners';
-@import 'generic/forms';
-@import 'generic/forms-checkbox';
-@import 'generic/forms-input';
-@import 'generic/forms-radio';
-@import 'generic/forms-select';
-@import 'generic/forms-select2';
-@import 'generic/forms-textarea';
-@import 'generic/forms-toggle';
-@import 'generic/forms-token-field';
-@import 'generic/forms-yesno';
-@import 'generic/grid';
-@import 'generic/helpers'; // must be the last
+@import "generic/admin-colors"; // Has to be after @wordpress/components/build-style/style
+@import "generic/typography";
+@import "generic/buttons";
+@import "generic/buttons-spinners";
+@import "generic/forms";
+@import "generic/forms-checkbox";
+@import "generic/forms-input";
+@import "generic/forms-radio";
+@import "generic/forms-select";
+@import "generic/forms-select2";
+@import "generic/forms-textarea";
+@import "generic/forms-toggle";
+@import "generic/forms-token-field";
+@import "generic/forms-yesno";
+@import "generic/grid";
+@import "generic/helpers"; // must be the last
 
 // Components
 // Actual UI components.
 
-@import 'components/badge';
-@import 'components/categories';
-@import 'components/datepicker';
-@import 'components/modal';
-@import 'components/parsley';
-@import 'components/premium_required';
-@import 'components/steps';
-@import 'components/tabs';
-@import 'components/tags';
-@import 'components/template_box';
-@import 'components/tooltips';
-@import 'components/top_bar';
-@import 'components-plugin/automatic-emails';
-@import 'components-plugin/browser-preview';
-@import 'components-plugin/common';
-@import 'components-plugin/legacy-modal';
-@import 'components-plugin/inline-notice';
-@import 'components-plugin/notice';
-@import 'components-plugin/listing';
-@import 'components-plugin/listing-forms';
-@import 'components-plugin/listing-newsletters';
-@import 'components-plugin/logs';
-@import 'components-plugin/forms';
-@import 'components-plugin/settings';
-@import 'components-plugin/progress-bar';
-@import 'components-plugin/segments';
-@import 'components-plugin/subscribers';
-@import 'components-plugin/pages';
-@import 'components-plugin/pages-custom';
-@import 'components-plugin/premium-tiers-hero-sections';
-@import 'components-plugin/premium-tiers-page';
-@import 'components-plugin/mp-toggle';
-@import 'components-plugin/menu';
-@import 'components-plugin/newsletter';
-@import 'components-plugin/newsletter-templates';
-@import 'components-plugin/newsletter-types';
-@import 'components-plugin/newsletter-template-styles';
-@import 'components-plugin/welcome-wizard';
-@import 'components-plugin/newsletter-congratulate';
-@import 'components-plugin/discounts';
-@import 'components-plugin/review-request';
-@import 'components-plugin/set-from-address-modal';
-@import 'components-plugin/stats';
-@import 'components-plugin/import-export';
-@import 'components-plugin/landingpage';
+@import "components/badge";
+@import "components/categories";
+@import "components/datepicker";
+@import "components/modal";
+@import "components/parsley";
+@import "components/premium_required";
+@import "components/steps";
+@import "components/tabs";
+@import "components/tags";
+@import "components/template_box";
+@import "components/tooltips";
+@import "components/top_bar";
+@import "components-plugin/automatic-emails";
+@import "components-plugin/browser-preview";
+@import "components-plugin/common";
+@import "components-plugin/legacy-modal";
+@import "components-plugin/inline-notice";
+@import "components-plugin/notice";
+@import "components-plugin/listing";
+@import "components-plugin/listing-forms";
+@import "components-plugin/listing-newsletters";
+@import "components-plugin/logs";
+@import "components-plugin/forms";
+@import "components-plugin/help";
+@import "components-plugin/settings";
+@import "components-plugin/progress-bar";
+@import "components-plugin/segments";
+@import "components-plugin/subscribers";
+@import "components-plugin/pages";
+@import "components-plugin/pages-custom";
+@import "components-plugin/premium-tiers-hero-sections";
+@import "components-plugin/premium-tiers-page";
+@import "components-plugin/mp-toggle";
+@import "components-plugin/menu";
+@import "components-plugin/newsletter";
+@import "components-plugin/newsletter-templates";
+@import "components-plugin/newsletter-types";
+@import "components-plugin/newsletter-template-styles";
+@import "components-plugin/welcome-wizard";
+@import "components-plugin/newsletter-congratulate";
+@import "components-plugin/discounts";
+@import "components-plugin/review-request";
+@import "components-plugin/set-from-address-modal";
+@import "components-plugin/stats";
+@import "components-plugin/import-export";
+@import "components-plugin/landingpage";

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -189,8 +189,10 @@ function buildSystemStatusReport(
     : MailPoet.I18n.t("unknown");
 
   let queueStatusText = MailPoet.I18n.t("unknown");
-  if (queueStatus.status === "paused") queueStatusText = MailPoet.I18n.t("paused");
-  else if (queueStatus.status !== undefined) queueStatusText = MailPoet.I18n.t("running");
+  if (queueStatus.status === "paused")
+    queueStatusText = MailPoet.I18n.t("paused");
+  else if (queueStatus.status !== undefined)
+    queueStatusText = MailPoet.I18n.t("running");
   const queueRetryAttempt =
     queueStatus.retryAttempt !== undefined && queueStatus.retryAttempt !== null
       ? queueStatus.retryAttempt
@@ -488,7 +490,12 @@ export function SystemStatus() {
     MailPoet.I18n.t("systemStatusCopyForSupport")
   );
   const reportText = useMemo(
-    () => buildSystemStatusReport(systemInfoData, systemStatusData, actionSchedulerData),
+    () =>
+      buildSystemStatusReport(
+        systemInfoData,
+        systemStatusData,
+        actionSchedulerData
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- data comes from window globals, stable for the page lifetime
     []
   );

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -1,6 +1,6 @@
 import { MailPoet } from "mailpoet";
 import ReactStringReplace from "react-string-replace";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { copyToClipboard } from "utils";
 import { CronStatus } from "./cron-status.jsx";
 import { QueueStatus } from "./queue-status";
@@ -182,7 +182,10 @@ function buildSystemStatusReport(
   let queueStatusText = MailPoet.I18n.t("unknown");
   if (queueStatus.status === "paused") queueStatusText = MailPoet.I18n.t("paused");
   else if (queueStatus.status !== undefined) queueStatusText = MailPoet.I18n.t("running");
-  const queueRetryAttempt = queueStatus.retryAttempt || MailPoet.I18n.t("none");
+  const queueRetryAttempt =
+    queueStatus.retryAttempt !== undefined && queueStatus.retryAttempt !== null
+      ? queueStatus.retryAttempt
+      : MailPoet.I18n.t("none");
   const queueRetryAt = queueStatus.retryAt
     ? formatTimestamp(queueStatus.retryAt)
     : MailPoet.I18n.t("unknown");
@@ -475,10 +478,10 @@ export function SystemStatus() {
   const [copyButtonLabel, setCopyButtonLabel] = useState(
     MailPoet.I18n.t("systemStatusCopyForSupport")
   );
-  const reportText = buildSystemStatusReport(
-    systemInfoData,
-    systemStatusData,
-    actionSchedulerData
+  const reportText = useMemo(
+    () => buildSystemStatusReport(systemInfoData, systemStatusData, actionSchedulerData),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- data comes from window globals, stable for the page lifetime
+    []
   );
 
   const handleCopyForSupport = async () => {

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -1,21 +1,21 @@
-import { MailPoet } from "mailpoet";
-import ReactStringReplace from "react-string-replace";
-import { useMemo, useState } from "react";
-import { copyToClipboard } from "utils";
-import { CronStatus } from "./cron-status.jsx";
-import { QueueStatus } from "./queue-status";
-import { ActionSchedulerStatus } from "./action-scheduler-status";
-import { DataInconsistencies } from "./data-inconsistencies";
+import { MailPoet } from 'mailpoet';
+import ReactStringReplace from 'react-string-replace';
+import { useMemo, useState } from 'react';
+import { copyToClipboard } from 'utils';
+import { CronStatus } from './cron-status.jsx';
+import { QueueStatus } from './queue-status';
+import { ActionSchedulerStatus } from './action-scheduler-status';
+import { DataInconsistencies } from './data-inconsistencies';
 
 function printValue(value) {
-  if (value === null || value === undefined || value === "") {
-    return MailPoet.I18n.t("none");
+  if (value === null || value === undefined || value === '') {
+    return MailPoet.I18n.t('none');
   }
-  if (typeof value === "boolean") {
-    return value ? MailPoet.I18n.t("yes") : MailPoet.I18n.t("no");
+  if (typeof value === 'boolean') {
+    return value ? MailPoet.I18n.t('yes') : MailPoet.I18n.t('no');
   }
   if (Array.isArray(value)) {
-    if (value.length === 0) return MailPoet.I18n.t("none");
+    if (value.length === 0) return MailPoet.I18n.t('none');
     return value
       .map((item) => {
         if (item && item.worker && item.message) {
@@ -23,21 +23,21 @@ function printValue(value) {
         }
         return `${item}`;
       })
-      .join("; ");
+      .join('; ');
   }
-  if (typeof value === "object") {
+  if (typeof value === 'object') {
     return JSON.stringify(value);
   }
   return `${value}`;
 }
 
 function formatTimestamp(seconds) {
-  if (!seconds) return MailPoet.I18n.t("unknown");
+  if (!seconds) return MailPoet.I18n.t('unknown');
   return MailPoet.Date.full(seconds * 1000);
 }
 
 function addSection(lines, title) {
-  lines.push("");
+  lines.push('');
   lines.push(`### ${title} ###`);
 }
 
@@ -48,32 +48,32 @@ function addBullet(lines, key, value) {
 function addActivePluginsList(lines, plugins) {
   const items = (plugins || []).filter(Boolean);
   if (!items.length) {
-    lines.push(`  - ${MailPoet.I18n.t("none")}`);
+    lines.push(`  - ${MailPoet.I18n.t('none')}`);
     return;
   }
   items.forEach((plugin) => {
     const latestVersion = plugin.versionLatest
       ? ` (update to version ${plugin.versionLatest} is available)`
-      : "";
+      : '';
     lines.push(
-      `  - ${plugin.name}: by ${plugin.author} - ${plugin.version}${latestVersion}`
+      `  - ${plugin.name}: by ${plugin.author} - ${plugin.version}${latestVersion}`,
     );
   });
 }
 
 function formatOptional(value) {
-  if (value === null || value === undefined || value === "") {
-    return MailPoet.I18n.t("none");
+  if (value === null || value === undefined || value === '') {
+    return MailPoet.I18n.t('none');
   }
   return value;
 }
 
 function formatYesNo(value) {
-  if (typeof value === "boolean") {
-    return value ? MailPoet.I18n.t("yes") : MailPoet.I18n.t("no");
+  if (typeof value === 'boolean') {
+    return value ? MailPoet.I18n.t('yes') : MailPoet.I18n.t('no');
   }
-  const normalized = `${value || ""}`.trim().toLowerCase();
-  if (normalized === "yes" || normalized === "no") {
+  const normalized = `${value || ''}`.trim().toLowerCase();
+  if (normalized === 'yes' || normalized === 'no') {
     return MailPoet.I18n.t(normalized);
   }
   return printValue(value);
@@ -81,7 +81,7 @@ function formatYesNo(value) {
 
 function parseCompositeField(value, knownKeys) {
   const result = {};
-  if (!value || typeof value !== "string") {
+  if (!value || typeof value !== 'string') {
     return result;
   }
 
@@ -93,11 +93,11 @@ function parseCompositeField(value, knownKeys) {
     const sortedKeys = [...knownKeys].sort((a, b) => b.length - a.length);
     // Escape regex-special characters in each key name.
     const escapedKeys = sortedKeys.map((k) =>
-      k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
     );
     const regex = new RegExp(
-      `(?:^| - )(?<key>${escapedKeys.join("|")}): `,
-      "g"
+      `(?:^| - )(?<key>${escapedKeys.join('|')}): `,
+      'g',
     );
     const matches = [...value.matchAll(regex)];
     matches.forEach((match, i) => {
@@ -108,8 +108,8 @@ function parseCompositeField(value, knownKeys) {
     return result;
   }
 
-  value.split(" - ").forEach((part) => {
-    const separatorIndex = part.indexOf(": ");
+  value.split(' - ').forEach((part) => {
+    const separatorIndex = part.indexOf(': ');
     if (separatorIndex === -1) return;
     result[part.slice(0, separatorIndex).trim()] = part
       .slice(separatorIndex + 2)
@@ -121,94 +121,94 @@ function parseCompositeField(value, knownKeys) {
 function buildSystemStatusReport(
   systemInfoData,
   systemStatusData,
-  actionSchedulerData
+  actionSchedulerData,
 ) {
   const lines = [];
   const queueStatus = systemStatusData.queueStatus || {};
   const systemInfo = systemInfoData || {};
-  const wpInfo = parseCompositeField(systemInfo["WP info"], [
-    "WP_MEMORY_LIMIT",
-    "WP_MAX_MEMORY_LIMIT",
-    "WP_DEBUG",
-    "WordPress language",
-    "WordPress timezone",
+  const wpInfo = parseCompositeField(systemInfo['WP info'], [
+    'WP_MEMORY_LIMIT',
+    'WP_MAX_MEMORY_LIMIT',
+    'WP_DEBUG',
+    'WordPress language',
+    'WordPress timezone',
   ]);
-  const phpInfo = parseCompositeField(systemInfo["PHP info"], [
-    "PHP max_execution_time",
-    "PHP memory_limit",
-    "PHP upload_max_filesize",
-    "PHP post_max_size",
+  const phpInfo = parseCompositeField(systemInfo['PHP info'], [
+    'PHP max_execution_time',
+    'PHP memory_limit',
+    'PHP upload_max_filesize',
+    'PHP post_max_size',
   ]);
   const sendingServiceInfo = parseCompositeField(
-    systemInfo["MailPoet Sending Service"],
-    ["Is reachable", "Ping response", "API key state", "Premium key state"]
+    systemInfo['MailPoet Sending Service'],
+    ['Is reachable', 'Ping response', 'API key state', 'Premium key state'],
   );
   const sendingDetails = parseCompositeField(
-    systemInfo["MailPoet sending info"],
+    systemInfo['MailPoet sending info'],
     [
       "Send all site's emails with",
-      "Task Scheduler method",
-      "Default FROM address",
-      "Default Reply-To address",
-      "Bounce Email Address",
-    ]
+      'Task Scheduler method',
+      'Default FROM address',
+      'Default Reply-To address',
+      'Bounce Email Address',
+    ],
   );
   const dataInconsistencyStatus = parseCompositeField(
-    systemInfo["Data inconsistency status"]
+    systemInfo['Data inconsistency status'],
   );
   const keyStateSummary = [
-    sendingServiceInfo["API key state"],
-    sendingServiceInfo["Premium key state"]
-      ? `premium: ${sendingServiceInfo["Premium key state"]}`
+    sendingServiceInfo['API key state'],
+    sendingServiceInfo['Premium key state']
+      ? `premium: ${sendingServiceInfo['Premium key state']}`
       : null,
   ]
     .filter(Boolean)
-    .join("; ");
+    .join('; ');
   const premiumKeyValue = keyStateSummary
-    ? `${systemInfo["MailPoet Premium/MSS key"]} (${keyStateSummary})`
-    : systemInfo["MailPoet Premium/MSS key"];
+    ? `${systemInfo['MailPoet Premium/MSS key']} (${keyStateSummary})`
+    : systemInfo['MailPoet Premium/MSS key'];
   const cronStatus = systemStatusData.cronStatus || {};
   const cronError = Array.isArray(cronStatus.last_error)
     ? cronStatus.last_error
         .map((error) => `${error.worker}: ${error.message}`)
-        .join("; ")
+        .join('; ')
     : cronStatus.last_error;
 
   const actionSchedulerVersion =
-    actionSchedulerData?.version || MailPoet.I18n.t("none");
+    actionSchedulerData?.version || MailPoet.I18n.t('none');
   const actionSchedulerStorage =
-    actionSchedulerData?.storage || MailPoet.I18n.t("none");
+    actionSchedulerData?.storage || MailPoet.I18n.t('none');
   const actionSchedulerNextTrigger = actionSchedulerData?.latestTrigger
     ? MailPoet.Date.full(actionSchedulerData.latestTrigger)
-    : MailPoet.I18n.t("unknown");
+    : MailPoet.I18n.t('unknown');
   const actionSchedulerLastTrigger = actionSchedulerData?.latestCompletedTrigger
     ? MailPoet.Date.full(actionSchedulerData.latestCompletedTrigger)
-    : MailPoet.I18n.t("unknown");
+    : MailPoet.I18n.t('unknown');
   const actionSchedulerLastRun = actionSchedulerData?.latestCompletedRun
     ? MailPoet.Date.full(actionSchedulerData.latestCompletedRun)
-    : MailPoet.I18n.t("unknown");
+    : MailPoet.I18n.t('unknown');
 
-  let queueStatusText = MailPoet.I18n.t("unknown");
-  if (queueStatus.status === "paused")
-    queueStatusText = MailPoet.I18n.t("paused");
+  let queueStatusText = MailPoet.I18n.t('unknown');
+  if (queueStatus.status === 'paused')
+    queueStatusText = MailPoet.I18n.t('paused');
   else if (queueStatus.status !== undefined)
-    queueStatusText = MailPoet.I18n.t("running");
+    queueStatusText = MailPoet.I18n.t('running');
   const queueRetryAttempt =
     queueStatus.retryAttempt !== undefined && queueStatus.retryAttempt !== null
       ? queueStatus.retryAttempt
-      : MailPoet.I18n.t("none");
+      : MailPoet.I18n.t('none');
   const queueRetryAt = queueStatus.retryAt
     ? formatTimestamp(queueStatus.retryAt)
-    : MailPoet.I18n.t("unknown");
-  const queueError = queueStatus.error?.errorMessage || MailPoet.I18n.t("none");
+    : MailPoet.I18n.t('unknown');
+  const queueError = queueStatus.error?.errorMessage || MailPoet.I18n.t('none');
   const queueCounts = queueStatus.tasksStatusCounts || {};
 
   const activePlugins = Array.isArray(systemStatusData.activePlugins)
     ? systemStatusData.activePlugins
         .map((plugin) => ({
-          name: `${plugin?.name || ""}`.trim(),
-          author: `${plugin?.author || ""}`.trim(),
-          version: `${plugin?.version || ""}`.trim(),
+          name: `${plugin?.name || ''}`.trim(),
+          author: `${plugin?.author || ''}`.trim(),
+          version: `${plugin?.version || ''}`.trim(),
           versionLatest: plugin?.versionLatest
             ? `${plugin.versionLatest}`.trim()
             : null,
@@ -216,172 +216,172 @@ function buildSystemStatusReport(
         .filter((plugin) => plugin.name && plugin.author && plugin.version)
     : [];
 
-  lines.push("### MailPoet System Status Report ###");
+  lines.push('### MailPoet System Status Report ###');
   lines.push(`Generated: ${new Date().toISOString()}`);
 
-  addSection(lines, "Site & Account");
-  addBullet(lines, "Site name", systemInfo.name);
-  addBullet(lines, "Email", systemInfo.email);
-  addBullet(lines, "MailPoet Premium/MSS key", premiumKeyValue);
-  addBullet(lines, "Plugin installed at", systemInfo["Plugin installed at"]);
+  addSection(lines, 'Site & Account');
+  addBullet(lines, 'Site name', systemInfo.name);
+  addBullet(lines, 'Email', systemInfo.email);
+  addBullet(lines, 'MailPoet Premium/MSS key', premiumKeyValue);
+  addBullet(lines, 'Plugin installed at', systemInfo['Plugin installed at']);
   addBullet(
     lines,
-    "Installed via WooCommerce onboarding wizard",
-    formatYesNo(systemInfo["Installed via WooCommerce onboarding wizard"])
+    'Installed via WooCommerce onboarding wizard',
+    formatYesNo(systemInfo['Installed via WooCommerce onboarding wizard']),
   );
   addBullet(
     lines,
-    "Total subscribers",
-    systemInfo["Total number of subscribers"]
+    'Total subscribers',
+    systemInfo['Total number of subscribers'],
   );
 
-  addSection(lines, "Versions");
-  addBullet(lines, "MailPoet Free", systemInfo["MailPoet Free version"]);
-  addBullet(lines, "MailPoet Premium", systemInfo["MailPoet Premium version"]);
-  addBullet(lines, "WordPress", systemInfo["WordPress version"]);
-  addBullet(lines, "PHP", systemInfo["PHP version"]);
-  addBullet(lines, "Database", systemInfo["Database version"]);
-  addBullet(lines, "Action Scheduler", actionSchedulerVersion);
+  addSection(lines, 'Versions');
+  addBullet(lines, 'MailPoet Free', systemInfo['MailPoet Free version']);
+  addBullet(lines, 'MailPoet Premium', systemInfo['MailPoet Premium version']);
+  addBullet(lines, 'WordPress', systemInfo['WordPress version']);
+  addBullet(lines, 'PHP', systemInfo['PHP version']);
+  addBullet(lines, 'Database', systemInfo['Database version']);
+  addBullet(lines, 'Action Scheduler', actionSchedulerVersion);
 
-  addSection(lines, "Environment");
-  addBullet(lines, "Web server", systemInfo["Web server"]);
-  addBullet(lines, "Server OS", systemInfo["Server OS"]);
-  addBullet(lines, "Multisite", systemInfo["Multisite environment?"]);
-  addBullet(lines, "Current theme", systemInfo["Current Theme"]);
-  addBullet(lines, "WordPress language", wpInfo["WordPress language"]);
-  addBullet(lines, "WordPress timezone", wpInfo["WordPress timezone"]);
+  addSection(lines, 'Environment');
+  addBullet(lines, 'Web server', systemInfo['Web server']);
+  addBullet(lines, 'Server OS', systemInfo['Server OS']);
+  addBullet(lines, 'Multisite', systemInfo['Multisite environment?']);
+  addBullet(lines, 'Current theme', systemInfo['Current Theme']);
+  addBullet(lines, 'WordPress language', wpInfo['WordPress language']);
+  addBullet(lines, 'WordPress timezone', wpInfo['WordPress timezone']);
 
-  addSection(lines, "WordPress & PHP Config");
-  addBullet(lines, "WP_MEMORY_LIMIT", wpInfo.WP_MEMORY_LIMIT);
-  addBullet(lines, "WP_MAX_MEMORY_LIMIT", wpInfo.WP_MAX_MEMORY_LIMIT);
-  addBullet(lines, "WP_DEBUG", wpInfo.WP_DEBUG);
-  addBullet(lines, "PHP max_execution_time", phpInfo["PHP max_execution_time"]);
-  addBullet(lines, "PHP memory_limit", phpInfo["PHP memory_limit"]);
+  addSection(lines, 'WordPress & PHP Config');
+  addBullet(lines, 'WP_MEMORY_LIMIT', wpInfo.WP_MEMORY_LIMIT);
+  addBullet(lines, 'WP_MAX_MEMORY_LIMIT', wpInfo.WP_MAX_MEMORY_LIMIT);
+  addBullet(lines, 'WP_DEBUG', wpInfo.WP_DEBUG);
+  addBullet(lines, 'PHP max_execution_time', phpInfo['PHP max_execution_time']);
+  addBullet(lines, 'PHP memory_limit', phpInfo['PHP memory_limit']);
   addBullet(
     lines,
-    "PHP upload_max_filesize",
-    phpInfo["PHP upload_max_filesize"]
+    'PHP upload_max_filesize',
+    phpInfo['PHP upload_max_filesize'],
   );
-  addBullet(lines, "PHP post_max_size", phpInfo["PHP post_max_size"]);
+  addBullet(lines, 'PHP post_max_size', phpInfo['PHP post_max_size']);
 
   addSection(lines, `Active Plugins (${activePlugins.length})`);
   addActivePluginsList(lines, activePlugins);
 
-  addSection(lines, "Sending Configuration");
-  addBullet(lines, "Sending method", systemInfo["Sending Method"]);
+  addSection(lines, 'Sending Configuration');
+  addBullet(lines, 'Sending method', systemInfo['Sending Method']);
   addBullet(
     lines,
     "Send all site's emails with",
-    sendingDetails["Send all site's emails with"]
+    sendingDetails["Send all site's emails with"],
   );
-  addBullet(lines, "Sending frequency", systemInfo["Sending Frequency"]);
+  addBullet(lines, 'Sending frequency', systemInfo['Sending Frequency']);
   addBullet(
     lines,
-    "Default FROM address",
-    formatOptional(sendingDetails["Default FROM address"])
-  );
-  addBullet(
-    lines,
-    "Default Reply-To address",
-    formatOptional(sendingDetails["Default Reply-To address"])
+    'Default FROM address',
+    formatOptional(sendingDetails['Default FROM address']),
   );
   addBullet(
     lines,
-    "Bounce email address",
-    formatOptional(sendingDetails["Bounce Email Address"])
+    'Default Reply-To address',
+    formatOptional(sendingDetails['Default Reply-To address']),
+  );
+  addBullet(
+    lines,
+    'Bounce email address',
+    formatOptional(sendingDetails['Bounce Email Address']),
   );
 
-  addSection(lines, "Connection to MailPoet Sending Service");
-  addBullet(lines, "Enabled", formatYesNo(systemStatusData.mss?.enabled));
-  addBullet(lines, "Reachable", formatYesNo(systemStatusData.mss?.isReachable));
-  addBullet(lines, "Ping response", sendingServiceInfo["Ping response"]);
-  addBullet(lines, "API key state", sendingServiceInfo["API key state"]);
+  addSection(lines, 'Connection to MailPoet Sending Service');
+  addBullet(lines, 'Enabled', formatYesNo(systemStatusData.mss?.enabled));
+  addBullet(lines, 'Reachable', formatYesNo(systemStatusData.mss?.isReachable));
+  addBullet(lines, 'Ping response', sendingServiceInfo['Ping response']);
+  addBullet(lines, 'API key state', sendingServiceInfo['API key state']);
   addBullet(
     lines,
-    "Premium key state",
-    sendingServiceInfo["Premium key state"]
+    'Premium key state',
+    sendingServiceInfo['Premium key state'],
   );
 
-  addSection(lines, "Task Scheduler / Cron");
-  addBullet(lines, "Status", cronStatus.status || MailPoet.I18n.t("unknown"));
+  addSection(lines, 'Task Scheduler / Cron');
+  addBullet(lines, 'Status', cronStatus.status || MailPoet.I18n.t('unknown'));
   addBullet(
     lines,
-    "Task Scheduler method",
-    sendingDetails["Task Scheduler method"]
+    'Task Scheduler method',
+    sendingDetails['Task Scheduler method'],
   );
-  addBullet(lines, "Ping URL", systemStatusData.cron?.url);
-  addBullet(lines, "Accessible", formatYesNo(cronStatus.accessible));
-  addBullet(lines, "Ping response", systemStatusData.cron?.pingResponse);
-  addBullet(lines, "Last updated", formatTimestamp(cronStatus.updated_at));
+  addBullet(lines, 'Ping URL', systemStatusData.cron?.url);
+  addBullet(lines, 'Accessible', formatYesNo(cronStatus.accessible));
+  addBullet(lines, 'Ping response', systemStatusData.cron?.pingResponse);
+  addBullet(lines, 'Last updated', formatTimestamp(cronStatus.updated_at));
   addBullet(
     lines,
-    "Last run started",
-    formatTimestamp(cronStatus.run_started_at)
+    'Last run started',
+    formatTimestamp(cronStatus.run_started_at),
   );
   addBullet(
     lines,
-    "Last run completed",
-    formatTimestamp(cronStatus.run_completed_at)
+    'Last run completed',
+    formatTimestamp(cronStatus.run_completed_at),
   );
-  addBullet(lines, "Last seen error", cronError || MailPoet.I18n.t("none"));
+  addBullet(lines, 'Last seen error', cronError || MailPoet.I18n.t('none'));
 
-  addSection(lines, "Action Scheduler Status");
-  addBullet(lines, "Storage type", actionSchedulerStorage);
-  addBullet(lines, "Next trigger run", actionSchedulerNextTrigger);
-  addBullet(lines, "Last trigger run", actionSchedulerLastTrigger);
-  addBullet(lines, "Last worker run", actionSchedulerLastRun);
+  addSection(lines, 'Action Scheduler Status');
+  addBullet(lines, 'Storage type', actionSchedulerStorage);
+  addBullet(lines, 'Next trigger run', actionSchedulerNextTrigger);
+  addBullet(lines, 'Last trigger run', actionSchedulerLastTrigger);
+  addBullet(lines, 'Last worker run', actionSchedulerLastRun);
 
-  addSection(lines, "Sending Queue");
-  addBullet(lines, "Status", queueStatusText);
-  addBullet(lines, "Started at", formatTimestamp(queueStatus.started));
-  addBullet(lines, "Sent emails", queueStatus.sent || 0);
-  addBullet(lines, "Retry attempt", queueRetryAttempt);
-  addBullet(lines, "Retry at", queueRetryAt);
-  addBullet(lines, "Error", queueError);
-  addBullet(lines, "Total completed tasks", queueCounts.completed || 0);
-  addBullet(lines, "Total running tasks", queueCounts.running || 0);
-  addBullet(lines, "Total paused tasks", queueCounts.paused || 0);
-  addBullet(lines, "Total cancelled tasks", queueCounts.cancelled || 0);
-  addBullet(lines, "Total scheduled tasks", queueCounts.scheduled || 0);
+  addSection(lines, 'Sending Queue');
+  addBullet(lines, 'Status', queueStatusText);
+  addBullet(lines, 'Started at', formatTimestamp(queueStatus.started));
+  addBullet(lines, 'Sent emails', queueStatus.sent || 0);
+  addBullet(lines, 'Retry attempt', queueRetryAttempt);
+  addBullet(lines, 'Retry at', queueRetryAt);
+  addBullet(lines, 'Error', queueError);
+  addBullet(lines, 'Total completed tasks', queueCounts.completed || 0);
+  addBullet(lines, 'Total running tasks', queueCounts.running || 0);
+  addBullet(lines, 'Total paused tasks', queueCounts.paused || 0);
+  addBullet(lines, 'Total cancelled tasks', queueCounts.cancelled || 0);
+  addBullet(lines, 'Total scheduled tasks', queueCounts.scheduled || 0);
 
-  addSection(lines, "Data Inconsistency");
+  addSection(lines, 'Data Inconsistency');
   addBullet(
     lines,
-    "Orphaned sending tasks",
-    dataInconsistencyStatus["Orphaned sending tasks"]
+    'Orphaned sending tasks',
+    dataInconsistencyStatus['Orphaned sending tasks'],
   );
   addBullet(
     lines,
-    "Orphaned sending task subscribers",
-    dataInconsistencyStatus["Orphaned sending task subscribers"]
+    'Orphaned sending task subscribers',
+    dataInconsistencyStatus['Orphaned sending task subscribers'],
   );
   addBullet(
     lines,
-    "Sending queue without newsletter",
-    dataInconsistencyStatus["Sending queue without newsletter"]
+    'Sending queue without newsletter',
+    dataInconsistencyStatus['Sending queue without newsletter'],
   );
   addBullet(
     lines,
-    "Orphaned subscriptions",
-    dataInconsistencyStatus["Orphaned subscriptions"]
+    'Orphaned subscriptions',
+    dataInconsistencyStatus['Orphaned subscriptions'],
   );
-  addBullet(lines, "Orphaned links", dataInconsistencyStatus["Orphaned links"]);
+  addBullet(lines, 'Orphaned links', dataInconsistencyStatus['Orphaned links']);
   addBullet(
     lines,
-    "Orphaned newsletter posts",
-    dataInconsistencyStatus["Orphaned newsletter posts"]
+    'Orphaned newsletter posts',
+    dataInconsistencyStatus['Orphaned newsletter posts'],
   );
 
-  lines.push("");
-  return lines.join("\n");
+  lines.push('');
+  return lines.join('\n');
 }
 
 function downloadReport(reportText) {
   const date = new Date().toISOString().slice(0, 10);
   const fileName = `mailpoet-system-status-${date}.txt`;
-  const blob = new Blob([reportText], { type: "text/plain;charset=utf-8" });
+  const blob = new Blob([reportText], { type: 'text/plain;charset=utf-8' });
   const url = window.URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
+  const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = fileName;
   document.body.appendChild(anchor);
@@ -395,9 +395,9 @@ function renderStatusMessage(
   successMessage,
   errorMessage,
   link,
-  additionalInfo
+  additionalInfo,
 ) {
-  const noticeType = status ? "success" : "error";
+  const noticeType = status ? 'success' : 'error';
   let noticeMessage = status ? successMessage : errorMessage;
 
   if (link) {
@@ -408,7 +408,7 @@ function renderStatusMessage(
         <a className="mailpoet-text-link" href={link} key="kb-link">
           {match}
         </a>
-      )
+      ),
     );
   }
 
@@ -428,14 +428,14 @@ function renderCronSection(data) {
   const status = data.cron.isReachable;
   const url = data.cron.url;
   const error = `${MailPoet.I18n.t(
-    "systemStatusConnectionUnsuccessful"
-  )} ${MailPoet.I18n.t("systemStatusCronConnectionUnsuccessfulInfo")}`;
-  const success = MailPoet.I18n.t("systemStatusConnectionSuccessful");
+    'systemStatusConnectionUnsuccessful',
+  )} ${MailPoet.I18n.t('systemStatusCronConnectionUnsuccessfulInfo')}`;
+  const success = MailPoet.I18n.t('systemStatusConnectionSuccessful');
   const additionalInfo = !status ? data.cron.pingResponse : null;
 
   return (
     <div>
-      <h4>{MailPoet.I18n.t("systemStatusCronTitle")}</h4>
+      <h4>{MailPoet.I18n.t('systemStatusCronTitle')}</h4>
       <p>
         <a
           className="mailpoet-text-link"
@@ -450,8 +450,8 @@ function renderCronSection(data) {
         status,
         success,
         error,
-        "https://kb.mailpoet.com/article/231-sending-does-not-work",
-        additionalInfo
+        'https://kb.mailpoet.com/article/231-sending-does-not-work',
+        additionalInfo,
       )}
     </div>
   );
@@ -460,44 +460,44 @@ function renderCronSection(data) {
 function renderMSSSection(data) {
   const errorMessage = data.mss.enabled
     ? `${MailPoet.I18n.t(
-        "systemStatusConnectionUnsuccessful"
-      )} ${MailPoet.I18n.t("systemStatusMSSConnectionUnsuccessfulInfo")}`
-    : MailPoet.I18n.t("systemStatusMSSConnectionCanNotConnect");
+        'systemStatusConnectionUnsuccessful',
+      )} ${MailPoet.I18n.t('systemStatusMSSConnectionUnsuccessfulInfo')}`
+    : MailPoet.I18n.t('systemStatusMSSConnectionCanNotConnect');
   const successMessage = data.mss.enabled
-    ? MailPoet.I18n.t("systemStatusConnectionSuccessful")
-    : MailPoet.I18n.t("systemStatusMSSConnectionCanConnect");
+    ? MailPoet.I18n.t('systemStatusConnectionSuccessful')
+    : MailPoet.I18n.t('systemStatusMSSConnectionCanConnect');
   return (
     <div>
-      <h4>{MailPoet.I18n.t("systemStatusMSSTitle")}</h4>
+      <h4>{MailPoet.I18n.t('systemStatusMSSTitle')}</h4>
       {renderStatusMessage(
         data.mss.isReachable,
         successMessage,
         errorMessage,
-        "https://kb.mailpoet.com/article/319-known-errors-when-validating-a-mailpoet-key",
-        null
+        'https://kb.mailpoet.com/article/319-known-errors-when-validating-a-mailpoet-key',
+        null,
       )}
     </div>
   );
 }
 
 export function SystemStatus() {
-  const reportId = "mailpoet-system-status-report";
+  const reportId = 'mailpoet-system-status-report';
   const systemInfoData = window.systemInfoData;
   const systemStatusData = window.systemStatusData;
   const actionSchedulerData = window.actionSchedulerData;
   const [isReportVisible, setIsReportVisible] = useState(false);
   const [copyButtonLabel, setCopyButtonLabel] = useState(
-    MailPoet.I18n.t("systemStatusCopyForSupport")
+    MailPoet.I18n.t('systemStatusCopyForSupport'),
   );
   const reportText = useMemo(
     () =>
       buildSystemStatusReport(
         systemInfoData,
         systemStatusData,
-        actionSchedulerData
+        actionSchedulerData,
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- data comes from window globals, stable for the page lifetime
-    []
+    [],
   );
 
   const handleCopyForSupport = async () => {
@@ -506,18 +506,18 @@ export function SystemStatus() {
         reportId,
         (wasSuccessful) => {
           if (!wasSuccessful) {
-            setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardFailure"));
+            setCopyButtonLabel(MailPoet.I18n.t('copyToClipboardFailure'));
             return;
           }
-          setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardSuccess"));
+          setCopyButtonLabel(MailPoet.I18n.t('copyToClipboardSuccess'));
           window.setTimeout(() => {
-            setCopyButtonLabel(MailPoet.I18n.t("systemStatusCopyForSupport"));
+            setCopyButtonLabel(MailPoet.I18n.t('systemStatusCopyForSupport'));
           }, 3000);
         },
-        true
+        true,
       );
     } catch {
-      setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardFailure"));
+      setCopyButtonLabel(MailPoet.I18n.t('copyToClipboardFailure'));
     }
   };
 
@@ -526,19 +526,19 @@ export function SystemStatus() {
       <div className="mailpoet_notice notice inline">
         <p>
           {systemStatusData.mss.enabled
-            ? MailPoet.I18n.t("systemStatusIntroCronMSS")
-            : MailPoet.I18n.t("systemStatusIntroCron")}
+            ? MailPoet.I18n.t('systemStatusIntroCronMSS')
+            : MailPoet.I18n.t('systemStatusIntroCron')}
         </p>
       </div>
       <div className="updated mailpoet-system-status-report inline">
-        <p>{MailPoet.I18n.t("systemStatusGetReportIntro")}</p>
+        <p>{MailPoet.I18n.t('systemStatusGetReportIntro')}</p>
         <p className="submit">
           <button
             type="button"
             className="button button-primary"
             onClick={() => setIsReportVisible(true)}
           >
-            {MailPoet.I18n.t("systemStatusGetReportTitle")}
+            {MailPoet.I18n.t('systemStatusGetReportTitle')}
           </button>
           <a
             className="button button-secondary"
@@ -546,7 +546,7 @@ export function SystemStatus() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            {MailPoet.I18n.t("systemStatusUnderstandingReport")}
+            {MailPoet.I18n.t('systemStatusUnderstandingReport')}
           </a>
         </p>
         {isReportVisible ? (
@@ -558,7 +558,7 @@ export function SystemStatus() {
                 className="button button-primary"
                 onClick={() => downloadReport(reportText)}
               >
-                {MailPoet.I18n.t("systemStatusDownloadReport")}
+                {MailPoet.I18n.t('systemStatusDownloadReport')}
               </button>
               <button
                 type="button"

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -1,18 +1,370 @@
-import { MailPoet } from 'mailpoet';
-import ReactStringReplace from 'react-string-replace';
-import { CronStatus } from './cron-status.jsx';
-import { QueueStatus } from './queue-status';
-import { ActionSchedulerStatus } from './action-scheduler-status';
-import { DataInconsistencies } from './data-inconsistencies';
+import { MailPoet } from "mailpoet";
+import ReactStringReplace from "react-string-replace";
+import { useState } from "react";
+import { copyToClipboard } from "utils";
+import { CronStatus } from "./cron-status.jsx";
+import { QueueStatus } from "./queue-status";
+import { ActionSchedulerStatus } from "./action-scheduler-status";
+import { DataInconsistencies } from "./data-inconsistencies";
+
+function printValue(value) {
+  if (value === null || value === undefined || value === "") {
+    return MailPoet.I18n.t("none");
+  }
+  if (typeof value === "boolean") {
+    return value ? MailPoet.I18n.t("yes") : MailPoet.I18n.t("no");
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return MailPoet.I18n.t("none");
+    return value
+      .map((item) => {
+        if (item && item.worker && item.message) {
+          return `${item.worker}: ${item.message}`;
+        }
+        return `${item}`;
+      })
+      .join("; ");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return `${value}`;
+}
+
+function formatTimestamp(seconds) {
+  if (!seconds) return MailPoet.I18n.t("unknown");
+  return MailPoet.Date.full(seconds * 1000);
+}
+
+function addSection(lines, title) {
+  lines.push("");
+  lines.push(`### ${title} ###`);
+}
+
+function addBullet(lines, key, value) {
+  lines.push(`  - ${key}: ${printValue(value)}`);
+}
+
+function addActivePluginsList(lines, plugins) {
+  const items = (plugins || []).filter(Boolean);
+  if (!items.length) {
+    lines.push("  - (none)");
+    return;
+  }
+  items.forEach((plugin) => {
+    const latestVersion = plugin.versionLatest
+      ? ` (update to version ${plugin.versionLatest} is available)`
+      : "";
+    lines.push(
+      `  - ${plugin.name}: by ${plugin.author} - ${plugin.version}${latestVersion}`
+    );
+  });
+}
+
+function formatOptional(value) {
+  if (value === null || value === undefined || value === "") {
+    return "(none)";
+  }
+  return value;
+}
+
+function formatYesNo(value) {
+  if (typeof value === "boolean") {
+    return value ? "yes" : "no";
+  }
+  const normalized = `${value || ""}`.trim().toLowerCase();
+  if (normalized === "yes" || normalized === "no") {
+    return normalized;
+  }
+  return printValue(value);
+}
+
+function parseCompositeField(value) {
+  const result = {};
+  if (!value || typeof value !== "string") {
+    return result;
+  }
+
+  const parts = value.split(" - ");
+  parts.forEach((part) => {
+    const separatorIndex = part.indexOf(": ");
+    if (separatorIndex === -1) {
+      return;
+    }
+    const key = part.slice(0, separatorIndex).trim();
+    const fieldValue = part.slice(separatorIndex + 2).trim();
+    result[key] = fieldValue;
+  });
+  return result;
+}
+
+function buildSystemStatusReport(
+  systemInfoData,
+  systemStatusData,
+  actionSchedulerData
+) {
+  const lines = [];
+  const queueStatus = systemStatusData.queueStatus || {};
+  const systemInfo = systemInfoData || {};
+  const wpInfo = parseCompositeField(systemInfo["WP info"]);
+  const phpInfo = parseCompositeField(systemInfo["PHP info"]);
+  const sendingServiceInfo = parseCompositeField(
+    systemInfo["MailPoet Sending Service"]
+  );
+  const sendingDetails = parseCompositeField(
+    systemInfo["MailPoet sending info"]
+  );
+  const dataInconsistencyStatus = parseCompositeField(
+    systemInfo["Data inconsistency status"]
+  );
+  const keyStateSummary = [
+    sendingServiceInfo["API key state"],
+    sendingServiceInfo["Premium key state"],
+  ]
+    .filter(Boolean)
+    .map((state, index) => (index === 0 ? state : `premium: ${state}`))
+    .join("; ");
+  const premiumKeyValue = keyStateSummary
+    ? `${systemInfo["MailPoet Premium/MSS key"]} (${keyStateSummary})`
+    : systemInfo["MailPoet Premium/MSS key"];
+  const cronStatus = systemStatusData.cronStatus || {};
+  const cronError = Array.isArray(cronStatus.last_error)
+    ? cronStatus.last_error
+        .map((error) => `${error.worker}: ${error.message}`)
+        .join("; ")
+    : cronStatus.last_error;
+
+  const actionSchedulerVersion = actionSchedulerData?.version || "(none)";
+  const actionSchedulerStorage = actionSchedulerData?.storage || "(none)";
+  const actionSchedulerNextTrigger = actionSchedulerData?.latestTrigger
+    ? MailPoet.Date.full(actionSchedulerData.latestTrigger)
+    : MailPoet.I18n.t("unknown");
+  const actionSchedulerLastTrigger = actionSchedulerData?.latestCompletedTrigger
+    ? MailPoet.Date.full(actionSchedulerData.latestCompletedTrigger)
+    : MailPoet.I18n.t("unknown");
+  const actionSchedulerLastRun = actionSchedulerData?.latestCompletedRun
+    ? MailPoet.Date.full(actionSchedulerData.latestCompletedRun)
+    : MailPoet.I18n.t("unknown");
+
+  const queueStatusText =
+    queueStatus.status === "paused" ? "paused" : "running";
+  const queueRetryAttempt = queueStatus.retryAttempt || MailPoet.I18n.t("none");
+  const queueRetryAt = queueStatus.retryAt
+    ? formatTimestamp(queueStatus.retryAt)
+    : MailPoet.I18n.t("unknown");
+  const queueError = queueStatus.error?.errorMessage || MailPoet.I18n.t("none");
+  const queueCounts = queueStatus.tasksStatusCounts || {};
+
+  const activePluginsFromStatus = Array.isArray(systemStatusData.activePlugins)
+    ? systemStatusData.activePlugins
+        .map((plugin) => ({
+          name: `${plugin?.name || ""}`.trim(),
+          author: `${plugin?.author || ""}`.trim(),
+          version: `${plugin?.version || ""}`.trim(),
+          versionLatest: plugin?.versionLatest
+            ? `${plugin.versionLatest}`.trim()
+            : null,
+        }))
+        .filter((plugin) => plugin.name && plugin.author && plugin.version)
+    : [];
+  const activePluginsFromSystemInfo = `${
+    systemInfo["Active Plugin names"] || ""
+  }`
+    .split(",")
+    .map((plugin) => `${plugin}`.trim())
+    .filter(Boolean)
+    .map((plugin) => ({
+      name: plugin,
+      author: MailPoet.I18n.t("unknown"),
+      version: MailPoet.I18n.t("unknown"),
+      versionLatest: null,
+    }));
+  const activePlugins = activePluginsFromStatus.length
+    ? activePluginsFromStatus
+    : activePluginsFromSystemInfo;
+
+  lines.push("### MailPoet System Status Report ###");
+  lines.push(`Generated: ${new Date().toISOString()}`);
+
+  addSection(lines, "Site & Account");
+  addBullet(lines, "Site name", systemInfo.name);
+  addBullet(lines, "Email", systemInfo.email);
+  addBullet(lines, "MailPoet Premium/MSS key", premiumKeyValue);
+  addBullet(lines, "Plugin installed at", systemInfo["Plugin installed at"]);
+  addBullet(
+    lines,
+    "Installed via WooCommerce onboarding wizard",
+    formatYesNo(systemInfo["Installed via WooCommerce onboarding wizard"])
+  );
+  addBullet(
+    lines,
+    "Total subscribers",
+    systemInfo["Total number of subscribers"]
+  );
+
+  addSection(lines, "Versions");
+  addBullet(lines, "MailPoet Free", systemInfo["MailPoet Free version"]);
+  addBullet(lines, "MailPoet Premium", systemInfo["MailPoet Premium version"]);
+  addBullet(lines, "WordPress", systemInfo["WordPress version"]);
+  addBullet(lines, "PHP", systemInfo["PHP version"]);
+  addBullet(lines, "Database", systemInfo["Database version"]);
+  addBullet(lines, "Action Scheduler", actionSchedulerVersion);
+
+  addSection(lines, "Environment");
+  addBullet(lines, "Web server", systemInfo["Web server"]);
+  addBullet(lines, "Server OS", systemInfo["Server OS"]);
+  addBullet(lines, "Multisite", systemInfo["Multisite environment?"]);
+  addBullet(lines, "Current theme", systemInfo["Current Theme"]);
+  addBullet(lines, "WordPress language", wpInfo["WordPress language"]);
+  addBullet(lines, "WordPress timezone", wpInfo["WordPress timezone"]);
+
+  addSection(lines, "WordPress & PHP Config");
+  addBullet(lines, "WP_MEMORY_LIMIT", wpInfo.WP_MEMORY_LIMIT);
+  addBullet(lines, "WP_MAX_MEMORY_LIMIT", wpInfo.WP_MAX_MEMORY_LIMIT);
+  addBullet(lines, "WP_DEBUG", wpInfo.WP_DEBUG);
+  addBullet(lines, "PHP max_execution_time", phpInfo["PHP max_execution_time"]);
+  addBullet(lines, "PHP memory_limit", phpInfo["PHP memory_limit"]);
+  addBullet(
+    lines,
+    "PHP upload_max_filesize",
+    phpInfo["PHP upload_max_filesize"]
+  );
+  addBullet(lines, "PHP post_max_size", phpInfo["PHP post_max_size"]);
+
+  addSection(lines, `Active Plugins (${activePlugins.length})`);
+  addActivePluginsList(lines, activePlugins);
+
+  addSection(lines, "Sending Configuration");
+  addBullet(lines, "Sending method", systemInfo["Sending Method"]);
+  addBullet(
+    lines,
+    "Send all site's emails with",
+    sendingDetails["Send all site's emails with"]
+  );
+  addBullet(lines, "Sending frequency", systemInfo["Sending Frequency"]);
+  addBullet(
+    lines,
+    "Default FROM address",
+    formatOptional(sendingDetails["Default FROM address"])
+  );
+  addBullet(
+    lines,
+    "Default Reply-To address",
+    formatOptional(sendingDetails["Default Reply-To address"])
+  );
+  addBullet(
+    lines,
+    "Bounce email address",
+    formatOptional(sendingDetails["Bounce Email Address"])
+  );
+
+  addSection(lines, "Connection to MailPoet Sending Service");
+  addBullet(lines, "Enabled", formatYesNo(systemStatusData.mss?.enabled));
+  addBullet(lines, "Reachable", formatYesNo(systemStatusData.mss?.isReachable));
+  addBullet(lines, "Ping response", sendingServiceInfo["Ping response"]);
+  addBullet(lines, "API key state", sendingServiceInfo["API key state"]);
+  addBullet(
+    lines,
+    "Premium key state",
+    sendingServiceInfo["Premium key state"]
+  );
+
+  addSection(lines, "Task Scheduler / Cron");
+  addBullet(lines, "Status", cronStatus.status || MailPoet.I18n.t("unknown"));
+  addBullet(
+    lines,
+    "Task Scheduler method",
+    sendingDetails["Task Scheduler method"]
+  );
+  addBullet(lines, "Ping URL", systemStatusData.cron?.url);
+  addBullet(lines, "Accessible", formatYesNo(cronStatus.accessible));
+  addBullet(lines, "Ping response", systemStatusData.cron?.pingResponse);
+  addBullet(lines, "Last updated", formatTimestamp(cronStatus.updated_at));
+  addBullet(
+    lines,
+    "Last run started",
+    formatTimestamp(cronStatus.run_started_at)
+  );
+  addBullet(
+    lines,
+    "Last run completed",
+    formatTimestamp(cronStatus.run_completed_at)
+  );
+  addBullet(lines, "Last seen error", cronError || MailPoet.I18n.t("none"));
+
+  addSection(lines, "Action Scheduler Status");
+  addBullet(lines, "Storage type", actionSchedulerStorage);
+  addBullet(lines, "Next trigger run", actionSchedulerNextTrigger);
+  addBullet(lines, "Last trigger run", actionSchedulerLastTrigger);
+  addBullet(lines, "Last worker run", actionSchedulerLastRun);
+
+  addSection(lines, "Sending Queue");
+  addBullet(lines, "Status", queueStatusText);
+  addBullet(lines, "Started at", formatTimestamp(queueStatus.started));
+  addBullet(lines, "Sent emails", queueStatus.sent || 0);
+  addBullet(lines, "Retry attempt", queueRetryAttempt);
+  addBullet(lines, "Retry at", queueRetryAt);
+  addBullet(lines, "Error", queueError);
+  addBullet(lines, "Total completed tasks", queueCounts.completed || 0);
+  addBullet(lines, "Total running tasks", queueCounts.running || 0);
+  addBullet(lines, "Total paused tasks", queueCounts.paused || 0);
+  addBullet(lines, "Total cancelled tasks", queueCounts.cancelled || 0);
+  addBullet(lines, "Total scheduled tasks", queueCounts.scheduled || 0);
+
+  addSection(lines, "Data Inconsistency");
+  addBullet(
+    lines,
+    "Orphaned sending tasks",
+    dataInconsistencyStatus["Orphaned sending tasks"]
+  );
+  addBullet(
+    lines,
+    "Orphaned sending task subscribers",
+    dataInconsistencyStatus["Orphaned sending task subscribers"]
+  );
+  addBullet(
+    lines,
+    "Sending queue without newsletter",
+    dataInconsistencyStatus["Sending queue without newsletter"]
+  );
+  addBullet(
+    lines,
+    "Orphaned subscriptions",
+    dataInconsistencyStatus["Orphaned subscriptions"]
+  );
+  addBullet(lines, "Orphaned links", dataInconsistencyStatus["Orphaned links"]);
+  addBullet(
+    lines,
+    "Orphaned newsletter posts",
+    dataInconsistencyStatus["Orphaned newsletter posts"]
+  );
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function downloadReport(reportText) {
+  const date = new Date().toISOString().slice(0, 10);
+  const fileName = `mailpoet-system-status-${date}.txt`;
+  const blob = new Blob([reportText], { type: "text/plain;charset=utf-8" });
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  window.URL.revokeObjectURL(url);
+}
 
 function renderStatusMessage(
   status,
   successMessage,
   errorMessage,
   link,
-  additionalInfo,
+  additionalInfo
 ) {
-  const noticeType = status ? 'success' : 'error';
+  const noticeType = status ? "success" : "error";
   let noticeMessage = status ? successMessage : errorMessage;
 
   if (link) {
@@ -23,7 +375,7 @@ function renderStatusMessage(
         <a className="mailpoet-text-link" href={link} key="kb-link">
           {match}
         </a>
-      ),
+      )
     );
   }
 
@@ -43,14 +395,14 @@ function renderCronSection(data) {
   const status = data.cron.isReachable;
   const url = data.cron.url;
   const error = `${MailPoet.I18n.t(
-    'systemStatusConnectionUnsuccessful',
-  )} ${MailPoet.I18n.t('systemStatusCronConnectionUnsuccessfulInfo')}`;
-  const success = MailPoet.I18n.t('systemStatusConnectionSuccessful');
+    "systemStatusConnectionUnsuccessful"
+  )} ${MailPoet.I18n.t("systemStatusCronConnectionUnsuccessfulInfo")}`;
+  const success = MailPoet.I18n.t("systemStatusConnectionSuccessful");
   const additionalInfo = !status ? data.cron.pingResponse : null;
 
   return (
     <div>
-      <h4>{MailPoet.I18n.t('systemStatusCronTitle')}</h4>
+      <h4>{MailPoet.I18n.t("systemStatusCronTitle")}</h4>
       <p>
         <a
           className="mailpoet-text-link"
@@ -65,8 +417,8 @@ function renderCronSection(data) {
         status,
         success,
         error,
-        'https://kb.mailpoet.com/article/231-sending-does-not-work',
-        additionalInfo,
+        "https://kb.mailpoet.com/article/231-sending-does-not-work",
+        additionalInfo
       )}
     </div>
   );
@@ -75,38 +427,107 @@ function renderCronSection(data) {
 function renderMSSSection(data) {
   const errorMessage = data.mss.enabled
     ? `${MailPoet.I18n.t(
-        'systemStatusConnectionUnsuccessful',
-      )} ${MailPoet.I18n.t('systemStatusMSSConnectionUnsuccessfulInfo')}`
-    : MailPoet.I18n.t('systemStatusMSSConnectionCanNotConnect');
+        "systemStatusConnectionUnsuccessful"
+      )} ${MailPoet.I18n.t("systemStatusMSSConnectionUnsuccessfulInfo")}`
+    : MailPoet.I18n.t("systemStatusMSSConnectionCanNotConnect");
   const successMessage = data.mss.enabled
-    ? MailPoet.I18n.t('systemStatusConnectionSuccessful')
-    : MailPoet.I18n.t('systemStatusMSSConnectionCanConnect');
+    ? MailPoet.I18n.t("systemStatusConnectionSuccessful")
+    : MailPoet.I18n.t("systemStatusMSSConnectionCanConnect");
   return (
     <div>
-      <h4>{MailPoet.I18n.t('systemStatusMSSTitle')}</h4>
+      <h4>{MailPoet.I18n.t("systemStatusMSSTitle")}</h4>
       {renderStatusMessage(
         data.mss.isReachable,
         successMessage,
         errorMessage,
-        'https://kb.mailpoet.com/article/319-known-errors-when-validating-a-mailpoet-key',
-        null,
+        "https://kb.mailpoet.com/article/319-known-errors-when-validating-a-mailpoet-key",
+        null
       )}
     </div>
   );
 }
 
 export function SystemStatus() {
+  const reportId = "mailpoet-system-status-report";
+  const systemInfoData = window.systemInfoData;
   const systemStatusData = window.systemStatusData;
   const actionSchedulerData = window.actionSchedulerData;
+  const [isReportVisible, setIsReportVisible] = useState(false);
+  const [copyButtonLabel, setCopyButtonLabel] = useState(
+    MailPoet.I18n.t("systemStatusCopyForSupport")
+  );
+  const reportText = buildSystemStatusReport(
+    systemInfoData,
+    systemStatusData,
+    actionSchedulerData
+  );
+
+  const handleCopyForSupport = async () => {
+    await copyToClipboard(
+      reportId,
+      (wasSuccessful) => {
+        if (!wasSuccessful) {
+          setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardFailure"));
+          return;
+        }
+        setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardSuccess"));
+        window.setTimeout(() => {
+          setCopyButtonLabel(MailPoet.I18n.t("systemStatusCopyForSupport"));
+        }, 3000);
+      },
+      true
+    );
+  };
 
   return (
     <>
       <div className="mailpoet_notice notice inline">
         <p>
           {systemStatusData.mss.enabled
-            ? MailPoet.I18n.t('systemStatusIntroCronMSS')
-            : MailPoet.I18n.t('systemStatusIntroCron')}
+            ? MailPoet.I18n.t("systemStatusIntroCronMSS")
+            : MailPoet.I18n.t("systemStatusIntroCron")}
         </p>
+      </div>
+      <div className="updated mailpoet-system-status-report inline">
+        <p>{MailPoet.I18n.t("systemStatusGetReportIntro")}</p>
+        <p className="submit">
+          <button
+            type="button"
+            className="button button-primary"
+            onClick={() => setIsReportVisible(true)}
+          >
+            {MailPoet.I18n.t("systemStatusGetReportTitle")}
+          </button>
+          <a
+            className="button button-secondary"
+            href="https://kb.mailpoet.com/article/understanding-the-mailpoet-system-status-page"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {MailPoet.I18n.t("systemStatusUnderstandingReport")}
+          </a>
+        </p>
+        {isReportVisible ? (
+          <div className="mailpoet-debug-report">
+            <textarea readOnly id={reportId} value={reportText} />
+            <p className="submit">
+              <button
+                type="button"
+                className="button button-primary"
+                onClick={() => downloadReport(reportText)}
+              >
+                {MailPoet.I18n.t("systemStatusDownloadReport")}
+              </button>
+              <button
+                type="button"
+                className="button"
+                onClick={handleCopyForSupport}
+              >
+                {copyButtonLabel}
+              </button>
+            </p>
+          </div>
+        ) : null}
       </div>
       {renderCronSection(systemStatusData)}
       {renderMSSSection(systemStatusData)}

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -48,7 +48,7 @@ function addBullet(lines, key, value) {
 function addActivePluginsList(lines, plugins) {
   const items = (plugins || []).filter(Boolean);
   if (!items.length) {
-    lines.push("  - (none)");
+    lines.push(`  - ${MailPoet.I18n.t("none")}`);
     return;
   }
   items.forEach((plugin) => {
@@ -165,8 +165,10 @@ function buildSystemStatusReport(
         .join("; ")
     : cronStatus.last_error;
 
-  const actionSchedulerVersion = actionSchedulerData?.version || "(none)";
-  const actionSchedulerStorage = actionSchedulerData?.storage || "(none)";
+  const actionSchedulerVersion =
+    actionSchedulerData?.version || MailPoet.I18n.t("none");
+  const actionSchedulerStorage =
+    actionSchedulerData?.storage || MailPoet.I18n.t("none");
   const actionSchedulerNextTrigger = actionSchedulerData?.latestTrigger
     ? MailPoet.Date.full(actionSchedulerData.latestTrigger)
     : MailPoet.I18n.t("unknown");
@@ -178,8 +180,8 @@ function buildSystemStatusReport(
     : MailPoet.I18n.t("unknown");
 
   let queueStatusText = MailPoet.I18n.t("unknown");
-  if (queueStatus.status === "paused") queueStatusText = "paused";
-  else if (queueStatus.status !== undefined) queueStatusText = "running";
+  if (queueStatus.status === "paused") queueStatusText = MailPoet.I18n.t("paused");
+  else if (queueStatus.status !== undefined) queueStatusText = MailPoet.I18n.t("running");
   const queueRetryAttempt = queueStatus.retryAttempt || MailPoet.I18n.t("none");
   const queueRetryAt = queueStatus.retryAt
     ? formatTimestamp(queueStatus.retryAt)
@@ -187,7 +189,7 @@ function buildSystemStatusReport(
   const queueError = queueStatus.error?.errorMessage || MailPoet.I18n.t("none");
   const queueCounts = queueStatus.tasksStatusCounts || {};
 
-  const activePluginsFromStatus = Array.isArray(systemStatusData.activePlugins)
+  const activePlugins = Array.isArray(systemStatusData.activePlugins)
     ? systemStatusData.activePlugins
         .map((plugin) => ({
           name: `${plugin?.name || ""}`.trim(),
@@ -199,21 +201,6 @@ function buildSystemStatusReport(
         }))
         .filter((plugin) => plugin.name && plugin.author && plugin.version)
     : [];
-  const activePluginsFromSystemInfo = `${
-    systemInfo["Active Plugin names"] || ""
-  }`
-    .split(",")
-    .map((plugin) => `${plugin}`.trim())
-    .filter(Boolean)
-    .map((plugin) => ({
-      name: plugin,
-      author: MailPoet.I18n.t("unknown"),
-      version: MailPoet.I18n.t("unknown"),
-      versionLatest: null,
-    }));
-  const activePlugins = activePluginsFromStatus.length
-    ? activePluginsFromStatus
-    : activePluginsFromSystemInfo;
 
   lines.push("### MailPoet System Status Report ###");
   lines.push(`Generated: ${new Date().toISOString()}`);

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -63,37 +63,49 @@ function addActivePluginsList(lines, plugins) {
 
 function formatOptional(value) {
   if (value === null || value === undefined || value === "") {
-    return "(none)";
+    return MailPoet.I18n.t("none");
   }
   return value;
 }
 
 function formatYesNo(value) {
   if (typeof value === "boolean") {
-    return value ? "yes" : "no";
+    return value ? MailPoet.I18n.t("yes") : MailPoet.I18n.t("no");
   }
   const normalized = `${value || ""}`.trim().toLowerCase();
   if (normalized === "yes" || normalized === "no") {
-    return normalized;
+    return MailPoet.I18n.t(normalized);
   }
   return printValue(value);
 }
 
-function parseCompositeField(value) {
+function parseCompositeField(value, knownKeys) {
   const result = {};
   if (!value || typeof value !== "string") {
     return result;
   }
 
-  const parts = value.split(" - ");
-  parts.forEach((part) => {
+  if (knownKeys && knownKeys.length > 0) {
+    const sortedKeys = [...knownKeys].sort((a, b) => b.length - a.length);
+    const escapedKeys = sortedKeys.map((k) =>
+      k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    );
+    const regex = new RegExp(`(?:^| - )(${escapedKeys.join("|")}): `, "g");
+    const matches = [...value.matchAll(regex)];
+    matches.forEach((match, i) => {
+      const valueStart = match.index + match[0].length;
+      const valueEnd = matches[i + 1] ? matches[i + 1].index : value.length;
+      result[match[1]] = value.slice(valueStart, valueEnd).trim();
+    });
+    return result;
+  }
+
+  value.split(" - ").forEach((part) => {
     const separatorIndex = part.indexOf(": ");
-    if (separatorIndex === -1) {
-      return;
-    }
-    const key = part.slice(0, separatorIndex).trim();
-    const fieldValue = part.slice(separatorIndex + 2).trim();
-    result[key] = fieldValue;
+    if (separatorIndex === -1) return;
+    result[part.slice(0, separatorIndex).trim()] = part
+      .slice(separatorIndex + 2)
+      .trim();
   });
   return result;
 }
@@ -106,13 +118,32 @@ function buildSystemStatusReport(
   const lines = [];
   const queueStatus = systemStatusData.queueStatus || {};
   const systemInfo = systemInfoData || {};
-  const wpInfo = parseCompositeField(systemInfo["WP info"]);
-  const phpInfo = parseCompositeField(systemInfo["PHP info"]);
+  const wpInfo = parseCompositeField(systemInfo["WP info"], [
+    "WP_MEMORY_LIMIT",
+    "WP_MAX_MEMORY_LIMIT",
+    "WP_DEBUG",
+    "WordPress language",
+    "WordPress timezone",
+  ]);
+  const phpInfo = parseCompositeField(systemInfo["PHP info"], [
+    "PHP max_execution_time",
+    "PHP memory_limit",
+    "PHP upload_max_filesize",
+    "PHP post_max_size",
+  ]);
   const sendingServiceInfo = parseCompositeField(
-    systemInfo["MailPoet Sending Service"]
+    systemInfo["MailPoet Sending Service"],
+    ["Is reachable", "Ping response", "API key state", "Premium key state"]
   );
   const sendingDetails = parseCompositeField(
-    systemInfo["MailPoet sending info"]
+    systemInfo["MailPoet sending info"],
+    [
+      "Send all site's emails with",
+      "Task Scheduler method",
+      "Default FROM address",
+      "Default Reply-To address",
+      "Bounce Email Address",
+    ]
   );
   const dataInconsistencyStatus = parseCompositeField(
     systemInfo["Data inconsistency status"]
@@ -146,8 +177,9 @@ function buildSystemStatusReport(
     ? MailPoet.Date.full(actionSchedulerData.latestCompletedRun)
     : MailPoet.I18n.t("unknown");
 
-  const queueStatusText =
-    queueStatus.status === "paused" ? "paused" : "running";
+  let queueStatusText = MailPoet.I18n.t("unknown");
+  if (queueStatus.status === "paused") queueStatusText = "paused";
+  else if (queueStatus.status !== undefined) queueStatusText = "running";
   const queueRetryAttempt = queueStatus.retryAttempt || MailPoet.I18n.t("none");
   const queueRetryAt = queueStatus.retryAt
     ? formatTimestamp(queueStatus.retryAt)
@@ -463,20 +495,24 @@ export function SystemStatus() {
   );
 
   const handleCopyForSupport = async () => {
-    await copyToClipboard(
-      reportId,
-      (wasSuccessful) => {
-        if (!wasSuccessful) {
-          setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardFailure"));
-          return;
-        }
-        setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardSuccess"));
-        window.setTimeout(() => {
-          setCopyButtonLabel(MailPoet.I18n.t("systemStatusCopyForSupport"));
-        }, 3000);
-      },
-      true
-    );
+    try {
+      await copyToClipboard(
+        reportId,
+        (wasSuccessful) => {
+          if (!wasSuccessful) {
+            setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardFailure"));
+            return;
+          }
+          setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardSuccess"));
+          window.setTimeout(() => {
+            setCopyButtonLabel(MailPoet.I18n.t("systemStatusCopyForSupport"));
+          }, 3000);
+        },
+        true
+      );
+    } catch {
+      setCopyButtonLabel(MailPoet.I18n.t("copyToClipboardFailure"));
+    }
   };
 
   return (

--- a/mailpoet/assets/js/src/help/system-status.jsx
+++ b/mailpoet/assets/js/src/help/system-status.jsx
@@ -86,16 +86,24 @@ function parseCompositeField(value, knownKeys) {
   }
 
   if (knownKeys && knownKeys.length > 0) {
+    // Backend encodes composite fields as "key: value - key: value - ...".
+    // Values may themselves contain " - " (e.g. error messages), so we anchor
+    // on the known key list rather than splitting. Keys are sorted longest-first
+    // so that longer keys take precedence when one is a prefix of another.
     const sortedKeys = [...knownKeys].sort((a, b) => b.length - a.length);
+    // Escape regex-special characters in each key name.
     const escapedKeys = sortedKeys.map((k) =>
       k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
     );
-    const regex = new RegExp(`(?:^| - )(${escapedKeys.join("|")}): `, "g");
+    const regex = new RegExp(
+      `(?:^| - )(?<key>${escapedKeys.join("|")}): `,
+      "g"
+    );
     const matches = [...value.matchAll(regex)];
     matches.forEach((match, i) => {
       const valueStart = match.index + match[0].length;
       const valueEnd = matches[i + 1] ? matches[i + 1].index : value.length;
-      result[match[1]] = value.slice(valueStart, valueEnd).trim();
+      result[match.groups.key] = value.slice(valueStart, valueEnd).trim();
     });
     return result;
   }
@@ -150,10 +158,11 @@ function buildSystemStatusReport(
   );
   const keyStateSummary = [
     sendingServiceInfo["API key state"],
-    sendingServiceInfo["Premium key state"],
+    sendingServiceInfo["Premium key state"]
+      ? `premium: ${sendingServiceInfo["Premium key state"]}`
+      : null,
   ]
     .filter(Boolean)
-    .map((state, index) => (index === 0 ? state : `premium: ${state}`))
     .join("; ");
   const premiumKeyValue = keyStateSummary
     ? `${systemInfo["MailPoet Premium/MSS key"]} (${keyStateSummary})`

--- a/mailpoet/changelog/2026-04-17-16-08-45-improved-improve-mailpoet-system-status-report-with-woocomm.md
+++ b/mailpoet/changelog/2026-04-17-16-08-45-improved-improve-mailpoet-system-status-report-with-woocomm.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improve MailPoet system status report with WooCommerce-style format and support-ready copy/download actions

--- a/mailpoet/lib/AdminPages/Pages/Help.php
+++ b/mailpoet/lib/AdminPages/Pages/Help.php
@@ -76,6 +76,7 @@ class Help {
       ],
       'cronStatus' => $this->cronHelper->getDaemon(),
       'queueStatus' => $mailerLog,
+      'activePlugins' => $this->systemReportCollector->getActivePluginsData(),
     ];
 
     $systemStatusData['cronStatus']['accessible'] = $this->cronHelper->isDaemonAccessible();

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -108,12 +108,7 @@ class SystemReportCollector {
     $ApiKeyState = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME . '.state');
     $premiumKeyState = $this->settings->get(Bridge::PREMIUM_KEY_STATE_SETTING_NAME . '.state');
 
-    $activePluginFiles = array_map(
-      static function(array $plugin): string {
-        return $plugin['plugin'];
-      },
-      $this->getActivePluginsData()
-    );
+    $activePluginFiles = $this->wp->getOption('active_plugins', []);
 
     // the HelpScout Beacon API has a limit of 20 attribute-value pairs (https://developer.helpscout.com/beacon-2/web/javascript-api/#beacon-session-data)
     return [

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -108,6 +108,13 @@ class SystemReportCollector {
     $ApiKeyState = $this->settings->get(Bridge::API_KEY_STATE_SETTING_NAME . '.state');
     $premiumKeyState = $this->settings->get(Bridge::PREMIUM_KEY_STATE_SETTING_NAME . '.state');
 
+    $activePluginFiles = array_map(
+      static function(array $plugin): string {
+        return $plugin['plugin'];
+      },
+      $this->getActivePluginsData()
+    );
+
     // the HelpScout Beacon API has a limit of 20 attribute-value pairs (https://developer.helpscout.com/beacon-2/web/javascript-api/#beacon-session-data)
     return [
       'PHP version' => PHP_VERSION,
@@ -134,7 +141,7 @@ class SystemReportCollector {
       'Multisite environment?' => (is_multisite() ? 'Yes' : 'No'),
       'Current Theme' => $currentTheme->get('Name') .
         ' (version ' . $currentTheme->get('Version') . ')',
-      'Active Plugin names' => join(", ", $this->wp->getOption('active_plugins')),
+      'Active Plugin names' => join(", ", $activePluginFiles),
       'Sending Method' => $mta['method'],
       'MailPoet Sending Service' => $this->formatCompositeField([
         'Is reachable' => $this->bridge->validateBridgePingResponse($pingBridgeResponse) ? 'Yes' : 'No',
@@ -179,6 +186,60 @@ class SystemReportCollector {
       ]),
       'Data inconsistency status' => $this->formatCompositeField($this->convertKeysToTitleCase($inconsistencyStatus)),
     ];
+  }
+
+  /**
+   * @return array<int, array{
+   *   plugin: string,
+   *   name: string,
+   *   author: string,
+   *   version: string,
+   *   versionLatest: ?string
+   * }>
+   */
+  public function getActivePluginsData(): array {
+    if (!function_exists('get_plugins')) {
+      require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+
+    $activePluginFiles = $this->wp->getOption('active_plugins', []);
+    $allPlugins = $this->wp->getPlugins();
+    $updateTransient = $this->wp->getSiteTransient('update_plugins');
+    $updateResponses = (
+      is_object($updateTransient) &&
+      isset($updateTransient->response) &&
+      is_array($updateTransient->response)
+    ) ? $updateTransient->response : [];
+
+    $activePlugins = [];
+    foreach ($activePluginFiles as $pluginFile) {
+      $plugin = $allPlugins[$pluginFile] ?? [];
+      $authorName = (string)($plugin['AuthorName'] ?? '');
+      if ($authorName === '') {
+        $authorName = $this->wp->wpStripAllTags((string)($plugin['Author'] ?? ''));
+      }
+      if ($authorName === '') {
+        $authorName = __('Unknown', 'mailpoet');
+      }
+
+      $latestVersion = null;
+      $pluginUpdate = $updateResponses[$pluginFile] ?? null;
+      if (is_object($pluginUpdate) && !empty($pluginUpdate->new_version)) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+        $latestVersion = (string)$pluginUpdate->new_version; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      } elseif (is_array($pluginUpdate) && !empty($pluginUpdate['new_version'])) {
+        $latestVersion = (string)$pluginUpdate['new_version'];
+      }
+
+      $activePlugins[] = [
+        'plugin' => (string)$pluginFile,
+        'name' => (string)($plugin['Name'] ?? $pluginFile),
+        'author' => $authorName,
+        'version' => (string)($plugin['Version'] ?? __('Unknown', 'mailpoet')),
+        'versionLatest' => $latestVersion,
+      ];
+    }
+
+    return $activePlugins;
   }
 
   public function getCronPingResponse(): string {

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -114,6 +114,17 @@ class SystemReportCollectorTest extends \MailPoetTest {
     verify($this->systemInfoData['Active Plugin names'])->equals(join(", ", $activePlugins));
   }
 
+  public function testItReturnsActivePluginsDetails() {
+    $collector = $this->diContainer->get(SystemReportCollector::class);
+    $activePlugins = $collector->getActivePluginsData();
+
+    $this->assertNotEmpty($activePlugins);
+    $this->assertIsString($activePlugins[0]['plugin']);
+    $this->assertIsString($activePlugins[0]['name']);
+    $this->assertIsString($activePlugins[0]['author']);
+    $this->assertIsString($activePlugins[0]['version']);
+  }
+
   public function testItReturnsSendingMethodDetails() {
     $mta = $this->settings->get('mta');
     verify($this->systemInfoData['Sending Method'])->equals($mta['method']);

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -38,7 +38,7 @@
     'systemStatusUnderstandingReport': __('Understanding the System Status'),
     'systemStatusDownloadReport': __('Download for Support'),
     'systemStatusCopyForSupport': __('Copy for Support'),
-    'yourPrivacyContent1': __('MailPoet respects your privacy. We don't track any information about your website or yourself without your explicit consent.'),
+    'yourPrivacyContent1': __('MailPoet respects your privacy. We don’t track any information about your website or yourself without your explicit consent.'),
     'yourPrivacyContent2': __('Third-party services used within the plugin may track information such as your email & IP address.'),
     'yourPrivacyContent3': __('If you send with MailPoet, we track data that is used to ensure that the service works correctly.'),
     'yourPrivacyButton': __('Read our Privacy Notice'),

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -1,9 +1,6 @@
-<% extends 'layout.html' %>
-
-<% block content %>
+<% extends 'layout.html' %> <% block content %>
 
 <div id="mailpoet_help">
-
   <script type="text/javascript">
     var systemInfoData = <%= json_encode(systemInfoData) %>;
     var systemStatusData = <%= json_encode(systemStatusData) %>;
@@ -11,77 +8,76 @@
   </script>
 
   <div id="help_container"></div>
-
 </div>
 
-  <%= localize({
-    'tabKnowledgeBaseTitle': __('Knowledge Base'),
-    'tabSystemInfoTitle': __('System Info'),
-    'tabSystemStatusTitle': __('System Status'),
-    'tabYourPrivacyTitle': __('Your Privacy'),
-    'systemStatusIntroCronMSS': __('For the plugin to work, it must be able to establish connection with the task scheduler and the key activation/MailPoet Sending Service.'),
-    'systemStatusCronTitle': __('Task Scheduler'),
-    'systemStatusMSSTitle': __('Connection to the MailPoet Sending Service'),
-    'systemStatusMSSConnectionUnsuccessfulInfo': __('Please contact our technical support for assistance.'),
-    'systemStatusMSSConnectionCanConnect': __('Your installation can connect to our sending service.'),
-    'knowledgeBaseIntro': __('Click on one of these categories below to find more information:'),
-    'knowledgeBaseButton': __('Visit our Knowledge Base for more articles'),
-    'systemInfoIntro': __('The information below is useful when you need to get in touch with our support. Just copy all the text below and paste it into a message to us.'),
-    'systemInfoDataError': __('Sorry, there was an error, please try again later.'),
-    'copyToClipboard': __('Copy to clipboard'),
-    'copyToClipboardSuccess': __('Copied to clipboard.'),
-    'copyToClipboardFailure': __('Could not copy to clipboard.'),
-    'systemStatusCronStatusTitle': __('Cron'),
-    'systemStatusQueueTitle': __('Sending Queue'),
-    'yourPrivacyContent1': __('MailPoet respects your privacy. We don’t track any information about your website or yourself without your explicit consent.'),
-    'yourPrivacyContent2': __('Third-party services used within the plugin may track information such as your email & IP address.'),
-    'yourPrivacyContent3': __('If you send with MailPoet, we track data that is used to ensure that the service works correctly.'),
-    'yourPrivacyButton': __('Read our Privacy Notice'),
-    'lastUpdated': _x('Last updated', 'A label in a status table e.g. Last updated: 2018-10-18 18:50'),
-    'lastRunStarted': _x('Last run started', 'A label in a status table e.g. Last run started: 2018-10-18 18:50'),
-    'lastRunCompleted': _x('Last run completed', 'A label in a status table e.g. Last run completed: 2018-10-18 18:50'),
-    'lastSeenError': _x('Last seen error', 'A label in a status table e.g. Last seen error: Process timeout'),
-    'lastSeenErrorDate': _x('Last seen error date', 'A label in a status table e.g. Last seen error date: 2018-10-18 18:50'),
-    'unknown': _x('unknown', 'An unknown state is a status table e.g. Last run started: unknown'),
-    'accessible': _x('Accessible', 'A label in a status table e.g. Accessible: yes'),
-    'status': __('Status'),
-    'yes': __('yes'),
-    'no': __('no'),
-    'none': _x('none', 'An empty state is a status table e.g. Error: none'),
-    'running': _x('running', 'A state of a process.'),
-    'paused': _x('paused', 'A state of a process.'),
-    'cronWaiting': _x('waiting for the next run', 'A state of a process.'),
-    'startedAt': _x('Started at', 'A label in a status table e.g. Started at: 2018-10-18 18:50'),
-    'sentEmails': _x('Sent emails', 'A label in a status table e.g. Sent emails: 50'),
-    'retryAttempt': _x('Retry attempt', 'A label in a status table e.g. Retry attempt: 2'),
-    'retryAt': _x('Retry at', 'A label in a status table e.g. Retry at: 2018-10-18 18:50'),
-    'error': _x('Error', 'A label in a status table e.g. Error: missing data'),
-    'totalCompletedTasks': __('Total completed tasks'),
-    'totalScheduledTasks': __('Total scheduled tasks'),
-    'totalCancelledTasks': __('Total cancelled tasks'),
-    'totalRunningTasks': __('Total running tasks'),
-    'totalPausedTasks': __('Total paused tasks'),
-    'scheduledTasks': __('Scheduled sending tasks'),
-    'runningTasks': __('Running sending tasks'),
-    'completedTasks': __('Completed sending tasks'),
-    'cancelledTasks': __('Cancelled sending tasks'),
-    'pausedTasks': __('Paused sending tasks'),
-    'type': _x('Type', 'Table column heading for task type.'),
-    'email': __('Email'),
-    'subscriber': __('Subscriber'),
-    'multipleSubscribers': _x('Multiple subscribers', 'Used when multiple subscribers are selected for a task and we don\'t list them all.'),
-    'priority': _x('Priority', 'Table column heading for task priority (number).' ),
-    'scheduledAt': __('Scheduled at'),
-    'cancelledAt': __('Cancelled at'),
-    'updatedAt': __('Updated at'),
-    'action': _x('Action', 'Table column heading to perform an action.'),
-    'nothingToShow': __('Nothing to show.'),
-    'preview': _x('Preview', 'Text of a link to email preview page.'),
-    'actionSchedulerStatus': __('WP Cron / Action Scheduler Status'),
-    'version': __('Version'),
-    'storage': __('Storage type'),
-    'latestActionSchedulerTrigger': _x('Next trigger run', 'Label for the next date and time of background job trigger run.'),
-    'latestActionSchedulerCompletedTrigger': _x('Last trigger run', 'Label for the last date and time of background job trigger run.'),
-    'latestActionSchedulerCompletedRun': _x('Last worker run', 'Label for the last date and time of background job worker run.'),
-  }) %>
-<% endblock %>
+<%= localize({ 'tabKnowledgeBaseTitle': __('Knowledge Base'),
+'tabSystemInfoTitle': __('System Info'), 'tabSystemStatusTitle': __('System
+Status'), 'tabYourPrivacyTitle': __('Your Privacy'), 'systemStatusIntroCronMSS':
+__('For the plugin to work, it must be able to establish connection with the
+task scheduler and the key activation/MailPoet Sending Service.'),
+'systemStatusCronTitle': __('Task Scheduler'), 'systemStatusMSSTitle':
+__('Connection to the MailPoet Sending Service'),
+'systemStatusMSSConnectionUnsuccessfulInfo': __('Please contact our technical
+support for assistance.'), 'systemStatusMSSConnectionCanConnect': __('Your
+installation can connect to our sending service.'), 'knowledgeBaseIntro':
+__('Click on one of these categories below to find more information:'),
+'knowledgeBaseButton': __('Visit our Knowledge Base for more articles'),
+'systemInfoIntro': __('The information below is useful when you need to get in
+touch with our support. Just copy all the text below and paste it into a message
+to us.'), 'systemInfoDataError': __('Sorry, there was an error, please try again
+later.'), 'copyToClipboard': __('Copy to clipboard'), 'copyToClipboardSuccess':
+__('Copied to clipboard.'), 'copyToClipboardFailure': __('Could not copy to
+clipboard.'), 'systemStatusCronStatusTitle': __('Cron'),
+'systemStatusQueueTitle': __('Sending Queue'), 'systemStatusGetReportTitle':
+__('Get System Status'), 'systemStatusGetReportIntro': __('The information below
+is useful when you need to get in touch with our support.'),
+'systemStatusUnderstandingReport': __('Understanding the System Status'),
+'systemStatusDownloadReport': __('Download for Support'),
+'systemStatusCopyForSupport': __('Copy for Support'), 'yourPrivacyContent1':
+__('MailPoet respects your privacy. We don’t track any information about your
+website or yourself without your explicit consent.'), 'yourPrivacyContent2':
+__('Third-party services used within the plugin may track information such as
+your email & IP address.'), 'yourPrivacyContent3': __('If you send with
+MailPoet, we track data that is used to ensure that the service works
+correctly.'), 'yourPrivacyButton': __('Read our Privacy Notice'), 'lastUpdated':
+_x('Last updated', 'A label in a status table e.g. Last updated: 2018-10-18
+18:50'), 'lastRunStarted': _x('Last run started', 'A label in a status table
+e.g. Last run started: 2018-10-18 18:50'), 'lastRunCompleted': _x('Last run
+completed', 'A label in a status table e.g. Last run completed: 2018-10-18
+18:50'), 'lastSeenError': _x('Last seen error', 'A label in a status table e.g.
+Last seen error: Process timeout'), 'lastSeenErrorDate': _x('Last seen error
+date', 'A label in a status table e.g. Last seen error date: 2018-10-18 18:50'),
+'unknown': _x('unknown', 'An unknown state is a status table e.g. Last run
+started: unknown'), 'accessible': _x('Accessible', 'A label in a status table
+e.g. Accessible: yes'), 'status': __('Status'), 'yes': __('yes'), 'no':
+__('no'), 'none': _x('none', 'An empty state is a status table e.g. Error:
+none'), 'running': _x('running', 'A state of a process.'), 'paused':
+_x('paused', 'A state of a process.'), 'cronWaiting': _x('waiting for the next
+run', 'A state of a process.'), 'startedAt': _x('Started at', 'A label in a
+status table e.g. Started at: 2018-10-18 18:50'), 'sentEmails': _x('Sent
+emails', 'A label in a status table e.g. Sent emails: 50'), 'retryAttempt':
+_x('Retry attempt', 'A label in a status table e.g. Retry attempt: 2'),
+'retryAt': _x('Retry at', 'A label in a status table e.g. Retry at: 2018-10-18
+18:50'), 'error': _x('Error', 'A label in a status table e.g. Error: missing
+data'), 'totalCompletedTasks': __('Total completed tasks'),
+'totalScheduledTasks': __('Total scheduled tasks'), 'totalCancelledTasks':
+__('Total cancelled tasks'), 'totalRunningTasks': __('Total running tasks'),
+'totalPausedTasks': __('Total paused tasks'), 'scheduledTasks': __('Scheduled
+sending tasks'), 'runningTasks': __('Running sending tasks'), 'completedTasks':
+__('Completed sending tasks'), 'cancelledTasks': __('Cancelled sending tasks'),
+'pausedTasks': __('Paused sending tasks'), 'type': _x('Type', 'Table column
+heading for task type.'), 'email': __('Email'), 'subscriber': __('Subscriber'),
+'multipleSubscribers': _x('Multiple subscribers', 'Used when multiple
+subscribers are selected for a task and we don\'t list them all.'), 'priority':
+_x('Priority', 'Table column heading for task priority (number).' ),
+'scheduledAt': __('Scheduled at'), 'cancelledAt': __('Cancelled at'),
+'updatedAt': __('Updated at'), 'action': _x('Action', 'Table column heading to
+perform an action.'), 'nothingToShow': __('Nothing to show.'), 'preview':
+_x('Preview', 'Text of a link to email preview page.'), 'actionSchedulerStatus':
+__('WP Cron / Action Scheduler Status'), 'version': __('Version'), 'storage':
+__('Storage type'), 'latestActionSchedulerTrigger': _x('Next trigger run',
+'Label for the next date and time of background job trigger run.'),
+'latestActionSchedulerCompletedTrigger': _x('Last trigger run', 'Label for the
+last date and time of background job trigger run.'),
+'latestActionSchedulerCompletedRun': _x('Last worker run', 'Label for the last
+date and time of background job worker run.'), }) %> <% endblock %>

--- a/mailpoet/views/help.html
+++ b/mailpoet/views/help.html
@@ -1,6 +1,9 @@
-<% extends 'layout.html' %> <% block content %>
+<% extends 'layout.html' %>
+
+<% block content %>
 
 <div id="mailpoet_help">
+
   <script type="text/javascript">
     var systemInfoData = <%= json_encode(systemInfoData) %>;
     var systemStatusData = <%= json_encode(systemStatusData) %>;
@@ -8,76 +11,82 @@
   </script>
 
   <div id="help_container"></div>
+
 </div>
 
-<%= localize({ 'tabKnowledgeBaseTitle': __('Knowledge Base'),
-'tabSystemInfoTitle': __('System Info'), 'tabSystemStatusTitle': __('System
-Status'), 'tabYourPrivacyTitle': __('Your Privacy'), 'systemStatusIntroCronMSS':
-__('For the plugin to work, it must be able to establish connection with the
-task scheduler and the key activation/MailPoet Sending Service.'),
-'systemStatusCronTitle': __('Task Scheduler'), 'systemStatusMSSTitle':
-__('Connection to the MailPoet Sending Service'),
-'systemStatusMSSConnectionUnsuccessfulInfo': __('Please contact our technical
-support for assistance.'), 'systemStatusMSSConnectionCanConnect': __('Your
-installation can connect to our sending service.'), 'knowledgeBaseIntro':
-__('Click on one of these categories below to find more information:'),
-'knowledgeBaseButton': __('Visit our Knowledge Base for more articles'),
-'systemInfoIntro': __('The information below is useful when you need to get in
-touch with our support. Just copy all the text below and paste it into a message
-to us.'), 'systemInfoDataError': __('Sorry, there was an error, please try again
-later.'), 'copyToClipboard': __('Copy to clipboard'), 'copyToClipboardSuccess':
-__('Copied to clipboard.'), 'copyToClipboardFailure': __('Could not copy to
-clipboard.'), 'systemStatusCronStatusTitle': __('Cron'),
-'systemStatusQueueTitle': __('Sending Queue'), 'systemStatusGetReportTitle':
-__('Get System Status'), 'systemStatusGetReportIntro': __('The information below
-is useful when you need to get in touch with our support.'),
-'systemStatusUnderstandingReport': __('Understanding the System Status'),
-'systemStatusDownloadReport': __('Download for Support'),
-'systemStatusCopyForSupport': __('Copy for Support'), 'yourPrivacyContent1':
-__('MailPoet respects your privacy. We don’t track any information about your
-website or yourself without your explicit consent.'), 'yourPrivacyContent2':
-__('Third-party services used within the plugin may track information such as
-your email & IP address.'), 'yourPrivacyContent3': __('If you send with
-MailPoet, we track data that is used to ensure that the service works
-correctly.'), 'yourPrivacyButton': __('Read our Privacy Notice'), 'lastUpdated':
-_x('Last updated', 'A label in a status table e.g. Last updated: 2018-10-18
-18:50'), 'lastRunStarted': _x('Last run started', 'A label in a status table
-e.g. Last run started: 2018-10-18 18:50'), 'lastRunCompleted': _x('Last run
-completed', 'A label in a status table e.g. Last run completed: 2018-10-18
-18:50'), 'lastSeenError': _x('Last seen error', 'A label in a status table e.g.
-Last seen error: Process timeout'), 'lastSeenErrorDate': _x('Last seen error
-date', 'A label in a status table e.g. Last seen error date: 2018-10-18 18:50'),
-'unknown': _x('unknown', 'An unknown state is a status table e.g. Last run
-started: unknown'), 'accessible': _x('Accessible', 'A label in a status table
-e.g. Accessible: yes'), 'status': __('Status'), 'yes': __('yes'), 'no':
-__('no'), 'none': _x('none', 'An empty state is a status table e.g. Error:
-none'), 'running': _x('running', 'A state of a process.'), 'paused':
-_x('paused', 'A state of a process.'), 'cronWaiting': _x('waiting for the next
-run', 'A state of a process.'), 'startedAt': _x('Started at', 'A label in a
-status table e.g. Started at: 2018-10-18 18:50'), 'sentEmails': _x('Sent
-emails', 'A label in a status table e.g. Sent emails: 50'), 'retryAttempt':
-_x('Retry attempt', 'A label in a status table e.g. Retry attempt: 2'),
-'retryAt': _x('Retry at', 'A label in a status table e.g. Retry at: 2018-10-18
-18:50'), 'error': _x('Error', 'A label in a status table e.g. Error: missing
-data'), 'totalCompletedTasks': __('Total completed tasks'),
-'totalScheduledTasks': __('Total scheduled tasks'), 'totalCancelledTasks':
-__('Total cancelled tasks'), 'totalRunningTasks': __('Total running tasks'),
-'totalPausedTasks': __('Total paused tasks'), 'scheduledTasks': __('Scheduled
-sending tasks'), 'runningTasks': __('Running sending tasks'), 'completedTasks':
-__('Completed sending tasks'), 'cancelledTasks': __('Cancelled sending tasks'),
-'pausedTasks': __('Paused sending tasks'), 'type': _x('Type', 'Table column
-heading for task type.'), 'email': __('Email'), 'subscriber': __('Subscriber'),
-'multipleSubscribers': _x('Multiple subscribers', 'Used when multiple
-subscribers are selected for a task and we don\'t list them all.'), 'priority':
-_x('Priority', 'Table column heading for task priority (number).' ),
-'scheduledAt': __('Scheduled at'), 'cancelledAt': __('Cancelled at'),
-'updatedAt': __('Updated at'), 'action': _x('Action', 'Table column heading to
-perform an action.'), 'nothingToShow': __('Nothing to show.'), 'preview':
-_x('Preview', 'Text of a link to email preview page.'), 'actionSchedulerStatus':
-__('WP Cron / Action Scheduler Status'), 'version': __('Version'), 'storage':
-__('Storage type'), 'latestActionSchedulerTrigger': _x('Next trigger run',
-'Label for the next date and time of background job trigger run.'),
-'latestActionSchedulerCompletedTrigger': _x('Last trigger run', 'Label for the
-last date and time of background job trigger run.'),
-'latestActionSchedulerCompletedRun': _x('Last worker run', 'Label for the last
-date and time of background job worker run.'), }) %> <% endblock %>
+  <%= localize({
+    'tabKnowledgeBaseTitle': __('Knowledge Base'),
+    'tabSystemInfoTitle': __('System Info'),
+    'tabSystemStatusTitle': __('System Status'),
+    'tabYourPrivacyTitle': __('Your Privacy'),
+    'systemStatusIntroCronMSS': __('For the plugin to work, it must be able to establish connection with the task scheduler and the key activation/MailPoet Sending Service.'),
+    'systemStatusCronTitle': __('Task Scheduler'),
+    'systemStatusMSSTitle': __('Connection to the MailPoet Sending Service'),
+    'systemStatusMSSConnectionUnsuccessfulInfo': __('Please contact our technical support for assistance.'),
+    'systemStatusMSSConnectionCanConnect': __('Your installation can connect to our sending service.'),
+    'knowledgeBaseIntro': __('Click on one of these categories below to find more information:'),
+    'knowledgeBaseButton': __('Visit our Knowledge Base for more articles'),
+    'systemInfoIntro': __('The information below is useful when you need to get in touch with our support. Just copy all the text below and paste it into a message to us.'),
+    'systemInfoDataError': __('Sorry, there was an error, please try again later.'),
+    'copyToClipboard': __('Copy to clipboard'),
+    'copyToClipboardSuccess': __('Copied to clipboard.'),
+    'copyToClipboardFailure': __('Could not copy to clipboard.'),
+    'systemStatusCronStatusTitle': __('Cron'),
+    'systemStatusQueueTitle': __('Sending Queue'),
+    'systemStatusGetReportTitle': __('Get System Status'),
+    'systemStatusGetReportIntro': __('The information below is useful when you need to get in touch with our support.'),
+    'systemStatusUnderstandingReport': __('Understanding the System Status'),
+    'systemStatusDownloadReport': __('Download for Support'),
+    'systemStatusCopyForSupport': __('Copy for Support'),
+    'yourPrivacyContent1': __('MailPoet respects your privacy. We don't track any information about your website or yourself without your explicit consent.'),
+    'yourPrivacyContent2': __('Third-party services used within the plugin may track information such as your email & IP address.'),
+    'yourPrivacyContent3': __('If you send with MailPoet, we track data that is used to ensure that the service works correctly.'),
+    'yourPrivacyButton': __('Read our Privacy Notice'),
+    'lastUpdated': _x('Last updated', 'A label in a status table e.g. Last updated: 2018-10-18 18:50'),
+    'lastRunStarted': _x('Last run started', 'A label in a status table e.g. Last run started: 2018-10-18 18:50'),
+    'lastRunCompleted': _x('Last run completed', 'A label in a status table e.g. Last run completed: 2018-10-18 18:50'),
+    'lastSeenError': _x('Last seen error', 'A label in a status table e.g. Last seen error: Process timeout'),
+    'lastSeenErrorDate': _x('Last seen error date', 'A label in a status table e.g. Last seen error date: 2018-10-18 18:50'),
+    'unknown': _x('unknown', 'An unknown state is a status table e.g. Last run started: unknown'),
+    'accessible': _x('Accessible', 'A label in a status table e.g. Accessible: yes'),
+    'status': __('Status'),
+    'yes': __('yes'),
+    'no': __('no'),
+    'none': _x('none', 'An empty state is a status table e.g. Error: none'),
+    'running': _x('running', 'A state of a process.'),
+    'paused': _x('paused', 'A state of a process.'),
+    'cronWaiting': _x('waiting for the next run', 'A state of a process.'),
+    'startedAt': _x('Started at', 'A label in a status table e.g. Started at: 2018-10-18 18:50'),
+    'sentEmails': _x('Sent emails', 'A label in a status table e.g. Sent emails: 50'),
+    'retryAttempt': _x('Retry attempt', 'A label in a status table e.g. Retry attempt: 2'),
+    'retryAt': _x('Retry at', 'A label in a status table e.g. Retry at: 2018-10-18 18:50'),
+    'error': _x('Error', 'A label in a status table e.g. Error: missing data'),
+    'totalCompletedTasks': __('Total completed tasks'),
+    'totalScheduledTasks': __('Total scheduled tasks'),
+    'totalCancelledTasks': __('Total cancelled tasks'),
+    'totalRunningTasks': __('Total running tasks'),
+    'totalPausedTasks': __('Total paused tasks'),
+    'scheduledTasks': __('Scheduled sending tasks'),
+    'runningTasks': __('Running sending tasks'),
+    'completedTasks': __('Completed sending tasks'),
+    'cancelledTasks': __('Cancelled sending tasks'),
+    'pausedTasks': __('Paused sending tasks'),
+    'type': _x('Type', 'Table column heading for task type.'),
+    'email': __('Email'),
+    'subscriber': __('Subscriber'),
+    'multipleSubscribers': _x('Multiple subscribers', 'Used when multiple subscribers are selected for a task and we don\'t list them all.'),
+    'priority': _x('Priority', 'Table column heading for task priority (number).' ),
+    'scheduledAt': __('Scheduled at'),
+    'cancelledAt': __('Cancelled at'),
+    'updatedAt': __('Updated at'),
+    'action': _x('Action', 'Table column heading to perform an action.'),
+    'nothingToShow': __('Nothing to show.'),
+    'preview': _x('Preview', 'Text of a link to email preview page.'),
+    'actionSchedulerStatus': __('WP Cron / Action Scheduler Status'),
+    'version': __('Version'),
+    'storage': __('Storage type'),
+    'latestActionSchedulerTrigger': _x('Next trigger run', 'Label for the next date and time of background job trigger run.'),
+    'latestActionSchedulerCompletedTrigger': _x('Last trigger run', 'Label for the last date and time of background job trigger run.'),
+    'latestActionSchedulerCompletedRun': _x('Last worker run', 'Label for the last date and time of background job worker run.'),
+  }) %>
+<% endblock %>


### PR DESCRIPTION
## Description

Improves MailPoet > Help > System Status to make support troubleshooting easier,
matching the UX pattern users already know from WooCommerce's System Status page.

**New UI (top of System Status tab):**
- "Get System Status" button reveals a formatted plaintext report in a textarea
- "Download for Support" downloads `mailpoet-system-status-YYYY-MM-DD.txt`
- "Copy for Support" copies to clipboard with a 3-second "Copied!" feedback state
- "Understanding the System Status" links to the KB article

**Report format** — structured sections covering all diagnostic areas:
Site & Account, Versions, Environment, WordPress & PHP Config, Active Plugins (with
update notices), Sending Configuration, MSS Connection, Task Scheduler/Cron,
Action Scheduler, Sending Queue, Data Inconsistency.

Active Plugins use WooCommerce-style format:
`Name: by Author - Version (update to version X is available)`

**Backend:** new `SystemReportCollector::getActivePluginsData()` returns plugin
metadata (name, author, version, available update) using only core WordPress APIs —
no WooCommerce dependency.

## Code review notes

`buildSystemStatusReport()` in `system-status.jsx` parses `systemInfoData` composite
string fields (e.g. `"MailPoet Sending Service"`, `"WP info"`, `"MailPoet sending info"`)
via `parseCompositeField()`. This is because `systemInfoData` was designed for the
HelpScout Beacon 20-attribute limit and encodes multiple values per key. Expanding
the backend format is out of scope here.

## QA notes

1. Go to **MailPoet > Help > System Status**
2. Click **Get System Status** — textarea appears with a structured report
3. Verify report sections match the format above (Site & Account, Versions, etc.)
4. Click **Download for Support** — `.txt` file downloads with today's date in the name
5. Click **Copy for Support** — clipboard populated; button shows "Copied!" for 3s then resets
6. To test update notices: have a plugin with a pending update — verify
   "(update to version X is available)" appears next to it in Active Plugins

## Linked tickets

[STOMAIL-7958](https://linear.app/a8c/issue/STOMAIL-7958/improve-system-status-page-woocommerce-style-report-with-copydownload)


## After-merge notes

_N/A_

## Screenshots or screencast

<img width="1280" height="730" alt="system-status-report2" src="https://github.com/user-attachments/assets/0cae3425-12bc-4b41-8c2d-a748dd1b2dba" />
<img width="1280" height="500" alt="system-status-panel" src="https://github.com/user-attachments/assets/9c1b3940-3d98-4b8d-8f83-879e59dddcad" />


## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=Improved --description="..."`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/system-status-report-copy-download)

_The latest successful build from `add/system-status-report-copy-download` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
3 issues found.

Security (3)
- Use of innerHTML / content.innerHTML in several places (tests and renderer code) — potential XSS risk if untrusted input is inserted.
- document.write / eval references found in repository docs / vendor code (AGENTS.md, vendor bundle) — flagged as risky patterns.
- Direct assignment to window.location.href in multiple UI files — potential open-redirect / navigation safety concern if values are unvalidated.

Suggestion (3)
- navigator.clipboard usage seen; ensure robust fallback and user permission handling (utils.tsx already contains fallback — verify coverage).
- Multiple window.location.href assignments could be hardened by validating/whitelisting redirect targets.
- Address any TODO/FIXME markers found during review where they affect production paths.

Bug (0)
- No clear functional bugs detected from the quick grep.

Performance (0)
- No obvious performance issues reported by the basic pattern scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->