### PR TITLE
mcp-server README: add --ignore-workspace to pnpm install

### DIFF
--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -86,7 +86,7 @@ From repo root:
 ```bash
 # 1. Install + build the MCP server
 cd tools/mcp-server
-pnpm install
+pnpm install --ignore-workspace
 pnpm build
 
 # 2. Generate the companion secret (must exist BEFORE wp-env starts, so the mapping picks it up)
@@ -97,6 +97,8 @@ pnpm init-secret
 cd ../..
 pnpm env:start       # or env:restart if already running
 ```
+
+> **Why `--ignore-workspace`?** `tools/mcp-server` is intentionally outside the repo's pnpm workspace (`pnpm-workspace.yaml` lists only `mailpoet` and `packages/js/*`) so that this experimental dev tool doesn't inherit the monorepo's React/JSX/TS pins, `minimumReleaseAge` gate, etc. Without the flag, `pnpm install` walks up to the workspace root and never installs deps locally — `pnpm build` then fails with TS errors about missing `@modelcontextprotocol/sdk` / `zod`.
 
 ## Running the server
 


### PR DESCRIPTION
## Description

Fixes the setup snippet in `tools/mcp-server/README.md` so that `pnpm install` actually creates `tools/mcp-server/node_modules` on a fresh clone.

`tools/mcp-server` is intentionally outside the repo's pnpm workspace (`pnpm-workspace.yaml` lists only `mailpoet` and `packages/js/*`) — the experimental dev tool shouldn't inherit the monorepo's React/JSX/TS pins, the `minimumReleaseAge` supply-chain gate, etc. But the README told developers to run plain `pnpm install`, which walks up the directory tree, finds `pnpm-workspace.yaml`, runs the workspace install, and never touches `tools/mcp-server/node_modules`. The next `pnpm build` then fails with TS errors about missing `@modelcontextprotocol/sdk`, `zod`, `@types/node` etc.

Switch the snippet to `pnpm install --ignore-workspace`, plus a short callout explaining why.

I also tried `tools/mcp-server/.npmrc` with `ignore-workspace=true`, but pnpm doesn't honour that setting at the subdirectory level — the workspace lookup happens before `.npmrc` is read. The flag is the only effective way today.

## Code review notes

Considered alternative: add `tools/mcp-server` to `pnpm-workspace.yaml`. Rejected — would pull MCP server into the workspace overrides (`@types/react`, `react`, `typescript: ^5.0.2`, `minimumReleaseAge: 1440`, etc.), which the TypeScript / Node-only MCP server doesn't want and would be harder to keep current.

## QA notes

```bash
# Reproduce the original failure
git pull
cd tools/mcp-server
rm -rf node_modules
pnpm install        # walks up, runs workspace install, no node_modules created here
pnpm build          # fails with: cannot find '@modelcontextprotocol/sdk', 'zod', etc.

# Verify the fix
rm -rf node_modules
pnpm install --ignore-workspace
ls node_modules/@modelcontextprotocol/sdk/package.json   # should exist
pnpm build          # should succeed
```

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

(no checkboxes apply — README-only change)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/mcp-server-readme-ignore-workspace)

_The latest successful build from `fix/mcp-server-readme-ignore-workspace` will be used. If none is available, the link won't work._