### PR TITLE
Update docs to reflect migration from ./do to pnpm scripts

### DIFF
--- a/.ai/skills/mailpoet-dev-cycle/SKILL.md
+++ b/.ai/skills/mailpoet-dev-cycle/SKILL.md
@@ -9,11 +9,11 @@ This skill covers linting, code quality, and building assets for MailPoet develo
 
 ## Working Directory
 
-This is a monorepo. All plugin-level `./do` commands MUST be run from the correct subdirectory:
+This is a monorepo. Prefer the root `pnpm` scripts for common build and QA work; they wrap the plugin-level Robo tasks from the correct directory.
 
-- **Free plugin** (default): `mailpoet/`
-- **Premium plugin**: `mailpoet-premium/`
-- **Repo root** `./do`: Docker wrapper that forwards commands. Use `./do --test` for test commands, `./do --premium` for premium.
+- **Free plugin** (default): run `pnpm <task>` from the repo root.
+- **Premium plugin**: run `pnpm <task>` from `mailpoet-premium/` when a premium package script exists.
+- **Robo-only helpers**: run `./do` from the relevant plugin directory only when no `pnpm` wrapper exists.
 
 Unless you are explicitly working on the premium plugin, always default to the free plugin directory.
 
@@ -38,25 +38,25 @@ All commands below default to the free plugin. Run from the repo root.
 
 ```bash
 # QA (all checks: PHP lint + PHPCS + ESLint + Stylelint)
-cd mailpoet && ./do qa
+pnpm qa
 
 # PHP only (lint + PHPCS)
-cd mailpoet && ./do qa:php
+pnpm qa:php
 
 # PHPStan static analysis
-cd mailpoet && ./do qa:phpstan
+pnpm qa:phpstan
 
 # JS/TS linting (ESLint + TypeScript check)
-cd mailpoet && ./do qa:lint-javascript
+pnpm qa:js
 
 # CSS/SCSS linting (Stylelint)
-cd mailpoet && ./do qa:lint-css
+pnpm qa:css
 
 # Prettier check / fix
-cd mailpoet && ./do qa:prettier-check
-cd mailpoet && ./do qa:prettier-write
+pnpm qa:prettier
+pnpm qa:fix
 
-# Fix a single file (PHPCS or ESLint based on extension)
+# Fix a single file (PHPCS or ESLint based on extension; Robo-only)
 cd mailpoet && ./do qa:fix-file path/to/file.php
 cd mailpoet && ./do qa:fix-file path/to/file.tsx
 ```
@@ -75,7 +75,7 @@ graph TD
     G --> E
     F -->|Yes| H[Run Prettier]
     H --> I{Prettier Clean?}
-    I -->|No| J["./do qa:prettier-write"]
+    I -->|No| J["pnpm qa:fix"]
     J --> H
     I -->|Yes| K[Commit]
 ```
@@ -84,8 +84,8 @@ graph TD
 
 Before committing, run these from the repo root:
 
-- [ ] `cd mailpoet && ./do qa` -- all PHP and frontend QA checks pass
-- [ ] `cd mailpoet && ./do qa:prettier-write` -- formatting is clean
+- [ ] `pnpm qa` -- all PHP and frontend QA checks pass
+- [ ] `pnpm qa:fix` -- formatting is clean
 - [ ] Run relevant tests (see the `writing-tests` skill for commands)
 
 ## Premium Plugin
@@ -93,12 +93,6 @@ Before committing, run these from the repo root:
 When working on `mailpoet-premium/`, substitute the directory:
 
 ```bash
-cd mailpoet-premium && ./do qa
-cd mailpoet-premium && ./do qa:phpstan
-```
-
-Or use the root wrapper:
-
-```bash
-./do --premium qa
+cd mailpoet-premium && pnpm qa
+cd mailpoet-premium && pnpm qa:phpstan
 ```

--- a/.ai/skills/mailpoet-dev-cycle/code-quality.md
+++ b/.ai/skills/mailpoet-dev-cycle/code-quality.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MailPoet uses ESLint for JavaScript/TypeScript, Stylelint for SCSS, and Prettier for formatting. All commands below run from `mailpoet/` (the free plugin directory) unless stated otherwise.
+MailPoet uses ESLint for JavaScript/TypeScript, Stylelint for SCSS, and Prettier for formatting. Use the root `pnpm` wrappers for the common free-plugin checks unless a command is explicitly marked as Robo-only.
 
 ## JavaScript / TypeScript Linting (ESLint)
 
@@ -17,10 +17,10 @@ ESLint uses a flat config at `mailpoet/eslint.config.js` which imports shared co
 ### Running ESLint
 
 ```bash
-# Run ESLint + TypeScript type checking (from mailpoet/)
-cd mailpoet && ./do qa:lint-javascript
+# Run ESLint + TypeScript type checking
+pnpm qa:js
 
