### PR TITLE
Add AI-powered subject and preview text suggestions

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/global.d.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/global.d.ts
@@ -15,4 +15,5 @@ interface Window {
     };
   };
   mailpoet_is_automation_newsletter: boolean;
+  mailpoet_ai_text_generation_available?: boolean;
 }

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/integration.scss
@@ -76,6 +76,70 @@
   }
 }
 
+.mailpoet-ai-suggestions {
+  min-width: 300px;
+  max-width: 400px;
+  padding: $grid-unit-10;
+
+  &__toggle {
+    margin-bottom: $grid-unit-15;
+    display: inline-flex !important;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__icon {
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: $grid-unit-10;
+    padding: $grid-unit-15 0;
+    color: $gray-700;
+  }
+
+  &__error {
+    padding: $grid-unit-10 0;
+
+    p {
+      color: $alert-red;
+      margin: 0 0 $grid-unit-10;
+    }
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    padding: $grid-unit-10;
+    border: 1px solid $gray-300;
+    border-radius: 2px;
+    margin-bottom: $grid-unit-10;
+    cursor: pointer;
+    text-align: left;
+    background: transparent;
+
+    &:hover {
+      background-color: $gray-100;
+      border-color: var(--wp-admin-theme-color);
+    }
+
+    strong {
+      color: $gray-900;
+      margin-bottom: 4px;
+    }
+
+    span {
+      color: $gray-700;
+      font-size: $font-size-small;
+    }
+  }
+}
+
 .mailpoet-inbox-preview-panel {
   &__card {
     padding: $grid-unit-15;

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -133,7 +133,6 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
               spacing={4}
             >
               <HStack alignment="center">
-                {/* @ts-expect-error size prop is available in the external @wordpress/components package */}
                 <Heading
                   className="block-editor-inspector-popover-header__heading"
                   level={2}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -149,9 +149,7 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
             {isLoading && (
               <div className="mailpoet-ai-suggestions__loading">
                 <Spinner />
-                <span>
-                  {__('Generating suggestions…', 'mailpoet')}
-                </span>
+                <span>{__('Generating suggestions…', 'mailpoet')}</span>
               </div>
             )}
 

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -1,0 +1,190 @@
+import {
+  Button,
+  Dropdown,
+  Notice,
+  Spinner,
+  __experimentalVStack as VStack,
+  __experimentalHStack as HStack,
+  __experimentalHeading as Heading,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import {
+  useRef,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+} from '@wordpress/element';
+import { select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { closeSmall } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+const sparklesSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M9.5 3l1.5 3.5L14.5 8l-3.5 1.5L9.5 13 8 9.5 4.5 8 8 6.5 9.5 3zm7 7l1 2.5 2.5 1-2.5 1-1 2.5-1-2.5L13 13.5l2.5-1 1-2.5zm-7 7l1 2 2 1-2 1-1 2-1-2-2-1 2-1 1-2z"/></svg>';
+
+type Suggestion = {
+  subject: string;
+  preheader: string;
+};
+
+type Props = {
+  onSelect: (suggestion: Suggestion) => void;
+};
+
+export function AiSubjectSuggestions({ onSelect }: Props) {
+  if (!window.mailpoet_ai_text_generation_available) {
+    return null;
+  }
+
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const popoverAnchor = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const container = popoverAnchor.current;
+    if (!container) return;
+    const btn = container.querySelector('.mailpoet-ai-suggestions__toggle');
+    if (!btn || btn.querySelector('.mailpoet-ai-suggestions__icon')) return;
+    const icon = document.createElement('span');
+    icon.className = 'mailpoet-ai-suggestions__icon';
+    icon.innerHTML = sparklesSvg;
+    btn.insertBefore(icon, btn.firstChild);
+  });
+
+  const fetchSuggestions = useCallback(() => {
+    abortControllerRef.current?.abort();
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+    setSuggestions([]);
+
+    const postId = select(editorStore).getCurrentPostId();
+
+    apiFetch<{ data: { suggestions: Suggestion[] } }>({
+      path: '/mailpoet/v1/email/generate-subject-suggestions',
+      method: 'POST',
+      data: { post_id: postId },
+      signal: controller.signal,
+    })
+      .then((response) => {
+        setSuggestions(response.data.suggestions);
+      })
+      .catch((err: Error & { code?: string }) => {
+        if (err.name === 'AbortError') {
+          return;
+        }
+        setError(
+          err.message ||
+            __('Failed to generate suggestions. Please try again.', 'mailpoet'),
+        );
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  return (
+    <div ref={popoverAnchor}>
+      <Dropdown
+        popoverProps={{
+          anchor: popoverAnchor.current,
+          placement: 'left-start',
+          offset: 36,
+          shift: true,
+        }}
+        renderToggle={({ isOpen, onToggle }) => (
+          <Button
+            variant="secondary"
+            onClick={() => {
+              if (!isOpen) {
+                fetchSuggestions();
+              }
+              onToggle();
+            }}
+            aria-expanded={isOpen}
+            className="mailpoet-ai-suggestions__toggle"
+          >
+            {__('Suggest with AI', 'mailpoet')}
+          </Button>
+        )}
+        renderContent={({ onClose }) => (
+          <div className="mailpoet-ai-suggestions">
+            <VStack
+              className="block-editor-inspector-popover-header"
+              spacing={4}
+            >
+              <HStack alignment="center">
+                {/* @ts-expect-error size prop is available in the external @wordpress/components package */}
+                <Heading
+                  className="block-editor-inspector-popover-header__heading"
+                  level={2}
+                  size={13}
+                >
+                  {__('AI suggestions', 'mailpoet')}
+                </Heading>
+                <Spacer />
+                <Button
+                  size="small"
+                  className="block-editor-inspector-popover-header__action"
+                  label={__('Close', 'mailpoet')}
+                  icon={closeSmall}
+                  onClick={onClose}
+                />
+              </HStack>
+            </VStack>
+
+            {isLoading && (
+              <div className="mailpoet-ai-suggestions__loading">
+                <Spinner />
+                <span>
+                  {__('Generating suggestions…', 'mailpoet')}
+                </span>
+              </div>
+            )}
+
+            {error && (
+              <div className="mailpoet-ai-suggestions__error">
+                <Notice status="error" isDismissible={false}>
+                  {error}
+                </Notice>
+                <Button variant="secondary" onClick={fetchSuggestions}>
+                  {__('Try again', 'mailpoet')}
+                </Button>
+              </div>
+            )}
+
+            {!isLoading &&
+              !error &&
+              suggestions.map((suggestion, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  className="mailpoet-ai-suggestions__item"
+                  onClick={() => {
+                    onSelect(suggestion);
+                    onClose();
+                  }}
+                >
+                  <strong>{suggestion.subject}</strong>
+                  <span>{suggestion.preheader}</span>
+                </button>
+              ))}
+          </div>
+        )}
+      />
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -171,9 +171,9 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
 
             {!isLoading &&
               !error &&
-              suggestions.map((suggestion, index) => (
+              suggestions.map((suggestion) => (
                 <button
-                  key={`${index}-${suggestion.subject}`}
+                  key={`${suggestion.subject}-${suggestion.preheader}`}
                   type="button"
                   className="mailpoet-ai-suggestions__item"
                   onClick={() => {

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -171,9 +171,9 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
 
             {!isLoading &&
               !error &&
-              suggestions.map((suggestion) => (
+              suggestions.map((suggestion, index) => (
                 <button
-                  key={suggestion.subject}
+                  key={`${index}-${suggestion.subject}`}
                   type="button"
                   className="mailpoet-ai-suggestions__item"
                   onClick={() => {

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -34,10 +34,7 @@ type Props = {
 };
 
 export function AiSubjectSuggestions({ onSelect }: Props) {
-  if (!window.mailpoet_ai_text_generation_available) {
-    return null;
-  }
-
+  const isAvailable = Boolean(window.mailpoet_ai_text_generation_available);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -80,21 +77,29 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
       signal: controller.signal,
     })
       .then((response) => {
+        if (abortControllerRef.current !== controller) return;
         setSuggestions(response.data.suggestions);
       })
       .catch((err: Error & { code?: string }) => {
         if (err.name === 'AbortError') {
           return;
         }
+        if (abortControllerRef.current !== controller) return;
         setError(
           err.message ||
             __('Failed to generate suggestions. Please try again.', 'mailpoet'),
         );
       })
       .finally(() => {
-        setIsLoading(false);
+        if (abortControllerRef.current === controller) {
+          setIsLoading(false);
+        }
       });
   }, []);
+
+  if (!isAvailable) {
+    return null;
+  }
 
   return (
     <div ref={popoverAnchor}>

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/ai-subject-suggestions.tsx
@@ -41,11 +41,12 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const popoverAnchor = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       abortControllerRef.current?.abort();
-    };
-  }, []);
+    },
+    [],
+  );
 
   useLayoutEffect(() => {
     const container = popoverAnchor.current;
@@ -171,9 +172,9 @@ export function AiSubjectSuggestions({ onSelect }: Props) {
 
             {!isLoading &&
               !error &&
-              suggestions.map((suggestion, index) => (
+              suggestions.map((suggestion) => (
                 <button
-                  key={index}
+                  key={suggestion.subject}
                   type="button"
                   className="mailpoet-ai-suggestions__item"
                   onClick={() => {

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/content-settings-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/content-settings-panel.tsx
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
+import { AiSubjectSuggestions } from './components/ai-subject-suggestions';
 
 const subjectMaxLength = 60;
 const previewTextMaxLength = 150;
@@ -97,6 +98,13 @@ export function ContentSettingsPanel() {
       title={__('Content settings', 'mailpoet')}
       className="mailpoet-content-settings-panel"
     >
+      <AiSubjectSuggestions
+        onSelect={(suggestion) => {
+          updateEmailMailPoetProperty('subject', suggestion.subject);
+          updateEmailMailPoetProperty('preheader', suggestion.preheader);
+        }}
+      />
+
       <TextareaControl
         label={__('Subject', 'mailpoet')}
         value={mailpoetEmailData?.subject || ''}

--- a/mailpoet/changelog/2026-04-21-14-58-59-add-ai-powered-subject-line-and-preview-text-suggestions.md
+++ b/mailpoet/changelog/2026-04-21-14-58-59-add-ai-powered-subject-line-and-preview-text-suggestions.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add AI-powered subject line and preview text suggestions in the email editor

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -355,6 +355,7 @@ class ContainerConfigurator implements IContainerConfigurator {
 
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Cli::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor::class)->setPublic(true);
+    $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\Endpoints\GenerateSubjectSuggestionsEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EditorPageRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\MailPoetCssInliner::class)->setPublic(true);
     $container->autowire(\MailPoet\EmailEditor\Integrations\MailPoet\EmailApiController::class)->setPublic(true);

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -195,6 +195,8 @@ class EditorPageRenderer {
       'mailpoet_installed_days_ago' => (int)$installedAtDiff->format('%a'),
       'mailpoet_is_automation_newsletter' => $isAutomationNewsletter,
       'mailpoet_automation_id' => $automationId,
+      'mailpoet_ai_text_generation_available' => function_exists('wp_ai_client_prompt')
+        && wp_ai_client_prompt('test')->is_supported_for_text_generation(),
     ];
     $this->wp->wpAddInlineScript('email_editor_integration', implode('', array_map(function ($key) use ($inline_script_data) {
       return sprintf("var %s=%s;", $key, wp_json_encode($inline_script_data[$key], JSON_HEX_TAG | JSON_UNESCAPED_SLASHES));

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailEditor.php
@@ -2,6 +2,8 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\API\REST\API;
+use MailPoet\EmailEditor\Integrations\MailPoet\Endpoints\GenerateSubjectSuggestionsEndpoint;
 use MailPoet\EmailEditor\Integrations\MailPoet\Patterns\PatternsController;
 use MailPoet\EmailEditor\Integrations\MailPoet\Templates\TemplatesController;
 use MailPoet\Newsletter\NewslettersRepository;
@@ -70,6 +72,7 @@ class EmailEditor {
       $this->templatesController->initialize();
     }
     $this->extendEmailPostApi();
+    $this->registerApiRoutes();
     $this->personalizationTagManager->initialize();
   }
 
@@ -97,6 +100,15 @@ class EmailEditor {
       return $post && $post->post_type === self::MAILPOET_EMAIL_POST_TYPE; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     }
     return false;
+  }
+
+  private function registerApiRoutes(): void {
+    $this->wp->addAction(API::REST_API_INIT_ACTION, function (API $api) {
+      $api->registerPostRoute(
+        'email/generate-subject-suggestions',
+        GenerateSubjectSuggestionsEndpoint::class
+      );
+    });
   }
 
   public function extendEmailPostApi() {

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\EmailEditor\Integrations\MailPoet\Endpoints;
+
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
+use MailPoet\API\REST\Endpoint;
+use MailPoet\API\REST\ErrorResponse;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\Validator\Builder;
+use MailPoet\Validator\Schema;
+use MailPoet\WP\Functions as WPFunctions;
+
+class GenerateSubjectSuggestionsEndpoint extends Endpoint {
+  private WPFunctions $wp;
+
+  private const TAG_CATEGORIES_FOR_SUBJECT = ['Subscriber', 'Site', 'Customer', 'Order'];
+
+  private const SUBJECT_MAX_LENGTH = 60;
+  private const PREHEADER_MAX_LENGTH = 150;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function handle(Request $request): Response {
+    $postId = (int)$request->getParam('post_id');
+
+    if (!function_exists('wp_ai_client_prompt')) {
+      return new ErrorResponse(
+        503,
+        __('AI text generation is not available.', 'mailpoet'),
+        'mailpoet_ai_unavailable'
+      );
+    }
+
+    $post = $this->wp->getPost($postId);
+    if (!$post instanceof \WP_Post || $post->post_type !== 'mailpoet_email') { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return new ErrorResponse(
+        404,
+        __('Email not found.', 'mailpoet'),
+        'mailpoet_ai_email_not_found'
+      );
+    }
+
+    $html = do_blocks($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $bodyText = $this->wp->wpStripAllTags($html);
+    $bodyText = (string)preg_replace('/\s+/', ' ', trim($bodyText));
+
+    if ($bodyText === '') {
+      return new ErrorResponse(
+        400,
+        __('Email body is empty. Add content before generating suggestions.', 'mailpoet'),
+        'mailpoet_ai_empty_content'
+      );
+    }
+
+    $personalizationTags = $this->getAvailablePersonalizationTags();
+    $tagsInstruction = '';
+    if (!empty($personalizationTags)) {
+      $tagsList = implode(', ', array_map(function ($tag) {
+        return $tag['token'] . ' (' . $tag['name'] . ')';
+      }, $personalizationTags));
+      $tagsInstruction = 'You may use these personalization tags in the subject lines and preview text to make them more personal: '
+        . $tagsList . '. Use them sparingly — not every suggestion needs a tag. Insert the tag token exactly as shown (e.g. [mailpoet/subscriber-firstname]). ';
+    }
+
+    $systemInstruction = 'You are an expert email marketer. Generate subject lines and preview text for marketing emails. '
+      . 'Match the tone and style of the email body — if it\'s a business email, keep it professional; '
+      . 'if it\'s fun or casual, feel free to use emojis. '
+      . 'IMPORTANT: Generate suggestions in the same language as the email body content. '
+      . $tagsInstruction
+      . 'Subject lines must be under 60 characters. Preview text must be under 150 characters and complement the subject line.';
+
+    $prompt = "Based on the following email body content, generate 4 different subject line and preview text pairs:\n\n" . $bodyText;
+
+    $schema = [
+      'type' => 'object',
+      'additionalProperties' => false,
+      'properties' => [
+        'suggestions' => [
+          'type' => 'array',
+          'items' => [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'properties' => [
+              'subject' => ['type' => 'string'],
+              'preheader' => ['type' => 'string'],
+            ],
+            'required' => ['subject', 'preheader'],
+          ],
+        ],
+      ],
+      'required' => ['suggestions'],
+    ];
+
+    $result = wp_ai_client_prompt($prompt)
+      ->using_system_instruction($systemInstruction)
+      ->as_json_response($schema)
+      ->generate_text();
+
+    if (is_wp_error($result)) {
+      return new ErrorResponse(
+        502,
+        __('Failed to generate suggestions. Please check your AI provider configuration and try again.', 'mailpoet'),
+        'mailpoet_ai_generation_failed'
+      );
+    }
+
+    $decoded = json_decode($result, true);
+    if (!is_array($decoded) || !isset($decoded['suggestions']) || !is_array($decoded['suggestions'])) {
+      return new ErrorResponse(
+        502,
+        __('AI returned an unexpected response.', 'mailpoet'),
+        'mailpoet_ai_invalid_response'
+      );
+    }
+
+    $validSuggestions = [];
+    foreach ($decoded['suggestions'] as $suggestion) {
+      if (
+        !is_array($suggestion)
+        || !isset($suggestion['subject'], $suggestion['preheader'])
+        || !is_string($suggestion['subject'])
+        || !is_string($suggestion['preheader'])
+        || mb_strlen($suggestion['subject']) > self::SUBJECT_MAX_LENGTH
+        || mb_strlen($suggestion['preheader']) > self::PREHEADER_MAX_LENGTH
+      ) {
+        continue;
+      }
+      $validSuggestions[] = [
+        'subject' => $suggestion['subject'],
+        'preheader' => $suggestion['preheader'],
+      ];
+    }
+
+    if (empty($validSuggestions)) {
+      return new ErrorResponse(
+        502,
+        __('AI did not return any valid suggestions. Please try again.', 'mailpoet'),
+        'mailpoet_ai_no_valid_suggestions'
+      );
+    }
+
+    return new Response(['suggestions' => $validSuggestions]);
+  }
+
+  /**
+   * @return array<int, array{name: string, token: string}>
+   */
+  private function getAvailablePersonalizationTags(): array {
+    if (!class_exists(Email_Editor_Container::class)) {
+      return [];
+    }
+    $registry = Email_Editor_Container::container()->get(Personalization_Tags_Registry::class);
+    $tags = [];
+    $urlKeywords = ['url', 'link'];
+    foreach ($registry->get_all() as $tag) {
+      $postTypes = $tag->get_post_types();
+      if (!empty($postTypes) && !in_array(EmailEditor::MAILPOET_EMAIL_POST_TYPE, $postTypes, true)) {
+        continue;
+      }
+      if (!in_array($tag->get_category(), self::TAG_CATEGORIES_FOR_SUBJECT, true)) {
+        continue;
+      }
+      $token = $tag->get_token();
+      $tokenLower = strtolower($token);
+      $isUrl = false;
+      foreach ($urlKeywords as $keyword) {
+        if (strpos($tokenLower, $keyword) !== false) {
+          $isUrl = true;
+          break;
+        }
+      }
+      if ($isUrl) {
+        continue;
+      }
+      $tags[] = [
+        'name' => $tag->get_name(),
+        'token' => $token,
+      ];
+    }
+    return $tags;
+  }
+
+  public function checkPermissions(): bool {
+    return current_user_can('edit_posts');
+  }
+
+  /** @return array<string, Schema> */
+  public static function getRequestSchema(): array {
+    return [
+      'post_id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -9,6 +9,7 @@ use MailPoet\API\REST\ErrorResponse;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Validator\Builder;
 use MailPoet\Validator\Schema;
 use MailPoet\WP\Functions as WPFunctions;
@@ -112,7 +113,14 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
       ->as_json_response($schema)
       ->generate_text();
 
+    $logger = LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_EMAIL_EDITOR);
+
     if (is_wp_error($result)) {
+      $logger->error('AI subject generation failed', [
+        'error_code' => $result->get_error_code(),
+        'error_message' => $result->get_error_message(),
+        'post_id' => $postId,
+      ]);
       return new ErrorResponse(
         502,
         __('Failed to generate suggestions. Please check your AI provider configuration and try again.', 'mailpoet'),
@@ -122,6 +130,10 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
 
     $decoded = json_decode($result, true);
     if (!is_array($decoded) || !isset($decoded['suggestions']) || !is_array($decoded['suggestions'])) {
+      $logger->error('AI subject generation returned invalid JSON', [
+        'raw_response' => is_string($result) ? mb_substr($result, 0, 500) : gettype($result),
+        'post_id' => $postId,
+      ]);
       return new ErrorResponse(
         502,
         __('AI returned an unexpected response.', 'mailpoet'),
@@ -139,6 +151,10 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
         || mb_strlen($suggestion['subject']) > self::SUBJECT_MAX_LENGTH
         || mb_strlen($suggestion['preheader']) > self::PREHEADER_MAX_LENGTH
       ) {
+        $logger->info('AI subject suggestion filtered out', [
+          'suggestion' => is_array($suggestion) ? $suggestion : gettype($suggestion),
+          'post_id' => $postId,
+        ]);
         continue;
       }
       $validSuggestions[] = [
@@ -148,6 +164,10 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
     }
 
     if (empty($validSuggestions)) {
+      $logger->error('AI subject generation returned no valid suggestions', [
+        'raw_suggestions' => $decoded['suggestions'],
+        'post_id' => $postId,
+      ]);
       return new ErrorResponse(
         502,
         __('AI did not return any valid suggestions. Please try again.', 'mailpoet'),

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -28,7 +28,7 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
   }
 
   public function handle(Request $request): Response {
-    $postId = (int)$request->getParam('post_id');
+    $postId = intval($request->getParam('post_id'));
 
     if (!function_exists('wp_ai_client_prompt')) {
       return new ErrorResponse(

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -28,7 +28,8 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
   }
 
   public function handle(Request $request): Response {
-    $postId = intval($request->getParam('post_id'));
+    /** @var int $postId validated by schema */
+    $postId = $request->getParam('post_id');
 
     if (!function_exists('wp_ai_client_prompt')) {
       return new ErrorResponse(

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -47,6 +47,14 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
       );
     }
 
+    if (!current_user_can('edit_post', $postId)) {
+      return new ErrorResponse(
+        403,
+        __('You are not allowed to generate suggestions for this email.', 'mailpoet'),
+        'mailpoet_ai_forbidden'
+      );
+    }
+
     $html = do_blocks($post->post_content); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $bodyText = $this->wp->wpStripAllTags($html);
     $bodyText = (string)preg_replace('/\s+/', ' ', trim($bodyText));

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -90,13 +90,11 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
 
     $schema = [
       'type' => 'object',
-      'additionalProperties' => false,
       'properties' => [
         'suggestions' => [
           'type' => 'array',
           'items' => [
             'type' => 'object',
-            'additionalProperties' => false,
             'properties' => [
               'subject' => ['type' => 'string'],
               'preheader' => ['type' => 'string'],
@@ -108,12 +106,21 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
       'required' => ['suggestions'],
     ];
 
-    $result = wp_ai_client_prompt($prompt)
+    $promptBuilder = wp_ai_client_prompt($prompt)
       ->using_system_instruction($systemInstruction)
-      ->as_json_response($schema)
-      ->generate_text();
+      ->as_json_response($schema);
 
     $logger = LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_EMAIL_EDITOR);
+
+    if (!$promptBuilder->is_supported_for_text_generation()) {
+      return new ErrorResponse(
+        503,
+        __('AI text generation is not available. Please check your AI provider configuration.', 'mailpoet'),
+        'mailpoet_ai_unavailable'
+      );
+    }
+
+    $result = $promptBuilder->generate_text();
 
     if (is_wp_error($result)) {
       $logger->error('AI subject generation failed', [
@@ -131,7 +138,8 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
     $decoded = json_decode($result, true);
     if (!is_array($decoded) || !isset($decoded['suggestions']) || !is_array($decoded['suggestions'])) {
       $logger->error('AI subject generation returned invalid JSON', [
-        'raw_response' => is_string($result) ? mb_substr($result, 0, 500) : gettype($result),
+        'response_type' => gettype($result),
+        'response_length' => is_string($result) ? mb_strlen($result) : null,
         'post_id' => $postId,
       ]);
       return new ErrorResponse(
@@ -152,7 +160,10 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
         || mb_strlen($suggestion['preheader']) > self::PREHEADER_MAX_LENGTH
       ) {
         $logger->info('AI subject suggestion filtered out', [
-          'suggestion' => is_array($suggestion) ? $suggestion : gettype($suggestion),
+          'suggestion_type' => gettype($suggestion),
+          'suggestion_keys' => is_array($suggestion) ? array_keys($suggestion) : [],
+          'subject_length' => is_array($suggestion) && isset($suggestion['subject']) && is_string($suggestion['subject']) ? mb_strlen($suggestion['subject']) : null,
+          'preheader_length' => is_array($suggestion) && isset($suggestion['preheader']) && is_string($suggestion['preheader']) ? mb_strlen($suggestion['preheader']) : null,
           'post_id' => $postId,
         ]);
         continue;
@@ -165,7 +176,7 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
 
     if (empty($validSuggestions)) {
       $logger->error('AI subject generation returned no valid suggestions', [
-        'raw_suggestions' => $decoded['suggestions'],
+        'suggestion_count' => count($decoded['suggestions']),
         'post_id' => $postId,
       ]);
       return new ErrorResponse(

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -84,31 +84,22 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
       . 'if it\'s fun or casual, feel free to use emojis. '
       . 'IMPORTANT: Generate suggestions in the same language as the email body content. '
       . $tagsInstruction
-      . 'Subject lines must be under 60 characters. Preview text must be under 150 characters and complement the subject line.';
+      . 'Subject lines must be under 60 characters. Preview text must be under 150 characters and complement the subject line. '
+      . 'Respond ONLY with valid JSON (no markdown, no code fences) in this exact format: '
+      . '{"suggestions":[{"subject":"...","preheader":"..."},{"subject":"...","preheader":"..."},{"subject":"...","preheader":"..."},{"subject":"...","preheader":"..."}]}';
 
     $prompt = "Based on the following email body content, generate 4 different subject line and preview text pairs:\n\n" . $bodyText;
 
-    $schema = [
-      'type' => 'object',
-      'properties' => [
-        'suggestions' => [
-          'type' => 'array',
-          'items' => [
-            'type' => 'object',
-            'properties' => [
-              'subject' => ['type' => 'string'],
-              'preheader' => ['type' => 'string'],
-            ],
-            'required' => ['subject', 'preheader'],
-          ],
-        ],
-      ],
-      'required' => ['suggestions'],
-    ];
-
     $promptBuilder = wp_ai_client_prompt($prompt)
       ->using_system_instruction($systemInstruction)
-      ->as_json_response($schema);
+      ->using_model_preference(
+        ['anthropic', 'claude-sonnet-4-6'],
+        ['google', 'gemini-3-flash-preview'],
+        ['google', 'gemini-2.5-flash'],
+        ['openai', 'gpt-5.4-mini'],
+        ['openai', 'gpt-4.1-mini']
+      )
+      ->as_json_response();
 
     $logger = LoggerFactory::getInstance()->getLogger(LoggerFactory::TOPIC_EMAIL_EDITOR);
 
@@ -135,11 +126,12 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
       );
     }
 
-    $decoded = json_decode($result, true);
-    if (!is_array($decoded) || !isset($decoded['suggestions']) || !is_array($decoded['suggestions'])) {
+    $decoded = $this->parseAiResponse($result);
+    if ($decoded === null) {
       $logger->error('AI subject generation returned invalid JSON', [
         'response_type' => gettype($result),
         'response_length' => is_string($result) ? mb_strlen($result) : null,
+        'response_preview' => is_string($result) ? mb_substr($result, 0, 200) : null,
         'post_id' => $postId,
       ]);
       return new ErrorResponse(
@@ -187,6 +179,28 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
     }
 
     return new Response(['suggestions' => $validSuggestions]);
+  }
+
+  /**
+   * @return array{suggestions: array<int, mixed>}|null
+   */
+  private function parseAiResponse(string $result): ?array {
+    $json = trim($result);
+    $json = preg_replace('/^```(?:json)?\s*/i', '', $json);
+    $json = preg_replace('/\s*```\s*$/', '', $json);
+    $json = trim($json);
+
+    $decoded = json_decode($json, true);
+
+    if (is_array($decoded) && isset($decoded['suggestions']) && is_array($decoded['suggestions'])) {
+      return $decoded;
+    }
+
+    if (is_array($decoded) && !isset($decoded['suggestions']) && isset($decoded[0])) {
+      return ['suggestions' => $decoded];
+    }
+
+    return null;
   }
 
   /**

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Endpoints/GenerateSubjectSuggestionsEndpoint.php
@@ -185,9 +185,7 @@ class GenerateSubjectSuggestionsEndpoint extends Endpoint {
    * @return array{suggestions: array<int, mixed>}|null
    */
   private function parseAiResponse(string $result): ?array {
-    $json = trim($result);
-    $json = preg_replace('/^```(?:json)?\s*/i', '', $json);
-    $json = preg_replace('/\s*```\s*$/', '', $json);
+    $json = preg_replace('/^```(?:json)?\s*|```\s*$/i', '', trim($result)) ?? trim($result);
     $json = trim($json);
 
     $decoded = json_decode($json, true);


### PR DESCRIPTION
## Description

Add a "Suggest with AI" button to the Content Settings panel in the Gutenberg email editor. Uses the WordPress 7.0 AI Client (`wp_ai_client_prompt()`) to generate subject line and preview text suggestions based on the email body content.

- ✨ Sparkles icon button, hidden when no AI provider is configured
- Generates 4 subject + preview text pairs matching the email's tone and language
- Aware of available personalization tags (e.g. `[mailpoet/subscriber-firstname]`)
- User picks from a dropdown popover, both fields are filled on selection
- Validates AI response and shows user-friendly error messages

## Code review notes

- The WordPress `Button` component strips non-text children inside `Dropdown`'s `renderToggle`, so the sparkles icon is injected via `useLayoutEffect` DOM manipulation — this is intentional, not a workaround that can be simplified.
- `using_temperature()` was removed from the AI Client call because some providers (Anthropic) reject it. The AI Client API doesn't normalize this across providers.
- JSON schema requires `additionalProperties: false` for Anthropic compatibility.

## QA notes

1. Install and activate an AI provider plugin (e.g. "AI Provider for Anthropic"), or use WordPress 7.0 and configure the API key in Settings → Connectors 
3. Open an email in the Gutenberg editor with some body content
4. In the sidebar under "Content settings", click "✨ Suggest with AI"
5. Verify 4 suggestions appear in a dropdown, each with a subject line and preview text
6. Click a suggestion — both Subject and Preview text fields should be populated
7. Test without an AI provider configured — the button should not appear
8. Test with an empty email body — should show an error message

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-7966](https://linear.app/a8c/issue/STOMAIL-7966/add-ai-powered-subject-line-and-preview-text-suggestions)

## After-merge notes

_N/A_

## Screenshots or screencast

### New UI which suggests AI-generated subjects

<img width="617" height="438" alt="Screenshot 2026-04-21 at 15 46 02" src="https://github.com/user-attachments/assets/e37823a2-6a74-41f5-870d-b951bd5b8d3c" />

### By clicking a row it gets filled

<img width="287" height="436" alt="Screenshot 2026-04-21 at 15 46 12" src="https://github.com/user-attachments/assets/779d9d90-462a-4e9a-bfe6-217ecdf7d480" />


## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:brave-handle)

_The latest successful build from `brave-handle` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 2

- Bug: Unsafe method call in EditorPageRenderer.php — wp_ai_client_prompt('test')->is_supported_for_text_generation() is invoked inline without validating the return value of wp_ai_client_prompt() (can cause a fatal error if it returns WP_Error or an unexpected type).
- Bug: Unsafe chaining in GenerateSubjectSuggestionsEndpoint.php — wp_ai_client_prompt($prompt) is assigned/chained without first checking the returned value for WP_Error or ensuring it provides the expected methods, which can cause fatal errors with certain providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->