### PR TITLE
Update PHP-Scoper

### DIFF
--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -3,7 +3,8 @@
 
 // Tools versions for PHP 7.4+
 $composerVersion = '2.9.3';
-$phpScoperVersion = '0.17.2';
+// 0.18+ requires PHP ^8.2. 0.17.2 runs on PHP 7.4+ but its bundled Safe stubs throw on PHP 8.4+.
+$phpScoperVersion = PHP_VERSION_ID >= 80200 ? '0.18.19' : '0.17.7';
 $legacyTracyVersion = '2.9.4'; // Tracy 2.9.4 supports PHP 7.4
 $tracyVersion = '2.11.1'; // Tracy 2.11.0+ supports PHP 8.4 and 8.5
 


### PR DESCRIPTION
## Description

PHP 8.2 requires PHP-Scoper 0.18+. 

## Code review notes

Not sure why this worked until now. We already loaded 0.18 on PHP 8.2, but that was reverted in https://github.com/mailpoet/mailpoet/pull/6467/changes#diff-15a52b7e4aba46ca20fc7d72fa3f8c33188279304780be2a47d990ea76e1db4fL4-L19

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:php-scoper-update)

_The latest successful build from `php-scoper-update` will be used. If none is available, the link won't work._