### PR TITLE
Simple audit for backend files

### DIFF
--- a/mailpoet/lib/API/JSON/v1/DynamicSegments.php
+++ b/mailpoet/lib/API/JSON/v1/DynamicSegments.php
@@ -218,7 +218,7 @@ class DynamicSegments extends APIEndpoint {
         $segment = $this->getSegment(['id' => $segmentId]);
         if ($segment) {
           $errors[] = sprintf(
-            // translators: %1$s is the name of the segment, %2$s is a comma-seperated list of emails for which the segment is used.
+            // translators: %1$s is the name of the segment, %2$s is a comma-separated list of emails for which the segment is used.
             _x('Segment \'%1$s\' cannot be deleted because it’s used for \'%2$s\' email', 'Alert shown when trying to delete segment, which is assigned to any automatic emails.', 'mailpoet'),
             $segment->getName(),
             join("', '", $activelyUsedNewslettersSubjects[$segmentId])

--- a/mailpoet/lib/API/JSON/v1/Forms.php
+++ b/mailpoet/lib/API/JSON/v1/Forms.php
@@ -122,7 +122,7 @@ class Forms extends APIEndpoint {
       return $this->badRequest([
         APIError::BAD_REQUEST =>
           sprintf(
-          // translators: %1$s is a comma-seperated list of allowed values, %2$s the status the user specified.
+          // translators: %1$s is a comma-separated list of allowed values, %2$s the status the user specified.
             __('Invalid status. Allowed values are (%1$s), you specified %2$s', 'mailpoet'),
             join(', ', [FormEntity::STATUS_ENABLED, FormEntity::STATUS_DISABLED]),
             $status

--- a/mailpoet/lib/API/JSON/v1/Segments.php
+++ b/mailpoet/lib/API/JSON/v1/Segments.php
@@ -192,7 +192,7 @@ class Segments extends APIEndpoint {
         APIError::BAD_REQUEST => str_replace(
           '%1$s',
           "'" . join("', '", $activelyUsedNewslettersSubjects[$segment->getId()]) . "'",
-          // translators: %1$s is a comma-seperated list of emails for which the segment is used.
+          // translators: %1$s is a comma-separated list of emails for which the segment is used.
           _x('List cannot be deleted because it’s used for %1$s email', 'Alert shown when trying to delete segment, which is assigned to any automatic emails.', 'mailpoet')
         ),
       ]);
@@ -204,7 +204,7 @@ class Segments extends APIEndpoint {
         APIError::BAD_REQUEST => str_replace(
           '%1$s',
           "'" . join("', '", $activelyUsedFormNames[$segment->getId()]) . "'",
-          // translators: %1$s is a comma-seperated list of forms for which the segment is used.
+          // translators: %1$s is a comma-separated list of forms for which the segment is used.
           _nx(
             'List cannot be deleted because it’s used for %1$s form',
             'List cannot be deleted because it’s used for %1$s forms',

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -98,7 +98,7 @@ class Segments {
         str_replace(
           '%1$s',
           "'" . join("', '", $activelyUsedNewslettersSubjects[$listId]) . "'",
-          // translators: %1$s is a comma-seperated list of emails for which the segment is used.
+          // translators: %1$s is a comma-separated list of emails for which the segment is used.
           _x('List cannot be deleted because it’s used for %1$s email', 'Alert shown when trying to delete segment, which is assigned to any automatic emails.', 'mailpoet')
         ),
         APIException::LIST_USED_IN_EMAIL
@@ -111,7 +111,7 @@ class Segments {
         str_replace(
           '%1$s',
           "'" . join("', '", $activelyUsedFormNames[$listId]) . "'",
-          // translators: %1$s is a comma-seperated list of forms for which the segment is used.
+          // translators: %1$s is a comma-separated list of forms for which the segment is used.
           _nx(
             'List cannot be deleted because it’s used for %1$s form',
             'List cannot be deleted because it’s used for %1$s forms',

--- a/mailpoet/lib/API/REST/Endpoint.php
+++ b/mailpoet/lib/API/REST/Endpoint.php
@@ -3,12 +3,13 @@
 namespace MailPoet\API\REST;
 
 use MailPoet\Validator\Schema;
+use MailPoet\WP\Functions as WPFunctions;
 
 abstract class Endpoint {
   abstract public function handle(Request $request): Response;
 
   public function checkPermissions(): bool {
-    return current_user_can('admin');
+    return WPFunctions::get()->currentUserCan('admin');
   }
 
   /** @return array<string, Schema> */

--- a/mailpoet/lib/AdminPages/PageRenderer.php
+++ b/mailpoet/lib/AdminPages/PageRenderer.php
@@ -226,7 +226,7 @@ class PageRenderer {
       ) {
         DIPanel::init();
       }
-      if (is_admin() && $this->subscribersCountCacheRecalculation->shouldBeScheduled()) {
+      if ($this->wp->isAdmin() && $this->subscribersCountCacheRecalculation->shouldBeScheduled()) {
         $this->subscribersCountCacheRecalculation->schedule();
       }
 

--- a/mailpoet/lib/Automation/Engine/API/Endpoint.php
+++ b/mailpoet/lib/Automation/Engine/API/Endpoint.php
@@ -4,9 +4,10 @@ namespace MailPoet\Automation\Engine\API;
 
 use MailPoet\API\REST\Endpoint as MailPoetEndpoint;
 use MailPoet\Automation\Engine\Engine;
+use MailPoet\WP\Functions as WPFunctions;
 
 abstract class Endpoint extends MailPoetEndpoint {
   public function checkPermissions(): bool {
-    return current_user_can(Engine::CAPABILITY_MANAGE_AUTOMATIONS);
+    return WPFunctions::get()->currentUserCan(Engine::CAPABILITY_MANAGE_AUTOMATIONS);
   }
 }

--- a/mailpoet/lib/Automation/Engine/API/Endpoint.php
+++ b/mailpoet/lib/Automation/Engine/API/Endpoint.php
@@ -4,10 +4,9 @@ namespace MailPoet\Automation\Engine\API;
 
 use MailPoet\API\REST\Endpoint as MailPoetEndpoint;
 use MailPoet\Automation\Engine\Engine;
-use MailPoet\WP\Functions as WPFunctions;
 
 abstract class Endpoint extends MailPoetEndpoint {
   public function checkPermissions(): bool {
-    return WPFunctions::get()->currentUserCan(Engine::CAPABILITY_MANAGE_AUTOMATIONS);
+    return current_user_can(Engine::CAPABILITY_MANAGE_AUTOMATIONS);
   }
 }

--- a/mailpoet/lib/Automation/Engine/Validation/AutomationGraph/AutomationWalker.php
+++ b/mailpoet/lib/Automation/Engine/Validation/AutomationGraph/AutomationWalker.php
@@ -47,7 +47,7 @@ class AutomationWalker {
     do {
       $record = array_pop($stack);
       if (!$record) {
-        throw new InvalidStateException();
+        throw new InvalidStateException('Unexpected empty stack during automation graph traversal');
       }
       yield $record;
       [$step, $parents] = $record;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Triggers/SomeoneSubscribesTrigger.php
@@ -85,7 +85,7 @@ class SomeoneSubscribesTrigger implements Trigger {
       return false;
     }
 
-    // Triggers when no segment IDs defined (= any segment) or the current segment paylo.
+    // Triggers when no segment IDs defined (= any segment) or the current segment payload.
     $triggerArgs = $args->getStep()->getArgs();
     $segmentIds = $triggerArgs['segment_ids'] ?? [];
     return !is_array($segmentIds) || !$segmentIds || in_array($segmentId, $segmentIds, true);

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderCreatedTrigger.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Triggers/Orders/OrderCreatedTrigger.php
@@ -63,7 +63,7 @@ class OrderCreatedTrigger implements Trigger {
      * It just creates the order object and saves it to the database. We need therefore to wait for the order to have at least the billing address stored.
      **/
     if (!$order->get_billing_email()) {
-      add_action(
+      $this->wp->addAction(
         'woocommerce_after_order_object_save',
         function($order) use ($orderId) {
           if ((int)$orderId !== (int)$order->get_id()) {

--- a/mailpoet/lib/Config/Capabilities.php
+++ b/mailpoet/lib/Config/Capabilities.php
@@ -22,7 +22,7 @@ class Capabilities {
     if ($renderer !== null) {
       $this->renderer = $renderer;
     }
-    if ($wp == null) {
+    if ($wp === null) {
       $wp = new WPFunctions;
     }
     $this->wp = $wp;

--- a/mailpoet/lib/Doctrine/PSRCacheItem.php
+++ b/mailpoet/lib/Doctrine/PSRCacheItem.php
@@ -41,7 +41,6 @@ class PSRCacheItem implements CacheItemInterface {
    * @inheritDoc
    */
   public function isHit(): bool {
-    // TODO: Implement isHit() method.
     return $this->isHit;
   }
 

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -43,7 +43,7 @@ class Widget extends \WP_Widget {
     $this->formsRepository = ContainerWrapper::getInstance()->get(FormsRepository::class);
     $this->customFonts = ContainerWrapper::getInstance()->get(CustomFonts::class);
 
-    if (!is_admin()) {
+    if (!$this->wp->isAdmin()) {
       $this->setupIframe();
     } else {
       WPFunctions::get()->addAction('widgets_admin_page', [
@@ -74,7 +74,7 @@ class Widget extends \WP_Widget {
       $languageAttributes[] = 'dir="rtl"';
     }
 
-    if (get_option('html_type') === 'text/html') {
+    if ($this->wp->getOption('html_type') === 'text/html') {
       $languageAttributes[] = sprintf('lang="%s"', WPFunctions::get()->getBloginfo('language'));
     }
 

--- a/mailpoet/lib/Newsletter/Links/Links.php
+++ b/mailpoet/lib/Newsletter/Links/Links.php
@@ -131,7 +131,7 @@ class Links {
     // match data tags
     $subscriber = $this->subscribersRepository->findOneById($subscriberId);
     if (!$subscriber) {
-      throw new InvalidStateException();
+      throw new InvalidStateException('Subscriber not found for link replacement');
     }
     preg_match_all($this->getLinkRegex(), $content, $matches);
     foreach ($matches[1] as $index => $match) {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -283,12 +283,12 @@ class NewsletterSaveController {
 
   private function getNewsletter(array $data): NewsletterEntity {
     if (!isset($data['id'])) {
-      throw new UnexpectedValueException();
+      throw new UnexpectedValueException('Missing newsletter ID in data');
     }
 
     $newsletter = $this->newslettersRepository->findOneById((int)$data['id']);
     if (!$newsletter) {
-      throw new NotFoundException();
+      throw new NotFoundException('Newsletter not found');
     }
     return $newsletter;
   }
@@ -472,7 +472,7 @@ class NewsletterSaveController {
       $task = $queue->getTask();
 
       if (!$task instanceof ScheduledTaskEntity) {
-        throw new InvalidStateException();
+        throw new InvalidStateException('Newsletter queue has no associated scheduled task');
       }
 
       $newsletterQueueTask->preProcessNewsletter($newsletter, $task);

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -43,7 +43,7 @@ class ScheduledTaskSubscribersRepository extends Repository {
     if (!$taskSubscriber) {
       $task = $this->entityManager->getReference(ScheduledTaskEntity::class, (int)$data['task_id']);
       $subscriber = $this->entityManager->getReference(SubscriberEntity::class, (int)$data['subscriber_id']);
-      if (!$task || !$subscriber) throw new InvalidStateException();
+      if (!$task || !$subscriber) throw new InvalidStateException('Task or subscriber not found');
 
       $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
       $this->persist($taskSubscriber);

--- a/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
@@ -29,7 +29,7 @@ class PostEditorBlock {
   public function init() {
     $this->subscriptionFormBlock->init();
 
-    if (is_admin()) {
+    if ($this->wp->isAdmin()) {
       $this->initAdmin();
     } else {
       $this->initFrontend();

--- a/mailpoet/lib/Services/Bridge/API.php
+++ b/mailpoet/lib/Services/Bridge/API.php
@@ -55,7 +55,7 @@ class API {
   private $wp;
   /** @var LoggerFactory */
   private $loggerFactory;
-  /** @var mixed|null It is an instance of \CurlHandle in PHP8 and aboove but a resource in PHP7 */
+  /** @var mixed|null It is an instance of \CurlHandle in PHP8 and above but a resource in PHP7 */
   private $curlHandle = null;
 
   public $urlMe = 'https://bridge.mailpoet.com/api/v0/me';

--- a/mailpoet/lib/Subscribers/SubscribersCountsController.php
+++ b/mailpoet/lib/Subscribers/SubscribersCountsController.php
@@ -69,7 +69,7 @@ class SubscribersCountsController {
     if (!$result) {
       $segment = $this->segmentsRepository->findOneById($segmentId);
       if (!$segment) {
-        throw new InvalidStateException();
+        throw new InvalidStateException("Segment with ID $segmentId not found");
       }
       $result = $this->recalculateSegmentStatisticsCache($segment);
     }

--- a/mailpoet/lib/Subscription/Comment.php
+++ b/mailpoet/lib/Subscription/Comment.php
@@ -75,7 +75,7 @@ class Comment {
           'subscribe_on_comment',
           true
         );
-      } else if ($commentStatus === Comment::APPROVED) {
+      } elseif ($commentStatus === Comment::APPROVED) {
         $this->subscribeAuthorOfComment($commentId);
       }
     }

--- a/mailpoet/lib/Subscription/Registration.php
+++ b/mailpoet/lib/Subscription/Registration.php
@@ -52,7 +52,7 @@ class Registration {
           id="mailpoet_subscribe_on_register"
           value="1"
           name="mailpoet[subscribe_on_register]"
-        />&nbsp;' . esc_attr($label) . '
+        />&nbsp;' . esc_html($label) . '
       </label>
     </p>';
 
@@ -60,7 +60,7 @@ class Registration {
 
     // We control the template and $form can be considered safe.
     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    print $form;
+    echo $form;
   }
 
   public function onMultiSiteRegister($result) {

--- a/mailpoet/lib/Tags/RestApi/Endpoints/TagsEndpoint.php
+++ b/mailpoet/lib/Tags/RestApi/Endpoints/TagsEndpoint.php
@@ -5,12 +5,13 @@ namespace MailPoet\Tags\RestApi\Endpoints;
 use MailPoet\API\REST\Endpoint;
 use MailPoet\Config\AccessControl;
 use MailPoet\Entities\TagEntity;
+use MailPoet\WP\Functions as WPFunctions;
 
 abstract class TagsEndpoint extends Endpoint {
   private const DATE_FORMAT = 'Y-m-d H:i:s';
 
   public function checkPermissions(): bool {
-    return current_user_can(AccessControl::PERMISSION_MANAGE_SUBSCRIBERS);
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_SUBSCRIBERS);
   }
 
   protected function buildItem(TagEntity $tag, int $subscribersCount = 0): array {

--- a/mailpoet/lib/Util/Cookies.php
+++ b/mailpoet/lib/Util/Cookies.php
@@ -21,7 +21,7 @@ class Cookies {
     $value = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     $error = json_last_error();
     if ($error || ($value === false)) {
-      throw new InvalidArgumentException();
+      throw new InvalidArgumentException('Failed to JSON-encode cookie value');
     }
 
     setcookie(

--- a/mailpoet/lib/Util/Notices/BlackFridayNotice.php
+++ b/mailpoet/lib/Util/Notices/BlackFridayNotice.php
@@ -35,7 +35,7 @@ class BlackFridayNotice {
       && !$this->servicesChecker->isBundledSubscription()
       && (time() >= strtotime(self::DATE_FROM))
       && (time() <= strtotime(self::DATE_TO))
-      && !get_transient(self::OPTION_NAME);
+      && !WPFunctions::get()->getTransient(self::OPTION_NAME);
     if ($shouldDisplay) {
       $this->display();
     }

--- a/mailpoet/lib/Util/Notices/HeadersAlreadySentNotice.php
+++ b/mailpoet/lib/Util/Notices/HeadersAlreadySentNotice.php
@@ -45,7 +45,7 @@ class HeadersAlreadySentNotice {
   }
 
   public function areHeadersAlreadySent() {
-    return !get_transient(self::OPTION_NAME)
+    return !$this->wp->getTransient(self::OPTION_NAME)
       && ($this->headersSent() || $this->isWhitespaceInBuffer());
   }
 

--- a/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
+++ b/mailpoet/lib/Util/Notices/PHPVersionWarnings.php
@@ -18,7 +18,7 @@ class PHPVersionWarnings {
   }
 
   public function isOutdatedPHPVersion($phpVersion) {
-    return version_compare($phpVersion, '8.0', '<') && !get_transient(self::OPTION_NAME);
+    return version_compare($phpVersion, '8.0', '<') && !WPFunctions::get()->getTransient(self::OPTION_NAME);
   }
 
   public function display($phpVersion) {

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -98,7 +98,7 @@ class Helper {
     return wc_get_price_decimals();
   }
 
-  public function wcGetPriceDecimalSeperator(): string {
+  public function wcGetPriceDecimalSeparator(): string {
     return wc_get_price_decimal_separator();
   }
 
@@ -257,10 +257,6 @@ class Helper {
     return array_values($result);
   }
 
-  public function wcGetPriceDecimalSeparator() {
-    return wc_get_price_decimal_separator();
-  }
-
   public function getLatestCoupon(): ?string {
     $coupons = $this->wp->getPosts([
       'numberposts' => 1,
@@ -316,7 +312,7 @@ class Helper {
   public function getWoocommerceStoreConfig(): array {
     return [
       'precision' => $this->wcGetPriceDecimals(),
-      'decimalSeparator' => $this->wcGetPriceDecimalSeperator(),
+      'decimalSeparator' => $this->wcGetPriceDecimalSeparator(),
       'thousandSeparator' => $this->wcGetPriceThousandSeparator(),
       'code' => $this->getWoocommerceCurrency(),
       'symbol' => html_entity_decode($this->getWoocommerceCurrencySymbol(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),


### PR DESCRIPTION
## Description

I directed Claude to audit backend files and look for obvious typos or issues or dead code.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/php-backend-audit-cleanup)

_The latest successful build from `fix/php-backend-audit-cleanup` will be used. If none is available, the link won't work._