### PR TITLE
Allow running `./do generate:data` outside test environment

### DIFF
--- a/mailpoet/tests/DataGenerator/_bootstrap.php
+++ b/mailpoet/tests/DataGenerator/_bootstrap.php
@@ -9,3 +9,10 @@ if (!function_exists('wp_mail')) {
 
 // Load WP
 require_once(getenv('WP_ROOT') . '/wp-load.php');
+
+// Load tests_env autoload so Codeception classes used by DataGenerator are available
+// when invoked outside the Codeception test container (e.g. via `./do generate:data`).
+$testsEnvAutoload = dirname(__DIR__, 3) . '/tests_env/vendor/autoload.php';
+if (file_exists($testsEnvAutoload)) {
+  require_once $testsEnvAutoload;
+}


### PR DESCRIPTION
## Description

`./do generate:data` is meant to be run in tests and relies on Codeception's methods. However, it can be useful also in normal dev environment. This PR requires tests autoload, so the command won't fail when run inside dev environment.

## Code review notes

Note that this still requires tests composer deps to be installed.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a conditional `tests_env` autoloader include so `./do generate:data` can run outside the Codeception container, with minimal behavioral impact when deps are missing.
> 
> **Overview**
> Allows `./do generate:data` to be run in a normal dev environment by updating `tests/DataGenerator/_bootstrap.php` to conditionally load `tests_env/vendor/autoload.php`, making Codeception classes available when the generator is invoked outside the test container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fded1647dba29e2f0d47957f0206a60e3d3cc62a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:generate-data)

_The latest successful build from `generate-data` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The change is a straightforward conditional autoload of the test environment's composer dependencies (`tests_env/vendor/autoload.php`) to enable running `./do generate:data` outside the Codeception test container. The implementation is cautious—using `file_exists()` before `require_once` to avoid hard failures if the file is not present. The relative path calculation using `dirname(__DIR__, 3)` is appropriate for the documented directory structure where this bootstrap file is located at `mailpoet/tests/DataGenerator/_bootstrap.php`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->