### PR TITLE
Redesign subscriber statistics, 3 of 3 (activity feed)

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -186,16 +186,155 @@
   min-height: 100%;
 }
 
-.mailpoet-subscriber-stats-activity-body {
-  .mailpoet-listing {
-    margin: 0;
+.mailpoet-subscriber-stats-activity-days {
+  margin: 0;
+}
+
+.mailpoet-subscriber-stats-activity-day {
+  &:not(:last-child) {
+    margin-bottom: $grid-gap-half;
+  }
+}
+
+.mailpoet-subscriber-stats-activity-day-title {
+  color: $color-gutenberg-grey-700;
+  font-size: $font-size-small;
+  font-weight: 400;
+  line-height: 20px;
+  margin: 0 0 10px;
+}
+
+.mailpoet-subscriber-stats-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+
+  &:before {
+    background: $color-tertiary-light;
+    bottom: 40px;
+    content: '';
+    left: 16px;
+    position: absolute;
+    top: 18px;
+    width: 1px;
+  }
+}
+
+.mailpoet-subscriber-stats-activity-item {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 32px minmax(0, 1fr);
+  padding: 12px 0 22px;
+  position: relative;
+}
+
+.mailpoet-subscriber-stats-activity-icon {
+  align-items: center;
+  background: $color-gutenberg-grey-100;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px #fff;
+  color: $color-gutenberg-grey-700;
+  display: inline-flex;
+  height: 32px;
+  justify-content: center;
+  position: relative;
+  width: 32px;
+  z-index: 1;
+
+  svg {
+    height: 16px;
+    width: 16px;
+  }
+}
+
+.mailpoet-subscriber-stats-activity-item-content {
+  min-width: 0;
+}
+
+.mailpoet-subscriber-stats-activity-item-main {
+  align-items: start;
+  display: grid;
+  gap: $grid-gap;
+  grid-template-columns: minmax(0, 1fr) max-content;
+}
+
+.mailpoet-subscriber-stats-activity-item-meta {
+  color: $color-gutenberg-grey-700;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 8px;
+  justify-content: space-between;
+  line-height: 18px;
+}
+
+.mailpoet-subscriber-stats-activity-item-title {
+  color: $color-gutenberg-grey-900;
+  font-size: $font-size-small;
+  font-weight: 600;
+  line-height: 20px;
+  margin-top: 2px;
+}
+
+.mailpoet-subscriber-stats-activity-item-description {
+  color: $color-gutenberg-grey-700;
+  font-size: 12px;
+  line-height: 18px;
+  margin-top: 2px;
+  overflow-wrap: anywhere;
+}
+
+.mailpoet-subscriber-stats-activity-item-date {
+  color: $color-gutenberg-grey-700;
+  font-size: $font-size-small;
+  line-height: 20px;
+  white-space: nowrap;
+}
+
+.mailpoet-subscriber-stats-activity-message {
+  color: $color-gutenberg-grey-700;
+  font-size: $font-size-small;
+  padding: $grid-gap 0;
+}
+
+.mailpoet-subscriber-stats-activity-list-sample {
+  opacity: 0.72;
+}
+
+.mailpoet-subscriber-stats-locked-activity {
+  display: grid;
+  gap: $grid-gap;
+}
+
+.mailpoet-subscriber-stats-activity-listing {
+  .mailpoet-listing-table {
+    border: 0;
+    box-shadow: none;
+
+    thead {
+      display: none;
+    }
+
+    tbody td {
+      padding: 0;
+    }
+
+    tr {
+      border-bottom: 0;
+      box-shadow: none;
+    }
+
+    tr:hover {
+      background: transparent;
+    }
   }
 }
 
 .mailpoet-subscriber-stats-no-access-content {
   display: flex;
   justify-content: center;
-  margin: 70px auto;
+  margin: 0 auto;
 }
 
 .mailpoet-subscriber-stats {
@@ -258,6 +397,18 @@
 
   .mailpoet-subscriber-stats-card-header .components-flex {
     gap: $grid-gap-half;
+  }
+
+  .mailpoet-subscriber-stats-activity-filter {
+    width: 100%;
+  }
+
+  .mailpoet-subscriber-stats-activity-item-main {
+    grid-template-columns: 1fr;
+  }
+
+  .mailpoet-subscriber-stats-activity-item-date {
+    white-space: normal;
   }
 
   .mailpoet-subscriber-stats-profile-row {

--- a/mailpoet/assets/js/src/subscribers/stats/activity-shell.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/activity-shell.tsx
@@ -1,8 +1,18 @@
-import { Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from 'react';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Flex,
+  FlexBlock,
+  SelectControl,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Location, Params } from 'react-router-dom';
 import { MailPoet } from 'mailpoet';
 import { OpenedEmailsStats } from './opened-email-stats';
+
+export type ActivityEventType = 'all' | 'open' | 'click' | 'purchase';
 
 type Props = {
   lastEngagementAt?: string;
@@ -10,11 +20,19 @@ type Props = {
   params: Params;
 };
 
+const EVENT_TYPE_OPTIONS: Array<{ label: string; value: ActivityEventType }> = [
+  { label: __('All events', 'mailpoet'), value: 'all' },
+  { label: __('Email opens', 'mailpoet'), value: 'open' },
+  { label: __('Link clicks', 'mailpoet'), value: 'click' },
+  { label: __('Purchases', 'mailpoet'), value: 'purchase' },
+];
+
 export function ActivityShell({
   lastEngagementAt,
   location,
   params,
 }: Props): JSX.Element {
+  const [eventType, setEventType] = useState<ActivityEventType>('all');
   const subtitle = lastEngagementAt
     ? sprintf(
         // translators: %s is a date and time when the subscriber was last seen.
@@ -29,17 +47,33 @@ export function ActivityShell({
       size="medium"
     >
       <CardHeader className="mailpoet-subscriber-stats-card-header">
-        <div>
-          <h2 className="mailpoet-subscriber-stats-card-title">
-            {__('Activity', 'mailpoet')}
-          </h2>
-          <div className="mailpoet-subscriber-stats-card-subtitle">
-            {subtitle}
-          </div>
-        </div>
+        <Flex align="center" gap={3}>
+          <FlexBlock>
+            <div>
+              <h2 className="mailpoet-subscriber-stats-card-title">
+                {__('Activity', 'mailpoet')}
+              </h2>
+              <div className="mailpoet-subscriber-stats-card-subtitle">
+                {subtitle}
+              </div>
+            </div>
+          </FlexBlock>
+          <SelectControl
+            className="mailpoet-subscriber-stats-activity-filter"
+            hideLabelFromVision
+            label={__('Activity event type', 'mailpoet')}
+            onChange={(value) => setEventType(value as ActivityEventType)}
+            options={EVENT_TYPE_OPTIONS}
+            value={eventType}
+          />
+        </Flex>
       </CardHeader>
       <CardBody className="mailpoet-subscriber-stats-activity-body">
-        <OpenedEmailsStats params={params} location={location} />
+        <OpenedEmailsStats
+          eventType={eventType}
+          params={params}
+          location={location}
+        />
       </CardBody>
     </Card>
   );

--- a/mailpoet/assets/js/src/subscribers/stats/no-access-info.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/no-access-info.tsx
@@ -1,11 +1,160 @@
 import { FunctionComponent } from 'react';
+import { Icon } from '@wordpress/components';
+import { cart, link as linkIcon, seen } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
 import { PremiumBannerWithUpgrade } from 'common/premium-banner-with-upgrade/premium-banner-with-upgrade';
 import { Button } from 'common/button/button';
 import ReactStringReplace from 'react-string-replace';
+import type { ActivityEventType } from './activity-shell';
 
-export function NoAccessInfo(): JSX.Element {
+type SampleActivityItem = {
+  key: string;
+  eventType: Exclude<ActivityEventType, 'all'>;
+  icon: JSX.Element;
+  title: string;
+  description: string;
+  date: Date;
+};
+
+type ActivityGroup = {
+  key: string;
+  label: string;
+  items: SampleActivityItem[];
+};
+
+type Props = {
+  eventType: ActivityEventType;
+};
+
+function getSampleDate(dayOffset: number, hoursOffset = 0): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - dayOffset);
+  date.setHours(Math.max(0, date.getHours() - hoursOffset));
+  return date;
+}
+
+function getSampleActivityItems(): SampleActivityItem[] {
+  return [
+    {
+      key: 'opened',
+      eventType: 'open',
+      icon: seen,
+      title: __('Opened email “Spring sale newsletter”', 'mailpoet'),
+      description: __('Opened the email on desktop.', 'mailpoet'),
+      date: getSampleDate(0, 2),
+    },
+    {
+      key: 'clicked',
+      eventType: 'click',
+      icon: linkIcon,
+      title: __('Clicked a link in email “Spring sale newsletter”', 'mailpoet'),
+      description: __('https://example.com/spring-collection', 'mailpoet'),
+      date: getSampleDate(0, 3),
+    },
+    {
+      key: 'purchased',
+      eventType: 'purchase',
+      icon: cart,
+      title: __('Completed purchase', 'mailpoet'),
+      description: __('Revenue tracked from an email click.', 'mailpoet'),
+      date: getSampleDate(1),
+    },
+  ];
+}
+
+function getDateKey(date: Date): string {
+  return MailPoet.Date.format(date, { format: 'Y-m-d' });
+}
+
+function getGroupLabel(date: Date): string {
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+
+  const dateKey = getDateKey(date);
+  if (dateKey === getDateKey(today)) {
+    return __('Today', 'mailpoet');
+  }
+  if (dateKey === getDateKey(yesterday)) {
+    return __('Yesterday', 'mailpoet');
+  }
+  return MailPoet.Date.short(date);
+}
+
+function groupActivityItems(items: SampleActivityItem[]): ActivityGroup[] {
+  return items.reduce<ActivityGroup[]>((groups, item) => {
+    const groupKey = getDateKey(item.date);
+    const currentGroup = groups.find((group) => group.key === groupKey);
+    if (currentGroup) {
+      currentGroup.items.push(item);
+      return groups;
+    }
+    groups.push({
+      key: groupKey,
+      label: getGroupLabel(item.date),
+      items: [item],
+    });
+    return groups;
+  }, []);
+}
+
+function SampleActivityRow({
+  item,
+}: {
+  item: SampleActivityItem;
+}): JSX.Element {
+  return (
+    <li className="mailpoet-subscriber-stats-activity-item">
+      <span
+        className="mailpoet-subscriber-stats-activity-icon"
+        aria-hidden="true"
+      >
+        <Icon icon={item.icon} />
+      </span>
+      <div className="mailpoet-subscriber-stats-activity-item-content">
+        <div className="mailpoet-subscriber-stats-activity-item-main">
+          <div>
+            <div className="mailpoet-subscriber-stats-activity-item-title">
+              {item.title}
+            </div>
+            <div className="mailpoet-subscriber-stats-activity-item-description">
+              {item.description}
+            </div>
+          </div>
+          <time
+            className="mailpoet-subscriber-stats-activity-item-date"
+            dateTime={item.date.toISOString()}
+          >
+            {MailPoet.Date.full(item.date)}
+          </time>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function SampleActivityGroup({ group }: { group: ActivityGroup }): JSX.Element {
+  return (
+    <li className="mailpoet-subscriber-stats-activity-day">
+      <h3 className="mailpoet-subscriber-stats-activity-day-title">
+        {group.label}
+      </h3>
+      <ul className="mailpoet-subscriber-stats-activity-list">
+        {group.items.map((item) => (
+          <SampleActivityRow item={item} key={item.key} />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+export function NoAccessInfo({ eventType }: Props): JSX.Element {
+  const activityItems = getSampleActivityItems()
+    .filter((item) => eventType === 'all' || item.eventType === eventType)
+    .sort((first, second) => second.date.getTime() - first.date.getTime());
+  const groups = groupActivityItems(activityItems);
+
   const getBannerMessage: FunctionComponent = () => {
     const message = __(
       'Learn more about how each of your subscribers is engaging with your emails. See which emails they’ve opened, the links they clicked. If you’re a WooCommerce store owner, you’ll also see any purchases made as a result of your emails. [link]Learn more[/link].',
@@ -42,48 +191,25 @@ export function NoAccessInfo(): JSX.Element {
   );
 
   return (
-    <div className="mailpoet-listing">
-      <table
-        className="mailpoet-listing-table"
-        data-automation-id="subscriber-stats-no-access"
+    <div
+      className="mailpoet-subscriber-stats-locked-activity"
+      data-automation-id="subscriber-stats-no-access"
+    >
+      <ul
+        className="mailpoet-subscriber-stats-activity-days mailpoet-subscriber-stats-activity-list-sample"
+        aria-label={__('Sample subscriber activity', 'mailpoet')}
       >
-        <thead>
-          <tr>
-            <th>{__('E-mail', 'mailpoet')}</th>
-            <th>
-              {
-                // translators: Table column label for subscriber actions e.g. email open, link clicked
-                __('Action', 'mailpoet')
-              }
-            </th>
-            <th>
-              {
-                // translators: Table column label for count of subscriber actions
-                __('Count', 'mailpoet')
-              }
-            </th>
-            <th>
-              {
-                // translators: Table column label for date when subscriber action happened
-                __('Action on', 'mailpoet')
-              }
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td colSpan={4}>
-              <div className="mailpoet-subscriber-stats-no-access-content">
-                <PremiumBannerWithUpgrade
-                  message={getBannerMessage({})}
-                  actionButton={getCtaButton({})}
-                  capabilities={{ detailedAnalytics: true }}
-                />
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        {groups.map((group) => (
+          <SampleActivityGroup group={group} key={group.key} />
+        ))}
+      </ul>
+      <div className="mailpoet-subscriber-stats-no-access-content">
+        <PremiumBannerWithUpgrade
+          message={getBannerMessage({})}
+          actionButton={getCtaButton({})}
+          capabilities={{ detailedAnalytics: true }}
+        />
+      </div>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/subscribers/stats/opened-email-stats.tsx
+++ b/mailpoet/assets/js/src/subscribers/stats/opened-email-stats.tsx
@@ -2,22 +2,29 @@ import { FunctionComponent, useMemo } from 'react';
 import { Hooks } from 'hooks';
 import { Location, Params } from 'react-router-dom';
 import { NoAccessInfo } from './no-access-info';
+import type { ActivityEventType } from './activity-shell';
 
 type Props = {
+  eventType: ActivityEventType;
   params: Params;
   location: Location;
 };
 
-export function OpenedEmailsStats({ params, location }: Props): JSX.Element {
+export function OpenedEmailsStats({
+  eventType,
+  params,
+  location,
+}: Props): JSX.Element {
   const Content = useMemo(
     () =>
       Hooks.applyFilters(
         'mailpoet_subscribers_opened_emails_stats',
-        () => <NoAccessInfo />,
+        () => <NoAccessInfo eventType={eventType} />,
         params,
         location,
+        eventType,
       ) as FunctionComponent,
-    [location, params],
+    [eventType, location, params],
   );
 
   return <Content />;

--- a/mailpoet/changelog/2026-04-27-08-23-32-improved-redesign-the-subscriber-activity-stats-section.md
+++ b/mailpoet/changelog/2026-04-27-08-23-32-improved-redesign-the-subscriber-activity-stats-section.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Redesign the subscriber statistics page


### PR DESCRIPTION
## Description

Follow-up for https://github.com/mailpoet/mailpoet/pull/6648 and https://github.com/mailpoet/mailpoet/pull/6653. This is the final PR, that introduces new, filterable activity feed on subscriber's statistics page.

In the free plugin, we show sample data + premium banner.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1041

## Linked tickets

Closes STOMAIL-7983

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="1733" height="962" alt="Screenshot 2026-04-27 at 11 32 45" src="https://github.com/user-attachments/assets/c35504fa-ff1d-4557-a43b-41488369a4c8" /> |  <img width="1732" height="985" alt="Screenshot 2026-04-27 at 11 30 35" src="https://github.com/user-attachments/assets/18e223af-a5be-40ec-8c15-2670caa19b8a" />   |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7973-redesign-subscriber-statistics)

_The latest successful build from `stomail-7973-redesign-subscriber-statistics` will be used. If none is available, the link won't work._