### PR TITLE
Bump email-editor to 2.12.0 for coupon auto-generation

### DIFF
--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.11.0"
+    "woocommerce/email-editor": "2.12.0"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "631745f69d0d49f37545cab8b2ba2596",
+    "content-hash": "a4e1f9cb901874a9ade4e43fbf5980d3",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.11.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "054d99fecd2ed46f5bdc0f0d781370cb2c07bfbc"
+                "reference": "7d2dfa8649f49879523413f1e0124786a60d9fc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/054d99fecd2ed46f5bdc0f0d781370cb2c07bfbc",
-                "reference": "054d99fecd2ed46f5bdc0f0d781370cb2c07bfbc",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/7d2dfa8649f49879523413f1e0124786a60d9fc5",
+                "reference": "7d2dfa8649f49879523413f1e0124786a60d9fc5",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.11.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.12.0"
             },
-            "time": "2026-04-06T10:32:50+00:00"
+            "time": "2026-04-27T10:07:06+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Description

Bump `woocommerce/email-editor` from 2.11.0 to 2.12.0. This version includes:

- `Coupon_Code` email renderer with `woocommerce_coupon_code_block_auto_generate` filter
- `Coupon_Code_Generator` for baseline coupon generation at send time
- Preview detection (`is_user_preview`) to avoid generating coupons during previews

These were added in [woocommerce/woocommerce#64342](https://github.com/woocommerce/woocommerce/pull/64342) and are required for the MailPoet coupon auto-generation integration (Phase 4).

## Code review notes

_N/A_

## QA notes

The block UI changes are in WooCommerce. This PR only bumps the PHP dependency — no functional changes in MailPoet yet. The MailPoet integration (GutenbergCouponGenerator, restrict-to-subscriber UI, template patterns) will follow in a separate PR.

## Linked PRs

- [woocommerce/woocommerce#64342](https://github.com/woocommerce/woocommerce/pull/64342) — WooCommerce PR that added the coupon block auto-generation

## Linked tickets

[STOMAIL-7969](https://linear.app/a8c/issue/STOMAIL-7969)

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-7969-bump-email-editor-coupon-auto-generation)

_The latest successful build from `update/stomail-7969-bump-email-editor-coupon-auto-generation` will be used. If none is available, the link won't work._