### PR TITLE
Export email stats, 2 of 3 (per-recipient stats as CSV or XLSX)

### DIFF
--- a/mailpoet/assets/js/src/newsletters/campaign-stats/export-button.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/export-button.tsx
@@ -1,10 +1,15 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button, Dropdown, MenuItem, MenuGroup } from '@wordpress/components';
 import { chevronDown, Icon } from '@wordpress/icons';
 import { MailPoet } from 'mailpoet';
+import { PremiumModal } from '../../common/premium-modal';
+import {
+  ExportFormat,
+  StatusPayload,
+  pollExportStatus,
+} from '../statistics-export/poll-export-status';
 import { NewsletterType } from './newsletter-type';
-
-type ExportFormat = 'csv' | 'xlsx';
 
 type Props = {
   newsletter: NewsletterType;
@@ -38,6 +43,7 @@ function exportCampaignStats(
       }
       MailPoet.trackEvent('Email statistics export completed', {
         'File Format': format,
+        'Export Type': 'aggregate',
       });
       window.location.href = fileUrl;
     })
@@ -48,50 +54,192 @@ function exportCampaignStats(
     });
 }
 
+const scheduleRecipientsExport = (
+  newsletterId: string | number,
+  format: ExportFormat,
+) =>
+  MailPoet.Ajax.post({
+    api_version: window.mailpoet_api_version,
+    endpoint: 'statisticsExport',
+    action: 'exportRecipients',
+    data: {
+      id: newsletterId,
+      format,
+    },
+  }).then((response) => response.data as StatusPayload);
+
+const useRecipientsExport = (newsletterId: string | number) => {
+  const [isExporting, setIsExporting] = useState(false);
+  const cancelRef = useRef<(() => void) | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (cancelRef.current !== null) {
+      cancelRef.current();
+      cancelRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const handleSuccess = useCallback(
+    (status: StatusPayload, format: ExportFormat) => {
+      setIsExporting(false);
+      if (!status.exportFileURL) {
+        MailPoet.Notice.error(
+          __('The export file could not be generated.', 'mailpoet'),
+          { scroll: true },
+        );
+        return;
+      }
+      MailPoet.trackEvent('Email statistics export completed', {
+        'File Format': format,
+        'Export Type': 'recipients',
+      });
+      window.location.href = status.exportFileURL;
+    },
+    [],
+  );
+
+  const handleFailure = useCallback((message: string) => {
+    setIsExporting(false);
+    MailPoet.Notice.error(message, { scroll: true });
+  }, []);
+
+  const start = useCallback(
+    (format: ExportFormat) => {
+      if (isExporting) {
+        return;
+      }
+      setIsExporting(true);
+      MailPoet.Notice.success(
+        __(
+          'Export queued. The download will start automatically when it is ready.',
+          'mailpoet',
+        ),
+        { timeout: 6000 },
+      );
+      scheduleRecipientsExport(newsletterId, format)
+        .then((status) => {
+          if (status.exportFileURL) {
+            handleSuccess(status, format);
+            return;
+          }
+          const handle = pollExportStatus(status.taskId, {
+            onComplete: (s) => handleSuccess(s, format),
+            onError: handleFailure,
+          });
+          cancelRef.current = handle.cancel;
+        })
+        .catch((response: ErrorResponse) => {
+          const message =
+            response?.errors?.[0]?.message ??
+            __('Could not start the export.', 'mailpoet');
+          handleFailure(message);
+        });
+    },
+    [handleFailure, handleSuccess, isExporting, newsletterId],
+  );
+
+  return { start, isExporting };
+};
+
 export function ExportButton({ newsletter }: Props): JSX.Element | null {
+  const [showPremiumModal, setShowPremiumModal] = useState(false);
+  const { start: startRecipientsExport, isExporting } = useRecipientsExport(
+    newsletter.id,
+  );
+
   if (!MailPoet.trackingConfig.emailTrackingEnabled) {
     return null;
   }
 
+  const isRecipientsRestricted =
+    !MailPoet.capabilities.detailedAnalytics ||
+    MailPoet.capabilities.detailedAnalytics.isRestricted;
+
+  const handleRecipientsClick = (format: ExportFormat, onClose: () => void) => {
+    onClose();
+    if (isRecipientsRestricted) {
+      setShowPremiumModal(true);
+      return;
+    }
+    startRecipientsExport(format);
+  };
+
   return (
-    <Dropdown
-      className="mailpoet-stats-export-dropdown"
-      focusOnMount={false}
-      popoverProps={{ placement: 'bottom-end' }}
-      renderToggle={({ isOpen, onToggle }) => (
-        <Button
-          variant="secondary"
-          onClick={onToggle}
-          aria-expanded={isOpen}
-          aria-label={__('Export', 'mailpoet')}
+    <>
+      <Dropdown
+        className="mailpoet-stats-export-dropdown"
+        focusOnMount={false}
+        popoverProps={{ placement: 'bottom-end' }}
+        renderToggle={({ isOpen, onToggle }) => (
+          <Button
+            variant="secondary"
+            onClick={onToggle}
+            aria-expanded={isOpen}
+            aria-label={__('Export', 'mailpoet')}
+            isBusy={isExporting}
+            disabled={isExporting}
+          >
+            {__('Export', 'mailpoet')}
+            <Icon icon={chevronDown} size={18} />
+          </Button>
+        )}
+        renderContent={({ onClose }) => (
+          <>
+            <MenuGroup label={__('Campaign summary', 'mailpoet')}>
+              <MenuItem
+                className="mailpoet-no-box-shadow"
+                onClick={() => {
+                  exportCampaignStats(newsletter.id, 'csv');
+                  onClose();
+                }}
+              >
+                {__('Export as CSV', 'mailpoet')}
+              </MenuItem>
+              <MenuItem
+                className="mailpoet-no-box-shadow"
+                onClick={() => {
+                  exportCampaignStats(newsletter.id, 'xlsx');
+                  onClose();
+                }}
+              >
+                {__('Export as Excel (XLSX)', 'mailpoet')}
+              </MenuItem>
+            </MenuGroup>
+            <MenuGroup label={__('Per recipient', 'mailpoet')}>
+              <MenuItem
+                className="mailpoet-no-box-shadow"
+                onClick={() => handleRecipientsClick('csv', onClose)}
+              >
+                {__('Recipients as CSV', 'mailpoet')}
+              </MenuItem>
+              <MenuItem
+                className="mailpoet-no-box-shadow"
+                onClick={() => handleRecipientsClick('xlsx', onClose)}
+              >
+                {__('Recipients as Excel (XLSX)', 'mailpoet')}
+              </MenuItem>
+            </MenuGroup>
+          </>
+        )}
+      />
+      {showPremiumModal && (
+        <PremiumModal
+          onRequestClose={() => setShowPremiumModal(false)}
+          data={{ capabilities: { detailedAnalytics: true } }}
+          tracking={{
+            utm_medium: 'upsell_modal',
+            utm_campaign: 'stats_recipients_export',
+          }}
         >
-          {__('Export', 'mailpoet')}
-          <Icon icon={chevronDown} size={18} />
-        </Button>
+          {__(
+            'Per-recipient statistics export is available with detailed analytics.',
+            'mailpoet',
+          )}
+        </PremiumModal>
       )}
-      renderContent={({ onClose }) => (
-        <MenuGroup>
-          <MenuItem
-            className="mailpoet-no-box-shadow"
-            onClick={() => {
-              exportCampaignStats(newsletter.id, 'csv');
-              onClose();
-            }}
-          >
-            {__('Export as CSV', 'mailpoet')}
-          </MenuItem>
-          <MenuItem
-            className="mailpoet-no-box-shadow"
-            onClick={() => {
-              exportCampaignStats(newsletter.id, 'xlsx');
-              onClose();
-            }}
-          >
-            {__('Export as Excel (XLSX)', 'mailpoet')}
-          </MenuItem>
-        </MenuGroup>
-      )}
-    />
+    </>
   );
 }
 

--- a/mailpoet/assets/js/src/newsletters/statistics-export/poll-export-status.ts
+++ b/mailpoet/assets/js/src/newsletters/statistics-export/poll-export-status.ts
@@ -13,6 +13,7 @@ export type StatusPayload = {
 
 const POLL_INTERVAL_MS = 2500;
 const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+const MAX_CONSECUTIVE_FAILURES = 3;
 
 export const fetchExportStatus = (taskId: number) =>
   MailPoet.Ajax.post({
@@ -33,6 +34,7 @@ export function pollExportStatus(
 ): { cancel: () => void } {
   let timer: number | null = null;
   let cancelled = false;
+  let consecutiveFailures = 0;
   const startedAt = Date.now();
 
   const cancel = () => {
@@ -62,6 +64,7 @@ export function pollExportStatus(
         if (cancelled) {
           return;
         }
+        consecutiveFailures = 0;
         if (status.error) {
           options.onError(status.error);
           return;
@@ -76,10 +79,15 @@ export function pollExportStatus(
         if (cancelled) {
           return;
         }
-        const message =
-          response?.errors?.[0]?.message ??
-          __('Could not check the export status.', 'mailpoet');
-        options.onError(message);
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          const message =
+            response?.errors?.[0]?.message ??
+            __('Could not check the export status.', 'mailpoet');
+          options.onError(message);
+          return;
+        }
+        timer = window.setTimeout(tick, POLL_INTERVAL_MS);
       });
   };
 

--- a/mailpoet/assets/js/src/newsletters/statistics-export/poll-export-status.ts
+++ b/mailpoet/assets/js/src/newsletters/statistics-export/poll-export-status.ts
@@ -1,0 +1,88 @@
+import { __ } from '@wordpress/i18n';
+import { MailPoet } from 'mailpoet';
+
+export type ExportFormat = 'csv' | 'xlsx';
+
+export type StatusPayload = {
+  taskId: number;
+  status: string;
+  exportFileURL?: string;
+  totalExported?: number;
+  error?: string;
+};
+
+const POLL_INTERVAL_MS = 2500;
+const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+export const fetchExportStatus = (taskId: number) =>
+  MailPoet.Ajax.post({
+    api_version: window.mailpoet_api_version,
+    endpoint: 'statisticsExport',
+    action: 'getStatus',
+    data: { task_id: taskId },
+  }).then((response) => response.data as StatusPayload);
+
+type PollOptions = {
+  onComplete: (status: StatusPayload) => void;
+  onError: (message: string) => void;
+};
+
+export function pollExportStatus(
+  taskId: number,
+  options: PollOptions,
+): { cancel: () => void } {
+  let timer: number | null = null;
+  let cancelled = false;
+  const startedAt = Date.now();
+
+  const cancel = () => {
+    cancelled = true;
+    if (timer !== null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const tick = () => {
+    if (cancelled) {
+      return;
+    }
+    if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+      options.onError(
+        __(
+          'The export is taking longer than expected. Please try again later.',
+          'mailpoet',
+        ),
+      );
+      return;
+    }
+
+    fetchExportStatus(taskId)
+      .then((status) => {
+        if (cancelled) {
+          return;
+        }
+        if (status.error) {
+          options.onError(status.error);
+          return;
+        }
+        if (status.exportFileURL) {
+          options.onComplete(status);
+          return;
+        }
+        timer = window.setTimeout(tick, POLL_INTERVAL_MS);
+      })
+      .catch((response: ErrorResponse) => {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          response?.errors?.[0]?.message ??
+          __('Could not check the export status.', 'mailpoet');
+        options.onError(message);
+      });
+  };
+
+  tick();
+  return { cancel };
+}

--- a/mailpoet/lib/API/JSON/v1/StatisticsExport.php
+++ b/mailpoet/lib/API/JSON/v1/StatisticsExport.php
@@ -142,8 +142,22 @@ class StatisticsExport extends APIEndpoint {
       ]);
     }
 
+    if ($this->isDetailedAnalyticsRestricted()) {
+      return $this->errorResponse([
+        APIError::FORBIDDEN => __('Per-recipient export requires a MailPoet plan with detailed analytics.', 'mailpoet'),
+      ], [], Response::STATUS_FORBIDDEN);
+    }
+
     $task = $this->scheduledTasksRepository->findOneById($taskId);
     if (!$task instanceof ScheduledTaskEntity || $task->getType() !== StatisticsExportWorker::TASK_TYPE) {
+      return $this->errorResponse([
+        APIError::NOT_FOUND => __('Export task not found.', 'mailpoet'),
+      ], [], Response::STATUS_NOT_FOUND);
+    }
+
+    $meta = $task->getMeta() ?? [];
+    $jobType = isset($meta['job_type']) ? (string)$meta['job_type'] : '';
+    if ($jobType !== StatisticsExportWorker::JOB_TYPE_RECIPIENTS) {
       return $this->errorResponse([
         APIError::NOT_FOUND => __('Export task not found.', 'mailpoet'),
       ], [], Response::STATUS_NOT_FOUND);

--- a/mailpoet/lib/API/JSON/v1/StatisticsExport.php
+++ b/mailpoet/lib/API/JSON/v1/StatisticsExport.php
@@ -163,6 +163,13 @@ class StatisticsExport extends APIEndpoint {
       ], [], Response::STATUS_NOT_FOUND);
     }
 
+    $requestedBy = isset($meta['requested_by']) ? (int)$meta['requested_by'] : 0;
+    if ($requestedBy !== (int)$this->wp->getCurrentUserId()) {
+      return $this->errorResponse([
+        APIError::NOT_FOUND => __('Export task not found.', 'mailpoet'),
+      ], [], Response::STATUS_NOT_FOUND);
+    }
+
     return $this->successResponse($this->buildStatusPayload($task));
   }
 

--- a/mailpoet/lib/API/JSON/v1/StatisticsExport.php
+++ b/mailpoet/lib/API/JSON/v1/StatisticsExport.php
@@ -6,9 +6,15 @@ use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\API\JSON\Error as APIError;
 use MailPoet\API\JSON\Response;
 use MailPoet\Config\AccessControl;
+use MailPoet\Cron\Workers\StatisticsExport as StatisticsExportWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Logging\LoggerFactory;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
 
 class StatisticsExport extends APIEndpoint {
   public $permissions = [
@@ -24,14 +30,29 @@ class StatisticsExport extends APIEndpoint {
   /** @var LoggerFactory */
   private $loggerFactory;
 
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  /** @var CapabilitiesManager */
+  private $capabilitiesManager;
+
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     NewslettersRepository $newslettersRepository,
     StatisticsExporter $exporter,
-    LoggerFactory $loggerFactory
+    LoggerFactory $loggerFactory,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    CapabilitiesManager $capabilitiesManager,
+    WPFunctions $wp
   ) {
     $this->newslettersRepository = $newslettersRepository;
     $this->exporter = $exporter;
     $this->loggerFactory = $loggerFactory;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->capabilitiesManager = $capabilitiesManager;
+    $this->wp = $wp;
   }
 
   public function exportCampaign($data = []) {
@@ -42,21 +63,14 @@ class StatisticsExport extends APIEndpoint {
       ]);
     }
 
-    $format = isset($data['format']) && is_string($data['format'])
-      ? strtolower($data['format'])
-      : StatisticsExporter::FORMAT_CSV;
-
-    if ($format !== StatisticsExporter::FORMAT_CSV && $format !== StatisticsExporter::FORMAT_XLSX) {
-      return $this->badRequest([
-        APIError::BAD_REQUEST => __('Unsupported export format. Use csv or xlsx.', 'mailpoet'),
-      ]);
+    $format = $this->resolveFormat($data);
+    if ($format === null) {
+      return $this->unsupportedFormatResponse();
     }
 
     $newsletter = $this->newslettersRepository->findOneById($newsletterId);
     if (!$newsletter) {
-      return $this->errorResponse([
-        APIError::NOT_FOUND => __('This email does not exist.', 'mailpoet'),
-      ], [], Response::STATUS_NOT_FOUND);
+      return $this->newsletterNotFoundResponse();
     }
 
     try {
@@ -77,5 +91,120 @@ class StatisticsExport extends APIEndpoint {
     }
 
     return $this->successResponse($result);
+  }
+
+  public function exportRecipients($data = []) {
+    $newsletterId = isset($data['id']) ? (int)$data['id'] : 0;
+    if ($newsletterId <= 0) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('Missing newsletter id.', 'mailpoet'),
+      ]);
+    }
+
+    $format = $this->resolveFormat($data);
+    if ($format === null) {
+      return $this->unsupportedFormatResponse();
+    }
+
+    if ($this->isDetailedAnalyticsRestricted()) {
+      return $this->errorResponse([
+        APIError::FORBIDDEN => __('Per-recipient export requires a MailPoet plan with detailed analytics.', 'mailpoet'),
+      ], [], Response::STATUS_FORBIDDEN);
+    }
+
+    $newsletter = $this->newslettersRepository->findOneById($newsletterId);
+    if (!$newsletter) {
+      return $this->newsletterNotFoundResponse();
+    }
+
+    $task = new ScheduledTaskEntity();
+    $task->setType(StatisticsExportWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setScheduledAt(Carbon::now()->millisecond(0));
+    $task->setPriority(ScheduledTaskEntity::PRIORITY_HIGH);
+    $task->setMeta([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS,
+      'newsletter_id' => $newsletter->getId(),
+      'format' => $format,
+      'requested_by' => (int)$this->wp->getCurrentUserId(),
+    ]);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+
+    return $this->successResponse($this->buildStatusPayload($task));
+  }
+
+  public function getStatus($data = []) {
+    $taskId = isset($data['task_id']) ? (int)$data['task_id'] : 0;
+    if ($taskId <= 0) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('Missing task id.', 'mailpoet'),
+      ]);
+    }
+
+    $task = $this->scheduledTasksRepository->findOneById($taskId);
+    if (!$task instanceof ScheduledTaskEntity || $task->getType() !== StatisticsExportWorker::TASK_TYPE) {
+      return $this->errorResponse([
+        APIError::NOT_FOUND => __('Export task not found.', 'mailpoet'),
+      ], [], Response::STATUS_NOT_FOUND);
+    }
+
+    return $this->successResponse($this->buildStatusPayload($task));
+  }
+
+  private function isDetailedAnalyticsRestricted(): bool {
+    $capability = $this->capabilitiesManager->getCapability('detailedAnalytics');
+    return $capability === null || $capability->isRestricted;
+  }
+
+  private function resolveFormat(array $data): ?string {
+    $format = isset($data['format']) && is_string($data['format'])
+      ? strtolower($data['format'])
+      : StatisticsExporter::FORMAT_CSV;
+    if ($format !== StatisticsExporter::FORMAT_CSV && $format !== StatisticsExporter::FORMAT_XLSX) {
+      return null;
+    }
+    return $format;
+  }
+
+  private function unsupportedFormatResponse() {
+    return $this->badRequest([
+      APIError::BAD_REQUEST => __('Unsupported export format. Use csv or xlsx.', 'mailpoet'),
+    ]);
+  }
+
+  private function newsletterNotFoundResponse() {
+    return $this->errorResponse([
+      APIError::NOT_FOUND => __('This email does not exist.', 'mailpoet'),
+    ], [], Response::STATUS_NOT_FOUND);
+  }
+
+  /**
+   * @return array{
+   *   taskId: int,
+   *   status: string,
+   *   exportFileURL?: string,
+   *   totalExported?: int,
+   *   error?: string,
+   * }
+   */
+  private function buildStatusPayload(ScheduledTaskEntity $task): array {
+    $meta = $task->getMeta() ?? [];
+    $status = $task->getStatus() ?? ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING;
+
+    $payload = [
+      'taskId' => (int)$task->getId(),
+      'status' => $status,
+    ];
+    if (isset($meta['export_file_url'])) {
+      $payload['exportFileURL'] = (string)$meta['export_file_url'];
+    }
+    if (isset($meta['total_exported'])) {
+      $payload['totalExported'] = (int)$meta['total_exported'];
+    }
+    if (isset($meta['error'])) {
+      $payload['error'] = (string)$meta['error'];
+    }
+    return $payload;
   }
 }

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -116,5 +116,6 @@ class Daemon {
     yield $this->workersFactory->createBackfillEngagementDataWorker();
     yield $this->workersFactory->createMixpanelWorker();
     yield $this->workersFactory->createTracksWorker();
+    yield $this->workersFactory->createStatisticsExportWorker();
   }
 }

