### PR TITLE
Add birthday email automation workflow setup

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
@@ -1,5 +1,4 @@
 import { getIsGarden } from 'common/functions';
-import { MailPoet } from 'mailpoet';
 import { registerStepType } from '../../editor/store';
 import { step as SendEmailStep } from './steps/send-email';
 import { step as SomeoneSubscribesTrigger } from './steps/someone-subscribes';

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/index.tsx
@@ -45,13 +45,7 @@ export const initialize = (): void => {
   registerStepType(TagAddedTrigger);
   registerStepType(TagRemovedTrigger);
   registerStepType(ClicksEmailLinkTrigger);
-  if (
-    MailPoet.FeaturesController.isSupported(
-      MailPoet.FeaturesController.FEATURE_BIRTHDAY_EMAILS,
-    )
-  ) {
-    registerStepType(AnnualDateTrigger);
-  }
+  registerStepType(AnnualDateTrigger);
   // Insert new steps here
   registerStepControls();
   registerAutomationSidebar();

--- a/mailpoet/assets/js/src/features-controller.js
+++ b/mailpoet/assets/js/src/features-controller.js
@@ -1,6 +1,5 @@
 export const FeaturesController = (config) => ({
   FEATURE_BRAND_TEMPLATES: 'brand_templates',
-  FEATURE_BIRTHDAY_EMAILS: 'birthday_emails',
 
   isSupported: (feature) => {
     return config[feature] || false;

--- a/mailpoet/changelog/2026-04-22-12-00-00-added-birthday-email-automation-with-date-shortcode-format.md
+++ b/mailpoet/changelog/2026-04-22-12-00-00-added-birthday-email-automation-with-date-shortcode-format.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Birthday email automation: date shortcode format parameter, pre-built template, configurable send time, and "custom field is set/not set" segment filters
+Birthday email automation — send automated birthday emails to subscribers using any date custom field, with configurable send time and date formatting in email content

--- a/mailpoet/changelog/2026-04-22-12-00-00-added-birthday-email-automation-with-date-shortcode-format.md
+++ b/mailpoet/changelog/2026-04-22-12-00-00-added-birthday-email-automation-with-date-shortcode-format.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Birthday email automation: date shortcode format parameter, pre-built template, configurable send time, and "custom field is set/not set" segment filters

--- a/mailpoet/lib/Automation/Engine/Registry.php
+++ b/mailpoet/lib/Automation/Engine/Registry.php
@@ -66,6 +66,7 @@ class Registry {
       'review' => new AutomationTemplateCategory('review', _x('Review', 'automation template category title', 'mailpoet')),
       'subscriptions' => new AutomationTemplateCategory('subscriptions', _x('Subscriptions', 'automation template category title', 'mailpoet')),
       'bookings' => new AutomationTemplateCategory('bookings', _x('Bookings', 'automation template category title', 'mailpoet')),
+      'celebrations' => new AutomationTemplateCategory('celebrations', _x('Celebrations', 'automation template category title', 'mailpoet')),
     ];
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -79,7 +79,32 @@ class TemplatesFactory {
       }
     }
 
+    $templates[] = $this->createBirthdayEmailTemplate();
+
     return $templates;
+  }
+
+  private function createBirthdayEmailTemplate(): AutomationTemplate {
+    return new AutomationTemplate(
+      'birthday-email',
+      'celebrations',
+      __('Birthday email', 'mailpoet'),
+      __(
+        'Send a birthday email to your subscribers on their special day. Select a date custom field to trigger the email annually.',
+        'mailpoet'
+      ),
+      function (): Automation {
+        return $this->builder->createFromSequence(
+          __('Birthday email', 'mailpoet'),
+          []
+        );
+      },
+      [
+        'automationSteps' => 1,
+      ],
+      AutomationTemplate::TYPE_PREMIUM,
+      'heart'
+    );
   }
 
   private function createSubscriberWelcomeEmailTemplate(): AutomationTemplate {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Templates/TemplatesFactory.php
@@ -89,10 +89,7 @@ class TemplatesFactory {
       'birthday-email',
       'celebrations',
       __('Birthday email', 'mailpoet'),
-      __(
-        'Send a birthday email to your subscribers on their special day. Select a date custom field to trigger the email annually.',
-        'mailpoet'
-      ),
+      __('Send a birthday email to your subscribers on their special day.', 'mailpoet'),
       function (): Automation {
         return $this->builder->createFromSequence(
           __('Birthday email', 'mailpoet'),

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -12,7 +12,7 @@ class FeaturesController {
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
-    self::FEATURE_BIRTHDAY_EMAILS => false,
+    self::FEATURE_BIRTHDAY_EMAILS => true,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -6,13 +6,11 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
-  const FEATURE_BIRTHDAY_EMAILS = 'birthday_emails';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
-    self::FEATURE_BIRTHDAY_EMAILS => true,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/Categories/Subscriber.php
@@ -19,12 +19,17 @@ class Subscriber implements CategoryInterface {
   /** @var SubscriberCustomFieldRepository */
   private $subscriberCustomFieldRepository;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     SubscribersRepository $subscribersRepository,
-    SubscriberCustomFieldRepository $subscriberCustomFieldRepository
+    SubscriberCustomFieldRepository $subscriberCustomFieldRepository,
+    WPFunctions $wp
   ) {
     $this->subscribersRepository = $subscribersRepository;
     $this->subscriberCustomFieldRepository = $subscriberCustomFieldRepository;
+    $this->wp = $wp;
   }
 
   public function process(
@@ -69,6 +74,17 @@ class Subscriber implements CategoryInterface {
             return $defaultValue;
           }
           $customFieldDefinition = $customField->getCustomField();
+          if (
+            $shortcodeDetails['action_argument'] === 'format'
+            && $customFieldDefinition instanceof CustomFieldEntity
+            && $customFieldDefinition->getType() === CustomFieldEntity::TYPE_DATE
+          ) {
+            $timestamp = strtotime($customField->getValue());
+            if ($timestamp !== false) {
+              return $this->wp->dateI18n($shortcodeDetails['action_argument_value'], $timestamp);
+            }
+            return $defaultValue;
+          }
           if (
             $customFieldDefinition instanceof CustomFieldEntity &&
             $customFieldDefinition->getType() === CustomFieldEntity::TYPE_CHECKBOX &&

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/MailPoetCustomFields.php
@@ -74,10 +74,10 @@ class MailPoetCustomFields implements Filter {
     $operator = $filterData->getParam('operator');
     $queryBuilder->setParameter($valueParam, $value);
     if ($operator === DynamicSegmentFilterData::IS_BLANK) {
-      $queryBuilder->andWhere('subscribers_custom_field.value IS NULL');
+      $queryBuilder->andWhere("subscribers_custom_field.value IS NULL OR subscribers_custom_field.value = ''");
       return $queryBuilder;
     } elseif ($operator === DynamicSegmentFilterData::IS_NOT_BLANK) {
-      $queryBuilder->andWhere('subscribers_custom_field.value IS NOT NULL');
+      $queryBuilder->andWhere("subscribers_custom_field.value IS NOT NULL AND subscribers_custom_field.value != ''");
       return $queryBuilder;
     } elseif ($dateType === 'month') {
       return $this->applyForDateMonth($queryBuilder, $valueParam);
@@ -122,9 +122,9 @@ class MailPoetCustomFields implements Filter {
     $operator = $filterData->getParam('operator');
 
     if ($operator === DynamicSegmentFilterData::IS_BLANK) {
-      $queryBuilder->andWhere('subscribers_custom_field.value IS NULL');
+      $queryBuilder->andWhere("subscribers_custom_field.value IS NULL OR subscribers_custom_field.value = ''");
     } elseif ($operator === DynamicSegmentFilterData::IS_NOT_BLANK) {
-      $queryBuilder->andWhere('subscribers_custom_field.value IS NOT NULL');
+      $queryBuilder->andWhere("subscribers_custom_field.value IS NOT NULL AND subscribers_custom_field.value != ''");
     } elseif ($value === '1') {
       $queryBuilder->andWhere('subscribers_custom_field.value = 1');
     } elseif ($value === '0') {

--- a/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Newsletter/ShortcodesTest.php
@@ -316,6 +316,69 @@ class ShortcodesTest extends \MailPoetTest {
     verify($result[0])->equals('');
   }
 
+  public function testItCanFormatDateCustomFieldShortcodes() {
+    $shortcodesObject = $this->shortcodesObject;
+    $subscriber = $this->subscriber;
+
+    $customField = new CustomFieldEntity();
+    $customField->setName('birthday');
+    $customField->setType(CustomFieldEntity::TYPE_DATE);
+    $customField->setParams(['date_type' => 'year_month_day', 'date_format' => 'YYYY-MM-DD']);
+    $this->entityManager->persist($customField);
+    $this->entityManager->flush();
+
+    $subscriberCustomField = new SubscriberCustomFieldEntity($subscriber, $customField, '2010-04-20 00:00:00');
+    $this->entityManager->persist($subscriberCustomField);
+    $this->entityManager->flush();
+
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ' | format:F j]']
+    );
+    verify($result[0])->equals('April 20');
+
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ' | format:Y]']
+    );
+    verify($result[0])->equals('2010');
+  }
+
+  public function testItReturnsEmptyStringForEmptyDateCustomFieldWithFormat() {
+    $shortcodesObject = $this->shortcodesObject;
+    $subscriber = $this->subscriber;
+
+    $customField = new CustomFieldEntity();
+    $customField->setName('birthday');
+    $customField->setType(CustomFieldEntity::TYPE_DATE);
+    $customField->setParams(['date_type' => 'year_month_day', 'date_format' => 'YYYY-MM-DD']);
+    $this->entityManager->persist($customField);
+    $this->entityManager->flush();
+
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ' | format:F j]']
+    );
+    verify($result[0])->equals('');
+  }
+
+  public function testItIgnoresFormatForNonDateCustomField() {
+    $shortcodesObject = $this->shortcodesObject;
+    $subscriber = $this->subscriber;
+
+    $customField = new CustomFieldEntity();
+    $customField->setName('nickname');
+    $customField->setType('text');
+    $this->entityManager->persist($customField);
+    $this->entityManager->flush();
+
+    $subscriberCustomField = new SubscriberCustomFieldEntity($subscriber, $customField, 'John');
+    $this->entityManager->persist($subscriberCustomField);
+    $this->entityManager->flush();
+
+    $result = $shortcodesObject->process(
+      ['[subscriber:cf_' . $customField->getId() . ' | format:F j]']
+    );
+    verify($result[0])->equals('John');
+  }
+
   public function testItCanProcessLinkShortcodes() {
     $shortcodesObject = $this->shortcodesObject;
     $result =

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationTemplatesGetEndpointTest.php
@@ -15,7 +15,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
 
   public function testGetAllTemplates() {
     $result = $this->get(self::ENDPOINT_PATH, []);
-    $this->assertCount(21, $result['data']);
+    $this->assertCount(22, $result['data']);
     $this->assertEquals('subscriber-welcome-email', $result['data'][0]['slug']);
   }
 
@@ -23,7 +23,7 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
     wp_set_current_user($this->editorUserId);
     $data = $this->get(self::ENDPOINT_PATH, []);
 
-    $this->assertCount(21, $data['data']);
+    $this->assertCount(22, $data['data']);
   }
 
   public function testGuestNotAllowed(): void {
@@ -73,6 +73,13 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
       ],
     ]);
     $this->assertCount(6, $result['data']);
+
+    $result = $this->get(self::ENDPOINT_PATH, [
+      'json' => [
+        'category' => 'celebrations',
+      ],
+    ]);
+    $this->assertCount(1, $result['data']);
   }
 
   public function testTemplatesHaveIconProperties(): void {
@@ -115,6 +122,8 @@ class AutomationTemplatesGetEndpointTest extends AutomationTest {
       'follow-up-on-churned-subscription' => 'payment',
       'follow-up-when-trial-ends' => 'payment',
       'win-back-churned-subscribers' => 'payment',
+      // Celebrations
+      'birthday-email' => 'heart',
     ];
 
     foreach ($result['data'] as $template) {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/MailPoetCustomFieldsTest.php
@@ -337,6 +337,52 @@ class MailPoetCustomFieldsTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing([], $emails);
   }
 
+  public function testDateEmptyStringCountsAsBlank(): void {
+    $customField = $this->createCustomField(CustomFieldEntity::TYPE_DATE);
+    $this->entityManager->persist($customField);
+    $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '2017-04-01 00:00:00'));
+    $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[1], $customField, ''));
+    $this->entityManager->flush();
+    $blankData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE, [
+      'custom_field_id' => $customField->getId(),
+      'custom_field_type' => CustomFieldEntity::TYPE_DATE,
+      'date_type' => 'year_month_day',
+      'operator' => 'is_blank',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($blankData, $this->filter);
+    $this->assertEqualsCanonicalizing([$this->subscribers[1]->getEmail(), $this->subscribers[2]->getEmail()], $emails);
+    $notBlankData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE, [
+      'custom_field_id' => $customField->getId(),
+      'custom_field_type' => CustomFieldEntity::TYPE_DATE,
+      'date_type' => 'year_month_day',
+      'operator' => 'is_not_blank',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($notBlankData, $this->filter);
+    $this->assertEqualsCanonicalizing([$this->subscribers[0]->getEmail()], $emails);
+  }
+
+  public function testCheckboxEmptyStringCountsAsBlank(): void {
+    $customField = $this->createCustomField(CustomFieldEntity::TYPE_CHECKBOX);
+    $this->entityManager->persist($customField);
+    $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[0], $customField, '1'));
+    $this->entityManager->persist(new SubscriberCustomFieldEntity($this->subscribers[1], $customField, ''));
+    $this->entityManager->flush();
+    $blankData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE, [
+      'custom_field_id' => $customField->getId(),
+      'custom_field_type' => CustomFieldEntity::TYPE_CHECKBOX,
+      'operator' => 'is_blank',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($blankData, $this->filter);
+    $this->assertEqualsCanonicalizing([$this->subscribers[1]->getEmail(), $this->subscribers[2]->getEmail()], $emails);
+    $notBlankData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, MailPoetCustomFields::TYPE, [
+      'custom_field_id' => $customField->getId(),
+      'custom_field_type' => CustomFieldEntity::TYPE_CHECKBOX,
+      'operator' => 'is_not_blank',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($notBlankData, $this->filter);
+    $this->assertEqualsCanonicalizing([$this->subscribers[0]->getEmail()], $emails);
+  }
+
   public function testTextAreaWorksWithBlankOptions(): void {
     $subscriber = $this->subscribers[1];
     $customField = $this->createCustomField(CustomFieldEntity::TYPE_TEXT);


### PR DESCRIPTION
## Description

Complete the birthday email automation feature (STOMAIL-7960) by adding the remaining pieces needed before enabling the feature flag:

- **Date shortcode format parameter** — `[subscriber:cf_X | format:F j]` outputs "April 20" instead of raw "2010-04-20 00:00:00". Uses `dateI18n()` for localized formatting.
- **Pre-built "Birthday Email" automation template** — new "Celebrations" category with a one-click premium template stub (premium plugin overrides with the real template).
- **Dynamic segment fix** — `IS_BLANK`/`IS_NOT_BLANK` operators for date and checkbox custom fields now correctly match empty strings in addition to NULL values.
- **Feature flag removed** — the feature will be enabled for all users

## Code review notes

_N/A_

## QA notes

1. Go to MailPoet → Automations → Start with a template
2. Verify the "Celebrations" category tab appears with 1 template
3. Verify the "Birthday email" template card shows with a lock icon (without premium) or is clickable (with premium)
4. Create a date custom field and a subscriber with a date value
5. In any email, use `[subscriber:cf_X | format:F j]` — verify it renders the formatted date
6. Go to Segments → Add new → MailPoet Custom Field → select a date field → verify "is blank" / "is not blank" operators work

## Linked PRs

- mailpoet/mailpoet-premium#1039 (premium counterpart)

## Linked tickets

- [STOMAIL-7960](https://linear.app/a8c/issue/STOMAIL-7960)

## After-merge notes

_N/A_

## Screenshots

### Birthday email template in the automation gallery

<img width="391" height="241" alt="Screenshot 2026-04-22 at 15 01 53" src="https://github.com/user-attachments/assets/b43bd7ec-9135-46bd-8874-fec1bee12aaf" />

--- 

<img width="775" height="682" alt="Screenshot 2026-04-22 at 15 31 05" src="https://github.com/user-attachments/assets/24312795-939d-4952-9b05-420595ffd920" />



### Date shortcode format parameter

<img width="797" height="474" alt="Screenshot 2026-04-23 at 8 09 44" src="https://github.com/user-attachments/assets/6fe9b780-75bd-4049-aa27-741b655f77d3" />


### Birthday trigger settings with Send time dropdown

<img width="274" height="262" alt="Screenshot 2026-04-23 at 8 05 42" src="https://github.com/user-attachments/assets/1536906c-87b0-4a0c-92af-99d7580a51ea" />




## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:birthday-email-automation-workflow-setup)

_The latest successful build from `birthday-email-automation-workflow-setup` will be used. If none is available, the link won't work._