### PR TITLE
Experimental: MailPoet dev MCP server for AI agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ packages/php/*/vendor
 tests_env/vendor
 .wp-env.override.json*
 !.wp-env.override.json.sample
+.wp-env/.mailpoet-dev-companion-secret
+.wp-env/mcp-usage.jsonl

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "mailpoet-dev": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./tools/mcp-server/dist/index.js"]
+    }
+  }
+}

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -7,6 +7,8 @@
   "port": 8888,
   "mappings": {
     "wp-content/mu-plugins/mailpoet-dev-smtp.php": "./.wp-env/mu-plugins/mailpoet-dev-smtp.php",
+    "wp-content/mu-plugins/mailpoet-dev-companion.php": "./.wp-env/mu-plugins/mailpoet-dev-companion.php",
+    "wp-content/mu-plugins/mailpoet-dev-companion-secret": "./.wp-env/.mailpoet-dev-companion-secret",
     "wp-env-scripts": "./.wp-env/scripts"
   },
   "lifecycleScripts": {

--- a/.wp-env/mu-plugins/mailpoet-dev-companion.php
+++ b/.wp-env/mu-plugins/mailpoet-dev-companion.php
@@ -49,7 +49,7 @@ add_action('rest_api_init', function () use ($mailpoetDevCompanionSecret) {
         'args' => [
             'email_contains' => ['type' => 'string', 'required' => false],
             'status' => ['type' => 'string', 'required' => false],
-            'segment_id' => ['type' => 'string', 'required' => false],
+            'segment_id' => ['type' => 'integer', 'required' => false],
             'limit' => ['type' => 'integer', 'required' => false, 'default' => 50],
             'offset' => ['type' => 'integer', 'required' => false, 'default' => 0],
         ],
@@ -148,8 +148,18 @@ function mailpoet_dev_companion_ping() {
 }
 
 function mailpoet_dev_companion_serialize_subscriber(\MailPoet\Entities\SubscriberEntity $s): array {
+    // SubscriberEntity::getSegments() maps from subscriberSegments regardless
+    // of subscription status, so an unsubscribed-from-segment row would still
+    // show up. Iterate the join entity directly and keep only STATUS_SUBSCRIBED.
     $segments = [];
-    foreach ($s->getSegments() as $seg) {
+    foreach ($s->getSubscriberSegments() as $ss) {
+        if ($ss->getStatus() !== \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED) {
+            continue;
+        }
+        $seg = $ss->getSegment();
+        if (!$seg) {
+            continue;
+        }
         $segments[] = ['id' => (string) $seg->getId(), 'name' => $seg->getName()];
     }
     return [
@@ -190,9 +200,17 @@ function mailpoet_dev_companion_list_subscribers(WP_REST_Request $request) {
     }
 
     $segmentId = $request->get_param('segment_id');
-    if (is_string($segmentId) && $segmentId !== '') {
-        $qb->innerJoin(\MailPoet\Entities\SubscriberSegmentEntity::class, 'ss', 'WITH', 'ss.subscriber = s AND ss.segment = :segmentId')
-            ->setParameter('segmentId', (int) $segmentId);
+    if ($segmentId !== null && $segmentId !== '' && (int) $segmentId > 0) {
+        // Only include subscribers that are currently subscribed to the segment
+        // (ignore past subscriptions that were cancelled).
+        $qb->innerJoin(
+            \MailPoet\Entities\SubscriberSegmentEntity::class,
+            'ss_filter',
+            'WITH',
+            'ss_filter.subscriber = s AND ss_filter.segment = :segmentId AND ss_filter.status = :subscribedStatus'
+        )
+            ->setParameter('segmentId', (int) $segmentId)
+            ->setParameter('subscribedStatus', \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED);
     }
 
     $countQb = clone $qb;
@@ -202,7 +220,13 @@ function mailpoet_dev_companion_list_subscribers(WP_REST_Request $request) {
     $limit = max(1, min(500, (int) $request->get_param('limit') ?: 50));
     $offset = max(0, (int) $request->get_param('offset') ?: 0);
 
-    $qb->setMaxResults($limit)->setFirstResult($offset);
+    // Eagerly fetch subscriberSegments + segment to avoid N+1 when the
+    // serializer walks the segment memberships per row.
+    $qb->leftJoin('s.subscriberSegments', 'ss_fetch')
+        ->leftJoin('ss_fetch.segment', 'seg_fetch')
+        ->addSelect('ss_fetch', 'seg_fetch')
+        ->setMaxResults($limit)
+        ->setFirstResult($offset);
 
     /** @var \MailPoet\Entities\SubscriberEntity[] $rows */
     $rows = $qb->getQuery()->getResult();
@@ -315,14 +339,10 @@ function mailpoet_dev_companion_create_subscriber(WP_REST_Request $request) {
         $subscriber->setLinkToken(\MailPoet\Util\Security::generateHash(\MailPoet\Entities\SubscriberEntity::LINK_TOKEN_LENGTH));
     }
 
-    try {
-        $em->persist($subscriber);
-        $em->flush();
-    } catch (\Throwable $e) {
-        return new WP_Error('persist_failed', $e->getMessage(), ['status' => 500]);
-    }
-
+    // Resolve + validate segments BEFORE persisting the subscriber, so an
+    // invalid segment_id doesn't leave a half-committed subscriber in the DB.
     $segmentIds = $request->get_param('segment_ids');
+    $segments = [];
     if (is_array($segmentIds) && $segmentIds !== []) {
         $segmentIdsInt = array_values(array_filter(array_map('intval', $segmentIds), static fn ($id) => $id > 0));
         if ($segmentIdsInt !== []) {
@@ -333,11 +353,21 @@ function mailpoet_dev_companion_create_subscriber(WP_REST_Request $request) {
                 return new WP_Error(
                     'segments_not_found',
                     'Some segment ids do not exist: ' . implode(', ', $missing),
-                    ['status' => 400, 'subscriber' => mailpoet_dev_companion_serialize_subscriber($subscriber)]
+                    ['status' => 400]
                 );
             }
-            $subscriberSegmentRepository->subscribeToSegments($subscriber, $segments, true);
         }
+    }
+
+    try {
+        $em->persist($subscriber);
+        $em->flush();
+    } catch (\Throwable $e) {
+        return new WP_Error('persist_failed', $e->getMessage(), ['status' => 500]);
+    }
+
+    if ($segments !== []) {
+        $subscriberSegmentRepository->subscribeToSegments($subscriber, $segments, true);
     }
 
     $em->refresh($subscriber);

--- a/.wp-env/mu-plugins/mailpoet-dev-companion.php
+++ b/.wp-env/mu-plugins/mailpoet-dev-companion.php
@@ -13,7 +13,10 @@ if (!defined('WP_DEBUG') || !WP_DEBUG) {
 }
 
 $mailpoetDevCompanionSecretPath = WPMU_PLUGIN_DIR . '/mailpoet-dev-companion-secret';