-# Fix a single JS/TS file (from mailpoet/)
+# Fix a single JS/TS file (Robo-only)
 cd mailpoet && ./do qa:fix-file assets/js/src/path/to/file.tsx
 ```
 
@@ -32,7 +32,7 @@ Under the hood, `qa:lint-javascript` runs `pnpm run check-types && pnpm run lint
 ### Fixing ESLint Issues
 
 ```bash
-# Auto-fix a single file
+# Auto-fix a single file (Robo-only)
 cd mailpoet && ./do qa:fix-file assets/js/src/settings/pages/basics/stats-notifications.tsx
 
 # Or run eslint directly with --fix
@@ -68,8 +68,8 @@ Stylelint config is at `mailpoet/.stylelintrc`. Key rules:
 ### Running Stylelint
 
 ```bash
-# Check all SCSS files (from mailpoet/)
-cd mailpoet && ./do qa:lint-css
+# Check all SCSS files
+pnpm qa:css
 
 # Fix SCSS files (auto-fix where possible)
 cd mailpoet && pnpm run stylelint -- "assets/css/src/**/*.scss"
@@ -111,27 +111,30 @@ Files excluded from Prettier are listed in `.prettierignore` (vendor, dist, gene
 ### Running Prettier
 
 ```bash
-# Check formatting (from mailpoet/)
-cd mailpoet && ./do qa:prettier-check
+# Check formatting
+pnpm qa:prettier
 
-# Auto-fix formatting (from mailpoet/)
-cd mailpoet && ./do qa:prettier-write
+# Auto-fix formatting
+pnpm qa:fix
 ```
 
 Prettier runs from the repo root internally via `npx prettier`. It applies to JS, TS, JSX, TSX, SCSS, JSON, and other supported file types.
 
 ### When to Run Prettier
 
-Always run `./do qa:prettier-write` before committing. CI checks formatting via `./do qa:prettier-check` during the build step.
+Always run `pnpm qa:fix` before committing. CI checks formatting via the underlying Robo Prettier check during the build step.
 
 ## Running All Frontend QA Checks
 
 ```bash
-# ESLint + Stylelint combined (from mailpoet/)
-cd mailpoet && ./do qa:frontend-assets
+# ESLint + TypeScript type checking
+pnpm qa:js
 
-# Everything: PHP lint + PHPCS + ESLint + Stylelint (from mailpoet/)
-cd mailpoet && ./do qa
+# Stylelint
+pnpm qa:css
+
+# Everything: PHP lint + PHPCS + ESLint + Stylelint
+pnpm qa
 ```
 
 ## lint-staged (Git Hooks)
@@ -152,14 +155,8 @@ Pre-commit hooks are configured via `lint-staged` in `mailpoet/package.json`. Th
 The premium plugin (`mailpoet-premium/`) has the same JS and CSS linting commands. Run from its directory:
 
 ```bash
-cd mailpoet-premium && ./do qa:lint-javascript
-cd mailpoet-premium && ./do qa:lint-css
-```
-
-Or via the root wrapper:
-
-```bash
-./do --premium qa:lint-javascript
+cd mailpoet-premium && pnpm qa:js
+cd mailpoet-premium && pnpm qa:css
 ```
 
 ## CI Reference

--- a/.ai/skills/mailpoet-dev-cycle/php-coding-standards.md
+++ b/.ai/skills/mailpoet-dev-cycle/php-coding-standards.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-MailPoet enforces PHP quality through three tools: **PHP lint** (syntax checking), **PHPCS** (coding standards), and **PHPStan** (static analysis). All commands below run from `mailpoet/` unless stated otherwise.
+MailPoet enforces PHP quality through three tools: **PHP lint** (syntax checking), **PHPCS** (coding standards), and **PHPStan** (static analysis). Use the root `pnpm` wrappers for common free-plugin checks; granular PHPCS helpers are still plugin-level Robo-only commands.
 
 ## PHP Lint (Syntax Check)
 
 ```bash
-# Check PHP syntax (from mailpoet/)
+# Check PHP syntax only (Robo-only)
 cd mailpoet && ./do qa:lint
 ```
 
@@ -18,16 +18,16 @@ Runs `parallel-lint lib/ tests/ mailpoet.php`. Fast check that catches syntax er
 ### Running PHPCS
 
 ```bash
-# PHP lint + PHPCS combined (from mailpoet/)
-cd mailpoet && ./do qa:php
+# PHP lint + PHPCS combined
+pnpm qa:php
 
-# PHPCS only on all files (from mailpoet/)
+# PHPCS only on all files (Robo-only)
 cd mailpoet && ./do qa:code-sniffer
 
-# PHPCS on specific files (from mailpoet/)
+# PHPCS on specific files (Robo-only)
 cd mailpoet && ./do qa:code-sniffer lib/Subscribers/SubscribersRepository.php
 
-# Auto-fix a single PHP file with PHPCBF (from mailpoet/)
+# Auto-fix a single PHP file with PHPCBF (Robo-only)
 cd mailpoet && ./do qa:fix-file lib/Subscribers/SubscribersRepository.php
 ```
 
@@ -119,7 +119,7 @@ FOUND 2 ERRORS AFFECTING 2 LINES
 ----------------------------------------------------------------------
 ```
 
-- `[x]` -- auto-fixable with `./do qa:fix-file`
+- `[x]` -- auto-fixable with `cd mailpoet && ./do qa:fix-file`
 - `[ ]` -- requires manual fix
 - The sniff code in parentheses identifies the exact rule
 
@@ -152,12 +152,12 @@ echo $rendered_html;
 ### Running PHPStan
 
 ```bash
-# Run PHPStan (from mailpoet/)
-cd mailpoet && ./do qa:phpstan
+# Run PHPStan
+pnpm qa:phpstan
 
 # Run with specific PHP version target
-cd mailpoet && ./do qa:phpstan --php-version=70400
-cd mailpoet && ./do qa:phpstan --php-version=80300
+pnpm qa:phpstan --php-version=70400
+pnpm qa:phpstan --php-version=80300
 ```
 
 ### Configuration
@@ -180,11 +180,11 @@ PHPStan config is at `mailpoet/tasks/phpstan/phpstan.neon`:
 ## Running All PHP QA
 
 ```bash
-# Full PHP QA: lint + PHPCS (from mailpoet/)
-cd mailpoet && ./do qa:php
+# Full PHP QA: lint + PHPCS
+pnpm qa:php
 
-# Full QA: PHP + frontend (from mailpoet/)
-cd mailpoet && ./do qa
+# Full QA: PHP + frontend
+pnpm qa
 ```
 
 ## Premium Plugin
@@ -192,16 +192,16 @@ cd mailpoet && ./do qa
 The premium plugin uses the same shared ruleset but with its own text domain. Run from `mailpoet-premium/`:
 
 ```bash
-# PHPCS (uses premium-ruleset.xml automatically)
+# PHPCS (uses premium-ruleset.xml automatically; Robo-only)
 cd mailpoet-premium && ./do qa:code-sniffer
 
 # Full QA (lint + PHPCS + ESLint + Stylelint)
-cd mailpoet-premium && ./do qa
+cd mailpoet-premium && pnpm qa
 
 # PHPStan (reuses free plugin's phpstan binary)
-cd mailpoet-premium && ./do qa:phpstan
+cd mailpoet-premium && pnpm qa:phpstan
 
-# Fix a single file
+# Fix a single file (Robo-only)
 cd mailpoet-premium && ./do qa:fix-file lib/SomePremiumClass.php
 ```
 
@@ -209,7 +209,7 @@ Key difference: text domain must be `mailpoet-premium` (not `mailpoet`) in trans
 
 ## CI Reference
 
-In CircleCI (`.circleci/config.yml`):
+In CircleCI (`.circleci/config.yml`), jobs still invoke the plugin-level Robo commands directly:
 
 | Job                      | What it runs                                             | PHP version      |
 | ------------------------ | -------------------------------------------------------- | ---------------- |
@@ -223,21 +223,21 @@ In CircleCI (`.circleci/config.yml`):
 ## Quick Command Reference
 
 ```bash
-# PHP syntax check
+# PHP syntax check (Robo-only)
 cd mailpoet && ./do qa:lint
 
-# PHPCS check
+# PHPCS check (Robo-only)
 cd mailpoet && ./do qa:code-sniffer
 
 # PHP lint + PHPCS
-cd mailpoet && ./do qa:php
+pnpm qa:php
 
 # PHPStan
-cd mailpoet && ./do qa:phpstan
+pnpm qa:phpstan
 
-# Auto-fix a file
+# Auto-fix a file (Robo-only)
 cd mailpoet && ./do qa:fix-file path/to/file.php
 
 # Full QA (PHP + JS + CSS)
-cd mailpoet && ./do qa
+pnpm qa
 ```

--- a/.ai/skills/writing-changelog/SKILL.md
+++ b/.ai/skills/writing-changelog/SKILL.md
@@ -7,7 +7,7 @@ description: 'Use when adding a changelog entry for a branch. Use after completi
 
 ## Overview
 
-User-facing changes MUST have a changelog entry. Each entry is a small Markdown file created by the `./do changelog:add` command. Follow the steps below in order.
+User-facing changes MUST have a changelog entry. Each entry is a small Markdown file created by the `pnpm changelog:add` command for free-plugin changes. Follow the steps below in order.
 
 ## Workflow
 
@@ -43,13 +43,16 @@ Write a **short, user-facing description**:
 
 ### Step 3: Create the Entry
 
-Run the command from the correct plugin directory:
-
-- **Free plugin changes** → run from `mailpoet/`
-- **Premium plugin changes** → run from `mailpoet-premium/`
+Run the command from the repo root for free-plugin changes:
 
 ```bash
-cd mailpoet && ./do changelog:add --type=<type> --description="<description>"
+pnpm changelog:add --type=<type> --description="<description>"
+```
+
+For premium-only changes, use the premium plugin's Robo command directly because there is no root `pnpm` wrapper for it yet:
+
+```bash
+cd mailpoet-premium && ./do changelog:add --type=<type> --description="<description>"
 ```
 
 ### When to Skip

--- a/.ai/skills/writing-tests/SKILL.md
+++ b/.ai/skills/writing-tests/SKILL.md
@@ -9,7 +9,7 @@ description: 'Use when writing, running, or debugging tests. Use when asked to a
 
 MailPoet has six test types across two plugins (free `mailpoet/` and premium `mailpoet-premium/`).
 
-**Running tests:** Unit and JavaScript tests run on the host machine from the plugin directory (e.g. `mailpoet/`). Integration, acceptance, and performance tests require Docker and must be run from the monorepo root.
+**Running tests:** Use the `pnpm test:*` scripts from the monorepo root for the common suites. Integration, acceptance, and performance tests require Docker. A few specialist helpers do not have `pnpm` wrappers yet; those are called out below as plugin-level Robo-only commands.
 
 ## Guidelines
 
@@ -27,15 +27,15 @@ MailPoet has six test types across two plugins (free `mailpoet/` and premium `ma
 
 ### PHP Unit Tests
 
-Fast, isolated tests. No WordPress, no database. Run directly on the host machine from `mailpoet/`. **Free plugin only** — premium has no unit tests.
+Fast, isolated tests. No WordPress, no database. Run directly on the host machine via the root `pnpm` wrapper. **Free plugin only** — premium has no unit tests.
 
 - **Location:** `mailpoet/tests/unit/`
 - **File pattern:** `*Test.php`
 - **Base class:** `MailPoetUnitTest`
-- **Run all:** `./do test:unit`
-- **Run one file:** `./do test:unit --file tests/unit/WooCommerce/TransactionalEmails/FontFamilyValidatorTest.php`
-- **Debug mode:** `./do test:debug-unit --file tests/unit/...`
-- **Re-run failed:** `./do test:failed-unit`
+- **Run all:** `pnpm test:unit`
+- **Run one file:** `pnpm test:unit --file=tests/unit/WooCommerce/TransactionalEmails/FontFamilyValidatorTest.php`
+- **Debug mode:** `pnpm test:unit --debug --file=tests/unit/...`
+- **Re-run failed:** `cd mailpoet && ./do test:failed-unit` (Robo-only)
 
 ### PHP Integration Tests
 
@@ -44,27 +44,27 @@ Tests with WordPress and database, run inside Docker. Slower than unit tests. Ru
 - **Location:** `mailpoet/tests/integration/` and `mailpoet-premium/tests/integration/`
 - **File pattern:** `*Test.php`
 - **Base class:** `\MailPoetTest` (extends Codeception)
-- **Run all:** `./do test:integration --skip-deps`
-- **Run one file:** `./do test:integration --skip-deps --file tests/integration/Logging/LogHandlerTest.php`
-- **Debug mode:** `./do test:debug-integration --file tests/integration/...`
-- **Re-run failed:** `./do test:failed-integration`
+- **Run all:** `pnpm test:integration`
+- **Run one file:** `pnpm test:integration --file=tests/integration/Logging/LogHandlerTest.php`
+- **Debug mode:** `pnpm test:integration --debug --file=tests/integration/...`
+- **Re-run failed:** `cd mailpoet && ./do test:failed-integration` (Robo-only)
 - **Variants:**
-  - `./do test:woo-integration` — with WooCommerce loaded
-  - `./do test:base-integration` — without WooCommerce
-  - `./do test:multisite-integration` — WordPress multisite
+  - `cd mailpoet && ./do test:woo-integration` — with WooCommerce loaded (Robo-only)
+  - `cd mailpoet && ./do test:base-integration` — without WooCommerce (Robo-only)
+  - `pnpm test:integration --multisite` — WordPress multisite
 
-Use `--skip-deps` to avoid rebuilding Docker containers every run.
+The `pnpm test:*` scripts already pass `--skip-deps` by default to avoid rebuilding Docker containers every run.
 
 ### PHP Acceptance Tests (E2E)
 
-Browser-based end-to-end tests using Selenium and Chrome in Docker. **The slowest test type** — only add these when testing a real browser flow that can't be covered by unit or integration tests. Run from the `mailpoet/` plugin directory.
+Browser-based end-to-end tests using Selenium and Chrome in Docker. **The slowest test type** — only add these when testing a real browser flow that can't be covered by unit or integration tests. Run from the monorepo root.
 
 - **Location:** `mailpoet/tests/acceptance/` and `mailpoet-premium/tests/acceptance/`
 - **File pattern:** `*Cest.php`
-- **Run all:** `./do test:acceptance --skip-deps`
-- **Run one file:** `./do test:acceptance --skip-deps --file tests/acceptance/Misc/WordPressSiteEditorCest.php`
-- **Multisite:** `./do test:acceptance-multisite --skip-deps --file ...`
-- **Reset Docker:** `./do delete:docker` — if you get unexpected errors, delete the Docker runtime and start fresh
+- **Run all:** `pnpm test:acceptance`
+- **Run one file:** `pnpm test:acceptance --file=tests/acceptance/Misc/WordPressSiteEditorCest.php`
+- **Multisite:** `cd mailpoet && ./do test:acceptance-multisite --skip-deps --file ...` (Robo-only)
+- **Reset Docker:** `cd mailpoet && ./do delete:docker` — if you get unexpected errors, delete the Docker runtime and start fresh (Robo-only)
 - **Debug with pause:** Add `$i->pause();` in your test to pause execution and inspect the browser state
 - **Watch tests in browser:** The browser runs in Docker. Connect via VNC at `vnc://localhost:5900` (password: `secret`).
 
@@ -74,31 +74,31 @@ Frontend tests using Mocha + Chai + Sinon. **Free plugin only.**
 
 - **Location:** `mailpoet/tests/javascript/`
 - **File pattern:** `*.spec.ts`
-- **Run:** `./do test:javascript`
+- **Run:** `pnpm test:javascript`
 
 ### Newsletter Editor JavaScript Tests (Legacy)
 
 Legacy Mocha test suite for the newsletter editor. **Do not write new tests here** — only modify existing ones if necessary. **Free plugin only.**
 
 - **Location:** `mailpoet/tests/javascript-newsletter-editor/`
-- **Run:** `./do test:newsletter-editor`
+- **Run:** `cd mailpoet && ./do test:newsletter-editor` (Robo-only)
 
 ### Performance Tests
 
 Load and performance testing with k6 and Playwright. **Free plugin only.**
 
 - **Location:** `mailpoet/tests/performance/`
-- **Setup:** `./do test:performance-setup`
-- **Run:** `./do test:performance --url=... --us=... --pw=...`
-- **Cleanup:** `./do test:performance-clean`
+- **Setup:** `cd mailpoet && ./do test:performance-setup` (Robo-only)
+- **Run:** `cd mailpoet && ./do test:performance --url=... --us=... --pw=...` (Robo-only)
+- **Cleanup:** `cd mailpoet && ./do test:performance-clean` (Robo-only)
 
 ## Quick Reference
 
-| Type              | Command                             | Runs in | Plugin    |
-| ----------------- | ----------------------------------- | ------- | --------- |
-| Unit              | `./do test:unit`                    | Local   | Free only |
-| Integration       | `./do test:integration --skip-deps` | Docker  | Both      |
-| Acceptance        | `./do test:acceptance --skip-deps`  | Docker  | Both      |
-| JavaScript        | `./do test:javascript`              | Local   | Free only |
-| Newsletter Editor | `./do test:newsletter-editor`       | Local   | Free only |
-| Performance       | `./do test:performance`             | Docker  | Free only |
+| Type              | Command                                      | Runs in | Plugin    |
+| ----------------- | -------------------------------------------- | ------- | --------- |
+| Unit              | `pnpm test:unit`                             | Local   | Free only |
+| Integration       | `pnpm test:integration`                      | Docker  | Both      |
+| Acceptance        | `pnpm test:acceptance`                       | Docker  | Both      |
+| JavaScript        | `pnpm test:javascript`                       | Local   | Free only |
+| Newsletter Editor | `cd mailpoet && ./do test:newsletter-editor` | Local   | Free only |
+| Performance       | `cd mailpoet && ./do test:performance`       | Docker  | Free only |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ _N/A_
 
 ## Tasks
 
-- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
+- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
 - [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
 - [ ] I added sufficient test coverage
 - [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,37 +135,36 @@ pnpm templates
 
 ### Plugin-Level Commands
 
-Run inside `mailpoet/` (same scripts are exposed as `pnpm <task>` there too):
+Use the `pnpm` scripts from the repo root by default. The same common scripts are also exposed inside `mailpoet/` and `mailpoet-premium/`. These wrappers call the plugin-level Robo tasks where appropriate.
 
 **Build:**
 
 ```bash
-./do compile:all                     # Compile JS + CSS
-./do compile:js                      # Compile JavaScript only
-./do compile:css                     # Compile SCSS only
-./do install                         # Install PHP + JS dependencies
+pnpm compile                         # Compile JS + CSS
+pnpm compile:js                      # Compile JavaScript only
+pnpm compile:css                     # Compile SCSS only
 ```
 
 **Quality Assurance (runs on host):**
 
 ```bash
-./do qa                              # Run all PHP + frontend QA checks
-./do qa:php                          # PHP lint + CodeSniffer
-./do qa:phpstan                      # PHPStan static analysis
-./do qa:lint-javascript              # ESLint + TypeScript check
-./do qa:lint-css                     # Stylelint for SCSS
-./do qa:prettier-check               # Check Prettier formatting
-./do qa:prettier-write               # Auto-fix Prettier formatting
-./do qa:fix-file <path>              # Auto-fix a single file (PHPCS or ESLint)
+pnpm qa                              # Run all PHP + frontend QA checks
+pnpm qa:php                          # PHP lint + CodeSniffer
+pnpm qa:phpstan                      # PHPStan static analysis
+pnpm qa:js                           # ESLint + TypeScript check
+pnpm qa:css                          # Stylelint for SCSS
+pnpm qa:prettier                     # Check Prettier formatting
+pnpm qa:fix                          # Auto-fix Prettier formatting
 ```
 
-**Testing:** `./do test:*` on host routes into `tests_env/` via docker compose. Typically better to use the `pnpm test:*` root aliases which default to `--skip-deps`.
+For Robo-only helpers without a `pnpm` wrapper, run `./do` from the relevant plugin directory, for example `cd mailpoet && ./do qa:fix-file <path>`.
+
+**Testing:** use the `pnpm test:*` root aliases, which route into `tests_env/` and default to `--skip-deps`.
 
 **Other:**
 
 ```bash
-./do changelog:add --type=<type> --description="<description>"
-./do changelog:preview               # Preview compiled changelog
+pnpm changelog:add --type=<type> --description="<description>"
 ```
 
 Migrations and templates require a running WordPress and must be invoked via `pnpm migrations:*` / `pnpm templates` (routes through the wp-env container). Running `./do migrations:*` directly from `mailpoet/` fails — no WordPress on the host.
@@ -188,7 +187,7 @@ Migrations and templates require a running WordPress and must be invoked via `pn
 - Follow the [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 - Prefer named exports over default exports
 - MUST default to TypeScript for new files
-- Formatting is handled by Prettier (`pnpm qa:fix` or `./do qa:prettier-write` in `mailpoet/`)
+- Formatting is handled by Prettier (`pnpm qa:fix`)
 
 ### SCSS
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pnpm test:install-deps         # Re-install composer deps before testing
                                # (default test:* scripts pass --skip-deps)
 ```
 
-Pass any plugin-level `./do` flags directly — they forward through pnpm:
+Pass test-runner flags directly — the `pnpm` scripts forward them to the underlying test command:
 
 ```shell
 pnpm test:integration --file=tests/integration/WP/EmojiTest.php

--- a/mailpoet/README.md
+++ b/mailpoet/README.md
@@ -46,10 +46,10 @@ ln -s $(pwd) <wordpress>/wp-content/plugins/mailpoet
 cp .env.sample .env
 
 # 5. Install dependencies (PHP and JS):
-./do install
+pnpm install
 
 # 6. Compile JS and CSS:
-./do compile:all
+pnpm compile
 ```
 
 ### Frameworks and libraries
@@ -70,65 +70,75 @@ cp .env.sample .env
 
 ## Workflow Commands
 
-This `./do` script runs plugin-level Robo tasks directly on the host. Use it for compile, lint, and QA — anything that only needs PHP/Node, not WordPress.
+Use `pnpm` scripts for the common workflow commands. They wrap the plugin-level Robo tasks where needed and can be run from the repo root or from this plugin directory.
 
 At the repo root there are also `pnpm` scripts (`pnpm env:start`, `pnpm test:integration`, `pnpm migrations:*`, …) that orchestrate the wp-env container and route WordPress-runtime tasks into it. See the [monorepo README](../README.md) for the full list.
 
+Use `./do` directly only for Robo helpers that do not have a `pnpm` wrapper yet. Those are listed separately below.
+
 **Rule of thumb:**
 
-- **On host (via `./do` or `pnpm`)**: compile, watch, lint, PHPStan, PHPCS, Prettier, JS tests (mocha)
+- **On host (via `pnpm`)**: compile, watch, lint, PHPStan, PHPCS, Prettier, JS tests (mocha)
 - **In wp-env container (via `pnpm`)**: migrations, templates, wp-cli commands, anything needing WordPress runtime
-- **In `tests_env/` container (via `pnpm test:*` or `./do test:*`)**: integration, unit, acceptance tests
+- **In `tests_env/` container (via `pnpm test:*`)**: integration, unit, acceptance tests
 
 ```bash
-$ ./do install             # install PHP and JS dependencies
-$ ./do update              # update PHP and JS dependencies
+$ pnpm install             # install PHP and JS dependencies
 
-$ ./do compile:css         # compiles SCSS files into CSS.
-$ ./do compile:js          # bundles JS files for the browser.
-$ ./do compile:all         # compiles CSS and JS files.
+$ pnpm compile:css         # compiles SCSS files into CSS.
+$ pnpm compile:js          # bundles JS files for the browser.
+$ pnpm compile             # compiles CSS and JS files.
 
-$ ./do watch:css           # watch CSS files for changes and compile them.
-$ ./do watch:js            # watch JS files for changes and compile them.
+$ pnpm watch:css           # watch CSS files for changes and compile them.
+$ pnpm watch:js            # watch JS files for changes and compile them.
 
-$ ./do test:unit [--file=...] [--debug]
+$ pnpm test:unit [--file=...] [--debug]
   # runs the PHP unit tests.
   # if --file specified then only tests on that file are executed.
   # if --debug then tests are executed in debugging mode.
-$ ./do test:integration [--file=...] [--multisite] [--debug]
+$ pnpm test:integration [--file=...] [--multisite] [--debug]
   # runs the PHP integration tests.
   # if --file specified then only tests on that file are executed.
   # if --multisite then tests are executed in a multisite wordpress setup.
   # if --debug then tests are executed in debugging mode.
-$ ./do test:multisite-integration # alias for ./do test:integration --multisite
-$ ./do test:debug-unit            # alias for ./do test:unit --debug
-$ ./do test:debug-integration     # alias for ./do test:integration --debug
-$ ./do test:failed-unit           # run the last failing unit test.
-$ ./do test:failed-integration    # run the last failing integration test.
-$ ./do test:javascript            # run the JS tests.
-$ ./do test:acceptance [--file=...] [--skip-deps]
+$ pnpm test:javascript            # run the JS tests.
+$ pnpm test:acceptance [--file=...]
   # run acceptances tests into a docker environment.
   # if --file given then only tests on that file are executed.
-  # if --skip-deps then it skips installation of composer dependencies.
+  # the pnpm wrapper passes --skip-deps by default.
+
+$ pnpm qa:php              # PHP lint + PHPCS.
+$ pnpm qa:js               # JS code linter + TypeScript check.
+$ pnpm qa:css              # CSS code linter.
+$ pnpm qa:phpstan          # PHP code static analysis using PHPStan.
+$ pnpm qa:prettier         # Prettier formatting check.
+$ pnpm qa:fix              # Prettier formatting write.
+$ pnpm qa                  # PHP and JS linters.
+
+$ pnpm changelog:add --type=<type> --description=<description> # Creates a new changelog entry
+```
+
+Robo-only helpers with no `pnpm` wrapper yet:
+
+```bash
+$ ./do update              # update PHP and JS dependencies
+$ ./do test:failed-unit           # run the last failing unit test.
+$ ./do test:failed-integration    # run the last failing integration test.
 $ ./do test:acceptance-multisite [--file=...] [--skip-deps]
+  # same as test:acceptance but runs into a multisite wordpress setup.
+$ ./do download:woo-commerce-zip [<tag>]
+$ ./do download:woo-commerce-subscriptions-zip [<tag>]
   # download 3rd party plugins for tests
   # if you pass tag it will attempt to download zip for the tag otherwise it downloads the latest release
   # e.g. ./do download:woo-commerce-zip 5.20.0
-$ ./do download:woo-commerce-zip [<tag>]
-$ ./do download:woo-commerce-subscriptions-zip [<tag>]
-  # same as test:acceptance but runs into a multisite wordpress setup.
 $ ./do delete:docker      # stop and remove all running docker containers.
 
-$ ./do qa:lint             # PHP code linter.
-$ ./do qa:lint-javascript  # JS code linter.
-$ ./do qa:phpstan          # PHP code static analysis using PHPStan.
-$ ./do qa                  # PHP and JS linters.
-
-$ ./do release:changelog-get  [--version-name=...]     # Prints out changelog and release notes for given version or for newest version.
-$ ./do release:changelog-update  [--version-name=...] [--quiet] # Updates changelog in readme.txt for given version or for newest version.
-$ ./do changelog:add --type=<type> --description=<description> # Creates a new changelog entry
-$ ./do changelog:preview [--version=<version>] # Preview compiled changelog for next version
-
+$ ./do qa:lint             # PHP syntax linter only.
+$ ./do qa:code-sniffer     # PHPCS only.
+$ ./do qa:fix-file <path>  # Auto-fix one PHP or JS/TS file.
+$ ./do release:changelog-get [--version-name=...] # Prints changelog and release notes.
+$ ./do release:changelog-update [--version-name=...] [--quiet] # Updates changelog in readme.txt.
+$ ./do changelog:preview [--version=<version>] # Preview compiled changelog for next version.
 $ ./do container:dump      # Generates DI container cache.
 ```
 
@@ -197,7 +207,7 @@ Dependencies handled by PHP-Scoper are configured in extra configuration files `
 Create changelog entries using:
 
 ```bash
-./do changelog:add --type=Fixed --description="Brief description of the change"
+pnpm changelog:add --type=Fixed --description="Brief description of the change"
 ```
 
 See [readme](changelog/README.md) for detailed documentation.
@@ -273,17 +283,17 @@ guides.
 
 ### Acceptance testing
 
-To run the whole acceptance testing suite you need the docker daemon to be running and after that use a command: `./do test:acceptance`.
+To run the whole acceptance testing suite you need the docker daemon to be running and after that use a command: `pnpm test:acceptance`.
 If you want to run only a single test use the parameter `--file`:
 
 ```bash
-./do test:acceptance --skip-deps --file tests/acceptance/ReceiveStandardEmailCest.php
+pnpm test:acceptance --file=tests/acceptance/ReceiveStandardEmailCest.php
 ```
 
-The argument `--skip-deps` is useful locally to speed up the run.
+The `pnpm` wrapper passes `--skip-deps` by default to speed up the run locally.
 
 If there are some unexpected errors you can delete all the runtime and start again.
-To delete all the docker runtime for acceptance tests use the command `./do delete:docker`.
+To delete all the docker runtime for acceptance tests use the Robo-only command `cd mailpoet && ./do delete:docker`.
 
 When debugging you can add `$i->pause();` in to your test which pauses the execution.
 

--- a/mailpoet/tests/DataGenerator/Generators/SampleData.php
+++ b/mailpoet/tests/DataGenerator/Generators/SampleData.php
@@ -39,9 +39,9 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
  * Generates a customizable MailPoet sample dataset for local development and tests.
  *
  * Local usage examples:
- *   ./do generate:data
- *   ./do generate:data --preset=small --subscribers=100 --woocommerce=0
- *   ./do generate:data 4 --preset=large --open-rate=0.5 --purchase-rate=0.2
+ *   pnpm generate:sample-data
+ *   pnpm generate:sample-data --preset=small --subscribers=100 --woocommerce=0
+ *   pnpm generate:sample-data 4 --preset=large --open-rate=0.5 --purchase-rate=0.2
  */
 class SampleData implements Generator {
   private const BULK_INSERT_BATCH_SIZE = 500;

--- a/mailpoet/tests/performance/README.md
+++ b/mailpoet/tests/performance/README.md
@@ -2,6 +2,8 @@
 
 Automated k6 performance tests for MailPoet. To be used for benchmarking performance (both single user and under load) by simulating and measuring the response time of browser-level and protocol-lever tests (protocol-level yet to be implemented).
 
+These commands are still plugin-level Robo-only helpers. Run them from the monorepo root with `cd mailpoet && ./do ...`; there is no `pnpm test:performance` wrapper yet.
+
 ## Table of contents
 
 - [Pre-requisites](#pre-requisites)
@@ -44,12 +46,12 @@ The local env's url of the performance test site is: `https://localhost:9500`
 
 When you're done with testing, you may want to stop the environment by the following command:
 
-`./do test:performance-clean`
+`cd mailpoet && ./do test:performance-clean`
 
 ### Config Variables
 
 `config.js` comes with some test data and \_\_ENV values stored in your .env file. You don't need to change the values there if you want to use different test site, user and password, but just include parameters when executing the test such as:
-`./do test:performance --scenario pullrequests --url="yoururl" --pw="yourpassword"`
+`cd mailpoet && ./do test:performance --scenario pullrequests --url="yoururl" --pw="yourpassword"`
 
 #### Config Variables List
 
@@ -77,7 +79,7 @@ When refering to running k6 tests usually it means executing some of the scenari
 
 To execute an individual test file (for example `newsletter-listing.js`):
 
-`./do test:performance tests/performance/tests/newsletter-listing.js`
+`cd mailpoet && ./do test:performance tests/performance/tests/newsletter-listing.js`
 
 This will run the individual test for 1 iteration.
 
@@ -85,7 +87,7 @@ This will run the individual test for 1 iteration.
 
 To execute a test scenario for pull requests, as an example:
 
-`./do test:performance --scenario pullrequests`
+`cd mailpoet && ./do test:performance --scenario pullrequests`
 
 This will run scenario with associated tests and options specificed inside `scenarios.js`.
 
@@ -101,7 +103,7 @@ The amount of think time can be controlled from `config.js`.
 ### Debugging Tests
 
 Browser-level tests: the easiest way is to turn off headless mode by running individual or scenario with this argument `--head` and it will execute test with browser. The example command would be:
-`./do test:performance [test script path here] --head`
+`cd mailpoet && ./do test:performance [test script path here] --head`
 
 Protocol-level tests: to help with getting a test working, the `--http-debug="full"` flag prints to console the full log of requests and their responses. It is also useful to use `console.log()` to print messages when debugging.
 

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -11,7 +11,7 @@ An [MCP](https://modelcontextprotocol.io) server that exposes MailPoet local-dev
 │   Claude / agent   │ ───────────▶  │  TS MCP server      │
 └────────────────────┘               │  (this package)     │
                                      └──────┬──────────────┘
-                                            │ shell-out (./do, docker)
+                                            │ shell-out (pnpm/Robo, docker)
                                             │ HTTP (Mailpit, companion)
                               ┌─────────────┼─────────────────────┐
                               ▼             ▼                     ▼


### PR DESCRIPTION
## Description

Following https://github.com/mailpoet/mailpoet/pull/6629, update AI-related docs to point them to using `pnpm` instead of `./do`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:pnpm-readme)

_The latest successful build from `pnpm-readme` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->