### PR TITLE
Export email stats, 1 of 3 (summary stats as CSV or XLSX) 

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_stats.scss
+++ b/mailpoet/assets/css/src/components-plugin/_stats.scss
@@ -124,6 +124,10 @@
   }
 }
 
+.mailpoet-stats-export-dropdown {
+  margin-right: 0.5rem;
+}
+
 .mailpoet-statistics-value-small {
   .mailpoet-statistics-value-number {
     font-size: $heading-font-size-h3;

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/export-button.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/export-button.tsx
@@ -1,0 +1,98 @@
+import { __ } from '@wordpress/i18n';
+import { Button, Dropdown, MenuItem, MenuGroup } from '@wordpress/components';
+import { chevronDown, Icon } from '@wordpress/icons';
+import { MailPoet } from 'mailpoet';
+import { NewsletterType } from './newsletter-type';
+
+type ExportFormat = 'csv' | 'xlsx';
+
+type Props = {
+  newsletter: NewsletterType;
+};
+
+function exportCampaignStats(
+  newsletterId: string | number,
+  format: ExportFormat,
+): void {
+  MailPoet.Modal.loading(true);
+  void MailPoet.Ajax.post({
+    api_version: window.mailpoet_api_version,
+    endpoint: 'statisticsExport',
+    action: 'exportCampaign',
+    data: {
+      id: newsletterId,
+      format,
+    },
+  })
+    .always(() => {
+      MailPoet.Modal.loading(false);
+    })
+    .done((response) => {
+      const fileUrl = response.data?.exportFileURL as string | undefined;
+      if (!fileUrl) {
+        MailPoet.Notice.error(
+          __('The export file could not be generated.', 'mailpoet'),
+          { scroll: true },
+        );
+        return;
+      }
+      MailPoet.trackEvent('Email statistics export completed', {
+        'File Format': format,
+      });
+      window.location.href = fileUrl;
+    })
+    .fail((response: ErrorResponse) => {
+      if (response.errors.length > 0) {
+        MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
+      }
+    });
+}
+
+export function ExportButton({ newsletter }: Props): JSX.Element | null {
+  if (!MailPoet.trackingConfig.emailTrackingEnabled) {
+    return null;
+  }
+
+  return (
+    <Dropdown
+      className="mailpoet-stats-export-dropdown"
+      focusOnMount={false}
+      popoverProps={{ placement: 'bottom-end' }}
+      renderToggle={({ isOpen, onToggle }) => (
+        <Button
+          variant="secondary"
+          onClick={onToggle}
+          aria-expanded={isOpen}
+          aria-label={__('Export', 'mailpoet')}
+        >
+          {__('Export', 'mailpoet')}
+          <Icon icon={chevronDown} size={18} />
+        </Button>
+      )}
+      renderContent={({ onClose }) => (
+        <MenuGroup>
+          <MenuItem
+            className="mailpoet-no-box-shadow"
+            onClick={() => {
+              exportCampaignStats(newsletter.id, 'csv');
+              onClose();
+            }}
+          >
+            {__('Export as CSV', 'mailpoet')}
+          </MenuItem>
+          <MenuItem
+            className="mailpoet-no-box-shadow"
+            onClick={() => {
+              exportCampaignStats(newsletter.id, 'xlsx');
+              onClose();
+            }}
+          >
+            {__('Export as Excel (XLSX)', 'mailpoet')}
+          </MenuItem>
+        </MenuGroup>
+      )}
+    />
+  );
+}
+
+ExportButton.displayName = 'ExportButton';

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/newsletter-stats-info.tsx
@@ -20,6 +20,7 @@ import {
   Tag,
   getNewsletterStatusString,
 } from 'common';
+import { ExportButton } from './export-button';
 import { NewsletterType } from './newsletter-type';
 
 // Menu Item type definition in @wordpress/components is missing variant and isBusy property
@@ -324,6 +325,7 @@ function NewsletterStatsInfo({ newsletter }: Props) {
       </div>
       <div className="mailpoet-stats-button-group">
         <ButtonGroup>
+          <ExportButton newsletter={newsletter} />
           <Button
             href={newsletter.preview_url}
             target="_blank"

--- a/mailpoet/changelog/2026-04-27-08-15-00-export-single-campaign-email-statistics-as-csv-or-xlsx.md
+++ b/mailpoet/changelog/2026-04-27-08-15-00-export-single-campaign-email-statistics-as-csv-or-xlsx.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Export single-campaign email statistics as CSV or XLSX

--- a/mailpoet/lib/API/JSON/v1/StatisticsExport.php
+++ b/mailpoet/lib/API/JSON/v1/StatisticsExport.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\JSON\v1;
+
+use MailPoet\API\JSON\Endpoint as APIEndpoint;
+use MailPoet\API\JSON\Error as APIError;
+use MailPoet\API\JSON\Response;
+use MailPoet\Config\AccessControl;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+
+class StatisticsExport extends APIEndpoint {
+  public $permissions = [
+    'global' => AccessControl::PERMISSION_MANAGE_EMAILS,
+  ];
+
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var StatisticsExporter */
+  private $exporter;
+
+  public function __construct(
+    NewslettersRepository $newslettersRepository,
+    StatisticsExporter $exporter
+  ) {
+    $this->newslettersRepository = $newslettersRepository;
+    $this->exporter = $exporter;
+  }
+
+  public function exportCampaign($data = []) {
+    $newsletterId = isset($data['id']) ? (int)$data['id'] : 0;
+    if ($newsletterId <= 0) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('Missing newsletter id.', 'mailpoet'),
+      ]);
+    }
+
+    $format = isset($data['format']) && is_string($data['format'])
+      ? strtolower($data['format'])
+      : StatisticsExporter::FORMAT_CSV;
+
+    if ($format !== StatisticsExporter::FORMAT_CSV && $format !== StatisticsExporter::FORMAT_XLSX) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('Unsupported export format. Use csv or xlsx.', 'mailpoet'),
+      ]);
+    }
+
+    $newsletter = $this->newslettersRepository->findOneById($newsletterId);
+    if (!$newsletter) {
+      return $this->errorResponse([
+        APIError::NOT_FOUND => __('This email does not exist.', 'mailpoet'),
+      ], [], Response::STATUS_NOT_FOUND);
+    }
+
+    try {
+      $result = $this->exporter->exportSingleAggregate($newsletter, $format);
+    } catch (\Throwable $e) {
+      return $this->errorResponse([
+        APIError::UNKNOWN => $e->getMessage(),
+      ], [], Response::STATUS_BAD_REQUEST);
+    }
+
+    return $this->successResponse($result);
+  }
+}