-if (!is_readable($mailpoetDevCompanionSecretPath)) {
+// is_readable() also returns true for directories. If the host secret file is
+// missing when wp-env starts, Docker creates an empty directory at the mount
+// point; guard with is_file() so that case takes the early-return.
+if (!is_file($mailpoetDevCompanionSecretPath) || !is_readable($mailpoetDevCompanionSecretPath)) {
     return;
 }
 
@@ -274,6 +277,9 @@ function mailpoet_dev_companion_create_subscriber(WP_REST_Request $request) {
     }
 
     $subscriber = $existing ?: new \MailPoet\Entities\SubscriberEntity();
+    // Activate the 'Saving' validation group so @Assert\Email runs at flush
+    // time (mirrors SubscriberSaveController behaviour).
+    $subscriber->setValidationGroups(['Saving', 'Default']);
     $subscriber->setEmail($email);
 
     $firstName = $request->get_param('first_name');
@@ -295,9 +301,8 @@ function mailpoet_dev_companion_create_subscriber(WP_REST_Request $request) {
     }
     $subscriber->setSource(is_string($source) && $source !== '' ? $source : 'api');
 
-    if ($subscriber->getStatus() === \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED && !$subscriber->getLastSubscribedAt()) {
-        $subscriber->setLastSubscribedAt(new \DateTimeImmutable());
-    }
+    // last_subscribed_at is set automatically by LastSubscribedAtListener
+    // when status is / becomes 'subscribed' — no manual setter needed here.
 
     if (!$subscriber->getUnsubscribeToken()) {
         do {

--- a/.wp-env/mu-plugins/mailpoet-dev-companion.php
+++ b/.wp-env/mu-plugins/mailpoet-dev-companion.php
@@ -1,0 +1,553 @@
+<?php
+/**
+ * Plugin Name: MailPoet Dev Companion
+ * Description: Dev-only REST endpoints under /wp-json/mailpoet-dev/v1/ for the MailPoet MCP server. Activates only when a shared secret file is present and WP_DEBUG is on.
+ *
+ * Auth: shared secret file at wp-content/mu-plugins/mailpoet-dev-companion-secret (mapped from host via .wp-env.json). Requests must send X-MailPoet-Dev-Secret matching the file contents.
+ *
+ * Safety: this file is a wp-env mu-plugin mapping only — it is NOT shipped with the MailPoet plugin. It silently no-ops when the secret file is missing or WP_DEBUG is false.
+ */
+
+if (!defined('WP_DEBUG') || !WP_DEBUG) {
+    return;
+}
+
+$mailpoetDevCompanionSecretPath = WPMU_PLUGIN_DIR . '/mailpoet-dev-companion-secret';
+if (!is_readable($mailpoetDevCompanionSecretPath)) {
+    return;
+}
+
+$mailpoetDevCompanionSecret = trim((string) @file_get_contents($mailpoetDevCompanionSecretPath));
+if (strlen($mailpoetDevCompanionSecret) < 32) {
+    return;
+}
+
+add_action('rest_api_init', function () use ($mailpoetDevCompanionSecret) {
+    $namespace = 'mailpoet-dev/v1';
+
+    $permission = function (WP_REST_Request $request) use ($mailpoetDevCompanionSecret) {
+        $provided = (string) $request->get_header('x_mailpoet_dev_secret');
+        if ($provided === '' || !hash_equals($mailpoetDevCompanionSecret, $provided)) {
+            return new WP_Error('mailpoet_dev_forbidden', 'Invalid or missing dev companion secret.', ['status' => 403]);
+        }
+        return true;
+    };
+
+    register_rest_route($namespace, '/ping', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_ping',
+    ]);
+
+    register_rest_route($namespace, '/subscribers', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_list_subscribers',
+        'args' => [
+            'email_contains' => ['type' => 'string', 'required' => false],
+            'status' => ['type' => 'string', 'required' => false],
+            'segment_id' => ['type' => 'string', 'required' => false],
+            'limit' => ['type' => 'integer', 'required' => false, 'default' => 50],
+            'offset' => ['type' => 'integer', 'required' => false, 'default' => 0],
+        ],
+    ]);
+
+    register_rest_route($namespace, '/subscribers', [
+        'methods' => 'POST',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_create_subscriber',
+        'args' => [
+            'email' => ['type' => 'string', 'required' => true],
+            'first_name' => ['type' => 'string', 'required' => false],
+            'last_name' => ['type' => 'string', 'required' => false],
+            'status' => ['type' => 'string', 'required' => false],
+            'source' => ['type' => 'string', 'required' => false],
+            'segment_ids' => ['type' => 'array', 'required' => false, 'items' => ['type' => 'integer']],
+            'upsert' => ['type' => 'boolean', 'required' => false, 'default' => false],
+        ],
+    ]);
+
+    register_rest_route($namespace, '/subscribers/(?P<id>[0-9]+)', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_get_subscriber',
+        'args' => ['id' => ['type' => 'integer', 'required' => true]],
+    ]);
+
+    register_rest_route($namespace, '/segments', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_list_segments',
+        'args' => [
+            'type' => ['type' => 'string', 'required' => false],
+            'include_counts' => ['type' => 'boolean', 'required' => false, 'default' => false],
+        ],
+    ]);
+
+    register_rest_route($namespace, '/feature-flags', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_list_feature_flags',
+    ]);
+
+    register_rest_route($namespace, '/feature-flags/(?P<name>[A-Za-z0-9_-]+)', [
+        'methods' => 'POST',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_set_feature_flag',
+        'args' => [
+            'name' => ['type' => 'string', 'required' => true],
+            'value' => ['type' => 'boolean', 'required' => true],
+        ],
+    ]);
+
+    register_rest_route($namespace, '/migrations', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_migrations_status',
+    ]);
+
+    register_rest_route($namespace, '/scheduler', [
+        'methods' => 'GET',
+        'permission_callback' => $permission,
+        'callback' => 'mailpoet_dev_companion_scheduler_list',
+        'args' => [
+            'status' => ['type' => 'string', 'required' => false],
+            'hook_contains' => ['type' => 'string', 'required' => false],
+            'group' => ['type' => 'string', 'required' => false],
+            'limit' => ['type' => 'integer', 'required' => false, 'default' => 50],
+        ],
+    ]);
+});
+
+function mailpoet_dev_companion_container() {
+    if (!class_exists(\MailPoet\DI\ContainerWrapper::class)) {
+        return new WP_Error('mailpoet_not_loaded', 'MailPoet plugin is not loaded.', ['status' => 503]);
+    }
+    try {
+        return \MailPoet\DI\ContainerWrapper::getInstance();
+    } catch (\Throwable $e) {
+        return new WP_Error('mailpoet_container_error', $e->getMessage(), ['status' => 500]);
+    }
+}
+
+function mailpoet_dev_companion_ping() {
+    $pluginVersion = defined('MAILPOET_VERSION') ? MAILPOET_VERSION : null;
+    $premiumActive = defined('MAILPOET_PREMIUM_VERSION')
+        || (function_exists('is_plugin_active') && is_plugin_active('mailpoet-premium/mailpoet-premium.php'));
+    return rest_ensure_response([
+        'ok' => true,
+        'plugin_version' => $pluginVersion,
+        'wp_version' => get_bloginfo('version'),
+        'php_version' => PHP_VERSION,
+        'premium_active' => (bool) $premiumActive,
+        'time' => gmdate('c'),
+    ]);
+}
+
+function mailpoet_dev_companion_serialize_subscriber(\MailPoet\Entities\SubscriberEntity $s): array {
+    $segments = [];
+    foreach ($s->getSegments() as $seg) {
+        $segments[] = ['id' => (string) $seg->getId(), 'name' => $seg->getName()];
+    }
+    return [
+        'id' => (string) $s->getId(),
+        'email' => $s->getEmail(),
+        'first_name' => $s->getFirstName() ?: null,
+        'last_name' => $s->getLastName() ?: null,
+        'status' => $s->getStatus(),
+        'created_at' => $s->getCreatedAt() ? $s->getCreatedAt()->format('c') : null,
+        'updated_at' => $s->getUpdatedAt() ? $s->getUpdatedAt()->format('c') : null,
+        'source' => $s->getSource() ?: null,
+        'segments' => $segments,
+    ];
+}
+
+function mailpoet_dev_companion_list_subscribers(WP_REST_Request $request) {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    /** @var \MailPoetVendor\Doctrine\ORM\EntityManager $em */
+    $em = $container->get(\MailPoetVendor\Doctrine\ORM\EntityManager::class);
+
+    $qb = $em->createQueryBuilder()
+        ->select('s')
+        ->from(\MailPoet\Entities\SubscriberEntity::class, 's')
+        ->where('s.deletedAt IS NULL')
+        ->orderBy('s.id', 'DESC');
+
+    $emailContains = $request->get_param('email_contains');
+    if (is_string($emailContains) && $emailContains !== '') {
+        $qb->andWhere('LOWER(s.email) LIKE :email')
+            ->setParameter('email', '%' . strtolower($emailContains) . '%');
+    }
+
+    $status = $request->get_param('status');
+    if (is_string($status) && $status !== '') {
+        $qb->andWhere('s.status = :status')->setParameter('status', $status);
+    }
+
+    $segmentId = $request->get_param('segment_id');
+    if (is_string($segmentId) && $segmentId !== '') {
+        $qb->innerJoin(\MailPoet\Entities\SubscriberSegmentEntity::class, 'ss', 'WITH', 'ss.subscriber = s AND ss.segment = :segmentId')
+            ->setParameter('segmentId', (int) $segmentId);
+    }
+
+    $countQb = clone $qb;
+    $countQb->select('COUNT(s.id)');
+    $total = (int) $countQb->getQuery()->getSingleScalarResult();
+
+    $limit = max(1, min(500, (int) $request->get_param('limit') ?: 50));
+    $offset = max(0, (int) $request->get_param('offset') ?: 0);
+
+    $qb->setMaxResults($limit)->setFirstResult($offset);
+
+    /** @var \MailPoet\Entities\SubscriberEntity[] $rows */
+    $rows = $qb->getQuery()->getResult();
+
+    $items = array_map('mailpoet_dev_companion_serialize_subscriber', $rows);
+
+    return rest_ensure_response([
+        'items' => $items,
+        'total' => $total,
+        'limit' => $limit,
+        'offset' => $offset,
+    ]);
+}
+
+function mailpoet_dev_companion_get_subscriber(WP_REST_Request $request) {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    /** @var \MailPoet\Subscribers\SubscribersRepository $subscribersRepository */
+    $subscribersRepository = $container->get(\MailPoet\Subscribers\SubscribersRepository::class);
+    $id = (int) $request->get_param('id');
+    $subscriber = $subscribersRepository->findOneById($id);
+    if (!$subscriber) {
+        return new WP_Error('not_found', "Subscriber $id not found.", ['status' => 404]);
+    }
+    return rest_ensure_response(mailpoet_dev_companion_serialize_subscriber($subscriber));
+}
+
+function mailpoet_dev_companion_create_subscriber(WP_REST_Request $request) {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    $email = strtolower(trim((string) $request->get_param('email')));
+    if ($email === '' || !is_email($email)) {
+        return new WP_Error('invalid_email', "Invalid email: '$email'.", ['status' => 400]);
+    }
+
+    $validStatuses = [
+        \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED,
+        \MailPoet\Entities\SubscriberEntity::STATUS_UNSUBSCRIBED,
+        \MailPoet\Entities\SubscriberEntity::STATUS_UNCONFIRMED,
+        \MailPoet\Entities\SubscriberEntity::STATUS_BOUNCED,
+        \MailPoet\Entities\SubscriberEntity::STATUS_INACTIVE,
+    ];
+    $status = $request->get_param('status');
+    if ($status !== null && !in_array($status, $validStatuses, true)) {
+        return new WP_Error('invalid_status', "Invalid status '$status'. Allowed: " . implode(', ', $validStatuses), ['status' => 400]);
+    }
+
+    try {
+        /** @var \MailPoetVendor\Doctrine\ORM\EntityManager $em */
+        $em = $container->get(\MailPoetVendor\Doctrine\ORM\EntityManager::class);
+        /** @var \MailPoet\Subscribers\SubscribersRepository $subscribersRepository */
+        $subscribersRepository = $container->get(\MailPoet\Subscribers\SubscribersRepository::class);
+        /** @var \MailPoet\Subscribers\SubscriberSegmentRepository $subscriberSegmentRepository */
+        $subscriberSegmentRepository = $container->get(\MailPoet\Subscribers\SubscriberSegmentRepository::class);
+        /** @var \MailPoet\Segments\SegmentsRepository $segmentsRepository */
+        $segmentsRepository = $container->get(\MailPoet\Segments\SegmentsRepository::class);
+    } catch (\Throwable $e) {
+        return new WP_Error('mailpoet_container_error', $e->getMessage(), ['status' => 500]);
+    }
+
+    $existing = $subscribersRepository->findOneBy(['email' => $email]);
+    $upsert = (bool) $request->get_param('upsert');
+
+    if ($existing && !$upsert) {
+        return new WP_Error(
+            'subscriber_exists',
+            "Subscriber '$email' already exists (id {$existing->getId()}). Pass upsert=true to update.",
+            ['status' => 409, 'subscriber' => mailpoet_dev_companion_serialize_subscriber($existing)]
+        );
+    }
+
+    $subscriber = $existing ?: new \MailPoet\Entities\SubscriberEntity();
+    $subscriber->setEmail($email);
+
+    $firstName = $request->get_param('first_name');
+    if (is_string($firstName)) $subscriber->setFirstName($firstName);
+
+    $lastName = $request->get_param('last_name');
+    if (is_string($lastName)) $subscriber->setLastName($lastName);
+
+    if (is_string($status) && $status !== '') {
+        $subscriber->setStatus($status);
+    } elseif (!$existing) {
+        $subscriber->setStatus(\MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED);
+    }
+
+    $source = $request->get_param('source');
+    $allowedSources = ['api', 'form', 'unknown', 'imported', 'administrator', 'wordpress_user', 'woocommerce_user', 'woocommerce_checkout'];
+    if (is_string($source) && $source !== '' && !in_array($source, $allowedSources, true)) {
+        return new WP_Error('invalid_source', "Invalid source '$source'. Allowed: " . implode(', ', $allowedSources), ['status' => 400]);
+    }
+    $subscriber->setSource(is_string($source) && $source !== '' ? $source : 'api');
+
+    if ($subscriber->getStatus() === \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED && !$subscriber->getLastSubscribedAt()) {
+        $subscriber->setLastSubscribedAt(new \DateTimeImmutable());
+    }
+
+    if (!$subscriber->getUnsubscribeToken()) {
+        do {
+            $token = \MailPoet\Util\Security::generateRandomString(\MailPoet\Util\Security::UNSUBSCRIBE_TOKEN_LENGTH);
+            $collision = $subscribersRepository->findBy(['unsubscribeToken' => $token]);
+        } while (count($collision) > 0);
+        $subscriber->setUnsubscribeToken($token);
+    }
+    if (!$subscriber->getLinkToken()) {
+        $subscriber->setLinkToken(\MailPoet\Util\Security::generateHash(\MailPoet\Entities\SubscriberEntity::LINK_TOKEN_LENGTH));
+    }
+
+    try {
+        $em->persist($subscriber);
+        $em->flush();
+    } catch (\Throwable $e) {
+        return new WP_Error('persist_failed', $e->getMessage(), ['status' => 500]);
+    }
+
+    $segmentIds = $request->get_param('segment_ids');
+    if (is_array($segmentIds) && $segmentIds !== []) {
+        $segmentIdsInt = array_values(array_filter(array_map('intval', $segmentIds), static fn ($id) => $id > 0));
+        if ($segmentIdsInt !== []) {
+            $segments = $segmentsRepository->findBy(['id' => $segmentIdsInt]);
+            $foundIds = array_map(static fn ($s) => $s->getId(), $segments);
+            $missing = array_values(array_diff($segmentIdsInt, $foundIds));
+            if ($missing !== []) {
+                return new WP_Error(
+                    'segments_not_found',
+                    'Some segment ids do not exist: ' . implode(', ', $missing),
+                    ['status' => 400, 'subscriber' => mailpoet_dev_companion_serialize_subscriber($subscriber)]
+                );
+            }
+            $subscriberSegmentRepository->subscribeToSegments($subscriber, $segments, true);
+        }
+    }
+
+    $em->refresh($subscriber);
+
+    return rest_ensure_response([
+        'subscriber' => mailpoet_dev_companion_serialize_subscriber($subscriber),
+        'created' => $existing === null,
+        'upserted' => $existing !== null,
+    ]);
+}
+
+function mailpoet_dev_companion_list_segments(WP_REST_Request $request) {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    /** @var \MailPoetVendor\Doctrine\ORM\EntityManager $em */
+    $em = $container->get(\MailPoetVendor\Doctrine\ORM\EntityManager::class);
+
+    $qb = $em->createQueryBuilder()
+        ->select('seg')
+        ->from(\MailPoet\Entities\SegmentEntity::class, 'seg')
+        ->where('seg.deletedAt IS NULL')
+        ->orderBy('seg.id', 'ASC');
+
+    $type = $request->get_param('type');
+    if (is_string($type) && $type !== '') {
+        $qb->andWhere('seg.type = :type')->setParameter('type', $type);
+    }
+
+    /** @var \MailPoet\Entities\SegmentEntity[] $segments */
+    $segments = $qb->getQuery()->getResult();
+
+    $includeCounts = (bool) $request->get_param('include_counts');
+    $items = [];
+    foreach ($segments as $seg) {
+        $row = [
+            'id' => (string) $seg->getId(),
+            'name' => $seg->getName(),
+            'type' => $seg->getType(),
+            'description' => $seg->getDescription() ?: null,
+            'created_at' => $seg->getCreatedAt() ? $seg->getCreatedAt()->format('c') : null,
+            'updated_at' => $seg->getUpdatedAt() ? $seg->getUpdatedAt()->format('c') : null,
+        ];
+        if ($includeCounts) {
+            $count = (int) $em->createQueryBuilder()
+                ->select('COUNT(ss.id)')
+                ->from(\MailPoet\Entities\SubscriberSegmentEntity::class, 'ss')
+                ->where('ss.segment = :seg AND ss.status = :status')
+                ->setParameter('seg', $seg)
+                ->setParameter('status', \MailPoet\Entities\SubscriberEntity::STATUS_SUBSCRIBED)
+                ->getQuery()
+                ->getSingleScalarResult();
+            $row['subscribed_count'] = $count;
+        }
+        $items[] = $row;
+    }
+
+    return rest_ensure_response(['items' => $items, 'total' => count($items)]);
+}
+
+function mailpoet_dev_companion_list_feature_flags() {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    try {
+        /** @var \MailPoet\Features\FeaturesController $controller */
+        $controller = $container->get(\MailPoet\Features\FeaturesController::class);
+    } catch (\Throwable $e) {
+        return new WP_Error('mailpoet_container_error', $e->getMessage(), ['status' => 500]);
+    }
+
+    $defaults = $controller->getDefaults();
+    $current = $controller->getAllFlags();
+
+    $items = [];
+    foreach ($defaults as $name => $default) {
+        $items[] = [
+            'name' => $name,
+            'enabled' => (bool) ($current[$name] ?? $default),
+            'default' => (bool) $default,
+        ];
+    }
+
+    return rest_ensure_response(['items' => $items, 'total' => count($items)]);
+}
+
+function mailpoet_dev_companion_set_feature_flag(WP_REST_Request $request) {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    $name = (string) $request->get_param('name');
+    $value = $request->get_param('value');
+
+    try {
+        /** @var \MailPoet\Features\FeaturesController $controller */
+        $controller = $container->get(\MailPoet\Features\FeaturesController::class);
+        /** @var \MailPoet\Features\FeatureFlagsRepository $repo */
+        $repo = $container->get(\MailPoet\Features\FeatureFlagsRepository::class);
+    } catch (\Throwable $e) {
+        return new WP_Error('mailpoet_container_error', $e->getMessage(), ['status' => 500]);
+    }
+
+    if (!$controller->exists($name)) {
+        return new WP_Error('unknown_flag', "Unknown feature flag '$name'. Known flags: " . implode(', ', array_keys($controller->getDefaults())), ['status' => 404]);
+    }
+
+    try {
+        $repo->createOrUpdate(['name' => $name, 'value' => (bool) $value]);
+        $controller->resetCache();
+    } catch (\Throwable $e) {
+        return new WP_Error('save_failed', $e->getMessage(), ['status' => 500]);
+    }
+
+    return rest_ensure_response([
+        'name' => $name,
+        'enabled' => (bool) $value,
+        'default' => (bool) ($controller->getDefaults()[$name] ?? false),
+    ]);
+}
+
+function mailpoet_dev_companion_migrations_status() {
+    $container = mailpoet_dev_companion_container();
+    if ($container instanceof WP_Error) return $container;
+
+    try {
+        /** @var \MailPoet\Migrator\Migrator $migrator */
+        $migrator = $container->get(\MailPoet\Migrator\Migrator::class);
+        $status = $migrator->getStatus();
+    } catch (\Throwable $e) {
+        return new WP_Error('migrator_error', $e->getMessage(), ['status' => 500]);
+    }
+
+    $items = [];
+    $counts = ['new' => 0, 'started' => 0, 'completed' => 0, 'failed' => 0, 'unknown' => 0];
+    foreach ($status as $m) {
+        if (!empty($m['unknown'])) {
+            $counts['unknown']++;
+        } elseif (isset($counts[$m['status']])) {
+            $counts[$m['status']]++;
+        }
+        $items[] = [
+            'name' => $m['name'],
+            'level' => $m['level'],
+            'status' => $m['status'],
+            'started_at' => $m['started_at'],
+            'completed_at' => $m['completed_at'],
+            'retries' => $m['retries'],
+            'error' => $m['error'],
+            'unknown' => (bool) $m['unknown'],
+        ];
+    }
+
+    return rest_ensure_response([
+        'items' => $items,
+        'counts' => $counts,
+        'total' => count($items),
+    ]);
+}
+
+function mailpoet_dev_companion_scheduler_list(WP_REST_Request $request) {
+    if (!function_exists('as_get_scheduled_actions') || !class_exists(\ActionScheduler_Store::class)) {
+        return new WP_Error('action_scheduler_missing', 'Action Scheduler is not loaded.', ['status' => 503]);
+    }
+
+    $args = ['per_page' => max(1, min(500, (int) $request->get_param('limit') ?: 50))];
+
+    $status = $request->get_param('status');
+    $allowedStatuses = [
+        \ActionScheduler_Store::STATUS_PENDING,
+        \ActionScheduler_Store::STATUS_RUNNING,
+        \ActionScheduler_Store::STATUS_COMPLETE,
+        \ActionScheduler_Store::STATUS_FAILED,
+        \ActionScheduler_Store::STATUS_CANCELED,
+    ];
+    if (is_string($status) && $status !== '') {
+        if (!in_array($status, $allowedStatuses, true)) {
+            return new WP_Error('invalid_status', "Invalid status '$status'. Allowed: " . implode(', ', $allowedStatuses), ['status' => 400]);
+        }
+        $args['status'] = $status;
+    }
+
+    $group = $request->get_param('group');
+    if (is_string($group) && $group !== '') {
+        $args['group'] = $group;
+    }
+
+    $hookContains = $request->get_param('hook_contains');
+    if (is_string($hookContains) && $hookContains !== '') {
+        $args['search'] = $hookContains;
+    }
+
+    try {
+        $actionIds = as_get_scheduled_actions($args, 'ids');
+        $store = \ActionScheduler_Store::instance();
+    } catch (\Throwable $e) {
+        return new WP_Error('scheduler_error', $e->getMessage(), ['status' => 500]);
+    }
+
+    $items = [];
+    foreach ($actionIds as $id) {
+        try {
+            $action = $store->fetch_action($id);
+            $scheduled = $action->get_schedule()->get_date();
+            $items[] = [
+                'id' => (string) $id,
+                'hook' => $action->get_hook(),
+                'group' => $action->get_group(),
+                'status' => $store->get_status($id),
+                'scheduled_at' => $scheduled ? $scheduled->format('c') : null,
+                'args' => $action->get_args(),
+            ];
+        } catch (\Throwable $e) {
+            $items[] = ['id' => (string) $id, 'error' => $e->getMessage()];
+        }
+    }
+
+    return rest_ensure_response(['items' => $items, 'total' => count($items)]);
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,13 @@ This is a **monorepo** containing:
 │   └── eslint-config/           # @mailpoet/eslint-config
 ├── doc/                         # API documentation and usage examples
 ├── scripts/                     # Dev helper scripts (setup, SMTP catcher, override generator)
-├── tools/                       # Build tooling (Webpack config)
+├── tools/                       # Build tooling (Webpack config) + experimental MCP server
+│   └── mcp-server/              # Dev-only MCP server exposing MailPoet to AI agents
 ├── tests_env/                   # Test environment (Docker + Codeception + Selenium)
 ├── templates/                   # Email templates
 ├── .wp-env.json                 # wp-env dev environment config
 ├── .wp-env.override.json.sample # Template for local wp-env overrides
-└── .wp-env/                     # wp-env helpers: mu-plugins/ (SMTP router), scripts/ (MailPoet SMTP auto-config)
+└── .wp-env/                     # wp-env helpers: mu-plugins/ (SMTP router + dev companion), scripts/
 ```
 
 ### Key PHP Namespaces (`mailpoet/lib/`)
@@ -395,6 +396,18 @@ Skills are progressively-revealed instructions loaded on demand.
 - `reviewing-code.md` -- Reviewing pull requests or local code changes. Use when asked to review a PR, review code, test changes, verify implementation quality, or do a code review.
 - `writing-changelog` -- Use when adding a changelog entry for user-facing changes. Guides through analyzing branch changes, picking the right type, and writing a user-friendly description.
 
+## Experimental: MCP Server for AI Agents
+
+`tools/mcp-server/` hosts an experimental [MCP](https://modelcontextprotocol.io) server that exposes MailPoet local-dev tooling to AI agents (Claude Code, etc.). Not shipped with the plugin, not part of CI, entirely local-dev only.
+
+It gives an agent structured access to things that would otherwise require parsing noisy Robo / wp-cli / container output: environment status, feature flags, migrations, Action Scheduler, subscribers + segments, captured Mailpit emails, unit/integration test runs, QA (phpstan/phpcs/eslint/stylelint/prettier/tsc) with structured violations, and the WP debug log.
+
+Architecture: TS MCP server on the host ↔ PHP companion mu-plugin inside wp-env over loopback HTTP with a shared secret. The companion uses MailPoet's own DI container and Doctrine repositories, so results reflect real entity state. The mu-plugin no-ops unless `WP_DEBUG` is on and the secret file exists — it cannot accidentally run in production.
+
+Every tool call is appended to `.wp-env/mcp-usage.jsonl` (tool name, duration, input keys only — no values) so usage can be analysed later to decide what to expand.
+
+See `tools/mcp-server/README.md` for setup, tool list, configuration, and how to add new tools.
+
 ## Additional Resources
 
 - Main README: `README.md`
@@ -402,3 +415,4 @@ Skills are progressively-revealed instructions loaded on demand.
 - Premium plugin README: `mailpoet-premium/README.md`
 - Contributing guide: `CONTRIBUTING.md`
 - Cursor rules: `.cursor/rules/` (review when working on the project)
+- MCP server (experimental): `tools/mcp-server/README.md`

--- a/tools/mcp-server/.gitignore
+++ b/tools/mcp-server/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.tsbuildinfo
+.mcp-server.log

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 An [MCP](https://modelcontextprotocol.io) server that exposes MailPoet local-dev tooling to AI agents (Claude Code, Claude Desktop, etc.).
 
-**Status:** experimental walking skeleton. Only four tools implemented so far.
+**Status:** experimental.
 
 ## Architecture
 
@@ -149,7 +149,7 @@ Conventions:
 - JSON-in, JSON-out. No passthrough text blobs when structure is possible.
 - `list` returns compact core + must-have relations; `get` returns full detail. `list` output has `items[]` and `total`.
 - Timestamps: ISO 8601 UTC strings.
-- Telemetry is automatic via `runHandler` — nothing extra to wire.
+- Telemetry is automatic via `runHandler` — nothing extra to wire. **Keep your handler body inside `runHandler(name, args, async () => { ... })`**; any throw that escapes `runHandler` (e.g. a try/catch at the outer layer) will not be recorded.
 
 ### Host-only tool (no MailPoet DI needed)
 

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -1,0 +1,135 @@
+# MailPoet Dev MCP Server (experimental)
+
+An [MCP](https://modelcontextprotocol.io) server that exposes MailPoet local-dev tooling to AI agents (Claude Code, Claude Desktop, etc.).
+
+**Status:** experimental walking skeleton. Only four tools implemented so far.
+
+## Architecture
+
+```
+┌────────────────────┐     stdio     ┌─────────────────────┐
+│   Claude / agent   │ ───────────▶  │  TS MCP server      │
+└────────────────────┘               │  (this package)     │
+                                     └──────┬──────────────┘
+                                            │ shell-out (./do, docker)
+                                            │ HTTP (Mailpit, companion)
+                              ┌─────────────┼─────────────────────┐
+                              ▼             ▼                     ▼
+                         mailpoet/       Mailpit :8082      WordPress :8888
+                         (tests, QA)     (captured mail)    + companion mu-plugin
+                                                            (DI → repositories)
+```
+
+- **TS server** on the host — MCP protocol, shell-outs, Mailpit calls.
+- **PHP companion mu-plugin** in `.wp-env/mu-plugins/mailpoet-dev-companion.php` — dev-only REST endpoints under `/wp-json/mailpoet-dev/v1/` backed by MailPoet's DI container and Doctrine repositories.
+- **Shared secret** at `.wp-env/.mailpoet-dev-companion-secret` (gitignored). TS server generates it; `.wp-env.json` maps it into the container; mu-plugin reads it for request auth.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `mp.env.status` | wp-env / Mailpit / companion reachability + plugin/WP/PHP versions |
+| `mp.env.feature_flags.list` / `.set` | Read/toggle experimental feature flags |
+| `mp.env.migrations.status` | MailPoet db+app migration state |
+| `mp.env.scheduler.list` | Action Scheduler actions (filter by status/hook/group) |
+| `mp.test.run` | Codeception unit or integration, returns structured failures |
+| `mp.mail.list` / `.get` / `.clear` | Mailpit: list summaries, get full message, clear mailbox (destructive, confirm=true) |
+| `mp.data.subscribers.list` / `.get` / `.create` | Subscribers CRUD via SubscribersRepository |
+| `mp.data.segments.list` | Segments + optional subscribed-counts |
+| `mp.qa.run` | phpstan / phpcs / eslint / stylelint / prettier / tsc — flat structured violations, default scope=changed-vs-trunk |
+| `mp.logs.wp_debug` | Tail WP debug.log, filter by level/grep |
+
+## Telemetry
+
+Every tool call is appended to `.wp-env/mcp-usage.jsonl` as a single-line JSON entry:
+
+```json
+{"ts":"2026-04-23T09:48:25.701Z","tool":"mp.data.segments.list","duration_ms":137,"status":"ok","input_keys":["include_counts"]}
+```
+
+Fields: `ts` (UTC ISO8601), `tool`, `duration_ms`, `status` (`ok` or `error`), `error_code` (on error only), `input_keys` (argument names only — values are not logged). Override path via `MAILPOET_MCP_TELEMETRY_LOG` env var.
+
+Quick analysis:
+
+```bash
+# top tools by count
+cat .wp-env/mcp-usage.jsonl | jq -r '.tool' | sort | uniq -c | sort -rn
+
+# average duration per tool
+cat .wp-env/mcp-usage.jsonl | jq -s 'group_by(.tool)[] | {tool: .[0].tool, n: length, avg_ms: (map(.duration_ms)|add/length|round)}'
+
+# recent errors
+cat .wp-env/mcp-usage.jsonl | jq 'select(.status=="error")' | tail -20
+```
+
+## Configuration
+
+URLs are resolved in priority order:
+
+1. **Env vars** (highest): `MAILPOET_MCP_WP_URL`, `MAILPOET_MCP_MAILPIT_URL`
+2. **`.wp-env.override.json`** `config.WP_HOME` / `config.WP_SITEURL` → WordPress URL
+3. **`.wp-env.json`** `config.WP_HOME` / `port` → fallback
+4. **Hardcoded defaults**: `http://localhost:8888`, `http://localhost:8082`
+
+For custom hosts (e.g. `http://mailpoet.local/`), the server auto-detects from `.wp-env.override.json` — no extra setup needed.
+
+## Setup
+
+From repo root:
+
+```bash
+# 1. Install + build the MCP server
+cd tools/mcp-server
+pnpm install
+pnpm build
+
+# 2. Generate the companion secret (must exist BEFORE wp-env starts, so the mapping picks it up)
+pnpm init-secret
+# → writes .wp-env/.mailpoet-dev-companion-secret
+
+# 3. Start wp-env (from repo root)
+cd ../..
+pnpm env:start       # or env:restart if already running
+```
+
+## Running the server
+
+For stdio (Claude Code / Claude Desktop), point the client at:
+
+```
+node /absolute/path/to/mailpoet-dev/tools/mcp-server/dist/index.js
+```
+
+For Claude Code, the easiest way is:
+
+```bash
+claude mcp add mailpoet-dev -- node /absolute/path/to/mailpoet-dev/tools/mcp-server/dist/index.js
+```
+
+Then in a Claude Code session call `mp.env.status` to verify end-to-end.
+
+## Manual smoke test (no MCP client needed)
+
+```bash
+# Check companion from the host
+SECRET=$(cat .wp-env/.mailpoet-dev-companion-secret)
+curl -s -H "X-MailPoet-Dev-Secret: $SECRET" \
+  http://localhost:8888/wp-json/mailpoet-dev/v1/ping | jq
+
+# List subscribers
+curl -s -H "X-MailPoet-Dev-Secret: $SECRET" \
+  "http://localhost:8888/wp-json/mailpoet-dev/v1/subscribers?limit=5" | jq
+```
+
+## Safety
+
+- Mu-plugin is a no-op unless **both** `WP_DEBUG=true` and the secret file exist. It's mapped in by `.wp-env.json` (dev-only), not part of the MailPoet plugin release artifact.
+- Shared secret uses `hash_equals` for constant-time compare.
+- Secret file is `0600` on host, gitignored, regenerated if deleted.
+
+## Development
+
+```bash
+pnpm dev          # tsc --watch
+pnpm typecheck    # tsc --noEmit
+```

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -133,3 +133,112 @@ curl -s -H "X-MailPoet-Dev-Secret: $SECRET" \
 pnpm dev          # tsc --watch
 pnpm typecheck    # tsc --noEmit
 ```
+
+## Adding a new tool
+
+Conventions:
+
+- Name: `mp.<domain>.<resource>.<verb>` (e.g. `mp.data.newsletters.list`). Domain is one of: `env`, `test`, `mail`, `data`, `qa`, `logs`.
+- Read-only by default. Writes get `readOnlyHint: false`; destructive writes also get `destructiveHint: true` and a confirm gate.
+- JSON-in, JSON-out. No passthrough text blobs when structure is possible.
+- `list` returns compact core + must-have relations; `get` returns full detail. `list` output has `items[]` and `total`.
+- Timestamps: ISO 8601 UTC strings.
+- Telemetry is automatic via `runHandler` — nothing extra to wire.
+
+### Host-only tool (no MailPoet DI needed)
+
+Use this pattern when the data source is the filesystem, a process, or an HTTP service you can reach from the host (Mailpit, a binary under `./tasks/`, git).
+
+1. Create `src/tools/<domain>-<name>.ts`:
+
+   ```ts
+   import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+   import { z } from "zod";
+   import type { Config } from "../config.js";
+   import { runHandler } from "./register.js";
+
+   export function registerMyTool(server: McpServer, config: Config): void {
+     server.registerTool(
+       "mp.<domain>.<name>",
+       {
+         title: "Short human title",
+         description: "What it does + when to use it + important caveats.",
+         inputSchema: {
+           foo: z.string().describe("Describe every argument."),
+         },
+         annotations: { readOnlyHint: true, openWorldHint: true },
+       },
+       async (args) =>
+         runHandler("mp.<domain>.<name>", args, async () => {
+           // Do the work. Throw `new ToolError(code, message, data)` for
+           // well-formed errors; anything else becomes `error.code = "unknown"`.
+           return { items: [], total: 0 };
+         }),
+     );
+   }
+   ```
+
+2. Wire it in `src/index.ts`:
+
+   ```ts
+   import { registerMyTool } from "./tools/<domain>-<name>.js";
+   // ...
+   registerMyTool(server, config);
+   ```
+
+3. `pnpm build`, restart the MCP server in your client.
+
+### Tool that needs MailPoet's DI container or Doctrine
+
+Add a companion REST endpoint in `.wp-env/mu-plugins/mailpoet-dev-companion.php`, then a thin TS tool that forwards to it.
+
+1. In the mu-plugin, register a route inside the existing `rest_api_init` callback:
+
+   ```php
+   register_rest_route($namespace, '/my-resource', [
+       'methods' => 'GET',                         // or 'POST'
+       'permission_callback' => $permission,      // reuse the shared secret check
+       'callback' => 'mailpoet_dev_companion_my_handler',
+       'args' => [ /* WP REST schema */ ],
+   ]);
+   ```
+
+2. Implement the handler as a top-level function. Always fetch services through `mailpoet_dev_companion_container()`. Mirror existing patterns — reuse `mailpoet_dev_companion_serialize_subscriber()` style helpers if the same shape already appears elsewhere.
+
+3. Use `$container->get(SomeRepository::class)` to pull in repositories. Public services only (Symfony DI inlines private ones — if you hit `"service ... has been removed or inlined"`, pick a public class that already wraps it, or use `EntityManager` directly).
+
+4. Add the TS tool as above, but use `CompanionClient`:
+
+   ```ts
+   import { CompanionClient } from "../clients/companion.js";
+   const companion = new CompanionClient(config);
+   // GET
+   await companion.request("my-resource", { query: { foo: args.foo } });
+   // POST
+   await companion.request("my-resource", { method: "POST", body: { foo: args.foo } });
+   ```
+
+5. `pnpm build` + (if mu-plugin changed) the next HTTP request picks up the new PHP. No wp-env restart needed unless you changed `.wp-env.json` mappings.
+
+### Testing locally
+
+Fastest smoke test without a real MCP client:
+
+```bash
+(
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"mp.<your.tool>","arguments":{}}}'
+  sleep 1
+) | node dist/index.js 2>/dev/null | tail -1 | jq
+```
+
+Companion endpoints can be hit directly with curl — see the "Manual smoke test" section above.
+
+### Gotchas
+
+- **Private DI services.** Calling `$container->get(SomeInternalService::class)` throws if it's not public. Either fetch a public wrapper or use static methods / `EntityManager` directly.
+- **SubscriberEntity `source`** has an allowlist (api/form/unknown/imported/administrator/wordpress_user/woocommerce_user/woocommerce_checkout) — `setSource()` throws on others.
+- **Action Scheduler** — MailPoet groups include `mailpoet-cron` and `mailpoet-automation`. Use `as_get_scheduled_actions()` / `ActionScheduler_Store::instance()`.
+- **Test runs** — always delete `tests/_output/report.xml` before spawning Codeception, otherwise a failed run will read stale JUnit data.
+- **Don't log argument values** in telemetry — `runHandler` records only input keys. If you add a new logging surface, preserve that invariant.

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -100,16 +100,12 @@ pnpm env:start       # or env:restart if already running
 
 ## Running the server
 
-For stdio (Claude Code / Claude Desktop), point the client at:
+The repo ships a project-level `.mcp.json` at the root, so Claude Code will auto-discover the server and prompt you to approve it the first time you run `claude` inside this directory — no manual `claude mcp add` step needed. Each dev still explicitly opts in when prompted.
 
-```
-node /absolute/path/to/mailpoet-dev/tools/mcp-server/dist/index.js
-```
-
-For Claude Code, the easiest way is:
+If auto-discovery isn't available (different client, or you opted out), register manually:
 
 ```bash
-claude mcp add mailpoet-dev -- node /absolute/path/to/mailpoet-dev/tools/mcp-server/dist/index.js
+claude mcp add mailpoet-dev -- node "$(pwd)/tools/mcp-server/dist/index.js"
 ```
 
 Then in a Claude Code session call `mp.env.status` to verify end-to-end.

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -26,25 +26,31 @@ An [MCP](https://modelcontextprotocol.io) server that exposes MailPoet local-dev
 
 ## Tools
 
-| Tool | Purpose |
-|---|---|
-| `mp.env.status` | wp-env / Mailpit / companion reachability + plugin/WP/PHP versions |
-| `mp.env.feature_flags.list` / `.set` | Read/toggle experimental feature flags |
-| `mp.env.migrations.status` | MailPoet db+app migration state |
-| `mp.env.scheduler.list` | Action Scheduler actions (filter by status/hook/group) |
-| `mp.test.run` | Codeception unit or integration, returns structured failures |
-| `mp.mail.list` / `.get` / `.clear` | Mailpit: list summaries, get full message, clear mailbox (destructive, confirm=true) |
-| `mp.data.subscribers.list` / `.get` / `.create` | Subscribers CRUD via SubscribersRepository |
-| `mp.data.segments.list` | Segments + optional subscribed-counts |
-| `mp.qa.run` | phpstan / phpcs / eslint / stylelint / prettier / tsc — flat structured violations, default scope=changed-vs-trunk |
-| `mp.logs.wp_debug` | Tail WP debug.log, filter by level/grep |
+| Tool                                            | Purpose                                                                                                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `mp.env.status`                                 | wp-env / Mailpit / companion reachability + plugin/WP/PHP versions                                                 |
+| `mp.env.feature_flags.list` / `.set`            | Read/toggle experimental feature flags                                                                             |
+| `mp.env.migrations.status`                      | MailPoet db+app migration state                                                                                    |
+| `mp.env.scheduler.list`                         | Action Scheduler actions (filter by status/hook/group)                                                             |
+| `mp.test.run`                                   | Codeception unit or integration, returns structured failures                                                       |
+| `mp.mail.list` / `.get` / `.clear`              | Mailpit: list summaries, get full message, clear mailbox (destructive, confirm=true)                               |
+| `mp.data.subscribers.list` / `.get` / `.create` | Subscribers CRUD via SubscribersRepository                                                                         |
+| `mp.data.segments.list`                         | Segments + optional subscribed-counts                                                                              |
+| `mp.qa.run`                                     | phpstan / phpcs / eslint / stylelint / prettier / tsc — flat structured violations, default scope=changed-vs-trunk |
+| `mp.logs.wp_debug`                              | Tail WP debug.log, filter by level/grep                                                                            |
 
 ## Telemetry
 
 Every tool call is appended to `.wp-env/mcp-usage.jsonl` as a single-line JSON entry:
 
 ```json
-{"ts":"2026-04-23T09:48:25.701Z","tool":"mp.data.segments.list","duration_ms":137,"status":"ok","input_keys":["include_counts"]}
+{
+  "ts": "2026-04-23T09:48:25.701Z",
+  "tool": "mp.data.segments.list",
+  "duration_ms": 137,
+  "status": "ok",
+  "input_keys": ["include_counts"]
+}
 ```
 
 Fields: `ts` (UTC ISO8601), `tool`, `duration_ms`, `status` (`ok` or `error`), `error_code` (on error only), `input_keys` (argument names only — values are not logged). Override path via `MAILPOET_MCP_TELEMETRY_LOG` env var.
@@ -152,24 +158,24 @@ Use this pattern when the data source is the filesystem, a process, or an HTTP s
 1. Create `src/tools/<domain>-<name>.ts`:
 
    ```ts
