### PR TITLE
Show if the list is private or not on the listing page

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -266,6 +266,14 @@ h1.title.mailpoet-newsletter-listing-heading {
       max-width: none;
     }
   }
+
+  .mailpoet-listing-stats-opened-clicked {
+    flex-direction: column;
+  }
+
+  .mailpoet-listing-stats-percentages {
+    margin-right: 0;
+  }
 }
 
 .mailpoet-listing-stats-tooltip-title {

--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -258,6 +258,16 @@ h1.title.mailpoet-newsletter-listing-heading {
   margin-right: 5px;
 }
 
+.mailpoet-segments-listing {
+  .mailpoet-listing-description-column {
+    max-width: 14vw;
+
+    @include respond-to(small-screen) {
+      max-width: none;
+    }
+  }
+}
+
 .mailpoet-listing-stats-tooltip-title {
   font-size: $font-size-extra-small;
   font-weight: bold;

--- a/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
+++ b/mailpoet/assets/css/src/components-plugin/_listing-newsletters.scss
@@ -274,6 +274,11 @@ h1.title.mailpoet-newsletter-listing-heading {
   .mailpoet-listing-stats-percentages {
     margin-right: 0;
   }
+
+  .mailpoet-listing-title-private-label {
+    color: $color-primary-inactive;
+    font-weight: normal;
+  }
 }
 
 .mailpoet-listing-stats-tooltip-title {

--- a/mailpoet/assets/js/src/segments/static/form.tsx
+++ b/mailpoet/assets/js/src/segments/static/form.tsx
@@ -20,11 +20,11 @@ const fields = [
     tip: MailPoet.I18n.t('segmentDescriptionTip'),
   },
   {
-    name: 'showInManageSubscriptionPage',
+    name: 'show_in_manage_subscription_page',
     label: MailPoet.I18n.t('showInManageSubscriptionPage'),
     type: 'checkbox',
     values: {
-      showInManageSubscriptionPage: MailPoet.I18n.t(
+      show_in_manage_subscription_page: MailPoet.I18n.t(
         'showInManageSubscriptionPageTip',
       ),
     },

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -309,7 +309,10 @@ class SegmentListComponent extends Component<SegmentListComponentProps> {
           {segmentName}
           {actions}
         </td>
-        <td data-colname={MailPoet.I18n.t('description')}>
+        <td
+          className="mailpoet-listing-description-column"
+          data-colname={MailPoet.I18n.t('description')}
+        >
           <abbr>{segment.description}</abbr>
         </td>
         {mailpoetTrackingEnabled ? (

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -22,6 +22,7 @@ type Segment = {
   name: string;
   description: string;
   average_engagement_score: number;
+  show_in_manage_subscription_page: boolean;
   subscribers_count: {
     subscribed?: number;
     unconfirmed?: number;
@@ -286,16 +287,28 @@ class SegmentListComponent extends Component<SegmentListComponentProps> {
 
     let segmentName;
 
+    const privateLabel =
+      Number(segment.show_in_manage_subscription_page) === 0 ? (
+        <span className="mailpoet-listing-title-private-label">
+          {' '}
+          {MailPoet.I18n.t('privateListLabel')}
+        </span>
+      ) : null;
+
     if (isSpecialSegment(segment)) {
       // the WP users and WooCommerce customers segments
       // are not editable so just display their names
       segmentName = (
-        <span className="mailpoet-listing-title">{segment.name}</span>
+        <span className="mailpoet-listing-title">
+          {segment.name}
+          {privateLabel}
+        </span>
       );
     } else {
       segmentName = (
         <Link className="mailpoet-listing-title" to={`/edit/${segment.id}`}>
           {segment.name}
+          {privateLabel}
         </Link>
       );
     }

--- a/mailpoet/changelog/2026-04-21-09-55-46-improved-show-list-visibility-and-refine-layout-on-the-list.md
+++ b/mailpoet/changelog/2026-04-21-09-55-46-improved-show-list-visibility-and-refine-layout-on-the-list.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Show list visibility on the Lists listing page

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -34,7 +34,7 @@ class SegmentsResponseBuilder {
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'average_engagement_score' => $segment->getAverageEngagementScore(),
       'filters_connect' => $segment->getFiltersConnectOperator(),
-      'showInManageSubscriptionPage' => (int)$segment->getDisplayInManageSubscriptionPage(),
+      'show_in_manage_subscription_page' => $segment->getDisplayInManageSubscriptionPage(),
     ];
   }
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SegmentsResponseBuilder.php
@@ -34,7 +34,7 @@ class SegmentsResponseBuilder {
       'deleted_at' => ($deletedAt = $segment->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
       'average_engagement_score' => $segment->getAverageEngagementScore(),
       'filters_connect' => $segment->getFiltersConnectOperator(),
-      'show_in_manage_subscription_page' => $segment->getDisplayInManageSubscriptionPage(),
+      'show_in_manage_subscription_page' => (int)$segment->getDisplayInManageSubscriptionPage(),
     ];
   }
 

--- a/mailpoet/lib/Segments/SegmentListingRepository.php
+++ b/mailpoet/lib/Segments/SegmentListingRepository.php
@@ -24,7 +24,7 @@ class SegmentListingRepository extends ListingRepository {
   }
 
   protected function applySelectClause(QueryBuilder $queryBuilder) {
-    $queryBuilder->select("PARTIAL s.{id,name,type,description,createdAt,updatedAt,deletedAt,averageEngagementScore}");
+    $queryBuilder->select("PARTIAL s.{id,name,type,description,createdAt,updatedAt,deletedAt,averageEngagementScore,displayInManageSubscriptionPage}");
   }
 
   protected function applyFromClause(QueryBuilder $queryBuilder) {

--- a/mailpoet/lib/Segments/SegmentSaveController.php
+++ b/mailpoet/lib/Segments/SegmentSaveController.php
@@ -33,7 +33,7 @@ class SegmentSaveController {
     $id = isset($data['id']) ? (int)$data['id'] : null;
     $name = $data['name'] ?? '';
     $description = $data['description'] ?? '';
-    $displayInManageSubPage = isset($data['showInManageSubscriptionPage']) ? (int)$data['showInManageSubscriptionPage'] : false;
+    $displayInManageSubPage = isset($data['show_in_manage_subscription_page']) ? (int)$data['show_in_manage_subscription_page'] : false;
 
     return $this->segmentsRepository->createOrUpdate($name, $description, SegmentEntity::TYPE_DEFAULT, [], $id, (bool)$displayInManageSubPage);
   }

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -39,6 +39,7 @@
 
   'showInManageSubscriptionPage': __('List visibility'),
   'showInManageSubscriptionPageTip': __('Show this list on the "Manage Subscription" page'),
+  'privateListLabel': _x('(private)', 'Appended after the list name on the Lists page to indicate that the list is not shown on the Manage Subscription page'),
 
   'mailpoetSubscribers': _x('%s MailPoet subscribers', 'number of subscribers in the plugin'),
   'mailpoetSubscribersTooltipFree': __('This is the total of all subscribers including %1$d WordPress users. To exclude WordPress users, please purchase one of our premium plans.'),


### PR DESCRIPTION
## Description

Add `(private)` after the name of lists, that are not visible on the Manage subscription page. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7963

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="1265" height="722" alt="Screenshot 2026-04-21 at 12 38 34" src="https://github.com/user-attachments/assets/6747bb62-5acb-46c5-b245-d357aac2ebec" /> | <img width="1264" height="733" alt="Screenshot 2026-04-21 at 12 34 24" src="https://github.com/user-attachments/assets/c8980308-5fca-4731-87f4-77e3945f691f" /> |

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7963-show-if-the-list-is-private-or-not-on-the-listing-page)

_The latest successful build from `stomail-7963-show-if-the-list-is-private-or-not-on-the-listing-page` will be used. If none is available, the link won't work._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the API payload/request field from `showInManageSubscriptionPage` to `show_in_manage_subscription_page`, which can break any consumers expecting the old key, and it updates listing queries/UI rendering based on that value.
> 
> **Overview**
> Shows list visibility directly on the Lists (segments) listing page by appending a translated `(private)` label to list names when they are hidden from the Manage Subscription page.
> 
> Standardizes the visibility flag naming across frontend and backend to `show_in_manage_subscription_page`, updates segment listing queries/JSON responses to include the flag, and tweaks listing CSS/layout (description column width and stats alignment) to accommodate the new label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686a1f001b72b1bf20e2c73b1229c5780b9b0caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**1 issue found**

**Bug:**
Type mismatch in `show_in_manage_subscription_page` field. The TypeScript type definition declares it as `boolean` in `list.tsx`, but the code checks `Number(segment.show_in_manage_subscription_page) === 0`, treating it as a numeric value (0 for private, non-zero for public). Additionally, the PHP backend casts the input to `int` in `SegmentSaveController.php` while the `SegmentEntity` stores and returns it as a `boolean`. This inconsistency between the TypeScript type declaration and the actual numeric comparison, combined with the int/boolean conversion on the backend, could lead to unexpected behavior or logical errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->