--- a/mailpoet/lib/Cron/Workers/ExportFilesCleanup.php
+++ b/mailpoet/lib/Cron/Workers/ExportFilesCleanup.php
@@ -2,16 +2,31 @@
 
 namespace MailPoet\Cron\Workers;
 
+use MailPoet\Config\Env;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
 use MailPoet\Subscribers\ImportExport\Export\Export;
 use MailPoetVendor\Carbon\Carbon;
 
 class ExportFilesCleanup extends SimpleWorker {
   const TASK_TYPE = 'export_files_cleanup';
   const DELETE_FILES_AFTER_X_DAYS = 1;
+  const DELETE_STATS_FILES_AFTER_X_DAYS = 7;
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
-    $iterator = new \GlobIterator(Export::getExportPath() . '/' . Export::getFilePrefix() . '*.*');
+    $this->cleanup(
+      Export::getExportPath() . '/' . Export::getFilePrefix() . '*.*',
+      self::DELETE_FILES_AFTER_X_DAYS
+    );
+    $this->cleanup(
+      Env::$tempPath . '/' . StatisticsExporter::FILE_PREFIX . '*.*',
+      self::DELETE_STATS_FILES_AFTER_X_DAYS
+    );
+    return true;
+  }
+
+  private function cleanup(string $globPattern, int $deleteAfterDays): void {
+    $iterator = new \GlobIterator($globPattern);
     foreach ($iterator as $file) {
       if (is_string($file)) {
         continue;
@@ -19,10 +34,9 @@ class ExportFilesCleanup extends SimpleWorker {
       $name = $file->getPathname();
       $created = $file->getMTime();
       $now = new Carbon();
-      if (Carbon::createFromTimestamp((int)$created)->lessThan($now->subDays(self::DELETE_FILES_AFTER_X_DAYS))) {
+      if (Carbon::createFromTimestamp((int)$created)->lessThan($now->subDays($deleteAfterDays))) {
         unlink($name);
-      };
+      }
     }
-    return true;
   }
 }

--- a/mailpoet/lib/Cron/Workers/StatisticsExport.php
+++ b/mailpoet/lib/Cron/Workers/StatisticsExport.php
@@ -45,6 +45,7 @@ class StatisticsExport extends SimpleWorker {
 
   public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
     $meta = $task->getMeta() ?? [];
+    unset($meta['export_file_url'], $meta['total_exported'], $meta['error']);
     $jobType = isset($meta['job_type']) ? (string)$meta['job_type'] : '';
     $format = isset($meta['format']) ? (string)$meta['format'] : StatisticsExporter::FORMAT_CSV;
 

--- a/mailpoet/lib/Cron/Workers/StatisticsExport.php
+++ b/mailpoet/lib/Cron/Workers/StatisticsExport.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+
+/**
+ * Async statistics export worker. Tasks are scheduled on demand from the
+ * StatisticsExport API endpoint and store the export parameters in the
+ * task's meta JSON column. After processing, the file URL is written back
+ * to meta so the UI can poll for completion and offer the download.
+ *
+ * Job meta shape:
+ *   - job_type: 'recipients'
+ *   - newsletter_id: int (recipients job only)
+ *   - format: StatisticsExporter::FORMAT_CSV | StatisticsExporter::FORMAT_XLSX
+ *   - requested_by: int (WP user id)
+ *   - export_file_url: string (set after processing)
+ *   - total_exported: int (set after processing)
+ *   - error: string (set on failure)
+ */
+class StatisticsExport extends SimpleWorker {
+  const TASK_TYPE = 'statistics_export';
+  const AUTOMATIC_SCHEDULING = false;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+
+  const JOB_TYPE_RECIPIENTS = 'recipients';
+
+  /** @var StatisticsExporter */
+  private $exporter;
+
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  public function __construct(
+    StatisticsExporter $exporter,
+    NewslettersRepository $newslettersRepository
+  ) {
+    $this->exporter = $exporter;
+    $this->newslettersRepository = $newslettersRepository;
+    parent::__construct();
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    $meta = $task->getMeta() ?? [];
+    $jobType = isset($meta['job_type']) ? (string)$meta['job_type'] : '';
+    $format = isset($meta['format']) ? (string)$meta['format'] : StatisticsExporter::FORMAT_CSV;
+
+    try {
+      if ($jobType === self::JOB_TYPE_RECIPIENTS) {
+        $newsletterId = isset($meta['newsletter_id']) ? (int)$meta['newsletter_id'] : 0;
+        $newsletter = $this->newslettersRepository->findOneById($newsletterId);
+        if (!$newsletter) {
+          throw new \RuntimeException(sprintf('Newsletter %d not found.', $newsletterId));
+        }
+        $result = $this->exporter->exportRecipients($newsletter, $format);
+      } else {
+        throw new \RuntimeException(sprintf('Unsupported export job type "%s".', $jobType));
+      }
+      $meta['export_file_url'] = $result['exportFileURL'];
+      $meta['total_exported'] = $result['totalExported'];
+    } catch (\Throwable $e) {
+      $meta['error'] = $e->getMessage();
+    }
+
+    $task->setMeta($meta);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+    return true;
+  }
+}

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -36,6 +36,7 @@ class WorkersFactory {
     SendingTaskSubscribersCleanup::TASK_TYPE,
     SendingQueueBodyCleanup::TASK_TYPE,
     Tracks::TASK_TYPE,
+    StatisticsExport::TASK_TYPE,
   ];
 
   /** @var ContainerWrapper */
@@ -183,5 +184,10 @@ class WorkersFactory {
 
   public function createTracksWorker() {
     return $this->container->get(Tracks::class);
+  }
+
+  /** @return StatisticsExport */
+  public function createStatisticsExportWorker() {
+    return $this->container->get(StatisticsExport::class);
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -336,6 +336,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\Workers\InactiveSubscribers::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\Mixpanel::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\Tracks::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\StatisticsExport::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\UnsubscribeTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SubscriberLinkTokens::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\AuthorizedSendingEmailsCheck::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -15,8 +15,17 @@ class StatisticsExporter {
   public const FORMAT_CSV = 'csv';
   public const FORMAT_XLSX = 'xlsx';
 
-  private const FILE_PREFIX = 'MailPoet_stats_export_';
+  public const FILE_PREFIX = 'MailPoet_stats_export_';
   private const RANDOM_NAME_LENGTH = 15;
+
+  /**
+   * Filter applied to populate per-recipient rows when exporting recipients.
+   * The free plugin ships an empty implementation; the premium plugin
+   * registers a callback that returns the per-recipient data.
+   *
+   * Filter signature: (array $rows, NewsletterEntity $newsletter): array
+   */
+  public const FILTER_RECIPIENT_ROWS = 'mailpoet_statistics_export_recipient_rows';
 
   /** @var NewsletterStatisticsRepository */
   private $statisticsRepository;
@@ -50,6 +59,51 @@ class StatisticsExporter {
     return [
       'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
       'totalExported' => 1,
+    ];
+  }
+
+  /**
+   * Export per-recipient stats for a newsletter to CSV or XLSX. Rows are
+   * populated via the FILTER_RECIPIENT_ROWS filter — the free plugin returns
+   * no rows, premium populates them.
+   *
+   * @return array{exportFileURL: string, totalExported: int}
+   */
+  public function exportRecipients(NewsletterEntity $newsletter, string $format): array {
+    $format = $this->normalizeFormat($format);
+    $headers = $this->getRecipientHeaders();
+
+    /** @var array<array<int|string|float|null>> $rows */
+    $rows = (array)$this->wp->applyFilters(self::FILTER_RECIPIENT_ROWS, [], $newsletter);
+
+    $this->ensureExportDirectory();
+    $filePath = $this->getExportFilePath($format);
+    $this->writeFile($filePath, $headers, $rows, $format);
+
+    return [
+      'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
+      'totalExported' => count($rows),
+    ];
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getRecipientHeaders(): array {
+    return [
+      __('Subscriber ID', 'mailpoet'),
+      __('Email', 'mailpoet'),
+      __('First name', 'mailpoet'),
+      __('Last name', 'mailpoet'),
+      __('Status', 'mailpoet'),
+      __('Opened', 'mailpoet'),
+      __('First open at', 'mailpoet'),
+      __('Open count', 'mailpoet'),
+      __('Machine opened', 'mailpoet'),
+      __('Clicked', 'mailpoet'),
+      __('Click count', 'mailpoet'),
+      __('Bounced', 'mailpoet'),
+      __('Unsubscribed', 'mailpoet'),
     ];
   }
 

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\API\JSON\v1;
 
+use Codeception\Stub;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\StatisticsExport;
 use MailPoet\Config\Env;
@@ -11,6 +12,8 @@ use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\Util\License\Features\Data\Capability;
 
 class StatisticsExportTest extends \MailPoetTest {
   /** @var StatisticsExport */
@@ -133,22 +136,51 @@ class StatisticsExportTest extends \MailPoetTest {
   }
 
   public function testItReturns404ForUnknownStatusTask() {
-    $response = $this->endpoint->getStatus(['task_id' => 99999999]);
+    $endpoint = $this->endpointWithDetailedAnalytics(false);
+    $response = $endpoint->getStatus(['task_id' => 99999999]);
+    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+  }
+
+  public function testItRejectsStatusWhenDetailedAnalyticsRestricted() {
+    $task = $this->createTask(['job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS]);
+    $response = $this->endpoint->getStatus(['task_id' => $task->getId()]);
+    verify($response->status)->equals(APIResponse::STATUS_FORBIDDEN);
+  }
+
+  public function testItReturns404ForUnrelatedTaskJobType() {
+    $endpoint = $this->endpointWithDetailedAnalytics(false);
+    $task = $this->createTask(['job_type' => 'something_else']);
+    $response = $endpoint->getStatus(['task_id' => $task->getId()]);
     verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
   }
 
   public function testItReturnsStatusForScheduledExportTask() {
-    $task = new ScheduledTaskEntity();
-    $task->setType(StatisticsExportWorker::TASK_TYPE);
-    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
-    $task->setMeta(['job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS]);
-    $repo = ContainerWrapper::getInstance()->get(ScheduledTasksRepository::class);
-    $repo->persist($task);
-    $repo->flush();
+    $endpoint = $this->endpointWithDetailedAnalytics(false);
+    $task = $this->createTask(['job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS]);
 
-    $response = $this->endpoint->getStatus(['task_id' => $task->getId()]);
+    $response = $endpoint->getStatus(['task_id' => $task->getId()]);
     verify($response->status)->equals(APIResponse::STATUS_OK);
     verify($response->data['taskId'])->equals($task->getId());
     verify($response->data['status'])->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  private function createTask(array $meta): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType(StatisticsExportWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setMeta($meta);
+    $repo = ContainerWrapper::getInstance()->get(ScheduledTasksRepository::class);
+    $repo->persist($task);
+    $repo->flush();
+    return $task;
+  }
+
+  private function endpointWithDetailedAnalytics(bool $isRestricted): StatisticsExport {
+    $capability = new Capability('detailedAnalytics', Capability::TYPE_BOOLEAN, $isRestricted);
+    return $this->getServiceWithOverrides(StatisticsExport::class, [
+      'capabilitiesManager' => Stub::makeEmpty(CapabilitiesManager::class, [
+        'getCapability' => $capability,
+      ]),
+    ]);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -157,12 +157,27 @@ class StatisticsExportTest extends \MailPoetTest {
 
   public function testItReturnsStatusForScheduledExportTask() {
     $endpoint = $this->endpointWithDetailedAnalytics(false);
-    $task = $this->createTask(['job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS]);
+    $userId = (int)wp_get_current_user()->ID;
+    $task = $this->createTask([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS,
+      'requested_by' => $userId,
+    ]);
 
     $response = $endpoint->getStatus(['task_id' => $task->getId()]);
     verify($response->status)->equals(APIResponse::STATUS_OK);
     verify($response->data['taskId'])->equals($task->getId());
     verify($response->data['status'])->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testItReturns404WhenStatusRequestedByDifferentUser() {
+    $endpoint = $this->endpointWithDetailedAnalytics(false);
+    $task = $this->createTask([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS,
+      'requested_by' => 999999,
+    ]);
+
+    $response = $endpoint->getStatus(['task_id' => $task->getId()]);
+    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
   }
 
   private function createTask(array $meta): ScheduledTaskEntity {

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -5,7 +5,10 @@ namespace MailPoet\Test\API\JSON\v1;
 use MailPoet\API\JSON\Response as APIResponse;
 use MailPoet\API\JSON\v1\StatisticsExport;
 use MailPoet\Config\Env;
+use MailPoet\Cron\Workers\StatisticsExport as StatisticsExportWorker;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 
@@ -118,5 +121,34 @@ class StatisticsExportTest extends \MailPoetTest {
 
     verify($response->status)->equals(APIResponse::STATUS_OK);
     verify($response->data['exportFileURL'])->stringEndsWith('.csv');
+  }
+
+  public function testItRejectsRecipientsExportWhenDetailedAnalyticsRestricted() {
+    $newsletter = (new NewsletterFactory())->create();
+    $response = $this->endpoint->exportRecipients([
+      'id' => $newsletter->getId(),
+      'format' => StatisticsExporter::FORMAT_CSV,
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_FORBIDDEN);
+  }
+
+  public function testItReturns404ForUnknownStatusTask() {
+    $response = $this->endpoint->getStatus(['task_id' => 99999999]);
+    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+  }
+
+  public function testItReturnsStatusForScheduledExportTask() {
+    $task = new ScheduledTaskEntity();
+    $task->setType(StatisticsExportWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setMeta(['job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS]);
+    $repo = ContainerWrapper::getInstance()->get(ScheduledTasksRepository::class);
+    $repo->persist($task);
+    $repo->flush();
+
+    $response = $this->endpoint->getStatus(['task_id' => $task->getId()]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['taskId'])->equals($task->getId());
+    verify($response->data['status'])->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -41,7 +41,6 @@ class StatisticsExportTest extends \MailPoetTest {
   }
 
   public function _after() {
-    parent::_after();
     foreach (glob($this->tempDir . '/*') ?: [] as $file) {
       unlink($file);
     }
@@ -50,6 +49,8 @@ class StatisticsExportTest extends \MailPoetTest {
     }
     Env::$tempPath = $this->previousTempPath;
     Env::$tempUrl = $this->previousTempUrl;
+
+    parent::_after();
   }
 
   public function testItRejectsMissingNewsletterId() {

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -323,6 +323,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createBackfillEngagementDataWorker' => $worker,
       'createMixpanelWorker' => $worker,
       'createTracksWorker' => $worker,
+      'createStatisticsExportWorker' => $worker,
       ]);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -123,6 +123,7 @@ class DaemonTest extends \MailPoetTest {
       'createBackfillEngagementDataWorker' => $this->createSimpleWorkerMock(),
       'createMixpanelWorker' => $this->createSimpleWorkerMock(),
       'createTracksWorker' => $this->createSimpleWorkerMock(),
+      'createStatisticsExportWorker' => $this->createSimpleWorkerMock(),
       ]);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
@@ -2,16 +2,58 @@
 
 namespace MailPoet\Test\Cron\Workers;
 
+use MailPoet\Config\Env;
 use MailPoet\Cron\Workers\ExportFilesCleanup;
 use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Subscribers\ImportExport\Export\Export;
 
 class ExportFilesCleanupTest extends \MailPoetTest {
-  public function testItWorks() {
-    $wpUploadDir = wp_upload_dir();
-    $oldFilePath = $wpUploadDir['basedir'] . '/mailpoet/MailPoet_export_old_file.csv';
-    $newFilePath = $wpUploadDir['basedir'] . '/mailpoet/MailPoet_export_new_file.csv';
-    touch($oldFilePath, time() - (60 * 60 * 24 * 7));
+  /** @var string */
+  private $previousTempPath;
+
+  /** @var string */
+  private $tempDir;
+
+  public function _before() {
+    parent::_before();
+
+    $this->previousTempPath = (string)Env::$tempPath;
+    $this->tempDir = sys_get_temp_dir() . '/mailpoet-export-cleanup-' . uniqid('', true);
+    mkdir($this->tempDir, 0777, true);
+    Env::$tempPath = $this->tempDir;
+  }
+
+  public function _after() {
+    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+      unlink($file);
+    }
+    if (is_dir($this->tempDir)) {
+      rmdir($this->tempDir);
+    }
+    Env::$tempPath = $this->previousTempPath;
+
+    parent::_after();
+  }
+
+  public function testItCleansUpOldSubscriberExportFiles() {
+    $oldFilePath = $this->tempDir . '/' . Export::getFilePrefix() . 'old_file.csv';
+    $newFilePath = $this->tempDir . '/' . Export::getFilePrefix() . 'new_file.csv';
+    touch($oldFilePath, time() - (60 * 60 * 24 * 2));
     touch($newFilePath);
+
+    $cleanup = new ExportFilesCleanup();
+    $cleanup->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
+
+    $this->assertFileExists($newFilePath);
+    $this->assertFileNotExists($oldFilePath);
+  }
+
+  public function testItCleansUpOldStatisticsExportFiles() {
+    $oldFilePath = $this->tempDir . '/' . StatisticsExporter::FILE_PREFIX . 'old_file.csv';
+    $newFilePath = $this->tempDir . '/' . StatisticsExporter::FILE_PREFIX . 'new_file.csv';
+    touch($oldFilePath, time() - (60 * 60 * 24 * 8));
+    touch($newFilePath, time() - (60 * 60 * 24 * 6));
 
     $cleanup = new ExportFilesCleanup();
     $cleanup->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));

--- a/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Cron\Workers;
+
+use MailPoet\Config\Env;
+use MailPoet\Cron\Workers\StatisticsExport as StatisticsExportWorker;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+class StatisticsExportTest extends \MailPoetTest {
+  /** @var StatisticsExportWorker */
+  private $worker;
+
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  /** @var string */
+  private $previousTempPath;
+
+  /** @var string */
+  private $previousTempUrl;
+
+  /** @var string */
+  private $tempDir;
+
+  public function _before() {
+    parent::_before();
+    $this->worker = $this->diContainer->get(StatisticsExportWorker::class);
+    $this->scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+
+    $this->previousTempPath = (string)Env::$tempPath;
+    $this->previousTempUrl = (string)Env::$tempUrl;
+    $this->tempDir = sys_get_temp_dir() . '/mailpoet-stats-export-' . uniqid('', true);
+    mkdir($this->tempDir, 0777, true);
+    Env::$tempPath = $this->tempDir;
+    Env::$tempUrl = 'https://example.test/uploads/mailpoet';
+  }
+
+  public function _after() {
+    parent::_after();
+    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+      unlink($file);
+    }
+    if (is_dir($this->tempDir)) {
+      rmdir($this->tempDir);
+    }
+    Env::$tempPath = $this->previousTempPath;
+    Env::$tempUrl = $this->previousTempUrl;
+  }
+
+  public function testItProcessesRecipientsExportTask() {
+    $newsletter = (new NewsletterFactory())->withSubject('Hello world')->create();
+    $task = $this->createTask([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_RECIPIENTS,
+      'newsletter_id' => $newsletter->getId(),
+      'format' => StatisticsExporter::FORMAT_CSV,
+    ]);
+
+    $result = $this->worker->processTaskStrategy($task, microtime(true));
+    verify($result)->true();
+
+    $meta = $task->getMeta() ?? [];
+    verify($meta['export_file_url'])->stringContainsString('MailPoet_stats_export_');
+    verify($meta['total_exported'])->equals(0);
+    verify(isset($meta['error']))->false();
+  }
+
+  public function testItRecordsErrorOnUnknownJobType() {
+    $task = $this->createTask([
+      'job_type' => 'unknown',
+      'format' => StatisticsExporter::FORMAT_CSV,
+    ]);
+
+    $result = $this->worker->processTaskStrategy($task, microtime(true));
+    verify($result)->true();
+
+    $meta = $task->getMeta() ?? [];
+    verify($meta['error'])->stringContainsString('Unsupported export job type');
+  }
+
+  private function createTask(array $meta): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType(StatisticsExportWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setMeta($meta);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+    return $task;
+  }
+}

--- a/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
@@ -39,7 +39,6 @@ class StatisticsExportTest extends \MailPoetTest {
   }
 
   public function _after() {
-    parent::_after();
     foreach (glob($this->tempDir . '/*') ?: [] as $file) {
       unlink($file);
     }
@@ -48,6 +47,8 @@ class StatisticsExportTest extends \MailPoetTest {
     }
     Env::$tempPath = $this->previousTempPath;
     Env::$tempUrl = $this->previousTempUrl;
+
+    parent::_after();
   }
 
   public function testItProcessesRecipientsExportTask() {

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -119,6 +119,67 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     verify(count($row))->equals(count($headers));
   }
 
+  public function testItExportsRecipientsFromFilterRows() {
+    $newsletter = $this->createNewsletter(99, 'Recipients', null, '2026-02-01 00:00:00');
+    $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
+
+    $rows = [
+      [
+        'subscriber_id' => 1,
+        'email' => 'a@example.test',
+        'first_name' => 'Alice',
+        'last_name' => 'Smith',
+        'status' => 'subscribed',
+        'opened' => 'Y',
+        'first_open_at' => '2026-02-02 12:00:00',
+        'open_count' => 3,
+        'machine_opened' => 'N',
+        'clicked' => 'Y',
+        'click_count' => 1,
+        'bounced' => 'N',
+        'unsubscribed' => 'N',
+      ],
+    ];
+
+    $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'wpMkdirP' => true,
+      'applyFilters' => function (string $hook, $value) use ($rows) {
+        if ($hook === StatisticsExporter::FILTER_RECIPIENT_ROWS) {
+          return $rows;
+        }
+        return $value;
+      },
+    ]);
+    $exporter = new StatisticsExporter($repository, $wp);
+
+    $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
+    verify($result['totalExported'])->equals(1);
+
+    $files = glob($this->tempDir . '/*.csv') ?: [];
+    verify($files)->arrayCount(1);
+    $body = substr((string)file_get_contents($files[0]), 3);
+    $exportedRows = $this->parseCsvRows($body);
+    verify($exportedRows)->arrayCount(2);
+    verify($exportedRows[1][1])->equals('a@example.test');
+    verify($exportedRows[1][2])->equals('Alice');
+  }
+
+  public function testItExportsRecipientsAsEmptyFileWhenFilterReturnsNoRows() {
+    $newsletter = $this->createNewsletter(99, 'Empty', null, '2026-02-01 00:00:00');
+    $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
+    $wp = $this->makeEmpty(WPFunctions::class, [
+      'wpMkdirP' => true,
+      'applyFilters' => function (string $hook, $value) {
+        return $value;
+      },
+    ]);
+    $exporter = new StatisticsExporter($repository, $wp);
+
+    $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
+    verify($result['totalExported'])->equals(0);
+  }
+
   private function createExporter(NewsletterStatistics $stats): StatisticsExporter {
     $repository = $this->makeEmpty(NewsletterStatisticsRepository::class, [
       'getStatistics' => $stats,

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -121,7 +121,6 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
 
   public function testItExportsRecipientsFromFilterRows() {
     $newsletter = $this->createNewsletter(99, 'Recipients', null, '2026-02-01 00:00:00');
-    $stats = $this->createStats(0, 0, 0, 0, 0, 0, null);
 
     $rows = [
       [


### PR DESCRIPTION
## Description

Follow-up for https://github.com/mailpoet/mailpoet/pull/6662. This PR adds per-recipient stats export for an email campaign (CSV and XLSX). This is a premium feature. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1042

## Linked tickets

Closes STOMAIL-7979

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1286" height="545" alt="Screenshot 2026-04-27 at 16 14 32" src="https://github.com/user-attachments/assets/184b2663-77c0-4365-95b6-022751d53e78" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7972-export-statistics-2)

_The latest successful build from `stomail-7972-export-statistics-2` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**2 issues found:**

1. **Bug - Unchecked Directory Creation**: StatisticsExporter::ensureExportDirectory() calls wpMkdirP() but does not verify its return value; a directory creation failure will lead to unclear errors when writing the export file.

2. **Suggestion - Incomplete Test Verification**: StatisticsExportTest::testItProcessesRecipientsExportTask() asserts export_file_url and total_exported but does not verify the export file exists on disk or inspect its contents; add file-existence/content assertions to strengthen coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->