### PR TITLE
Tags management

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-tags.scss
+++ b/mailpoet/assets/css/src/mailpoet-tags.scss
@@ -1,0 +1,17 @@
+@import '../../../node_modules/@wordpress/dataviews/build-style/style';
+
+#mailpoet_tags_container .components-notice {
+  margin: 8px 0 0;
+}
+
+.mailpoet-tags-dataviews {
+  margin-top: 8px;
+
+  .dataviews-wrapper {
+    min-height: 200px;
+  }
+}
+
+.mailpoet-tags-dataviews__toolbar {
+  padding: 8px;
+}

--- a/mailpoet/assets/js/src/subscribers/heading.tsx
+++ b/mailpoet/assets/js/src/subscribers/heading.tsx
@@ -44,6 +44,13 @@ export function SubscribersHeading() {
         >
           {__('Export', 'mailpoet')}
         </a>
+        <a
+          className="page-title-action not-small-screen"
+          href="?page=mailpoet-tags"
+          data-automation-id="manage-tags-button"
+        >
+          {__('Tags', 'mailpoet')}
+        </a>
       </PageHeader>
       <div className="mailpoet-segment-subscriber-count">
         <SubscribersInPlan

--- a/mailpoet/assets/js/src/subscribers/tags/api.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/api.ts
@@ -1,0 +1,107 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import type { Tag, TagListMeta } from './types';
+
+type WindowApi = {
+  mailpoet_tags_api: {
+    root: string;
+    nonce: string;
+  };
+  mailpoet_tags_subscribers_listing_url: string;
+};
+
+declare const window: Window & WindowApi;
+
+let initialized = false;
+function ensureInitialized(): void {
+  if (initialized) return;
+  const config = window.mailpoet_tags_api;
+  apiFetch.use(apiFetch.createRootURLMiddleware(`${config.root}/`));
+  apiFetch.use(apiFetch.createNonceMiddleware(config.nonce));
+  initialized = true;
+}
+
+type ListParams = {
+  search?: string;
+  orderby?: string;
+  order?: 'asc' | 'desc';
+  page?: number;
+  per_page?: number;
+};
+
+type ApiEnvelope<T> = {
+  data: T;
+};
+
+type ListResponse = ApiEnvelope<{
+  items: Tag[];
+  meta: TagListMeta;
+}>;
+
+type ItemResponse = ApiEnvelope<Tag>;
+
+export async function getTags(params: ListParams = {}): Promise<{
+  items: Tag[];
+  meta: TagListMeta;
+}> {
+  ensureInitialized();
+  const response = await apiFetch<ListResponse>({
+    path: addQueryArgs('/mailpoet/v1/tags', params),
+    method: 'GET',
+  });
+  return response.data;
+}
+
+export async function createTag(data: {
+  name: string;
+  description?: string;
+}): Promise<Tag> {
+  ensureInitialized();
+  const response = await apiFetch<ItemResponse>({
+    path: '/mailpoet/v1/tags',
+    method: 'POST',
+    data,
+  });
+  return response.data;
+}
+
+export async function updateTag(
+  id: number,
+  data: { name?: string; description?: string },
+): Promise<Tag> {
+  ensureInitialized();
+  const response = await apiFetch<ItemResponse>({
+    path: `/mailpoet/v1/tags/${id}`,
+    method: 'PUT',
+    data,
+  });
+  return response.data;
+}
+
+export async function deleteTag(id: number): Promise<void> {
+  ensureInitialized();
+  await apiFetch({
+    path: `/mailpoet/v1/tags/${id}`,
+    method: 'DELETE',
+  });
+}
+
+export async function bulkDeleteTags(ids: number[]): Promise<number> {
+  ensureInitialized();
+  const response = await apiFetch<ApiEnvelope<{ deleted: number }>>({
+    path: '/mailpoet/v1/tags/bulk-delete',
+    method: 'POST',
+    data: { ids },
+  });
+  return response.data.deleted;
+}
+
+export function getSubscribersListingUrl(tagId?: number): string {
+  const baseUrl =
+    window.mailpoet_tags_subscribers_listing_url ??
+    '?page=mailpoet-subscribers';
+  if (tagId === undefined) {
+    return baseUrl;
+  }
+  return `${baseUrl}#/filter[tag=${tagId}]`;
+}

--- a/mailpoet/assets/js/src/subscribers/tags/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/fields.ts
@@ -1,0 +1,67 @@
+import { __ } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { createElement } from 'react';
+import type { Field } from '@wordpress/dataviews';
+import type { Tag } from './types';
+import { getSubscribersListingUrl } from './api';
+
+export const listFields: Field<Tag>[] = [
+  {
+    id: 'name',
+    label: __('Name', 'mailpoet'),
+    type: 'text',
+    enableGlobalSearch: true,
+    enableSorting: true,
+  },
+  {
+    id: 'description',
+    label: __('Description', 'mailpoet'),
+    type: 'text',
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) => createElement('span', null, item.description || '—'),
+  },
+  {
+    id: 'subscribers_count',
+    label: __('Subscribers', 'mailpoet'),
+    type: 'integer',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    render: ({ item }) =>
+      createElement(
+        'a',
+        {
+          href: getSubscribersListingUrl(item.id),
+        },
+        item.subscribers_count.toLocaleString(),
+      ),
+  },
+  {
+    id: 'created_at',
+    label: __('Created', 'mailpoet'),
+    type: 'datetime',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    render: ({ item }) =>
+      createElement(
+        'span',
+        null,
+        item.created_at ? dateI18n('M j, Y', item.created_at, undefined) : '',
+      ),
+  },
+];
+
+export const formFields: Field<Tag>[] = [
+  {
+    id: 'name',
+    label: __('Name', 'mailpoet'),
+    type: 'text',
+    isValid: { required: true, minLength: 1 },
+  },
+  {
+    id: 'description',
+    label: __('Description', 'mailpoet'),
+    type: 'text',
+    Edit: { control: 'textarea', rows: 3 },
+  },
+];