-   import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-   import { z } from "zod";
-   import type { Config } from "../config.js";
-   import { runHandler } from "./register.js";
+   import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+   import { z } from 'zod';
+   import type { Config } from '../config.js';
+   import { runHandler } from './register.js';
 
    export function registerMyTool(server: McpServer, config: Config): void {
      server.registerTool(
-       "mp.<domain>.<name>",
+       'mp.<domain>.<name>',
        {
-         title: "Short human title",
-         description: "What it does + when to use it + important caveats.",
+         title: 'Short human title',
+         description: 'What it does + when to use it + important caveats.',
          inputSchema: {
-           foo: z.string().describe("Describe every argument."),
+           foo: z.string().describe('Describe every argument.'),
          },
          annotations: { readOnlyHint: true, openWorldHint: true },
        },
        async (args) =>
-         runHandler("mp.<domain>.<name>", args, async () => {
+         runHandler('mp.<domain>.<name>', args, async () => {
            // Do the work. Throw `new ToolError(code, message, data)` for
            // well-formed errors; anything else becomes `error.code = "unknown"`.
            return { items: [], total: 0 };
@@ -181,7 +187,7 @@ Use this pattern when the data source is the filesystem, a process, or an HTTP s
 2. Wire it in `src/index.ts`:
 
    ```ts
-   import { registerMyTool } from "./tools/<domain>-<name>.js";
+   import { registerMyTool } from './tools/<domain>-<name>.js';
    // ...
    registerMyTool(server, config);
    ```
@@ -210,12 +216,15 @@ Add a companion REST endpoint in `.wp-env/mu-plugins/mailpoet-dev-companion.php`
 4. Add the TS tool as above, but use `CompanionClient`:
 
    ```ts
-   import { CompanionClient } from "../clients/companion.js";
+   import { CompanionClient } from '../clients/companion.js';
    const companion = new CompanionClient(config);
    // GET
-   await companion.request("my-resource", { query: { foo: args.foo } });
+   await companion.request('my-resource', { query: { foo: args.foo } });
    // POST
-   await companion.request("my-resource", { method: "POST", body: { foo: args.foo } });
+   await companion.request('my-resource', {
+     method: 'POST',
+     body: { foo: args.foo },
+   });
    ```
 
 5. `pnpm build` + (if mu-plugin changed) the next HTTP request picks up the new PHP. No wp-env restart needed unless you changed `.wp-env.json` mappings.

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mailpoet/mcp-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MCP server exposing MailPoet local dev tools to AI agents (Claude Code, etc.). Experimental.",
   "private": true,
   "type": "module",

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@mailpoet/mcp-server",
+  "version": "0.0.1",
+  "description": "MCP server exposing MailPoet local dev tools to AI agents (Claude Code, etc.). Experimental.",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "mailpoet-mcp-server": "./dist/index.js",
+    "mailpoet-mcp-init": "./dist/init.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "init-secret": "node dist/init.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "fast-xml-parser": "^4.5.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tools/mcp-server/pnpm-lock.yaml
+++ b/tools/mcp-server/pnpm-lock.yaml
@@ -1,0 +1,819 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.4
+        version: 1.29.0(zod@3.25.76)
+      fast-xml-parser:
+        specifier: ^4.5.0
+        version: 4.5.6
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+packages:
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.4.0:
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-parser@4.5.6:
+    resolution: {integrity: sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==}
+    hasBin: true
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.0(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  depd@2.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
+  express-rate-limit@8.4.0(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fast-xml-parser@4.5.6:
+    dependencies:
+      strnum: 1.1.2
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.14: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.2: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pkce-challenge@5.0.1: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  strnum@1.1.2: {}
+
+  toidentifier@1.0.1: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/tools/mcp-server/src/clients/companion.ts
+++ b/tools/mcp-server/src/clients/companion.ts
@@ -56,9 +56,17 @@ export class CompanionClient {
       } catch {
         parsed = text;
       }
+      // A 403 from the companion is almost always a secret mismatch — either
+      // the MCP server has a newer secret than wp-env picked up (file regenerated
+      // without an env restart), or the mu-plugin's gate check failed. Surface
+      // that up-front so the agent doesn't chase generic "forbidden" trails.
+      const hint =
+        response.status === 403
+          ? ' (likely a companion secret mismatch — run `pnpm env:restart` so wp-env remounts the secret file)'
+          : '';
       throw new ToolError(
         'companion_error',
-        `Companion returned ${response.status}`,
+        `Companion returned ${response.status}${hint}`,
         parsed,
       );
     }

--- a/tools/mcp-server/src/clients/companion.ts
+++ b/tools/mcp-server/src/clients/companion.ts
@@ -1,11 +1,22 @@
-import type { Config } from "../config.js";
-import { ToolError } from "../util/errors.js";
+import type { Config } from '../config.js';
+import { ToolError } from '../util/errors.js';
 
 export class CompanionClient {
   constructor(private readonly config: Config) {}
 
-  async request<T>(path: string, init: { method?: string; query?: Record<string, string | number | undefined>; body?: unknown } = {}): Promise<T> {
-    const url = new URL(this.config.companionBaseUrl.replace(/\/$/, "") + "/" + path.replace(/^\//, ""));
+  async request<T>(
+    path: string,
+    init: {
+      method?: string;
+      query?: Record<string, string | number | undefined>;
+      body?: unknown;
+    } = {},
+  ): Promise<T> {
+    const url = new URL(
+      this.config.companionBaseUrl.replace(/\/$/, '') +
+        '/' +
+        path.replace(/^\//, ''),
+    );
     if (init.query) {
       for (const [k, v] of Object.entries(init.query)) {
         if (v !== undefined) url.searchParams.set(k, String(v));
@@ -13,21 +24,28 @@ export class CompanionClient {
     }
 
     const headers: Record<string, string> = {
-      "X-MailPoet-Dev-Secret": this.config.companionSecret,
-      Accept: "application/json",
+      'X-MailPoet-Dev-Secret': this.config.companionSecret,
+      Accept: 'application/json',
     };
     let body: string | undefined;
     if (init.body !== undefined) {
-      headers["Content-Type"] = "application/json";
+      headers['Content-Type'] = 'application/json';
       body = JSON.stringify(init.body);
     }
 
     let response: Response;
     try {
-      response = await fetch(url, { method: init.method ?? "GET", headers, body });
+      response = await fetch(url, {
+        method: init.method ?? 'GET',
+        headers,
+        body,
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      throw new ToolError("companion_unreachable", `Could not reach MailPoet dev companion at ${url.origin}. Is wp-env running? (${msg})`);
+      throw new ToolError(
+        'companion_unreachable',
+        `Could not reach MailPoet dev companion at ${url.origin}. Is wp-env running? (${msg})`,
+      );
     }
 
     const text = await response.text();
@@ -38,13 +56,21 @@ export class CompanionClient {
       } catch {
         parsed = text;
       }
-      throw new ToolError("companion_error", `Companion returned ${response.status}`, parsed);
+      throw new ToolError(
+        'companion_error',
+        `Companion returned ${response.status}`,
+        parsed,
+      );
     }
 
     try {
       return JSON.parse(text) as T;
     } catch (e) {
-      throw new ToolError("companion_bad_json", "Companion response was not JSON", { sample: text.slice(0, 500) });
+      throw new ToolError(
+        'companion_bad_json',
+        'Companion response was not JSON',
+        { sample: text.slice(0, 500) },
+      );
     }
   }
 }

--- a/tools/mcp-server/src/clients/companion.ts
+++ b/tools/mcp-server/src/clients/companion.ts
@@ -1,0 +1,50 @@
+import type { Config } from "../config.js";
+import { ToolError } from "../util/errors.js";
+
+export class CompanionClient {
+  constructor(private readonly config: Config) {}
+
+  async request<T>(path: string, init: { method?: string; query?: Record<string, string | number | undefined>; body?: unknown } = {}): Promise<T> {
+    const url = new URL(this.config.companionBaseUrl.replace(/\/$/, "") + "/" + path.replace(/^\//, ""));
+    if (init.query) {
+      for (const [k, v] of Object.entries(init.query)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
+
+    const headers: Record<string, string> = {
+      "X-MailPoet-Dev-Secret": this.config.companionSecret,
+      Accept: "application/json",
+    };
+    let body: string | undefined;
+    if (init.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.body);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, { method: init.method ?? "GET", headers, body });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ToolError("companion_unreachable", `Could not reach MailPoet dev companion at ${url.origin}. Is wp-env running? (${msg})`);
+    }
+
+    const text = await response.text();
+    if (!response.ok) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+      throw new ToolError("companion_error", `Companion returned ${response.status}`, parsed);
+    }
+
+    try {
+      return JSON.parse(text) as T;
+    } catch (e) {
+      throw new ToolError("companion_bad_json", "Companion response was not JSON", { sample: text.slice(0, 500) });
+    }
+  }
+}

--- a/tools/mcp-server/src/clients/mailpit.ts
+++ b/tools/mcp-server/src/clients/mailpit.ts
@@ -1,0 +1,83 @@
+import type { Config } from "../config.js";
+import { ToolError } from "../util/errors.js";
+
+export interface MailpitMessageSummary {
+  ID: string;
+  MessageID: string;
+  From: { Name: string; Address: string };
+  To: { Name: string; Address: string }[];
+  Cc?: { Name: string; Address: string }[];
+  Subject: string;
+  Created: string;
+  Size: number;
+  Attachments: number;
+  Snippet?: string;
+}
+
+export interface MailpitListResponse {
+  messages: MailpitMessageSummary[];
+  messages_count: number;
+  total: number;
+  unread: number;
+  start: number;
+  tags: string[];
+}
+
+export interface MailpitMessageDetail {
+  ID: string;
+  MessageID: string;
+  From: { Name: string; Address: string };
+  To: { Name: string; Address: string }[];
+  Cc?: { Name: string; Address: string }[];
+  Bcc?: { Name: string; Address: string }[];
+  Subject: string;
+  Date: string;
+  Text: string;
+  HTML: string;
+  Size: number;
+  Attachments: { FileName: string; ContentType: string; Size: number; PartID: string }[];
+  Headers?: Record<string, string[]>;
+}
+
+export class MailpitClient {
+  constructor(private readonly config: Config) {}
+
+  private async request<T>(path: string, init: RequestInit = {}, parseJson = true): Promise<T> {
+    const url = this.config.mailpitUrl.replace(/\/$/, "") + path;
+    let response: Response;
+    try {
+      response = await fetch(url, { ...init, headers: { Accept: "application/json", ...(init.headers ?? {}) } });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ToolError(
+        "mailpit_unreachable",
+        `Mailpit not reachable at ${this.config.mailpitUrl}. Is the SMTP catcher running? (${msg})`,
+      );
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new ToolError("mailpit_error", `Mailpit returned ${response.status}`, text.slice(0, 500));
+    }
+    if (!parseJson) return undefined as unknown as T;
+    return (await response.json()) as T;
+  }
+
+  async listMessages(params: { start?: number; limit?: number; query?: string }): Promise<MailpitListResponse> {
+    const search = new URLSearchParams();
+    if (params.query) search.set("query", params.query);
+    if (params.start !== undefined) search.set("start", String(params.start));
+    if (params.limit !== undefined) search.set("limit", String(params.limit));
+    const path = params.query
+      ? `/api/v1/search?${search.toString()}`
+      : `/api/v1/messages${search.size ? "?" + search.toString() : ""}`;
+    return this.request(path);
+  }
+
+  async getMessage(id: string): Promise<MailpitMessageDetail> {
+    return this.request(`/api/v1/message/${encodeURIComponent(id)}`);
+  }
+
+  async deleteAll(): Promise<void> {
+    await this.request("/api/v1/messages", { method: "DELETE" }, false);
+  }
+}

--- a/tools/mcp-server/src/clients/mailpit.ts
+++ b/tools/mcp-server/src/clients/mailpit.ts
@@ -1,5 +1,5 @@
-import type { Config } from "../config.js";
-import { ToolError } from "../util/errors.js";
+import type { Config } from '../config.js';
+import { ToolError } from '../util/errors.js';
 
 export interface MailpitMessageSummary {
   ID: string;
@@ -35,41 +35,61 @@ export interface MailpitMessageDetail {
   Text: string;
   HTML: string;
   Size: number;
-  Attachments: { FileName: string; ContentType: string; Size: number; PartID: string }[];
+  Attachments: {
+    FileName: string;
+    ContentType: string;
+    Size: number;
+    PartID: string;
+  }[];
   Headers?: Record<string, string[]>;
 }
 
 export class MailpitClient {
   constructor(private readonly config: Config) {}
 
-  private async request<T>(path: string, init: RequestInit = {}, parseJson = true): Promise<T> {
-    const url = this.config.mailpitUrl.replace(/\/$/, "") + path;
+  private async request<T>(
+    path: string,
+    init: RequestInit = {},
+    parseJson = true,
+  ): Promise<T> {
+    const url = this.config.mailpitUrl.replace(/\/$/, '') + path;
     let response: Response;
     try {
-      response = await fetch(url, { ...init, headers: { Accept: "application/json", ...(init.headers ?? {}) } });
+      response = await fetch(url, {
+        ...init,
+        headers: { Accept: 'application/json', ...(init.headers ?? {}) },
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       throw new ToolError(
-        "mailpit_unreachable",
+        'mailpit_unreachable',
         `Mailpit not reachable at ${this.config.mailpitUrl}. Is the SMTP catcher running? (${msg})`,
       );
     }
     if (!response.ok) {
       const text = await response.text();
-      throw new ToolError("mailpit_error", `Mailpit returned ${response.status}`, text.slice(0, 500));
+      throw new ToolError(
+        'mailpit_error',
+        `Mailpit returned ${response.status}`,
+        text.slice(0, 500),
+      );
     }
     if (!parseJson) return undefined as unknown as T;
     return (await response.json()) as T;
   }
 
-  async listMessages(params: { start?: number; limit?: number; query?: string }): Promise<MailpitListResponse> {
+  async listMessages(params: {
+    start?: number;
+    limit?: number;
+    query?: string;
+  }): Promise<MailpitListResponse> {
     const search = new URLSearchParams();
-    if (params.query) search.set("query", params.query);
-    if (params.start !== undefined) search.set("start", String(params.start));
-    if (params.limit !== undefined) search.set("limit", String(params.limit));
+    if (params.query) search.set('query', params.query);
+    if (params.start !== undefined) search.set('start', String(params.start));
+    if (params.limit !== undefined) search.set('limit', String(params.limit));
     const path = params.query
       ? `/api/v1/search?${search.toString()}`
-      : `/api/v1/messages${search.size ? "?" + search.toString() : ""}`;
+      : `/api/v1/messages${search.size ? '?' + search.toString() : ''}`;
     return this.request(path);
   }
 
@@ -78,6 +98,6 @@ export class MailpitClient {
   }
 
   async deleteAll(): Promise<void> {
-    await this.request("/api/v1/messages", { method: "DELETE" }, false);
+    await this.request('/api/v1/messages', { method: 'DELETE' }, false);
   }
 }

--- a/tools/mcp-server/src/config.ts
+++ b/tools/mcp-server/src/config.ts
@@ -82,6 +82,13 @@ function readOrGenerateSecret(path: string): string {
   if (existsSync(path)) {
     const s = readFileSync(path, 'utf8').trim();
     if (s.length >= 32) return s;
+    // Never silently overwrite: wp-env bind-mounts the file at container start,
+    // so regenerating on the host while the container is running would cause
+    // every companion request to 403 with no obvious cause. Force the user to
+    // delete the file explicitly.
+    throw new Error(
+      `Companion secret at ${path} is shorter than 32 chars. Delete it and re-run to regenerate (then 'pnpm env:restart' so wp-env picks up the new file).`,
+    );
   }
   const secret = randomBytes(32).toString('hex');
   mkdirSync(dirname(path), { recursive: true });

--- a/tools/mcp-server/src/config.ts
+++ b/tools/mcp-server/src/config.ts
@@ -1,7 +1,13 @@
-import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { randomBytes } from 'node:crypto';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -24,37 +30,43 @@ interface WpEnvFile {
 function findRepoRoot(): string {
   let cur = resolve(here);
   for (let i = 0; i < 10; i++) {
-    if (existsSync(resolve(cur, ".wp-env.json"))) return cur;
+    if (existsSync(resolve(cur, '.wp-env.json'))) return cur;
     const parent = dirname(cur);
     if (parent === cur) break;
     cur = parent;
   }
-  throw new Error("Unable to locate repo root (no .wp-env.json found walking up from mcp-server).");
+  throw new Error(
+    'Unable to locate repo root (no .wp-env.json found walking up from mcp-server).',
+  );
 }
 
 function readJsonIfExists<T>(path: string): T | null {
   if (!existsSync(path)) return null;
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as T;
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
   } catch {
     return null;
   }
 }
 
 function stripTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, "");
+  return url.replace(/\/+$/, '');
 }
 
 function resolveWpBaseUrl(repoRoot: string): string {
   const envOverride = process.env.MAILPOET_MCP_WP_URL?.trim();
   if (envOverride) return stripTrailingSlash(envOverride);
 
-  const override = readJsonIfExists<WpEnvFile>(resolve(repoRoot, ".wp-env.override.json"));
-  const base = readJsonIfExists<WpEnvFile>(resolve(repoRoot, ".wp-env.json"));
+  const override = readJsonIfExists<WpEnvFile>(
+    resolve(repoRoot, '.wp-env.override.json'),
+  );
+  const base = readJsonIfExists<WpEnvFile>(resolve(repoRoot, '.wp-env.json'));
 
   // WP_HOME / WP_SITEURL in override take precedence — they reflect the real externally-visible URL.
-  const home = (override?.config?.WP_HOME as string | undefined) ?? (base?.config?.WP_HOME as string | undefined);
-  if (typeof home === "string" && home) return stripTrailingSlash(home);
+  const home =
+    (override?.config?.WP_HOME as string | undefined) ??
+    (base?.config?.WP_HOME as string | undefined);
+  if (typeof home === 'string' && home) return stripTrailingSlash(home);
 
   const port = override?.port ?? base?.port ?? 8888;
   return `http://localhost:${port}`;
@@ -63,17 +75,17 @@ function resolveWpBaseUrl(repoRoot: string): string {
 function resolveMailpitUrl(): string {
   const envOverride = process.env.MAILPOET_MCP_MAILPIT_URL?.trim();
   if (envOverride) return stripTrailingSlash(envOverride);
-  return "http://localhost:8082";
+  return 'http://localhost:8082';
 }
 
 function readOrGenerateSecret(path: string): string {
   if (existsSync(path)) {
-    const s = readFileSync(path, "utf8").trim();
+    const s = readFileSync(path, 'utf8').trim();
     if (s.length >= 32) return s;
   }
-  const secret = randomBytes(32).toString("hex");
+  const secret = randomBytes(32).toString('hex');
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, secret + "\n", { mode: 0o600 });
+  writeFileSync(path, secret + '\n', { mode: 0o600 });
   chmodSync(path, 0o600);
   return secret;
 }
@@ -82,13 +94,19 @@ export function loadConfig(): Config {
   const repoRoot = findRepoRoot();
   const wpBaseUrl = resolveWpBaseUrl(repoRoot);
   const mailpitUrl = resolveMailpitUrl();
-  const companionSecretPath = resolve(repoRoot, ".wp-env", ".mailpoet-dev-companion-secret");
+  const companionSecretPath = resolve(
+    repoRoot,
+    '.wp-env',
+    '.mailpoet-dev-companion-secret',
+  );
   const companionSecret = readOrGenerateSecret(companionSecretPath);
-  const telemetryLogPath = process.env.MAILPOET_MCP_TELEMETRY_LOG?.trim() || resolve(repoRoot, ".wp-env", "mcp-usage.jsonl");
+  const telemetryLogPath =
+    process.env.MAILPOET_MCP_TELEMETRY_LOG?.trim() ||
+    resolve(repoRoot, '.wp-env', 'mcp-usage.jsonl');
 
   return {
     repoRoot,
-    mailpoetDir: resolve(repoRoot, "mailpoet"),
+    mailpoetDir: resolve(repoRoot, 'mailpoet'),
     wpBaseUrl,
     mailpitUrl,
     companionBaseUrl: `${wpBaseUrl}/wp-json/mailpoet-dev/v1`,

--- a/tools/mcp-server/src/config.ts
+++ b/tools/mcp-server/src/config.ts
@@ -66,7 +66,18 @@ function resolveWpBaseUrl(repoRoot: string): string {
   const home =
     (override?.config?.WP_HOME as string | undefined) ??
     (base?.config?.WP_HOME as string | undefined);
-  if (typeof home === 'string' && home) return stripTrailingSlash(home);
+  if (typeof home === 'string' && home) {
+    // wp-env serves HTTP only. If WP_HOME is HTTPS (occasionally set for
+    // canonical URL generation), the companion probe would fail. Warn once
+    // and point at the override env var rather than silently ignoring it.
+    if (home.toLowerCase().startsWith('https://')) {
+      process.stderr.write(
+        `[mailpoet-dev-mcp] warning: WP_HOME is HTTPS (${home}) but wp-env serves HTTP. ` +
+          `Set MAILPOET_MCP_WP_URL=http://... to override if companion requests fail.\n`,
+      );
+    }
+    return stripTrailingSlash(home);
+  }
 
   const port = override?.port ?? base?.port ?? 8888;
   return `http://localhost:${port}`;

--- a/tools/mcp-server/src/config.ts
+++ b/tools/mcp-server/src/config.ts
@@ -1,0 +1,99 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export interface Config {
+  repoRoot: string;
+  mailpoetDir: string;
+  wpBaseUrl: string;
+  mailpitUrl: string;
+  companionBaseUrl: string;
+  companionSecretPath: string;
+  companionSecret: string;
+  telemetryLogPath: string;
+}
+
+interface WpEnvFile {
+  port?: number;
+  config?: Record<string, unknown>;
+}
+
+function findRepoRoot(): string {
+  let cur = resolve(here);
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(resolve(cur, ".wp-env.json"))) return cur;
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  throw new Error("Unable to locate repo root (no .wp-env.json found walking up from mcp-server).");
+}
+
+function readJsonIfExists<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function resolveWpBaseUrl(repoRoot: string): string {
+  const envOverride = process.env.MAILPOET_MCP_WP_URL?.trim();
+  if (envOverride) return stripTrailingSlash(envOverride);
+
+  const override = readJsonIfExists<WpEnvFile>(resolve(repoRoot, ".wp-env.override.json"));
+  const base = readJsonIfExists<WpEnvFile>(resolve(repoRoot, ".wp-env.json"));
+
+  // WP_HOME / WP_SITEURL in override take precedence — they reflect the real externally-visible URL.
+  const home = (override?.config?.WP_HOME as string | undefined) ?? (base?.config?.WP_HOME as string | undefined);
+  if (typeof home === "string" && home) return stripTrailingSlash(home);
+
+  const port = override?.port ?? base?.port ?? 8888;
+  return `http://localhost:${port}`;
+}
+
+function resolveMailpitUrl(): string {
+  const envOverride = process.env.MAILPOET_MCP_MAILPIT_URL?.trim();
+  if (envOverride) return stripTrailingSlash(envOverride);
+  return "http://localhost:8082";
+}
+
+function readOrGenerateSecret(path: string): string {
+  if (existsSync(path)) {
+    const s = readFileSync(path, "utf8").trim();
+    if (s.length >= 32) return s;
+  }
+  const secret = randomBytes(32).toString("hex");
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, secret + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+  return secret;
+}
+
+export function loadConfig(): Config {
+  const repoRoot = findRepoRoot();
+  const wpBaseUrl = resolveWpBaseUrl(repoRoot);
+  const mailpitUrl = resolveMailpitUrl();
+  const companionSecretPath = resolve(repoRoot, ".wp-env", ".mailpoet-dev-companion-secret");
+  const companionSecret = readOrGenerateSecret(companionSecretPath);
+  const telemetryLogPath = process.env.MAILPOET_MCP_TELEMETRY_LOG?.trim() || resolve(repoRoot, ".wp-env", "mcp-usage.jsonl");
+
+  return {
+    repoRoot,
+    mailpoetDir: resolve(repoRoot, "mailpoet"),
+    wpBaseUrl,
+    mailpitUrl,
+    companionBaseUrl: `${wpBaseUrl}/wp-json/mailpoet-dev/v1`,
+    companionSecretPath,
+    companionSecret,
+    telemetryLogPath,
+  };
+}

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -1,30 +1,30 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadConfig } from "./config.js";
-import { initTelemetry } from "./util/telemetry.js";
-import { registerEnvStatus } from "./tools/env-status.js";
-import { registerEnvFeatureFlags } from "./tools/env-feature-flags.js";
-import { registerEnvMigrations } from "./tools/env-migrations.js";
-import { registerEnvScheduler } from "./tools/env-scheduler.js";
-import { registerTestRun } from "./tools/test-run.js";
-import { registerMailList } from "./tools/mail-list.js";
-import { registerMailGet } from "./tools/mail-get.js";
-import { registerMailClear } from "./tools/mail-clear.js";
-import { registerDataSubscribersList } from "./tools/data-subscribers-list.js";
-import { registerDataSubscribersGet } from "./tools/data-subscribers-get.js";
-import { registerDataSubscribersCreate } from "./tools/data-subscribers-create.js";
-import { registerDataSegmentsList } from "./tools/data-segments-list.js";
-import { registerQaRun } from "./tools/qa-run.js";
-import { registerLogsWpDebug } from "./tools/logs-wp-debug.js";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { loadConfig } from './config.js';
+import { initTelemetry } from './util/telemetry.js';
+import { registerEnvStatus } from './tools/env-status.js';
+import { registerEnvFeatureFlags } from './tools/env-feature-flags.js';
+import { registerEnvMigrations } from './tools/env-migrations.js';
+import { registerEnvScheduler } from './tools/env-scheduler.js';
+import { registerTestRun } from './tools/test-run.js';
+import { registerMailList } from './tools/mail-list.js';
+import { registerMailGet } from './tools/mail-get.js';
+import { registerMailClear } from './tools/mail-clear.js';
+import { registerDataSubscribersList } from './tools/data-subscribers-list.js';
+import { registerDataSubscribersGet } from './tools/data-subscribers-get.js';
+import { registerDataSubscribersCreate } from './tools/data-subscribers-create.js';
+import { registerDataSegmentsList } from './tools/data-segments-list.js';
+import { registerQaRun } from './tools/qa-run.js';
+import { registerLogsWpDebug } from './tools/logs-wp-debug.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
   initTelemetry(config.telemetryLogPath);
 
   const server = new McpServer({
-    name: "mailpoet-dev",
-    version: "0.0.2",
+    name: 'mailpoet-dev',
+    version: '0.0.2',
   });
 
   registerEnvStatus(server, config);
@@ -51,6 +51,10 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  process.stderr.write(`[mailpoet-dev-mcp] fatal: ${err instanceof Error ? err.stack : String(err)}\n`);
+  process.stderr.write(
+    `[mailpoet-dev-mcp] fatal: ${
+      err instanceof Error ? err.stack : String(err)
+    }\n`,
+  );
   process.exit(1);
 });

--- a/tools/mcp-server/src/index.ts
+++ b/tools/mcp-server/src/index.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { loadConfig } from "./config.js";
+import { initTelemetry } from "./util/telemetry.js";
+import { registerEnvStatus } from "./tools/env-status.js";
+import { registerEnvFeatureFlags } from "./tools/env-feature-flags.js";
+import { registerEnvMigrations } from "./tools/env-migrations.js";
+import { registerEnvScheduler } from "./tools/env-scheduler.js";
+import { registerTestRun } from "./tools/test-run.js";
+import { registerMailList } from "./tools/mail-list.js";
+import { registerMailGet } from "./tools/mail-get.js";
+import { registerMailClear } from "./tools/mail-clear.js";
+import { registerDataSubscribersList } from "./tools/data-subscribers-list.js";
+import { registerDataSubscribersGet } from "./tools/data-subscribers-get.js";
+import { registerDataSubscribersCreate } from "./tools/data-subscribers-create.js";
+import { registerDataSegmentsList } from "./tools/data-segments-list.js";
+import { registerQaRun } from "./tools/qa-run.js";
+import { registerLogsWpDebug } from "./tools/logs-wp-debug.js";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  initTelemetry(config.telemetryLogPath);
+
+  const server = new McpServer({
+    name: "mailpoet-dev",
+    version: "0.0.2",
+  });
+
+  registerEnvStatus(server, config);
+  registerEnvFeatureFlags(server, config);
+  registerEnvMigrations(server, config);
+  registerEnvScheduler(server, config);
+  registerTestRun(server, config);
+  registerMailList(server, config);
+  registerMailGet(server, config);
+  registerMailClear(server, config);
+  registerDataSubscribersList(server, config);
+  registerDataSubscribersGet(server, config);
+  registerDataSubscribersCreate(server, config);
+  registerDataSegmentsList(server, config);
+  registerQaRun(server, config);
+  registerLogsWpDebug(server, config);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  process.stderr.write(
+    `[mailpoet-dev-mcp] ready (repo=${config.repoRoot}, wp=${config.wpBaseUrl}, mailpit=${config.mailpitUrl}, telemetry=${config.telemetryLogPath})\n`,
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`[mailpoet-dev-mcp] fatal: ${err instanceof Error ? err.stack : String(err)}\n`);
+  process.exit(1);
+});

--- a/tools/mcp-server/src/init.ts
+++ b/tools/mcp-server/src/init.ts
@@ -2,7 +2,7 @@
 // Generates the companion secret file if missing and prints its path.
 // Run this once before `pnpm env:start` so wp-env can map the secret into the container.
 
-import { loadConfig } from "./config.js";
+import { loadConfig } from './config.js';
 
 const config = loadConfig();
 process.stdout.write(
@@ -11,9 +11,9 @@ process.stdout.write(
       ok: true,
       secret_path: config.companionSecretPath,
       companion_url: config.companionBaseUrl,
-      note: "Secret generated or already present. Start wp-env next to mount it into the container.",
+      note: 'Secret generated or already present. Start wp-env next to mount it into the container.',
     },
     null,
     2,
-  ) + "\n",
+  ) + '\n',
 );

--- a/tools/mcp-server/src/init.ts
+++ b/tools/mcp-server/src/init.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Generates the companion secret file if missing and prints its path.
+// Run this once before `pnpm env:start` so wp-env can map the secret into the container.
+
+import { loadConfig } from "./config.js";
+
+const config = loadConfig();
+process.stdout.write(
+  JSON.stringify(
+    {
+      ok: true,
+      secret_path: config.companionSecretPath,
+      companion_url: config.companionBaseUrl,
+      note: "Secret generated or already present. Start wp-env next to mount it into the container.",
+    },
+    null,
+    2,
+  ) + "\n",
+);

--- a/tools/mcp-server/src/tools/data-segments-list.ts
+++ b/tools/mcp-server/src/tools/data-segments-list.ts
@@ -1,0 +1,29 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+export function registerDataSegmentsList(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.data.segments.list",
+    {
+      title: "List MailPoet segments",
+      description:
+        "Lists segments (lists + dynamic segments + WP/Woo auto-segments). Optionally includes the subscribed-count per segment.",
+      inputSchema: {
+        type: z.string().optional().describe("Filter by segment type (e.g. 'default', 'dynamic', 'wp_users', 'woocommerce_users')."),
+        include_counts: z.boolean().optional().describe("If true, include the number of subscribed subscribers per segment. Slower."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.data.segments.list", args, async () => {
+        return await companion.request("segments", {
+          query: { type: args.type, include_counts: args.include_counts ? "true" : undefined },
+        });
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/data-segments-list.ts
+++ b/tools/mcp-server/src/tools/data-segments-list.ts
@@ -1,28 +1,44 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
-export function registerDataSegmentsList(server: McpServer, config: Config): void {
+export function registerDataSegmentsList(
+  server: McpServer,
+  config: Config,
+): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.data.segments.list",
+    'mp.data.segments.list',
     {
-      title: "List MailPoet segments",
+      title: 'List MailPoet segments',
       description:
-        "Lists segments (lists + dynamic segments + WP/Woo auto-segments). Optionally includes the subscribed-count per segment.",
+        'Lists segments (lists + dynamic segments + WP/Woo auto-segments). Optionally includes the subscribed-count per segment.',
       inputSchema: {
-        type: z.string().optional().describe("Filter by segment type (e.g. 'default', 'dynamic', 'wp_users', 'woocommerce_users')."),
-        include_counts: z.boolean().optional().describe("If true, include the number of subscribed subscribers per segment. Slower."),
+        type: z
+          .string()
+          .optional()
+          .describe(
+            "Filter by segment type (e.g. 'default', 'dynamic', 'wp_users', 'woocommerce_users').",
+          ),
+        include_counts: z
+          .boolean()
+          .optional()
+          .describe(
+            'If true, include the number of subscribed subscribers per segment. Slower.',
+          ),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.data.segments.list", args, async () => {
-        return await companion.request("segments", {
-          query: { type: args.type, include_counts: args.include_counts ? "true" : undefined },
+      runHandler('mp.data.segments.list', args, async () => {
+        return await companion.request('segments', {
+          query: {
+            type: args.type,
+            include_counts: args.include_counts ? 'true' : undefined,
+          },
         });
       }),
   );

--- a/tools/mcp-server/src/tools/data-subscribers-create.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-create.ts
@@ -1,0 +1,65 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+interface CreateResponse {
+  subscriber: {
+    id: string;
+    email: string;
+    first_name: string | null;
+    last_name: string | null;
+    status: string;
+    created_at: string | null;
+    updated_at: string | null;
+    source: string | null;
+    segments: { id: string; name: string }[];
+  };
+  created: boolean;
+  upserted: boolean;
+}
+
+export function registerDataSubscribersCreate(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.data.subscribers.create",
+    {
+      title: "Create a MailPoet subscriber",
+      description:
+        "Creates a single MailPoet subscriber via Doctrine directly — no confirmation email, no welcome scheduler, no segment-subscribed hook. Fails with 409 on duplicate email unless upsert=true. Source must be one of MailPoet's allowlist: api (default), form, unknown, imported, administrator, wordpress_user, woocommerce_user, woocommerce_checkout.",
+      inputSchema: {
+        email: z.string().email().describe("Subscriber email (required, will be lowercased)."),
+        first_name: z.string().optional().describe("First name."),
+        last_name: z.string().optional().describe("Last name."),
+        status: z
+          .enum(["subscribed", "unsubscribed", "unconfirmed", "bounced", "inactive"])
+          .optional()
+          .describe("Subscriber status. Defaults to 'subscribed' for new rows; existing status is preserved on upsert unless explicitly set."),
+        source: z
+          .enum(["api", "form", "unknown", "imported", "administrator", "wordpress_user", "woocommerce_user", "woocommerce_checkout"])
+          .optional()
+          .describe("Source tag. Must be one of MailPoet's allowed values. Defaults to 'api'."),
+        segment_ids: z.array(z.number().int().positive()).optional().describe("Segment IDs to subscribe to. Each is added without firing `mailpoet_segment_subscribed` (no welcome emails)."),
+        upsert: z.boolean().optional().describe("If true, update the existing row instead of failing on duplicate email. Default: false."),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.data.subscribers.create", args, async () => {
+        return await companion.request<CreateResponse>("subscribers", {
+          method: "POST",
+          body: {
+            email: args.email,
+            first_name: args.first_name,
+            last_name: args.last_name,
+            status: args.status,
+            source: args.source,
+            segment_ids: args.segment_ids,
+            upsert: args.upsert ?? false,
+          },
+        });
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/data-subscribers-create.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-create.ts
@@ -31,7 +31,7 @@ export function registerDataSubscribersCreate(
     {
       title: 'Create a MailPoet subscriber',
       description:
-        "Creates a single MailPoet subscriber via Doctrine directly — no confirmation email, no welcome scheduler, no segment-subscribed hook. Fails with 409 on duplicate email unless upsert=true. Source must be one of MailPoet's allowlist: api (default), form, unknown, imported, administrator, wordpress_user, woocommerce_user, woocommerce_checkout.",
+        "Creates a single MailPoet subscriber via Doctrine directly. Bypasses SubscriberSaveController, so NO confirmation email, NO welcome scheduler, and NO `mailpoet_segment_subscribed` action. Doctrine lifecycle listeners still run, so the `mailpoet_subscriber_created` / `_updated` / `_status_changed` WordPress actions WILL fire at request shutdown. Fails with 409 on duplicate email unless upsert=true. Source must be one of MailPoet's allowlist: api (default), form, unknown, imported, administrator, wordpress_user, woocommerce_user, woocommerce_checkout.",
       inputSchema: {
         email: z
           .string()

--- a/tools/mcp-server/src/tools/data-subscribers-create.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-create.ts
@@ -1,8 +1,8 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
 interface CreateResponse {
   subscriber: {
@@ -20,36 +20,76 @@ interface CreateResponse {
   upserted: boolean;
 }
 
-export function registerDataSubscribersCreate(server: McpServer, config: Config): void {
+export function registerDataSubscribersCreate(
+  server: McpServer,
+  config: Config,
+): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.data.subscribers.create",
+    'mp.data.subscribers.create',
     {
-      title: "Create a MailPoet subscriber",
+      title: 'Create a MailPoet subscriber',
       description:
         "Creates a single MailPoet subscriber via Doctrine directly — no confirmation email, no welcome scheduler, no segment-subscribed hook. Fails with 409 on duplicate email unless upsert=true. Source must be one of MailPoet's allowlist: api (default), form, unknown, imported, administrator, wordpress_user, woocommerce_user, woocommerce_checkout.",
       inputSchema: {
-        email: z.string().email().describe("Subscriber email (required, will be lowercased)."),
-        first_name: z.string().optional().describe("First name."),
-        last_name: z.string().optional().describe("Last name."),
+        email: z
+          .string()
+          .email()
+          .describe('Subscriber email (required, will be lowercased).'),
+        first_name: z.string().optional().describe('First name.'),
+        last_name: z.string().optional().describe('Last name.'),
         status: z
-          .enum(["subscribed", "unsubscribed", "unconfirmed", "bounced", "inactive"])
+          .enum([
+            'subscribed',
+            'unsubscribed',
+            'unconfirmed',
+            'bounced',
+            'inactive',
+          ])
           .optional()
-          .describe("Subscriber status. Defaults to 'subscribed' for new rows; existing status is preserved on upsert unless explicitly set."),
+          .describe(
+            "Subscriber status. Defaults to 'subscribed' for new rows; existing status is preserved on upsert unless explicitly set.",
+          ),
         source: z
-          .enum(["api", "form", "unknown", "imported", "administrator", "wordpress_user", "woocommerce_user", "woocommerce_checkout"])
+          .enum([
+            'api',
+            'form',
+            'unknown',
+            'imported',
+            'administrator',
+            'wordpress_user',
+            'woocommerce_user',
+            'woocommerce_checkout',
+          ])
           .optional()
-          .describe("Source tag. Must be one of MailPoet's allowed values. Defaults to 'api'."),
-        segment_ids: z.array(z.number().int().positive()).optional().describe("Segment IDs to subscribe to. Each is added without firing `mailpoet_segment_subscribed` (no welcome emails)."),
-        upsert: z.boolean().optional().describe("If true, update the existing row instead of failing on duplicate email. Default: false."),
+          .describe(
+            "Source tag. Must be one of MailPoet's allowed values. Defaults to 'api'.",
+          ),
+        segment_ids: z
+          .array(z.number().int().positive())
+          .optional()
+          .describe(
+            'Segment IDs to subscribe to. Each is added without firing `mailpoet_segment_subscribed` (no welcome emails).',
+          ),
+        upsert: z
+          .boolean()
+          .optional()
+          .describe(
+            'If true, update the existing row instead of failing on duplicate email. Default: false.',
+          ),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
     },
     async (args) =>
-      runHandler("mp.data.subscribers.create", args, async () => {
-        return await companion.request<CreateResponse>("subscribers", {
-          method: "POST",
+      runHandler('mp.data.subscribers.create', args, async () => {
+        return await companion.request<CreateResponse>('subscribers', {
+          method: 'POST',
           body: {
             email: args.email,
             first_name: args.first_name,

--- a/tools/mcp-server/src/tools/data-subscribers-get.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-get.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+export function registerDataSubscribersGet(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.data.subscribers.get",
+    {
+      title: "Get a MailPoet subscriber by id",
+      description:
+        "Fetches a single subscriber by id with all segment memberships. Use mp.data.subscribers.list to find the id.",
+      inputSchema: {
+        id: z.number().int().positive().describe("Subscriber id."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.data.subscribers.get", args, async () => {
+        return await companion.request(`subscribers/${args.id}`);
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/data-subscribers-get.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-get.ts
@@ -1,25 +1,28 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
-export function registerDataSubscribersGet(server: McpServer, config: Config): void {
+export function registerDataSubscribersGet(
+  server: McpServer,
+  config: Config,
+): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.data.subscribers.get",
+    'mp.data.subscribers.get',
     {
-      title: "Get a MailPoet subscriber by id",
+      title: 'Get a MailPoet subscriber by id',
       description:
-        "Fetches a single subscriber by id with all segment memberships. Use mp.data.subscribers.list to find the id.",
+        'Fetches a single subscriber by id with all segment memberships. Use mp.data.subscribers.list to find the id.',
       inputSchema: {
-        id: z.number().int().positive().describe("Subscriber id."),
+        id: z.number().int().positive().describe('Subscriber id.'),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.data.subscribers.get", args, async () => {
+      runHandler('mp.data.subscribers.get', args, async () => {
         return await companion.request(`subscribers/${args.id}`);
       }),
   );

--- a/tools/mcp-server/src/tools/data-subscribers-list.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-list.ts
@@ -10,8 +10,8 @@ interface CompanionSubscriber {
   first_name: string | null;
   last_name: string | null;
   status: string;
-  created_at: string;
-  updated_at: string;
+  created_at: string | null;
+  updated_at: string | null;
   source: string | null;
   segments: { id: string; name: string }[];
 }

--- a/tools/mcp-server/src/tools/data-subscribers-list.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-list.ts
@@ -1,0 +1,60 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+interface CompanionSubscriber {
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  source: string | null;
+  segments: { id: string; name: string }[];
+}
+
+interface CompanionSubscribersResponse {
+  items: CompanionSubscriber[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export function registerDataSubscribersList(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.data.subscribers.list",
+    {
+      title: "List MailPoet subscribers",
+      description:
+        "Lists MailPoet subscribers via the dev companion mu-plugin. Uses MailPoet's own SubscribersRepository, so results reflect real entity state (including segment memberships). Requires wp-env running and the companion mu-plugin active.",
+      inputSchema: {
+        email_contains: z.string().optional().describe("Case-insensitive substring match on email."),
+        status: z
+          .enum(["subscribed", "unsubscribed", "unconfirmed", "bounced", "inactive"])
+          .optional()
+          .describe("Filter by subscriber status."),
+        segment_id: z.string().optional().describe("Only subscribers belonging to this segment (numeric id as string)."),
+        limit: z.number().int().min(1).max(500).optional().describe("Max results (default 50)."),
+        offset: z.number().int().min(0).optional().describe("Offset into the result set (default 0)."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.data.subscribers.list", args, async () => {
+        return await companion.request<CompanionSubscribersResponse>("subscribers", {
+          query: {
+            email_contains: args.email_contains,
+            status: args.status,
+            segment_id: args.segment_id,
+            limit: args.limit ?? 50,
+            offset: args.offset ?? 0,
+          },
+        });
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/data-subscribers-list.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-list.ts
@@ -1,8 +1,8 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
 interface CompanionSubscriber {
   id: string;
@@ -23,38 +23,69 @@ interface CompanionSubscribersResponse {
   offset: number;
 }
 
-export function registerDataSubscribersList(server: McpServer, config: Config): void {
+export function registerDataSubscribersList(
+  server: McpServer,
+  config: Config,
+): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.data.subscribers.list",
+    'mp.data.subscribers.list',
     {
-      title: "List MailPoet subscribers",
+      title: 'List MailPoet subscribers',
       description:
         "Lists MailPoet subscribers via the dev companion mu-plugin. Uses MailPoet's own SubscribersRepository, so results reflect real entity state (including segment memberships). Requires wp-env running and the companion mu-plugin active.",
       inputSchema: {
-        email_contains: z.string().optional().describe("Case-insensitive substring match on email."),
-        status: z
-          .enum(["subscribed", "unsubscribed", "unconfirmed", "bounced", "inactive"])
+        email_contains: z
+          .string()
           .optional()
-          .describe("Filter by subscriber status."),
-        segment_id: z.string().optional().describe("Only subscribers belonging to this segment (numeric id as string)."),
-        limit: z.number().int().min(1).max(500).optional().describe("Max results (default 50)."),
-        offset: z.number().int().min(0).optional().describe("Offset into the result set (default 0)."),
+          .describe('Case-insensitive substring match on email.'),
+        status: z
+          .enum([
+            'subscribed',
+            'unsubscribed',
+            'unconfirmed',
+            'bounced',
+            'inactive',
+          ])
+          .optional()
+          .describe('Filter by subscriber status.'),
+        segment_id: z
+          .string()
+          .optional()
+          .describe(
+            'Only subscribers belonging to this segment (numeric id as string).',
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe('Max results (default 50).'),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe('Offset into the result set (default 0).'),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.data.subscribers.list", args, async () => {
-        return await companion.request<CompanionSubscribersResponse>("subscribers", {
-          query: {
-            email_contains: args.email_contains,
-            status: args.status,
-            segment_id: args.segment_id,
-            limit: args.limit ?? 50,
-            offset: args.offset ?? 0,
+      runHandler('mp.data.subscribers.list', args, async () => {
+        return await companion.request<CompanionSubscribersResponse>(
+          'subscribers',
+          {
+            query: {
+              email_contains: args.email_contains,
+              status: args.status,
+              segment_id: args.segment_id,
+              limit: args.limit ?? 50,
+              offset: args.offset ?? 0,
+            },
           },
-        });
+        );
       }),
   );
 }

--- a/tools/mcp-server/src/tools/data-subscribers-list.ts
+++ b/tools/mcp-server/src/tools/data-subscribers-list.ts
@@ -51,10 +51,12 @@ export function registerDataSubscribersList(
           .optional()
           .describe('Filter by subscriber status.'),
         segment_id: z
-          .string()
+          .number()
+          .int()
+          .positive()
           .optional()
           .describe(
-            'Only subscribers belonging to this segment (numeric id as string).',
+            'Only return subscribers currently subscribed to this segment.',
           ),
         limit: z
           .number()

--- a/tools/mcp-server/src/tools/env-feature-flags.ts
+++ b/tools/mcp-server/src/tools/env-feature-flags.ts
@@ -1,0 +1,44 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+export function registerEnvFeatureFlags(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.env.feature_flags.list",
+    {
+      title: "List MailPoet feature flags",
+      description: "Lists all known feature flags with their current state (enabled/default). Flags are registered in FeaturesController::$defaults.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async () =>
+      runHandler("mp.env.feature_flags.list", {}, async () => {
+        return await companion.request("feature-flags");
+      }),
+  );
+
+  server.registerTool(
+    "mp.env.feature_flags.set",
+    {
+      title: "Toggle a MailPoet feature flag",
+      description:
+        "Enables or disables a feature flag by name. Only flags registered in FeaturesController::$defaults can be toggled. Equivalent to going to /admin.php?page=mailpoet-experimental in wp-admin.",
+      inputSchema: {
+        name: z.string().describe("Flag name (e.g. 'brand_templates', 'birthday_emails')."),
+        value: z.boolean().describe("true to enable, false to disable."),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.env.feature_flags.set", args, async () => {
+        return await companion.request(`feature-flags/${encodeURIComponent(args.name)}`, {
+          method: "POST",
+          body: { value: args.value },
+        });
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/env-feature-flags.ts
+++ b/tools/mcp-server/src/tools/env-feature-flags.ts
@@ -1,44 +1,58 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
-export function registerEnvFeatureFlags(server: McpServer, config: Config): void {
+export function registerEnvFeatureFlags(
+  server: McpServer,
+  config: Config,
+): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.env.feature_flags.list",
+    'mp.env.feature_flags.list',
     {
-      title: "List MailPoet feature flags",
-      description: "Lists all known feature flags with their current state (enabled/default). Flags are registered in FeaturesController::$defaults.",
+      title: 'List MailPoet feature flags',
+      description:
+        'Lists all known feature flags with their current state (enabled/default). Flags are registered in FeaturesController::$defaults.',
       inputSchema: {},
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () =>
-      runHandler("mp.env.feature_flags.list", {}, async () => {
-        return await companion.request("feature-flags");
+      runHandler('mp.env.feature_flags.list', {}, async () => {
+        return await companion.request('feature-flags');
       }),
   );
 
   server.registerTool(
-    "mp.env.feature_flags.set",
+    'mp.env.feature_flags.set',
     {
-      title: "Toggle a MailPoet feature flag",
+      title: 'Toggle a MailPoet feature flag',
       description:
-        "Enables or disables a feature flag by name. Only flags registered in FeaturesController::$defaults can be toggled. Equivalent to going to /admin.php?page=mailpoet-experimental in wp-admin.",
+        'Enables or disables a feature flag by name. Only flags registered in FeaturesController::$defaults can be toggled. Equivalent to going to /admin.php?page=mailpoet-experimental in wp-admin.',
       inputSchema: {
-        name: z.string().describe("Flag name (e.g. 'brand_templates', 'birthday_emails')."),
-        value: z.boolean().describe("true to enable, false to disable."),
+        name: z
+          .string()
+          .describe("Flag name (e.g. 'brand_templates', 'birthday_emails')."),
+        value: z.boolean().describe('true to enable, false to disable.'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
     },
     async (args) =>
-      runHandler("mp.env.feature_flags.set", args, async () => {
-        return await companion.request(`feature-flags/${encodeURIComponent(args.name)}`, {
-          method: "POST",
-          body: { value: args.value },
-        });
+      runHandler('mp.env.feature_flags.set', args, async () => {
+        return await companion.request(
+          `feature-flags/${encodeURIComponent(args.name)}`,
+          {
+            method: 'POST',
+            body: { value: args.value },
+          },
+        );
       }),
   );
 }

--- a/tools/mcp-server/src/tools/env-migrations.ts
+++ b/tools/mcp-server/src/tools/env-migrations.ts
@@ -1,23 +1,23 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
 export function registerEnvMigrations(server: McpServer, config: Config): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.env.migrations.status",
+    'mp.env.migrations.status',
     {
-      title: "MailPoet migrations status",
+      title: 'MailPoet migrations status',
       description:
-        "Lists all MailPoet migrations (db + app) with their state: new, started, completed, failed, unknown. Unknown = migration recorded in the store but no longer defined in code (renamed/removed).",
+        'Lists all MailPoet migrations (db + app) with their state: new, started, completed, failed, unknown. Unknown = migration recorded in the store but no longer defined in code (renamed/removed).',
       inputSchema: {},
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () =>
-      runHandler("mp.env.migrations.status", {}, async () => {
-        return await companion.request("migrations");
+      runHandler('mp.env.migrations.status', {}, async () => {
+        return await companion.request('migrations');
       }),
   );
 }

--- a/tools/mcp-server/src/tools/env-migrations.ts
+++ b/tools/mcp-server/src/tools/env-migrations.ts
@@ -1,0 +1,23 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+export function registerEnvMigrations(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.env.migrations.status",
+    {
+      title: "MailPoet migrations status",
+      description:
+        "Lists all MailPoet migrations (db + app) with their state: new, started, completed, failed, unknown. Unknown = migration recorded in the store but no longer defined in code (renamed/removed).",
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async () =>
+      runHandler("mp.env.migrations.status", {}, async () => {
+        return await companion.request("migrations");
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/env-scheduler.ts
+++ b/tools/mcp-server/src/tools/env-scheduler.ts
@@ -1,0 +1,39 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+export function registerEnvScheduler(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.env.scheduler.list",
+    {
+      title: "List Action Scheduler actions",
+      description:
+        "Lists scheduled actions from WordPress Action Scheduler (the engine MailPoet uses for background jobs). Filterable by status, hook substring, and group. Useful for debugging stuck cron / automation runs.",
+      inputSchema: {
+        status: z
+          .enum(["pending", "in-progress", "complete", "failed", "canceled"])
+          .optional()
+          .describe("Filter by action status."),
+        hook_contains: z.string().optional().describe("Only return actions whose hook name contains this substring (e.g. 'mailpoet/cron')."),
+        group: z.string().optional().describe("Filter by Action Scheduler group (e.g. 'mailpoet-cron', 'mailpoet-automation')."),
+        limit: z.number().int().min(1).max(500).optional().describe("Max results (default 50)."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.env.scheduler.list", args, async () => {
+        return await companion.request("scheduler", {
+          query: {
+            status: args.status,
+            hook_contains: args.hook_contains,
+            group: args.group,
+            limit: args.limit ?? 50,
+          },
+        });
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/env-scheduler.ts
+++ b/tools/mcp-server/src/tools/env-scheduler.ts
@@ -1,32 +1,48 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
 export function registerEnvScheduler(server: McpServer, config: Config): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.env.scheduler.list",
+    'mp.env.scheduler.list',
     {
-      title: "List Action Scheduler actions",
+      title: 'List Action Scheduler actions',
       description:
-        "Lists scheduled actions from WordPress Action Scheduler (the engine MailPoet uses for background jobs). Filterable by status, hook substring, and group. Useful for debugging stuck cron / automation runs.",
+        'Lists scheduled actions from WordPress Action Scheduler (the engine MailPoet uses for background jobs). Filterable by status, hook substring, and group. Useful for debugging stuck cron / automation runs.',
       inputSchema: {
         status: z
-          .enum(["pending", "in-progress", "complete", "failed", "canceled"])
+          .enum(['pending', 'in-progress', 'complete', 'failed', 'canceled'])
           .optional()
-          .describe("Filter by action status."),
-        hook_contains: z.string().optional().describe("Only return actions whose hook name contains this substring (e.g. 'mailpoet/cron')."),
-        group: z.string().optional().describe("Filter by Action Scheduler group (e.g. 'mailpoet-cron', 'mailpoet-automation')."),
-        limit: z.number().int().min(1).max(500).optional().describe("Max results (default 50)."),
+          .describe('Filter by action status.'),
+        hook_contains: z
+          .string()
+          .optional()
+          .describe(
+            "Only return actions whose hook name contains this substring (e.g. 'mailpoet/cron').",
+          ),
+        group: z
+          .string()
+          .optional()
+          .describe(
+            "Filter by Action Scheduler group (e.g. 'mailpoet-cron', 'mailpoet-automation').",
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe('Max results (default 50).'),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.env.scheduler.list", args, async () => {
-        return await companion.request("scheduler", {
+      runHandler('mp.env.scheduler.list', args, async () => {
+        return await companion.request('scheduler', {
           query: {
             status: args.status,
             hook_contains: args.hook_contains,

--- a/tools/mcp-server/src/tools/env-status.ts
+++ b/tools/mcp-server/src/tools/env-status.ts
@@ -1,7 +1,7 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Config } from "../config.js";
-import { CompanionClient } from "../clients/companion.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Config } from '../config.js';
+import { CompanionClient } from '../clients/companion.js';
+import { runHandler } from './register.js';
 
 interface ProbeResult {
   reachable: boolean;
@@ -12,7 +12,10 @@ async function probe(url: string, timeoutMs = 1500): Promise<ProbeResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(url, { signal: controller.signal, redirect: "manual" });
+    const res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'manual',
+    });
     return { reachable: res.status > 0 };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -26,17 +29,20 @@ export function registerEnvStatus(server: McpServer, config: Config): void {
   const companion = new CompanionClient(config);
 
   server.registerTool(
-    "mp.env.status",
+    'mp.env.status',
     {
-      title: "MailPoet env status",
+      title: 'MailPoet env status',
       description:
-        "Reports the state of the local MailPoet dev environment: wp-env (WordPress at :8888), Mailpit (:8082), and the MailPoet Dev Companion mu-plugin. Includes plugin/WP/PHP versions when the companion is reachable.",
+        'Reports the state of the local MailPoet dev environment: wp-env (WordPress at :8888), Mailpit (:8082), and the MailPoet Dev Companion mu-plugin. Includes plugin/WP/PHP versions when the companion is reachable.',
       inputSchema: {},
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async () =>
-      runHandler("mp.env.status", {}, async () => {
-        const [wp, mailpit] = await Promise.all([probe(config.wpBaseUrl), probe(config.mailpitUrl)]);
+      runHandler('mp.env.status', {}, async () => {
+        const [wp, mailpit] = await Promise.all([
+          probe(config.wpBaseUrl),
+          probe(config.mailpitUrl),
+        ]);
 
         let companionReachable = false;
         let companionError: string | null = null;
@@ -47,21 +53,29 @@ export function registerEnvStatus(server: McpServer, config: Config): void {
             wp_version: string | null;
             php_version: string | null;
             premium_active: boolean;
-          }>("ping");
+          }>('ping');
           companionReachable = true;
           versions = {
             plugin: info.plugin_version,
             wp: info.wp_version,
             php: info.php_version,
-            premium: info.premium_active ? "active" : "inactive",
+            premium: info.premium_active ? 'active' : 'inactive',
           };
         } catch (e) {
           companionError = e instanceof Error ? e.message : String(e);
         }
 
         return {
-          wp_env: { running: wp.reachable, url: config.wpBaseUrl, ...(wp.error ? { error: wp.error } : {}) },
-          mailpit: { running: mailpit.reachable, url: config.mailpitUrl, ...(mailpit.error ? { error: mailpit.error } : {}) },
+          wp_env: {
+            running: wp.reachable,
+            url: config.wpBaseUrl,
+            ...(wp.error ? { error: wp.error } : {}),
+          },
+          mailpit: {
+            running: mailpit.reachable,
+            url: config.mailpitUrl,
+            ...(mailpit.error ? { error: mailpit.error } : {}),
+          },
           companion: {
             reachable: companionReachable,
             url: config.companionBaseUrl,

--- a/tools/mcp-server/src/tools/env-status.ts
+++ b/tools/mcp-server/src/tools/env-status.ts
@@ -1,0 +1,75 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Config } from "../config.js";
+import { CompanionClient } from "../clients/companion.js";
+import { runHandler } from "./register.js";
+
+interface ProbeResult {
+  reachable: boolean;
+  error?: string;
+}
+
+async function probe(url: string, timeoutMs = 1500): Promise<ProbeResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal, redirect: "manual" });
+    return { reachable: res.status > 0 };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { reachable: false, error: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function registerEnvStatus(server: McpServer, config: Config): void {
+  const companion = new CompanionClient(config);
+
+  server.registerTool(
+    "mp.env.status",
+    {
+      title: "MailPoet env status",
+      description:
+        "Reports the state of the local MailPoet dev environment: wp-env (WordPress at :8888), Mailpit (:8082), and the MailPoet Dev Companion mu-plugin. Includes plugin/WP/PHP versions when the companion is reachable.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async () =>
+      runHandler("mp.env.status", {}, async () => {
+        const [wp, mailpit] = await Promise.all([probe(config.wpBaseUrl), probe(config.mailpitUrl)]);
+
+        let companionReachable = false;
+        let companionError: string | null = null;
+        let versions: Record<string, string | null> | null = null;
+        try {
+          const info = await companion.request<{
+            plugin_version: string | null;
+            wp_version: string | null;
+            php_version: string | null;
+            premium_active: boolean;
+          }>("ping");
+          companionReachable = true;
+          versions = {
+            plugin: info.plugin_version,
+            wp: info.wp_version,
+            php: info.php_version,
+            premium: info.premium_active ? "active" : "inactive",
+          };
+        } catch (e) {
+          companionError = e instanceof Error ? e.message : String(e);
+        }
+
+        return {
+          wp_env: { running: wp.reachable, url: config.wpBaseUrl, ...(wp.error ? { error: wp.error } : {}) },
+          mailpit: { running: mailpit.reachable, url: config.mailpitUrl, ...(mailpit.error ? { error: mailpit.error } : {}) },
+          companion: {
+            reachable: companionReachable,
+            url: config.companionBaseUrl,
+            secret_path: config.companionSecretPath,
+            ...(companionError ? { error: companionError } : {}),
+          },
+          versions,
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/logs-wp-debug.ts
+++ b/tools/mcp-server/src/tools/logs-wp-debug.ts
@@ -1,0 +1,77 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { exec } from "../util/exec.js";
+import { ToolError } from "../util/errors.js";
+import { runHandler } from "./register.js";
+
+interface LogEntry {
+  raw: string;
+  timestamp: string | null;
+  level: string | null;
+  message: string;
+}
+
+// [23-Apr-2026 09:30:36 UTC] PHP Notice:  Some message...
+const LINE_RE = /^\[([^\]]+)\]\s+(PHP [^:]+):\s+(.*)$/;
+
+function parseLine(line: string): LogEntry {
+  const m = LINE_RE.exec(line);
+  if (!m) return { raw: line, timestamp: null, level: null, message: line };
+  return { raw: line, timestamp: m[1] ?? null, level: m[2] ?? null, message: m[3] ?? "" };
+}
+
+export function registerLogsWpDebug(server: McpServer, config: Config): void {
+  server.registerTool(
+    "mp.logs.wp_debug",
+    {
+      title: "Tail WordPress debug.log",
+      description:
+        "Reads wp-content/debug.log from inside the wp-env cli container via `wp-env run cli`. Returns structured entries. Filters: tail (last N lines), level (PHP Notice / Warning / Fatal / Deprecated), grep (substring match on full line before parsing).",
+      inputSchema: {
+        tail: z.number().int().min(1).max(5000).optional().describe("Read last N lines of the log (default 200)."),
+        level: z.string().optional().describe("Filter entries whose level contains this string (case-insensitive), e.g. 'Fatal', 'Notice'."),
+        grep: z.string().optional().describe("Substring filter applied to the raw line before parsing."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.logs.wp_debug", args, async () => {
+        const tail = args.tail ?? 200;
+        const res = await exec(
+          "npx",
+          ["wp-env", "run", "cli", "bash", "-lc", `tail -n ${tail} /var/www/html/wp-content/debug.log 2>/dev/null || true`],
+          { cwd: config.repoRoot, timeoutMs: 30_000 },
+        );
+
+        if (res.exitCode !== 0 && !res.stdout) {
+          throw new ToolError("wp_env_unavailable", `wp-env run failed: ${res.stderr.trim() || "exit " + res.exitCode}`);
+        }
+
+        // wp-env run wraps output with its own noise; strip leading lines that don't look like debug.log entries.
+        // The debug.log itself is at the tail. We split on newlines and keep them all — caller can filter with grep.
+        const allLines = res.stdout.split("\n").filter((l) => l !== "");
+
+        const grep = args.grep ? args.grep.toLowerCase() : null;
+        const levelFilter = args.level ? args.level.toLowerCase() : null;
+
+        const entries: LogEntry[] = [];
+        for (const line of allLines) {
+          if (grep && !line.toLowerCase().includes(grep)) continue;
+          const parsed = parseLine(line);
+          if (levelFilter && !(parsed.level ?? "").toLowerCase().includes(levelFilter)) continue;
+          entries.push(parsed);
+        }
+
+        return {
+          tail_requested: tail,
+          entries_returned: entries.length,
+          entries,
+          note:
+            entries.length === 0
+              ? "No matching entries. The log may be empty, or wp-env not running, or the file doesn't exist yet."
+              : undefined,
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/logs-wp-debug.ts
+++ b/tools/mcp-server/src/tools/logs-wp-debug.ts
@@ -1,9 +1,9 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { exec } from "../util/exec.js";
-import { ToolError } from "../util/errors.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { exec } from '../util/exec.js';
+import { ToolError } from '../util/errors.js';
+import { runHandler } from './register.js';
 
 interface LogEntry {
   raw: string;
@@ -18,39 +18,68 @@ const LINE_RE = /^\[([^\]]+)\]\s+(PHP [^:]+):\s+(.*)$/;
 function parseLine(line: string): LogEntry {
   const m = LINE_RE.exec(line);
   if (!m) return { raw: line, timestamp: null, level: null, message: line };
-  return { raw: line, timestamp: m[1] ?? null, level: m[2] ?? null, message: m[3] ?? "" };
+  return {
+    raw: line,
+    timestamp: m[1] ?? null,
+    level: m[2] ?? null,
+    message: m[3] ?? '',
+  };
 }
 
 export function registerLogsWpDebug(server: McpServer, config: Config): void {
   server.registerTool(
-    "mp.logs.wp_debug",
+    'mp.logs.wp_debug',
     {
-      title: "Tail WordPress debug.log",
+      title: 'Tail WordPress debug.log',
       description:
-        "Reads wp-content/debug.log from inside the wp-env cli container via `wp-env run cli`. Returns structured entries. Filters: tail (last N lines), level (PHP Notice / Warning / Fatal / Deprecated), grep (substring match on full line before parsing).",
+        'Reads wp-content/debug.log from inside the wp-env cli container via `wp-env run cli`. Returns structured entries. Filters: tail (last N lines), level (PHP Notice / Warning / Fatal / Deprecated), grep (substring match on full line before parsing).',
       inputSchema: {
-        tail: z.number().int().min(1).max(5000).optional().describe("Read last N lines of the log (default 200)."),
-        level: z.string().optional().describe("Filter entries whose level contains this string (case-insensitive), e.g. 'Fatal', 'Notice'."),
-        grep: z.string().optional().describe("Substring filter applied to the raw line before parsing."),
+        tail: z
+          .number()
+          .int()
+          .min(1)
+          .max(5000)
+          .optional()
+          .describe('Read last N lines of the log (default 200).'),
+        level: z
+          .string()
+          .optional()
+          .describe(
+            "Filter entries whose level contains this string (case-insensitive), e.g. 'Fatal', 'Notice'.",
+          ),
+        grep: z
+          .string()
+          .optional()
+          .describe('Substring filter applied to the raw line before parsing.'),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.logs.wp_debug", args, async () => {
+      runHandler('mp.logs.wp_debug', args, async () => {
         const tail = args.tail ?? 200;
         const res = await exec(
-          "npx",
-          ["wp-env", "run", "cli", "bash", "-lc", `tail -n ${tail} /var/www/html/wp-content/debug.log 2>/dev/null || true`],
+          'npx',
+          [
+            'wp-env',
+            'run',
+            'cli',
+            'bash',
+            '-lc',
+            `tail -n ${tail} /var/www/html/wp-content/debug.log 2>/dev/null || true`,
+          ],
           { cwd: config.repoRoot, timeoutMs: 30_000 },
         );
 
         if (res.exitCode !== 0 && !res.stdout) {
-          throw new ToolError("wp_env_unavailable", `wp-env run failed: ${res.stderr.trim() || "exit " + res.exitCode}`);
+          throw new ToolError(
+            'wp_env_unavailable',
+            `wp-env run failed: ${res.stderr.trim() || 'exit ' + res.exitCode}`,
+          );
         }
 
         // wp-env run wraps output with its own noise; strip leading lines that don't look like debug.log entries.
         // The debug.log itself is at the tail. We split on newlines and keep them all — caller can filter with grep.
-        const allLines = res.stdout.split("\n").filter((l) => l !== "");
+        const allLines = res.stdout.split('\n').filter((l) => l !== '');
 
         const grep = args.grep ? args.grep.toLowerCase() : null;
         const levelFilter = args.level ? args.level.toLowerCase() : null;
@@ -59,7 +88,11 @@ export function registerLogsWpDebug(server: McpServer, config: Config): void {
         for (const line of allLines) {
           if (grep && !line.toLowerCase().includes(grep)) continue;
           const parsed = parseLine(line);
-          if (levelFilter && !(parsed.level ?? "").toLowerCase().includes(levelFilter)) continue;
+          if (
+            levelFilter &&
+            !(parsed.level ?? '').toLowerCase().includes(levelFilter)
+          )
+            continue;
           entries.push(parsed);
         }
 

--- a/tools/mcp-server/src/tools/mail-clear.ts
+++ b/tools/mcp-server/src/tools/mail-clear.ts
@@ -1,28 +1,40 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { MailpitClient } from "../clients/mailpit.js";
-import { ToolError } from "../util/errors.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { MailpitClient } from '../clients/mailpit.js';
+import { ToolError } from '../util/errors.js';
+import { runHandler } from './register.js';
 
 export function registerMailClear(server: McpServer, config: Config): void {
   const mailpit = new MailpitClient(config);
 
   server.registerTool(
-    "mp.mail.clear",
+    'mp.mail.clear',
     {
-      title: "Clear Mailpit mailbox (destructive)",
+      title: 'Clear Mailpit mailbox (destructive)',
       description:
-        "Deletes ALL captured emails from Mailpit. Requires confirm=true to execute — otherwise returns a safety error. Typical use: reset mailbox between test scenarios.",
+        'Deletes ALL captured emails from Mailpit. Requires confirm=true to execute — otherwise returns a safety error. Typical use: reset mailbox between test scenarios.',
       inputSchema: {
-        confirm: z.literal(true).describe("Must be exactly true to actually delete. Any other value aborts."),
+        confirm: z
+          .literal(true)
+          .describe(
+            'Must be exactly true to actually delete. Any other value aborts.',
+          ),
       },
-      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
     },
     async (args) =>
-      runHandler("mp.mail.clear", args, async () => {
+      runHandler('mp.mail.clear', args, async () => {
         if (args.confirm !== true) {
-          throw new ToolError("confirmation_required", "Refusing to clear mailbox without confirm=true.");
+          throw new ToolError(
+            'confirmation_required',
+            'Refusing to clear mailbox without confirm=true.',
+          );
         }
         const before = await mailpit.listMessages({ limit: 1 });
         await mailpit.deleteAll();

--- a/tools/mcp-server/src/tools/mail-clear.ts
+++ b/tools/mcp-server/src/tools/mail-clear.ts
@@ -1,0 +1,35 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { MailpitClient } from "../clients/mailpit.js";
+import { ToolError } from "../util/errors.js";
+import { runHandler } from "./register.js";
+
+export function registerMailClear(server: McpServer, config: Config): void {
+  const mailpit = new MailpitClient(config);
+
+  server.registerTool(
+    "mp.mail.clear",
+    {
+      title: "Clear Mailpit mailbox (destructive)",
+      description:
+        "Deletes ALL captured emails from Mailpit. Requires confirm=true to execute — otherwise returns a safety error. Typical use: reset mailbox between test scenarios.",
+      inputSchema: {
+        confirm: z.literal(true).describe("Must be exactly true to actually delete. Any other value aborts."),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.mail.clear", args, async () => {
+        if (args.confirm !== true) {
+          throw new ToolError("confirmation_required", "Refusing to clear mailbox without confirm=true.");
+        }
+        const before = await mailpit.listMessages({ limit: 1 });
+        await mailpit.deleteAll();
+        return {
+          cleared: true,
+          deleted_count: before.total,
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/mail-get.ts
+++ b/tools/mcp-server/src/tools/mail-get.ts
@@ -1,0 +1,46 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { MailpitClient } from "../clients/mailpit.js";
+import { runHandler } from "./register.js";
+
+export function registerMailGet(server: McpServer, config: Config): void {
+  const mailpit = new MailpitClient(config);
+
+  server.registerTool(
+    "mp.mail.get",
+    {
+      title: "Get a captured email by id (Mailpit)",
+      description:
+        "Fetches full details of a single Mailpit message: headers, text body, HTML body, and attachment metadata (without binary content). Use mp.mail.list first to get the id.",
+      inputSchema: {
+        id: z.string().min(1).describe("Mailpit message ID (from mp.mail.list items[].id)."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.mail.get", args, async () => {
+        const m = await mailpit.getMessage(args.id);
+        return {
+          id: m.ID,
+          message_id: m.MessageID,
+          from: { name: m.From?.Name ?? null, address: m.From?.Address ?? "" },
+          to: (m.To ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
+          cc: (m.Cc ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
+          bcc: (m.Bcc ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
+          subject: m.Subject,
+          date: m.Date,
+          size_bytes: m.Size,
+          text: m.Text || null,
+          html: m.HTML || null,
+          attachments: (m.Attachments ?? []).map((a) => ({
+            filename: a.FileName,
+            content_type: a.ContentType,
+            size_bytes: a.Size,
+            part_id: a.PartID,
+          })),
+          headers: m.Headers ?? null,
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/mail-get.ts
+++ b/tools/mcp-server/src/tools/mail-get.ts
@@ -1,33 +1,45 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { MailpitClient } from "../clients/mailpit.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { MailpitClient } from '../clients/mailpit.js';
+import { runHandler } from './register.js';
 
 export function registerMailGet(server: McpServer, config: Config): void {
   const mailpit = new MailpitClient(config);
 
   server.registerTool(
-    "mp.mail.get",
+    'mp.mail.get',
     {
-      title: "Get a captured email by id (Mailpit)",
+      title: 'Get a captured email by id (Mailpit)',
       description:
-        "Fetches full details of a single Mailpit message: headers, text body, HTML body, and attachment metadata (without binary content). Use mp.mail.list first to get the id.",
+        'Fetches full details of a single Mailpit message: headers, text body, HTML body, and attachment metadata (without binary content). Use mp.mail.list first to get the id.',
       inputSchema: {
-        id: z.string().min(1).describe("Mailpit message ID (from mp.mail.list items[].id)."),
+        id: z
+          .string()
+          .min(1)
+          .describe('Mailpit message ID (from mp.mail.list items[].id).'),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.mail.get", args, async () => {
+      runHandler('mp.mail.get', args, async () => {
         const m = await mailpit.getMessage(args.id);
         return {
           id: m.ID,
           message_id: m.MessageID,
-          from: { name: m.From?.Name ?? null, address: m.From?.Address ?? "" },
-          to: (m.To ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
-          cc: (m.Cc ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
-          bcc: (m.Bcc ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
+          from: { name: m.From?.Name ?? null, address: m.From?.Address ?? '' },
+          to: (m.To ?? []).map((t) => ({
+            name: t.Name || null,
+            address: t.Address,
+          })),
+          cc: (m.Cc ?? []).map((t) => ({
+            name: t.Name || null,
+            address: t.Address,
+          })),
+          bcc: (m.Bcc ?? []).map((t) => ({
+            name: t.Name || null,
+            address: t.Address,
+          })),
           subject: m.Subject,
           date: m.Date,
           size_bytes: m.Size,

--- a/tools/mcp-server/src/tools/mail-list.ts
+++ b/tools/mcp-server/src/tools/mail-list.ts
@@ -1,36 +1,59 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { MailpitClient } from "../clients/mailpit.js";
-import { runHandler } from "./register.js";
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { MailpitClient } from '../clients/mailpit.js';
+import { runHandler } from './register.js';
 
 export function registerMailList(server: McpServer, config: Config): void {
   const mailpit = new MailpitClient(config);
 
   server.registerTool(
-    "mp.mail.list",
+    'mp.mail.list',
     {
-      title: "List captured emails (Mailpit)",
+      title: 'List captured emails (Mailpit)',
       description:
-        "Lists emails captured by the local Mailpit SMTP catcher. Returns summaries (no body). Use an optional search query to filter by subject/from/to/body (Mailpit search syntax).",
+        'Lists emails captured by the local Mailpit SMTP catcher. Returns summaries (no body). Use an optional search query to filter by subject/from/to/body (Mailpit search syntax).',
       inputSchema: {
-        query: z.string().optional().describe("Mailpit search query (e.g. 'to:alice@example.com', 'subject:welcome')."),
-        limit: z.number().int().min(1).max(200).optional().describe("Max results (default 50)."),
-        start: z.number().int().min(0).optional().describe("Offset into the result set."),
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Mailpit search query (e.g. 'to:alice@example.com', 'subject:welcome').",
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe('Max results (default 50).'),
+        start: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe('Offset into the result set.'),
       },
       annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async (args) =>
-      runHandler("mp.mail.list", args, async () => {
+      runHandler('mp.mail.list', args, async () => {
         const limit = args.limit ?? 50;
         const start = args.start ?? 0;
-        const response = await mailpit.listMessages({ query: args.query, limit, start });
+        const response = await mailpit.listMessages({
+          query: args.query,
+          limit,
+          start,
+        });
 
         const items = response.messages.map((m) => ({
           id: m.ID,
           message_id: m.MessageID,
-          from: { name: m.From?.Name ?? null, address: m.From?.Address ?? "" },
-          to: (m.To ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
+          from: { name: m.From?.Name ?? null, address: m.From?.Address ?? '' },
+          to: (m.To ?? []).map((t) => ({
+            name: t.Name || null,
+            address: t.Address,
+          })),
           subject: m.Subject,
           received_at: m.Created,
           size_bytes: m.Size,

--- a/tools/mcp-server/src/tools/mail-list.ts
+++ b/tools/mcp-server/src/tools/mail-list.ts
@@ -1,0 +1,50 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { MailpitClient } from "../clients/mailpit.js";
+import { runHandler } from "./register.js";
+
+export function registerMailList(server: McpServer, config: Config): void {
+  const mailpit = new MailpitClient(config);
+
+  server.registerTool(
+    "mp.mail.list",
+    {
+      title: "List captured emails (Mailpit)",
+      description:
+        "Lists emails captured by the local Mailpit SMTP catcher. Returns summaries (no body). Use an optional search query to filter by subject/from/to/body (Mailpit search syntax).",
+      inputSchema: {
+        query: z.string().optional().describe("Mailpit search query (e.g. 'to:alice@example.com', 'subject:welcome')."),
+        limit: z.number().int().min(1).max(200).optional().describe("Max results (default 50)."),
+        start: z.number().int().min(0).optional().describe("Offset into the result set."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async (args) =>
+      runHandler("mp.mail.list", args, async () => {
+        const limit = args.limit ?? 50;
+        const start = args.start ?? 0;
+        const response = await mailpit.listMessages({ query: args.query, limit, start });
+
+        const items = response.messages.map((m) => ({
+          id: m.ID,
+          message_id: m.MessageID,
+          from: { name: m.From?.Name ?? null, address: m.From?.Address ?? "" },
+          to: (m.To ?? []).map((t) => ({ name: t.Name || null, address: t.Address })),
+          subject: m.Subject,
+          received_at: m.Created,
+          size_bytes: m.Size,
+          attachments: m.Attachments,
+          snippet: m.Snippet ?? null,
+        }));
+
+        return {
+          items,
+          start,
+          limit,
+          total: response.total,
+          unread: response.unread,
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/qa-run.ts
+++ b/tools/mcp-server/src/tools/qa-run.ts
@@ -185,6 +185,14 @@ function badJsonError(
   });
 }
 
+// mailpoet/tests/plugins/ holds downloaded third-party WooCommerce plugin
+// zips + extracted code used by acceptance tests (see RoboFile::downloadWoo*).
+// It's gitignored, but guard against it anyway so an accidental commit
+// doesn't send third-party code through the linters.
+function isTestPluginsPath(repoRel: string): boolean {
+  return repoRel.startsWith('mailpoet/tests/plugins/');
+}
+
 // PHPStan's config (mailpoet/tasks/phpstan/phpstan.neon) only sets up stubs
 // and autoload for plugin code. Files outside mailpoet/ (e.g. .wp-env/
 // mu-plugins/) produce hundreds of false 'class.notFound' errors because
@@ -204,6 +212,7 @@ function isPhpstanAnalyzable(repoRel: string): boolean {
 // outside that scope doesn't make sense — the ruleset can't find project
 // context for it.
 function isPhpcsAnalyzable(repoRel: string): boolean {
+  if (isTestPluginsPath(repoRel)) return false;
   return (
     repoRel.startsWith('mailpoet/lib/') || repoRel.startsWith('mailpoet/tests/')
   );
@@ -213,6 +222,7 @@ function isPhpcsAnalyzable(repoRel: string): boolean {
 // ignored files to eslint produces one "File ignored" warning per file —
 // noise that isn't actionable. Skip these paths up front.
 function isEslintAnalyzable(repoRel: string): boolean {
+  if (isTestPluginsPath(repoRel)) return false;
   return !repoRel.startsWith('tools/mcp-server/');
 }
 
@@ -291,7 +301,8 @@ async function runPhpcs(
       ...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))),
     );
   } else {
-    args.push('lib/', 'tests/');
+    // tests/plugins/ holds third-party WooCommerce zips + extracts.
+    args.push('--ignore=tests/plugins/*', 'lib/', 'tests/');
   }
   const res = await exec(phpcs, args, {
     cwd: config.mailpoetDir,

--- a/tools/mcp-server/src/tools/qa-run.ts
+++ b/tools/mcp-server/src/tools/qa-run.ts
@@ -1,20 +1,27 @@
-import { resolve, relative, extname } from "node:path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { exec } from "../util/exec.js";
-import { ToolError } from "../util/errors.js";
-import { runHandler } from "./register.js";
+import { resolve, relative, extname } from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { exec } from '../util/exec.js';
+import { ToolError } from '../util/errors.js';
+import { runHandler } from './register.js';
 
-const QaTool = z.enum(["phpstan", "phpcs", "eslint", "stylelint", "prettier", "tsc"]);
+const QaTool = z.enum([
+  'phpstan',
+  'phpcs',
+  'eslint',
+  'stylelint',
+  'prettier',
+  'tsc',
+]);
 type QaTool = z.infer<typeof QaTool>;
-const QaScope = z.enum(["all", "changed", "file"]);
+const QaScope = z.enum(['all', 'changed', 'file']);
 
-type Severity = "error" | "warning" | "info";
+type Severity = 'error' | 'warning' | 'info';
 
 interface Violation {
   tool: QaTool;
-  file: string;      // relative to repo root
+  file: string; // relative to repo root
   line: number;
   column: number | null;
   rule: string;
@@ -24,29 +31,57 @@ interface Violation {
 }
 
 const EXTENSIONS_BY_TOOL: Record<QaTool, string[]> = {
-  phpstan: [".php"],
-  phpcs: [".php"],
-  eslint: [".js", ".jsx", ".ts", ".tsx"],
-  stylelint: [".scss", ".css"],
-  prettier: [".js", ".jsx", ".ts", ".tsx", ".scss", ".css", ".json", ".md", ".yml", ".yaml", ".html"],
+  phpstan: ['.php'],
+  phpcs: ['.php'],
+  eslint: ['.js', '.jsx', '.ts', '.tsx'],
+  stylelint: ['.scss', '.css'],
+  prettier: [
+    '.js',
+    '.jsx',
+    '.ts',
+    '.tsx',
+    '.scss',
+    '.css',
+    '.json',
+    '.md',
+    '.yml',
+    '.yaml',
+    '.html',
+  ],
   tsc: [],
 };
 
-async function changedFiles(repoRoot: string, extensions: string[]): Promise<string[]> {
-  const res = await exec("git", ["diff", "--name-only", "--diff-filter=ACMR", "trunk...HEAD"], { cwd: repoRoot });
+async function changedFiles(
+  repoRoot: string,
+  extensions: string[],
+): Promise<string[]> {
+  const res = await exec(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACMR', 'trunk...HEAD'],
+    { cwd: repoRoot },
+  );
   if (res.exitCode !== 0) {
-    throw new ToolError("git_diff_failed", `git diff failed: ${res.stderr.trim() || res.stdout.trim()}`);
+    throw new ToolError(
+      'git_diff_failed',
+      `git diff failed: ${res.stderr.trim() || res.stdout.trim()}`,
+    );
   }
-  const files = res.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  const files = res.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
   if (extensions.length === 0) return files;
   return files.filter((f) => extensions.includes(extname(f)));
 }
 
-async function uncommittedFiles(repoRoot: string, extensions: string[]): Promise<string[]> {
-  const res = await exec("git", ["status", "--porcelain"], { cwd: repoRoot });
+async function uncommittedFiles(
+  repoRoot: string,
+  extensions: string[],
+): Promise<string[]> {
+  const res = await exec('git', ['status', '--porcelain'], { cwd: repoRoot });
   if (res.exitCode !== 0) return [];
   const files = res.stdout
-    .split("\n")
+    .split('\n')
     .map((l) => l.slice(3).trim())
     .filter(Boolean);
   if (extensions.length === 0) return files;
@@ -54,14 +89,18 @@ async function uncommittedFiles(repoRoot: string, extensions: string[]): Promise
 }
 
 async function resolveScope(
-  scope: "all" | "changed" | "file",
+  scope: 'all' | 'changed' | 'file',
   path: string | undefined,
   tool: QaTool,
   config: Config,
-): Promise<{ files: string[] | "all"; resolvedFromBranch: boolean }> {
-  if (scope === "all") return { files: "all", resolvedFromBranch: false };
-  if (scope === "file") {
-    if (!path) throw new ToolError("path_required", "scope='file' requires a 'path' argument.");
+): Promise<{ files: string[] | 'all'; resolvedFromBranch: boolean }> {
+  if (scope === 'all') return { files: 'all', resolvedFromBranch: false };
+  if (scope === 'file') {
+    if (!path)
+      throw new ToolError(
+        'path_required',
+        "scope='file' requires a 'path' argument.",
+      );
     return { files: [path], resolvedFromBranch: false };
   }
   const exts = EXTENSIONS_BY_TOOL[tool];
@@ -79,32 +118,60 @@ function toRepoRel(absOrRel: string, config: Config): string {
   return relative(config.repoRoot, resolve(config.repoRoot, absOrRel));
 }
 
-async function runPhpstan(files: string[] | "all", config: Config): Promise<Violation[]> {
-  const phpstan = "./tasks/phpstan/vendor/bin/phpstan";
-  const args = ["analyse", "--no-progress", "--error-format=json", "--memory-limit=2G"];
-  if (files !== "all") {
+async function runPhpstan(
+  files: string[] | 'all',
+  config: Config,
+): Promise<Violation[]> {
+  const phpstan = './tasks/phpstan/vendor/bin/phpstan';
+  const args = [
+    'analyse',
+    '--no-progress',
+    '--error-format=json',
+    '--memory-limit=2G',
+  ];
+  if (files !== 'all') {
     if (files.length === 0) return [];
-    const rel = files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config)));
+    const rel = files.map((f) =>
+      relative(config.mailpoetDir, toAbsolute(f, config)),
+    );
     args.push(...rel);
   }
-  const res = await exec(phpstan, args, { cwd: config.mailpoetDir, timeoutMs: 5 * 60 * 1000 });
+  const res = await exec(phpstan, args, {
+    cwd: config.mailpoetDir,
+    timeoutMs: 5 * 60 * 1000,
+  });
   // PHPStan exits 1 when it finds violations; that's expected.
-  let parsed: { files: Record<string, { messages: { message: string; line: number; ignorable?: boolean; identifier?: string }[] }> };
+  let parsed: {
+    files: Record<
+      string,
+      {
+        messages: {
+          message: string;
+          line: number;
+          ignorable?: boolean;
+          identifier?: string;
+        }[];
+      }
+    >;
+  };
   try {
     parsed = JSON.parse(res.stdout);
   } catch {
-    throw new ToolError("phpstan_bad_json", "PHPStan output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+    throw new ToolError('phpstan_bad_json', 'PHPStan output was not JSON', {
+      stdout: res.stdout.slice(0, 500),
+      stderr: res.stderr.slice(0, 500),
+    });
   }
   const out: Violation[] = [];
   for (const [file, fileData] of Object.entries(parsed.files ?? {})) {
     for (const msg of fileData.messages) {
       out.push({
-        tool: "phpstan",
+        tool: 'phpstan',
         file: toRepoRel(file, config),
         line: msg.line ?? 0,
         column: null,
-        rule: msg.identifier || "phpstan",
-        severity: "error",
+        rule: msg.identifier || 'phpstan',
+        severity: 'error',
         message: msg.message,
         fixable: false,
       });
@@ -113,32 +180,65 @@ async function runPhpstan(files: string[] | "all", config: Config): Promise<Viol
   return out;
 }
 
-async function runPhpcs(files: string[] | "all", config: Config): Promise<Violation[]> {
-  const phpcs = "./tasks/code_sniffer/vendor/bin/phpcs";
-  const args = ["--report=json", "--standard=./tasks/code_sniffer/MailPoet/ruleset.xml"];
-  if (files !== "all") {
+async function runPhpcs(
+  files: string[] | 'all',
+  config: Config,
+): Promise<Violation[]> {
+  const phpcs = './tasks/code_sniffer/vendor/bin/phpcs';
+  const args = [
+    '--report=json',
+    '--standard=./tasks/code_sniffer/MailPoet/ruleset.xml',
+  ];
+  if (files !== 'all') {
     if (files.length === 0) return [];
-    args.push(...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))));
+    args.push(
+      ...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))),
+    );
   } else {
-    args.push("lib/", "tests/");
+    args.push('lib/', 'tests/');
   }
-  const res = await exec(phpcs, args, { cwd: config.mailpoetDir, timeoutMs: 5 * 60 * 1000 });
-  let parsed: { files: Record<string, { messages: { message: string; source: string; line: number; column: number; type: string; fixable: boolean }[] }> };
+  const res = await exec(phpcs, args, {
+    cwd: config.mailpoetDir,
+    timeoutMs: 5 * 60 * 1000,
+  });
+  let parsed: {
+    files: Record<
+      string,
+      {
+        messages: {
+          message: string;
+          source: string;
+          line: number;
+          column: number;
+          type: string;
+          fixable: boolean;
+        }[];
+      }
+    >;
+  };
   try {
     parsed = JSON.parse(res.stdout);
   } catch {
-    throw new ToolError("phpcs_bad_json", "PHPCS output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+    throw new ToolError('phpcs_bad_json', 'PHPCS output was not JSON', {
+      stdout: res.stdout.slice(0, 500),
+      stderr: res.stderr.slice(0, 500),
+    });
   }
   const out: Violation[] = [];
   for (const [file, fileData] of Object.entries(parsed.files ?? {})) {
     for (const m of fileData.messages) {
       out.push({
-        tool: "phpcs",
+        tool: 'phpcs',
         file: toRepoRel(file, config),
         line: m.line,
         column: m.column,
         rule: m.source,
-        severity: m.type === "ERROR" ? "error" : m.type === "WARNING" ? "warning" : "info",
+        severity:
+          m.type === 'ERROR'
+            ? 'error'
+            : m.type === 'WARNING'
+            ? 'warning'
+            : 'info',
         message: m.message,
         fixable: !!m.fixable,
       });
@@ -147,35 +247,53 @@ async function runPhpcs(files: string[] | "all", config: Config): Promise<Violat
   return out;
 }
 
-async function runEslint(files: string[] | "all", config: Config): Promise<Violation[]> {
-  const args = ["--format=json", "--max-warnings", "9999"];
-  if (files !== "all") {
+async function runEslint(
+  files: string[] | 'all',
+  config: Config,
+): Promise<Violation[]> {
+  const args = ['--format=json', '--max-warnings', '9999'];
+  if (files !== 'all') {
     if (files.length === 0) return [];
-    args.push(...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))));
+    args.push(
+      ...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))),
+    );
   } else {
-    args.push("assets/js/src/**/*.{js,jsx,ts,tsx}");
+    args.push('assets/js/src/**/*.{js,jsx,ts,tsx}');
   }
-  const res = await exec("./node_modules/.bin/eslint", args, {
+  const res = await exec('./node_modules/.bin/eslint', args, {
     cwd: config.mailpoetDir,
     timeoutMs: 5 * 60 * 1000,
-    env: { ...process.env, NODE_OPTIONS: "--max_old_space_size=2048" },
+    env: { ...process.env, NODE_OPTIONS: '--max_old_space_size=2048' },
   });
-  let parsed: { filePath: string; messages: { ruleId: string | null; severity: number; message: string; line: number; column: number; fix?: unknown }[] }[];
+  let parsed: {
+    filePath: string;
+    messages: {
+      ruleId: string | null;
+      severity: number;
+      message: string;
+      line: number;
+      column: number;
+      fix?: unknown;
+    }[];
+  }[];
   try {
     parsed = JSON.parse(res.stdout);
   } catch {
-    throw new ToolError("eslint_bad_json", "ESLint output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+    throw new ToolError('eslint_bad_json', 'ESLint output was not JSON', {
+      stdout: res.stdout.slice(0, 500),
+      stderr: res.stderr.slice(0, 500),
+    });
   }
   const out: Violation[] = [];
   for (const fileReport of parsed) {
     for (const m of fileReport.messages) {
       out.push({
-        tool: "eslint",
+        tool: 'eslint',
         file: toRepoRel(fileReport.filePath, config),
         line: m.line,
         column: m.column,
-        rule: m.ruleId ?? "eslint",
-        severity: m.severity === 2 ? "error" : "warning",
+        rule: m.ruleId ?? 'eslint',
+        severity: m.severity === 2 ? 'error' : 'warning',
         message: m.message,
         fixable: !!m.fix,
       });
@@ -184,31 +302,51 @@ async function runEslint(files: string[] | "all", config: Config): Promise<Viola
   return out;
 }
 
-async function runStylelint(files: string[] | "all", config: Config): Promise<Violation[]> {
-  const args = ["--formatter=json"];
-  if (files !== "all") {
+async function runStylelint(
+  files: string[] | 'all',
+  config: Config,
+): Promise<Violation[]> {
+  const args = ['--formatter=json'];
+  if (files !== 'all') {
     if (files.length === 0) return [];
-    args.push(...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))));
+    args.push(
+      ...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))),
+    );
   } else {
-    args.push("assets/css/src/**/*.scss");
+    args.push('assets/css/src/**/*.scss');
   }
-  const res = await exec("./node_modules/.bin/stylelint", args, { cwd: config.mailpoetDir, timeoutMs: 5 * 60 * 1000 });
-  let parsed: { source: string; warnings: { line: number; column: number; rule: string; severity: string; text: string }[] }[];
+  const res = await exec('./node_modules/.bin/stylelint', args, {
+    cwd: config.mailpoetDir,
+    timeoutMs: 5 * 60 * 1000,
+  });
+  let parsed: {
+    source: string;
+    warnings: {
+      line: number;
+      column: number;
+      rule: string;
+      severity: string;
+      text: string;
+    }[];
+  }[];
   try {
-    parsed = JSON.parse(res.stdout || "[]");
+    parsed = JSON.parse(res.stdout || '[]');
   } catch {
-    throw new ToolError("stylelint_bad_json", "Stylelint output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+    throw new ToolError('stylelint_bad_json', 'Stylelint output was not JSON', {
+      stdout: res.stdout.slice(0, 500),
+      stderr: res.stderr.slice(0, 500),
+    });
   }
   const out: Violation[] = [];
   for (const file of parsed) {
     for (const w of file.warnings) {
       out.push({
-        tool: "stylelint",
+        tool: 'stylelint',
         file: toRepoRel(file.source, config),
         line: w.line,
         column: w.column,
         rule: w.rule,
-        severity: w.severity === "error" ? "error" : "warning",
+        severity: w.severity === 'error' ? 'error' : 'warning',
         message: w.text,
         fixable: false,
       });
@@ -217,27 +355,33 @@ async function runStylelint(files: string[] | "all", config: Config): Promise<Vi
   return out;
 }
 
-async function runPrettier(files: string[] | "all", config: Config): Promise<Violation[]> {
-  const args = ["--list-different"];
-  if (files !== "all") {
+async function runPrettier(
+  files: string[] | 'all',
+  config: Config,
+): Promise<Violation[]> {
+  const args = ['--list-different'];
+  if (files !== 'all') {
     if (files.length === 0) return [];
     args.push(...files);
   } else {
-    args.push(".");
+    args.push('.');
   }
-  const res = await exec("npx", ["prettier", ...args], { cwd: config.repoRoot, timeoutMs: 5 * 60 * 1000 });
+  const res = await exec('npx', ['prettier', ...args], {
+    cwd: config.repoRoot,
+    timeoutMs: 5 * 60 * 1000,
+  });
   const out: Violation[] = [];
-  for (const line of res.stdout.split("\n")) {
+  for (const line of res.stdout.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     out.push({
-      tool: "prettier",
+      tool: 'prettier',
       file: toRepoRel(trimmed, config),
       line: 0,
       column: null,
-      rule: "prettier/formatting",
-      severity: "warning",
-      message: "File is not Prettier-formatted.",
+      rule: 'prettier/formatting',
+      severity: 'warning',
+      message: 'File is not Prettier-formatted.',
       fixable: true,
     });
   }
@@ -245,24 +389,28 @@ async function runPrettier(files: string[] | "all", config: Config): Promise<Vio
 }
 
 async function runTsc(config: Config): Promise<Violation[]> {
-  const res = await exec("./node_modules/.bin/tsc", ["--noEmit", "--pretty", "false"], {
-    cwd: config.mailpoetDir,
-    timeoutMs: 5 * 60 * 1000,
-    env: { ...process.env, NODE_OPTIONS: "--max_old_space_size=2048" },
-  });
+  const res = await exec(
+    './node_modules/.bin/tsc',
+    ['--noEmit', '--pretty', 'false'],
+    {
+      cwd: config.mailpoetDir,
+      timeoutMs: 5 * 60 * 1000,
+      env: { ...process.env, NODE_OPTIONS: '--max_old_space_size=2048' },
+    },
+  );
   const out: Violation[] = [];
   // TSC line format: "path/to/file.ts(line,col): error TSxxxx: message"
   const re = /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$/;
-  for (const line of res.stdout.split("\n")) {
+  for (const line of res.stdout.split('\n')) {
     const m = re.exec(line.trim());
     if (!m) continue;
     out.push({
-      tool: "tsc",
+      tool: 'tsc',
       file: toRepoRel(resolve(config.mailpoetDir, m[1]!), config),
       line: Number(m[2]),
       column: Number(m[3]),
       rule: m[5]!,
-      severity: m[4] === "error" ? "error" : "warning",
+      severity: m[4] === 'error' ? 'error' : 'warning',
       message: m[6]!,
       fixable: false,
     });
@@ -272,43 +420,57 @@ async function runTsc(config: Config): Promise<Violation[]> {
 
 export function registerQaRun(server: McpServer, config: Config): void {
   server.registerTool(
-    "mp.qa.run",
+    'mp.qa.run',
     {
-      title: "Run a QA / lint tool",
+      title: 'Run a QA / lint tool',
       description:
         "Runs one of the MailPoet QA tools (phpstan, phpcs, eslint, stylelint, prettier, tsc) and returns a flat list of structured violations. Default scope='changed' runs against files modified vs trunk (committed + uncommitted). scope='file' requires 'path'. scope='all' runs everywhere (slow).",
       inputSchema: {
-        tool: QaTool.describe("Which linter / static analyser to run."),
-        scope: QaScope.optional().describe("'changed' (default): files changed vs trunk + uncommitted. 'file': single path. 'all': everywhere."),
-        path: z.string().optional().describe("Path relative to repo root. Required when scope='file'."),
+        tool: QaTool.describe('Which linter / static analyser to run.'),
+        scope: QaScope.optional().describe(
+          "'changed' (default): files changed vs trunk + uncommitted. 'file': single path. 'all': everywhere.",
+        ),
+        path: z
+          .string()
+          .optional()
+          .describe("Path relative to repo root. Required when scope='file'."),
       },
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async (args) =>
-      runHandler("mp.qa.run", args, async () => {
+      runHandler('mp.qa.run', args, async () => {
         const tool = args.tool;
-        const scope = args.scope ?? "changed";
+        const scope = args.scope ?? 'changed';
 
-        const { files, resolvedFromBranch } = await resolveScope(scope, args.path, tool, config);
+        const { files, resolvedFromBranch } = await resolveScope(
+          scope,
+          args.path,
+          tool,
+          config,
+        );
         const started = Date.now();
 
         let violations: Violation[];
-        if (tool === "phpstan") violations = await runPhpstan(files, config);
-        else if (tool === "phpcs") violations = await runPhpcs(files, config);
-        else if (tool === "eslint") violations = await runEslint(files, config);
-        else if (tool === "stylelint") violations = await runStylelint(files, config);
-        else if (tool === "prettier") violations = await runPrettier(files, config);
+        if (tool === 'phpstan') violations = await runPhpstan(files, config);
+        else if (tool === 'phpcs') violations = await runPhpcs(files, config);
+        else if (tool === 'eslint') violations = await runEslint(files, config);
+        else if (tool === 'stylelint')
+          violations = await runStylelint(files, config);
+        else if (tool === 'prettier')
+          violations = await runPrettier(files, config);
         else violations = await runTsc(config);
 
-        const errors = violations.filter((v) => v.severity === "error").length;
-        const warnings = violations.filter((v) => v.severity === "warning").length;
+        const errors = violations.filter((v) => v.severity === 'error').length;
+        const warnings = violations.filter(
+          (v) => v.severity === 'warning',
+        ).length;
         const fixable = violations.filter((v) => v.fixable).length;
 
         return {
           tool,
           scope,
           resolved_from_branch: resolvedFromBranch,
-          files_analyzed: files === "all" ? null : files.length,
+          files_analyzed: files === 'all' ? null : files.length,
           duration_ms: Date.now() - started,
           violations,
           summary: { errors, warnings, fixable },

--- a/tools/mcp-server/src/tools/qa-run.ts
+++ b/tools/mcp-server/src/tools/qa-run.ts
@@ -107,6 +107,18 @@ async function uncommittedFiles(
   return files.filter((f) => extensions.includes(extname(f)));
 }
 
+// Per-tool scope filter. Changed-file discovery returns every modified file
+// matching the tool's extension, but some tools can't meaningfully analyze
+// files outside their configured scope (e.g. phpstan without WordPress
+// stubs, eslint paths ignored by the mailpoet config). Filtering up front
+// keeps `files_analyzed` accurate in the response.
+function scopeFilter(tool: QaTool): (repoRel: string) => boolean {
+  if (tool === 'phpstan') return isPhpstanAnalyzable;
+  if (tool === 'phpcs') return isPhpcsAnalyzable;
+  if (tool === 'eslint') return isEslintAnalyzable;
+  return () => true;
+}
+
 async function resolveScope(
   scope: 'all' | 'changed' | 'file',
   path: string | undefined,
@@ -138,7 +150,9 @@ async function resolveScope(
   const exts = EXTENSIONS_BY_TOOL[tool];
   const committed = await changedFiles(config.repoRoot, exts);
   const uncommitted = await uncommittedFiles(config.repoRoot, exts);
-  const merged = Array.from(new Set([...committed, ...uncommitted]));
+  const merged = Array.from(new Set([...committed, ...uncommitted])).filter(
+    scopeFilter(tool),
+  );
   return { files: merged, resolvedFromBranch: true };
 }
 
@@ -171,11 +185,46 @@ function badJsonError(
   });
 }
 
+// PHPStan's config (mailpoet/tasks/phpstan/phpstan.neon) only sets up stubs
+// and autoload for plugin code. Files outside mailpoet/ (e.g. .wp-env/
+// mu-plugins/) produce hundreds of false 'class.notFound' errors because
+// WordPress stubs aren't registered for them. Match RoboFile's scope.
+function isPhpstanAnalyzable(repoRel: string): boolean {
+  return (
+    repoRel.startsWith('mailpoet/lib/') ||
+    repoRel.startsWith('mailpoet/tests/_support/') ||
+    repoRel.startsWith('mailpoet/tests/DataFactories/') ||
+    repoRel.startsWith('mailpoet/tests/acceptance/') ||
+    repoRel.startsWith('mailpoet/tests/integration/') ||
+    repoRel.startsWith('mailpoet/tests/unit/')
+  );
+}
+
+// PHPCS's MailPoet ruleset targets lib/ and tests/. Linting a PHP file
+// outside that scope doesn't make sense — the ruleset can't find project
+// context for it.
+function isPhpcsAnalyzable(repoRel: string): boolean {
+  return (
+    repoRel.startsWith('mailpoet/lib/') || repoRel.startsWith('mailpoet/tests/')
+  );
+}
+
+// mailpoet's eslint config ignores paths like tools/mcp-server/. Passing
+// ignored files to eslint produces one "File ignored" warning per file —
+// noise that isn't actionable. Skip these paths up front.
+function isEslintAnalyzable(repoRel: string): boolean {
+  return !repoRel.startsWith('tools/mcp-server/');
+}
+
 async function runPhpstan(
   files: string[] | 'all',
   config: Config,
 ): Promise<Violation[]> {
-  const phpstan = './tasks/phpstan/vendor/bin/phpstan';
+  // PHPStan must run from mailpoet/tasks/phpstan/ so it picks up
+  // phpstan.neon there and avoids autoloading conflicts from the plugin's
+  // own vendor/ (see RoboFile::qaPhpstan for the same reasoning).
+  const phpstanDir = resolve(config.mailpoetDir, 'tasks/phpstan');
+  const phpstan = './vendor/bin/phpstan';
   const args = [
     'analyse',
     '--no-progress',
@@ -184,13 +233,10 @@ async function runPhpstan(
   ];
   if (files !== 'all') {
     if (files.length === 0) return [];
-    const rel = files.map((f) =>
-      relative(config.mailpoetDir, toAbsolute(f, config)),
-    );
-    args.push(...rel);
+    args.push(...files.map((f) => toAbsolute(f, config)));
   }
   const res = await exec(phpstan, args, {
-    cwd: config.mailpoetDir,
+    cwd: phpstanDir,
     timeoutMs: 5 * 60 * 1000,
   });
   // PHPStan exits 1 when it finds violations; that's expected.
@@ -237,7 +283,7 @@ async function runPhpcs(
   const phpcs = './tasks/code_sniffer/vendor/bin/phpcs';
   const args = [
     '--report=json',
-    '--standard=./tasks/code_sniffer/MailPoet/ruleset.xml',
+    '--standard=./tasks/code_sniffer/MailPoet/free-ruleset.xml',
   ];
   if (files !== 'all') {
     if (files.length === 0) return [];

--- a/tools/mcp-server/src/tools/qa-run.ts
+++ b/tools/mcp-server/src/tools/qa-run.ts
@@ -80,10 +80,29 @@ async function uncommittedFiles(
 ): Promise<string[]> {
   const res = await exec('git', ['status', '--porcelain'], { cwd: repoRoot });
   if (res.exitCode !== 0) return [];
-  const files = res.stdout
-    .split('\n')
-    .map((l) => l.slice(3).trim())
-    .filter(Boolean);
+  // git status --porcelain format:
+  //   XY path          — standard changes (X = staged, Y = unstaged)
+  //   R  old -> new    — rename (index or worktree)
+  //   C  old -> new    — copy
+  //   D  path          — deletion — skip, file is gone
+  // We want the current path on disk, excluding deletions.
+  const files: string[] = [];
+  for (const rawLine of res.stdout.split('\n')) {
+    if (rawLine.length < 4) continue;
+    const x = rawLine[0];
+    const y = rawLine[1];
+    // Skip deletions in either index or worktree — no file to lint.
+    if (x === 'D' || y === 'D') continue;
+    const rest = rawLine.slice(3).trim();
+    if (!rest) continue;
+    // Rename / copy keep the new name (after ' -> ').
+    if (x === 'R' || x === 'C') {
+      const idx = rest.indexOf(' -> ');
+      files.push(idx === -1 ? rest : rest.slice(idx + 4).trim());
+    } else {
+      files.push(rest);
+    }
+  }
   if (extensions.length === 0) return files;
   return files.filter((f) => extensions.includes(extname(f)));
 }
@@ -101,6 +120,19 @@ async function resolveScope(
         'path_required',
         "scope='file' requires a 'path' argument.",
       );
+    // Defensive: don't let an agent point a linter at ../../etc/passwd.
+    // spawn() has no shell, and linters are read-only, so the practical
+    // blast radius is nil — but this keeps the invariant obvious.
+    const absolute = resolve(config.repoRoot, path);
+    const repoRootWithSep = config.repoRoot.endsWith('/')
+      ? config.repoRoot
+      : config.repoRoot + '/';
+    if (absolute !== config.repoRoot && !absolute.startsWith(repoRootWithSep)) {
+      throw new ToolError(
+        'path_outside_repo',
+        `Path '${path}' resolves outside the repo root (${config.repoRoot}).`,
+      );
+    }
     return { files: [path], resolvedFromBranch: false };
   }
   const exts = EXTENSIONS_BY_TOOL[tool];

--- a/tools/mcp-server/src/tools/qa-run.ts
+++ b/tools/mcp-server/src/tools/qa-run.ts
@@ -1,0 +1,318 @@
+import { resolve, relative, extname } from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { exec } from "../util/exec.js";
+import { ToolError } from "../util/errors.js";
+import { runHandler } from "./register.js";
+
+const QaTool = z.enum(["phpstan", "phpcs", "eslint", "stylelint", "prettier", "tsc"]);
+type QaTool = z.infer<typeof QaTool>;
+const QaScope = z.enum(["all", "changed", "file"]);
+
+type Severity = "error" | "warning" | "info";
+
+interface Violation {
+  tool: QaTool;
+  file: string;      // relative to repo root
+  line: number;
+  column: number | null;
+  rule: string;
+  severity: Severity;
+  message: string;
+  fixable: boolean;
+}
+
+const EXTENSIONS_BY_TOOL: Record<QaTool, string[]> = {
+  phpstan: [".php"],
+  phpcs: [".php"],
+  eslint: [".js", ".jsx", ".ts", ".tsx"],
+  stylelint: [".scss", ".css"],
+  prettier: [".js", ".jsx", ".ts", ".tsx", ".scss", ".css", ".json", ".md", ".yml", ".yaml", ".html"],
+  tsc: [],
+};
+
+async function changedFiles(repoRoot: string, extensions: string[]): Promise<string[]> {
+  const res = await exec("git", ["diff", "--name-only", "--diff-filter=ACMR", "trunk...HEAD"], { cwd: repoRoot });
+  if (res.exitCode !== 0) {
+    throw new ToolError("git_diff_failed", `git diff failed: ${res.stderr.trim() || res.stdout.trim()}`);
+  }
+  const files = res.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  if (extensions.length === 0) return files;
+  return files.filter((f) => extensions.includes(extname(f)));
+}
+
+async function uncommittedFiles(repoRoot: string, extensions: string[]): Promise<string[]> {
+  const res = await exec("git", ["status", "--porcelain"], { cwd: repoRoot });
+  if (res.exitCode !== 0) return [];
+  const files = res.stdout
+    .split("\n")
+    .map((l) => l.slice(3).trim())
+    .filter(Boolean);
+  if (extensions.length === 0) return files;
+  return files.filter((f) => extensions.includes(extname(f)));
+}
+
+async function resolveScope(
+  scope: "all" | "changed" | "file",
+  path: string | undefined,
+  tool: QaTool,
+  config: Config,
+): Promise<{ files: string[] | "all"; resolvedFromBranch: boolean }> {
+  if (scope === "all") return { files: "all", resolvedFromBranch: false };
+  if (scope === "file") {
+    if (!path) throw new ToolError("path_required", "scope='file' requires a 'path' argument.");
+    return { files: [path], resolvedFromBranch: false };
+  }
+  const exts = EXTENSIONS_BY_TOOL[tool];
+  const committed = await changedFiles(config.repoRoot, exts);
+  const uncommitted = await uncommittedFiles(config.repoRoot, exts);
+  const merged = Array.from(new Set([...committed, ...uncommitted]));
+  return { files: merged, resolvedFromBranch: true };
+}
+
+function toAbsolute(path: string, config: Config): string {
+  return resolve(config.repoRoot, path);
+}
+
+function toRepoRel(absOrRel: string, config: Config): string {
+  return relative(config.repoRoot, resolve(config.repoRoot, absOrRel));
+}
+
+async function runPhpstan(files: string[] | "all", config: Config): Promise<Violation[]> {
+  const phpstan = "./tasks/phpstan/vendor/bin/phpstan";
+  const args = ["analyse", "--no-progress", "--error-format=json", "--memory-limit=2G"];
+  if (files !== "all") {
+    if (files.length === 0) return [];
+    const rel = files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config)));
+    args.push(...rel);
+  }
+  const res = await exec(phpstan, args, { cwd: config.mailpoetDir, timeoutMs: 5 * 60 * 1000 });
+  // PHPStan exits 1 when it finds violations; that's expected.
+  let parsed: { files: Record<string, { messages: { message: string; line: number; ignorable?: boolean; identifier?: string }[] }> };
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    throw new ToolError("phpstan_bad_json", "PHPStan output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+  }
+  const out: Violation[] = [];
+  for (const [file, fileData] of Object.entries(parsed.files ?? {})) {
+    for (const msg of fileData.messages) {
+      out.push({
+        tool: "phpstan",
+        file: toRepoRel(file, config),
+        line: msg.line ?? 0,
+        column: null,
+        rule: msg.identifier || "phpstan",
+        severity: "error",
+        message: msg.message,
+        fixable: false,
+      });
+    }
+  }
+  return out;
+}
+
+async function runPhpcs(files: string[] | "all", config: Config): Promise<Violation[]> {
+  const phpcs = "./tasks/code_sniffer/vendor/bin/phpcs";
+  const args = ["--report=json", "--standard=./tasks/code_sniffer/MailPoet/ruleset.xml"];
+  if (files !== "all") {
+    if (files.length === 0) return [];
+    args.push(...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))));
+  } else {
+    args.push("lib/", "tests/");
+  }
+  const res = await exec(phpcs, args, { cwd: config.mailpoetDir, timeoutMs: 5 * 60 * 1000 });
+  let parsed: { files: Record<string, { messages: { message: string; source: string; line: number; column: number; type: string; fixable: boolean }[] }> };
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    throw new ToolError("phpcs_bad_json", "PHPCS output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+  }
+  const out: Violation[] = [];
+  for (const [file, fileData] of Object.entries(parsed.files ?? {})) {
+    for (const m of fileData.messages) {
+      out.push({
+        tool: "phpcs",
+        file: toRepoRel(file, config),
+        line: m.line,
+        column: m.column,
+        rule: m.source,
+        severity: m.type === "ERROR" ? "error" : m.type === "WARNING" ? "warning" : "info",
+        message: m.message,
+        fixable: !!m.fixable,
+      });
+    }
+  }
+  return out;
+}
+
+async function runEslint(files: string[] | "all", config: Config): Promise<Violation[]> {
+  const args = ["--format=json", "--max-warnings", "9999"];
+  if (files !== "all") {
+    if (files.length === 0) return [];
+    args.push(...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))));
+  } else {
+    args.push("assets/js/src/**/*.{js,jsx,ts,tsx}");
+  }
+  const res = await exec("./node_modules/.bin/eslint", args, {
+    cwd: config.mailpoetDir,
+    timeoutMs: 5 * 60 * 1000,
+    env: { ...process.env, NODE_OPTIONS: "--max_old_space_size=2048" },
+  });
+  let parsed: { filePath: string; messages: { ruleId: string | null; severity: number; message: string; line: number; column: number; fix?: unknown }[] }[];
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    throw new ToolError("eslint_bad_json", "ESLint output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+  }
+  const out: Violation[] = [];
+  for (const fileReport of parsed) {
+    for (const m of fileReport.messages) {
+      out.push({
+        tool: "eslint",
+        file: toRepoRel(fileReport.filePath, config),
+        line: m.line,
+        column: m.column,
+        rule: m.ruleId ?? "eslint",
+        severity: m.severity === 2 ? "error" : "warning",
+        message: m.message,
+        fixable: !!m.fix,
+      });
+    }
+  }
+  return out;
+}
+
+async function runStylelint(files: string[] | "all", config: Config): Promise<Violation[]> {
+  const args = ["--formatter=json"];
+  if (files !== "all") {
+    if (files.length === 0) return [];
+    args.push(...files.map((f) => relative(config.mailpoetDir, toAbsolute(f, config))));
+  } else {
+    args.push("assets/css/src/**/*.scss");
+  }
+  const res = await exec("./node_modules/.bin/stylelint", args, { cwd: config.mailpoetDir, timeoutMs: 5 * 60 * 1000 });
+  let parsed: { source: string; warnings: { line: number; column: number; rule: string; severity: string; text: string }[] }[];
+  try {
+    parsed = JSON.parse(res.stdout || "[]");
+  } catch {
+    throw new ToolError("stylelint_bad_json", "Stylelint output was not JSON", { stdout: res.stdout.slice(0, 500), stderr: res.stderr.slice(0, 500) });
+  }
+  const out: Violation[] = [];
+  for (const file of parsed) {
+    for (const w of file.warnings) {
+      out.push({
+        tool: "stylelint",
+        file: toRepoRel(file.source, config),
+        line: w.line,
+        column: w.column,
+        rule: w.rule,
+        severity: w.severity === "error" ? "error" : "warning",
+        message: w.text,
+        fixable: false,
+      });
+    }
+  }
+  return out;
+}
+
+async function runPrettier(files: string[] | "all", config: Config): Promise<Violation[]> {
+  const args = ["--list-different"];
+  if (files !== "all") {
+    if (files.length === 0) return [];
+    args.push(...files);
+  } else {
+    args.push(".");
+  }
+  const res = await exec("npx", ["prettier", ...args], { cwd: config.repoRoot, timeoutMs: 5 * 60 * 1000 });
+  const out: Violation[] = [];
+  for (const line of res.stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    out.push({
+      tool: "prettier",
+      file: toRepoRel(trimmed, config),
+      line: 0,
+      column: null,
+      rule: "prettier/formatting",
+      severity: "warning",
+      message: "File is not Prettier-formatted.",
+      fixable: true,
+    });
+  }
+  return out;
+}
+
+async function runTsc(config: Config): Promise<Violation[]> {
+  const res = await exec("./node_modules/.bin/tsc", ["--noEmit", "--pretty", "false"], {
+    cwd: config.mailpoetDir,
+    timeoutMs: 5 * 60 * 1000,
+    env: { ...process.env, NODE_OPTIONS: "--max_old_space_size=2048" },
+  });
+  const out: Violation[] = [];
+  // TSC line format: "path/to/file.ts(line,col): error TSxxxx: message"
+  const re = /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$/;
+  for (const line of res.stdout.split("\n")) {
+    const m = re.exec(line.trim());
+    if (!m) continue;
+    out.push({
+      tool: "tsc",
+      file: toRepoRel(resolve(config.mailpoetDir, m[1]!), config),
+      line: Number(m[2]),
+      column: Number(m[3]),
+      rule: m[5]!,
+      severity: m[4] === "error" ? "error" : "warning",
+      message: m[6]!,
+      fixable: false,
+    });
+  }
+  return out;
+}
+
+export function registerQaRun(server: McpServer, config: Config): void {
+  server.registerTool(
+    "mp.qa.run",
+    {
+      title: "Run a QA / lint tool",
+      description:
+        "Runs one of the MailPoet QA tools (phpstan, phpcs, eslint, stylelint, prettier, tsc) and returns a flat list of structured violations. Default scope='changed' runs against files modified vs trunk (committed + uncommitted). scope='file' requires 'path'. scope='all' runs everywhere (slow).",
+      inputSchema: {
+        tool: QaTool.describe("Which linter / static analyser to run."),
+        scope: QaScope.optional().describe("'changed' (default): files changed vs trunk + uncommitted. 'file': single path. 'all': everywhere."),
+        path: z.string().optional().describe("Path relative to repo root. Required when scope='file'."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args) =>
+      runHandler("mp.qa.run", args, async () => {
+        const tool = args.tool;
+        const scope = args.scope ?? "changed";
+
+        const { files, resolvedFromBranch } = await resolveScope(scope, args.path, tool, config);
+        const started = Date.now();
+
+        let violations: Violation[];
+        if (tool === "phpstan") violations = await runPhpstan(files, config);
+        else if (tool === "phpcs") violations = await runPhpcs(files, config);
+        else if (tool === "eslint") violations = await runEslint(files, config);
+        else if (tool === "stylelint") violations = await runStylelint(files, config);
+        else if (tool === "prettier") violations = await runPrettier(files, config);
+        else violations = await runTsc(config);
+
+        const errors = violations.filter((v) => v.severity === "error").length;
+        const warnings = violations.filter((v) => v.severity === "warning").length;
+        const fixable = violations.filter((v) => v.fixable).length;
+
+        return {
+          tool,
+          scope,
+          resolved_from_branch: resolvedFromBranch,
+          files_analyzed: files === "all" ? null : files.length,
+          duration_ms: Date.now() - started,
+          violations,
+          summary: { errors, warnings, fixable },
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/tools/qa-run.ts
+++ b/tools/mcp-server/src/tools/qa-run.ts
@@ -118,6 +118,27 @@ function toRepoRel(absOrRel: string, config: Config): string {
   return relative(config.repoRoot, resolve(config.repoRoot, absOrRel));
 }
 
+// When a linter dies before writing any JSON (PHPStan OOM, missing config
+// file, etc.), its real error usually lands on stderr. Surface that in the
+// tool error message so the agent doesn't see a useless "output was not JSON".
+function badJsonError(
+  code: string,
+  toolLabel: string,
+  res: { stdout: string; stderr: string; exitCode: number },
+): ToolError {
+  const stdoutTrim = res.stdout.trim();
+  const stderrTrim = res.stderr.trim();
+  const hint =
+    stdoutTrim === '' && stderrTrim !== ''
+      ? `${toolLabel} produced no stdout. stderr: ${stderrTrim.slice(0, 300)}`
+      : `${toolLabel} output was not JSON.`;
+  return new ToolError(code, hint, {
+    exit_code: res.exitCode,
+    stdout: res.stdout.slice(0, 500),
+    stderr: res.stderr.slice(0, 500),
+  });
+}
+
 async function runPhpstan(
   files: string[] | 'all',
   config: Config,
@@ -157,10 +178,7 @@ async function runPhpstan(
   try {
     parsed = JSON.parse(res.stdout);
   } catch {
-    throw new ToolError('phpstan_bad_json', 'PHPStan output was not JSON', {
-      stdout: res.stdout.slice(0, 500),
-      stderr: res.stderr.slice(0, 500),
-    });
+    throw badJsonError('phpstan_bad_json', 'PHPStan', res);
   }
   const out: Violation[] = [];
   for (const [file, fileData] of Object.entries(parsed.files ?? {})) {
@@ -219,10 +237,7 @@ async function runPhpcs(
   try {
     parsed = JSON.parse(res.stdout);
   } catch {
-    throw new ToolError('phpcs_bad_json', 'PHPCS output was not JSON', {
-      stdout: res.stdout.slice(0, 500),
-      stderr: res.stderr.slice(0, 500),
-    });
+    throw badJsonError('phpcs_bad_json', 'PHPCS', res);
   }
   const out: Violation[] = [];
   for (const [file, fileData] of Object.entries(parsed.files ?? {})) {
@@ -279,10 +294,7 @@ async function runEslint(
   try {
     parsed = JSON.parse(res.stdout);
   } catch {
-    throw new ToolError('eslint_bad_json', 'ESLint output was not JSON', {
-      stdout: res.stdout.slice(0, 500),
-      stderr: res.stderr.slice(0, 500),
-    });
+    throw badJsonError('eslint_bad_json', 'ESLint', res);
   }
   const out: Violation[] = [];
   for (const fileReport of parsed) {
@@ -332,10 +344,7 @@ async function runStylelint(
   try {
     parsed = JSON.parse(res.stdout || '[]');
   } catch {
-    throw new ToolError('stylelint_bad_json', 'Stylelint output was not JSON', {
-      stdout: res.stdout.slice(0, 500),
-      stderr: res.stderr.slice(0, 500),
-    });
+    throw badJsonError('stylelint_bad_json', 'Stylelint', res);
   }
   const out: Violation[] = [];
   for (const file of parsed) {

--- a/tools/mcp-server/src/tools/register.ts
+++ b/tools/mcp-server/src/tools/register.ts
@@ -1,14 +1,16 @@
-import { toToolResult } from "../util/errors.js";
-import { ToolError } from "../util/errors.js";
-import { recordToolCall } from "../util/telemetry.js";
+import { toToolResult } from '../util/errors.js';
+import { ToolError } from '../util/errors.js';
+import { recordToolCall } from '../util/telemetry.js';
 
 export type McpTextResult = {
-  content: { type: "text"; text: string }[];
+  content: { type: 'text'; text: string }[];
   isError?: boolean;
 };
 
 export function toMcpResponse(result: unknown): McpTextResult {
-  return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+  };
 }
 
 export async function runHandler(
@@ -24,7 +26,7 @@ export async function runHandler(
       ts: new Date().toISOString(),
       tool: toolName,
       duration_ms: Date.now() - started,
-      status: "ok",
+      status: 'ok',
       input_keys: inputKeys,
     });
     return toMcpResponse(result);
@@ -34,8 +36,8 @@ export async function runHandler(
       ts: new Date().toISOString(),
       tool: toolName,
       duration_ms: Date.now() - started,
-      status: "error",
-      error_code: err instanceof ToolError ? err.code : "unknown",
+      status: 'error',
+      error_code: err instanceof ToolError ? err.code : 'unknown',
       input_keys: inputKeys,
     });
     return errResult;

--- a/tools/mcp-server/src/tools/register.ts
+++ b/tools/mcp-server/src/tools/register.ts
@@ -1,0 +1,43 @@
+import { toToolResult } from "../util/errors.js";
+import { ToolError } from "../util/errors.js";
+import { recordToolCall } from "../util/telemetry.js";
+
+export type McpTextResult = {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+};
+
+export function toMcpResponse(result: unknown): McpTextResult {
+  return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+}
+
+export async function runHandler(
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+  handler: () => Promise<unknown>,
+): Promise<McpTextResult> {
+  const started = Date.now();
+  const inputKeys = args ? Object.keys(args) : [];
+  try {
+    const result = await handler();
+    recordToolCall({
+      ts: new Date().toISOString(),
+      tool: toolName,
+      duration_ms: Date.now() - started,
+      status: "ok",
+      input_keys: inputKeys,
+    });
+    return toMcpResponse(result);
+  } catch (err) {
+    const errResult = toToolResult(err);
+    recordToolCall({
+      ts: new Date().toISOString(),
+      tool: toolName,
+      duration_ms: Date.now() - started,
+      status: "error",
+      error_code: err instanceof ToolError ? err.code : "unknown",
+      input_keys: inputKeys,
+    });
+    return errResult;
+  }
+}

--- a/tools/mcp-server/src/tools/test-run.ts
+++ b/tools/mcp-server/src/tools/test-run.ts
@@ -1,13 +1,13 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { XMLParser } from "fast-xml-parser";
-import { z } from "zod";
-import type { Config } from "../config.js";
-import { exec } from "../util/exec.js";
-import { runHandler } from "./register.js";
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { XMLParser } from 'fast-xml-parser';
+import { z } from 'zod';
+import type { Config } from '../config.js';
+import { exec } from '../util/exec.js';
+import { runHandler } from './register.js';
 
-const Suite = z.enum(["unit", "integration"]);
+const Suite = z.enum(['unit', 'integration']);
 
 interface TestFailure {
   test: string;
@@ -29,12 +29,20 @@ interface ParsedReport {
 
 function parseJunit(xmlPath: string): ParsedReport | null {
   if (!existsSync(xmlPath)) return null;
-  const xml = readFileSync(xmlPath, "utf8");
-  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_", trimValues: true });
+  const xml = readFileSync(xmlPath, 'utf8');
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    trimValues: true,
+  });
   const doc = parser.parse(xml);
 
   const root = doc.testsuites ?? doc;
-  const suites = Array.isArray(root.testsuite) ? root.testsuite : root.testsuite ? [root.testsuite] : [];
+  const suites = Array.isArray(root.testsuite)
+    ? root.testsuite
+    : root.testsuite
+    ? [root.testsuite]
+    : [];
 
   let total = 0;
   let failed = 0;
@@ -45,11 +53,11 @@ function parseJunit(xmlPath: string): ParsedReport | null {
 
   const walk = (suiteNode: Record<string, unknown>): void => {
     const n = (k: string): number => Number(suiteNode[k] ?? 0);
-    total += n("@_tests");
-    failed += n("@_failures");
-    skipped += n("@_skipped");
-    errors += n("@_errors");
-    durationSec += n("@_time");
+    total += n('@_tests');
+    failed += n('@_failures');
+    skipped += n('@_skipped');
+    errors += n('@_errors');
+    durationSec += n('@_time');
 
     const cases = Array.isArray(suiteNode.testcase)
       ? (suiteNode.testcase as Record<string, unknown>[])
@@ -61,13 +69,20 @@ function parseJunit(xmlPath: string): ParsedReport | null {
       const fail = tc.failure ?? tc.error;
       if (!fail) continue;
       const f = Array.isArray(fail) ? fail[0] : fail;
-      const fObj = typeof f === "object" && f !== null ? (f as Record<string, unknown>) : null;
-      const text = fObj && "#text" in fObj ? String(fObj["#text"]) : String(f ?? "");
-      const message = fObj && "@_message" in fObj ? String(fObj["@_message"]) : text.split("\n")[0] ?? "";
-      const clsName = String(tc["@_classname"] ?? "");
-      const testName = String(tc["@_name"] ?? "");
-      const fileAttr = tc["@_file"];
-      const lineAttr = tc["@_line"];
+      const fObj =
+        typeof f === 'object' && f !== null
+          ? (f as Record<string, unknown>)
+          : null;
+      const text =
+        fObj && '#text' in fObj ? String(fObj['#text']) : String(f ?? '');
+      const message =
+        fObj && '@_message' in fObj
+          ? String(fObj['@_message'])
+          : text.split('\n')[0] ?? '';
+      const clsName = String(tc['@_classname'] ?? '');
+      const testName = String(tc['@_name'] ?? '');
+      const fileAttr = tc['@_file'];
+      const lineAttr = tc['@_line'];
       failures.push({
         test: clsName ? `${clsName}::${testName}` : testName,
         file: fileAttr ? String(fileAttr) : null,
@@ -100,47 +115,66 @@ function parseJunit(xmlPath: string): ParsedReport | null {
 
 export function registerTestRun(server: McpServer, config: Config): void {
   server.registerTool(
-    "mp.test.run",
+    'mp.test.run',
     {
-      title: "Run MailPoet tests",
+      title: 'Run MailPoet tests',
       description:
         "Runs a MailPoet Codeception test suite and returns structured failures. Supports 'unit' (fast, on host) and 'integration' (tests_env docker stack, --skip-deps by default). Full raw output is written to a file; the response returns only structured failures plus the log path to keep tokens small.",
       inputSchema: {
         suite: Suite.describe("Test suite to run: 'unit' or 'integration'."),
-        filter: z.string().optional().describe("Codeception --filter pattern."),
-        file: z.string().optional().describe("Path to a specific test file, relative to mailpoet/ (e.g. 'tests/unit/WP/EmojiTest.php')."),
+        filter: z.string().optional().describe('Codeception --filter pattern.'),
+        file: z
+          .string()
+          .optional()
+          .describe(
+            "Path to a specific test file, relative to mailpoet/ (e.g. 'tests/unit/WP/EmojiTest.php').",
+          ),
       },
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
     },
     async (args) =>
-      runHandler("mp.test.run", args, async () => {
-        const xmlPath = resolve(config.mailpoetDir, "tests/_output/report.xml");
-        const logPath = resolve(config.mailpoetDir, "tests/_output/mcp-last-run.log");
+      runHandler('mp.test.run', args, async () => {
+        const xmlPath = resolve(config.mailpoetDir, 'tests/_output/report.xml');
+        const logPath = resolve(
+          config.mailpoetDir,
+          'tests/_output/mcp-last-run.log',
+        );
 
         // Delete any stale JUnit report so that if Codeception never reaches the
         // point of emitting a new one (e.g. invalid file path, bootstrap error),
         // we return zeroed counts instead of the previous run's data.
         if (existsSync(xmlPath)) rmSync(xmlPath);
 
-        const cmdArgs = [args.suite === "unit" ? "test:unit" : "test:integration", "--xml"];
-        if (args.suite === "integration") cmdArgs.push("--skip-deps");
+        const cmdArgs = [
+          args.suite === 'unit' ? 'test:unit' : 'test:integration',
+          '--xml',
+        ];
+        if (args.suite === 'integration') cmdArgs.push('--skip-deps');
         if (args.file) cmdArgs.push(`--file=${args.file}`);
         if (args.filter) cmdArgs.push(`--filter=${args.filter}`);
 
-        const result = await exec("./do", cmdArgs, {
+        const result = await exec('./do', cmdArgs, {
           cwd: config.mailpoetDir,
-          timeoutMs: args.suite === "integration" ? 30 * 60 * 1000 : 10 * 60 * 1000,
+          timeoutMs:
+            args.suite === 'integration' ? 30 * 60 * 1000 : 10 * 60 * 1000,
         });
         writeFileSync(
           logPath,
-          `$ ./do ${cmdArgs.join(" ")}\n\n[exit ${result.exitCode}]\n\n# stdout\n${result.stdout}\n\n# stderr\n${result.stderr}\n`,
+          `$ ./do ${cmdArgs.join(' ')}\n\n[exit ${
+            result.exitCode
+          }]\n\n# stdout\n${result.stdout}\n\n# stderr\n${result.stderr}\n`,
         );
 
         const report = parseJunit(xmlPath);
 
         return {
           suite: args.suite,
-          status: result.exitCode === 0 ? "passed" : "failed",
+          status: result.exitCode === 0 ? 'passed' : 'failed',
           exit_code: result.exitCode,
           duration_ms: result.duration_ms,
           counts: report
@@ -157,7 +191,7 @@ export function registerTestRun(server: McpServer, config: Config): void {
           junit_xml_path: existsSync(xmlPath) ? xmlPath : null,
           note:
             report === null
-              ? "JUnit XML not found — check the log file for details. The Codeception run may have errored before emitting a report."
+              ? 'JUnit XML not found — check the log file for details. The Codeception run may have errored before emitting a report.'
               : undefined,
         };
       }),

--- a/tools/mcp-server/src/tools/test-run.ts
+++ b/tools/mcp-server/src/tools/test-run.ts
@@ -122,9 +122,22 @@ export function registerTestRun(server: McpServer, config: Config): void {
         "Runs a MailPoet Codeception test suite and returns structured failures. Supports 'unit' (fast, on host) and 'integration' (tests_env docker stack, --skip-deps by default). Full raw output is written to a file; the response returns only structured failures plus the log path to keep tokens small.",
       inputSchema: {
         suite: Suite.describe("Test suite to run: 'unit' or 'integration'."),
-        filter: z.string().optional().describe('Codeception --filter pattern.'),
+        filter: z
+          .string()
+          .regex(
+            /^[\w:./\\-]+$/,
+            'Filter must only contain alphanumerics, :, \\, /, ., _, -. Regex metacharacters are rejected because Robo composes the shell command as a string.',
+          )
+          .optional()
+          .describe(
+            "Codeception --filter pattern. Restricted charset to avoid shell-injection via Robo's string-based _exec (e.g. 'testFoo', 'Foo\\\\BarTest::testBaz').",
+          ),
         file: z
           .string()
+          .regex(
+            /^[\w./-]+$/,
+            'File path must only contain alphanumerics, ., /, -, _. Shell metacharacters are rejected.',
+          )
           .optional()
           .describe(
             "Path to a specific test file, relative to mailpoet/ (e.g. 'tests/unit/WP/EmojiTest.php').",

--- a/tools/mcp-server/src/tools/test-run.ts
+++ b/tools/mcp-server/src/tools/test-run.ts
@@ -51,13 +51,13 @@ function parseJunit(xmlPath: string): ParsedReport | null {
   let durationSec = 0;
   const failures: TestFailure[] = [];
 
+  // Count per <testcase> rather than summing <testsuite tests="..."> attributes:
+  // nested JUnit structures (testsuites > testsuite > testsuite) have parent
+  // nodes that aggregate their children, so summing every level double-counts.
+  // Per-testcase is unambiguous and matches what we actually show.
   const walk = (suiteNode: Record<string, unknown>): void => {
-    const n = (k: string): number => Number(suiteNode[k] ?? 0);
-    total += n('@_tests');
-    failed += n('@_failures');
-    skipped += n('@_skipped');
-    errors += n('@_errors');
-    durationSec += n('@_time');
+    const time = Number(suiteNode['@_time'] ?? 0);
+    durationSec += time;
 
     const cases = Array.isArray(suiteNode.testcase)
       ? (suiteNode.testcase as Record<string, unknown>[])
@@ -66,9 +66,22 @@ function parseJunit(xmlPath: string): ParsedReport | null {
       : [];
 
     for (const tc of cases) {
-      const fail = tc.failure ?? tc.error;
-      if (!fail) continue;
-      const f = Array.isArray(fail) ? fail[0] : fail;
+      total++;
+      const fail = tc.failure;
+      const err = tc.error;
+      const skip = tc.skipped;
+
+      if (fail) {
+        failed++;
+      } else if (err) {
+        errors++;
+      } else if (skip) {
+        skipped++;
+      }
+
+      const issue = fail ?? err;
+      if (!issue) continue;
+      const f = Array.isArray(issue) ? issue[0] : issue;
       const fObj =
         typeof f === 'object' && f !== null
           ? (f as Record<string, unknown>)
@@ -183,7 +196,16 @@ export function registerTestRun(server: McpServer, config: Config): void {
           }]\n\n# stdout\n${result.stdout}\n\n# stderr\n${result.stderr}\n`,
         );
 
-        const report = parseJunit(xmlPath);
+        // A crashed Codeception run can write a truncated XML that
+        // fast-xml-parser refuses to parse. Treat that as "no report" rather
+        // than letting the parser error surface as an unhandled throw.
+        let report: ParsedReport | null = null;
+        let parseError: string | null = null;
+        try {
+          report = parseJunit(xmlPath);
+        } catch (e) {
+          parseError = e instanceof Error ? e.message : String(e);
+        }
 
         return {
           suite: args.suite,
@@ -202,9 +224,12 @@ export function registerTestRun(server: McpServer, config: Config): void {
           failures: report?.failures ?? [],
           log_path: logPath,
           junit_xml_path: existsSync(xmlPath) ? xmlPath : null,
+          parse_error: parseError,
           note:
             report === null
-              ? 'JUnit XML not found — check the log file for details. The Codeception run may have errored before emitting a report.'
+              ? parseError
+                ? `JUnit XML could not be parsed (${parseError}). Check the log file for details.`
+                : 'JUnit XML not found — check the log file for details. The Codeception run may have errored before emitting a report.'
               : undefined,
         };
       }),

--- a/tools/mcp-server/src/tools/test-run.ts
+++ b/tools/mcp-server/src/tools/test-run.ts
@@ -1,0 +1,165 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { XMLParser } from "fast-xml-parser";
+import { z } from "zod";
+import type { Config } from "../config.js";
+import { exec } from "../util/exec.js";
+import { runHandler } from "./register.js";
+
+const Suite = z.enum(["unit", "integration"]);
+
+interface TestFailure {
+  test: string;
+  file: string | null;
+  line: number | null;
+  message: string;
+  trace: string;
+}
+
+interface ParsedReport {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  errors: number;
+  duration_ms: number;
+  failures: TestFailure[];
+}
+
+function parseJunit(xmlPath: string): ParsedReport | null {
+  if (!existsSync(xmlPath)) return null;
+  const xml = readFileSync(xmlPath, "utf8");
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_", trimValues: true });
+  const doc = parser.parse(xml);
+
+  const root = doc.testsuites ?? doc;
+  const suites = Array.isArray(root.testsuite) ? root.testsuite : root.testsuite ? [root.testsuite] : [];
+
+  let total = 0;
+  let failed = 0;
+  let skipped = 0;
+  let errors = 0;
+  let durationSec = 0;
+  const failures: TestFailure[] = [];
+
+  const walk = (suiteNode: Record<string, unknown>): void => {
+    const n = (k: string): number => Number(suiteNode[k] ?? 0);
+    total += n("@_tests");
+    failed += n("@_failures");
+    skipped += n("@_skipped");
+    errors += n("@_errors");
+    durationSec += n("@_time");
+
+    const cases = Array.isArray(suiteNode.testcase)
+      ? (suiteNode.testcase as Record<string, unknown>[])
+      : suiteNode.testcase
+      ? [suiteNode.testcase as Record<string, unknown>]
+      : [];
+
+    for (const tc of cases) {
+      const fail = tc.failure ?? tc.error;
+      if (!fail) continue;
+      const f = Array.isArray(fail) ? fail[0] : fail;
+      const fObj = typeof f === "object" && f !== null ? (f as Record<string, unknown>) : null;
+      const text = fObj && "#text" in fObj ? String(fObj["#text"]) : String(f ?? "");
+      const message = fObj && "@_message" in fObj ? String(fObj["@_message"]) : text.split("\n")[0] ?? "";
+      const clsName = String(tc["@_classname"] ?? "");
+      const testName = String(tc["@_name"] ?? "");
+      const fileAttr = tc["@_file"];
+      const lineAttr = tc["@_line"];
+      failures.push({
+        test: clsName ? `${clsName}::${testName}` : testName,
+        file: fileAttr ? String(fileAttr) : null,
+        line: lineAttr !== undefined ? Number(lineAttr) : null,
+        message,
+        trace: text,
+      });
+    }
+
+    const nested = Array.isArray(suiteNode.testsuite)
+      ? suiteNode.testsuite
+      : suiteNode.testsuite
+      ? [suiteNode.testsuite]
+      : [];
+    for (const child of nested) walk(child as Record<string, unknown>);
+  };
+
+  for (const s of suites) walk(s as Record<string, unknown>);
+
+  return {
+    total,
+    passed: Math.max(0, total - failed - errors - skipped),
+    failed,
+    skipped,
+    errors,
+    duration_ms: Math.round(durationSec * 1000),
+    failures,
+  };
+}
+
+export function registerTestRun(server: McpServer, config: Config): void {
+  server.registerTool(
+    "mp.test.run",
+    {
+      title: "Run MailPoet tests",
+      description:
+        "Runs a MailPoet Codeception test suite and returns structured failures. Supports 'unit' (fast, on host) and 'integration' (tests_env docker stack, --skip-deps by default). Full raw output is written to a file; the response returns only structured failures plus the log path to keep tokens small.",
+      inputSchema: {
+        suite: Suite.describe("Test suite to run: 'unit' or 'integration'."),
+        filter: z.string().optional().describe("Codeception --filter pattern."),
+        file: z.string().optional().describe("Path to a specific test file, relative to mailpoet/ (e.g. 'tests/unit/WP/EmojiTest.php')."),
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    },
+    async (args) =>
+      runHandler("mp.test.run", args, async () => {
+        const xmlPath = resolve(config.mailpoetDir, "tests/_output/report.xml");
+        const logPath = resolve(config.mailpoetDir, "tests/_output/mcp-last-run.log");
+
+        // Delete any stale JUnit report so that if Codeception never reaches the
+        // point of emitting a new one (e.g. invalid file path, bootstrap error),
+        // we return zeroed counts instead of the previous run's data.
+        if (existsSync(xmlPath)) rmSync(xmlPath);
+
+        const cmdArgs = [args.suite === "unit" ? "test:unit" : "test:integration", "--xml"];
+        if (args.suite === "integration") cmdArgs.push("--skip-deps");
+        if (args.file) cmdArgs.push(`--file=${args.file}`);
+        if (args.filter) cmdArgs.push(`--filter=${args.filter}`);
+
+        const result = await exec("./do", cmdArgs, {
+          cwd: config.mailpoetDir,
+          timeoutMs: args.suite === "integration" ? 30 * 60 * 1000 : 10 * 60 * 1000,
+        });
+        writeFileSync(
+          logPath,
+          `$ ./do ${cmdArgs.join(" ")}\n\n[exit ${result.exitCode}]\n\n# stdout\n${result.stdout}\n\n# stderr\n${result.stderr}\n`,
+        );
+
+        const report = parseJunit(xmlPath);
+
+        return {
+          suite: args.suite,
+          status: result.exitCode === 0 ? "passed" : "failed",
+          exit_code: result.exitCode,
+          duration_ms: result.duration_ms,
+          counts: report
+            ? {
+                total: report.total,
+                passed: report.passed,
+                failed: report.failed,
+                skipped: report.skipped,
+                errors: report.errors,
+              }
+            : null,
+          failures: report?.failures ?? [],
+          log_path: logPath,
+          junit_xml_path: existsSync(xmlPath) ? xmlPath : null,
+          note:
+            report === null
+              ? "JUnit XML not found — check the log file for details. The Codeception run may have errored before emitting a report."
+              : undefined,
+        };
+      }),
+  );
+}

--- a/tools/mcp-server/src/util/errors.ts
+++ b/tools/mcp-server/src/util/errors.ts
@@ -9,14 +9,21 @@ export class ToolError extends Error {
   }
 }
 
-export function toToolResult(err: unknown): { isError: true; content: { type: "text"; text: string }[] } {
+export function toToolResult(err: unknown): {
+  isError: true;
+  content: { type: 'text'; text: string }[];
+} {
   if (err instanceof ToolError) {
     return {
       isError: true,
       content: [
         {
-          type: "text",
-          text: JSON.stringify({ error: { code: err.code, message: err.message, data: err.data } }, null, 2),
+          type: 'text',
+          text: JSON.stringify(
+            { error: { code: err.code, message: err.message, data: err.data } },
+            null,
+            2,
+          ),
         },
       ],
     };
@@ -24,6 +31,11 @@ export function toToolResult(err: unknown): { isError: true; content: { type: "t
   const message = err instanceof Error ? err.message : String(err);
   return {
     isError: true,
-    content: [{ type: "text", text: JSON.stringify({ error: { code: "unknown", message } }, null, 2) }],
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ error: { code: 'unknown', message } }, null, 2),
+      },
+    ],
   };
 }

--- a/tools/mcp-server/src/util/errors.ts
+++ b/tools/mcp-server/src/util/errors.ts
@@ -1,0 +1,29 @@
+export class ToolError extends Error {
+  readonly code: string;
+  readonly data?: unknown;
+
+  constructor(code: string, message: string, data?: unknown) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export function toToolResult(err: unknown): { isError: true; content: { type: "text"; text: string }[] } {
+  if (err instanceof ToolError) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ error: { code: err.code, message: err.message, data: err.data } }, null, 2),
+        },
+      ],
+    };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    isError: true,
+    content: [{ type: "text", text: JSON.stringify({ error: { code: "unknown", message } }, null, 2) }],
+  };
+}

--- a/tools/mcp-server/src/util/exec.ts
+++ b/tools/mcp-server/src/util/exec.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
-import type { SpawnOptionsWithoutStdio } from "node:child_process";
+import { spawn } from 'node:child_process';
+import type { SpawnOptionsWithoutStdio } from 'node:child_process';
 
 export interface ExecResult {
   exitCode: number;
@@ -13,38 +13,51 @@ export interface ExecOptions extends SpawnOptionsWithoutStdio {
   input?: string;
 }
 
-export function exec(command: string, args: string[], options: ExecOptions = {}): Promise<ExecResult> {
+export function exec(
+  command: string,
+  args: string[],
+  options: ExecOptions = {},
+): Promise<ExecResult> {
   const { timeoutMs, input, ...spawnOpts } = options;
   return new Promise((resolvePromise, reject) => {
     const started = Date.now();
-    const child = spawn(command, args, { ...spawnOpts, stdio: ["pipe", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
+    const child = spawn(command, args, {
+      ...spawnOpts,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
     let timedOut = false;
 
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
     });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
     });
 
     const timer = timeoutMs
       ? setTimeout(() => {
           timedOut = true;
-          child.kill("SIGTERM");
+          child.kill('SIGTERM');
         }, timeoutMs)
       : null;
 
-    child.on("error", (err) => {
+    child.on('error', (err) => {
       if (timer) clearTimeout(timer);
       reject(err);
     });
 
-    child.on("close", (code) => {
+    child.on('close', (code) => {
       if (timer) clearTimeout(timer);
       if (timedOut) {
-        reject(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
+        reject(
+          new Error(
+            `Command timed out after ${timeoutMs}ms: ${command} ${args.join(
+              ' ',
+            )}`,
+          ),
+        );
         return;
       }
       resolvePromise({

--- a/tools/mcp-server/src/util/exec.ts
+++ b/tools/mcp-server/src/util/exec.ts
@@ -1,0 +1,65 @@
+import { spawn } from "node:child_process";
+import type { SpawnOptionsWithoutStdio } from "node:child_process";
+
+export interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  duration_ms: number;
+}
+
+export interface ExecOptions extends SpawnOptionsWithoutStdio {
+  timeoutMs?: number;
+  input?: string;
+}
+
+export function exec(command: string, args: string[], options: ExecOptions = {}): Promise<ExecResult> {
+  const { timeoutMs, input, ...spawnOpts } = options;
+  return new Promise((resolvePromise, reject) => {
+    const started = Date.now();
+    const child = spawn(command, args, { ...spawnOpts, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+        }, timeoutMs)
+      : null;
+
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
+        return;
+      }
+      resolvePromise({
+        exitCode: code ?? -1,
+        stdout,
+        stderr,
+        duration_ms: Date.now() - started,
+      });
+    });
+
+    if (input !== undefined) {
+      child.stdin.write(input);
+      child.stdin.end();
+    } else {
+      child.stdin.end();
+    }
+  });
+}

--- a/tools/mcp-server/src/util/telemetry.ts
+++ b/tools/mcp-server/src/util/telemetry.ts
@@ -1,13 +1,13 @@
-import { appendFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 export interface TelemetryEvent {
-  ts: string;              // ISO8601 UTC
-  tool: string;            // e.g. "mp.env.status"
+  ts: string; // ISO8601 UTC
+  tool: string; // e.g. "mp.env.status"
   duration_ms: number;
-  status: "ok" | "error";
+  status: 'ok' | 'error';
   error_code?: string;
-  input_keys: string[];    // keys of the arguments object, not values (avoid leaking secrets/PII)
+  input_keys: string[]; // keys of the arguments object, not values (avoid leaking secrets/PII)
 }
 
 let logPath: string | null = null;
@@ -25,11 +25,15 @@ export function initTelemetry(path: string): void {
 export function recordToolCall(event: TelemetryEvent): void {
   if (!logPath) return;
   try {
-    appendFileSync(logPath, JSON.stringify(event) + "\n");
+    appendFileSync(logPath, JSON.stringify(event) + '\n');
   } catch (e) {
     if (!warnedOnce) {
       warnedOnce = true;
-      process.stderr.write(`[mailpoet-dev-mcp] telemetry write failed: ${e instanceof Error ? e.message : String(e)}\n`);
+      process.stderr.write(
+        `[mailpoet-dev-mcp] telemetry write failed: ${
+          e instanceof Error ? e.message : String(e)
+        }\n`,
+      );
     }
   }
 }

--- a/tools/mcp-server/src/util/telemetry.ts
+++ b/tools/mcp-server/src/util/telemetry.ts
@@ -1,0 +1,35 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface TelemetryEvent {
+  ts: string;              // ISO8601 UTC
+  tool: string;            // e.g. "mp.env.status"
+  duration_ms: number;
+  status: "ok" | "error";
+  error_code?: string;
+  input_keys: string[];    // keys of the arguments object, not values (avoid leaking secrets/PII)
+}
+
+let logPath: string | null = null;
+let warnedOnce = false;
+
+export function initTelemetry(path: string): void {
+  logPath = path;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    // swallow — logging must never kill the server
+  }
+}
+
+export function recordToolCall(event: TelemetryEvent): void {
+  if (!logPath) return;
+  try {
+    appendFileSync(logPath, JSON.stringify(event) + "\n");
+  } catch (e) {
+    if (!warnedOnce) {
+      warnedOnce = true;
+      process.stderr.write(`[mailpoet-dev-mcp] telemetry write failed: ${e instanceof Error ? e.message : String(e)}\n`);
+    }
+  }
+}

--- a/tools/mcp-server/tsconfig.json
+++ b/tools/mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

Experimental walking skeleton of an MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server that exposes MailPoet local-dev tooling to AI agents (Claude Code, etc.). The goal is to stop agents burning tokens on parsing noisy Robo / wp-cli / container output for routine things like "what's in Mailpit?", "list subscribers in segment X", "run PHPStan on changed files", "tail the debug log", "what's queued in Action Scheduler?".

- **Entirely dev-only.** Not shipped with the MailPoet plugin, not part of CI. The PHP companion no-ops unless both `WP_DEBUG=true` and a local secret file exist.
- **Architecture:** TS MCP server on the host ↔ PHP companion mu-plugin inside wp-env over loopback HTTP with a shared secret. Companion uses MailPoet's own DI container and Doctrine repositories so results reflect real entity state — no parallel data model.
- **15 tools across 6 namespaces:** `mp.env.*`, `mp.test.*`, `mp.mail.*`, `mp.data.*`, `mp.qa.*`, `mp.logs.*`.
- **Telemetry.** Every tool call is appended to `.wp-env/mcp-usage.jsonl` (tool name, duration, status, input keys only — argument values never logged) so we can iterate on real usage after a few weeks rather than design guesses.

Documented in `AGENTS.md` (discoverability) and `tools/mcp-server/README.md` (setup + how to add a new tool).

## Code review notes

Areas worth extra scrutiny:

- **`.wp-env.json` mappings + mu-plugin activation gate.** The companion lives in `.wp-env/mu-plugins/mailpoet-dev-companion.php`, is mapped in alongside the existing SMTP mu-plugin, and returns early unless `WP_DEBUG` is on and the secret file (`.wp-env/.mailpoet-dev-companion-secret`, gitignored, `0600`) is present. The secret file must exist before `pnpm env:start` so the volume mapping picks it up — the README documents the ordering.
- **Auth is secret-only (no nonce, no WP user).** Constant-time compare via `hash_equals`. IP check was dropped because wp-env requests can originate from the Docker bridge range, not `127.0.0.1`. The `WP_DEBUG` + secret-file gate is the primary safety net against this leaking into any non-dev context.
- **Destructive tools.** `mp.mail.clear` uses `z.literal(true)` for `confirm`, so MCP schema validation rejects `confirm: false` before the handler even runs. `mp.env.feature_flags.set` has `destructiveHint: true`. `mp.data.subscribers.create` hard-caps `upsert` behind an explicit flag and errors `409` otherwise.
- **Companion and DI.** Uses `ContainerWrapper::getInstance()->get(…)` for public services and `EntityManager` directly for queries. Some services (e.g. `MailPoet\Util\Security`) are inlined/private in the compiled container — for those we call static methods or inline the logic rather than make them public.
- **`SubscriberEntity::setSource()` allowlist.** The companion POST rejects sources outside MailPoet's allowlist (api/form/unknown/imported/administrator/wordpress_user/woocommerce_user/woocommerce_checkout) with a 400 before calling the setter — otherwise the setter throws `InvalidArgumentException`.
- **`mp.test.run` JUnit handling.** `tests/_output/report.xml` is deleted before each run; otherwise a failed/aborted Codeception run would report stale counts from the previous successful run. Raw stdout/stderr goes to `mcp-last-run.log` so the tool response stays small.
- **Telemetry privacy invariant.** Only argument *keys* are logged, never values. If anyone adds a new telemetry surface, preserve that — the README calls this out.
- **No tests yet.** This is experimental tooling; the plan is to let telemetry drive which tools survive the next iteration before investing in test coverage.

## QA notes

To try it out locally:

```bash
# From repo root:
cd tools/mcp-server
pnpm install
pnpm build
pnpm init-secret              # generates .wp-env/.mailpoet-dev-companion-secret

cd ../..
pnpm env:restart              # so the mu-plugin + secret mapping load

# Manual smoke test of the companion (no MCP client needed):
SECRET=$(cat .wp-env/.mailpoet-dev-companion-secret)
curl -s -H "X-MailPoet-Dev-Secret: $SECRET" \
  http://localhost:8888/wp-json/mailpoet-dev/v1/ping | jq
```

Register the server with Claude Code (or any MCP client):

```bash
claude mcp add mailpoet-dev -- node "$(pwd)/tools/mcp-server/dist/index.js"
```

Then exercise a few tools: `mp.env.status`, `mp.data.subscribers.list`, `mp.data.segments.list include_counts:true`, `mp.env.scheduler.list`, `mp.mail.list`, `mp.qa.run tool:"prettier" scope:"changed"`, `mp.logs.wp_debug tail:50`.

Things to verify:

- Server reachable, all 15 tools listed.
- Companion reachable through the host's WordPress URL (auto-detects `WP_HOME` from `.wp-env.override.json` — custom domains work out of the box).
- `mp.mail.clear` with `confirm: false` rejected at the schema layer, with `confirm: true` it deletes.
- `.wp-env/mcp-usage.jsonl` gains one line per tool call; inspect with `jq`.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

Treat this as a staging ground. In 2–4 weeks of real use we should look at `.wp-env/mcp-usage.jsonl`, decide which tools are worth keeping/expanding and which should be cut, then iterate. Tools that aren't called have zero value but nonzero maintenance cost.

## Screenshots or screencast

_N/A_ (CLI tool, no UI.)

## Tasks

- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:experiment/mailpoet-mcp-server)

_The latest successful build from `experiment/mailpoet-mcp-server` will be used. If none is available, the link won't work._