### PR TITLE
Use different PHP-Scoper version for PHP 8.4+

### DIFF
--- a/mailpoet/tools/install.php
+++ b/mailpoet/tools/install.php
@@ -3,13 +3,18 @@
 
 // Tools versions for PHP 7.4+
 $composerVersion = '2.9.3';
-$phpScoperVersion = '0.17.2';
+$legacyPhpScoperVersion = '0.17.2'; // 0.17.2 supports PHP 7.4-8.3; fails on 8.4+ due to bundled thecodingmachine/safe v2
+$phpScoperVersion = '0.18.19'; // 0.18.19 requires PHP 8.2+ and supports PHP 8.4 and 8.5
 $legacyTracyVersion = '2.9.4'; // Tracy 2.9.4 supports PHP 7.4
 $tracyVersion = '2.11.1'; // Tracy 2.11.0+ supports PHP 8.4 and 8.5
 
+$phpScoperUrl = PHP_VERSION_ID >= 80400
+  ? "https://github.com/humbug/php-scoper/releases/download/$phpScoperVersion/php-scoper.phar"
+  : "https://github.com/humbug/php-scoper/releases/download/$legacyPhpScoperVersion/php-scoper.phar";
+
 $tools = [
   "https://github.com/composer/composer/releases/download/$composerVersion/composer.phar" => 'composer.phar',
-  "https://github.com/humbug/php-scoper/releases/download/$phpScoperVersion/php-scoper.phar" => 'php-scoper.phar',
+  $phpScoperUrl => 'php-scoper.phar',
   "https://github.com/nette/tracy/releases/download/v$legacyTracyVersion/tracy.phar" => 'tracy-legacy.phar',
   "https://github.com/nette/tracy/releases/download/v$tracyVersion/tracy.phar" => 'tracy.phar',
 ];


### PR DESCRIPTION
## Description

There are some errors when running PHP-Scoper under PHP 8.4. That's because we use version 0.17 which officially doesn't support PHP 8.4.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:php-scoper-update)

_The latest successful build from `php-scoper-update` will be used. If none is available, the link won't work._