--- a/mailpoet/assets/js/src/subscribers/tags/index.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/index.tsx
@@ -1,0 +1,21 @@
+import { createRoot } from 'react-dom/client';
+import { GlobalContext, useGlobalContextValue } from 'context';
+import { registerTranslations, ErrorBoundary } from 'common';
+import { TagsPage } from './tags-page';
+
+function App() {
+  return (
+    <GlobalContext.Provider value={useGlobalContextValue(window)}>
+      <ErrorBoundary>
+        <TagsPage />
+      </ErrorBoundary>
+    </GlobalContext.Provider>
+  );
+}
+
+const container = document.getElementById('mailpoet_tags_container');
+if (container) {
+  registerTranslations();
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/mailpoet/assets/js/src/subscribers/tags/tags-form.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/tags-form.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import {
+  Modal,
+  Button,
+  Flex,
+  FlexItem,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { DataForm } from '@wordpress/dataviews';
+import { formFields } from './fields';
+import type { Tag, ApiErrorResponse } from './types';
+import { createTag, updateTag } from './api';
+
+type FormData = Pick<Tag, 'name' | 'description'>;
+
+type Props = {
+  initialTag?: Tag;
+  onClose: () => void;
+  onSuccess: (tag: Tag) => void;
+};
+
+export function TagsForm({ initialTag, onClose, onSuccess }: Props) {
+  const isEdit = !!initialTag;
+  const [data, setData] = useState<FormData>(() => ({
+    name: initialTag?.name ?? '',
+    description: initialTag?.description ?? '',
+  }));
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Modal focuses its close button first; move focus to the name field.
+    requestAnimationFrame(() => {
+      const nameInput = document.querySelector<HTMLInputElement>(
+        '.mailpoet-tags-form-modal input',
+      );
+      nameInput?.focus();
+    });
+  }, []);
+
+  const title = isEdit
+    ? __('Edit tag', 'mailpoet')
+    : __('Add new tag', 'mailpoet');
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!data.name.trim()) {
+      setError(__('Tag name is required.', 'mailpoet'));
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        name: data.name.trim(),
+        description: data.description,
+      };
+      const saved = initialTag
+        ? await updateTag(initialTag.id, payload)
+        : await createTag(payload);
+      onSuccess(saved);
+    } catch (err) {
+      const apiError = err as ApiErrorResponse;
+      setError(
+        apiError?.message ||
+          __('Something went wrong. Please try again.', 'mailpoet'),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={title}
+      onRequestClose={onClose}
+      className="mailpoet-tags-form-modal"
+      focusOnMount
+    >
+      <form onSubmit={handleSubmit}>
+        <DataForm<FormData>
+          data={data}
+          fields={formFields as never}
+          form={{
+            fields: ['name', 'description'],
+          }}
+          onChange={(edits) => setData((current) => ({ ...current, ...edits }))}
+        />
+        {error && (
+          <>
+            <Spacer marginTop={4} />
+            <div className="mailpoet-tags-form-error" role="alert">
+              {error}
+            </div>
+          </>
+        )}
+        <Spacer marginTop={6} />
+        <Flex justify="flex-end" gap={3}>
+          <FlexItem>
+            <Button
+              variant="tertiary"
+              onClick={onClose}
+              disabled={isSaving}
+              __next40pxDefaultSize
+            >
+              {__('Cancel', 'mailpoet')}
+            </Button>
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant="primary"
+              type="submit"
+              isBusy={isSaving}
+              disabled={isSaving}
+              __next40pxDefaultSize
+            >
+              {isEdit ? __('Save', 'mailpoet') : __('Create tag', 'mailpoet')}
+            </Button>
+          </FlexItem>
+        </Flex>
+      </form>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
@@ -38,8 +38,11 @@ export function TagsPage() {
   const [formState, setFormState] = useState<FormState>({ kind: 'closed' });
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
+  const latestRequestIdRef = useRef(0);
 
   const loadTags = useCallback(async () => {
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
     setIsLoading(true);
     try {
       const requestedPage = view.page ?? 1;
@@ -50,6 +53,10 @@ export function TagsPage() {
         page: requestedPage,
         per_page: view.perPage ?? 20,
       });
+
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
 
       const lastValidPage = Math.max(1, result.meta.pages);
       if (requestedPage > lastValidPage) {
@@ -63,12 +70,17 @@ export function TagsPage() {
       setItems(result.items);
       setMeta(result.meta);
     } catch (err) {
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
       const apiError = err as ApiErrorResponse;
       setGlobalError(
         apiError?.message || __('Failed to load tags.', 'mailpoet'),
       );
     } finally {
-      setIsLoading(false);
+      if (requestId === latestRequestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [view.search, view.sort, view.page, view.perPage]);
 

--- a/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/tags/tags-page.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { DataViews, View, Action } from '@wordpress/dataviews';
+import { BackButton, PageHeader } from 'common/page-header';
+import { TopBarWithBoundary } from 'common/top-bar/top-bar';
+import { listFields } from './fields';
+import { TagsForm } from './tags-form';
+import {
+  bulkDeleteTags,
+  deleteTag,
+  getSubscribersListingUrl,
+  getTags,
+} from './api';
+import type { ApiErrorResponse, Tag, TagListMeta } from './types';
+
+type FormState =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; tag: Tag };
+
+const DEFAULT_VIEW: View = {
+  type: 'table',
+  perPage: 20,
+  page: 1,
+  sort: { field: 'name', direction: 'asc' },
+  fields: ['description', 'subscribers_count', 'created_at'],
+  titleField: 'name',
+  showTitle: true,
+};
+
+export function TagsPage() {
+  const [view, setView] = useState<View>(DEFAULT_VIEW);
+  const [items, setItems] = useState<Tag[]>([]);
+  const [meta, setMeta] = useState<TagListMeta>({ count: 0, pages: 0 });
+  const [isLoading, setIsLoading] = useState(false);
+  const [selection, setSelection] = useState<string[]>([]);
+  const [formState, setFormState] = useState<FormState>({ kind: 'closed' });
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
+
+  const loadTags = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const requestedPage = view.page ?? 1;
+      const result = await getTags({
+        search: view.search || '',
+        orderby: view.sort?.field ?? 'name',
+        order: view.sort?.direction ?? 'asc',
+        page: requestedPage,
+        per_page: view.perPage ?? 20,
+      });
+
+      const lastValidPage = Math.max(1, result.meta.pages);
+      if (requestedPage > lastValidPage) {
+        setView((currentView) => ({
+          ...currentView,
+          page: lastValidPage,
+        }));
+        return;
+      }
+
+      setItems(result.items);
+      setMeta(result.meta);
+    } catch (err) {
+      const apiError = err as ApiErrorResponse;
+      setGlobalError(
+        apiError?.message || __('Failed to load tags.', 'mailpoet'),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [view.search, view.sort, view.page, view.perPage]);
+
+  useEffect(() => {
+    void loadTags();
+  }, [loadTags]);
+
+  const handleFormSuccess = (tag: Tag) => {
+    setFormState({ kind: 'closed' });
+    setGlobalSuccess(
+      formState.kind === 'edit'
+        ? sprintf(__('Tag "%s" updated.', 'mailpoet'), tag.name)
+        : sprintf(__('Tag "%s" created.', 'mailpoet'), tag.name),
+    );
+    void loadTags();
+  };
+
+  const handleDelete = useCallback(
+    async (ids: number[]) => {
+      const confirmMessage =
+        ids.length === 1
+          ? __(
+              'Delete this tag? It will be removed from all subscribers.',
+              'mailpoet',
+            )
+          : sprintf(
+              /* translators: %d is the number of tags */
+              _n(
+                'Delete %d tag? It will be removed from all subscribers.',
+                'Delete %d tags? They will be removed from all subscribers.',
+                ids.length,
+                'mailpoet',
+              ),
+              ids.length,
+            );
+      // eslint-disable-next-line no-alert
+      if (!window.confirm(confirmMessage)) {
+        return;
+      }
+      try {
+        if (ids.length === 1) {
+          await deleteTag(ids[0]);
+        } else {
+          await bulkDeleteTags(ids);
+        }
+        setSelection([]);
+        setGlobalSuccess(
+          ids.length === 1
+            ? __('Tag deleted.', 'mailpoet')
+            : sprintf(
+                /* translators: %d is the number of tags */
+                _n(
+                  '%d tag deleted.',
+                  '%d tags deleted.',
+                  ids.length,
+                  'mailpoet',
+                ),
+                ids.length,
+              ),
+        );
+        void loadTags();
+      } catch (err) {
+        const apiError = err as ApiErrorResponse;
+        setGlobalError(
+          apiError?.message || __('Failed to delete tags.', 'mailpoet'),
+        );
+      }
+    },
+    [loadTags],
+  );
+
+  const actions = useMemo<Action<Tag>[]>(
+    () => [
+      {
+        id: 'edit',
+        label: __('Edit', 'mailpoet'),
+        isPrimary: true,
+        icon: 'edit',
+        supportsBulk: false,
+        callback: (selected) => {
+          if (selected[0]) {
+            setFormState({ kind: 'edit', tag: selected[0] });
+          }
+        },
+      },
+      {
+        id: 'delete',
+        label: __('Delete', 'mailpoet'),
+        isPrimary: false,
+        supportsBulk: true,
+        callback: (selected) => {
+          void handleDelete(selected.map((tag) => tag.id));
+        },
+      },
+    ],
+    [handleDelete],
+  );
+
+  const paginationInfo = useMemo(
+    () => ({ totalItems: meta.count, totalPages: meta.pages }),
+    [meta],
+  );
+
+  return (
+    <>
+      <TopBarWithBoundary />
+      <PageHeader
+        heading={__('Tags', 'mailpoet')}
+        headingPrefix={
+          <BackButton
+            href={getSubscribersListingUrl()}
+            label={__('Subscribers', 'mailpoet')}
+            aria-label={__('Back to subscribers list', 'mailpoet')}
+          />
+        }
+      >
+        <button
+          type="button"
+          className="page-title-action"
+          onClick={() => setFormState({ kind: 'create' })}
+          data-automation-id="add-new-tag-button"
+        >
+          {__('Add new tag', 'mailpoet')}
+        </button>
+      </PageHeader>
+
+      {globalError && (
+        <Notice status="error" onRemove={() => setGlobalError(null)}>
+          {globalError}
+        </Notice>
+      )}
+      {globalSuccess && (
+        <Notice status="success" onRemove={() => setGlobalSuccess(null)}>
+          {globalSuccess}
+        </Notice>
+      )}
+
+      <div className="mailpoet-tags-dataviews">
+        <DataViews<Tag>
+          data={items}
+          fields={listFields}
+          view={view}
+          onChangeView={setView}
+          actions={actions}
+          paginationInfo={paginationInfo}
+          defaultLayouts={{ table: {} }}
+          getItemId={(item) => String(item.id)}
+          selection={selection}
+          onChangeSelection={setSelection}
+          isLoading={isLoading}
+          empty={<div>{__('No tags yet.', 'mailpoet')}</div>}
+        >
+          <div className="mailpoet-tags-dataviews__toolbar">
+            <DataViews.Search label={__('Search tags', 'mailpoet')} />
+          </div>
+          <DataViews.Layout />
+          <DataViews.Footer />
+        </DataViews>
+      </div>
+
+      {formState.kind !== 'closed' && (
+        <TagsForm
+          initialTag={formState.kind === 'edit' ? formState.tag : undefined}
+          onClose={() => setFormState({ kind: 'closed' })}
+          onSuccess={handleFormSuccess}
+        />
+      )}
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/tags/types.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/types.ts
@@ -1,0 +1,22 @@
+export type Tag = {
+  id: number;
+  name: string;
+  description: string;
+  subscribers_count: number;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type TagListMeta = {
+  count: number;
+  pages: number;
+};
+
+export type ApiErrorResponse = {
+  code: string;
+  message: string;
+  data?: {
+    status?: number;
+    errors?: Record<string, string>;
+  };
+};

--- a/mailpoet/changelog/2026-04-23-08-54-19-added-add-manage-tags-page-under-subscribers-with-list-c.md
+++ b/mailpoet/changelog/2026-04-23-08-54-19-added-add-manage-tags-page-under-subscribers-with-list-c.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Subscribers' tags management page with list, create, edit, and delete actions

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -44,6 +44,11 @@ class AssetsController {
     $this->enqueueJsEntrypoint('settings');
   }
 
+  public function setupTagsDependencies(): void {
+    $this->enqueueJsEntrypoint('tags');
+    $this->wp->wpEnqueueStyle('mailpoet_tags', $this->getCssUrl('mailpoet-tags.css'));
+  }
+
   public function setupDynamicSegmentsDependencies(): void {
     $this->wp->wpEnqueueStyle('mailpoet_templates', $this->getCssUrl('mailpoet-templates.css'));
     $this->wp->wpEnqueueStyle('mailpoet_dynamic_segments', $this->getCssUrl('mailpoet-dynamic-segments.css'));

--- a/mailpoet/lib/AdminPages/Pages/Tags.php
+++ b/mailpoet/lib/AdminPages/Pages/Tags.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\AssetsController;
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Tags {
+  /** @var AssetsController */
+  private $assetsController;
+
+  /** @var PageRenderer */
+  private $pageRenderer;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    AssetsController $assetsController,
+    PageRenderer $pageRenderer,
+    WPFunctions $wp
+  ) {
+    $this->assetsController = $assetsController;
+    $this->pageRenderer = $pageRenderer;
+    $this->wp = $wp;
+  }
+
+  public function render(): void {
+    $this->assetsController->setupTagsDependencies();
+    $this->pageRenderer->displayPage('subscribers/tags.html', [
+      'api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
+      'subscribers_listing_url' => $this->wp->escUrlRaw($this->wp->adminUrl('admin.php?page=mailpoet-subscribers')),
+    ]);
+  }
+}

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -24,6 +24,7 @@ use MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration;
 use MailPoet\Router;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\SubscriberActivityTracker;
+use MailPoet\Tags\RestApi\Api as TagsRestApi;
 use MailPoet\Util\ConflictResolver;
 use MailPoet\Util\LegacyDatabase;
 use MailPoet\Util\Notices\PermanentNotices;
@@ -109,6 +110,9 @@ class Initializer {
   /** @var Engine */
   private $automationEngine;
 
+  /** @var TagsRestApi */
+  private $tagsRestApi;
+
   /** @var MailPoetIntegration */
   private $automationMailPoetIntegration;
 
@@ -169,7 +173,8 @@ class Initializer {
     DaemonActionSchedulerRunner $actionSchedulerRunner,
     BlockTypesController $blockTypesController,
     MailpoetEmailEditorIntegration $mailpoetEmailEditorIntegration,
-    Url $urlHelper
+    Url $urlHelper,
+    TagsRestApi $tagsRestApi
   ) {
     $this->rendererFactory = $rendererFactory;
     $this->accessControl = $accessControl;
@@ -202,6 +207,7 @@ class Initializer {
     $this->mailpoetEmailEditorIntegration = $mailpoetEmailEditorIntegration;
     $this->blockTypesController = $blockTypesController;
     $this->urlHelper = $urlHelper;
+    $this->tagsRestApi = $tagsRestApi;
 
     $emailEditorContainer = Email_Editor_Container::container();
     $this->emailEditorBootstrap = $emailEditorContainer->get(EmailEditorBootstrap::class);
@@ -368,6 +374,7 @@ class Initializer {
       $this->subscriberActivityTracker->trackActivity();
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();
+      $this->tagsRestApi->initialize();
       $this->blockTypesController->initialize();
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -23,6 +23,7 @@ use MailPoet\AdminPages\Pages\StaticSegments;
 use MailPoet\AdminPages\Pages\Subscribers;
 use MailPoet\AdminPages\Pages\SubscribersExport;
 use MailPoet\AdminPages\Pages\SubscribersImport;
+use MailPoet\AdminPages\Pages\Tags as TagsPage;
 use MailPoet\AdminPages\Pages\Upgrade;
 use MailPoet\AdminPages\Pages\WelcomeWizard;
 use MailPoet\AdminPages\Pages\WooCommerceSetup;
@@ -46,6 +47,7 @@ class Menu {
   const SUBSCRIBERS_PAGE_SLUG = 'mailpoet-subscribers';
   const IMPORT_PAGE_SLUG = 'mailpoet-import';
   const EXPORT_PAGE_SLUG = 'mailpoet-export';
+  const TAGS_PAGE_SLUG = 'mailpoet-tags';
   const LISTS_PAGE_SLUG = 'mailpoet-lists';
   const SEGMENTS_PAGE_SLUG = 'mailpoet-segments';
   const SETTINGS_PAGE_SLUG = 'mailpoet-settings';
@@ -384,6 +386,19 @@ class Menu {
       ]
     );
 
+    // tags
+    $this->wp->addSubmenuPage(
+      self::SUBSCRIBERS_PAGE_SLUG,
+      $this->setPageTitle(__('Tags', 'mailpoet')),
+      esc_html__('Tags', 'mailpoet'),
+      AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
+      self::TAGS_PAGE_SLUG,
+      [
+        $this,
+        'tags',
+      ]
+    );
+
     // Lists page
     $listsPage = $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,
@@ -713,6 +728,10 @@ class Menu {
 
   public function export() {
     $this->container->get(SubscribersExport::class)->render();
+  }
+
+  public function tags() {
+    $this->container->get(TagsPage::class)->render();
   }
 
   public function formEditor() {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -53,6 +53,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\Subscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersExport::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\Tags::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceSetup::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Landingpage::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -691,6 +691,12 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cache\TransientCache::class)->setPublic(true);
     // Tags
     $container->autowire(\MailPoet\Tags\TagRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Tags\RestApi\Api::class)->setPublic(true);
+    $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagsGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagsPostEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagPutEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagDeleteEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagsBulkDeleteEndpoint::class)->setPublic(true);
     // CAPTCHA
     $container->autowire(\MailPoet\Captcha\ReCaptchaHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\Captcha\ReCaptchaValidator::class)->setPublic(true);

--- a/mailpoet/lib/Tags/RestApi/Api.php
+++ b/mailpoet/lib/Tags/RestApi/Api.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi;
+
+use MailPoet\API\REST\API as RestApi;
+use MailPoet\Tags\RestApi\Endpoints\TagDeleteEndpoint;
+use MailPoet\Tags\RestApi\Endpoints\TagPutEndpoint;
+use MailPoet\Tags\RestApi\Endpoints\TagsBulkDeleteEndpoint;
+use MailPoet\Tags\RestApi\Endpoints\TagsGetEndpoint;
+use MailPoet\Tags\RestApi\Endpoints\TagsPostEndpoint;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Api {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function initialize(): void {
+    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (RestApi $api): void {
+      $api->registerGetRoute('tags', TagsGetEndpoint::class);
+      $api->registerPostRoute('tags', TagsPostEndpoint::class);
+      $api->registerPutRoute('tags/(?P<id>\d+)', TagPutEndpoint::class);
+      $api->registerDeleteRoute('tags/(?P<id>\d+)', TagDeleteEndpoint::class);
+      $api->registerPostRoute('tags/bulk-delete', TagsBulkDeleteEndpoint::class);
+    });
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/Api.php
+++ b/mailpoet/lib/Tags/RestApi/Api.php
@@ -11,22 +11,27 @@ use MailPoet\Tags\RestApi\Endpoints\TagsPostEndpoint;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Api {
+  /** @var RestApi */
+  private $api;
+
   /** @var WPFunctions */
   private $wp;
 
   public function __construct(
+    RestApi $api,
     WPFunctions $wp
   ) {
+    $this->api = $api;
     $this->wp = $wp;
   }
 
   public function initialize(): void {
-    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (RestApi $api): void {
-      $api->registerGetRoute('tags', TagsGetEndpoint::class);
-      $api->registerPostRoute('tags', TagsPostEndpoint::class);
-      $api->registerPutRoute('tags/(?P<id>\d+)', TagPutEndpoint::class);
-      $api->registerDeleteRoute('tags/(?P<id>\d+)', TagDeleteEndpoint::class);
-      $api->registerPostRoute('tags/bulk-delete', TagsBulkDeleteEndpoint::class);
+    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
+      $this->api->registerGetRoute('tags', TagsGetEndpoint::class);
+      $this->api->registerPostRoute('tags', TagsPostEndpoint::class);
+      $this->api->registerPutRoute('tags/(?P<id>\d+)', TagPutEndpoint::class);
+      $this->api->registerDeleteRoute('tags/(?P<id>\d+)', TagDeleteEndpoint::class);
+      $this->api->registerPostRoute('tags/bulk-delete', TagsBulkDeleteEndpoint::class);
     });
   }
 }

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagDeleteEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagDeleteEndpoint.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Tags\RestApi\TagApiException;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Validator\Builder;
+
+class TagDeleteEndpoint extends TagsEndpoint {
+  /** @var TagRepository */
+  private $tagRepository;
+
+  public function __construct(
+    TagRepository $tagRepository
+  ) {
+    $this->tagRepository = $tagRepository;
+  }
+
+  public function handle(Request $request): Response {
+    /** @var mixed $rawId */
+    $rawId = $request->getParam('id');
+    $id = (int)(is_scalar($rawId) ? $rawId : 0);
+    $tag = $this->tagRepository->findOneById($id);
+    if (!$tag instanceof TagEntity) {
+      throw new TagApiException(
+        __('The tag does not exist.', 'mailpoet'),
+        404,
+        'mailpoet_tags_not_found'
+      );
+    }
+
+    $this->tagRepository->deleteTag($tag);
+    return new Response(null);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagPutEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagPutEndpoint.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Tags\RestApi\TagApiException;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Validator\Builder;
+
+class TagPutEndpoint extends TagsEndpoint {
+  /** @var TagRepository */
+  private $tagRepository;
+
+  public function __construct(
+    TagRepository $tagRepository
+  ) {
+    $this->tagRepository = $tagRepository;
+  }
+
+  public function handle(Request $request): Response {
+    /** @var mixed $rawId */
+    $rawId = $request->getParam('id');
+    $id = (int)(is_scalar($rawId) ? $rawId : 0);
+    $tag = $this->tagRepository->findOneById($id);
+    if (!$tag instanceof TagEntity) {
+      throw new TagApiException(
+        __('The tag does not exist.', 'mailpoet'),
+        404,
+        'mailpoet_tags_not_found'
+      );
+    }
+
+    $params = $request->getParams();
+    $hasName = array_key_exists('name', $params);
+    $hasDescription = array_key_exists('description', $params);
+
+    if ($hasName) {
+      $name = sanitize_text_field((string)$params['name']);
+      if ($name === '') {
+        throw new TagApiException(
+          __('Tag name is required.', 'mailpoet'),
+          400,
+          'mailpoet_tags_name_required'
+        );
+      }
+      $existing = $this->tagRepository->findOneBy(['name' => $name]);
+      if ($existing instanceof TagEntity && $existing->getId() !== $id) {
+        throw new TagApiException(
+          __('A tag with this name already exists.', 'mailpoet'),
+          409,
+          'mailpoet_tags_duplicate'
+        );
+      }
+      $tag->setName($name);
+    }
+
+    if ($hasDescription) {
+      $tag->setDescription(sanitize_textarea_field((string)$params['description']));
+    }
+
+    $this->tagRepository->flush();
+
+    return new Response($this->buildItem($tag, $this->tagRepository->getSubscribersCount($id)));
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+      'name' => Builder::string()->minLength(1),
+      'description' => Builder::string(),
+    ];
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsBulkDeleteEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsBulkDeleteEndpoint.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Tags\RestApi\TagApiException;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Validator\Builder;
+
+class TagsBulkDeleteEndpoint extends TagsEndpoint {
+  /** @var TagRepository */
+  private $tagRepository;
+
+  public function __construct(
+    TagRepository $tagRepository
+  ) {
+    $this->tagRepository = $tagRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $rawIds = $request->getParam('ids');
+    if (!is_array($rawIds) || $rawIds === []) {
+      throw new TagApiException(
+        __('At least one tag id is required.', 'mailpoet'),
+        400,
+        'mailpoet_tags_ids_required'
+      );
+    }
+
+    $ids = array_values(array_filter(array_map('intval', $rawIds)));
+    $deleted = $this->tagRepository->bulkDelete($ids);
+
+    return new Response(['deleted' => $deleted]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'ids' => Builder::array(Builder::integer())->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsBulkDeleteEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsBulkDeleteEndpoint.php
@@ -28,7 +28,19 @@ class TagsBulkDeleteEndpoint extends TagsEndpoint {
       );
     }
 
-    $ids = array_values(array_filter(array_map('intval', $rawIds)));
+    $ids = array_values(array_filter(
+      array_map('intval', $rawIds),
+      static function (int $id): bool {
+        return $id > 0;
+      }
+    ));
+    if ($ids === []) {
+      throw new TagApiException(
+        __('At least one tag id is required.', 'mailpoet'),
+        400,
+        'mailpoet_tags_ids_required'
+      );
+    }
     $deleted = $this->tagRepository->bulkDelete($ids);
 
     return new Response(['deleted' => $deleted]);

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsEndpoint.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi\Endpoints;
+
+use MailPoet\API\REST\Endpoint;
+use MailPoet\Config\AccessControl;
+use MailPoet\Entities\TagEntity;
+
+abstract class TagsEndpoint extends Endpoint {
+  private const DATE_FORMAT = 'Y-m-d H:i:s';
+
+  public function checkPermissions(): bool {
+    return current_user_can(AccessControl::PERMISSION_MANAGE_SUBSCRIBERS);
+  }
+
+  protected function buildItem(TagEntity $tag, int $subscribersCount = 0): array {
+    return [
+      'id' => (int)$tag->getId(),
+      'name' => $tag->getName(),
+      'description' => $tag->getDescription(),
+      'subscribers_count' => $subscribersCount,
+      'created_at' => ($createdAt = $tag->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
+      'updated_at' => ($updatedAt = $tag->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
+    ];
+  }
+
+  /**
+   * @param array{id: int, name: string, description: string, subscribers_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface} $row
+   */
+  protected function buildItemFromRow(array $row): array {
+    return [
+      'id' => (int)$row['id'],
+      'name' => (string)$row['name'],
+      'description' => (string)$row['description'],
+      'subscribers_count' => (int)$row['subscribers_count'],
+      'created_at' => $row['created_at'] instanceof \DateTimeInterface ? $row['created_at']->format(self::DATE_FORMAT) : null,
+      'updated_at' => $row['updated_at'] instanceof \DateTimeInterface ? $row['updated_at']->format(self::DATE_FORMAT) : null,
+    ];
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Validator\Builder;
+
+class TagsGetEndpoint extends TagsEndpoint {
+  /** @var TagRepository */
+  private $tagRepository;
+
+  public function __construct(
+    TagRepository $tagRepository
+  ) {
+    $this->tagRepository = $tagRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $search = is_string($request->getParam('search')) ? (string)$request->getParam('search') : '';
+    $orderby = is_string($request->getParam('orderby')) ? (string)$request->getParam('orderby') : 'name';
+    $order = is_string($request->getParam('order')) ? (string)$request->getParam('order') : 'asc';
+    $page = is_numeric($request->getParam('page')) ? (int)$request->getParam('page') : 1;
+    $perPage = is_numeric($request->getParam('per_page')) ? (int)$request->getParam('per_page') : 25;
+
+    $result = $this->tagRepository->listWithCounts([
+      'search' => $search,
+      'orderby' => $orderby,
+      'order' => $order,
+      'page' => $page,
+      'per_page' => $perPage,
+    ]);
+
+    $items = array_map([$this, 'buildItemFromRow'], $result['items']);
+    $pages = $result['total'] === 0 ? 0 : (int)ceil($result['total'] / max(1, $perPage));
+
+    return new Response([
+      'items' => $items,
+      'meta' => [
+        'count' => $result['total'],
+        'pages' => $pages,
+      ],
+    ]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'search' => Builder::string(),
+      'orderby' => Builder::string(),
+      'order' => Builder::string(),
+      'page' => Builder::integer(),
+      'per_page' => Builder::integer(),
+    ];
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsGetEndpoint.php
@@ -21,8 +21,8 @@ class TagsGetEndpoint extends TagsEndpoint {
     $search = is_string($request->getParam('search')) ? (string)$request->getParam('search') : '';
     $orderby = is_string($request->getParam('orderby')) ? (string)$request->getParam('orderby') : 'name';
     $order = is_string($request->getParam('order')) ? (string)$request->getParam('order') : 'asc';
-    $page = is_numeric($request->getParam('page')) ? (int)$request->getParam('page') : 1;
-    $perPage = is_numeric($request->getParam('per_page')) ? (int)$request->getParam('per_page') : 25;
+    $page = is_numeric($request->getParam('page')) ? max(1, (int)$request->getParam('page')) : 1;
+    $perPage = is_numeric($request->getParam('per_page')) ? max(1, min(100, (int)$request->getParam('per_page'))) : 25;
 
     $result = $this->tagRepository->listWithCounts([
       'search' => $search,

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsPostEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsPostEndpoint.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Tags\RestApi\TagApiException;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Validator\Builder;
+
+class TagsPostEndpoint extends TagsEndpoint {
+  /** @var TagRepository */
+  private $tagRepository;
+
+  public function __construct(
+    TagRepository $tagRepository
+  ) {
+    $this->tagRepository = $tagRepository;
+  }
+
+  public function handle(Request $request): Response {
+    /** @var mixed $rawName */
+    $rawName = $request->getParam('name');
+    /** @var mixed $rawDescription */
+    $rawDescription = $request->getParam('description');
+    $name = sanitize_text_field(is_scalar($rawName) ? (string)$rawName : '');
+    $description = sanitize_textarea_field(is_scalar($rawDescription) ? (string)$rawDescription : '');
+
+    if ($name === '') {
+      throw new TagApiException(
+        __('Tag name is required.', 'mailpoet'),
+        400,
+        'mailpoet_tags_name_required'
+      );
+    }
+
+    $existing = $this->tagRepository->findOneBy(['name' => $name]);
+    if ($existing instanceof TagEntity) {
+      throw new TagApiException(
+        __('A tag with this name already exists.', 'mailpoet'),
+        409,
+        'mailpoet_tags_duplicate'
+      );
+    }
+
+    $tag = new TagEntity($name, $description);
+    $this->tagRepository->persist($tag);
+    $this->tagRepository->flush();
+
+    return new Response($this->buildItem($tag, 0), 201);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'name' => Builder::string()->required()->minLength(1),
+      'description' => Builder::string(),
+    ];
+  }
+}

--- a/mailpoet/lib/Tags/RestApi/TagApiException.php
+++ b/mailpoet/lib/Tags/RestApi/TagApiException.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Tags\RestApi;
+
+use Exception as PhpException;
+use MailPoet\API\REST\Exception as RestException;
+use Throwable;
+
+class TagApiException extends PhpException implements RestException {
+  /** @var int */
+  private $statusCode;
+
+  /** @var string */
+  private $errorCode;
+
+  /** @var array<string, string> */
+  private $errors;
+
+  /**
+   * @param array<string, string> $errors
+   */
+  public function __construct(
+    string $message,
+    int $statusCode = 400,
+    string $errorCode = 'mailpoet_tags_error',
+    array $errors = [],
+    ?Throwable $previous = null
+  ) {
+    parent::__construct($message, 0, $previous);
+    $this->statusCode = $statusCode;
+    $this->errorCode = $errorCode;
+    $this->errors = $errors;
+  }
+
+  public function getStatusCode(): int {
+    return $this->statusCode;
+  }
+
+  public function getErrorCode(): string {
+    return $this->errorCode;
+  }
+
+  public function getErrors(): array {
+    return $this->errors;
+  }
+}

--- a/mailpoet/lib/Tags/TagRepository.php
+++ b/mailpoet/lib/Tags/TagRepository.php
@@ -39,15 +39,120 @@ class TagRepository extends Repository {
    * Deletes a tag along with any subscriber_tag rows referencing it.
    */
   public function deleteTag(TagEntity $tag): void {
-    $tagId = $tag->getId();
+    $this->bulkDelete([$tag->getId()]);
+  }
+
+  /**
+   * Deletes multiple tags along with any subscriber_tag rows referencing them.
+   *
+   * @param array<int|null> $ids
+   * @return int Number of tags deleted.
+   */
+  public function bulkDelete(array $ids): int {
+    $ids = array_values(array_filter(array_map(
+      static function ($id): int {
+        return (int)$id;
+      },
+      $ids
+    )));
+    if (!$ids) {
+      return 0;
+    }
     $subscriberTagTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
     $this->entityManager->getConnection()->executeStatement(
       "DELETE FROM $subscriberTagTable WHERE tag_id IN (:ids)",
-      ['ids' => [$tagId]],
+      ['ids' => $ids],
       ['ids' => ArrayParameterType::INTEGER]
     );
-    $this->remove($tag);
-    $this->flush();
+
+    $tagsTable = $this->entityManager->getClassMetadata(TagEntity::class)->getTableName();
+    $deleted = (int)$this->entityManager->getConnection()->executeStatement(
+      "DELETE FROM $tagsTable WHERE id IN (:ids)",
+      ['ids' => $ids],
+      ['ids' => ArrayParameterType::INTEGER]
+    );
+
+    // Clear Doctrine's UnitOfWork so stale references don't linger.
+    $this->entityManager->clear(TagEntity::class);
+    return $deleted;
+  }
+
+  /**
+   * Listing with subscriber counts + search + sort + pagination.
+   *
+   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int} $args
+   * @return array{items: array<int, array{id: int, name: string, description: string, subscribers_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface}>, total: int}
+   */
+  public function listWithCounts(array $args = []): array {
+    $search = isset($args['search']) ? trim((string)$args['search']) : '';
+    $orderby = isset($args['orderby']) && is_string($args['orderby']) ? $args['orderby'] : 'name';
+    $order = isset($args['order']) && strtolower((string)$args['order']) === 'desc' ? 'DESC' : 'ASC';
+    $page = isset($args['page']) ? max(1, (int)$args['page']) : 1;
+    $perPage = isset($args['per_page']) ? max(1, min(100, (int)$args['per_page'])) : 25;
+
+    $sortable = [
+      'name' => 't.name',
+      'created_at' => 't.createdAt',
+      'subscribers_count' => 'subscribersCount',
+    ];
+    $orderByExpr = $sortable[$orderby] ?? $sortable['name'];
+
+    $qb = $this->entityManager->createQueryBuilder()
+      ->select('t.id AS id, t.name AS name, t.description AS description, t.createdAt AS created_at, t.updatedAt AS updated_at, COUNT(DISTINCT s.id) AS subscribersCount')
+      ->from(TagEntity::class, 't')
+      ->leftJoin('t.subscriberTags', 'st')
+      ->leftJoin('st.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
+      ->groupBy('t.id')
+      ->orderBy($orderByExpr, $order)
+      ->setFirstResult(($page - 1) * $perPage)
+      ->setMaxResults($perPage);
+
+    if ($search !== '') {
+      $qb->andWhere('t.name LIKE :search OR t.description LIKE :search')
+        ->setParameter('search', '%' . $search . '%');
+    }
+
+    /** @var array<array{id: int, name: string, description: string, created_at: mixed, updated_at: mixed, subscribersCount: int|string}> $rows */
+    $rows = $qb->getQuery()->getArrayResult();
+
+    $countQb = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(t.id)')
+      ->from(TagEntity::class, 't');
+    if ($search !== '') {
+      $countQb->andWhere('t.name LIKE :search OR t.description LIKE :search')
+        ->setParameter('search', '%' . $search . '%');
+    }
+    $total = (int)$countQb->getQuery()->getSingleScalarResult();
+
+    $items = [];
+    foreach ($rows as $row) {
+      $createdAt = $row['created_at'] ?? null;
+      $updatedAt = $row['updated_at'] ?? null;
+      $items[] = [
+        'id' => (int)$row['id'],
+        'name' => (string)$row['name'],
+        'description' => (string)$row['description'],
+        'subscribers_count' => (int)$row['subscribersCount'],
+        'created_at' => $createdAt instanceof \DateTimeInterface ? $createdAt : null,
+        'updated_at' => $updatedAt instanceof \DateTimeInterface ? $updatedAt : null,
+      ];
+    }
+
+    return ['items' => $items, 'total' => $total];
+  }
+
+  /**
+   * Count non-deleted subscribers attached to a tag.
+   */
+  public function getSubscribersCount(int $tagId): int {
+    $qb = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(DISTINCT s.id)')
+      ->from(TagEntity::class, 't')
+      ->leftJoin('t.subscriberTags', 'st')
+      ->leftJoin('st.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
+      ->where('t.id = :id')
+      ->setParameter('id', $tagId);
+    return (int)$qb->getQuery()->getSingleScalarResult();
   }
 
   public function getSubscriberStatisticsCount(?string $status, bool $isDeleted): array {

--- a/mailpoet/lib/Tags/TagRepository.php
+++ b/mailpoet/lib/Tags/TagRepository.php
@@ -103,7 +103,13 @@ class TagRepository extends Repository {
       ->leftJoin('t.subscriberTags', 'st')
       ->leftJoin('st.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
       ->groupBy('t.id')
-      ->orderBy($orderByExpr, $order)
+      ->orderBy($orderByExpr, $order);
+
+    // Add deterministic secondary ordering so paginated results are stable when the primary sort has ties.
+    if ($orderby !== 'name') {
+      $qb->addOrderBy('t.name', 'ASC');
+    }
+    $qb->addOrderBy('t.id', 'ASC')
       ->setFirstResult(($page - 1) * $perPage)
       ->setMaxResults($perPage);
 

--- a/mailpoet/lib/Tags/TagRepository.php
+++ b/mailpoet/lib/Tags/TagRepository.php
@@ -6,6 +6,7 @@ use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
  * @extends Repository<TagEntity>
@@ -58,19 +59,23 @@ class TagRepository extends Repository {
     if (!$ids) {
       return 0;
     }
-    $subscriberTagTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
-    $this->entityManager->getConnection()->executeStatement(
-      "DELETE FROM $subscriberTagTable WHERE tag_id IN (:ids)",
-      ['ids' => $ids],
-      ['ids' => ArrayParameterType::INTEGER]
-    );
 
-    $tagsTable = $this->entityManager->getClassMetadata(TagEntity::class)->getTableName();
-    $deleted = (int)$this->entityManager->getConnection()->executeStatement(
-      "DELETE FROM $tagsTable WHERE id IN (:ids)",
-      ['ids' => $ids],
-      ['ids' => ArrayParameterType::INTEGER]
-    );
+    $deleted = 0;
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, &$deleted): void {
+      $subscriberTagTable = $entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
+      $entityManager->getConnection()->executeStatement(
+        "DELETE FROM $subscriberTagTable WHERE tag_id IN (:ids)",
+        ['ids' => $ids],
+        ['ids' => ArrayParameterType::INTEGER]
+      );
+
+      $tagsTable = $entityManager->getClassMetadata(TagEntity::class)->getTableName();
+      $deleted = (int)$entityManager->getConnection()->executeStatement(
+        "DELETE FROM $tagsTable WHERE id IN (:ids)",
+        ['ids' => $ids],
+        ['ids' => ArrayParameterType::INTEGER]
+      );
+    });
 
     // Clear Doctrine's UnitOfWork so stale references don't linger.
     $this->entityManager->clear(TagEntity::class);

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -64,6 +64,7 @@
     "@wordpress/core-data": "^7.43.0",
     "@wordpress/data": "^10.43.0",
     "@wordpress/data-controls": "^4.43.0",
+    "@wordpress/dataviews": "^14.1.0",
     "@wordpress/date": "^5.43.0",
     "@wordpress/edit-post": "^8.43.0",
     "@wordpress/edit-site": "^6.43.0",

--- a/mailpoet/tests/integration/REST/Tags/TagsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Tags/TagsEndpointsTest.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\Tags;
+
+use MailPoet\REST\Test;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Test\DataFactories\Tag as TagFactory;
+
+require_once __DIR__ . '/../Test.php';
+
+class TagsEndpointsTest extends Test {
+  private const BASE_PATH = '/mailpoet/v1/tags';
+
+  /** @var TagRepository */
+  private $repository;
+
+  /** @var int */
+  private $editorUserId;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(TagRepository::class);
+    wp_set_current_user(1);
+    $userId = wp_create_user('tags_editor_' . uniqid(), 'password', 'tags-editor-' . uniqid() . '@localhost.test');
+    $this->assertIsNumeric($userId);
+    $user = new \WP_User($userId);
+    $user->add_role('editor');
+    $this->editorUserId = $userId;
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+    is_multisite() ? wpmu_delete_user($this->editorUserId) : wp_delete_user($this->editorUserId);
+  }
+
+  public function testGetReturnsTagsWithCounts(): void {
+    $customers = (new TagFactory())->withName('Customers')->create();
+    (new TagFactory())->withName('Prospects')->create();
+    (new SubscriberFactory())->withEmail('x@example.com')->withTags([$customers])->create();
+
+    $data = $this->get(self::BASE_PATH);
+    $this->assertIsArray($data);
+    $items = $data['data']['items'];
+    $this->assertCount(2, $items);
+    $this->assertSame(2, $data['data']['meta']['count']);
+    $this->assertSame(1, $data['data']['meta']['pages']);
+
+    $byName = array_column($items, null, 'name');
+    $this->assertSame(1, $byName['Customers']['subscribers_count']);
+    $this->assertSame(0, $byName['Prospects']['subscribers_count']);
+  }
+
+  public function testGetSupportsSearchAndPagination(): void {
+    (new TagFactory())->withName('Customers')->create();
+    (new TagFactory())->withName('Prospective')->create();
+    (new TagFactory())->withName('VIP')->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['search' => 'Pro']]);
+    $this->assertSame(1, $data['data']['meta']['count']);
+    $this->assertSame('Prospective', $data['data']['items'][0]['name']);
+
+    $page1 = $this->get(self::BASE_PATH, ['query' => ['per_page' => 2, 'page' => 1, 'orderby' => 'name', 'order' => 'asc']]);
+    $this->assertCount(2, $page1['data']['items']);
+    $this->assertSame(2, $page1['data']['meta']['pages']);
+  }
+
+  public function testGetRejectsGuest(): void {
+    wp_set_current_user(0);
+    $data = $this->get(self::BASE_PATH);
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  public function testPostCreatesTag(): void {
+    $data = $this->post(self::BASE_PATH, ['json' => ['name' => 'New tag', 'description' => 'desc']]);
+    $this->assertSame('New tag', $data['data']['name']);
+    $this->assertSame('desc', $data['data']['description']);
+    $this->assertSame(0, $data['data']['subscribers_count']);
+    $this->assertNotNull($this->repository->findOneBy(['name' => 'New tag']));
+  }
+
+  public function testPostRejectsEmptyName(): void {
+    $data = $this->post(self::BASE_PATH, ['json' => ['name' => '   ']]);
+    $this->assertSame('mailpoet_tags_name_required', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
+  }
+
+  public function testPostRejectsDuplicateName(): void {
+    (new TagFactory())->withName('Duplicate')->create();
+    $data = $this->post(self::BASE_PATH, ['json' => ['name' => 'Duplicate']]);
+    $this->assertSame('mailpoet_tags_duplicate', $data['code']);
+    $this->assertSame(409, $data['data']['status']);
+  }
+
+  public function testPutUpdatesTag(): void {
+    $tag = (new TagFactory())->withName('Old')->create();
+
+    $data = $this->put(sprintf('%s/%d', self::BASE_PATH, $tag->getId()), [
+      'json' => ['name' => 'Renamed', 'description' => 'updated'],
+    ]);
+    $this->assertSame('Renamed', $data['data']['name']);
+    $this->assertSame('updated', $data['data']['description']);
+
+    $refreshed = $this->repository->findOneById($tag->getId());
+    $this->assertNotNull($refreshed);
+    $this->assertSame('Renamed', $refreshed->getName());
+  }
+
+  public function testPutRejectsDuplicateName(): void {
+    (new TagFactory())->withName('Existing')->create();
+    $tag = (new TagFactory())->withName('Other')->create();
+
+    $data = $this->put(sprintf('%s/%d', self::BASE_PATH, $tag->getId()), [
+      'json' => ['name' => 'Existing'],
+    ]);
+    $this->assertSame('mailpoet_tags_duplicate', $data['code']);
+  }
+
+  public function testPutReturns404ForMissingTag(): void {
+    $data = $this->put(self::BASE_PATH . '/999999', ['json' => ['name' => 'X']]);
+    $this->assertSame('mailpoet_tags_not_found', $data['code']);
+    $this->assertSame(404, $data['data']['status']);
+  }
+
+  public function testDeleteRemovesTag(): void {
+    $tag = (new TagFactory())->withName('Gone')->create();
+
+    $data = $this->delete(sprintf('%s/%d', self::BASE_PATH, $tag->getId()));
+    $this->assertSame(['data' => null], $data);
+
+    $this->assertNull($this->repository->findOneById($tag->getId()));
+  }
+
+  public function testBulkDeleteRemovesMultipleTags(): void {
+    $a = (new TagFactory())->withName('A')->create();
+    $b = (new TagFactory())->withName('B')->create();
+    $c = (new TagFactory())->withName('C')->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-delete', [
+      'json' => ['ids' => [(int)$a->getId(), (int)$b->getId()]],
+    ]);
+    $this->assertSame(2, $data['data']['deleted']);
+
+    $this->assertNull($this->repository->findOneById($a->getId()));
+    $this->assertNull($this->repository->findOneById($b->getId()));
+    $this->assertNotNull($this->repository->findOneById($c->getId()));
+  }
+
+  public function testBulkDeleteRejectsGuest(): void {
+    $tag = (new TagFactory())->withName('Keep')->create();
+    wp_set_current_user(0);
+
+    $data = $this->post(self::BASE_PATH . '/bulk-delete', [
+      'json' => ['ids' => [(int)$tag->getId()]],
+    ]);
+    $this->assertSame('rest_forbidden', $data['code']);
+
+    $this->assertNotNull($this->repository->findOneById($tag->getId()));
+  }
+}

--- a/mailpoet/tests/integration/Tags/TagRepositoryTest.php
+++ b/mailpoet/tests/integration/Tags/TagRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Tags;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\TagEntity;
+use MailPoet\Tags\TagRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Test\DataFactories\Tag as TagFactory;
+
+class TagRepositoryTest extends \MailPoetTest {
+  /** @var TagRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(TagRepository::class);
+  }
+
+  public function testListWithCountsReturnsTagsWithSubscriberCounts(): void {
+    $tagA = (new TagFactory())->withName('Alpha')->create();
+    $tagB = (new TagFactory())->withName('Beta')->create();
+    (new TagFactory())->withName('Gamma')->create();
+
+    (new SubscriberFactory())->withEmail('a@example.com')->withTags([$tagA])->create();
+    (new SubscriberFactory())->withEmail('b@example.com')->withTags([$tagA, $tagB])->create();
+
+    $result = $this->repository->listWithCounts();
+    $this->assertSame(3, $result['total']);
+    $items = $this->indexByName($result['items']);
+
+    $this->assertSame(2, $items['Alpha']['subscribers_count']);
+    $this->assertSame(1, $items['Beta']['subscribers_count']);
+    $this->assertSame(0, $items['Gamma']['subscribers_count']);
+  }
+
+  public function testListWithCountsIgnoresSoftDeletedSubscribers(): void {
+    $tag = (new TagFactory())->withName('Tag1')->create();
+
+    (new SubscriberFactory())->withEmail('active@example.com')->withTags([$tag])->create();
+    (new SubscriberFactory())
+      ->withEmail('deleted@example.com')
+      ->withTags([$tag])
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+
+    $result = $this->repository->listWithCounts();
+    $items = $this->indexByName($result['items']);
+    $this->assertSame(1, $items['Tag1']['subscribers_count']);
+  }
+
+  public function testListWithCountsSupportsSearch(): void {
+    (new TagFactory())->withName('Customers')->create();
+    (new TagFactory())->withName('Prospects')->withDescription('customer prospects')->create();
+    (new TagFactory())->withName('VIP')->create();
+
+    $result = $this->repository->listWithCounts(['search' => 'custom']);
+    $this->assertSame(2, $result['total']);
+    $names = array_column($result['items'], 'name');
+    $this->assertContains('Customers', $names);
+    $this->assertContains('Prospects', $names);
+  }
+
+  public function testListWithCountsSupportsSortByName(): void {
+    (new TagFactory())->withName('Zulu')->create();
+    (new TagFactory())->withName('Alpha')->create();
+    (new TagFactory())->withName('Mike')->create();
+
+    $asc = $this->repository->listWithCounts(['orderby' => 'name', 'order' => 'asc']);
+    $this->assertSame(['Alpha', 'Mike', 'Zulu'], array_column($asc['items'], 'name'));
+
+    $desc = $this->repository->listWithCounts(['orderby' => 'name', 'order' => 'desc']);
+    $this->assertSame(['Zulu', 'Mike', 'Alpha'], array_column($desc['items'], 'name'));
+  }
+
+  public function testListWithCountsSupportsSortBySubscribersCount(): void {
+    $empty = (new TagFactory())->withName('Empty')->create();
+    $one = (new TagFactory())->withName('One')->create();
+    $two = (new TagFactory())->withName('Two')->create();
+    unset($empty);
+
+    (new SubscriberFactory())->withEmail('s1@example.com')->withTags([$one])->create();
+    (new SubscriberFactory())->withEmail('s2@example.com')->withTags([$two])->create();
+    (new SubscriberFactory())->withEmail('s3@example.com')->withTags([$two])->create();
+
+    $result = $this->repository->listWithCounts(['orderby' => 'subscribers_count', 'order' => 'desc']);
+    $this->assertSame(['Two', 'One', 'Empty'], array_column($result['items'], 'name'));
+  }
+
+  public function testListWithCountsPaginates(): void {
+    for ($i = 1; $i <= 5; $i++) {
+      (new TagFactory())->withName(sprintf('Tag-%02d', $i))->create();
+    }
+
+    $page1 = $this->repository->listWithCounts(['per_page' => 2, 'page' => 1, 'orderby' => 'name', 'order' => 'asc']);
+    $this->assertSame(5, $page1['total']);
+    $this->assertCount(2, $page1['items']);
+    $this->assertSame(['Tag-01', 'Tag-02'], array_column($page1['items'], 'name'));
+
+    $page3 = $this->repository->listWithCounts(['per_page' => 2, 'page' => 3, 'orderby' => 'name', 'order' => 'asc']);
+    $this->assertCount(1, $page3['items']);
+    $this->assertSame(['Tag-05'], array_column($page3['items'], 'name'));
+  }
+
+  public function testBulkDeleteRemovesTagsAndSubscriberLinks(): void {
+    $tagA = (new TagFactory())->withName('A')->create();
+    $tagB = (new TagFactory())->withName('B')->create();
+    $tagC = (new TagFactory())->withName('C')->create();
+
+    $subscriber = (new SubscriberFactory())->withEmail('link@example.com')->withTags([$tagA, $tagB, $tagC])->create();
+
+    $deleted = $this->repository->bulkDelete([(int)$tagA->getId(), (int)$tagB->getId()]);
+    $this->assertSame(2, $deleted);
+
+    $this->entityManager->clear();
+    $this->assertNull($this->repository->findOneById($tagA->getId()));
+    $this->assertNull($this->repository->findOneById($tagB->getId()));
+    $this->assertNotNull($this->repository->findOneById($tagC->getId()));
+
+    $refreshed = $this->entityManager->find(SubscriberEntity::class, $subscriber->getId());
+    $this->assertInstanceOf(SubscriberEntity::class, $refreshed);
+    $remainingTagIds = [];
+    foreach ($refreshed->getSubscriberTags() as $subscriberTag) {
+      $tag = $subscriberTag->getTag();
+      if ($tag instanceof TagEntity) {
+        $remainingTagIds[] = (int)$tag->getId();
+      }
+    }
+    $this->assertSame([(int)$tagC->getId()], $remainingTagIds);
+  }
+
+  public function testBulkDeleteReturnsZeroForEmptyInput(): void {
+    $this->assertSame(0, $this->repository->bulkDelete([]));
+    $this->assertSame(0, $this->repository->bulkDelete([0, null]));
+  }
+
+  public function testGetSubscribersCountCountsOnlyNonDeleted(): void {
+    $tag = (new TagFactory())->withName('Counted')->create();
+
+    (new SubscriberFactory())->withEmail('alive1@example.com')->withTags([$tag])->create();
+    (new SubscriberFactory())->withEmail('alive2@example.com')->withTags([$tag])->create();
+    (new SubscriberFactory())
+      ->withEmail('removed@example.com')
+      ->withTags([$tag])
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+
+    $this->assertSame(2, $this->repository->getSubscribersCount((int)$tag->getId()));
+  }
+
+  /**
+   * @param array<int, array{name: string, subscribers_count: int}> $items
+   * @return array<string, array{name: string, subscribers_count: int}>
+   */
+  private function indexByName(array $items): array {
+    $indexed = [];
+    foreach ($items as $item) {
+      $indexed[$item['name']] = $item;
+    }
+    return $indexed;
+  }
+}

--- a/mailpoet/views/subscribers/tags.html
+++ b/mailpoet/views/subscribers/tags.html
@@ -1,0 +1,10 @@
+<% extends 'layout.html' %>
+
+<% block content %>
+<div id="mailpoet_tags_container"></div>
+
+<script type="text/javascript">
+  var mailpoet_tags_api = <%= json_encode(api) %>;
+  var mailpoet_tags_subscribers_listing_url = <%= json_encode(subscribers_listing_url) %>;
+</script>
+<% endblock %>

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -265,6 +265,7 @@ const adminConfig = {
     newsletter_editor: 'newsletter-editor/webpack-index.jsx',
     form_editor: 'form-editor/form-editor.jsx',
     settings: 'settings/index.tsx',
+    tags: 'subscribers/tags/index.tsx',
   },
   plugins: [
     ...baseConfig.plugins,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@wordpress/data-controls':
         specifier: ^4.43.0
         version: 4.44.0(react@18.3.1)
+      '@wordpress/dataviews':
+        specifier: ^14.1.0
+        version: 14.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/date':
         specifier: ^5.43.0
         version: 5.44.0
@@ -607,9 +610,6 @@ packages:
   '@ariakit/core@0.3.11':
     resolution: {integrity: sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==}
 
-  '@ariakit/core@0.4.18':
-    resolution: {integrity: sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==}
-
   '@ariakit/core@0.4.20':
     resolution: {integrity: sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==}
 
@@ -618,12 +618,6 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
-
-  '@ariakit/react-core@0.4.21':
-    resolution: {integrity: sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@ariakit/react-core@0.4.26':
     resolution: {integrity: sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==}
@@ -636,12 +630,6 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
-
-  '@ariakit/react@0.4.21':
-    resolution: {integrity: sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@ariakit/react@0.4.26':
     resolution: {integrity: sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==}
@@ -4817,12 +4805,6 @@ packages:
     resolution: {integrity: sha512-NXBq1ODjl6inMWx/l7KCbATcjdoeIOqYeL9i9alqdAfWeKx1EH9PIvKWylIkqZk7erXxCxldiRkuyjTtwjNBxw==}
     engines: {node: '>=12'}
 
-  '@wordpress/primitives@4.39.0':
-    resolution: {integrity: sha512-RV9s+KzyuS8p0YKczLecmhFAtOHIWkCToHyDSmRf8N3XOy4id/T0+B5SJ2nMZJleG1oYINf5lrVcccqP2VmFJg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/primitives@4.44.0':
     resolution: {integrity: sha512-IqLL1EfhhyD9hp3G0q0Djp5HYbqXr7/f+FIj98SCovZnoo6YrVYwzFSrUvjFLr7RchyF19VzOEc0w0PpyhtxYA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -5025,10 +5007,6 @@ packages:
   '@wordpress/warning@2.58.0':
     resolution: {integrity: sha512-9bZlORhyMY2nbWozeyC5kqJsFzEPP4DCLhGmjtbv+YWGHttUrxUZEfrKdqO+rUODA8rP5zeIly1nCQOUnkw4Lg==}
     engines: {node: '>=12'}
-
-  '@wordpress/warning@3.39.0':
-    resolution: {integrity: sha512-NV2WoU4XxTqZU/3k2D5m5cHIw/uM2dlDgW5u1U5fmFIYLGg43WWMlSHQEu6F4tm7fqFt7k4qwT/FymucqHYp7Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/warning@3.44.0':
     resolution: {integrity: sha512-avxdbIYhDuUh2qi2oiq7KeqYOVv2RubqV8UI/Q7bctZSFSXJE8RQGSR/W2YjABeyWBIjlyX/U5lOxVs2PIfy/w==}
@@ -11877,21 +11855,11 @@ snapshots:
 
   '@ariakit/core@0.3.11': {}
 
-  '@ariakit/core@0.4.18': {}
-
   '@ariakit/core@0.4.20': {}
 
   '@ariakit/react-core@0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/core': 0.3.11
-      '@floating-ui/dom': 1.7.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
-  '@ariakit/react-core@0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/core': 0.4.18
       '@floating-ui/dom': 1.7.5
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -11908,12 +11876,6 @@ snapshots:
   '@ariakit/react@0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react-core': 0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@ariakit/react@0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react-core': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -11968,7 +11930,7 @@ snapshots:
       '@wordpress/html-entities': 4.22.0
       '@wordpress/i18n': 5.26.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/primitives': 4.39.0(react@18.3.1)
+      '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/react-i18n': 4.34.0
       '@wordpress/url': 4.44.0
       canvas-confetti: 1.9.3
@@ -15889,13 +15851,13 @@ snapshots:
 
   '@radix-ui/primitive@1.0.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
 
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-compose-refs@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
@@ -15906,7 +15868,7 @@ snapshots:
 
   '@radix-ui/react-context@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
 
   '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
@@ -15917,7 +15879,7 @@ snapshots:
 
   '@radix-ui/react-dialog@1.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       '@radix-ui/react-context': 1.0.0(react@18.3.1)
@@ -15961,7 +15923,7 @@ snapshots:
 
   '@radix-ui/react-dismissable-layer@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -15985,7 +15947,7 @@ snapshots:
 
   '@radix-ui/react-focus-guards@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
 
   '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.28)(react@18.3.1)':
@@ -15996,7 +15958,7 @@ snapshots:
 
   '@radix-ui/react-focus-scope@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
@@ -16016,7 +15978,7 @@ snapshots:
 
   '@radix-ui/react-id@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.3.1)
       react: 18.3.1
 
@@ -16029,7 +15991,7 @@ snapshots:
 
   '@radix-ui/react-portal@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16046,7 +16008,7 @@ snapshots:
 
   '@radix-ui/react-presence@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.3.1)
       react: 18.3.1
@@ -16064,7 +16026,7 @@ snapshots:
 
   '@radix-ui/react-primitive@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-slot': 1.0.0(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16089,7 +16051,7 @@ snapshots:
 
   '@radix-ui/react-slot@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       react: 18.3.1
 
@@ -16109,7 +16071,7 @@ snapshots:
 
   '@radix-ui/react-use-callback-ref@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.28)(react@18.3.1)':
@@ -16120,7 +16082,7 @@ snapshots:
 
   '@radix-ui/react-use-controllable-state@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
       react: 18.3.1
 
@@ -16141,7 +16103,7 @@ snapshots:
 
   '@radix-ui/react-use-escape-keydown@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
       react: 18.3.1
 
@@ -16154,7 +16116,7 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
@@ -17510,7 +17472,7 @@ snapshots:
 
   '@wordpress/block-editor@12.26.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@emotion/react': 11.11.4(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@react-spring/web': 9.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17721,7 +17683,7 @@ snapshots:
 
   '@wordpress/blocks@12.35.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@wordpress/autop': 3.58.0
       '@wordpress/blob': 3.58.0
       '@wordpress/block-serialization-default-parser': 4.58.0
@@ -17784,7 +17746,7 @@ snapshots:
 
   '@wordpress/commands@0.29.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@wordpress/components': 27.6.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 9.28.0(react@18.3.1)
       '@wordpress/element': 5.35.0
@@ -17901,7 +17863,7 @@ snapshots:
 
   '@wordpress/components@29.12.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.25.7
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -17916,7 +17878,7 @@ snapshots:
       '@wordpress/a11y': 4.44.0
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/date': 5.44.0
-      '@wordpress/deprecated': 4.39.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/dom': 4.39.0
       '@wordpress/element': 6.44.0
       '@wordpress/escape-html': 3.44.0
@@ -17926,10 +17888,10 @@ snapshots:
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.44.0
       '@wordpress/keycodes': 4.44.0
-      '@wordpress/primitives': 4.39.0(react@18.3.1)
+      '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
       '@wordpress/rich-text': 7.44.0(react@18.3.1)
-      '@wordpress/warning': 3.39.0
+      '@wordpress/warning': 3.44.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -18047,7 +18009,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.7
       '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.39.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/dom': 4.39.0
       '@wordpress/element': 6.44.0
       '@wordpress/is-shallow-equal': 5.44.0
@@ -18225,7 +18187,7 @@ snapshots:
 
   '@wordpress/dataviews@14.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
-      '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ariakit/react': 0.4.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles': 6.20.0
       '@wordpress/components': 32.6.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.44.0(react@18.3.1)
@@ -18265,7 +18227,7 @@ snapshots:
   '@wordpress/date@5.22.0':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@wordpress/deprecated': 4.39.0
+      '@wordpress/deprecated': 4.44.0
       moment: 2.30.1
       moment-timezone: 0.5.48
 
@@ -18775,14 +18737,14 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.7
       '@wordpress/element': 6.44.0
-      '@wordpress/primitives': 4.39.0(react@18.3.1)
+      '@wordpress/primitives': 4.44.0(react@18.3.1)
     transitivePeerDependencies:
       - react
 
   '@wordpress/icons@11.6.0(react@18.3.1)':
     dependencies:
       '@wordpress/element': 6.44.0
-      '@wordpress/primitives': 4.39.0(react@18.3.1)
+      '@wordpress/primitives': 4.44.0(react@18.3.1)
       react: 18.3.1
 
   '@wordpress/icons@12.2.0(react@18.3.1)':
@@ -18872,7 +18834,7 @@ snapshots:
 
   '@wordpress/keyboard-shortcuts@4.35.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@wordpress/data': 9.28.0(react@18.3.1)
       '@wordpress/element': 5.35.0
       '@wordpress/keycodes': 3.58.0
@@ -18970,7 +18932,7 @@ snapshots:
 
   '@wordpress/notices@4.26.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@wordpress/a11y': 3.58.0
       '@wordpress/data': 9.28.0(react@18.3.1)
       react: 18.3.1
@@ -19043,7 +19005,7 @@ snapshots:
 
   '@wordpress/preferences@3.35.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@wordpress/a11y': 3.58.0
       '@wordpress/components': 27.6.0(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 6.35.0(react@18.3.1)
@@ -19089,12 +19051,6 @@ snapshots:
       '@babel/runtime': 7.28.6
       '@wordpress/element': 5.35.0
       clsx: 2.1.1
-
-  '@wordpress/primitives@4.39.0(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.44.0
-      clsx: 2.1.1
-      react: 18.3.1
 
   '@wordpress/primitives@4.44.0(react@18.3.1)':
     dependencies:
@@ -19346,7 +19302,7 @@ snapshots:
 
   '@wordpress/style-engine@1.41.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       change-case: 4.1.2
 
   '@wordpress/style-engine@2.39.0':
@@ -19372,7 +19328,7 @@ snapshots:
 
   '@wordpress/sync@0.20.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/simple-peer': 9.11.8
       '@wordpress/url': 3.59.0
       import-locals: 2.0.0
@@ -19423,7 +19379,7 @@ snapshots:
 
   '@wordpress/token-list@2.58.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
 
   '@wordpress/token-list@3.44.0': {}
 
@@ -19473,7 +19429,7 @@ snapshots:
 
   '@wordpress/undo-manager@0.18.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@wordpress/is-shallow-equal': 4.58.0
 
   '@wordpress/undo-manager@1.39.0':
@@ -19544,8 +19500,6 @@ snapshots:
 
   '@wordpress/warning@2.58.0': {}
 
-  '@wordpress/warning@3.39.0': {}
-
   '@wordpress/warning@3.44.0': {}
 
   '@wordpress/widgets@4.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))':
@@ -19575,7 +19529,7 @@ snapshots:
 
   '@wordpress/wordcount@3.58.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
 
   '@wordpress/wordcount@4.44.0': {}
 


### PR DESCRIPTION
## Description

New page under **MailPoet > Subscribers > Tags** to list, create, edit, and delete subscriber tags.

## Code review notes

This PR introduces `@wordpress/dataviews` package and uses both `DataViews` and `DataForm`. While this is yet another listing component we use in MailPoet, this is now the preferred way for any new pages, and we'll try to eventually migrate other pages to use the same components.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7964

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="731" height="448" alt="Screenshot 2026-04-23 at 17 32 03" src="https://github.com/user-attachments/assets/2472d305-05d4-4e11-b9e0-df12d9bfd07a" />

<img width="1448" height="984" alt="Screenshot 2026-04-23 at 14 59 32" src="https://github.com/user-attachments/assets/f0929167-55ca-4589-91f7-25cbf1ff473a" />

## Tasks

- [x] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7964-tags-managements)

_The latest successful build from `stomail-7964-tags-managements` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 1 (Suggestion)**

**Category: Code Quality / Type Safety**

**Issue: Unsafe type assertion in error handling (Multiple locations)**

In the tags management implementation, caught errors are being cast to `ApiErrorResponse` without proper type validation in three locations:
- `tags-form.tsx` - error handling in `handleSubmit`
- `tags-page.tsx` - error handling in `loadTags` function
- `tags-page.tsx` - error handling in `handleDelete` function

The pattern used is:
```javascript
const apiError = err as ApiErrorResponse;
setError(
  apiError?.message || __('Something went wrong. Please try again.', 'mailpoet'),
);
```

While the optional chaining (`?.message`) and fallback messages provide runtime safety, the type assertion without validation violates TypeScript best practices. The caught error (`err`) is of type `unknown` and may not conform to the `ApiErrorResponse` interface (which requires `code` and `message` fields). Using `as ApiErrorResponse` instructs TypeScript to skip type checking, potentially masking unexpected error structures.

**Recommendation**: Implement a type guard function to safely validate error structure before accessing properties, or acknowledge that `@wordpress/api-fetch` guarantees a specific error format and document this assumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->