### PR TITLE
Export email stats, 3 of 3 (bulk export email summary stats as CSV)

### DIFF
--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -16,6 +16,7 @@ import {
   checkCronStatus,
   checkMailerStatus,
 } from 'newsletters/listings/utils.jsx';
+import { pollExportStatus } from 'newsletters/statistics-export/poll-export-status';
 import { NewsletterTypes } from 'newsletters/types';
 import { GlobalContext } from 'context';
 import { ErrorBoundary, withBoundary } from '../../common';
@@ -100,6 +101,45 @@ const columns = [
   },
 ];
 
+const handleBulkExportSuccess = (response, format) => {
+  if (!response?.data?.taskId) {
+    MailPoet.Notice.error(__('Could not start the export.', 'mailpoet'), {
+      scroll: true,
+    });
+    return;
+  }
+  MailPoet.Notice.success(
+    __(
+      'Export queued. The download will start automatically when it is ready.',
+      'mailpoet',
+    ),
+    { timeout: 6000 },
+  );
+  pollExportStatus(response.data.taskId, {
+    onComplete: (status) => {
+      if (!status.exportFileURL) {
+        MailPoet.Notice.error(
+          __('The export file could not be generated.', 'mailpoet'),
+          { scroll: true },
+        );
+        return;
+      }
+      MailPoet.trackEvent('Email statistics export completed', {
+        'File Format': format,
+        'Export Type': 'bulk',
+      });
+      window.location.href = status.exportFileURL;
+    },
+    onError: (message) => {
+      MailPoet.Notice.error(message, { scroll: true });
+    },
+  });
+};
+
+const isDetailedAnalyticsRestricted = () =>
+  !MailPoet.capabilities.detailedAnalytics ||
+  MailPoet.capabilities.detailedAnalytics.isRestricted;
+
 const bulkActions = [
   {
     name: 'trash',
@@ -107,6 +147,15 @@ const bulkActions = [
     onSuccess: messages.onTrash,
   },
 ];
+
+if (mailpoetTrackingEnabled && !isDetailedAnalyticsRestricted()) {
+  bulkActions.push({
+    name: 'export_stats',
+    label: __('Export statistics', 'mailpoet'),
+    getData: () => ({ format: 'csv' }),
+    onSuccess: (response) => handleBulkExportSuccess(response, 'csv'),
+  });
+}
 
 const confirmEdit = (newsletter) => {
   const editorHref = MailPoet.getActiveEmailEditorUrl(newsletter);

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -8,6 +8,7 @@ use MailPoet\API\JSON\Response;
 use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\Config\AccessControl;
 use MailPoet\Cron\CronHelper;
+use MailPoet\Cron\Workers\StatisticsExport as StatisticsExportWorker;
 use MailPoet\Doctrine\Validator\ValidationException;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
@@ -25,10 +26,13 @@ use MailPoet\Newsletter\Preview\SendPreviewController;
 use MailPoet\Newsletter\Preview\SendPreviewException;
 use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Services\AuthorizedEmailsController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\UnexpectedValueException;
+use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -93,6 +97,12 @@ class Newsletters extends APIEndpoint {
   /** @var AuthorizedEmailsController */
   private $authorizedEmailsController;
 
+  /** @var ScheduledTasksRepository */
+  private $scheduledTasksRepository;
+
+  /** @var CapabilitiesManager */
+  private $capabilitiesManager;
+
   public function __construct(
     Listing\Handler $listingHandler,
     WPFunctions $wp,
@@ -111,7 +121,9 @@ class Newsletters extends APIEndpoint {
     NewsletterUrl $newsletterUrl,
     Scheduler $scheduler,
     NewsletterValidator $newsletterValidator,
-    AuthorizedEmailsController $authorizedEmailsController
+    AuthorizedEmailsController $authorizedEmailsController,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    CapabilitiesManager $capabilitiesManager
   ) {
     $this->listingHandler = $listingHandler;
     $this->wp = $wp;
@@ -131,6 +143,8 @@ class Newsletters extends APIEndpoint {
     $this->scheduler = $scheduler;
     $this->newsletterValidator = $newsletterValidator;
     $this->authorizedEmailsController = $authorizedEmailsController;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->capabilitiesManager = $capabilitiesManager;
   }
 
   public function get($data = []) {
@@ -409,11 +423,62 @@ class Newsletters extends APIEndpoint {
       $this->wp->doAction('mailpoet_api_newsletters_delete_before', $ids);
       $this->newsletterDeleteController->bulkDelete($ids);
       $this->wp->doAction('mailpoet_api_newsletters_delete_after', $ids);
+    } elseif ($data['action'] === 'export_stats') {
+      return $this->scheduleStatsExport($ids, $data);
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
     }
     return $this->successResponse(null, ['count' => count($ids)]);
+  }
+
+  /**
+   * Schedules an asynchronous bulk stats export task and returns its id.
+   * Premium-gated via the detailedAnalytics capability.
+   *
+   * @param int[] $ids
+   */
+  private function scheduleStatsExport(array $ids, array $data) {
+    $capability = $this->capabilitiesManager->getCapability('detailedAnalytics');
+    if ($capability === null || $capability->isRestricted) {
+      return $this->errorResponse([
+        APIError::FORBIDDEN => __('Bulk statistics export requires a MailPoet plan with detailed analytics.', 'mailpoet'),
+      ], [], Response::STATUS_FORBIDDEN);
+    }
+
+    if (empty($ids)) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('No newsletters selected for export.', 'mailpoet'),
+      ]);
+    }
+
+    $format = isset($data['format']) && is_string($data['format'])
+      ? strtolower($data['format'])
+      : StatisticsExporter::FORMAT_CSV;
+    if ($format !== StatisticsExporter::FORMAT_CSV && $format !== StatisticsExporter::FORMAT_XLSX) {
+      return $this->badRequest([
+        APIError::BAD_REQUEST => __('Unsupported export format. Use csv or xlsx.', 'mailpoet'),
+      ]);
+    }
+
+    $task = new ScheduledTaskEntity();
+    $task->setType(StatisticsExportWorker::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $task->setScheduledAt(Carbon::now()->millisecond(0));
+    $task->setPriority(ScheduledTaskEntity::PRIORITY_HIGH);
+    $task->setMeta([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_BULK,
+      'newsletter_ids' => array_values(array_map('intval', $ids)),
+      'format' => $format,
+      'requested_by' => (int)$this->wp->getCurrentUserId(),
+    ]);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+
+    return $this->successResponse([
+      'taskId' => (int)$task->getId(),
+      'count' => count($ids),
+    ]);
   }
 
   public function create($data = []) {

--- a/mailpoet/lib/API/JSON/v1/StatisticsExport.php
+++ b/mailpoet/lib/API/JSON/v1/StatisticsExport.php
@@ -157,7 +157,11 @@ class StatisticsExport extends APIEndpoint {
 
     $meta = $task->getMeta() ?? [];
     $jobType = isset($meta['job_type']) ? (string)$meta['job_type'] : '';
-    if ($jobType !== StatisticsExportWorker::JOB_TYPE_RECIPIENTS) {
+    $allowedJobTypes = [
+      StatisticsExportWorker::JOB_TYPE_RECIPIENTS,
+      StatisticsExportWorker::JOB_TYPE_BULK,
+    ];
+    if (!in_array($jobType, $allowedJobTypes, true)) {
       return $this->errorResponse([
         APIError::NOT_FOUND => __('Export task not found.', 'mailpoet'),
       ], [], Response::STATUS_NOT_FOUND);

--- a/mailpoet/lib/Cron/Workers/StatisticsExport.php
+++ b/mailpoet/lib/Cron/Workers/StatisticsExport.php
@@ -13,8 +13,9 @@ use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
  * to meta so the UI can poll for completion and offer the download.
  *
  * Job meta shape:
- *   - job_type: 'recipients'
+ *   - job_type: 'recipients' | 'bulk'
  *   - newsletter_id: int (recipients job only)
+ *   - newsletter_ids: int[] (bulk job only)
  *   - format: StatisticsExporter::FORMAT_CSV | StatisticsExporter::FORMAT_XLSX
  *   - requested_by: int (WP user id)
  *   - export_file_url: string (set after processing)
@@ -27,6 +28,7 @@ class StatisticsExport extends SimpleWorker {
   const SUPPORT_MULTIPLE_INSTANCES = false;
 
   const JOB_TYPE_RECIPIENTS = 'recipients';
+  const JOB_TYPE_BULK = 'bulk';
 
   /** @var StatisticsExporter */
   private $exporter;
@@ -57,6 +59,18 @@ class StatisticsExport extends SimpleWorker {
           throw new \RuntimeException(sprintf('Newsletter %d not found.', $newsletterId));
         }
         $result = $this->exporter->exportRecipients($newsletter, $format);
+      } elseif ($jobType === self::JOB_TYPE_BULK) {
+        $newsletterIds = isset($meta['newsletter_ids']) && is_array($meta['newsletter_ids'])
+          ? array_map('intval', $meta['newsletter_ids'])
+          : [];
+        $newsletters = [];
+        foreach ($newsletterIds as $id) {
+          $newsletter = $this->newslettersRepository->findOneById($id);
+          if ($newsletter) {
+            $newsletters[] = $newsletter;
+          }
+        }
+        $result = $this->exporter->exportBulkAggregate($newsletters, $format);
       } else {
         throw new \RuntimeException(sprintf('Unsupported export job type "%s".', $jobType));
       }

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -63,6 +63,36 @@ class StatisticsExporter {
   }
 
   /**
+   * Export aggregate stats for multiple newsletters to CSV or XLSX (one
+   * row per newsletter). Used by the bulk export action on the listing.
+   *
+   * @param NewsletterEntity[] $newsletters
+   * @return array{exportFileURL: string, totalExported: int}
+   */
+  public function exportBulkAggregate(array $newsletters, string $format): array {
+    $format = $this->normalizeFormat($format);
+    $headers = $this->getAggregateHeaders();
+
+    $rows = [];
+    foreach ($newsletters as $newsletter) {
+      if (!$newsletter instanceof NewsletterEntity) {
+        continue;
+      }
+      $stats = $this->statisticsRepository->getStatistics($newsletter);
+      $rows[] = $this->buildAggregateRow($newsletter, $stats);
+    }
+
+    $this->ensureExportDirectory();
+    $filePath = $this->getExportFilePath($format);
+    $this->writeFile($filePath, $headers, $rows, $format);
+
+    return [
+      'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
+      'totalExported' => count($rows),
+    ];
+  }
+
+  /**
    * Export per-recipient stats for a newsletter to CSV or XLSX. Rows are
    * populated via the FILTER_RECIPIENT_ROWS filter — the free plugin returns
    * no rows, premium populates them.

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -169,6 +169,23 @@ class StatisticsExportTest extends \MailPoetTest {
     verify($response->data['status'])->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
   }
 
+  public function testItReturnsStatusForBulkExportTask() {
+    $endpoint = $this->endpointWithDetailedAnalytics(false);
+    $userId = (int)wp_get_current_user()->ID;
+    $newsletter = (new NewsletterFactory())->withSubject('Bulk')->create();
+    $task = $this->createTask([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_BULK,
+      'newsletter_ids' => [$newsletter->getId()],
+      'format' => StatisticsExporter::FORMAT_CSV,
+      'requested_by' => $userId,
+    ]);
+
+    $response = $endpoint->getStatus(['task_id' => $task->getId()]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['taskId'])->equals($task->getId());
+    verify($response->data['status'])->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
   public function testItReturns404WhenStatusRequestedByDifferentUser() {
     $endpoint = $this->endpointWithDetailedAnalytics(false);
     $task = $this->createTask([

--- a/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
@@ -68,6 +68,23 @@ class StatisticsExportTest extends \MailPoetTest {
     verify(isset($meta['error']))->false();
   }
 
+  public function testItProcessesBulkExportTask() {
+    $a = (new NewsletterFactory())->withSubject('A')->create();
+    $b = (new NewsletterFactory())->withSubject('B')->create();
+    $task = $this->createTask([
+      'job_type' => StatisticsExportWorker::JOB_TYPE_BULK,
+      'newsletter_ids' => [$a->getId(), $b->getId()],
+      'format' => StatisticsExporter::FORMAT_CSV,
+    ]);
+
+    $result = $this->worker->processTaskStrategy($task, microtime(true));
+    verify($result)->true();
+
+    $meta = $task->getMeta() ?? [];
+    verify($meta['export_file_url'])->stringContainsString('MailPoet_stats_export_');
+    verify($meta['total_exported'])->equals(2);
+  }
+
   public function testItRecordsErrorOnUnknownJobType() {
     $task = $this->createTask([
       'job_type' => 'unknown',

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -119,6 +119,23 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     verify(count($row))->equals(count($headers));
   }
 
+  public function testItExportsBulkAggregateAsCsv() {
+    $newsletterA = $this->createNewsletter(1, 'A', null, '2026-01-01 00:00:00');
+    $newsletterB = $this->createNewsletter(2, 'B', null, '2026-01-02 00:00:00');
+    $stats = $this->createStats(10, 5, 0, 2, 0, 1, null);
+
+    $exporter = $this->createExporter($stats);
+    $result = $exporter->exportBulkAggregate([$newsletterA, $newsletterB], StatisticsExporter::FORMAT_CSV);
+
+    verify($result['totalExported'])->equals(2);
+    $files = glob($this->tempDir . '/*.csv') ?: [];
+    verify($files)->arrayCount(1);
+
+    $body = substr((string)file_get_contents($files[0]), 3);
+    $lines = explode("\n", trim($body));
+    verify($lines)->arrayCount(3);
+  }
+
   public function testItExportsRecipientsFromFilterRows() {
     $newsletter = $this->createNewsletter(99, 'Recipients', null, '2026-02-01 00:00:00');
 


### PR DESCRIPTION
## Description

Final PR, after https://github.com/mailpoet/mailpoet/pull/6662, https://github.com/mailpoet/mailpoet/pull/6663 and https://github.com/mailpoet/mailpoet-premium/pull/1042 to allow exporting email stats.

This PR adds option to bulk export email summary stats. This is premium feature. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

Closes STOMAIL-7980
Closes STOMAIL-7972

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1610" height="774" alt="Screenshot 2026-04-27 at 21 56 19" src="https://github.com/user-attachments/assets/18395178-7e13-4fae-a28f-2415c98859fe" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7972-export-statistics)

_The latest successful build from `stomail-7972-export-statistics` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->