--- a/mailpoet/lib/API/JSON/v1/StatisticsExport.php
+++ b/mailpoet/lib/API/JSON/v1/StatisticsExport.php
@@ -6,6 +6,7 @@ use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\Response;
 use MailPoet\Config\AccessControl;
+use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
 
@@ -20,12 +21,17 @@ class StatisticsExport extends APIEndpoint {
   /** @var StatisticsExporter */
   private $exporter;
 
+  /** @var LoggerFactory */
+  private $loggerFactory;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
-    StatisticsExporter $exporter
+    StatisticsExporter $exporter,
+    LoggerFactory $loggerFactory
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->exporter = $exporter;
+    $this->loggerFactory = $loggerFactory;
   }
 
   public function exportCampaign($data = []) {
@@ -56,8 +62,17 @@ class StatisticsExport extends APIEndpoint {
     try {
       $result = $this->exporter->exportSingleAggregate($newsletter, $format);
     } catch (\Throwable $e) {
+      if (function_exists('error_log')) {
+        // phpcs:disable QITStandard.PHP.DebugCode.DebugFunctionFound
+        error_log((string)$e); // phpcs:ignore Squiz.PHP.DiscouragedFunctions
+        // phpcs:enable QITStandard.PHP.DebugCode.DebugFunctionFound
+      }
+      $this->loggerFactory->getLogger(LoggerFactory::TOPIC_API)->warning('Campaign statistics export failed.', [
+        'exceptionMessage' => $e->getMessage(),
+        'exceptionTrace' => $e->getTraceAsString(),
+      ]);
       return $this->errorResponse([
-        APIError::UNKNOWN => $e->getMessage(),
+        APIError::UNKNOWN => __('Could not generate the export. Please try again.', 'mailpoet'),
       ], [], Response::STATUS_BAD_REQUEST);
     }
 

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -97,6 +97,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\API\JSON\v1\UserFlags::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\SendingTaskSubscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Setup::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\StatisticsExport::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\SubscriberStats::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\WoocommerceSettings::class)->setPublic(true);
@@ -606,6 +607,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Subscriber::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Site::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Statistics\Export\StatisticsExporter::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\AutomationEmailScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\WelcomeScheduler::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -1,0 +1,183 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Statistics\Export;
+
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\Statistics\NewsletterStatistics;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
+use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\XLSXWriter;
+
+class StatisticsExporter {
+  public const FORMAT_CSV = 'csv';
+  public const FORMAT_XLSX = 'xlsx';
+
+  private const FILE_PREFIX = 'MailPoet_stats_export_';
+  private const RANDOM_NAME_LENGTH = 15;
+
+  /** @var NewsletterStatisticsRepository */
+  private $statisticsRepository;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    NewsletterStatisticsRepository $statisticsRepository,
+    WPFunctions $wp
+  ) {
+    $this->statisticsRepository = $statisticsRepository;
+    $this->wp = $wp;
+  }
+
+  /**
+   * Export aggregate stats for a single newsletter to CSV or XLSX.
+   *
+   * @return array{exportFileURL: string, totalExported: int}
+   */
+  public function exportSingleAggregate(NewsletterEntity $newsletter, string $format): array {
+    $format = $this->normalizeFormat($format);
+    $headers = $this->getAggregateHeaders();
+    $stats = $this->statisticsRepository->getStatistics($newsletter);
+    $row = $this->buildAggregateRow($newsletter, $stats);
+
+    $this->ensureExportDirectory();
+    $filePath = $this->getExportFilePath($format);
+    $this->writeFile($filePath, $headers, [$row], $format);
+
+    return [
+      'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
+      'totalExported' => 1,
+    ];
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getAggregateHeaders(): array {
+    return [
+      __('Newsletter ID', 'mailpoet'),
+      __('Subject', 'mailpoet'),
+      __('Campaign name', 'mailpoet'),
+      __('Sent at', 'mailpoet'),
+      __('Total sent', 'mailpoet'),
+      __('Unique opens', 'mailpoet'),
+      __('Machine opens', 'mailpoet'),
+      __('Unique clicks', 'mailpoet'),
+      __('Bounces', 'mailpoet'),
+      __('Unsubscribes', 'mailpoet'),
+      __('Revenue', 'mailpoet'),
+      __('Currency', 'mailpoet'),
+      __('Orders', 'mailpoet'),
+    ];
+  }
+
+  /**
+   * Build one aggregate row for a newsletter, in the same column order as
+   * `getAggregateHeaders()`. Public so it can be reused by bulk export in phase 3.
+   *
+   * @return array<int|string|float|null>
+   */
+  public function buildAggregateRow(NewsletterEntity $newsletter, NewsletterStatistics $stats): array {
+    $sentAt = $newsletter->getSentAt();
+    $revenue = $stats->getWooCommerceRevenue();
+
+    return [
+      (int)$newsletter->getId(),
+      (string)$newsletter->getSubject(),
+      (string)($newsletter->getCampaignName() ?? ''),
+      $sentAt ? $sentAt->format('Y-m-d H:i:s') : '',
+      $stats->getTotalSentCount(),
+      $stats->getOpenCount(),
+      $stats->getMachineOpenCount(),
+      $stats->getClickCount(),
+      $stats->getBounceCount(),
+      $stats->getUnsubscribeCount(),
+      $revenue instanceof WooCommerceRevenue ? $revenue->getValue() : '',
+      $revenue instanceof WooCommerceRevenue ? $revenue->getCurrency() : '',
+      $revenue instanceof WooCommerceRevenue ? $revenue->getOrdersCount() : '',
+    ];
+  }
+
+  /**
+   * @param string[] $headers
+   * @param array<array<int|string|float|null>> $rows
+   */
+  private function writeFile(string $filePath, array $headers, array $rows, string $format): void {
+    if ($format === self::FORMAT_XLSX) {
+      $this->writeXlsx($filePath, $headers, $rows);
+      return;
+    }
+    $this->writeCsv($filePath, $headers, $rows);
+  }
+
+  /**
+   * @param string[] $headers
+   * @param array<array<int|string|float|null>> $rows
+   */
+  private function writeCsv(string $filePath, array $headers, array $rows): void {
+    $handle = fopen($filePath, 'w');
+    if ($handle === false) {
+      throw new \RuntimeException('Failed opening file for export.');
+    }
+
+    // UTF-8 BOM so Excel auto-detects encoding (matches Subscribers/ImportExport/Export/Export.php)
+    fwrite($handle, chr(0xEF) . chr(0xBB) . chr(0xBF));
+    $this->writeCsvLine($handle, $headers);
+    foreach ($rows as $row) {
+      $this->writeCsvLine($handle, $row);
+    }
+    fclose($handle);
+  }
+
+  /**
+   * @param resource $handle
+   * @param array<int|string|float|null> $row
+   */
+  private function writeCsvLine($handle, array $row): void {
+    $escaped = [];
+    foreach ($row as $cell) {
+      $escaped[] = '"' . str_replace('"', '\"', (string)$cell) . '"';
+    }
+    fwrite($handle, implode(',', $escaped) . "\n");
+  }
+
+  /**
+   * @param string[] $headers
+   * @param array<array<int|string|float|null>> $rows
+   */
+  private function writeXlsx(string $filePath, array $headers, array $rows): void {
+    $writer = new XLSXWriter();
+    $sheetName = __('Statistics', 'mailpoet');
+    $writer->writeSheetHeader($sheetName, array_fill_keys($headers, 'string'));
+    foreach ($rows as $row) {
+      $writer->writeSheetRow($sheetName, $row);
+    }
+    $writer->writeToFile($filePath);
+  }
+
+  private function ensureExportDirectory(): void {
+    $path = Env::$tempPath;
+    if (!is_dir($path)) {
+      $this->wp->wpMkdirP($path);
+    }
+  }
+
+  private function getExportFilePath(string $format): string {
+    return Env::$tempPath . '/' . self::FILE_PREFIX . Security::generateRandomString(self::RANDOM_NAME_LENGTH) . '.' . $format;
+  }
+
+  private function getExportFileUrl(string $filename): string {
+    return Env::$tempUrl . '/' . $filename;
+  }
+
+  private function normalizeFormat(string $format): string {
+    $format = strtolower($format);
+    if ($format !== self::FORMAT_CSV && $format !== self::FORMAT_XLSX) {
+      throw new \InvalidArgumentException(sprintf('Unsupported export format "%s".', $format));
+    }
+    return $format;
+  }
+}

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -137,11 +137,7 @@ class StatisticsExporter {
    * @param array<int|string|float|null> $row
    */
   private function writeCsvLine($handle, array $row): void {
-    $escaped = [];
-    foreach ($row as $cell) {
-      $escaped[] = '"' . str_replace('"', '\"', (string)$cell) . '"';
-    }
-    fwrite($handle, implode(',', $escaped) . "\n");
+    fputcsv($handle, array_map('strval', $row), ',', '"', '');
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -137,6 +137,7 @@ class StatisticsExporter {
    * @param array<int|string|float|null> $row
    */
   private function writeCsvLine($handle, array $row): void {
+    // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv -- Export handles are created under Env::$tempPath, which is MailPoet's WordPress temp directory.
     fputcsv($handle, array_map('strval', $row), ',', '"', '');
   }
 

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\API\JSON\v1;
+
+use MailPoet\API\JSON\Response as APIResponse;
+use MailPoet\API\JSON\v1\StatisticsExport;
+use MailPoet\Config\Env;
+use MailPoet\DI\ContainerWrapper;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+class StatisticsExportTest extends \MailPoetTest {
+  /** @var StatisticsExport */
+  private $endpoint;
+
+  /** @var string */
+  private $previousTempPath;
+
+  /** @var string */
+  private $previousTempUrl;
+
+  /** @var string */
+  private $tempDir;
+
+  public function _before() {
+    parent::_before();
+    $this->endpoint = ContainerWrapper::getInstance()->get(StatisticsExport::class);
+
+    $this->previousTempPath = (string)Env::$tempPath;
+    $this->previousTempUrl = (string)Env::$tempUrl;
+    $this->tempDir = sys_get_temp_dir() . '/mailpoet-stats-export-' . uniqid('', true);
+    mkdir($this->tempDir, 0777, true);
+    Env::$tempPath = $this->tempDir;
+    Env::$tempUrl = 'https://example.test/uploads/mailpoet';
+  }
+
+  public function _after() {
+    parent::_after();
+    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+      unlink($file);
+    }
+    if (is_dir($this->tempDir)) {
+      rmdir($this->tempDir);
+    }
+    Env::$tempPath = $this->previousTempPath;
+    Env::$tempUrl = $this->previousTempUrl;
+  }
+
+  public function testItRejectsMissingNewsletterId() {
+    $response = $this->endpoint->exportCampaign([]);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+  }
+
+  public function testItRejectsUnsupportedFormat() {
+    $newsletter = (new NewsletterFactory())->withSubject('Hello')->create();
+    $response = $this->endpoint->exportCampaign([
+      'id' => $newsletter->getId(),
+      'format' => 'pdf',
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+  }
+
+  public function testItReturns404ForUnknownNewsletter() {
+    $response = $this->endpoint->exportCampaign([
+      'id' => 999999,
+      'format' => StatisticsExporter::FORMAT_CSV,
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+  }
+
+  public function testItExportsCampaignAggregateAsCsv() {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Spring sale!')
+      ->create();
+
+    $response = $this->endpoint->exportCampaign([
+      'id' => $newsletter->getId(),
+      'format' => StatisticsExporter::FORMAT_CSV,
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['totalExported'])->equals(1);
+    verify($response->data['exportFileURL'])->stringStartsWith('https://example.test/uploads/mailpoet/MailPoet_stats_export_');
+    verify($response->data['exportFileURL'])->stringEndsWith('.csv');
+
+    $files = glob($this->tempDir . '/*.csv') ?: [];
+    verify($files)->arrayCount(1);
+
+    $content = (string)file_get_contents($files[0]);
+    verify(substr($content, 0, 3))->equals(chr(0xEF) . chr(0xBB) . chr(0xBF));
+    verify($content)->stringContainsString('Spring sale!');
+  }
+
+  public function testItExportsCampaignAggregateAsXlsx() {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Black Friday')
+      ->create();
+
+    $response = $this->endpoint->exportCampaign([
+      'id' => $newsletter->getId(),
+      'format' => StatisticsExporter::FORMAT_XLSX,
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['exportFileURL'])->stringEndsWith('.xlsx');
+
+    $files = glob($this->tempDir . '/*.xlsx') ?: [];
+    verify($files)->arrayCount(1);
+    verify(filesize($files[0]))->greaterThan(0);
+  }
+
+  public function testItDefaultsToCsvWhenFormatMissing() {
+    $newsletter = (new NewsletterFactory())->create();
+
+    $response = $this->endpoint->exportCampaign([
+      'id' => $newsletter->getId(),
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['exportFileURL'])->stringEndsWith('.csv');
+  }
+}

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -58,18 +58,17 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     // Starts with the UTF-8 BOM (EF BB BF).
     verify(substr($content, 0, 3))->equals(chr(0xEF) . chr(0xBB) . chr(0xBF));
 
-    $body = substr($content, 3);
-    $lines = explode("\n", trim($body));
-    verify($lines)->arrayCount(2);
-    verify($lines[0])->stringContainsString('Newsletter ID');
-    verify($lines[0])->stringContainsString('Subject');
-    verify($lines[0])->stringContainsString('Total sent');
-    verify($lines[0])->stringContainsString('Revenue');
-    verify($lines[1])->stringContainsString('"123"');
-    verify($lines[1])->stringContainsString('"Spring sale!"');
-    verify($lines[1])->stringContainsString('"Spring 2026"');
-    verify($lines[1])->stringContainsString('"2026-04-15 10:00:00"');
-    verify($lines[1])->stringContainsString('"500"');
+    $rows = $this->parseCsvRows(substr($content, 3));
+    verify($rows)->arrayCount(2);
+    verify($rows[0][0])->equals('Newsletter ID');
+    verify($rows[0][1])->equals('Subject');
+    verify($rows[0][4])->equals('Total sent');
+    verify($rows[0][10])->equals('Revenue');
+    verify($rows[1][0])->equals('123');
+    verify($rows[1][1])->equals('Spring "sale"!');
+    verify($rows[1][2])->equals('Spring, 2026');
+    verify($rows[1][3])->equals('2026-04-15 10:00:00');
+    verify($rows[1][4])->equals('500');
   }
 
   public function testItIncludesWooCommerceRevenueColumnsWhenPresent() {
@@ -81,13 +80,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
 
     $files = glob($this->tempDir . '/*.csv') ?: [];
-    $body = substr((string)file_get_contents($files[0]), 3);
-    $rows = array_map(
-      static function (string $line): array {
-        return str_getcsv($line, ',', '"', '\\');
-      },
-      explode("\n", trim($body))
-    );
+    $rows = $this->parseCsvRows(substr((string)file_get_contents($files[0]), 3));
     verify($rows[1][10])->equals('1234.56');
     verify($rows[1][11])->equals('USD');
     verify($rows[1][12])->equals('12');
@@ -134,6 +127,18 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
       'wpMkdirP' => true,
     ]);
     return new StatisticsExporter($repository, $wp);
+  }
+
+  /**
+   * @return array<array<string|null>>
+   */
+  private function parseCsvRows(string $body): array {
+    return array_map(
+      static function (string $line): array {
+        return str_getcsv($line, ',', '"', '');
+      },
+      explode("\n", trim($body))
+    );
   }
 
   private function createNewsletter(int $id, string $subject, ?string $campaignName, ?string $sentAt): NewsletterEntity {

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Statistics\Export;
+
+use MailPoet\Config\Env;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\Statistics\NewsletterStatistics;
+use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
+use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\WooCommerce\Helper;
+use MailPoet\WP\Functions as WPFunctions;
+
+class StatisticsExporterTest extends \MailPoetUnitTest {
+  /** @var string */
+  private $previousTempPath;
+
+  /** @var string */
+  private $previousTempUrl;
+
+  /** @var string */
+  private $tempDir;
+
+  public function _before() {
+    $this->previousTempPath = (string)Env::$tempPath;
+    $this->previousTempUrl = (string)Env::$tempUrl;
+    $this->tempDir = sys_get_temp_dir() . '/mailpoet-stats-export-' . uniqid('', true);
+    mkdir($this->tempDir, 0777, true);
+    Env::$tempPath = $this->tempDir;
+    Env::$tempUrl = 'https://example.test/uploads/mailpoet';
+  }
+
+  public function _after() {
+    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+      unlink($file);
+    }
+    if (is_dir($this->tempDir)) {
+      rmdir($this->tempDir);
+    }
+    Env::$tempPath = $this->previousTempPath;
+    Env::$tempUrl = $this->previousTempUrl;
+  }
+
+  public function testItExportsAggregateAsCsvWithBomAndHeader() {
+    $newsletter = $this->createNewsletter(123, 'Spring sale!', 'Spring 2026', '2026-04-15 10:00:00');
+    $stats = $this->createStats(500, 200, 30, 80, 5, 10, null);
+
+    $exporter = $this->createExporter($newsletter, $stats);
+    $result = $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
+
+    verify($result['totalExported'])->equals(1);
+    verify($result['exportFileURL'])->stringStartsWith('https://example.test/uploads/mailpoet/MailPoet_stats_export_');
+    verify($result['exportFileURL'])->stringEndsWith('.csv');
+
+    $files = glob($this->tempDir . '/*.csv') ?: [];
+    verify($files)->arrayCount(1);
+
+    $content = (string)file_get_contents($files[0]);
+    // Starts with the UTF-8 BOM (EF BB BF).
+    verify(substr($content, 0, 3))->equals(chr(0xEF) . chr(0xBB) . chr(0xBF));
+
+    $body = substr($content, 3);
+    $lines = explode("\n", trim($body));
+    verify($lines)->arrayCount(2);
+    verify($lines[0])->stringContainsString('Newsletter ID');
+    verify($lines[0])->stringContainsString('Subject');
+    verify($lines[0])->stringContainsString('Total sent');
+    verify($lines[0])->stringContainsString('Revenue');
+    verify($lines[1])->stringContainsString('"123"');
+    verify($lines[1])->stringContainsString('"Spring sale!"');
+    verify($lines[1])->stringContainsString('"Spring 2026"');
+    verify($lines[1])->stringContainsString('"2026-04-15 10:00:00"');
+    verify($lines[1])->stringContainsString('"500"');
+  }
+
+  public function testItIncludesWooCommerceRevenueColumnsWhenPresent() {
+    $newsletter = $this->createNewsletter(7, 'Black Friday', null, '2026-11-29 09:00:00');
+    $revenue = new WooCommerceRevenue('USD', 1234.56, 12, $this->makeEmpty(Helper::class));
+    $stats = $this->createStats(1000, 400, 50, 200, 10, 20, $revenue);
+
+    $exporter = $this->createExporter($newsletter, $stats);
+    $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
+
+    $files = glob($this->tempDir . '/*.csv') ?: [];
+    $body = substr((string)file_get_contents($files[0]), 3);
+    $rows = array_map(
+      static function (string $line): array {
+        return str_getcsv($line, ',', '"', '\\');
+      },
+      explode("\n", trim($body))
+    );
+    verify($rows[1][10])->equals('1234.56');
+    verify($rows[1][11])->equals('USD');
+    verify($rows[1][12])->equals('12');
+  }
+
+  public function testItExportsAggregateAsXlsx() {
+    $newsletter = $this->createNewsletter(42, 'Hello', null, '2026-01-01 00:00:00');
+    $stats = $this->createStats(10, 5, 0, 1, 0, 0, null);
+
+    $exporter = $this->createExporter($newsletter, $stats);
+    $result = $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_XLSX);
+
+    verify($result['exportFileURL'])->stringEndsWith('.xlsx');
+    $files = glob($this->tempDir . '/*.xlsx') ?: [];
+    verify($files)->arrayCount(1);
+    verify(filesize($files[0]))->greaterThan(0);
+  }
+
+  public function testItRejectsUnsupportedFormat() {
+    $newsletter = $this->createNewsletter(1, 'x', null, null);
+    $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
+    $exporter = $this->createExporter($newsletter, $stats);
+
+    $this->expectException(\InvalidArgumentException::class);
+    $exporter->exportSingleAggregate($newsletter, 'pdf');
+  }
+
+  public function testBuildAggregateRowMatchesHeaderColumnCount() {
+    $newsletter = $this->createNewsletter(1, 's', null, null);
+    $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
+    $exporter = $this->createExporter($newsletter, $stats);
+
+    $headers = $exporter->getAggregateHeaders();
+    $row = $exporter->buildAggregateRow($newsletter, $stats);
+
+    verify(count($row))->equals(count($headers));
+  }
+
+  private function createExporter(NewsletterEntity $newsletter, NewsletterStatistics $stats): StatisticsExporter {
+    $repository = $this->makeEmpty(NewsletterStatisticsRepository::class, [
+      'getStatistics' => $stats,
+    ]);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'wpMkdirP' => true,
+    ]);
+    return new StatisticsExporter($repository, $wp);
+  }
+
+  private function createNewsletter(int $id, string $subject, ?string $campaignName, ?string $sentAt): NewsletterEntity {
+    $newsletter = $this->makeEmpty(NewsletterEntity::class, [
+      'getId' => $id,
+      'getSubject' => $subject,
+      'getCampaignName' => $campaignName,
+      'getSentAt' => $sentAt ? new \DateTimeImmutable($sentAt) : null,
+    ]);
+    return $newsletter;
+  }
+
+  private function createStats(
+    int $totalSent,
+    int $opens,
+    int $machineOpens,
+    int $clicks,
+    int $bounces,
+    int $unsubscribes,
+    ?WooCommerceRevenue $revenue
+  ): NewsletterStatistics {
+    $stats = new NewsletterStatistics($clicks, $opens, $unsubscribes, $bounces, $totalSent, $revenue);
+    $stats->setMachineOpenCount($machineOpens);
+    return $stats;
+  }
+}

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -41,10 +41,10 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
   }
 
   public function testItExportsAggregateAsCsvWithBomAndHeader() {
-    $newsletter = $this->createNewsletter(123, 'Spring sale!', 'Spring 2026', '2026-04-15 10:00:00');
+    $newsletter = $this->createNewsletter(123, 'Spring "sale"!', 'Spring, 2026', '2026-04-15 10:00:00');
     $stats = $this->createStats(500, 200, 30, 80, 5, 10, null);
 
-    $exporter = $this->createExporter($newsletter, $stats);
+    $exporter = $this->createExporter($stats);
     $result = $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
 
     verify($result['totalExported'])->equals(1);
@@ -77,7 +77,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $revenue = new WooCommerceRevenue('USD', 1234.56, 12, $this->makeEmpty(Helper::class));
     $stats = $this->createStats(1000, 400, 50, 200, 10, 20, $revenue);
 
-    $exporter = $this->createExporter($newsletter, $stats);
+    $exporter = $this->createExporter($stats);
     $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
 
     $files = glob($this->tempDir . '/*.csv') ?: [];
@@ -97,7 +97,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $newsletter = $this->createNewsletter(42, 'Hello', null, '2026-01-01 00:00:00');
     $stats = $this->createStats(10, 5, 0, 1, 0, 0, null);
 
-    $exporter = $this->createExporter($newsletter, $stats);
+    $exporter = $this->createExporter($stats);
     $result = $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_XLSX);
 
     verify($result['exportFileURL'])->stringEndsWith('.xlsx');
@@ -109,7 +109,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
   public function testItRejectsUnsupportedFormat() {
     $newsletter = $this->createNewsletter(1, 'x', null, null);
     $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
-    $exporter = $this->createExporter($newsletter, $stats);
+    $exporter = $this->createExporter($stats);
 
     $this->expectException(\InvalidArgumentException::class);
     $exporter->exportSingleAggregate($newsletter, 'pdf');
@@ -118,7 +118,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
   public function testBuildAggregateRowMatchesHeaderColumnCount() {
     $newsletter = $this->createNewsletter(1, 's', null, null);
     $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
-    $exporter = $this->createExporter($newsletter, $stats);
+    $exporter = $this->createExporter($stats);
 
     $headers = $exporter->getAggregateHeaders();
     $row = $exporter->buildAggregateRow($newsletter, $stats);
@@ -126,7 +126,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     verify(count($row))->equals(count($headers));
   }
 
-  private function createExporter(NewsletterEntity $newsletter, NewsletterStatistics $stats): StatisticsExporter {
+  private function createExporter(NewsletterStatistics $stats): StatisticsExporter {
     $repository = $this->makeEmpty(NewsletterStatisticsRepository::class, [
       'getStatistics' => $stats,
     ]);


### PR DESCRIPTION
## Description

Allow exporting single email-campaign summary stats as CSV or XLSX).

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7978

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1078" height="572" alt="Screenshot 2026-04-27 at 14 57 41" src="https://github.com/user-attachments/assets/97a38c3b-d274-4735-8eea-4763cd9f4829" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7972-export-statistics-1)

_The latest successful build from `stomail-7972-export-statistics-1` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 1

**Bug (1):**
- **Non-standard CSV Quote Escaping** (StatisticsExporter.php, line 142): The CSV writer uses backslash-escaping for quotes (`str_replace('"', '\"', ...)`) instead of the RFC 4180 standard double-quote escaping (`str_replace('"', '""', ...)`). While the unit tests pass because they use matching backslash parsing (`str_getcsv()` with `\\` escape character), this produces non-standard CSV format that may not be compatible with Excel and other CSV readers that expect RFC 4180 compliant format with `""` for escaped quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->