### PR TITLE
Translate email editor UI strings

### DIFF
--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/index.ts
@@ -11,12 +11,15 @@ import { registerPlugin } from '@wordpress/plugins';
 import { MailPoet } from 'mailpoet';
 import { initializeEditor } from '@woocommerce/email-editor';
 import { EmailContentValidationRule } from '@woocommerce/email-editor/build-types/store';
+import { registerTranslations } from 'common';
 import { withSatismeterSurvey } from './satismeter-survey';
 import { EmailSidebarExtension } from './email-sidebar-extension';
 import { AutomationSaveButton } from './components/automation-save-button';
 import './index.scss';
 import { emailValidationRule } from './validate-email-content';
 import { initStripPostStatusOnSaveMiddleware } from './middleware/strip-post-status-on-save';
+
+registerTranslations();
 
 addFilter(
   'woocommerce_email_editor_wrap_editor_component',

--- a/mailpoet/changelog/2026-04-23-12-22-23-fixed-missing-translations-in-the-new-email-editor.md
+++ b/mailpoet/changelog/2026-04-23-12-22-23-fixed-missing-translations-in-the-new-email-editor.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Missing translations in the new email editor

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EditorPageRenderer.php
@@ -97,6 +97,7 @@ class EditorPageRenderer {
       $editorIntegrationAssetsParams['version'],
       true
     );
+    $this->wp->wpSetScriptTranslations('email_editor_integration', 'mailpoet');
     $this->wp->wpEnqueueStyle(
       'email_editor_integration',
       Env::$assetsUrl . '/dist/js/email_editor_integration/email_editor_integration.css',


### PR DESCRIPTION
## Description

Strings in the new block-based email editor that use the `mailpoet` text domain were never being translated, even on sites where MailPoet translations were installed for the active WP locale. Two standard pieces of the i18n wiring were missing for the editor bundle:

- `wp_set_script_translations()` was not called after enqueueing the `email_editor_integration` script, so WordPress never loaded the `.json` translation files.
- `registerTranslations()` — the helper that bridges WP's core `@wordpress/i18n` locale data to our bundled copy — was never called in the email editor entry point, even though every other admin entry point (newsletters, automation, settings, segments, forms, …) calls it.

This PR adds both calls. Strings under the `mailpoet` domain in the editor (e.g. "Review & send", "Review & schedule", the MailPoet sidebar panels, validation messages) now translate correctly.

## Code review notes

- The JS change mirrors the pattern used by every other admin entry point in `assets/js/src/` — `import { registerTranslations } from 'common'` + a top-level call. No new pattern introduced.
- Strings originating from the upstream `@woocommerce/email-editor` package are hardcoded with the `woocommerce` text domain and are deliberately **not** addressed here — that's tracked separately in STOMAIL-7524 / WOOPRD-794.
- Per-subscriber multilingual email content (WOOPLUG-6172) is a different feature and also out of scope.

## QA notes

1. Switch the WP site to a non-English locale for which MailPoet translations are installed (e.g. `cs_CZ`).
2. Open a newsletter in the new block-based email editor.
3. Verify MailPoet-domain strings are translated — e.g. the Send button label, MailPoet sidebar panel labels (Tracking, Content settings, Inbox preview, Recipients), and content validation error messages.
4. Strings coming from the upstream WooCommerce email editor package (e.g. some personalization-tag UI, template-selection labels) will remain in English — this is expected and tracked in STOMAIL-7524 / WOOPRD-794.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-7971](https://linear.app/a8c/issue/STOMAIL-7971/email-editor-ui-strings-are-not-translated)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7971-email-editor-ui-strings-are-not-translated)

_The latest successful build from `fix/stomail-7971-email-editor-ui-strings-are-not-translated` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->