### PR TITLE
Migrate list and segment listings to DataViews

### DIFF
--- a/mailpoet/assets/css/src/mailpoet-dataviews.scss
+++ b/mailpoet/assets/css/src/mailpoet-dataviews.scss
@@ -3,3 +3,41 @@
 // alongside the registered `wp-components` style handle. Per-listing tweaks
 // belong in their feature-specific stylesheet (see `_listing-forms.scss`).
 @import '../../../node_modules/@wordpress/dataviews/build-style/style';
+
+.mailpoet-segments-dataviews__tabs {
+  margin-top: $grid-gap-half;
+
+  > [role='tablist'] {
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    margin: 0;
+    padding: 0 8px;
+  }
+}
+
+.mailpoet-segments-dataviews {
+  margin-top: 0;
+
+  .dataviews-wrapper {
+    min-height: 200px;
+  }
+}
+
+.mailpoet-segments-dataviews__toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px;
+}
+
+.mailpoet-segments-dataviews .mailpoet-listing-actions {
+  display: flex;
+  gap: 8px;
+  line-height: 15px;
+  visibility: hidden;
+}
+
+.mailpoet-segments-dataviews tr:hover .mailpoet-listing-actions {
+  visibility: visible;
+}

--- a/mailpoet/assets/css/src/mailpoet-dataviews.scss
+++ b/mailpoet/assets/css/src/mailpoet-dataviews.scss
@@ -2,6 +2,8 @@
 // `@wordpress/dataviews`. Loaded by AdminPages\AssetsController::setupDataViewsDependencies()
 // alongside the registered `wp-components` style handle. Per-listing tweaks
 // belong in their feature-specific stylesheet (see `_listing-forms.scss`).
+@import 'settings/grid';
+@import 'settings/colors';
 @import '../../../node_modules/@wordpress/dataviews/build-style/style';
 
 .mailpoet-segments-dataviews__tabs {
@@ -40,4 +42,11 @@
 
 .mailpoet-segments-dataviews tr:hover .mailpoet-listing-actions {
   visibility: visible;
+}
+
+.mailpoet-segments-dataviews__row-note {
+  color: $color-text-light;
+  font-weight: 400;
+  margin-top: 4px;
+  max-width: 680px;
 }

--- a/mailpoet/assets/js/src/common/dataviews/types.ts
+++ b/mailpoet/assets/js/src/common/dataviews/types.ts
@@ -1,8 +1,12 @@
 export type ListingQueryParams = {
-  page: number;
-  per_page: number;
+  page?: number;
+  per_page?: number;
+  offset?: number;
+  limit?: number;
   orderby?: string;
   order?: 'asc' | 'desc';
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
   search?: string;
   group?: string;
   filter?: Record<string, unknown>;

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -113,6 +113,7 @@ export function useDataViewsQuery<T>({
             : '';
         setItems([]);
         setMeta({ count: 0, pages: 0 });
+        setGroups([]);
         setError(message || 'Failed to load data.');
       })
       .finally(() => {

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 import type { View } from '@wordpress/dataviews';
 import type { ListingMeta, ListingQueryParams, ListingResponse } from './types';
 
@@ -18,7 +25,7 @@ type UseDataViewsQueryOptions<T> = {
 
 type UseDataViewsQueryResult<T> = {
   view: View;
-  setView: (view: View) => void;
+  setView: Dispatch<SetStateAction<View>>;
   items: T[];
   meta: ListingMeta;
   groups: ListingResponse<T>['groups'];
@@ -104,6 +111,8 @@ export function useDataViewsQuery<T>({
           err && typeof err === 'object' && 'message' in err
             ? String((err as { message?: unknown }).message ?? '')
             : '';
+        setItems([]);
+        setMeta({ count: 0, pages: 0 });
         setError(message || 'Failed to load data.');
       })
       .finally(() => {

--- a/mailpoet/assets/js/src/segments/dynamic/api.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/api.ts
@@ -24,6 +24,18 @@ function ensureInitialized(): void {
   initialized = true;
 }
 
+function cleanQueryParams(params: ListingQueryParams): Record<string, unknown> {
+  return Object.entries(params).reduce<Record<string, unknown>>(
+    (query, [key, value]) => {
+      if (value !== undefined) {
+        return { ...query, [key]: value };
+      }
+      return query;
+    },
+    {},
+  );
+}
+
 export type DynamicSegmentListingItem = {
   id: number;
   name: string;
@@ -31,7 +43,7 @@ export type DynamicSegmentListingItem = {
   count_all: string;
   count_subscribed: string;
   created_at: string;
-  updated_at?: string;
+  updated_at: string | null;
   deleted_at: string | null;
   subscribers_url: string;
   is_plugin_missing: boolean;
@@ -56,7 +68,7 @@ export async function getDynamicSegments(
   const response = await apiFetch<ListingEnvelope<DynamicSegmentListingItem>>({
     path: addQueryArgs(
       '/mailpoet/v1/dynamic-segments',
-      params as Record<string, unknown>,
+      cleanQueryParams(params),
     ),
     method: 'GET',
   });

--- a/mailpoet/assets/js/src/segments/dynamic/api.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/api.ts
@@ -1,0 +1,82 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import type {
+  ListingEnvelope,
+  ListingQueryParams,
+  ListingResponse,
+} from 'common/dataviews';
+
+declare global {
+  interface Window {
+    mailpoet_segments_api: {
+      root: string;
+      nonce: string;
+    };
+  }
+}
+
+let initialized = false;
+function ensureInitialized(): void {
+  if (initialized) return;
+  const config = window.mailpoet_segments_api;
+  apiFetch.use(apiFetch.createRootURLMiddleware(`${config.root}/`));
+  apiFetch.use(apiFetch.createNonceMiddleware(config.nonce));
+  initialized = true;
+}
+
+export type DynamicSegmentListingItem = {
+  id: number;
+  name: string;
+  description?: string;
+  count_all: string;
+  count_subscribed: string;
+  created_at: string;
+  updated_at?: string;
+  deleted_at: string | null;
+  subscribers_url: string;
+  is_plugin_missing: boolean;
+  missing_plugin_message?: {
+    message: string;
+  };
+};
+
+export type DynamicSegmentBulkAction = 'trash' | 'restore' | 'delete';
+
+export type DynamicSegmentBulkActionResult = {
+  updated: number;
+  deleted: number;
+  skipped: number;
+  errors: Array<{ id: number | null; message: string }>;
+};
+
+export async function getDynamicSegments(
+  params: ListingQueryParams,
+): Promise<ListingResponse<DynamicSegmentListingItem>> {
+  ensureInitialized();
+  const response = await apiFetch<ListingEnvelope<DynamicSegmentListingItem>>({
+    path: addQueryArgs(
+      '/mailpoet/v1/dynamic-segments',
+      params as Record<string, unknown>,
+    ),
+    method: 'GET',
+  });
+  return response.data;
+}
+
+export async function bulkAction(
+  action: DynamicSegmentBulkAction,
+  ids: number[],
+  params?: Partial<ListingQueryParams> & { select_all?: boolean },
+): Promise<DynamicSegmentBulkActionResult> {
+  ensureInitialized();
+  const response = await apiFetch<{ data: DynamicSegmentBulkActionResult }>({
+    path: '/mailpoet/v1/dynamic-segments/bulk-action',
+    method: 'POST',
+    data: {
+      action,
+      ids,
+      ...params,
+    },
+  });
+  return response.data;
+}

--- a/mailpoet/assets/js/src/segments/dynamic/fields.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/fields.ts
@@ -5,11 +5,18 @@ import { MailPoet } from 'mailpoet';
 import * as ROUTES from 'segments/routes';
 import type { DynamicSegmentListingItem } from './api';
 
-function dateTime(value: string | null | undefined): JSX.Element {
+function dateTime(
+  value: string | null | undefined,
+  segmentId?: number,
+): JSX.Element {
   if (!value) return createElement('span', null, '—');
   return createElement(
     'span',
-    { 'data-automation-id': 'mailpoet_dynamic_segment_created_at' },
+    {
+      'data-automation-id': segmentId
+        ? `mailpoet_dynamic_segment_created_at_${segmentId}`
+        : 'mailpoet_dynamic_segment_created_at',
+    },
     createElement('span', null, MailPoet.Date.short(value)),
     createElement('br', null),
     createElement('span', null, MailPoet.Date.time(value)),
@@ -89,6 +96,6 @@ export const dynamicSegmentFields: Field<DynamicSegmentListingItem>[] = [
     type: 'datetime',
     enableSorting: true,
     enableGlobalSearch: false,
-    render: ({ item }) => dateTime(item.created_at),
+    render: ({ item }) => dateTime(item.updated_at, item.id),
   },
 ];

--- a/mailpoet/assets/js/src/segments/dynamic/fields.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/fields.ts
@@ -14,8 +14,8 @@ function dateTime(
     'span',
     {
       'data-automation-id': segmentId
-        ? `mailpoet_dynamic_segment_created_at_${segmentId}`
-        : 'mailpoet_dynamic_segment_created_at',
+        ? `mailpoet_dynamic_segment_updated_at_${segmentId}`
+        : 'mailpoet_dynamic_segment_updated_at',
     },
     createElement('span', null, MailPoet.Date.short(value)),
     createElement('br', null),

--- a/mailpoet/assets/js/src/segments/dynamic/fields.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/fields.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import type { Field } from '@wordpress/dataviews';
 import { MailPoet } from 'mailpoet';
 import * as ROUTES from 'segments/routes';
@@ -20,6 +20,14 @@ function dateTime(
     createElement('span', null, MailPoet.Date.short(value)),
     createElement('br', null),
     createElement('span', null, MailPoet.Date.time(value)),
+  );
+}
+
+function editUnavailableMessage(item: DynamicSegmentListingItem): string {
+  return sprintf(
+    __('Edit unavailable: %s', 'mailpoet'),
+    item.missing_plugin_message?.message ??
+      __('Required plugin is inactive.', 'mailpoet'),
   );
 }
 
@@ -44,6 +52,16 @@ export const dynamicSegmentFields: Field<DynamicSegmentListingItem>[] = [
               item.name,
             ),
         item.description ? createElement('div', null, item.description) : null,
+        item.is_plugin_missing
+          ? createElement(
+              'div',
+              {
+                className: 'mailpoet-segments-dataviews__row-note',
+                'data-automation-id': `mailpoet_dynamic_segment_plugin_missing_message_${item.id}`,
+              },
+              editUnavailableMessage(item),
+            )
+          : null,
       ),
   },
   {
@@ -53,13 +71,7 @@ export const dynamicSegmentFields: Field<DynamicSegmentListingItem>[] = [
     enableGlobalSearch: false,
     render: ({ item }) =>
       item.is_plugin_missing
-        ? createElement(
-            'div',
-            {
-              'data-automation-id': `mailpoet_dynamic_segment_plugin_missing_message_${item.id}`,
-            },
-            item.missing_plugin_message?.message ?? '',
-          )
+        ? createElement('span', null, '—')
         : createElement(
             'div',
             {

--- a/mailpoet/assets/js/src/segments/dynamic/fields.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/fields.ts
@@ -1,0 +1,94 @@
+import { createElement } from 'react';
+import { __ } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+import { MailPoet } from 'mailpoet';
+import * as ROUTES from 'segments/routes';
+import type { DynamicSegmentListingItem } from './api';
+
+function dateTime(value: string | null | undefined): JSX.Element {
+  if (!value) return createElement('span', null, '—');
+  return createElement(
+    'span',
+    { 'data-automation-id': 'mailpoet_dynamic_segment_created_at' },
+    createElement('span', null, MailPoet.Date.short(value)),
+    createElement('br', null),
+    createElement('span', null, MailPoet.Date.time(value)),
+  );
+}
+
+export const dynamicSegmentFields: Field<DynamicSegmentListingItem>[] = [
+  {
+    id: 'name',
+    label: __('Segment', 'mailpoet'),
+    type: 'text',
+    enableSorting: true,
+    enableGlobalSearch: true,
+    render: ({ item }) =>
+      createElement(
+        'div',
+        {
+          'data-automation-id': `mailpoet_dynamic_segment_name_${item.id}`,
+        },
+        item.is_plugin_missing
+          ? createElement('span', null, item.name)
+          : createElement(
+              'a',
+              { href: `#${ROUTES.EDIT_DYNAMIC_SEGMENT}/${item.id}` },
+              item.name,
+            ),
+        item.description ? createElement('div', null, item.description) : null,
+      ),
+  },
+  {
+    id: 'subscribers',
+    label: __('Number of subscribers', 'mailpoet'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) =>
+      item.is_plugin_missing
+        ? createElement(
+            'div',
+            {
+              'data-automation-id': `mailpoet_dynamic_segment_plugin_missing_message_${item.id}`,
+            },
+            item.missing_plugin_message?.message ?? '',
+          )
+        : createElement(
+            'div',
+            {
+              'data-automation-id': `mailpoet_dynamic_segment_count_all_${item.id}`,
+            },
+            item.count_all,
+          ),
+  },
+  {
+    id: 'subscribed',
+    label: __('Subscribed', 'mailpoet'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) => {
+      if (item.is_plugin_missing) return null;
+      if (item.count_subscribed === '0') {
+        return createElement('span', null, item.count_subscribed);
+      }
+      return createElement(
+        'a',
+        {
+          'data-automation-id': `mailpoet_dynamic_segment_count_subscribed_${item.id}`,
+          className:
+            'components-button is-link mailpoet-listing-text-right-align',
+          href: item.subscribers_url,
+        },
+        item.count_subscribed,
+      );
+    },
+  },
+  {
+    id: 'updated_at',
+    label: __('Modified', 'mailpoet'),
+    type: 'datetime',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    render: ({ item }) => dateTime(item.created_at),
+  },
+];

--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -1,6 +1,15 @@
-import { __ } from '@wordpress/i18n';
-import { ListingTabs } from './list/listing-tabs';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+  __experimentalConfirmDialog as ConfirmDialog,
+  Notice,
+  TabPanel,
+} from '@wordpress/components';
+import { DataViews, View, Action } from '@wordpress/dataviews';
+import { escapeHTML } from '@wordpress/escape-html';
+import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
 import { Notices } from './list/notices';
+import { getSegmentsQuery, updateSegmentsQuery } from './list/query';
 import * as ROUTES from '../routes';
 import { PageHeader } from '../../common/page-header';
 import { SubscribersCacheMessage } from '../../common/subscribers-cache-message';
@@ -8,8 +17,425 @@ import { SubscribersInPlan } from '../../common/subscribers-in-plan';
 import { TopBarWithBoundary } from '../../common/top-bar/top-bar';
 import { MailPoet } from '../../mailpoet';
 import { MssAccessNotices } from '../../notices/mss-access-notices';
+import {
+  bulkAction,
+  getDynamicSegments,
+  type DynamicSegmentBulkAction,
+  type DynamicSegmentBulkActionResult,
+  type DynamicSegmentListingItem,
+} from './api';
+import { dynamicSegmentFields } from './fields';
+import { isErrorResponse } from '../../ajax';
+
+type Group = 'all' | 'trash';
+
+type PendingAction = {
+  action: DynamicSegmentBulkAction;
+  selected: DynamicSegmentListingItem[];
+} | null;
+
+const DEFAULT_VIEW_BASE: View = {
+  type: 'table',
+  fields: ['subscribers', 'subscribed', 'updated_at'],
+  titleField: 'name',
+  showTitle: true,
+};
+
+function viewFromQuery(query: ReturnType<typeof getSegmentsQuery>): View {
+  return {
+    ...DEFAULT_VIEW_BASE,
+    perPage: query.limit,
+    page: Math.floor(query.offset / query.limit) + 1,
+    search: query.search,
+    sort: {
+      field: query.sort_by,
+      direction: query.sort_order === 'asc' ? 'asc' : 'desc',
+    },
+  };
+}
+
+function viewMatchesQuery(
+  view: View,
+  query: ReturnType<typeof getSegmentsQuery>,
+): boolean {
+  return (
+    (view.perPage ?? 25) === query.limit &&
+    (view.page ?? 1) === Math.floor(query.offset / query.limit) + 1 &&
+    (view.search ?? '') === query.search &&
+    (view.sort?.field ?? 'updated_at') === query.sort_by &&
+    (view.sort?.direction ?? 'desc') === query.sort_order
+  );
+}
+
+function actionCount(
+  action: DynamicSegmentBulkAction,
+  result: DynamicSegmentBulkActionResult,
+): number {
+  return action === 'delete' ? result.deleted : result.updated;
+}
+
+function successMessage(
+  action: DynamicSegmentBulkAction,
+  count: number,
+): string {
+  if (action === 'trash') {
+    return sprintf(
+      /* translators: %d - number of segments */
+      _n(
+        'Segment moved to trash.',
+        '%d segments moved to trash.',
+        count,
+        'mailpoet',
+      ),
+      count,
+    );
+  }
+  if (action === 'restore') {
+    return sprintf(
+      /* translators: %d - number of segments */
+      _n('Segment restored.', '%d segments restored.', count, 'mailpoet'),
+      count,
+    );
+  }
+  return sprintf(
+    /* translators: %d - number of segments */
+    _n(
+      'Segment permanently deleted.',
+      '%d segments permanently deleted.',
+      count,
+      'mailpoet',
+    ),
+    count,
+  );
+}
+
+function confirmCopy(pendingAction: PendingAction): {
+  title: string;
+  message: JSX.Element | string;
+  confirmText: string;
+} {
+  if (!pendingAction) return { title: '', message: '', confirmText: '' };
+  const { action, selected } = pendingAction;
+  const list = selected.map(({ name }) => `"${name}"`).join(', ');
+
+  if (action === 'trash') {
+    return {
+      title: _n(
+        'Trash selected segment',
+        'Trash selected segments',
+        selected.length,
+        'mailpoet',
+      ),
+      message: sprintf(
+        // translators: %s is the list of selected segments.
+        _n(
+          'Are you sure you want to trash the selected segment %s?',
+          'Are you sure you want to trash the selected segments %s?',
+          selected.length,
+          'mailpoet',
+        ),
+        list,
+      ),
+      confirmText: __('Trash', 'mailpoet'),
+    };
+  }
+
+  if (action === 'restore') {
+    return {
+      title: _n(
+        'Restore selected segment',
+        'Restore selected segments',
+        selected.length,
+        'mailpoet',
+      ),
+      message: sprintf(
+        // translators: %s is the list of selected segments.
+        _n(
+          'Are you sure you want to restore the selected segment %s?',
+          'Are you sure you want to restore segments %s?',
+          selected.length,
+          'mailpoet',
+        ),
+        list,
+      ),
+      confirmText: __('Restore', 'mailpoet'),
+    };
+  }
+
+  return {
+    title: _n(
+      'Delete selected segment permanently',
+      'Delete selected segments permanently',
+      selected.length,
+      'mailpoet',
+    ),
+    message: (
+      <>
+        {sprintf(
+          // translators: %s is the list of selected segments.
+          _n(
+            'Are you sure you want to delete the selected segment %s permanently?',
+            'Are you sure you want to delete the selected segments %s permanently?',
+            selected.length,
+            'mailpoet',
+          ),
+          list,
+        )}{' '}
+        <strong>{__('This action can not be reversed.', 'mailpoet')}</strong>
+      </>
+    ),
+    confirmText: __('Delete permanently', 'mailpoet'),
+  };
+}
 
 export function DynamicSegmentList(): JSX.Element {
+  const [initialQuery] = useState(() => getSegmentsQuery());
+  const [group, setGroup] = useState<Group>(initialQuery.group as Group);
+  const [selection, setSelection] = useState<string[]>([]);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const latestViewRef = useRef<View>(viewFromQuery(initialQuery));
+  const latestGroupRef = useRef<Group>(initialQuery.group as Group);
+
+  const load = useCallback(
+    (params: ListingQueryParams) => getDynamicSegments({ ...params, group }),
+    [group],
+  );
+
+  const {
+    view,
+    setView,
+    items,
+    meta,
+    groups,
+    isLoading,
+    error: loadError,
+    clearError: clearLoadError,
+    refresh,
+  } = useDataViewsQuery<DynamicSegmentListingItem>({
+    initialView: viewFromQuery(initialQuery),
+    load,
+  });
+
+  useEffect(() => {
+    latestViewRef.current = view;
+    latestGroupRef.current = group;
+  }, [group, view]);
+
+  useEffect(() => {
+    updateSegmentsQuery({
+      group,
+      limit: view.perPage ?? 25,
+      offset: ((view.page ?? 1) - 1) * (view.perPage ?? 25),
+      search: view.search ?? '',
+      sort_by: view.sort?.field ?? 'updated_at',
+      sort_order: view.sort?.direction ?? 'desc',
+    });
+  }, [group, view]);
+
+  useEffect(() => {
+    const applyHashState = (): void => {
+      const nextQuery = getSegmentsQuery();
+      const nextGroup = nextQuery.group as Group;
+      if (nextGroup !== latestGroupRef.current) {
+        setGroup(nextGroup);
+      }
+      if (!viewMatchesQuery(latestViewRef.current, nextQuery)) {
+        setView((currentView) =>
+          viewMatchesQuery(currentView, nextQuery)
+            ? currentView
+            : viewFromQuery(nextQuery),
+        );
+      }
+      setSelection([]);
+      setGlobalError(null);
+      setGlobalSuccess(null);
+      clearLoadError();
+    };
+
+    window.addEventListener('hashchange', applyHashState);
+    return () => window.removeEventListener('hashchange', applyHashState);
+  }, [clearLoadError, setView]);
+
+  const handleBulkAction = useCallback(
+    async (
+      action: DynamicSegmentBulkAction,
+      targets: DynamicSegmentListingItem[],
+    ) => {
+      if (targets.length === 0) return;
+      try {
+        const result = await bulkAction(
+          action,
+          targets.map((segment) => Number(segment.id)),
+        );
+        const count = actionCount(action, result);
+        setSelection([]);
+        setGlobalError(
+          result.errors.length
+            ? result.errors.map((error) => error.message).join('\n')
+            : null,
+        );
+        setGlobalSuccess(count > 0 ? successMessage(action, count) : null);
+        refresh();
+      } catch (err) {
+        const apiError = err as { message?: string };
+        setGlobalSuccess(null);
+        setGlobalError(
+          apiError?.message ||
+            __('The bulk action could not be completed.', 'mailpoet'),
+        );
+      }
+    },
+    [refresh],
+  );
+
+  const handleDuplicate = useCallback(
+    async (segment: DynamicSegmentListingItem) => {
+      try {
+        const response = await MailPoet.Ajax.post({
+          api_version: 'v1',
+          endpoint: 'dynamic_segments',
+          action: 'duplicate',
+          data: { id: segment.id },
+        });
+        const newSegment = response.data as DynamicSegmentListingItem;
+        MailPoet.Notice.success(
+          sprintf(
+            __('Segment "%s" has been duplicated.', 'mailpoet'),
+            escapeHTML(newSegment.name),
+          ),
+        );
+        refresh();
+      } catch (errorResponse: unknown) {
+        if (isErrorResponse(errorResponse)) {
+          MailPoet.Notice.showApiErrorNotice(errorResponse);
+        }
+      }
+    },
+    [refresh],
+  );
+
+  const actions = useMemo<Action<DynamicSegmentListingItem>[]>(
+    () => [
+      {
+        id: 'view_subscribers',
+        label: __('View subscribers', 'mailpoet'),
+        supportsBulk: false,
+        callback: (targets) => {
+          const segment = targets[0];
+          if (segment) window.location.href = segment.subscribers_url;
+        },
+      },
+      {
+        id: 'edit',
+        label: __('Edit', 'mailpoet'),
+        isPrimary: true,
+        supportsBulk: false,
+        isEligible: (item) => !item.deleted_at && !item.is_plugin_missing,
+        callback: (targets) => {
+          const segment = targets[0];
+          if (segment) {
+            window.location.hash = `${ROUTES.EDIT_DYNAMIC_SEGMENT}/${segment.id}`;
+          }
+        },
+      },
+      {
+        id: 'edit_missing_plugin',
+        label: (selected) =>
+          sprintf(
+            __('Edit unavailable: %s', 'mailpoet'),
+            selected[0]?.missing_plugin_message?.message ??
+              __('Required plugin is inactive.', 'mailpoet'),
+          ),
+        disabled: true,
+        isPrimary: true,
+        supportsBulk: false,
+        isEligible: (item) => !item.deleted_at && item.is_plugin_missing,
+        callback: () => undefined,
+      },
+      {
+        id: 'duplicate',
+        label: __('Duplicate', 'mailpoet'),
+        supportsBulk: false,
+        isEligible: (item) => !item.deleted_at,
+        callback: (targets) => {
+          if (targets[0]) void handleDuplicate(targets[0]);
+        },
+      },
+      {
+        id: 'trash',
+        label: __('Move to trash', 'mailpoet'),
+        supportsBulk: true,
+        isEligible: (item) => !item.deleted_at,
+        callback: (targets) => {
+          setPendingAction({ action: 'trash', selected: targets });
+        },
+      },
+      {
+        id: 'restore',
+        label: __('Restore', 'mailpoet'),
+        supportsBulk: true,
+        isEligible: (item) => !!item.deleted_at,
+        callback: (targets) => {
+          setPendingAction({ action: 'restore', selected: targets });
+        },
+      },
+      {
+        id: 'delete',
+        label: __('Delete permanently', 'mailpoet'),
+        supportsBulk: true,
+        isDestructive: true,
+        isEligible: (item) => !!item.deleted_at,
+        callback: (targets) => {
+          setPendingAction({ action: 'delete', selected: targets });
+        },
+      },
+    ],
+    [handleDuplicate],
+  );
+
+  const paginationInfo = useMemo(
+    () => ({ totalItems: meta.count, totalPages: meta.pages }),
+    [meta],
+  );
+
+  const tabs = useMemo(() => {
+    const counts: Record<Group, number | null> = { all: null, trash: null };
+    (groups ?? []).forEach((entry) => {
+      if (entry.name === 'all' || entry.name === 'trash') {
+        counts[entry.name] = entry.count;
+      }
+    });
+    const formatTitle = (label: string, count: number | null): string =>
+      count === null ? label : `${label} (${count})`;
+    return [
+      {
+        name: 'all',
+        title: formatTitle(__('All', 'mailpoet'), counts.all),
+        className: 'mailpoet-dataviews-group-all mailpoet-tab-all',
+      },
+      {
+        name: 'trash',
+        title: formatTitle(__('Trash', 'mailpoet'), counts.trash),
+        className: 'mailpoet-dataviews-group-trash mailpoet-tab-trash',
+      },
+    ];
+  }, [groups]);
+
+  const handleTabSelect = (tabName: string): void => {
+    if (tabName !== 'all' && tabName !== 'trash') return;
+    if (tabName === group) return;
+    setGroup(tabName);
+    setSelection([]);
+    setGlobalError(null);
+    setGlobalSuccess(null);
+    clearLoadError();
+    setView({ ...view, page: 1 });
+  };
+
+  const copy = confirmCopy(pendingAction);
+
   return (
     <>
       <TopBarWithBoundary hideScreenOptions />
@@ -35,7 +461,73 @@ export function DynamicSegmentList(): JSX.Element {
         />
       </div>
       <MssAccessNotices />
-      <ListingTabs />
+      {loadError && (
+        <Notice status="error" onRemove={clearLoadError}>
+          {loadError}
+        </Notice>
+      )}
+      {globalError && (
+        <Notice status="error" onRemove={() => setGlobalError(null)}>
+          {globalError}
+        </Notice>
+      )}
+      {globalSuccess && (
+        <Notice status="success" onRemove={() => setGlobalSuccess(null)}>
+          {globalSuccess}
+        </Notice>
+      )}
+      <TabPanel
+        key={group}
+        className="mailpoet-segments-dataviews__tabs"
+        activeClass="is-active"
+        tabs={tabs}
+        initialTabName={group}
+        onSelect={handleTabSelect}
+      >
+        {() => (
+          <div
+            className="mailpoet-segments-dataviews mailpoet-segments-listing"
+            data-automation-id="dynamic_segments_listing"
+          >
+            <DataViews<DynamicSegmentListingItem>
+              data={items}
+              fields={dynamicSegmentFields}
+              view={view}
+              onChangeView={setView}
+              actions={actions}
+              paginationInfo={paginationInfo}
+              defaultLayouts={{ table: {} }}
+              getItemId={(item) => String(item.id)}
+              selection={selection}
+              onChangeSelection={setSelection}
+              isLoading={isLoading}
+              empty={<div>{__('No data to display', 'mailpoet')}</div>}
+            >
+              <div className="mailpoet-segments-dataviews__toolbar">
+                <DataViews.Search label={__('Search', 'mailpoet')} />
+              </div>
+              <DataViews.Layout />
+              <DataViews.Footer />
+            </DataViews>
+          </div>
+        )}
+      </TabPanel>
+      <ConfirmDialog
+        className="mailpoet-confirm-dialog"
+        isOpen={!!pendingAction}
+        title={copy.title}
+        confirmButtonText={copy.confirmText}
+        __experimentalHideHeader={false}
+        onConfirm={() => {
+          if (pendingAction) {
+            void handleBulkAction(pendingAction.action, pendingAction.selected);
+          }
+          setPendingAction(null);
+        }}
+        onCancel={() => setPendingAction(null)}
+      >
+        <p>{copy.message}</p>
+      </ConfirmDialog>
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -67,6 +67,12 @@ function viewMatchesQuery(
   );
 }
 
+function usesNonPageAlignedOffset(
+  query: ReturnType<typeof getSegmentsQuery>,
+): boolean {
+  return query.limit > 0 && query.offset % query.limit !== 0;
+}
+
 function actionCount(
   action: DynamicSegmentBulkAction,
   result: DynamicSegmentBulkActionResult,
@@ -195,6 +201,9 @@ export function DynamicSegmentList(): JSX.Element {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const legacyOffsetRef = useRef<number | null>(
+    usesNonPageAlignedOffset(initialQuery) ? initialQuery.offset : null,
+  );
   const latestViewRef = useRef<View>(viewFromQuery(initialQuery));
   const latestGroupRef = useRef<Group>(initialQuery.group as Group);
 
@@ -216,6 +225,25 @@ export function DynamicSegmentList(): JSX.Element {
   } = useDataViewsQuery<DynamicSegmentListingItem>({
     initialView: viewFromQuery(initialQuery),
     load,
+    extraParams: (currentView) => {
+      if (
+        legacyOffsetRef.current !== null &&
+        viewMatchesQuery(currentView, {
+          ...initialQuery,
+          offset: legacyOffsetRef.current,
+        })
+      ) {
+        return {
+          page: undefined,
+          per_page: undefined,
+          offset: legacyOffsetRef.current,
+          limit: currentView.perPage ?? initialQuery.limit,
+          sort_by: currentView.sort?.field ?? 'updated_at',
+          sort_order: currentView.sort?.direction ?? 'desc',
+        };
+      }
+      return {};
+    },
   });
 
   useEffect(() => {
@@ -224,6 +252,15 @@ export function DynamicSegmentList(): JSX.Element {
   }, [group, view]);
 
   useEffect(() => {
+    if (
+      legacyOffsetRef.current !== null &&
+      viewMatchesQuery(view, {
+        ...initialQuery,
+        offset: legacyOffsetRef.current,
+      })
+    ) {
+      return;
+    }
     updateSegmentsQuery({
       group,
       limit: view.perPage ?? 25,
@@ -232,12 +269,15 @@ export function DynamicSegmentList(): JSX.Element {
       sort_by: view.sort?.field ?? 'updated_at',
       sort_order: view.sort?.direction ?? 'desc',
     });
-  }, [group, view]);
+  }, [group, initialQuery, view]);
 
   useEffect(() => {
     const applyHashState = (): void => {
       const nextQuery = getSegmentsQuery();
       const nextGroup = nextQuery.group as Group;
+      legacyOffsetRef.current = usesNonPageAlignedOffset(nextQuery)
+        ? nextQuery.offset
+        : null;
       if (nextGroup !== latestGroupRef.current) {
         setGroup(nextGroup);
       }
@@ -257,6 +297,11 @@ export function DynamicSegmentList(): JSX.Element {
     window.addEventListener('hashchange', applyHashState);
     return () => window.removeEventListener('hashchange', applyHashState);
   }, [clearLoadError, setView]);
+
+  const handleViewChange = (nextView: View): void => {
+    legacyOffsetRef.current = null;
+    setView(nextView);
+  };
 
   const handleBulkAction = useCallback(
     async (
@@ -426,6 +471,7 @@ export function DynamicSegmentList(): JSX.Element {
   const handleTabSelect = (tabName: string): void => {
     if (tabName !== 'all' && tabName !== 'trash') return;
     if (tabName === group) return;
+    legacyOffsetRef.current = null;
     setGroup(tabName);
     setSelection([]);
     setGlobalError(null);
@@ -493,7 +539,7 @@ export function DynamicSegmentList(): JSX.Element {
               data={items}
               fields={dynamicSegmentFields}
               view={view}
-              onChangeView={setView}
+              onChangeView={handleViewChange}
               actions={actions}
               paginationInfo={paginationInfo}
               defaultLayouts={{ table: {} }}

--- a/mailpoet/assets/js/src/segments/dynamic/list.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list.tsx
@@ -387,14 +387,8 @@ export function DynamicSegmentList(): JSX.Element {
       },
       {
         id: 'edit_missing_plugin',
-        label: (selected) =>
-          sprintf(
-            __('Edit unavailable: %s', 'mailpoet'),
-            selected[0]?.missing_plugin_message?.message ??
-              __('Required plugin is inactive.', 'mailpoet'),
-          ),
+        label: __('Edit unavailable', 'mailpoet'),
         disabled: true,
-        isPrimary: true,
         supportsBulk: false,
         isEligible: (item) => !item.deleted_at && item.is_plugin_missing,
         callback: () => undefined,

--- a/mailpoet/assets/js/src/segments/static/api.ts
+++ b/mailpoet/assets/js/src/segments/static/api.ts
@@ -25,7 +25,7 @@ function ensureInitialized(): void {
 }
 
 export type SegmentListingItem = {
-  id: number;
+  id: string;
   name: string;
   description: string;
   type: string;

--- a/mailpoet/assets/js/src/segments/static/api.ts
+++ b/mailpoet/assets/js/src/segments/static/api.ts
@@ -1,0 +1,86 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import type {
+  ListingEnvelope,
+  ListingQueryParams,
+  ListingResponse,
+} from 'common/dataviews';
+
+declare global {
+  interface Window {
+    mailpoet_segments_api: {
+      root: string;
+      nonce: string;
+    };
+  }
+}
+
+let initialized = false;
+function ensureInitialized(): void {
+  if (initialized) return;
+  const config = window.mailpoet_segments_api;
+  apiFetch.use(apiFetch.createRootURLMiddleware(`${config.root}/`));
+  apiFetch.use(apiFetch.createNonceMiddleware(config.nonce));
+  initialized = true;
+}
+
+export type SegmentListingItem = {
+  id: number;
+  name: string;
+  description: string;
+  type: string;
+  average_engagement_score: number;
+  show_in_manage_subscription_page: boolean | number;
+  subscribers_count: {
+    subscribed?: number;
+    unconfirmed?: number;
+    unsubscribed?: number;
+    inactive?: number;
+    bounced?: number;
+  };
+  created_at: string | null;
+  updated_at: string | null;
+  deleted_at: string | null;
+  subscribers_url: string;
+};
+
+export type SegmentBulkAction = 'trash' | 'restore' | 'delete' | 'empty_trash';
+
+export type SegmentBulkActionResult = {
+  updated: number;
+  deleted: number;
+  skipped: number;
+  errors: Array<{ id: number | null; message: string }>;
+};
+
+export async function getSegments(
+  params: ListingQueryParams,
+): Promise<ListingResponse<SegmentListingItem>> {
+  ensureInitialized();
+  const response = await apiFetch<ListingEnvelope<SegmentListingItem>>({
+    path: addQueryArgs(
+      '/mailpoet/v1/segments',
+      params as Record<string, unknown>,
+    ),
+    method: 'GET',
+  });
+  return response.data;
+}
+
+export async function bulkAction(
+  action: SegmentBulkAction,
+  ids: number[],
+  params?: Partial<ListingQueryParams> & { select_all?: boolean },
+): Promise<SegmentBulkActionResult> {
+  ensureInitialized();
+  const response = await apiFetch<{ data: SegmentBulkActionResult }>({
+    path: '/mailpoet/v1/segments/bulk-action',
+    method: 'POST',
+    data: {
+      action,
+      ids,
+      ...params,
+    },
+  });
+  return response.data;
+}

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -5,8 +5,14 @@ import { MailPoet } from 'mailpoet';
 import { ListingsEngagementScore } from 'subscribers/listings-engagement-score';
 import type { SegmentListingItem } from './api';
 
-function count(item: SegmentListingItem, status: string): string {
-  return Number(item.subscribers_count[status] ?? 0).toLocaleString();
+function count(item: SegmentListingItem, status: string): JSX.Element {
+  return createElement(
+    'span',
+    {
+      'data-automation-id': `listing_item_${item.id}_${status}_count`,
+    },
+    Number(item.subscribers_count[status] ?? 0).toLocaleString(),
+  );
 }
 
 function dateTime(value: string | null): JSX.Element {
@@ -113,38 +119,35 @@ export const segmentFields: Field<SegmentListingItem>[] = [
     label: MailPoet.I18n.t('subscribed'),
     enableSorting: false,
     enableGlobalSearch: false,
-    render: ({ item }) =>
-      createElement('span', null, count(item, 'subscribed')),
+    render: ({ item }) => count(item, 'subscribed'),
   },
   {
     id: 'unconfirmed',
     label: MailPoet.I18n.t('unconfirmed'),
     enableSorting: false,
     enableGlobalSearch: false,
-    render: ({ item }) =>
-      createElement('span', null, count(item, 'unconfirmed')),
+    render: ({ item }) => count(item, 'unconfirmed'),
   },
   {
     id: 'unsubscribed',
     label: MailPoet.I18n.t('unsubscribed'),
     enableSorting: false,
     enableGlobalSearch: false,
-    render: ({ item }) =>
-      createElement('span', null, count(item, 'unsubscribed')),
+    render: ({ item }) => count(item, 'unsubscribed'),
   },
   {
     id: 'inactive',
     label: MailPoet.I18n.t('inactive'),
     enableSorting: false,
     enableGlobalSearch: false,
-    render: ({ item }) => createElement('span', null, count(item, 'inactive')),
+    render: ({ item }) => count(item, 'inactive'),
   },
   {
     id: 'bounced',
     label: MailPoet.I18n.t('bounced'),
     enableSorting: false,
     enableGlobalSearch: false,
-    render: ({ item }) => createElement('span', null, count(item, 'bounced')),
+    render: ({ item }) => count(item, 'bounced'),
   },
   {
     id: 'created_at',

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -102,7 +102,7 @@ export const segmentFields: Field<SegmentListingItem>[] = [
           enableGlobalSearch: false,
           render: ({ item }) =>
             createElement(ListingsEngagementScore, {
-              id: item.id,
+              id: Number(item.id),
               engagementScore: item.average_engagement_score,
             }),
         },

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -1,0 +1,157 @@
+import { createElement } from 'react';
+import { __ } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+import { MailPoet } from 'mailpoet';
+import { ListingsEngagementScore } from 'subscribers/listings-engagement-score';
+import type { SegmentListingItem } from './api';
+
+function count(item: SegmentListingItem, status: string): string {
+  return Number(item.subscribers_count[status] ?? 0).toLocaleString();
+}
+
+function dateTime(value: string | null): JSX.Element {
+  if (!value) return createElement('span', null, '—');
+  return createElement(
+    'span',
+    null,
+    createElement('span', null, MailPoet.Date.short(value)),
+    createElement('br', null),
+    createElement('span', null, MailPoet.Date.time(value)),
+  );
+}
+
+export const segmentFields: Field<SegmentListingItem>[] = [
+  {
+    id: 'name',
+    label: __('Name', 'mailpoet'),
+    type: 'text',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    render: ({ item }) => {
+      const privateLabel =
+        Number(item.show_in_manage_subscription_page) === 0
+          ? createElement(
+              'span',
+              { className: 'mailpoet-listing-title-private-label' },
+              ` ${MailPoet.I18n.t('privateListLabel')}`,
+            )
+          : null;
+      const children = [item.name, privateLabel].filter(Boolean) as Array<
+        string | JSX.Element
+      >;
+      const props = {
+        className: 'mailpoet-listing-title',
+        'data-automation-id': `listing_item_${item.id}`,
+      };
+      const wrapLegacyNameSelector = (title: JSX.Element): JSX.Element =>
+        createElement(
+          'span',
+          { 'data-automation-id': `segment_name_${item.name}` },
+          title,
+        );
+      const legacyViewSubscribersAction = createElement(
+        'div',
+        { className: 'mailpoet-listing-actions-holder' },
+        createElement(
+          'div',
+          { className: 'mailpoet-listing-actions' },
+          createElement(
+            'a',
+            {
+              'data-automation-id': `view_subscribers_${item.name}`,
+              href: item.subscribers_url,
+            },
+            MailPoet.I18n.t('viewSubscribers'),
+          ),
+        ),
+      );
+      if (item.type === 'wp_users' || item.type === 'woocommerce_users') {
+        return createElement(
+          'div',
+          null,
+          wrapLegacyNameSelector(createElement('span', props, ...children)),
+          legacyViewSubscribersAction,
+        );
+      }
+      return createElement(
+        'div',
+        null,
+        wrapLegacyNameSelector(
+          createElement(
+            'a',
+            { ...props, href: `#/edit/${item.id}` },
+            ...children,
+          ),
+        ),
+        legacyViewSubscribersAction,
+      );
+    },
+  },
+  {
+    id: 'description',
+    label: __('Description', 'mailpoet'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+  },
+  ...(MailPoet.trackingConfig.emailTrackingEnabled
+    ? [
+        {
+          id: 'average_engagement_score',
+          label: MailPoet.I18n.t('listScore'),
+          enableSorting: true,
+          enableGlobalSearch: false,
+          render: ({ item }) =>
+            createElement(ListingsEngagementScore, {
+              id: item.id,
+              engagementScore: item.average_engagement_score,
+            }),
+        },
+      ]
+    : []),
+  {
+    id: 'subscribed',
+    label: MailPoet.I18n.t('subscribed'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) =>
+      createElement('span', null, count(item, 'subscribed')),
+  },
+  {
+    id: 'unconfirmed',
+    label: MailPoet.I18n.t('unconfirmed'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) =>
+      createElement('span', null, count(item, 'unconfirmed')),
+  },
+  {
+    id: 'unsubscribed',
+    label: MailPoet.I18n.t('unsubscribed'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) =>
+      createElement('span', null, count(item, 'unsubscribed')),
+  },
+  {
+    id: 'inactive',
+    label: MailPoet.I18n.t('inactive'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) => createElement('span', null, count(item, 'inactive')),
+  },
+  {
+    id: 'bounced',
+    label: MailPoet.I18n.t('bounced'),
+    enableSorting: false,
+    enableGlobalSearch: false,
+    render: ({ item }) => createElement('span', null, count(item, 'bounced')),
+  },
+  {
+    id: 'created_at',
+    label: MailPoet.I18n.t('createdOn'),
+    type: 'datetime',
+    enableSorting: true,
+    enableGlobalSearch: false,
+    render: ({ item }) => dateTime(item.created_at),
+  },
+];

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
   __experimentalConfirmDialog as ConfirmDialog,
@@ -253,10 +253,6 @@ function SegmentListComponent(): JSX.Element {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
-  const [selectAllMatching, setSelectAllMatching] = useState(false);
-  const selectAllMatchingRef = useRef(false);
-  const selectAllParamsRef = useRef<SelectAllParams>();
-  const totalMatchingCountRef = useRef(0);
   const [initialView] = useState<View>(() => ({
     ...DEFAULT_VIEW,
     page: hashState.page ?? DEFAULT_VIEW.page,
@@ -291,46 +287,6 @@ function SegmentListComponent(): JSX.Element {
     updateHash(group, view);
   }, [group, view]);
 
-  const selectAllParams = useMemo(
-    () => ({
-      select_all: true,
-      group,
-      page: view.page ?? 1,
-      per_page: view.perPage ?? listingPerPage,
-      orderby: view.sort?.field,
-      order: view.sort?.direction,
-    }),
-    [group, view],
-  );
-  selectAllMatchingRef.current = selectAllMatching;
-  selectAllParamsRef.current = selectAllParams;
-  totalMatchingCountRef.current = meta.count;
-
-  const updateSelectAllMatching = useCallback((value: boolean): void => {
-    selectAllMatchingRef.current = value;
-    setSelectAllMatching(value);
-  }, []);
-
-  const getBulkSelection = useCallback(
-    (
-      targets: SegmentListingItem[],
-    ): {
-      targets: SegmentListingItem[];
-      params?: SelectAllParams;
-      count: number;
-    } => {
-      if (!selectAllMatchingRef.current) {
-        return { targets, count: targets.length };
-      }
-      return {
-        targets: [],
-        params: selectAllParamsRef.current,
-        count: totalMatchingCountRef.current,
-      };
-    },
-    [],
-  );
-
   const handleBulkAction = useCallback(
     async (
       action: SegmentBulkAction,
@@ -346,7 +302,6 @@ function SegmentListComponent(): JSX.Element {
         const result = await bulkAction(action, ids, params);
         const count = countForAction(action, result);
         setSelection([]);
-        updateSelectAllMatching(false);
         setGlobalError(
           result.errors.length
             ? result.errors.map((error) => error.message).join('\n')
@@ -367,7 +322,7 @@ function SegmentListComponent(): JSX.Element {
         );
       }
     },
-    [refresh, updateSelectAllMatching],
+    [refresh],
   );
 
   const handleDuplicate = useCallback(
@@ -500,12 +455,7 @@ function SegmentListComponent(): JSX.Element {
           !isWPUsersSegment(item) &&
           !isWooCommerceCustomersSegment(item),
         callback: (targets) => {
-          const bulkSelection = getBulkSelection(targets);
-          void handleBulkAction(
-            'trash',
-            bulkSelection.targets,
-            bulkSelection.params,
-          );
+          void handleBulkAction('trash', targets);
         },
       },
       {
@@ -523,12 +473,7 @@ function SegmentListComponent(): JSX.Element {
         supportsBulk: true,
         isEligible: (item) => !!item.deleted_at && !isWPUsersSegment(item),
         callback: (targets) => {
-          const bulkSelection = getBulkSelection(targets);
-          void handleBulkAction(
-            'restore',
-            bulkSelection.targets,
-            bulkSelection.params,
-          );
+          void handleBulkAction('restore', targets);
         },
       },
       {
@@ -538,17 +483,15 @@ function SegmentListComponent(): JSX.Element {
         isDestructive: true,
         isEligible: (item) => !!item.deleted_at && !isSpecialSegment(item),
         callback: (targets) => {
-          const bulkSelection = getBulkSelection(targets);
           setPendingAction({
             action: 'delete',
-            targets: bulkSelection.targets,
-            count: bulkSelection.count,
-            params: bulkSelection.params,
+            targets,
+            count: targets.length,
           });
         },
       },
     ],
-    [getBulkSelection, handleBulkAction, handleDuplicate, handleSynchronize],
+    [handleBulkAction, handleDuplicate, handleSynchronize],
   );
 
   const paginationInfo = useMemo(
@@ -592,11 +535,10 @@ function SegmentListComponent(): JSX.Element {
     if (tabName === group) return;
     setGroup(tabName);
     setSelection([]);
-    updateSelectAllMatching(false);
     setGlobalError(null);
     setGlobalSuccess(null);
     clearLoadError();
-    setView({ ...view, page: 1 });
+    setView((currentView) => ({ ...currentView, page: 1 }));
   };
 
   useEffect(() => {
@@ -608,30 +550,13 @@ function SegmentListComponent(): JSX.Element {
     ) {
       setGroup('all');
       setSelection([]);
-      updateSelectAllMatching(false);
-      setView({ ...view, page: 1 });
+      setView((currentView) => ({ ...currentView, page: 1 }));
     }
-  }, [
-    group,
-    groupCounts.trash,
-    isLoading,
-    loadError,
-    setView,
-    updateSelectAllMatching,
-    view,
-  ]);
+  }, [group, groupCounts.trash, isLoading, loadError, setView]);
 
   const handleSelectionChange = (nextSelection: string[]): void => {
     setSelection(nextSelection);
-    updateSelectAllMatching(false);
   };
-
-  const hasSelectedCurrentPage =
-    selection.length > 0 &&
-    items.length > 0 &&
-    items.every((item) => selection.includes(String(item.id)));
-  const canSelectAllMatching =
-    hasSelectedCurrentPage && meta.count > selection.length;
 
   const emptyLabel =
     group === 'trash'
@@ -672,9 +597,7 @@ function SegmentListComponent(): JSX.Element {
             data-automation-id="segments_listing"
           >
             <DataViews<SegmentListingItem>
-              key={`${group}-${
-                selectAllMatching ? 'all-matching' : 'page-selection'
-              }`}
+              key={group}
               data={items}
               fields={segmentFields}
               view={view}
@@ -691,60 +614,30 @@ function SegmentListComponent(): JSX.Element {
               <div className="mailpoet-segments-dataviews__toolbar">
                 <DataViews.Search label={__('Search', 'mailpoet')} />
               </div>
-              {(canSelectAllMatching ||
-                (selectAllMatching && selection.length > 0) ||
-                (group === 'trash' && (groupCounts.trash ?? 0) > 0)) && (
+              {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
                 <div className="mailpoet-segments-dataviews__toolbar">
-                  {canSelectAllMatching && !selectAllMatching && (
-                    <button
-                      type="button"
-                      className="button-link"
-                      data-automation-id="select_all_items_all_pages"
-                      onClick={() => updateSelectAllMatching(true)}
-                    >
-                      {sprintf(
-                        /* translators: %d is the total number of lists. */
-                        __('Select all %d lists on all pages', 'mailpoet'),
-                        meta.count,
-                      )}
-                    </button>
-                  )}
-                  {selectAllMatching && selection.length > 0 && (
-                    <span data-automation-id="all_items_all_pages_selected">
-                      {sprintf(
-                        /* translators: %d is the total number of selected lists. */
-                        __(
-                          'All %d lists on all pages are selected.',
-                          'mailpoet',
-                        ),
-                        meta.count,
-                      )}
-                    </span>
-                  )}
-                  {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
-                    <button
-                      type="button"
-                      className="button"
-                      data-automation-id="empty_trash"
-                      onClick={() => {
-                        setPendingAction({
-                          action: 'empty_trash',
-                          targets: [],
-                          count: groupCounts.trash ?? 0,
-                          params: {
-                            select_all: true,
-                            group: 'trash',
-                            page: view.page ?? 1,
-                            per_page: view.perPage ?? listingPerPage,
-                            orderby: view.sort?.field,
-                            order: view.sort?.direction,
-                          },
-                        });
-                      }}
-                    >
-                      {__('Empty Trash', 'mailpoet')}
-                    </button>
-                  )}
+                  <button
+                    type="button"
+                    className="button"
+                    data-automation-id="empty_trash"
+                    onClick={() => {
+                      setPendingAction({
+                        action: 'empty_trash',
+                        targets: [],
+                        count: groupCounts.trash ?? 0,
+                        params: {
+                          select_all: true,
+                          group: 'trash',
+                          page: view.page ?? 1,
+                          per_page: view.perPage ?? listingPerPage,
+                          orderby: view.sort?.field,
+                          order: view.sort?.direction,
+                        },
+                      });
+                    }}
+                  >
+                    {__('Empty Trash', 'mailpoet')}
+                  </button>
                 </div>
               )}
               <DataViews.Layout />

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -325,15 +325,6 @@ function SegmentListComponent(): JSX.Element {
             ? successMessage(action, count, targets.some(isWPUsersSegment))
             : null,
         );
-        if (
-          (action === 'restore' ||
-            action === 'delete' ||
-            action === 'empty_trash') &&
-          group === 'trash'
-        ) {
-          setGroup('all');
-          setView({ ...view, page: 1 });
-        }
         refresh();
       } catch (err) {
         const apiError = err as { message?: string };
@@ -344,7 +335,7 @@ function SegmentListComponent(): JSX.Element {
         );
       }
     },
-    [group, refresh, setView, view],
+    [refresh],
   );
 
   const handleDuplicate = useCallback(

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -252,6 +252,7 @@ function SegmentListComponent(): JSX.Element {
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [selectAllMatching, setSelectAllMatching] = useState(false);
   const [initialView] = useState<View>(() => ({
     ...DEFAULT_VIEW,
     page: hashState.page ?? DEFAULT_VIEW.page,
@@ -286,6 +287,18 @@ function SegmentListComponent(): JSX.Element {
     updateHash(group, view);
   }, [group, view]);
 
+  const selectAllParams = useMemo(
+    () => ({
+      select_all: true,
+      group,
+      page: view.page ?? 1,
+      per_page: view.perPage ?? listingPerPage,
+      orderby: view.sort?.field,
+      order: view.sort?.direction,
+    }),
+    [group, view],
+  );
+
   const handleBulkAction = useCallback(
     async (
       action: SegmentBulkAction,
@@ -301,6 +314,7 @@ function SegmentListComponent(): JSX.Element {
         const result = await bulkAction(action, ids, params);
         const count = countForAction(action, result);
         setSelection([]);
+        setSelectAllMatching(false);
         setGlobalError(
           result.errors.length
             ? result.errors.map((error) => error.message).join('\n')
@@ -463,7 +477,11 @@ function SegmentListComponent(): JSX.Element {
           !isWPUsersSegment(item) &&
           !isWooCommerceCustomersSegment(item),
         callback: (targets) => {
-          void handleBulkAction('trash', targets);
+          void handleBulkAction(
+            'trash',
+            selectAllMatching ? [] : targets,
+            selectAllMatching ? selectAllParams : undefined,
+          );
         },
       },
       {
@@ -481,7 +499,11 @@ function SegmentListComponent(): JSX.Element {
         supportsBulk: true,
         isEligible: (item) => !!item.deleted_at && !isWPUsersSegment(item),
         callback: (targets) => {
-          void handleBulkAction('restore', targets);
+          void handleBulkAction(
+            'restore',
+            selectAllMatching ? [] : targets,
+            selectAllMatching ? selectAllParams : undefined,
+          );
         },
       },
       {
@@ -493,13 +515,21 @@ function SegmentListComponent(): JSX.Element {
         callback: (targets) => {
           setPendingAction({
             action: 'delete',
-            targets,
-            count: targets.length,
+            targets: selectAllMatching ? [] : targets,
+            count: selectAllMatching ? meta.count : targets.length,
+            params: selectAllMatching ? selectAllParams : undefined,
           });
         },
       },
     ],
-    [handleBulkAction, handleDuplicate, handleSynchronize],
+    [
+      handleBulkAction,
+      handleDuplicate,
+      handleSynchronize,
+      meta.count,
+      selectAllMatching,
+      selectAllParams,
+    ],
   );
 
   const paginationInfo = useMemo(
@@ -543,11 +573,38 @@ function SegmentListComponent(): JSX.Element {
     if (tabName === group) return;
     setGroup(tabName);
     setSelection([]);
+    setSelectAllMatching(false);
     setGlobalError(null);
     setGlobalSuccess(null);
     clearLoadError();
     setView({ ...view, page: 1 });
   };
+
+  useEffect(() => {
+    if (
+      group === 'trash' &&
+      !isLoading &&
+      !loadError &&
+      groupCounts.trash === 0
+    ) {
+      setGroup('all');
+      setSelection([]);
+      setSelectAllMatching(false);
+      setView({ ...view, page: 1 });
+    }
+  }, [group, groupCounts.trash, isLoading, loadError, setView, view]);
+
+  const handleSelectionChange = (nextSelection: string[]): void => {
+    setSelection(nextSelection);
+    setSelectAllMatching(false);
+  };
+
+  const hasSelectedCurrentPage =
+    selection.length > 0 &&
+    items.length > 0 &&
+    items.every((item) => selection.includes(String(item.id)));
+  const canSelectAllMatching =
+    hasSelectedCurrentPage && meta.count > selection.length;
 
   const emptyLabel =
     group === 'trash'
@@ -597,16 +654,45 @@ function SegmentListComponent(): JSX.Element {
               defaultLayouts={{ table: {} }}
               getItemId={(item) => String(item.id)}
               selection={selection}
-              onChangeSelection={setSelection}
+              onChangeSelection={handleSelectionChange}
               isLoading={isLoading}
               empty={<div>{emptyLabel}</div>}
             >
-              {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
+              {(canSelectAllMatching ||
+                (selectAllMatching && selection.length > 0) ||
+                (group === 'trash' && (groupCounts.trash ?? 0) > 0)) && (
                 <div className="mailpoet-segments-dataviews__toolbar">
+                  {canSelectAllMatching && !selectAllMatching && (
+                    <button
+                      type="button"
+                      className="button-link"
+                      data-automation-id="select_all_items_all_pages"
+                      onClick={() => setSelectAllMatching(true)}
+                    >
+                      {sprintf(
+                        /* translators: %d is the total number of lists. */
+                        __('Select all %d lists on all pages', 'mailpoet'),
+                        meta.count,
+                      )}
+                    </button>
+                  )}
+                  {selectAllMatching && selection.length > 0 && (
+                    <span data-automation-id="all_items_all_pages_selected">
+                      {sprintf(
+                        /* translators: %d is the total number of selected lists. */
+                        __(
+                          'All %d lists on all pages are selected.',
+                          'mailpoet',
+                        ),
+                        meta.count,
+                      )}
+                    </span>
+                  )}
                   <button
                     type="button"
                     className="button"
                     data-automation-id="empty_trash"
+                    hidden={group !== 'trash' || (groupCounts.trash ?? 0) === 0}
                     onClick={() => {
                       setPendingAction({
                         action: 'empty_trash',

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -688,6 +688,9 @@ function SegmentListComponent(): JSX.Element {
               isLoading={isLoading}
               empty={<div>{emptyLabel}</div>}
             >
+              <div className="mailpoet-segments-dataviews__toolbar">
+                <DataViews.Search label={__('Search', 'mailpoet')} />
+              </div>
               {(canSelectAllMatching ||
                 (selectAllMatching && selection.length > 0) ||
                 (group === 'trash' && (groupCounts.trash ?? 0) > 0)) && (

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
   __experimentalConfirmDialog as ConfirmDialog,
@@ -21,11 +21,12 @@ import {
 import { segmentFields } from './fields';
 
 type Group = 'all' | 'trash';
+type SelectAllParams = Partial<ListingQueryParams> & { select_all?: boolean };
 
 type PendingAction = {
   action: SegmentBulkAction;
   targets: SegmentListingItem[];
-  params?: Partial<ListingQueryParams> & { select_all?: boolean };
+  params?: SelectAllParams;
   count: number;
 } | null;
 
@@ -253,6 +254,9 @@ function SegmentListComponent(): JSX.Element {
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
   const [selectAllMatching, setSelectAllMatching] = useState(false);
+  const selectAllMatchingRef = useRef(false);
+  const selectAllParamsRef = useRef<SelectAllParams>();
+  const totalMatchingCountRef = useRef(0);
   const [initialView] = useState<View>(() => ({
     ...DEFAULT_VIEW,
     page: hashState.page ?? DEFAULT_VIEW.page,
@@ -298,12 +302,40 @@ function SegmentListComponent(): JSX.Element {
     }),
     [group, view],
   );
+  selectAllMatchingRef.current = selectAllMatching;
+  selectAllParamsRef.current = selectAllParams;
+  totalMatchingCountRef.current = meta.count;
+
+  const updateSelectAllMatching = useCallback((value: boolean): void => {
+    selectAllMatchingRef.current = value;
+    setSelectAllMatching(value);
+  }, []);
+
+  const getBulkSelection = useCallback(
+    (
+      targets: SegmentListingItem[],
+    ): {
+      targets: SegmentListingItem[];
+      params?: SelectAllParams;
+      count: number;
+    } => {
+      if (!selectAllMatchingRef.current) {
+        return { targets, count: targets.length };
+      }
+      return {
+        targets: [],
+        params: selectAllParamsRef.current,
+        count: totalMatchingCountRef.current,
+      };
+    },
+    [],
+  );
 
   const handleBulkAction = useCallback(
     async (
       action: SegmentBulkAction,
       targets: SegmentListingItem[],
-      params?: Partial<ListingQueryParams> & { select_all?: boolean },
+      params?: SelectAllParams,
     ) => {
       const ids = targets.map((segment) => Number(segment.id));
       if (!params?.select_all && action !== 'empty_trash' && ids.length === 0) {
@@ -314,7 +346,7 @@ function SegmentListComponent(): JSX.Element {
         const result = await bulkAction(action, ids, params);
         const count = countForAction(action, result);
         setSelection([]);
-        setSelectAllMatching(false);
+        updateSelectAllMatching(false);
         setGlobalError(
           result.errors.length
             ? result.errors.map((error) => error.message).join('\n')
@@ -335,7 +367,7 @@ function SegmentListComponent(): JSX.Element {
         );
       }
     },
-    [refresh],
+    [refresh, updateSelectAllMatching],
   );
 
   const handleDuplicate = useCallback(
@@ -468,10 +500,11 @@ function SegmentListComponent(): JSX.Element {
           !isWPUsersSegment(item) &&
           !isWooCommerceCustomersSegment(item),
         callback: (targets) => {
+          const bulkSelection = getBulkSelection(targets);
           void handleBulkAction(
             'trash',
-            selectAllMatching ? [] : targets,
-            selectAllMatching ? selectAllParams : undefined,
+            bulkSelection.targets,
+            bulkSelection.params,
           );
         },
       },
@@ -490,10 +523,11 @@ function SegmentListComponent(): JSX.Element {
         supportsBulk: true,
         isEligible: (item) => !!item.deleted_at && !isWPUsersSegment(item),
         callback: (targets) => {
+          const bulkSelection = getBulkSelection(targets);
           void handleBulkAction(
             'restore',
-            selectAllMatching ? [] : targets,
-            selectAllMatching ? selectAllParams : undefined,
+            bulkSelection.targets,
+            bulkSelection.params,
           );
         },
       },
@@ -504,23 +538,17 @@ function SegmentListComponent(): JSX.Element {
         isDestructive: true,
         isEligible: (item) => !!item.deleted_at && !isSpecialSegment(item),
         callback: (targets) => {
+          const bulkSelection = getBulkSelection(targets);
           setPendingAction({
             action: 'delete',
-            targets: selectAllMatching ? [] : targets,
-            count: selectAllMatching ? meta.count : targets.length,
-            params: selectAllMatching ? selectAllParams : undefined,
+            targets: bulkSelection.targets,
+            count: bulkSelection.count,
+            params: bulkSelection.params,
           });
         },
       },
     ],
-    [
-      handleBulkAction,
-      handleDuplicate,
-      handleSynchronize,
-      meta.count,
-      selectAllMatching,
-      selectAllParams,
-    ],
+    [getBulkSelection, handleBulkAction, handleDuplicate, handleSynchronize],
   );
 
   const paginationInfo = useMemo(
@@ -564,7 +592,7 @@ function SegmentListComponent(): JSX.Element {
     if (tabName === group) return;
     setGroup(tabName);
     setSelection([]);
-    setSelectAllMatching(false);
+    updateSelectAllMatching(false);
     setGlobalError(null);
     setGlobalSuccess(null);
     clearLoadError();
@@ -580,14 +608,22 @@ function SegmentListComponent(): JSX.Element {
     ) {
       setGroup('all');
       setSelection([]);
-      setSelectAllMatching(false);
+      updateSelectAllMatching(false);
       setView({ ...view, page: 1 });
     }
-  }, [group, groupCounts.trash, isLoading, loadError, setView, view]);
+  }, [
+    group,
+    groupCounts.trash,
+    isLoading,
+    loadError,
+    setView,
+    updateSelectAllMatching,
+    view,
+  ]);
 
   const handleSelectionChange = (nextSelection: string[]): void => {
     setSelection(nextSelection);
-    setSelectAllMatching(false);
+    updateSelectAllMatching(false);
   };
 
   const hasSelectedCurrentPage =
@@ -636,6 +672,9 @@ function SegmentListComponent(): JSX.Element {
             data-automation-id="segments_listing"
           >
             <DataViews<SegmentListingItem>
+              key={`${group}-${
+                selectAllMatching ? 'all-matching' : 'page-selection'
+              }`}
               data={items}
               fields={segmentFields}
               view={view}
@@ -658,7 +697,7 @@ function SegmentListComponent(): JSX.Element {
                       type="button"
                       className="button-link"
                       data-automation-id="select_all_items_all_pages"
-                      onClick={() => setSelectAllMatching(true)}
+                      onClick={() => updateSelectAllMatching(true)}
                     >
                       {sprintf(
                         /* translators: %d is the total number of lists. */
@@ -679,29 +718,30 @@ function SegmentListComponent(): JSX.Element {
                       )}
                     </span>
                   )}
-                  <button
-                    type="button"
-                    className="button"
-                    data-automation-id="empty_trash"
-                    hidden={group !== 'trash' || (groupCounts.trash ?? 0) === 0}
-                    onClick={() => {
-                      setPendingAction({
-                        action: 'empty_trash',
-                        targets: [],
-                        count: groupCounts.trash ?? 0,
-                        params: {
-                          select_all: true,
-                          group: 'trash',
-                          page: view.page ?? 1,
-                          per_page: view.perPage ?? listingPerPage,
-                          orderby: view.sort?.field,
-                          order: view.sort?.direction,
-                        },
-                      });
-                    }}
-                  >
-                    {__('Empty Trash', 'mailpoet')}
-                  </button>
+                  {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
+                    <button
+                      type="button"
+                      className="button"
+                      data-automation-id="empty_trash"
+                      onClick={() => {
+                        setPendingAction({
+                          action: 'empty_trash',
+                          targets: [],
+                          count: groupCounts.trash ?? 0,
+                          params: {
+                            select_all: true,
+                            group: 'trash',
+                            page: view.page ?? 1,
+                            per_page: view.perPage ?? listingPerPage,
+                            orderby: view.sort?.field,
+                            order: view.sort?.direction,
+                          },
+                        });
+                      }}
+                    >
+                      {__('Empty Trash', 'mailpoet')}
+                    </button>
+                  )}
                 </div>
               )}
               <DataViews.Layout />

--- a/mailpoet/assets/js/src/segments/static/list.tsx
+++ b/mailpoet/assets/js/src/segments/static/list.tsx
@@ -1,176 +1,347 @@
-import { Component, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
-  Link,
-  useLocation,
-  useParams,
-  Location,
-  Params,
-} from 'react-router-dom';
+  __experimentalConfirmDialog as ConfirmDialog,
+  Notice,
+  TabPanel,
+} from '@wordpress/components';
+import { escapeHTML } from '@wordpress/escape-html';
+import { DataViews, View, Action } from '@wordpress/dataviews';
 import { MailPoet } from 'mailpoet';
-import classnames from 'classnames';
-import { escapeHTML, escapeAttribute } from '@wordpress/escape-html';
-
-import { Listing } from 'listing/listing.jsx';
-import { SegmentResponse } from 'segments/types';
-import { ListingsEngagementScore } from 'subscribers/listings-engagement-score';
-import { ListHeading } from 'segments/static/heading';
 import { HideScreenOptions } from 'common/hide-screen-options/hide-screen-options';
+import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
+import { ListHeading } from 'segments/static/heading';
+import {
+  bulkAction,
+  getSegments,
+  type SegmentBulkAction,
+  type SegmentBulkActionResult,
+  type SegmentListingItem,
+} from './api';
+import { segmentFields } from './fields';
 
-type Segment = {
-  type: string;
-  id: number;
-  name: string;
-  description: string;
-  average_engagement_score: number;
-  show_in_manage_subscription_page: boolean;
-  subscribers_count: {
-    subscribed?: number;
-    unconfirmed?: number;
-    unsubscribed?: number;
-    inactive?: number;
-    bounced?: number;
+type Group = 'all' | 'trash';
+
+type PendingAction = {
+  action: SegmentBulkAction;
+  targets: SegmentListingItem[];
+  params?: Partial<ListingQueryParams> & { select_all?: boolean };
+  count: number;
+} | null;
+
+const listingPerPage = Number(window.mailpoet_listing_per_page);
+
+const DEFAULT_VIEW: View = {
+  type: 'table',
+  perPage: listingPerPage,
+  page: 1,
+  sort: { field: 'name', direction: 'asc' },
+  fields: [
+    'description',
+    ...(MailPoet.trackingConfig.emailTrackingEnabled
+      ? ['average_engagement_score']
+      : []),
+    'subscribed',
+    'unconfirmed',
+    'unsubscribed',
+    'inactive',
+    'bounced',
+    'created_at',
+  ],
+  titleField: 'name',
+  showTitle: true,
+};
+
+function isWPUsersSegment(segment: SegmentListingItem): boolean {
+  return segment.type === 'wp_users';
+}
+
+function isWooCommerceCustomersSegment(segment: SegmentListingItem): boolean {
+  return segment.type === 'woocommerce_users';
+}
+
+function isSpecialSegment(segment: SegmentListingItem): boolean {
+  return isWPUsersSegment(segment) || isWooCommerceCustomersSegment(segment);
+}
+
+function parseHash(): Partial<{
+  group: Group;
+  page: number;
+  perPage: number;
+  orderby: string;
+  order: 'asc' | 'desc';
+}> {
+  return window.location.hash
+    .split('/')
+    .map((part) => part.replace(/\]$/, '').split('['))
+    .reduce((params, [key, value]) => {
+      if (!value) return params;
+      if (key === 'group' && (value === 'all' || value === 'trash')) {
+        return { ...params, group: value };
+      }
+      if ((key === 'page' || key === 'paged') && Number(value) > 0) {
+        return { ...params, page: Number(value) };
+      }
+      if ((key === 'per_page' || key === 'limit') && Number(value) > 0) {
+        return { ...params, perPage: Number(value) };
+      }
+      if (key === 'sort_by' || key === 'orderby') {
+        return { ...params, orderby: value };
+      }
+      if (
+        (key === 'sort_order' || key === 'order') &&
+        (value === 'asc' || value === 'desc')
+      ) {
+        return { ...params, order: value };
+      }
+      return params;
+    }, {});
+}
+
+function updateHash(group: Group, view: View): void {
+  const entries: Array<[string, string | number | undefined]> = [
+    ['group', group],
+    ['page', view.page && view.page !== 1 ? view.page : undefined],
+    [
+      'limit',
+      view.perPage && view.perPage !== listingPerPage
+        ? view.perPage
+        : undefined,
+    ],
+    [
+      'sort_by',
+      view.sort?.field && view.sort.field !== 'name'
+        ? view.sort.field
+        : undefined,
+    ],
+    [
+      'sort_order',
+      view.sort?.direction && view.sort.direction !== 'asc'
+        ? view.sort.direction
+        : undefined,
+    ],
+  ];
+  const path = entries.reduce(
+    (hash, [key, value]) => (value ? `${hash}/${key}[${value}]` : hash),
+    '',
+  );
+  window.history.replaceState(null, '', `#/lists${path}`);
+}
+
+function countForAction(
+  action: SegmentBulkAction,
+  result: SegmentBulkActionResult,
+): number {
+  if (action === 'delete' || action === 'empty_trash') return result.deleted;
+  return result.updated;
+}
+
+function successMessage(
+  action: SegmentBulkAction,
+  count: number,
+  isWPUsers = false,
+): string {
+  if (action === 'trash') {
+    const label = isWPUsers
+      ? __('1 list was moved to the trash.', 'mailpoet')
+      : sprintf(
+          /* translators: %d is the number of lists. */
+          _n(
+            '%d list was moved to the trash.',
+            '%d lists were moved to the trash.',
+            count,
+            'mailpoet',
+          ),
+          count,
+        );
+    return `${label} ${__(
+      'Note that deleting a list does not delete its subscribers.',
+      'mailpoet',
+    )}`;
+  }
+  if (action === 'restore') {
+    return count === 1
+      ? __('1 list has been restored from the Trash.', 'mailpoet')
+      : sprintf(
+          /* translators: %d is the number of lists. */
+          _n(
+            '%d list has been restored from the Trash.',
+            '%d lists have been restored from the Trash.',
+            count,
+            'mailpoet',
+          ),
+          count,
+        );
+  }
+  const label = sprintf(
+    /* translators: %d is the number of lists. */
+    _n(
+      '%d list was permanently deleted.',
+      '%d lists were permanently deleted.',
+      count,
+      'mailpoet',
+    ),
+    count,
+  );
+  return `${label} ${__(
+    'Note that deleting a list does not delete its subscribers.',
+    'mailpoet',
+  )}`;
+}
+
+function confirmCopy(pendingAction: PendingAction): {
+  title: string;
+  message: JSX.Element | string;
+  confirmText: string;
+} {
+  if (!pendingAction) return { title: '', message: '', confirmText: '' };
+  const { action, count } = pendingAction;
+
+  if (action === 'empty_trash') {
+    return {
+      title: __('Empty Trash', 'mailpoet'),
+      message: (
+        <>
+          {sprintf(
+            /* translators: %d is the number of lists. */
+            _n(
+              'Are you sure you want to permanently delete %d list from the Trash?',
+              'Are you sure you want to permanently delete %d lists from the Trash?',
+              count,
+              'mailpoet',
+            ),
+            count,
+          )}{' '}
+          <strong>{__('This action can not be reversed.', 'mailpoet')}</strong>
+        </>
+      ),
+      confirmText: __('Empty Trash', 'mailpoet'),
+    };
+  }
+
+  return {
+    title: _n(
+      'Delete selected list permanently',
+      'Delete selected lists permanently',
+      count,
+      'mailpoet',
+    ),
+    message: (
+      <>
+        {sprintf(
+          /* translators: %d is the number of lists. */
+          _n(
+            'Are you sure you want to permanently delete %d selected list?',
+            'Are you sure you want to permanently delete %d selected lists?',
+            count,
+            'mailpoet',
+          ),
+          count,
+        )}{' '}
+        <strong>{__('This action can not be reversed.', 'mailpoet')}</strong>
+      </>
+    ),
+    confirmText: __('Delete permanently', 'mailpoet'),
   };
-  created_at: string;
-  subscribers_url: string;
-};
+}
 
-const isWPUsersSegment = (segment: Segment) => segment.type === 'wp_users';
-const isWooCommerceCustomersSegment = (segment: Segment) =>
-  segment.type === 'woocommerce_users';
-const isSpecialSegment = (segment: Segment) =>
-  isWPUsersSegment(segment) || isWooCommerceCustomersSegment(segment);
-const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
-
-const columns = [
-  {
-    name: 'name',
-    label: MailPoet.I18n.t('name'),
-    sortable: true,
-  },
-  {
-    name: 'description',
-    label: MailPoet.I18n.t('description'),
-  },
-  {
-    name: 'average_subscriber_score',
-    label: MailPoet.I18n.t('listScore'),
-    display: mailpoetTrackingEnabled,
-  },
-  {
-    name: 'subscribed',
-    label: MailPoet.I18n.t('subscribed'),
-    className: 'mailpoet-listing-column-narrow',
-  },
-  {
-    name: 'unconfirmed',
-    label: MailPoet.I18n.t('unconfirmed'),
-    className: 'mailpoet-listing-column-narrow',
-  },
-  {
-    name: 'unsubscribed',
-    label: MailPoet.I18n.t('unsubscribed'),
-    className: 'mailpoet-listing-column-narrow',
-  },
-  {
-    name: 'inactive',
-    label: MailPoet.I18n.t('inactive'),
-    className: 'mailpoet-listing-column-narrow',
-  },
-  {
-    name: 'bounced',
-    label: MailPoet.I18n.t('bounced'),
-    className: 'mailpoet-listing-column-narrow',
-  },
-  {
-    name: 'created_at',
-    label: MailPoet.I18n.t('createdOn'),
-    sortable: true,
-  },
-];
-
-const messages = {
-  onTrash: (response) => {
-    const count = Number(response.meta.count);
-    let message = null;
-
-    if (count === 1) {
-      message = MailPoet.I18n.t('oneSegmentTrashed');
-    } else {
-      message = MailPoet.I18n.t('multipleSegmentsTrashed').replace(
-        '%1$d',
-        count.toLocaleString(),
-      );
-    }
-    MailPoet.Notice.success(message);
-  },
-  onDelete: (response) => {
-    const count = Number(response.meta.count);
-    let message = null;
-
-    if (count === 1) {
-      message = MailPoet.I18n.t('oneSegmentDeleted');
-    } else {
-      message = MailPoet.I18n.t('multipleSegmentsDeleted').replace(
-        '%1$d',
-        count.toLocaleString(),
-      );
-    }
-    MailPoet.Notice.success(message);
-  },
-  onRestore: (response) => {
-    const count = Number(response.meta.count);
-    let message = null;
-
-    if (count === 1) {
-      message = MailPoet.I18n.t('oneSegmentRestored');
-    } else {
-      message = MailPoet.I18n.t('multipleSegmentsRestored').replace(
-        '%1$d',
-        count.toLocaleString(),
-      );
-    }
-    MailPoet.Notice.success(message);
-  },
-};
-
-const bulkActions = [
-  {
-    name: 'trash',
-    label: MailPoet.I18n.t('moveToTrash'),
-    onSuccess: messages.onTrash,
-  },
-];
-
-const isItemDeletable = (segment: Segment) => {
-  const isDeletable = !isSpecialSegment(segment);
-  return isDeletable;
-};
-
-const itemActions = [
-  {
-    name: 'edit',
-    className: 'mailpoet-hide-on-mobile',
-    link: function link(item: Segment) {
-      return <Link to={`/edit/${item.id}`}>{MailPoet.I18n.t('edit')}</Link>;
+function SegmentListComponent(): JSX.Element {
+  const hashState = parseHash();
+  const [group, setGroup] = useState<Group>(hashState.group ?? 'all');
+  const [selection, setSelection] = useState<string[]>([]);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [initialView] = useState<View>(() => ({
+    ...DEFAULT_VIEW,
+    page: hashState.page ?? DEFAULT_VIEW.page,
+    perPage: hashState.perPage ?? DEFAULT_VIEW.perPage,
+    sort: {
+      field: hashState.orderby ?? DEFAULT_VIEW.sort?.field ?? 'name',
+      direction: hashState.order ?? DEFAULT_VIEW.sort?.direction ?? 'asc',
     },
-    display: function display(segment: Segment) {
-      return !isSpecialSegment(segment);
+  }));
+
+  const load = useCallback(
+    (params: ListingQueryParams) => getSegments({ ...params, group }),
+    [group],
+  );
+
+  const {
+    view,
+    setView,
+    items,
+    meta,
+    groups,
+    isLoading,
+    error: loadError,
+    clearError: clearLoadError,
+    refresh,
+  } = useDataViewsQuery<SegmentListingItem>({
+    initialView,
+    load,
+  });
+
+  useEffect(() => {
+    updateHash(group, view);
+  }, [group, view]);
+
+  const handleBulkAction = useCallback(
+    async (
+      action: SegmentBulkAction,
+      targets: SegmentListingItem[],
+      params?: Partial<ListingQueryParams> & { select_all?: boolean },
+    ) => {
+      const ids = targets.map((segment) => Number(segment.id));
+      if (!params?.select_all && action !== 'empty_trash' && ids.length === 0) {
+        return;
+      }
+
+      try {
+        const result = await bulkAction(action, ids, params);
+        const count = countForAction(action, result);
+        setSelection([]);
+        setGlobalError(
+          result.errors.length
+            ? result.errors.map((error) => error.message).join('\n')
+            : null,
+        );
+        setGlobalSuccess(
+          count > 0
+            ? successMessage(action, count, targets.some(isWPUsersSegment))
+            : null,
+        );
+        if (
+          (action === 'restore' ||
+            action === 'delete' ||
+            action === 'empty_trash') &&
+          group === 'trash'
+        ) {
+          setGroup('all');
+          setView({ ...view, page: 1 });
+        }
+        refresh();
+      } catch (err) {
+        const apiError = err as { message?: string };
+        setGlobalSuccess(null);
+        setGlobalError(
+          apiError?.message ||
+            __('The bulk action could not be completed.', 'mailpoet'),
+        );
+      }
     },
-  },
-  {
-    name: 'duplicate_segment',
-    className: 'mailpoet-hide-on-mobile',
-    label: MailPoet.I18n.t('duplicate'),
-    onClick: (item, refresh) =>
-      MailPoet.Ajax.post({
+    [group, refresh, setView, view],
+  );
+
+  const handleDuplicate = useCallback(
+    (segment: SegmentListingItem) => {
+      void MailPoet.Ajax.post({
         api_version: window.mailpoet_api_version,
         endpoint: 'segments',
         action: 'duplicate',
-        data: {
-          id: item.id,
-        },
+        data: { id: segment.id },
       })
-        .done((response: SegmentResponse) => {
+        .done((response: { data: { name: string } }) => {
           MailPoet.Notice.success(
             MailPoet.I18n.t('listDuplicated').replace(
               '%1$s',
@@ -181,52 +352,31 @@ const itemActions = [
         })
         .fail((response) => {
           MailPoet.Notice.showApiErrorNotice(response, { scroll: true });
-        }),
-    display: function display(segment: Segment) {
-      return !isSpecialSegment(segment);
+        });
     },
-  },
-  {
-    name: 'read_more',
-    className: 'mailpoet-hide-on-mobile',
-    link: function link() {
-      return (
-        <a
-          href="https://kb.mailpoet.com/article/133-the-wordpress-users-list"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {MailPoet.I18n.t('readMore')}
-        </a>
-      );
-    },
-    display: function display(segment: Segment) {
-      return isWPUsersSegment(segment);
-    },
-  },
-  {
-    name: 'synchronize_segment',
-    label: MailPoet.I18n.t('forceSync'),
-    onClick: async function onClick(item: Segment, refresh) {
+    [refresh],
+  );
+
+  const handleSynchronize = useCallback(
+    (segment: SegmentListingItem) => {
       MailPoet.Modal.loading(true);
-      await MailPoet.Ajax.post({
+      void MailPoet.Ajax.post({
         api_version: window.mailpoet_api_version,
         endpoint: 'segments',
         action: 'synchronize',
-        data: {
-          type: item.type,
-        },
+        data: { type: segment.type },
       })
         .done(() => {
-          let message = MailPoet.I18n.t('listSynchronized').replace(
-            '%1$s',
-            item.name,
-          );
-          if (item.type === 'woocommerce_users') {
-            message = MailPoet.I18n.t(
-              'listSynchronizationWasScheduled',
-            ).replace('%1$s', item.name);
-          }
+          const message =
+            segment.type === 'woocommerce_users'
+              ? MailPoet.I18n.t('listSynchronizationWasScheduled').replace(
+                  '%1$s',
+                  segment.name,
+                )
+              : MailPoet.I18n.t('listSynchronized').replace(
+                  '%1$s',
+                  segment.name,
+                );
           MailPoet.Modal.loading(false);
           MailPoet.Notice.success(message);
           refresh();
@@ -238,184 +388,275 @@ const itemActions = [
           }
         });
     },
-    display: function display(segment: Segment) {
-      return (
-        isWPUsersSegment(segment) || isWooCommerceCustomersSegment(segment)
-      );
-    },
-  },
-  {
-    name: 'view_subscribers',
-    link: function link(item: Segment) {
-      return (
-        <a
-          href={item.subscribers_url}
-          data-automation-id={`view_subscribers_${item.name}`}
-        >
-          {MailPoet.I18n.t('viewSubscribers')}
-        </a>
-      );
-    },
-  },
-  {
-    name: 'trash',
-    className: 'mailpoet-hide-on-mobile',
-    display: function display(segment: Segment) {
-      return !isWooCommerceCustomersSegment(segment);
-    },
-  },
-];
+    [refresh],
+  );
 
-type SegmentListComponentProps = {
-  params: Params;
-  location: Location;
-};
+  const actions = useMemo<Action<SegmentListingItem>[]>(
+    () => [
+      {
+        id: 'edit',
+        label: __('Edit', 'mailpoet'),
+        isPrimary: true,
+        supportsBulk: false,
+        isEligible: (item) => !item.deleted_at && !isSpecialSegment(item),
+        callback: (targets) => {
+          const segment = targets[0];
+          if (segment) window.location.hash = `/edit/${segment.id}`;
+        },
+      },
+      {
+        id: 'duplicate',
+        label: MailPoet.I18n.t('duplicate'),
+        supportsBulk: false,
+        isEligible: (item) => !item.deleted_at && !isSpecialSegment(item),
+        callback: (targets) => {
+          if (targets[0]) handleDuplicate(targets[0]);
+        },
+      },
+      {
+        id: 'read_more',
+        label: MailPoet.I18n.t('readMore'),
+        supportsBulk: false,
+        isEligible: (item) => isWPUsersSegment(item),
+        callback: () => {
+          window.open(
+            'https://kb.mailpoet.com/article/133-the-wordpress-users-list',
+            '_blank',
+            'noopener,noreferrer',
+          );
+        },
+      },
+      {
+        id: 'synchronize',
+        label: MailPoet.I18n.t('forceSync'),
+        supportsBulk: false,
+        isEligible: (item) =>
+          isWPUsersSegment(item) || isWooCommerceCustomersSegment(item),
+        callback: (targets) => {
+          if (targets[0]) handleSynchronize(targets[0]);
+        },
+      },
+      {
+        id: 'view_subscribers',
+        label: MailPoet.I18n.t('viewSubscribers'),
+        supportsBulk: false,
+        callback: (targets) => {
+          const segment = targets[0];
+          if (segment) window.location.href = segment.subscribers_url;
+        },
+      },
+      {
+        id: 'trash_wp_users',
+        label: __('Trash and disable', 'mailpoet'),
+        supportsBulk: false,
+        isEligible: (item) => !item.deleted_at && isWPUsersSegment(item),
+        callback: (targets) => {
+          void handleBulkAction('trash', targets);
+        },
+      },
+      {
+        id: 'trash',
+        label: MailPoet.I18n.t('moveToTrash'),
+        supportsBulk: true,
+        isEligible: (item) =>
+          !item.deleted_at &&
+          !isWPUsersSegment(item) &&
+          !isWooCommerceCustomersSegment(item),
+        callback: (targets) => {
+          void handleBulkAction('trash', targets);
+        },
+      },
+      {
+        id: 'restore_wp_users',
+        label: __('Restore and enable', 'mailpoet'),
+        supportsBulk: false,
+        isEligible: (item) => !!item.deleted_at && isWPUsersSegment(item),
+        callback: (targets) => {
+          void handleBulkAction('restore', targets);
+        },
+      },
+      {
+        id: 'restore',
+        label: __('Restore', 'mailpoet'),
+        supportsBulk: true,
+        isEligible: (item) => !!item.deleted_at && !isWPUsersSegment(item),
+        callback: (targets) => {
+          void handleBulkAction('restore', targets);
+        },
+      },
+      {
+        id: 'delete',
+        label: __('Delete permanently', 'mailpoet'),
+        supportsBulk: true,
+        isDestructive: true,
+        isEligible: (item) => !!item.deleted_at && !isSpecialSegment(item),
+        callback: (targets) => {
+          setPendingAction({
+            action: 'delete',
+            targets,
+            count: targets.length,
+          });
+        },
+      },
+    ],
+    [handleBulkAction, handleDuplicate, handleSynchronize],
+  );
 
-class SegmentListComponent extends Component<SegmentListComponentProps> {
-  renderItem = (segment: Segment, actions: ReactNode) => {
-    const rowClasses = classnames(
-      'manage-column',
-      'column-primary',
-      'has-row-actions',
-    );
+  const paginationInfo = useMemo(
+    () => ({ totalItems: meta.count, totalPages: meta.pages }),
+    [meta],
+  );
 
-    const subscribed = Number(segment.subscribers_count.subscribed || 0);
-    const unconfirmed = Number(segment.subscribers_count.unconfirmed || 0);
-    const unsubscribed = Number(segment.subscribers_count.unsubscribed || 0);
-    const inactive = Number(segment.subscribers_count.inactive || 0);
-    const bounced = Number(segment.subscribers_count.bounced || 0);
+  const groupCounts = useMemo(() => {
+    const counts: Record<Group, number | null> = { all: null, trash: null };
+    (groups ?? []).forEach((entry) => {
+      if (entry.name === 'all' || entry.name === 'trash') {
+        counts[entry.name] = entry.count;
+      }
+    });
+    return counts;
+  }, [groups]);
 
-    let segmentName;
+  const tabs = useMemo(() => {
+    const formatTitle = (label: string, count: number | null): string =>
+      count === null ? label : `${label} (${count})`;
+    return [
+      {
+        name: 'all',
+        title: formatTitle(__('All', 'mailpoet'), groupCounts.all),
+        className: 'mailpoet-dataviews-group-all',
+      },
+      ...(group === 'trash' || (groupCounts.trash ?? 0) > 0
+        ? [
+            {
+              name: 'trash',
+              title: formatTitle(__('Trash', 'mailpoet'), groupCounts.trash),
+              className: 'mailpoet-dataviews-group-trash',
+            },
+          ]
+        : []),
+    ];
+  }, [group, groupCounts]);
 
-    const privateLabel =
-      Number(segment.show_in_manage_subscription_page) === 0 ? (
-        <span className="mailpoet-listing-title-private-label">
-          {' '}
-          {MailPoet.I18n.t('privateListLabel')}
-        </span>
-      ) : null;
-
-    if (isSpecialSegment(segment)) {
-      // the WP users and WooCommerce customers segments
-      // are not editable so just display their names
-      segmentName = (
-        <span className="mailpoet-listing-title">
-          {segment.name}
-          {privateLabel}
-        </span>
-      );
-    } else {
-      segmentName = (
-        <Link className="mailpoet-listing-title" to={`/edit/${segment.id}`}>
-          {segment.name}
-          {privateLabel}
-        </Link>
-      );
-    }
-
-    return (
-      <div>
-        <td
-          className={rowClasses}
-          data-automation-id={`segment_name_${escapeAttribute(segment.name)}`}
-        >
-          {segmentName}
-          {actions}
-        </td>
-        <td
-          className="mailpoet-listing-description-column"
-          data-colname={MailPoet.I18n.t('description')}
-        >
-          <abbr>{segment.description}</abbr>
-        </td>
-        {mailpoetTrackingEnabled ? (
-          <td
-            className="column mailpoet-listing-stats-column"
-            data-colname={MailPoet.I18n.t('averageScore')}
-          >
-            <div className="mailpoet-listing-stats">
-              <ListingsEngagementScore
-                id={segment.id}
-                engagementScore={segment.average_engagement_score}
-              />
-            </div>
-          </td>
-        ) : null}
-        <td
-          className="mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('subscribed')}
-        >
-          <abbr>{subscribed.toLocaleString()}</abbr>
-        </td>
-        <td
-          className="mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('unconfirmed')}
-        >
-          <abbr>{unconfirmed.toLocaleString()}</abbr>
-        </td>
-        <td
-          className="mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('unsubscribed')}
-        >
-          <abbr>{unsubscribed.toLocaleString()}</abbr>
-        </td>
-        <td
-          className="mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('inactive')}
-        >
-          <abbr>{inactive.toLocaleString()}</abbr>
-        </td>
-        <td
-          className="mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('bounced')}
-        >
-          <abbr>{bounced.toLocaleString()}</abbr>
-        </td>
-        <td
-          className="column-date mailpoet-hide-on-mobile"
-          data-colname={MailPoet.I18n.t('createdOn')}
-        >
-          {MailPoet.Date.short(segment.created_at)}
-          <br />
-          {MailPoet.Date.time(segment.created_at)}
-        </td>
-      </div>
-    );
+  const handleTabSelect = (tabName: string): void => {
+    if (tabName !== 'all' && tabName !== 'trash') return;
+    if (tabName === group) return;
+    setGroup(tabName);
+    setSelection([]);
+    setGlobalError(null);
+    setGlobalSuccess(null);
+    clearLoadError();
+    setView({ ...view, page: 1 });
   };
 
-  render() {
-    return (
-      <>
-        <HideScreenOptions />
-        <ListHeading />
-        <div className="mailpoet-segments-listing">
-          <Listing
-            limit={window.mailpoet_listing_per_page}
-            location={this.props.location}
-            params={this.props.params}
-            messages={messages}
-            search={false}
-            endpoint="segments"
-            base_url="lists"
-            onRenderItem={this.renderItem}
-            columns={columns}
-            bulk_actions={bulkActions}
-            item_actions={itemActions}
-            sort_by="name"
-            sort_order="asc"
-            isItemDeletable={isItemDeletable}
-            isItemToggleable={isWPUsersSegment}
-          />
-        </div>
-      </>
-    );
-  }
+  const emptyLabel =
+    group === 'trash'
+      ? __('Trash is empty.', 'mailpoet')
+      : __('No lists found.', 'mailpoet');
+  const pendingActionCopy = confirmCopy(pendingAction);
+
+  return (
+    <>
+      <HideScreenOptions />
+      <ListHeading />
+      {loadError && (
+        <Notice status="error" onRemove={clearLoadError}>
+          {loadError}
+        </Notice>
+      )}
+      {globalError && (
+        <Notice status="error" onRemove={() => setGlobalError(null)}>
+          {globalError}
+        </Notice>
+      )}
+      {globalSuccess && (
+        <Notice status="success" onRemove={() => setGlobalSuccess(null)}>
+          {globalSuccess}
+        </Notice>
+      )}
+      <TabPanel
+        key={group}
+        className="mailpoet-segments-dataviews__tabs"
+        activeClass="is-active"
+        tabs={tabs}
+        initialTabName={group}
+        onSelect={handleTabSelect}
+      >
+        {() => (
+          <div
+            className="mailpoet-segments-dataviews mailpoet-segments-listing"
+            data-automation-id="segments_listing"
+          >
+            <DataViews<SegmentListingItem>
+              data={items}
+              fields={segmentFields}
+              view={view}
+              onChangeView={setView}
+              actions={actions}
+              paginationInfo={paginationInfo}
+              defaultLayouts={{ table: {} }}
+              getItemId={(item) => String(item.id)}
+              selection={selection}
+              onChangeSelection={setSelection}
+              isLoading={isLoading}
+              empty={<div>{emptyLabel}</div>}
+            >
+              {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
+                <div className="mailpoet-segments-dataviews__toolbar">
+                  <button
+                    type="button"
+                    className="button"
+                    data-automation-id="empty_trash"
+                    onClick={() => {
+                      setPendingAction({
+                        action: 'empty_trash',
+                        targets: [],
+                        count: groupCounts.trash ?? 0,
+                        params: {
+                          select_all: true,
+                          group: 'trash',
+                          page: view.page ?? 1,
+                          per_page: view.perPage ?? listingPerPage,
+                          orderby: view.sort?.field,
+                          order: view.sort?.direction,
+                        },
+                      });
+                    }}
+                  >
+                    {__('Empty Trash', 'mailpoet')}
+                  </button>
+                </div>
+              )}
+              <DataViews.Layout />
+              <DataViews.Footer />
+            </DataViews>
+          </div>
+        )}
+      </TabPanel>
+      <ConfirmDialog
+        className="mailpoet-confirm-dialog"
+        isOpen={!!pendingAction}
+        title={pendingActionCopy.title}
+        confirmButtonText={pendingActionCopy.confirmText}
+        __experimentalHideHeader={false}
+        onConfirm={() => {
+          if (pendingAction) {
+            void handleBulkAction(
+              pendingAction.action,
+              pendingAction.targets,
+              pendingAction.params,
+            );
+          }
+          setPendingAction(null);
+        }}
+        onCancel={() => setPendingAction(null)}
+      >
+        <p>{pendingActionCopy.message}</p>
+      </ConfirmDialog>
+    </>
+  );
 }
 
-export function SegmentList(props) {
-  const params = useParams();
-  const location = useLocation();
-  return (
-    <SegmentListComponent {...props} params={params} location={location} />
-  );
+export function SegmentList(): JSX.Element {
+  return <SegmentListComponent />;
 }

--- a/mailpoet/changelog/2026-04-28-13-01-00-improved-migrated-lists-and-dynamic-segments-listing-pages-.md
+++ b/mailpoet/changelog/2026-04-28-13-01-00-improved-migrated-lists-and-dynamic-segments-listing-pages-.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Migrated Lists and Dynamic Segments listing pages to DataViews

--- a/mailpoet/lib/API/REST/AbstractListingEndpoint.php
+++ b/mailpoet/lib/API/REST/AbstractListingEndpoint.php
@@ -100,15 +100,24 @@ abstract class AbstractListingEndpoint extends Endpoint {
     return null;
   }
 
-  private function buildDefinition(Request $request): ListingDefinition {
-    $page = is_numeric($request->getParam('page'))
-      ? min(self::MAX_PAGE, max(1, (int)$request->getParam('page')))
-      : 1;
+  protected function getDefaultPerPage(): int {
+    return self::DEFAULT_PER_PAGE;
+  }
 
-    $perPageParam = $request->getParam('per_page');
+  protected function getDefaultParameters(): array {
+    return [];
+  }
+
+  private function buildDefinition(Request $request): ListingDefinition {
+    $perPageParam = $request->getParam('per_page') ?? $request->getParam('limit');
     $perPage = is_numeric($perPageParam)
       ? max(1, min(self::MAX_PER_PAGE, (int)$perPageParam))
-      : self::DEFAULT_PER_PAGE;
+      : $this->getDefaultPerPage();
+
+    $offsetParam = $request->getParam('offset');
+    $page = is_numeric($request->getParam('page'))
+      ? min(self::MAX_PAGE, max(1, (int)$request->getParam('page')))
+      : (is_numeric($offsetParam) ? min(self::MAX_PAGE, max(1, (int)floor((int)$offsetParam / $perPage) + 1)) : 1);
 
     $orderByParam = $request->getParam('orderby');
     $sortBy = is_string($orderByParam) && $orderByParam !== '' ? $orderByParam : $this->getDefaultSortBy();
@@ -133,6 +142,7 @@ abstract class AbstractListingEndpoint extends Endpoint {
       'search' => $search,
       'group' => $group,
       'filter' => $filters,
+      'params' => $this->getDefaultParameters(),
     ]);
   }
 }

--- a/mailpoet/lib/API/REST/AbstractListingEndpoint.php
+++ b/mailpoet/lib/API/REST/AbstractListingEndpoint.php
@@ -69,6 +69,8 @@ abstract class AbstractListingEndpoint extends Endpoint {
       'per_page' => Builder::integer(),
       'orderby' => Builder::string(),
       'order' => Builder::string(),
+      'sort_by' => Builder::string(),
+      'sort_order' => Builder::string(),
       'search' => Builder::string(),
       'group' => Builder::string(),
       'filter' => Builder::object(),
@@ -114,15 +116,16 @@ abstract class AbstractListingEndpoint extends Endpoint {
       ? max(1, min(self::MAX_PER_PAGE, (int)$perPageParam))
       : $this->getDefaultPerPage();
 
+    $pageParam = $request->getParam('page');
     $offsetParam = $request->getParam('offset');
-    $page = is_numeric($request->getParam('page'))
-      ? min(self::MAX_PAGE, max(1, (int)$request->getParam('page')))
-      : (is_numeric($offsetParam) ? min(self::MAX_PAGE, max(1, (int)floor((int)$offsetParam / $perPage) + 1)) : 1);
+    $offset = is_numeric($pageParam)
+      ? (min(self::MAX_PAGE, max(1, (int)$pageParam)) - 1) * $perPage
+      : (is_numeric($offsetParam) ? (int)$offsetParam : 0);
 
-    $orderByParam = $request->getParam('orderby');
+    $orderByParam = $request->getParam('orderby') ?? $request->getParam('sort_by');
     $sortBy = is_string($orderByParam) && $orderByParam !== '' ? $orderByParam : $this->getDefaultSortBy();
 
-    $orderParam = $request->getParam('order');
+    $orderParam = $request->getParam('order') ?? $request->getParam('sort_order');
     $sortOrder = is_string($orderParam) ? strtolower($orderParam) : $this->getDefaultSortOrder();
 
     $searchParam = $request->getParam('search');
@@ -135,7 +138,7 @@ abstract class AbstractListingEndpoint extends Endpoint {
     $filters = is_array($filterParam) ? $filterParam : [];
 
     return $this->listingHandler->getListingDefinition([
-      'offset' => ($page - 1) * $perPage,
+      'offset' => $offset,
       'limit' => $perPage,
       'sort_by' => $sortBy,
       'sort_order' => $sortOrder,

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -216,6 +216,11 @@ class DynamicSegments {
     }, $this->automationStorage->getAutomations());
 
     $this->assetsController->setupDynamicSegmentsDependencies();
+    $this->assetsController->setupDataViewsDependencies();
+    $data['api'] = [
+      'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+      'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+    ];
     $this->pageRenderer->displayPage('segments/dynamic.html', $data);
   }
 

--- a/mailpoet/lib/AdminPages/Pages/StaticSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/StaticSegments.php
@@ -2,30 +2,48 @@
 
 namespace MailPoet\AdminPages\Pages;
 
+use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Listing\PageLimit;
+use MailPoet\WP\Functions as WPFunctions;
 
 class StaticSegments {
+  /** @var AssetsController */
+  private $assetsController;
+
   /** @var PageRenderer */
   private $pageRenderer;
 
   /** @var PageLimit */
   private $listingPageLimit;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
+    AssetsController $assetsController,
     PageRenderer $pageRenderer,
-    PageLimit $listingPageLimit
+    PageLimit $listingPageLimit,
+    WPFunctions $wp
   ) {
+    $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
+    $this->wp = $wp;
   }
 
   /**
    * @return void
    */
   public function render() {
+    $this->assetsController->setupDataViewsDependencies();
+
     $data = [];
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('segments');
+    $data['api'] = [
+      'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+      'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+    ];
 
     $this->pageRenderer->displayPage('segments/static.html', $data);
   }

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -23,6 +23,7 @@ use MailPoet\Migrator\Cli as MigratorCli;
 use MailPoet\PostEditorBlocks\PostEditorBlock;
 use MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration;
 use MailPoet\Router;
+use MailPoet\Segments\RestApi\Api as SegmentsRestApi;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\SubscriberActivityTracker;
 use MailPoet\Tags\RestApi\Api as TagsRestApi;
@@ -117,6 +118,9 @@ class Initializer {
   /** @var FormsRestApi */
   private $formsRestApi;
 
+  /** @var SegmentsRestApi */
+  private $segmentsRestApi;
+
   /** @var MailPoetIntegration */
   private $automationMailPoetIntegration;
 
@@ -179,7 +183,8 @@ class Initializer {
     MailpoetEmailEditorIntegration $mailpoetEmailEditorIntegration,
     Url $urlHelper,
     TagsRestApi $tagsRestApi,
-    FormsRestApi $formsRestApi
+    FormsRestApi $formsRestApi,
+    SegmentsRestApi $segmentsRestApi
   ) {
     $this->rendererFactory = $rendererFactory;
     $this->accessControl = $accessControl;
@@ -214,6 +219,7 @@ class Initializer {
     $this->urlHelper = $urlHelper;
     $this->tagsRestApi = $tagsRestApi;
     $this->formsRestApi = $formsRestApi;
+    $this->segmentsRestApi = $segmentsRestApi;
 
     $emailEditorContainer = Email_Editor_Container::container();
     $this->emailEditorBootstrap = $emailEditorContainer->get(EmailEditorBootstrap::class);
@@ -382,6 +388,7 @@ class Initializer {
       $this->automationEngine->initialize();
       $this->tagsRestApi->initialize();
       $this->formsRestApi->initialize();
+      $this->segmentsRestApi->initialize();
       $this->blockTypesController->initialize();
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -708,6 +708,12 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Form\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\RestApi\Endpoints\FormsListingEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\RestApi\Endpoints\FormsBulkActionEndpoint::class)->setPublic(true);
+    // Segments REST API
+    $container->autowire(\MailPoet\Segments\RestApi\Api::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\RestApi\Endpoints\SegmentsListingEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\RestApi\Endpoints\SegmentsBulkActionEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\RestApi\Endpoints\DynamicSegmentsListingEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\RestApi\Endpoints\DynamicSegmentsBulkActionEndpoint::class)->setPublic(true);
     // CAPTCHA
     $container->autowire(\MailPoet\Captcha\ReCaptchaHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\Captcha\ReCaptchaValidator::class)->setPublic(true);

--- a/mailpoet/lib/Segments/RestApi/Api.php
+++ b/mailpoet/lib/Segments/RestApi/Api.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi;
+
+use MailPoet\API\REST\API as RestApi;
+use MailPoet\Segments\RestApi\Endpoints\DynamicSegmentsBulkActionEndpoint;
+use MailPoet\Segments\RestApi\Endpoints\DynamicSegmentsListingEndpoint;
+use MailPoet\Segments\RestApi\Endpoints\SegmentsBulkActionEndpoint;
+use MailPoet\Segments\RestApi\Endpoints\SegmentsListingEndpoint;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Api {
+  /** @var RestApi */
+  private $api;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    RestApi $api,
+    WPFunctions $wp
+  ) {
+    $this->api = $api;
+    $this->wp = $wp;
+  }
+
+  public function initialize(): void {
+    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
+      $this->api->registerGetRoute('segments', SegmentsListingEndpoint::class);
+      $this->api->registerPostRoute('segments/bulk-action', SegmentsBulkActionEndpoint::class);
+      $this->api->registerGetRoute('dynamic-segments', DynamicSegmentsListingEndpoint::class);
+      $this->api->registerPostRoute('dynamic-segments/bulk-action', DynamicSegmentsBulkActionEndpoint::class);
+    });
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/AbstractSegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/AbstractSegmentsListingEndpoint.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\REST\AbstractListingEndpoint;
+use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Validator\Builder;
+
+abstract class AbstractSegmentsListingEndpoint extends AbstractListingEndpoint {
+  use SegmentRequestValidationTrait;
+
+  /** @var string[] */
+  private $allowedSortFields;
+
+  /** @var int */
+  private $defaultPerPage;
+
+  /**
+   * @param string[] $allowedSortFields
+   */
+  public function __construct(
+    ListingHandler $listingHandler,
+    array $allowedSortFields,
+    int $defaultPerPage
+  ) {
+    parent::__construct($listingHandler);
+    $this->allowedSortFields = $allowedSortFields;
+    $this->defaultPerPage = $defaultPerPage;
+  }
+
+  public function handle(Request $request): Response {
+    $this->validateListingRequest($request);
+    return parent::handle($request);
+  }
+
+  public static function getRequestSchema(): array {
+    $schema = parent::getRequestSchema();
+    $schema['limit'] = Builder::integer();
+    $schema['offset'] = Builder::integer();
+    return $schema;
+  }
+
+  abstract protected function allowsSearch(): bool;
+
+  protected function getDefaultGroup(): ?string {
+    return 'all';
+  }
+
+  protected function validateListingRequest(Request $request): void {
+    $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
+    $this->validateOrder(is_string($request->getParam('order')) ? (string)$request->getParam('order') : null, $this->getDefaultSortOrder());
+
+    $orderby = is_string($request->getParam('orderby')) && $request->getParam('orderby') !== ''
+      ? (string)$request->getParam('orderby')
+      : $this->getDefaultSortBy();
+    if (!in_array($orderby, $this->allowedSortFields, true)) {
+      throw new ApiException(
+        sprintf(
+          // translators: %s is the list of supported sort fields.
+          __('Unsupported sort field. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', $this->allowedSortFields)
+        ),
+        400,
+        'mailpoet_segments_invalid_orderby'
+      );
+    }
+
+    $this->validatePage($request->getParam('page'));
+    $this->validateOffset($request->getParam('offset'));
+    $this->validatePerPage($request->getParam('per_page') ?? $request->getParam('limit'), $this->defaultPerPage);
+
+    if (!$this->allowsSearch() && is_string($request->getParam('search')) && trim((string)$request->getParam('search')) !== '') {
+      throw new ApiException(
+        __('Search is not supported for this listing.', 'mailpoet'),
+        400,
+        'mailpoet_segments_search_not_supported'
+      );
+    }
+  }
+
+  protected function getDefaultPerPage(): int {
+    return $this->defaultPerPage;
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/AbstractSegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/AbstractSegmentsListingEndpoint.php
@@ -40,6 +40,8 @@ abstract class AbstractSegmentsListingEndpoint extends AbstractListingEndpoint {
     $schema = parent::getRequestSchema();
     $schema['limit'] = Builder::integer();
     $schema['offset'] = Builder::integer();
+    $schema['sort_by'] = Builder::string();
+    $schema['sort_order'] = Builder::string();
     return $schema;
   }
 
@@ -51,10 +53,12 @@ abstract class AbstractSegmentsListingEndpoint extends AbstractListingEndpoint {
 
   protected function validateListingRequest(Request $request): void {
     $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
-    $this->validateOrder(is_string($request->getParam('order')) ? (string)$request->getParam('order') : null, $this->getDefaultSortOrder());
+    $orderParam = $request->getParam('order') ?? $request->getParam('sort_order');
+    $this->validateOrder(is_string($orderParam) ? (string)$orderParam : null, $this->getDefaultSortOrder());
 
-    $orderby = is_string($request->getParam('orderby')) && $request->getParam('orderby') !== ''
-      ? (string)$request->getParam('orderby')
+    $orderbyParam = $request->getParam('orderby') ?? $request->getParam('sort_by');
+    $orderby = is_string($orderbyParam) && $orderbyParam !== ''
+      ? (string)$orderbyParam
       : $this->getDefaultSortBy();
     if (!in_array($orderby, $this->allowedSortFields, true)) {
       throw new ApiException(

--- a/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsBulkActionEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsBulkActionEndpoint.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Validator\Builder;
+
+class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
+  private const ACTION_TRASH = 'trash';
+  private const ACTION_RESTORE = 'restore';
+  private const ACTION_DELETE = 'delete';
+
+  private const SUPPORTED_ACTIONS = [
+    self::ACTION_TRASH,
+    self::ACTION_RESTORE,
+    self::ACTION_DELETE,
+  ];
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var NewsletterSegmentRepository */
+  private $newsletterSegmentRepository;
+
+  public function __construct(
+    SegmentsRepository $segmentsRepository,
+    NewsletterSegmentRepository $newsletterSegmentRepository
+  ) {
+    $this->segmentsRepository = $segmentsRepository;
+    $this->newsletterSegmentRepository = $newsletterSegmentRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $action = $this->validateAction($request);
+    $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
+    $this->validateOrder(is_string($request->getParam('order')) ? (string)$request->getParam('order') : null, 'desc');
+    $this->validatePage($request->getParam('page'));
+    $this->validatePerPage($request->getParam('per_page'), 25);
+    $orderby = is_string($request->getParam('orderby')) && $request->getParam('orderby') !== ''
+      ? (string)$request->getParam('orderby')
+      : 'updated_at';
+    $allowedSortFields = ['name', 'created_at', 'updated_at'];
+    if (!in_array($orderby, $allowedSortFields, true)) {
+      throw new ApiException(
+        sprintf(
+          // translators: %s is the list of supported sort fields.
+          __('Unsupported sort field. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', $allowedSortFields)
+        ),
+        400,
+        'mailpoet_segments_invalid_orderby'
+      );
+    }
+    $ids = $this->validateIds($request->getParam('ids'));
+
+    $result = [
+      'updated' => 0,
+      'deleted' => 0,
+      'skipped' => 0,
+      'errors' => [],
+    ];
+
+    if ($action === self::ACTION_TRASH) {
+      $this->trashSegments($ids, $result);
+    } elseif ($action === self::ACTION_RESTORE) {
+      $result['updated'] = $this->segmentsRepository->bulkRestore($this->getDynamicIds($ids, $result), SegmentEntity::TYPE_DYNAMIC);
+    } else {
+      $result['deleted'] = $this->segmentsRepository->bulkDelete($this->getDynamicIds($ids, $result), SegmentEntity::TYPE_DYNAMIC);
+    }
+
+    return new Response($result);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'action' => Builder::string()->required(),
+      'ids' => Builder::array(Builder::integer())->required(),
+      'group' => Builder::string(),
+      'page' => Builder::integer(),
+      'per_page' => Builder::integer(),
+      'orderby' => Builder::string(),
+      'order' => Builder::string(),
+    ];
+  }
+
+  private function validateAction(Request $request): string {
+    $action = is_string($request->getParam('action')) ? (string)$request->getParam('action') : '';
+    if (!in_array($action, self::SUPPORTED_ACTIONS, true)) {
+      throw new ApiException(
+        sprintf(
+          // translators: %s is the list of supported bulk actions.
+          __('Unsupported bulk action. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', self::SUPPORTED_ACTIONS)
+        ),
+        400,
+        'mailpoet_dynamic_segments_invalid_bulk_action'
+      );
+    }
+    return $action;
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function trashSegments(array $ids, array &$result): void {
+    $newsletterBlockers = $this->newsletterSegmentRepository->getSubjectsOfActivelyUsedEmailsForSegments($ids);
+    $trashIds = [];
+    foreach ($this->getDynamicIds($ids, $result) as $id) {
+      if (isset($newsletterBlockers[$id])) {
+        $segment = $this->segmentsRepository->findOneById($id);
+        $this->skip($result, $id, sprintf(
+          // translators: %1$s is the name of the segment, %2$s is a comma-separated list of emails for which the segment is used.
+          _x('Segment \'%1$s\' cannot be deleted because it’s used for \'%2$s\' email', 'Alert shown when trying to delete segment, which is assigned to any automatic emails.', 'mailpoet'),
+          $segment instanceof SegmentEntity ? $segment->getName() : (string)$id,
+          join("', '", $newsletterBlockers[$id])
+        ));
+        continue;
+      }
+      $trashIds[] = $id;
+    }
+    $result['updated'] = $this->segmentsRepository->bulkTrash($trashIds, SegmentEntity::TYPE_DYNAMIC);
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   * @return int[]
+   */
+  private function getDynamicIds(array $ids, array &$result): array {
+    $dynamicIds = [];
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if (!$segment instanceof SegmentEntity) {
+        $this->skip($result, $id, __('This segment does not exist.', 'mailpoet'));
+        continue;
+      }
+      if ($segment->getType() !== SegmentEntity::TYPE_DYNAMIC) {
+        $this->skip($result, $id, __('This segment action only supports dynamic segments.', 'mailpoet'));
+        continue;
+      }
+      $dynamicIds[] = $id;
+    }
+    return $dynamicIds;
+  }
+
+  /**
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function skip(array &$result, ?int $id, string $message): void {
+    $result['skipped']++;
+    $result['errors'][] = [
+      'id' => $id,
+      'message' => $message,
+    ];
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsBulkActionEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsBulkActionEndpoint.php
@@ -6,7 +6,9 @@ use MailPoet\API\REST\ApiException;
 use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Listing\Handler as ListingHandler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
+use MailPoet\Segments\DynamicSegments\DynamicSegmentsListingRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Validator\Builder;
 
@@ -24,13 +26,23 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
   /** @var SegmentsRepository */
   private $segmentsRepository;
 
+  /** @var ListingHandler */
+  private $listingHandler;
+
+  /** @var DynamicSegmentsListingRepository */
+  private $dynamicSegmentsListingRepository;
+
   /** @var NewsletterSegmentRepository */
   private $newsletterSegmentRepository;
 
   public function __construct(
+    ListingHandler $listingHandler,
+    DynamicSegmentsListingRepository $dynamicSegmentsListingRepository,
     SegmentsRepository $segmentsRepository,
     NewsletterSegmentRepository $newsletterSegmentRepository
   ) {
+    $this->listingHandler = $listingHandler;
+    $this->dynamicSegmentsListingRepository = $dynamicSegmentsListingRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->newsletterSegmentRepository = $newsletterSegmentRepository;
   }
@@ -38,11 +50,14 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
   public function handle(Request $request): Response {
     $action = $this->validateAction($request);
     $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
-    $this->validateOrder(is_string($request->getParam('order')) ? (string)$request->getParam('order') : null, 'desc');
+    $orderParam = $request->getParam('order') ?? $request->getParam('sort_order');
+    $this->validateOrder(is_string($orderParam) ? (string)$orderParam : null, 'desc');
     $this->validatePage($request->getParam('page'));
-    $this->validatePerPage($request->getParam('per_page'), 25);
-    $orderby = is_string($request->getParam('orderby')) && $request->getParam('orderby') !== ''
-      ? (string)$request->getParam('orderby')
+    $this->validateOffset($request->getParam('offset'));
+    $this->validatePerPage($request->getParam('per_page') ?? $request->getParam('limit'), 25);
+    $orderbyParam = $request->getParam('orderby') ?? $request->getParam('sort_by');
+    $orderby = is_string($orderbyParam) && $orderbyParam !== ''
+      ? (string)$orderbyParam
       : 'updated_at';
     $allowedSortFields = ['name', 'created_at', 'updated_at'];
     if (!in_array($orderby, $allowedSortFields, true)) {
@@ -56,7 +71,11 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
         'mailpoet_segments_invalid_orderby'
       );
     }
-    $ids = $this->validateIds($request->getParam('ids'));
+    $ids = $this->getSelectedIds($request, $orderby, is_string($orderParam) ? strtolower($orderParam) : 'desc');
+    $this->validateDynamicSelection($ids);
+    if ($action === self::ACTION_DELETE) {
+      $this->validateDeletionSelection($ids);
+    }
 
     $result = [
       'updated' => 0,
@@ -68,9 +87,9 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
     if ($action === self::ACTION_TRASH) {
       $this->trashSegments($ids, $result);
     } elseif ($action === self::ACTION_RESTORE) {
-      $result['updated'] = $this->segmentsRepository->bulkRestore($this->getDynamicIds($ids, $result), SegmentEntity::TYPE_DYNAMIC);
+      $result['updated'] = $this->segmentsRepository->bulkRestore($ids, SegmentEntity::TYPE_DYNAMIC);
     } else {
-      $result['deleted'] = $this->segmentsRepository->bulkDelete($this->getDynamicIds($ids, $result), SegmentEntity::TYPE_DYNAMIC);
+      $result['deleted'] = $this->segmentsRepository->bulkDelete($ids, SegmentEntity::TYPE_DYNAMIC);
     }
 
     return new Response($result);
@@ -79,12 +98,18 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
   public static function getRequestSchema(): array {
     return [
       'action' => Builder::string()->required(),
-      'ids' => Builder::array(Builder::integer())->required(),
+      'ids' => Builder::array(Builder::integer()),
+      'select_all' => Builder::boolean(),
       'group' => Builder::string(),
+      'search' => Builder::string(),
       'page' => Builder::integer(),
       'per_page' => Builder::integer(),
+      'limit' => Builder::integer(),
+      'offset' => Builder::integer(),
       'orderby' => Builder::string(),
       'order' => Builder::string(),
+      'sort_by' => Builder::string(),
+      'sort_order' => Builder::string(),
     ];
   }
 
@@ -105,13 +130,40 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
   }
 
   /**
+   * @return int[]
+   */
+  private function getSelectedIds(Request $request, string $sortBy, string $sortOrder): array {
+    if ($request->getParam('select_all') !== true) {
+      return $this->validateIds($request->getParam('ids'));
+    }
+
+    $definition = $this->listingHandler->getListingDefinition([
+      'group' => $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null),
+      'search' => is_string($request->getParam('search')) ? (string)$request->getParam('search') : null,
+      'sort_by' => $sortBy,
+      'sort_order' => $sortOrder,
+      'params' => ['segments'],
+    ]);
+    $ids = $this->dynamicSegmentsListingRepository->getActionableIds($definition);
+    $ids = array_map('intval', $ids);
+    if ($ids === []) {
+      throw new ApiException(
+        __('At least one segment id is required.', 'mailpoet'),
+        400,
+        'mailpoet_segments_ids_required'
+      );
+    }
+    return $ids;
+  }
+
+  /**
    * @param int[] $ids
    * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
    */
   private function trashSegments(array $ids, array &$result): void {
     $newsletterBlockers = $this->newsletterSegmentRepository->getSubjectsOfActivelyUsedEmailsForSegments($ids);
     $trashIds = [];
-    foreach ($this->getDynamicIds($ids, $result) as $id) {
+    foreach ($ids as $id) {
       if (isset($newsletterBlockers[$id])) {
         $segment = $this->segmentsRepository->findOneById($id);
         $this->skip($result, $id, sprintf(
@@ -129,24 +181,41 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
 
   /**
    * @param int[] $ids
-   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
-   * @return int[]
    */
-  private function getDynamicIds(array $ids, array &$result): array {
-    $dynamicIds = [];
+  private function validateDynamicSelection(array $ids): void {
     foreach ($ids as $id) {
       $segment = $this->segmentsRepository->findOneById($id);
       if (!$segment instanceof SegmentEntity) {
-        $this->skip($result, $id, __('This segment does not exist.', 'mailpoet'));
-        continue;
+        throw new ApiException(
+          __('One or more selected dynamic segments were not found.', 'mailpoet'),
+          400,
+          'mailpoet_dynamic_segments_not_found'
+        );
       }
       if ($segment->getType() !== SegmentEntity::TYPE_DYNAMIC) {
-        $this->skip($result, $id, __('This segment action only supports dynamic segments.', 'mailpoet'));
-        continue;
+        throw new ApiException(
+          __('This endpoint only supports dynamic segments.', 'mailpoet'),
+          400,
+          'mailpoet_dynamic_segments_invalid_type'
+        );
       }
-      $dynamicIds[] = $id;
     }
-    return $dynamicIds;
+  }
+
+  /**
+   * @param int[] $ids
+   */
+  private function validateDeletionSelection(array $ids): void {
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if ($segment instanceof SegmentEntity && $segment->getDeletedAt() === null) {
+        throw new ApiException(
+          __('Only dynamic segments in the trash can be permanently deleted.', 'mailpoet'),
+          400,
+          'mailpoet_dynamic_segments_delete_requires_trash'
+        );
+      }
+    }
   }
 
   /**

--- a/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsListingEndpoint.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\JSON\ResponseBuilders\DynamicSegmentsResponseBuilder;
+use MailPoet\Config\AccessControl;
+use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Listing\ListingRepository;
+use MailPoet\Segments\DynamicSegments\DynamicSegmentsListingRepository;
+use MailPoet\WP\Functions as WPFunctions;
+
+class DynamicSegmentsListingEndpoint extends AbstractSegmentsListingEndpoint {
+  /** @var DynamicSegmentsListingRepository */
+  private $dynamicSegmentsListingRepository;
+
+  /** @var DynamicSegmentsResponseBuilder */
+  private $dynamicSegmentsResponseBuilder;
+
+  public function __construct(
+    ListingHandler $listingHandler,
+    DynamicSegmentsListingRepository $dynamicSegmentsListingRepository,
+    DynamicSegmentsResponseBuilder $dynamicSegmentsResponseBuilder
+  ) {
+    parent::__construct($listingHandler, [
+      'name',
+      'created_at',
+      'updated_at',
+    ], 25);
+    $this->dynamicSegmentsListingRepository = $dynamicSegmentsListingRepository;
+    $this->dynamicSegmentsResponseBuilder = $dynamicSegmentsResponseBuilder;
+  }
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_SEGMENTS);
+  }
+
+  protected function getListingRepository(): ListingRepository {
+    return $this->dynamicSegmentsListingRepository;
+  }
+
+  protected function buildItems(array $rows): array {
+    return $this->dynamicSegmentsResponseBuilder->buildForListing($rows);
+  }
+
+  protected function getDefaultSortBy(): string {
+    return 'updated_at';
+  }
+
+  protected function getDefaultSortOrder(): string {
+    return 'desc';
+  }
+
+  protected function allowsSearch(): bool {
+    return true;
+  }
+
+  protected function getDefaultParameters(): array {
+    return ['segments'];
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentRequestValidationTrait.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentRequestValidationTrait.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\REST\ApiException;
+
+trait SegmentRequestValidationTrait {
+  protected function validateGroup(?string $group): string {
+    $group = $group ?: 'all';
+    if (!in_array($group, ['all', 'trash'], true)) {
+      throw new ApiException(
+        __('Unsupported group. Allowed values are: all, trash.', 'mailpoet'),
+        400,
+        'mailpoet_segments_invalid_group'
+      );
+    }
+    return $group;
+  }
+
+  protected function validateOrder(?string $order, string $default): string {
+    $order = strtolower($order ?: $default);
+    if (!in_array($order, ['asc', 'desc'], true)) {
+      throw new ApiException(
+        __('Unsupported sort order. Allowed values are: asc, desc.', 'mailpoet'),
+        400,
+        'mailpoet_segments_invalid_order'
+      );
+    }
+    return $order;
+  }
+
+  protected function validatePage($page): int {
+    if ($page === null || $page === '') {
+      return 1;
+    }
+    if (!is_numeric($page) || (string)(int)$page !== (string)$page || (int)$page < 1 || (int)$page > 100000) {
+      throw new ApiException(
+        __('Page must be a positive integer.', 'mailpoet'),
+        400,
+        'mailpoet_segments_invalid_page'
+      );
+    }
+    return (int)$page;
+  }
+
+  protected function validatePerPage($perPage, int $default): int {
+    if ($perPage === null || $perPage === '') {
+      return $default;
+    }
+    if (!is_numeric($perPage) || (string)(int)$perPage !== (string)$perPage || (int)$perPage < 1 || (int)$perPage > 100) {
+      throw new ApiException(
+        sprintf(
+          // translators: %d is maximum items per page.
+          __('Per page must be a positive integer no greater than %d.', 'mailpoet'),
+          100
+        ),
+        400,
+        'mailpoet_segments_invalid_per_page'
+      );
+    }
+    return (int)$perPage;
+  }
+
+  protected function validateOffset($offset): int {
+    if ($offset === null || $offset === '') {
+      return 0;
+    }
+    if (!is_numeric($offset) || (string)(int)$offset !== (string)$offset || (int)$offset < 0) {
+      throw new ApiException(
+        __('Offset must be a non-negative integer.', 'mailpoet'),
+        400,
+        'mailpoet_segments_invalid_offset'
+      );
+    }
+    return (int)$offset;
+  }
+
+  /**
+   * @param mixed $ids
+   * @return int[]
+   */
+  protected function validateIds($ids): array {
+    if (!is_array($ids) || $ids === []) {
+      throw new ApiException(
+        __('At least one segment id is required.', 'mailpoet'),
+        400,
+        'mailpoet_segments_ids_required'
+      );
+    }
+
+    $validIds = [];
+    foreach ($ids as $id) {
+      if (!is_int($id) && !(is_string($id) && ctype_digit($id))) {
+        throw new ApiException(
+          __('Segment ids must be positive integers.', 'mailpoet'),
+          400,
+          'mailpoet_segments_invalid_ids'
+        );
+      }
+      $id = (int)$id;
+      if ($id < 1) {
+        throw new ApiException(
+          __('Segment ids must be positive integers.', 'mailpoet'),
+          400,
+          'mailpoet_segments_invalid_ids'
+        );
+      }
+      $validIds[] = $id;
+    }
+
+    return array_values(array_unique($validIds));
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentRequestValidationTrait.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentRequestValidationTrait.php
@@ -65,9 +65,14 @@ trait SegmentRequestValidationTrait {
     if ($offset === null || $offset === '') {
       return 0;
     }
-    if (!is_numeric($offset) || (string)(int)$offset !== (string)$offset || (int)$offset < 0) {
+    if (
+      !is_numeric($offset)
+      || (string)(int)$offset !== (string)$offset
+      || (int)$offset < 0
+      || (int)$offset > 100000
+    ) {
       throw new ApiException(
-        __('Offset must be a non-negative integer.', 'mailpoet'),
+        __('Offset must be a non-negative integer no greater than 100000.', 'mailpoet'),
         400,
         'mailpoet_segments_invalid_offset'
       );

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsBulkActionEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsBulkActionEndpoint.php
@@ -1,0 +1,277 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Form\FormsRepository;
+use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
+use MailPoet\Segments\SegmentListingRepository;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Validator\Builder;
+
+class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
+  private const ACTION_TRASH = 'trash';
+  private const ACTION_RESTORE = 'restore';
+  private const ACTION_DELETE = 'delete';
+  private const ACTION_EMPTY_TRASH = 'empty_trash';
+
+  private const SUPPORTED_ACTIONS = [
+    self::ACTION_TRASH,
+    self::ACTION_RESTORE,
+    self::ACTION_DELETE,
+    self::ACTION_EMPTY_TRASH,
+  ];
+
+  /** @var ListingHandler */
+  private $listingHandler;
+
+  /** @var SegmentListingRepository */
+  private $segmentListingRepository;
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var NewsletterSegmentRepository */
+  private $newsletterSegmentRepository;
+
+  /** @var FormsRepository */
+  private $formsRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  public function __construct(
+    ListingHandler $listingHandler,
+    SegmentListingRepository $segmentListingRepository,
+    SegmentsRepository $segmentsRepository,
+    NewsletterSegmentRepository $newsletterSegmentRepository,
+    FormsRepository $formsRepository,
+    SubscribersRepository $subscribersRepository
+  ) {
+    $this->listingHandler = $listingHandler;
+    $this->segmentListingRepository = $segmentListingRepository;
+    $this->segmentsRepository = $segmentsRepository;
+    $this->newsletterSegmentRepository = $newsletterSegmentRepository;
+    $this->formsRepository = $formsRepository;
+    $this->subscribersRepository = $subscribersRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $action = $this->validateAction($request);
+    $this->validateListingParams($request);
+    $ids = $this->getSelectedIds($request, $action);
+
+    $result = [
+      'updated' => 0,
+      'deleted' => 0,
+      'skipped' => 0,
+      'errors' => [],
+    ];
+
+    if ($action === self::ACTION_TRASH) {
+      $this->trashSegments($ids, $result);
+    } elseif ($action === self::ACTION_RESTORE) {
+      $this->restoreSegments($ids, $result);
+    } else {
+      $this->deleteSegments($ids, $result);
+    }
+
+    return new Response($result);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'action' => Builder::string()->required(),
+      'ids' => Builder::array(Builder::integer()),
+      'select_all' => Builder::boolean(),
+      'group' => Builder::string(),
+      'page' => Builder::integer(),
+      'per_page' => Builder::integer(),
+      'orderby' => Builder::string(),
+      'order' => Builder::string(),
+    ];
+  }
+
+  private function validateAction(Request $request): string {
+    $action = is_string($request->getParam('action')) ? (string)$request->getParam('action') : '';
+    if (!in_array($action, self::SUPPORTED_ACTIONS, true)) {
+      throw new ApiException(
+        sprintf(
+          // translators: %s is the list of supported bulk actions.
+          __('Unsupported bulk action. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', self::SUPPORTED_ACTIONS)
+        ),
+        400,
+        'mailpoet_segments_invalid_bulk_action'
+      );
+    }
+    return $action;
+  }
+
+  private function validateListingParams(Request $request): void {
+    $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
+    $this->validateOrder(is_string($request->getParam('order')) ? (string)$request->getParam('order') : null, 'asc');
+    $this->validatePage($request->getParam('page'));
+    $this->validatePerPage($request->getParam('per_page'), 20);
+
+    $orderby = is_string($request->getParam('orderby')) && $request->getParam('orderby') !== ''
+      ? (string)$request->getParam('orderby')
+      : 'name';
+    $allowedSortFields = ['name', 'created_at', 'updated_at', 'average_engagement_score'];
+    if (!in_array($orderby, $allowedSortFields, true)) {
+      throw new ApiException(
+        sprintf(
+          // translators: %s is the list of supported sort fields.
+          __('Unsupported sort field. Allowed values are: %s.', 'mailpoet'),
+          implode(', ', $allowedSortFields)
+        ),
+        400,
+        'mailpoet_segments_invalid_orderby'
+      );
+    }
+  }
+
+  /**
+   * @return int[]
+   */
+  private function getSelectedIds(Request $request, string $action): array {
+    if ($action === self::ACTION_EMPTY_TRASH) {
+      return $this->getAllMatchingIds('trash');
+    }
+
+    if ($request->getParam('select_all') === true) {
+      $group = $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
+      return $this->getAllMatchingIds($group);
+    }
+
+    return $this->validateIds($request->getParam('ids'));
+  }
+
+  /**
+   * @return int[]
+   */
+  private function getAllMatchingIds(string $group): array {
+    $definition = $this->listingHandler->getListingDefinition([
+      'group' => $group,
+      'sort_by' => 'name',
+      'sort_order' => 'asc',
+      'params' => ['lists'],
+    ]);
+    $ids = $this->segmentListingRepository->getActionableIds($definition);
+    return array_map('intval', $ids);
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function trashSegments(array $ids, array &$result): void {
+    $newsletterBlockers = $this->newsletterSegmentRepository->getSubjectsOfActivelyUsedEmailsForSegments($ids);
+    $formBlockers = $this->formsRepository->getNamesOfFormsForSegments();
+
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if (!$segment instanceof SegmentEntity) {
+        $this->skip($result, $id, __('This list does not exist.', 'mailpoet'));
+        continue;
+      }
+      if (!in_array($segment->getType(), [SegmentEntity::TYPE_DEFAULT, SegmentEntity::TYPE_WP_USERS], true)) {
+        $this->skip($result, $id, __('This list cannot be moved to trash.', 'mailpoet'));
+        continue;
+      }
+      if (isset($newsletterBlockers[$id])) {
+        $this->skip($result, $id, str_replace(
+          '%1$s',
+          "'" . join("', '", $newsletterBlockers[$id]) . "'",
+          // translators: %1$s is a comma-separated list of emails for which the segment is used.
+          _x('List cannot be deleted because it’s used for %1$s email', 'Alert shown when trying to delete segment, which is assigned to any automatic emails.', 'mailpoet')
+        ));
+        continue;
+      }
+      if (isset($formBlockers[$id])) {
+        $this->skip($result, $id, str_replace(
+          '%1$s',
+          "'" . join("', '", $formBlockers[$id]) . "'",
+          // translators: %1$s is a comma-separated list of forms for which the segment is used.
+          _nx(
+            'List cannot be deleted because it’s used for %1$s form',
+            'List cannot be deleted because it’s used for %1$s forms',
+            count($formBlockers[$id]),
+            'Alert shown when trying to delete segment, when it is assigned to a form.',
+            'mailpoet'
+          )
+        ));
+        continue;
+      }
+      if ($segment->getType() === SegmentEntity::TYPE_WP_USERS) {
+        $subscribers = $this->subscribersRepository->findExclusiveSubscribersBySegment((int)$segment->getId());
+        $subscriberIds = array_map(static function ($subscriber): int {
+          return (int)$subscriber->getId();
+        }, $subscribers);
+        $this->subscribersRepository->bulkTrash($subscriberIds);
+      }
+      $result['updated'] += $this->segmentsRepository->doTrash([$id], $segment->getType());
+    }
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function restoreSegments(array $ids, array &$result): void {
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if (!$segment instanceof SegmentEntity) {
+        $this->skip($result, $id, __('This list does not exist.', 'mailpoet'));
+        continue;
+      }
+      if (!in_array($segment->getType(), [SegmentEntity::TYPE_DEFAULT, SegmentEntity::TYPE_WP_USERS], true)) {
+        $this->skip($result, $id, __('This list cannot be restored.', 'mailpoet'));
+        continue;
+      }
+      if ($segment->getType() === SegmentEntity::TYPE_WP_USERS) {
+        $subscribers = $this->subscribersRepository->findBySegment((int)$segment->getId());
+        $subscriberIds = array_map(static function ($subscriber): int {
+          return (int)$subscriber->getId();
+        }, $subscribers);
+        $this->subscribersRepository->bulkRestore($subscriberIds);
+      }
+      $result['updated'] += $this->segmentsRepository->bulkRestore([$id], $segment->getType());
+    }
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function deleteSegments(array $ids, array &$result): void {
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if (!$segment instanceof SegmentEntity) {
+        $this->skip($result, $id, __('This list does not exist.', 'mailpoet'));
+        continue;
+      }
+      if ($segment->getType() !== SegmentEntity::TYPE_DEFAULT) {
+        $this->skip($result, $id, __('This list cannot be deleted.', 'mailpoet'));
+        continue;
+      }
+      $result['deleted'] += $this->segmentsRepository->bulkDelete([$id]);
+    }
+  }
+
+  /**
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function skip(array &$result, ?int $id, string $message): void {
+    $result['skipped']++;
+    $result['errors'][] = [
+      'id' => $id,
+      'message' => $message,
+    ];
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsBulkActionEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsBulkActionEndpoint.php
@@ -65,6 +65,10 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
     $action = $this->validateAction($request);
     $this->validateListingParams($request);
     $ids = $this->getSelectedIds($request, $action);
+    $this->validateTypeBoundaries($ids);
+    if ($action === self::ACTION_DELETE) {
+      $this->validateDeletionSelection($ids);
+    }
 
     $result = [
       'updated' => 0,
@@ -94,6 +98,8 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
       'per_page' => Builder::integer(),
       'orderby' => Builder::string(),
       'order' => Builder::string(),
+      'sort_by' => Builder::string(),
+      'sort_order' => Builder::string(),
     ];
   }
 
@@ -115,12 +121,14 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
 
   private function validateListingParams(Request $request): void {
     $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
-    $this->validateOrder(is_string($request->getParam('order')) ? (string)$request->getParam('order') : null, 'asc');
+    $orderParam = $request->getParam('order') ?? $request->getParam('sort_order');
+    $this->validateOrder(is_string($orderParam) ? (string)$orderParam : null, 'asc');
     $this->validatePage($request->getParam('page'));
     $this->validatePerPage($request->getParam('per_page'), 20);
 
-    $orderby = is_string($request->getParam('orderby')) && $request->getParam('orderby') !== ''
-      ? (string)$request->getParam('orderby')
+    $orderbyParam = $request->getParam('orderby') ?? $request->getParam('sort_by');
+    $orderby = is_string($orderbyParam) && $orderbyParam !== ''
+      ? (string)$orderbyParam
       : 'name';
     $allowedSortFields = ['name', 'created_at', 'updated_at', 'average_engagement_score'];
     if (!in_array($orderby, $allowedSortFields, true)) {
@@ -261,6 +269,38 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
         continue;
       }
       $result['deleted'] += $this->segmentsRepository->bulkDelete([$id]);
+    }
+  }
+
+  /**
+   * @param int[] $ids
+   */
+  private function validateTypeBoundaries(array $ids): void {
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if ($segment instanceof SegmentEntity && $segment->getType() === SegmentEntity::TYPE_DYNAMIC) {
+        throw new ApiException(
+          __('This endpoint only supports lists.', 'mailpoet'),
+          400,
+          'mailpoet_segments_invalid_type'
+        );
+      }
+    }
+  }
+
+  /**
+   * @param int[] $ids
+   */
+  private function validateDeletionSelection(array $ids): void {
+    foreach ($ids as $id) {
+      $segment = $this->segmentsRepository->findOneById($id);
+      if ($segment instanceof SegmentEntity && $segment->getDeletedAt() === null) {
+        throw new ApiException(
+          __('Only lists in the trash can be permanently deleted.', 'mailpoet'),
+          400,
+          'mailpoet_segments_delete_requires_trash'
+        );
+      }
     }
   }
 

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsEndpoint.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\REST\Endpoint;
+use MailPoet\Config\AccessControl;
+use MailPoet\WP\Functions as WPFunctions;
+
+abstract class SegmentsEndpoint extends Endpoint {
+  use SegmentRequestValidationTrait;
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_SEGMENTS);
+  }
+}

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsListingEndpoint.php
@@ -52,7 +52,7 @@ class SegmentsListingEndpoint extends AbstractSegmentsListingEndpoint {
   }
 
   protected function allowsSearch(): bool {
-    return false;
+    return true;
   }
 
   protected function getDefaultParameters(): array {

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsListingEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsListingEndpoint.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\RestApi\Endpoints;
+
+use MailPoet\API\JSON\ResponseBuilders\SegmentsResponseBuilder;
+use MailPoet\Config\AccessControl;
+use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Listing\ListingRepository;
+use MailPoet\Segments\SegmentListingRepository;
+use MailPoet\WP\Functions as WPFunctions;
+
+class SegmentsListingEndpoint extends AbstractSegmentsListingEndpoint {
+  /** @var SegmentListingRepository */
+  private $segmentListingRepository;
+
+  /** @var SegmentsResponseBuilder */
+  private $segmentsResponseBuilder;
+
+  public function __construct(
+    ListingHandler $listingHandler,
+    SegmentListingRepository $segmentListingRepository,
+    SegmentsResponseBuilder $segmentsResponseBuilder
+  ) {
+    parent::__construct($listingHandler, [
+      'name',
+      'created_at',
+      'updated_at',
+      'average_engagement_score',
+    ], 20);
+    $this->segmentListingRepository = $segmentListingRepository;
+    $this->segmentsResponseBuilder = $segmentsResponseBuilder;
+  }
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_SEGMENTS);
+  }
+
+  protected function getListingRepository(): ListingRepository {
+    return $this->segmentListingRepository;
+  }
+
+  protected function buildItems(array $rows): array {
+    return $this->segmentsResponseBuilder->buildForListing($rows);
+  }
+
+  protected function getDefaultSortBy(): string {
+    return 'name';
+  }
+
+  protected function getDefaultSortOrder(): string {
+    return 'asc';
+  }
+
+  protected function allowsSearch(): bool {
+    return false;
+  }
+
+  protected function getDefaultParameters(): array {
+    return ['lists'];
+  }
+}

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -1052,6 +1052,7 @@ class AcceptanceTester extends \Codeception\Actor {
     $i = $this;
     try {
       $i->selectOption('Bulk actions', $actionName);
+      $i->click(['css' => 'input[value="Apply"], button[value="Apply"]']);
       return;
     } catch (Exception $exception) {
       $dataViewsAction = ['xpath' => '//div[contains(@class, "dataviews-bulk-actions-footer__action-buttons")]//button[normalize-space(.)="' . $actionName . '"]'];

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -475,8 +475,20 @@ class AcceptanceTester extends \Codeception\Actor {
 
   public function waitForNoticeAndClose($text, $timeout = 10, $selector = null) {
     $this->_waitForText($text, $this->getDefaultTimeout($timeout), $selector);
-    $this->waitForElementVisible('.notice-dismiss', 1);
-    $this->click('.notice-dismiss');
+    try {
+      $this->waitForElementVisible('.notice-dismiss', 1);
+      $this->click('.notice-dismiss');
+    } catch (Exception $exception) {
+      // DataViews notices may not render a WordPress notice dismiss button.
+    }
+  }
+
+  public function clickModalButton(string $label): void {
+    $button = [
+      'xpath' => '//div[contains(@class, "components-modal__screen-overlay")]//button[normalize-space(.)="' . $label . '"]',
+    ];
+    $this->waitForElementClickable($button);
+    $this->click($button);
   }
 
   public function closeNoticeIfVisible() {

--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -192,25 +192,35 @@ class AcceptanceTester extends \Codeception\Actor {
 
   public function clickWooTableActionByItemName($itemName, $actionLinkText) {
     $i = $this;
-    $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//a[text()="' . $actionLinkText . '"]'];
-    $i->waitForElementVisible($xpath);
-    $i->waitForElementClickable($xpath);
-    $i->moveMouseOver($xpath);
-    $i->click($xpath);
+    try {
+      $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//a[text()="' . $actionLinkText . '"]'];
+      $i->waitForElementVisible($xpath, 1);
+      $i->waitForElementClickable($xpath, 1);
+      $i->moveMouseOver($xpath);
+      $i->click($xpath);
+      return;
+    } catch (Exception $exception) {
+      $i->clickItemRowActionByItemName($itemName, $actionLinkText);
+    }
   }
 
   public function clickWooTableMoreButtonByItemName($itemName) {
     $i = $this;
-    $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//div[contains(@class, "mailpoet-listing-more-button")]'];
-    $i->waitForElementClickable($xpath);
-    $i->click($xpath);
+    try {
+      $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//div[contains(@class, "mailpoet-listing-more-button")]'];
+      $i->waitForElementClickable($xpath, 1);
+      $i->click($xpath);
+      return;
+    } catch (Exception $exception) {
+      $dataViewsActionsToggleXpath = ['xpath' => '//tr[.//*[normalize-space(text())="' . $itemName . '"]]//button[@aria-label="Actions" and @aria-haspopup="menu"]'];
+      $i->waitForElementClickable($dataViewsActionsToggleXpath);
+      $i->click($dataViewsActionsToggleXpath);
+    }
   }
 
   public function clickWooTableActionInsideMoreButton(string $itemName, string $moreButtonAction, ?string $confirmAction = null) {
     $i = $this;
-    $i->clickWooTableMoreButtonByItemName($itemName);
-    $i->waitForText($itemName);
-    $i->click($moreButtonAction);
+    $i->clickItemRowActionByItemName($itemName, $moreButtonAction);
     if ($confirmAction) {
       $i->click($confirmAction);
     }
@@ -311,8 +321,15 @@ class AcceptanceTester extends \Codeception\Actor {
 
   public function selectAllListingItems() {
     $i = $this;
-    $i->waitForElementVisible('[data-automation-id="select_all"]');
-    $i->click('[data-automation-id="select_all"]');
+    try {
+      $i->waitForElementVisible('[data-automation-id="select_all"]', 1);
+      $i->click('[data-automation-id="select_all"]');
+      return;
+    } catch (Exception $exception) {
+      $dataViewsSelectAll = ['xpath' => '//table//thead//input[@type="checkbox"]'];
+      $i->waitForElementVisible($dataViewsSelectAll);
+      $i->click($dataViewsSelectAll);
+    }
   }
 
   public function waitForListingItemsToLoad() {
@@ -1027,13 +1044,25 @@ class AcceptanceTester extends \Codeception\Actor {
 
   public function checkWooTableCheckboxForItemName(string $itemName): void {
     $i = $this;
-    $xpath = ['xpath' => '//tr[.//a[text()="' . $itemName . '"]]//input[@type="checkbox"]'];
+    $xpath = ['xpath' => '//tr[.//*[normalize-space(text())="' . $itemName . '"]]//input[@type="checkbox"]'];
     $i->click($xpath);
+  }
+
+  public function selectListingBulkAction(string $actionName): void {
+    $i = $this;
+    try {
+      $i->selectOption('Bulk actions', $actionName);
+      return;
+    } catch (Exception $exception) {
+      $dataViewsAction = ['xpath' => '//div[contains(@class, "dataviews-bulk-actions-footer__action-buttons")]//button[normalize-space(.)="' . $actionName . '"]'];
+      $i->waitForElementClickable($dataViewsAction);
+      $i->click($dataViewsAction);
+    }
   }
 
   public function changeWooTableTab(string $name): void {
     $i = $this;
-    $i->click('button.mailpoet-tab-' . $name);
+    $i->changeGroupInListingFilter($name);
   }
 
   public function clearTransientCache(): void {

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -99,7 +99,7 @@ class ManageListsCest {
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($editedListTitle);
     $i->clickItemRowActionByItemName($editedListTitle, 'Delete permanently');
-    $i->click('Delete permanently');
+    $i->clickModalButton('Delete permanently');
     $i->waitForNoticeAndClose('1 list was permanently deleted. Note that deleting a list does not delete its subscribers.');
     $i->seeNoJSErrors();
     $i->waitForElementNotVisible('[data-automation-id="filters_trash"]');
@@ -130,7 +130,7 @@ class ManageListsCest {
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newListTitle);
     $i->click('[data-automation-id="empty_trash"]');
-    $i->click('Empty Trash');
+    $i->clickModalButton('Empty Trash');
 
     $i->waitForText('1 list was permanently deleted. Note that deleting a list does not delete its subscribers.');
     $i->dontSee($newListTitle);

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -140,8 +140,8 @@ class ManageListsCest {
     $i->see('List to keep');
   }
 
-  public function bulkTrashAllListsOnAllPages(\AcceptanceTester $i) {
-    $i->wantTo('Trash all lists across pages using the all-pages selection');
+  public function bulkTrashSelectedListsOnCurrentPage(\AcceptanceTester $i) {
+    $i->wantTo('Trash selected lists without offering all-pages selection');
     $listNames = [
       '00 Select All Pages List A',
       '00 Select All Pages List B',
@@ -164,18 +164,16 @@ class ManageListsCest {
 
     $i->checkWooTableCheckboxForItemName($listNames[0]);
     $i->checkWooTableCheckboxForItemName($listNames[1]);
-    $i->waitForElement('[data-automation-id="select_all_items_all_pages"]');
+    $i->dontSeeElement('[data-automation-id="select_all_items_all_pages"]');
     $i->dontSeeElement('[data-automation-id="empty_trash"]');
-    $i->click('[data-automation-id="select_all_items_all_pages"]');
-    $i->waitForElement('[data-automation-id="all_items_all_pages_selected"]');
     $i->selectListingBulkAction('Move to trash');
 
-    $i->waitForText('lists were moved to the trash.');
+    $i->waitForText('2 lists were moved to the trash.');
     ContainerWrapper::getInstance()->get(EntityManager::class)->clear();
     $segmentsRepository = ContainerWrapper::getInstance()->get(SegmentsRepository::class);
     $listOnAnotherPage = $segmentsRepository->findOneById($listIds[2]);
     Assert::assertInstanceOf(SegmentEntity::class, $listOnAnotherPage);
-    Assert::assertNotNull($listOnAnotherPage->getDeletedAt());
+    Assert::assertNull($listOnAnotherPage->getDeletedAt());
   }
 
   public function disableAndEnableWPUserList(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -9,6 +9,7 @@ use MailPoet\Test\DataFactories\Form;
 use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Test\DataFactories\Segment;
 use MailPoet\Test\DataFactories\User;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Assert;
 
 class ManageListsCest {
@@ -137,6 +138,44 @@ class ManageListsCest {
     $i->seeNoJSErrors();
     $i->changeGroupInListingFilter('all');
     $i->see('List to keep');
+  }
+
+  public function bulkTrashAllListsOnAllPages(\AcceptanceTester $i) {
+    $i->wantTo('Trash all lists across pages using the all-pages selection');
+    $listNames = [
+      '00 Select All Pages List A',
+      '00 Select All Pages List B',
+      '00 Select All Pages List C',
+    ];
+    $listIds = [];
+    foreach ($listNames as $listName) {
+      $segment = (new Segment())
+        ->withName($listName)
+        ->withDescription('Description')
+        ->create();
+      $listIds[] = $segment->getId();
+    }
+
+    $i->login();
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-lists#/lists/limit[2]');
+    $i->waitForText($listNames[0], 5, '[data-automation-id="segments_listing"]');
+    $i->waitForText($listNames[1], 5, '[data-automation-id="segments_listing"]');
+    $i->dontSee($listNames[2], '[data-automation-id="segments_listing"]');
+
+    $i->checkWooTableCheckboxForItemName($listNames[0]);
+    $i->checkWooTableCheckboxForItemName($listNames[1]);
+    $i->waitForElement('[data-automation-id="select_all_items_all_pages"]');
+    $i->dontSeeElement('[data-automation-id="empty_trash"]');
+    $i->click('[data-automation-id="select_all_items_all_pages"]');
+    $i->waitForElement('[data-automation-id="all_items_all_pages_selected"]');
+    $i->selectListingBulkAction('Move to trash');
+
+    $i->waitForText('lists were moved to the trash.');
+    ContainerWrapper::getInstance()->get(EntityManager::class)->clear();
+    $segmentsRepository = ContainerWrapper::getInstance()->get(SegmentsRepository::class);
+    $listOnAnotherPage = $segmentsRepository->findOneById($listIds[2]);
+    Assert::assertInstanceOf(SegmentEntity::class, $listOnAnotherPage);
+    Assert::assertNotNull($listOnAnotherPage->getDeletedAt());
   }
 
   public function disableAndEnableWPUserList(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Lists/ManageListsCest.php
+++ b/mailpoet/tests/acceptance/Lists/ManageListsCest.php
@@ -99,6 +99,7 @@ class ManageListsCest {
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($editedListTitle);
     $i->clickItemRowActionByItemName($editedListTitle, 'Delete permanently');
+    $i->click('Delete permanently');
     $i->waitForNoticeAndClose('1 list was permanently deleted. Note that deleting a list does not delete its subscribers.');
     $i->seeNoJSErrors();
     $i->waitForElementNotVisible('[data-automation-id="filters_trash"]');
@@ -129,6 +130,7 @@ class ManageListsCest {
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newListTitle);
     $i->click('[data-automation-id="empty_trash"]');
+    $i->click('Empty Trash');
 
     $i->waitForText('1 list was permanently deleted. Note that deleting a list does not delete its subscribers.');
     $i->dontSee($newListTitle);
@@ -199,10 +201,10 @@ class ManageListsCest {
     $i->clickItemRowActionByItemName($listTitle, 'Move to trash');
     $i->waitForText("List cannot be deleted because it’s used for '{$subject}' email");
     $i->seeNoJSErrors();
-    $i->checkOption('[data-automation-id="listing-row-checkbox-' . $segment->getId() . '"]');
+    $i->checkWooTableCheckboxForItemName($listTitle);
     $i->waitForText('Move to trash');
     $i->click('Move to trash');
-    $i->waitForText('0 lists were moved to the trash.');
+    $i->waitForText("List cannot be deleted because it’s used for '{$subject}' email");
   }
 
   public function cantTrashOrBulkTrashListWithForm(\AcceptanceTester $i) {
@@ -225,10 +227,10 @@ class ManageListsCest {
     $i->clickItemRowActionByItemName($listTitle, 'Move to trash');
     $i->waitForText("List cannot be deleted because it’s used for '{$formName}' form");
     $i->seeNoJSErrors();
-    $i->checkOption('[data-automation-id="listing-row-checkbox-' . $segment->getId() . '"]');
+    $i->checkWooTableCheckboxForItemName($listTitle);
     $i->waitForText('Move to trash');
     $i->click('Move to trash');
-    $i->waitForText('0 lists were moved to the trash.');
+    $i->waitForText("List cannot be deleted because it’s used for '{$formName}' form");
   }
 
   public function cannotDisableWPUserList(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -144,7 +144,6 @@ class SwitchingLanguagesCest {
     $i->wantTo('Check some Lists strings');
     $i->amOnMailpoetPage('lists');
     $i->waitForText('Abonnenten');
-    $i->waitForText('Listen-Bewertung');
     $i->waitForText('Neue Liste hinzufügen');
     $i->waitForText('Ausgetragen');
 

--- a/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
+++ b/mailpoet/tests/acceptance/Misc/SwitchingLanguagesCest.php
@@ -145,7 +145,6 @@ class SwitchingLanguagesCest {
     $i->amOnMailpoetPage('lists');
     $i->waitForText('Abonnenten');
     $i->waitForText('Neue Liste hinzufügen');
-    $i->waitForText('Ausgetragen');
 
     $i->wantTo('Check Settings tabs strings');
     $i->amOnMailpoetPage('settings');

--- a/mailpoet/tests/acceptance/Segments/MailPoetCustomFieldSegmentCest.php
+++ b/mailpoet/tests/acceptance/Segments/MailPoetCustomFieldSegmentCest.php
@@ -55,7 +55,7 @@ class MailPoetCustomFieldSegmentCest {
     $i->wantTo('Check subscribers of the segment');
     $i->amOnMailpoetPage('Segments');
     $i->waitForText($segmentTitle);
-    $i->click('View subscribers');
+    $i->clickWooTableActionByItemName($segmentTitle, 'View subscribers');
     $i->seeInCurrentUrl('mailpoet-subscribers#');
     $i->see($segmentTitle, ['css' => 'select[name=segment]']);
     $i->see('test2@example.com');

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -268,7 +268,7 @@ class ManageSegmentsCest {
     $i->waitForText($segment1Name);
     $i->checkWooTableCheckboxForItemName($segment1Name);
     $i->checkWooTableCheckboxForItemName($segment2Name);
-    $i->selectOption('Bulk actions', 'Restore');
+    $i->selectListingBulkAction('Restore');
     $i->click('Restore'); // confirmation modal
     $i->wantTo('Check that segments were restored and trash filter is not present');
     $i->waitForText('No data to display');
@@ -278,7 +278,7 @@ class ManageSegmentsCest {
 
     $i->wantTo('Select all segments and move them back to trash');
     $i->selectAllListingItems();
-    $i->selectOption('Bulk actions', 'Trash');
+    $i->selectListingBulkAction('Move to trash');
     $i->waitForText('Are you sure you want to trash the selected segments');
     $i->click(['xpath' => '//button[text()="Trash"]']); // confirmation modal, xpath to avoid clicking the Trash tab
     $i->waitForText('No data to display');
@@ -287,7 +287,7 @@ class ManageSegmentsCest {
     $i->changeWooTableTab('trash');
     $i->waitForText($segment1Name);
     $i->selectAllListingItems();
-    $i->selectOption('Bulk actions', 'Delete permanently');
+    $i->selectListingBulkAction('Delete permanently');
     $i->click('Delete permanently'); // modal confirmation
     $i->waitForText('No data to display');
   }
@@ -314,7 +314,7 @@ class ManageSegmentsCest {
     $i->waitForText("Segment '{$segmentTitle}' cannot be deleted because it’s used for '{$subject}' email");
     $i->seeNoJSErrors();
     $i->checkWooTableCheckboxForItemName($segment->getName());
-    $i->selectOption('Bulk actions', 'Trash');
+    $i->selectListingBulkAction('Move to trash');
     $i->click(['xpath' => '//button[text()="Trash"]']); // confirmation modal, xpath to avoid clicking the Trash tab
     $i->waitForText("Segment '{$segmentTitle}' cannot be deleted because it’s used for '{$subject}' email");
   }

--- a/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/ManageSegmentsCest.php
@@ -269,7 +269,7 @@ class ManageSegmentsCest {
     $i->checkWooTableCheckboxForItemName($segment1Name);
     $i->checkWooTableCheckboxForItemName($segment2Name);
     $i->selectListingBulkAction('Restore');
-    $i->click('Restore'); // confirmation modal
+    $i->clickModalButton('Restore');
     $i->wantTo('Check that segments were restored and trash filter is not present');
     $i->waitForText('No data to display');
     $i->changeWooTableTab('all');
@@ -288,7 +288,7 @@ class ManageSegmentsCest {
     $i->waitForText($segment1Name);
     $i->selectAllListingItems();
     $i->selectListingBulkAction('Delete permanently');
-    $i->click('Delete permanently'); // modal confirmation
+    $i->clickModalButton('Delete permanently');
     $i->waitForText('No data to display');
   }
 

--- a/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
@@ -268,25 +268,22 @@ class WooCommerceDynamicSegmentsCest {
     $i->see($message, $customerCountrySegmentRow);
 
     $i->wantTo('Check that Edit links are not clickable');
-    $i->assertAttributeContains("[data-automation-id=mailpoet_dynamic_segment_edit_button_{$this->categorySegment->getId()}]", 'disabled', '');
-    $i->assertAttributeContains("[data-automation-id=mailpoet_dynamic_segment_edit_button_{$this->productSegment->getId()}]", 'disabled', '');
-    $i->assertAttributeContains("[data-automation-id=mailpoet_dynamic_segment_edit_button_{$this->numberOfOrdersSegment->getId()}]", 'disabled', '');
-    $i->assertAttributeContains("[data-automation-id=mailpoet_dynamic_segment_edit_button_{$this->totalSpentSegment->getId()}]", 'disabled', '');
-    $i->assertAttributeContains("[data-automation-id=mailpoet_dynamic_segment_edit_button_{$this->customerCountrySegment->getId()}]", 'disabled', '');
+    $this->seeDisabledEditAction($i, $this->categorySegment);
+    $this->seeDisabledEditAction($i, $this->productSegment);
+    $this->seeDisabledEditAction($i, $this->numberOfOrdersSegment);
+    $this->seeDisabledEditAction($i, $this->totalSpentSegment);
+    $this->seeDisabledEditAction($i, $this->customerCountrySegment);
     $i->seeNoJSErrors();
   }
 
   private function clickAction(\AcceptanceTester $i, SegmentEntity $segmentEntity, $actionName) {
-    $column = sprintf('[data-automation-id="mailpoet_dynamic_segment_actions_%d"]', $segmentEntity->getId());
+    $i->clickWooTableActionByItemName($segmentEntity->getName(), $actionName);
+  }
 
-    switch ($actionName) {
-      case 'View subscribers':
-        $actionName = 'a';
-        break;
-      case 'Edit':
-        $actionName = 'a:nth-child(2)';
-        break;
-    }
-    $i->click($actionName, $column);
+  private function seeDisabledEditAction(\AcceptanceTester $i, SegmentEntity $segmentEntity): void {
+    $rowEditAction = [
+      'xpath' => '//tr[.//*[normalize-space(text())="' . $segmentEntity->getName() . '"]]//button[contains(normalize-space(.), "Edit unavailable:") and @disabled]',
+    ];
+    $i->waitForElementVisible($rowEditAction);
   }
 }

--- a/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
+++ b/mailpoet/tests/acceptance/Segments/WooCommerceDynamicSegmentsCest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\Acceptance;
 
+use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Test\DataFactories\DynamicSegment;
 use MailPoet\Test\DataFactories\Settings;
@@ -281,9 +282,11 @@ class WooCommerceDynamicSegmentsCest {
   }
 
   private function seeDisabledEditAction(\AcceptanceTester $i, SegmentEntity $segmentEntity): void {
+    $i->clickWooTableMoreButtonByItemName($segmentEntity->getName());
     $rowEditAction = [
-      'xpath' => '//tr[.//*[normalize-space(text())="' . $segmentEntity->getName() . '"]]//button[contains(normalize-space(.), "Edit unavailable:") and @disabled]',
+      'xpath' => '//*[@role="menuitem" and normalize-space(.)="Edit unavailable" and @aria-disabled="true"]',
     ];
     $i->waitForElementVisible($rowEditAction);
+    $i->pressKey('body', WebDriverKeys::ESCAPE);
   }
 }

--- a/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
+++ b/mailpoet/tests/acceptance/Settings/ReinstallFromScratchCest.php
@@ -54,7 +54,7 @@ class ReinstallFromScratchCest {
     $i->amOnMailpoetPage('Lists');
     $i->waitForText('WordPress Users', 30, '[data-automation-id="listing_item_1"]');
     $i->see('Newsletter mailing list', '[data-automation-id="listing_item_3"]');
-    $i->seeNumberOfElements('[data-automation-id^=listing_item_]', 2);
+    $i->seeNumberOfElements('.mailpoet-listing-title', 2);
     // Check subscribers
     $i->amOnMailPoetPage('Subscribers');
     $i->waitForText('admin', 30, '.mailpoet-listing-table');

--- a/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/ManageSubscribersCest.php
@@ -351,6 +351,10 @@ class ManageSubscribersCest {
   }
 
   private function seeListCountByStatus(\AcceptanceTester $i, $count, $listName, $status) {
-    $i->see($count, "//*[@class='mailpoet-listing-title'][contains(text(), '$listName')]/ancestor::tr/td[@data-colname='$status']");
+    $status = strtolower($status);
+    $i->see(
+      $count,
+      "//*[@class='mailpoet-listing-title'][contains(text(), '$listName')]/ancestor::tr//*[@data-automation-id and contains(@data-automation-id, '_{$status}_count')]"
+    );
   }
 }

--- a/mailpoet/tests/integration/REST/Segments/DynamicSegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/DynamicSegmentsEndpointsTest.php
@@ -2,10 +2,13 @@
 
 namespace MailPoet\Test\REST\Segments;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\REST\Test;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoetVendor\Carbon\Carbon;
 
 require_once __DIR__ . '/../Test.php';
 
@@ -91,6 +94,46 @@ class DynamicSegmentsEndpointsTest extends Test {
     $this->assertContains((string)$trashed->getId(), $ids);
   }
 
+  public function testGetUsesDefaultPaginationAndSortWhenParamsAreOmitted(): void {
+    $suffix = uniqid();
+    $older = (new SegmentFactory())->withName("zzz_default_older_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $newer = (new SegmentFactory())->withName("zzz_default_newer_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $fillers = [];
+    for ($i = 0; $i < 25; $i++) {
+      $fillers[] = (new SegmentFactory())->withName("zzz_default_filler_{$suffix}_{$i}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    }
+    $this->setUpdatedAt($older, new Carbon('2024-01-01 00:00:00'));
+    $this->setUpdatedAt($newer, new Carbon('2024-01-02 00:00:00'));
+    foreach ($fillers as $filler) {
+      $this->setUpdatedAt($filler, new Carbon('2023-01-01 00:00:00'));
+    }
+    $this->entityManager->flush();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['search' => $suffix]]);
+    $names = array_column($data['data']['items'], 'name');
+
+    $this->assertCount(25, $data['data']['items']);
+    $this->assertSame("zzz_default_newer_{$suffix}", $names[0]);
+  }
+
+  public function testGetSupportsLegacySortAliasesAndOffset(): void {
+    $suffix = uniqid();
+    (new SegmentFactory())->withName("zzz_alias_a_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new SegmentFactory())->withName("zzz_alias_b_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new SegmentFactory())->withName("zzz_alias_c_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'limit' => 1,
+      'offset' => 2,
+      'sort_by' => 'name',
+      'sort_order' => 'asc',
+    ]]);
+
+    $this->assertSame(3, $data['data']['meta']['count']);
+    $this->assertSame("zzz_alias_c_{$suffix}", $data['data']['items'][0]['name']);
+  }
+
   public function testGetRejectsInvalidListingParamsAndUsersWithoutPermission(): void {
     $this->assertSame('mailpoet_segments_invalid_group', $this->get(self::BASE_PATH, ['query' => ['group' => 'archived']])['code']);
     $this->assertSame('mailpoet_segments_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'bad_field']])['code']);
@@ -124,6 +167,12 @@ class DynamicSegmentsEndpointsTest extends Test {
     $this->assertNull($restoredSegment->getDeletedAt());
 
     $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$segment->getId()]],
+    ]);
+    $this->entityManager->clear();
+    $this->assertSame(1, $data['data']['updated']);
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
       'json' => ['action' => 'delete', 'ids' => [(int)$segment->getId()]],
     ]);
     $this->entityManager->clear();
@@ -131,7 +180,7 @@ class DynamicSegmentsEndpointsTest extends Test {
     $this->assertNull($this->segmentsRepository->findOneById($segment->getId()));
   }
 
-  public function testBulkActionReportsWrongTypeAsSkipped(): void {
+  public function testBulkActionRejectsWrongTypeWithoutMutatingRows(): void {
     $static = (new SegmentFactory())->withName('Static')->create();
     $dynamic = (new SegmentFactory())->withName('Dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
 
@@ -140,15 +189,97 @@ class DynamicSegmentsEndpointsTest extends Test {
     ]);
     $this->entityManager->clear();
 
-    $this->assertSame(1, $data['data']['updated']);
-    $this->assertSame(1, $data['data']['skipped']);
-    $this->assertSame((int)$static->getId(), $data['data']['errors'][0]['id']);
+    $this->assertSame('mailpoet_dynamic_segments_invalid_type', $data['code']);
     $staticAfterAction = $this->segmentsRepository->findOneById($static->getId());
     $dynamicAfterAction = $this->segmentsRepository->findOneById($dynamic->getId());
     $this->assertInstanceOf(SegmentEntity::class, $staticAfterAction);
     $this->assertInstanceOf(SegmentEntity::class, $dynamicAfterAction);
     $this->assertNull($staticAfterAction->getDeletedAt());
-    $this->assertNotNull($dynamicAfterAction->getDeletedAt());
+    $this->assertNull($dynamicAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionRejectsMissingIdsWithoutMutatingRows(): void {
+    $dynamic = (new SegmentFactory())->withName('Dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$dynamic->getId(), 999999]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame('mailpoet_dynamic_segments_not_found', $data['code']);
+    $dynamicAfterAction = $this->segmentsRepository->findOneById($dynamic->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $dynamicAfterAction);
+    $this->assertNull($dynamicAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionRejectsPermanentDeleteForActiveDynamicSegments(): void {
+    $active = (new SegmentFactory())->withName('Active dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $trashed = (new SegmentFactory())->withName('Trashed dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->withDeleted()->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'delete', 'ids' => [(int)$active->getId(), (int)$trashed->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame('mailpoet_dynamic_segments_delete_requires_trash', $data['code']);
+    $this->assertInstanceOf(SegmentEntity::class, $this->segmentsRepository->findOneById($active->getId()));
+    $this->assertInstanceOf(SegmentEntity::class, $this->segmentsRepository->findOneById($trashed->getId()));
+  }
+
+  public function testBulkActionSupportsSelectAllMatchingDynamicSegments(): void {
+    $suffix = uniqid();
+    $first = (new SegmentFactory())->withName("zzz_select_all_first_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $second = (new SegmentFactory())->withName("zzz_select_all_second_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new SegmentFactory())->withName("zzz_select_all_other")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'select_all' => true, 'search' => $suffix, 'sort_by' => 'name', 'sort_order' => 'asc'],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame(2, $data['data']['updated']);
+    $firstAfterAction = $this->segmentsRepository->findOneById($first->getId());
+    $secondAfterAction = $this->segmentsRepository->findOneById($second->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $firstAfterAction);
+    $this->assertInstanceOf(SegmentEntity::class, $secondAfterAction);
+    $this->assertNotNull($firstAfterAction->getDeletedAt());
+    $this->assertNotNull($secondAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionGuestCannotMutateRows(): void {
+    $segment = (new SegmentFactory())->withName('Guest protected')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    wp_set_current_user(0);
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$segment->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame('rest_forbidden', $data['code']);
+    $segmentAfterAction = $this->segmentsRepository->findOneById($segment->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $segmentAfterAction);
+    $this->assertNull($segmentAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionReportsActiveNewsletterBlocker(): void {
+    $segment = (new SegmentFactory())->withName('Blocked dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new NewsletterFactory())
+      ->withSubject('Dynamic blocker')
+      ->withScheduledStatus()
+      ->withScheduledQueue(['status' => ScheduledTaskEntity::STATUS_SCHEDULED])
+      ->withSegments([$segment])
+      ->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$segment->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame(0, $data['data']['updated']);
+    $this->assertSame(1, $data['data']['skipped']);
+    $segmentAfterAction = $this->segmentsRepository->findOneById($segment->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $segmentAfterAction);
+    $this->assertNull($segmentAfterAction->getDeletedAt());
   }
 
   public function testBulkActionRejectsInvalidInputs(): void {
@@ -160,5 +291,16 @@ class DynamicSegmentsEndpointsTest extends Test {
     $this->assertSame('mailpoet_segments_ids_required', $this->post(self::BASE_PATH . '/bulk-action', [
       'json' => ['action' => 'trash', 'ids' => []],
     ])['code']);
+  }
+
+  private function setUpdatedAt(SegmentEntity $segment, Carbon $updatedAt): void {
+    $this->entityManager->createQueryBuilder()
+      ->update(SegmentEntity::class, 's')
+      ->set('s.updatedAt', ':updatedAt')
+      ->where('s.id = :id')
+      ->setParameter('updatedAt', $updatedAt)
+      ->setParameter('id', $segment->getId())
+      ->getQuery()
+      ->execute();
   }
 }

--- a/mailpoet/tests/integration/REST/Segments/DynamicSegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/DynamicSegmentsEndpointsTest.php
@@ -140,6 +140,7 @@ class DynamicSegmentsEndpointsTest extends Test {
     $this->assertSame('mailpoet_segments_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'sideways']])['code']);
     $this->assertSame('mailpoet_segments_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
     $this->assertSame('mailpoet_segments_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['limit' => 101]])['code']);
+    $this->assertSame('mailpoet_segments_invalid_offset', $this->get(self::BASE_PATH, ['query' => ['offset' => 100001]])['code']);
 
     wp_set_current_user($this->editorUserId);
     $this->assertSame('rest_forbidden', $this->get(self::BASE_PATH)['code']);

--- a/mailpoet/tests/integration/REST/Segments/DynamicSegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/DynamicSegmentsEndpointsTest.php
@@ -1,0 +1,164 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\Segments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\REST\Test;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+
+require_once __DIR__ . '/../Test.php';
+
+class DynamicSegmentsEndpointsTest extends Test {
+  private const BASE_PATH = '/mailpoet/v1/dynamic-segments';
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var int */
+  private $editorUserId;
+
+  public function _before() {
+    parent::_before();
+    $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
+    wp_set_current_user(1);
+    $userId = wp_create_user('dynamic_segments_editor_' . uniqid(), 'password', 'dynamic-segments-editor-' . uniqid() . '@localhost.test');
+    $this->assertIsNumeric($userId);
+    $user = new \WP_User($userId);
+    $user->add_role('editor');
+    $this->editorUserId = $userId;
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+    is_multisite() ? wpmu_delete_user($this->editorUserId) : wp_delete_user($this->editorUserId);
+  }
+
+  public function testGetReturnsDynamicSegmentsEnvelope(): void {
+    $suffix = uniqid();
+    $segment = (new SegmentFactory())->withName("zzz_dynamic_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new SegmentFactory())->withName("zzz_static_{$suffix}")->create();
+    (new SegmentFactory())->withName("zzz_trashed_dynamic_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->withDeleted()->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'per_page' => 100,
+      'orderby' => 'name',
+      'order' => 'asc',
+    ]]);
+
+    $this->assertIsArray($data['data']);
+    $this->assertArrayHasKey('items', $data['data']);
+    $this->assertArrayHasKey('meta', $data['data']);
+    $this->assertArrayHasKey('filters', $data['data']);
+    $this->assertArrayHasKey('groups', $data['data']);
+
+    $items = $data['data']['items'];
+    $names = array_column($items, 'name');
+    $this->assertContains("zzz_dynamic_{$suffix}", $names);
+    $this->assertNotContains("zzz_static_{$suffix}", $names);
+    $this->assertNotContains("zzz_trashed_dynamic_{$suffix}", $names);
+
+    $item = $items[array_search("zzz_dynamic_{$suffix}", $names, true)];
+    $this->assertSame((string)$segment->getId(), $item['id']);
+    $this->assertSame(SegmentEntity::TYPE_DYNAMIC, $item['type']);
+    $this->assertArrayHasKey('count_all', $item);
+    $this->assertArrayHasKey('count_subscribed', $item);
+    $this->assertArrayHasKey('is_plugin_missing', $item);
+    $this->assertArrayHasKey('missing_plugin_message', $item);
+    $this->assertArrayHasKey('subscribers_url', $item);
+  }
+
+  public function testGetSupportsTrashGroupSearchPaginationAndDefaults(): void {
+    $suffix = uniqid();
+    (new SegmentFactory())->withName("zzz_search_b_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new SegmentFactory())->withName("zzz_search_a_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $trashed = (new SegmentFactory())->withName("zzz_search_trash_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->withDeleted()->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'per_page' => 1,
+      'page' => 1,
+      'orderby' => 'name',
+      'order' => 'asc',
+    ]]);
+    $this->assertSame(2, $data['data']['meta']['count']);
+    $this->assertSame(2, $data['data']['meta']['pages']);
+    $this->assertSame("zzz_search_a_{$suffix}", $data['data']['items'][0]['name']);
+
+    $trashData = $this->get(self::BASE_PATH, ['query' => ['group' => 'trash', 'search' => $suffix, 'per_page' => 100]]);
+    $ids = array_column($trashData['data']['items'], 'id');
+    $this->assertContains((string)$trashed->getId(), $ids);
+  }
+
+  public function testGetRejectsInvalidListingParamsAndUsersWithoutPermission(): void {
+    $this->assertSame('mailpoet_segments_invalid_group', $this->get(self::BASE_PATH, ['query' => ['group' => 'archived']])['code']);
+    $this->assertSame('mailpoet_segments_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'bad_field']])['code']);
+    $this->assertSame('mailpoet_segments_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'sideways']])['code']);
+    $this->assertSame('mailpoet_segments_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
+    $this->assertSame('mailpoet_segments_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['limit' => 101]])['code']);
+
+    wp_set_current_user($this->editorUserId);
+    $this->assertSame('rest_forbidden', $this->get(self::BASE_PATH)['code']);
+  }
+
+  public function testBulkActionTrashesRestoresAndDeletesDynamicSegments(): void {
+    $segment = (new SegmentFactory())->withName('Dynamic one')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$segment->getId()]],
+    ]);
+    $this->entityManager->clear();
+    $this->assertSame(1, $data['data']['updated']);
+    $trashedSegment = $this->segmentsRepository->findOneById($segment->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $trashedSegment);
+    $this->assertNotNull($trashedSegment->getDeletedAt());
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'restore', 'ids' => [(int)$segment->getId()]],
+    ]);
+    $this->entityManager->clear();
+    $this->assertSame(1, $data['data']['updated']);
+    $restoredSegment = $this->segmentsRepository->findOneById($segment->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $restoredSegment);
+    $this->assertNull($restoredSegment->getDeletedAt());
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'delete', 'ids' => [(int)$segment->getId()]],
+    ]);
+    $this->entityManager->clear();
+    $this->assertSame(1, $data['data']['deleted']);
+    $this->assertNull($this->segmentsRepository->findOneById($segment->getId()));
+  }
+
+  public function testBulkActionReportsWrongTypeAsSkipped(): void {
+    $static = (new SegmentFactory())->withName('Static')->create();
+    $dynamic = (new SegmentFactory())->withName('Dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$static->getId(), (int)$dynamic->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame(1, $data['data']['updated']);
+    $this->assertSame(1, $data['data']['skipped']);
+    $this->assertSame((int)$static->getId(), $data['data']['errors'][0]['id']);
+    $staticAfterAction = $this->segmentsRepository->findOneById($static->getId());
+    $dynamicAfterAction = $this->segmentsRepository->findOneById($dynamic->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $staticAfterAction);
+    $this->assertInstanceOf(SegmentEntity::class, $dynamicAfterAction);
+    $this->assertNull($staticAfterAction->getDeletedAt());
+    $this->assertNotNull($dynamicAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionRejectsInvalidInputs(): void {
+    $segment = (new SegmentFactory())->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+
+    $this->assertSame('mailpoet_dynamic_segments_invalid_bulk_action', $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'publish', 'ids' => [(int)$segment->getId()]],
+    ])['code']);
+    $this->assertSame('mailpoet_segments_ids_required', $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => []],
+    ])['code']);
+  }
+}

--- a/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
@@ -144,6 +144,32 @@ class SegmentsEndpointsTest extends Test {
     $this->assertNull($restoredWpUsers->getDeletedAt());
   }
 
+  public function testBulkActionSelectAllRestoresStaticTrash(): void {
+    $trashedOne = (new SegmentFactory())->withName('Select all restore one')->withDeleted()->create();
+    $trashedTwo = (new SegmentFactory())->withName('Select all restore two')->withDeleted()->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => [
+        'action' => 'restore',
+        'select_all' => true,
+        'group' => 'trash',
+        'page' => 1,
+        'per_page' => 20,
+        'orderby' => 'name',
+        'order' => 'asc',
+      ],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertGreaterThanOrEqual(2, $data['data']['updated']);
+    $restoredOne = $this->segmentsRepository->findOneById($trashedOne->getId());
+    $restoredTwo = $this->segmentsRepository->findOneById($trashedTwo->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $restoredOne);
+    $this->assertInstanceOf(SegmentEntity::class, $restoredTwo);
+    $this->assertNull($restoredOne->getDeletedAt());
+    $this->assertNull($restoredTwo->getDeletedAt());
+  }
+
   public function testBulkActionReportsPartialFailures(): void {
     $blocked = (new SegmentFactory())->withName('Blocked')->create();
     $ok = (new SegmentFactory())->withName('OK')->create();

--- a/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
@@ -100,6 +100,7 @@ class SegmentsEndpointsTest extends Test {
     $this->assertSame('mailpoet_segments_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'sideways']])['code']);
     $this->assertSame('mailpoet_segments_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
     $this->assertSame('mailpoet_segments_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['per_page' => 101]])['code']);
+    $this->assertSame('mailpoet_segments_invalid_offset', $this->get(self::BASE_PATH, ['query' => ['offset' => 100001]])['code']);
     $this->assertSame('mailpoet_segments_search_not_supported', $this->get(self::BASE_PATH, ['query' => ['search' => 'hidden']])['code']);
   }
 

--- a/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
@@ -2,12 +2,14 @@
 
 namespace MailPoet\Test\REST\Segments;
 
+use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\REST\Test;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Form as FormFactory;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 
@@ -161,6 +163,90 @@ class SegmentsEndpointsTest extends Test {
     $this->assertInstanceOf(SegmentEntity::class, $okAfterAction);
     $this->assertNull($blockedAfterAction->getDeletedAt());
     $this->assertNotNull($okAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionRejectsWrongTypeWithoutMutatingRows(): void {
+    $dynamic = (new SegmentFactory())->withName('Dynamic')->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    $list = (new SegmentFactory())->withName('Static')->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$dynamic->getId(), (int)$list->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame('mailpoet_segments_invalid_type', $data['code']);
+    $dynamicAfterAction = $this->segmentsRepository->findOneById($dynamic->getId());
+    $listAfterAction = $this->segmentsRepository->findOneById($list->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $dynamicAfterAction);
+    $this->assertInstanceOf(SegmentEntity::class, $listAfterAction);
+    $this->assertNull($dynamicAfterAction->getDeletedAt());
+    $this->assertNull($listAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionRejectsPermanentDeleteForActiveLists(): void {
+    $active = (new SegmentFactory())->withName('Active')->create();
+    $trashed = (new SegmentFactory())->withName('Trashed')->withDeleted()->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'delete', 'ids' => [(int)$active->getId(), (int)$trashed->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame('mailpoet_segments_delete_requires_trash', $data['code']);
+    $this->assertInstanceOf(SegmentEntity::class, $this->segmentsRepository->findOneById($active->getId()));
+    $this->assertInstanceOf(SegmentEntity::class, $this->segmentsRepository->findOneById($trashed->getId()));
+  }
+
+  public function testBulkActionGuestCannotMutateRows(): void {
+    $list = (new SegmentFactory())->withName('Guest protected')->create();
+    wp_set_current_user(0);
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$list->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame('rest_forbidden', $data['code']);
+    $listAfterAction = $this->segmentsRepository->findOneById($list->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $listAfterAction);
+    $this->assertNull($listAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionReportsActiveNewsletterBlocker(): void {
+    $blocked = (new SegmentFactory())->withName('Blocked by newsletter')->create();
+    (new NewsletterFactory())
+      ->withSubject('Blocking newsletter')
+      ->withScheduledStatus()
+      ->withScheduledQueue(['status' => ScheduledTaskEntity::STATUS_SCHEDULED])
+      ->withSegments([$blocked])
+      ->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$blocked->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame(0, $data['data']['updated']);
+    $this->assertSame(1, $data['data']['skipped']);
+    $this->assertSame((int)$blocked->getId(), $data['data']['errors'][0]['id']);
+    $blockedAfterAction = $this->segmentsRepository->findOneById($blocked->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $blockedAfterAction);
+    $this->assertNull($blockedAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionSkipsWooCommerceSpecialSegment(): void {
+    $woocommerce = (new SegmentFactory())->withName('WooCommerce Customers')->withType(SegmentEntity::TYPE_WC_USERS)->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$woocommerce->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame(0, $data['data']['updated']);
+    $this->assertSame(1, $data['data']['skipped']);
+    $woocommerceAfterAction = $this->segmentsRepository->findOneById($woocommerce->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $woocommerceAfterAction);
+    $this->assertNull($woocommerceAfterAction->getDeletedAt());
   }
 
   public function testBulkActionDeletesAndEmptyTrashDeletesStaticListsOnly(): void {

--- a/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
@@ -1,0 +1,190 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\Segments;
+
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\REST\Test;
+use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Form as FormFactory;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+require_once __DIR__ . '/../Test.php';
+
+class SegmentsEndpointsTest extends Test {
+  private const BASE_PATH = '/mailpoet/v1/segments';
+
+  /** @var SegmentsRepository */
+  private $segmentsRepository;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var int */
+  private $editorUserId;
+
+  public function _before() {
+    parent::_before();
+    $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    wp_set_current_user(1);
+    $userId = wp_create_user('segments_editor_' . uniqid(), 'password', 'segments-editor-' . uniqid() . '@localhost.test');
+    $this->assertIsNumeric($userId);
+    $user = new \WP_User($userId);
+    $user->add_role('editor');
+    $this->editorUserId = $userId;
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+    is_multisite() ? wpmu_delete_user($this->editorUserId) : wp_delete_user($this->editorUserId);
+  }
+
+  public function testGetReturnsStaticListsEnvelope(): void {
+    $suffix = uniqid();
+    $list = (new SegmentFactory())->withName("zzz_list_{$suffix}")->withDescription('Description')->create();
+    (new SegmentFactory())->withName("zzz_trashed_{$suffix}")->withDeleted()->create();
+    (new SegmentFactory())->withName("zzz_dynamic_{$suffix}")->withType(SegmentEntity::TYPE_DYNAMIC)->create();
+    (new SubscriberFactory())->withSegments([$list])->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'per_page' => 100,
+      'orderby' => 'name',
+      'order' => 'asc',
+    ]]);
+
+    $this->assertIsArray($data['data']);
+    $this->assertArrayHasKey('items', $data['data']);
+    $this->assertArrayHasKey('meta', $data['data']);
+    $this->assertArrayHasKey('filters', $data['data']);
+    $this->assertArrayHasKey('groups', $data['data']);
+
+    $items = $data['data']['items'];
+    $names = array_column($items, 'name');
+    $this->assertContains("zzz_list_{$suffix}", $names);
+    $this->assertNotContains("zzz_trashed_{$suffix}", $names);
+    $this->assertNotContains("zzz_dynamic_{$suffix}", $names);
+
+    $item = $items[array_search("zzz_list_{$suffix}", $names, true)];
+    $this->assertSame((string)$list->getId(), $item['id']);
+    $this->assertSame(SegmentEntity::TYPE_DEFAULT, $item['type']);
+    $this->assertArrayHasKey('subscribers_count', $item);
+    $this->assertArrayHasKey('subscribers_url', $item);
+    $this->assertArrayHasKey('show_in_manage_subscription_page', $item);
+  }
+
+  public function testGetReturnsTrashGroupAndCounts(): void {
+    $trashed = (new SegmentFactory())->withName('Trashed_' . uniqid())->withDeleted()->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['group' => 'trash', 'per_page' => 100]]);
+    $ids = array_column($data['data']['items'], 'id');
+    $this->assertContains((string)$trashed->getId(), $ids);
+    foreach ($data['data']['items'] as $item) {
+      $this->assertNotNull($item['deleted_at']);
+    }
+
+    $groups = array_column($data['data']['groups'], 'count', 'name');
+    $this->assertArrayHasKey('all', $groups);
+    $this->assertArrayHasKey('trash', $groups);
+    $this->assertGreaterThanOrEqual(1, $groups['trash']);
+  }
+
+  public function testGetRejectsInvalidListingParams(): void {
+    $this->assertSame('mailpoet_segments_invalid_group', $this->get(self::BASE_PATH, ['query' => ['group' => 'archived']])['code']);
+    $this->assertSame('mailpoet_segments_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'bad_field']])['code']);
+    $this->assertSame('mailpoet_segments_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'sideways']])['code']);
+    $this->assertSame('mailpoet_segments_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
+    $this->assertSame('mailpoet_segments_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['per_page' => 101]])['code']);
+    $this->assertSame('mailpoet_segments_search_not_supported', $this->get(self::BASE_PATH, ['query' => ['search' => 'hidden']])['code']);
+  }
+
+  public function testGetRejectsUsersWithoutPermission(): void {
+    wp_set_current_user($this->editorUserId);
+
+    $data = $this->get(self::BASE_PATH);
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  public function testBulkActionTrashesAndRestoresStaticLists(): void {
+    $list = (new SegmentFactory())->withName('Trash me')->create();
+    $wpUsers = (new SegmentFactory())->withName('WP Users')->withType(SegmentEntity::TYPE_WP_USERS)->create();
+    $subscriber = (new SubscriberFactory())->withSegments([$wpUsers])->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$list->getId(), (int)$wpUsers->getId()]],
+    ]);
+    $this->entityManager->clear();
+    $this->assertSame(2, $data['data']['updated']);
+    $this->assertSame(0, $data['data']['skipped']);
+    $trashedList = $this->segmentsRepository->findOneById($list->getId());
+    $trashedWpUsers = $this->segmentsRepository->findOneById($wpUsers->getId());
+    $trashedSubscriber = $this->subscribersRepository->findOneById($subscriber->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $trashedList);
+    $this->assertInstanceOf(SegmentEntity::class, $trashedWpUsers);
+    $this->assertInstanceOf(SubscriberEntity::class, $trashedSubscriber);
+    $this->assertNotNull($trashedList->getDeletedAt());
+    $this->assertNotNull($trashedWpUsers->getDeletedAt());
+    $this->assertNotNull($trashedSubscriber->getDeletedAt());
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'restore', 'ids' => [(int)$list->getId(), (int)$wpUsers->getId()]],
+    ]);
+    $this->entityManager->clear();
+    $this->assertSame(2, $data['data']['updated']);
+    $restoredList = $this->segmentsRepository->findOneById($list->getId());
+    $restoredWpUsers = $this->segmentsRepository->findOneById($wpUsers->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $restoredList);
+    $this->assertInstanceOf(SegmentEntity::class, $restoredWpUsers);
+    $this->assertNull($restoredList->getDeletedAt());
+    $this->assertNull($restoredWpUsers->getDeletedAt());
+  }
+
+  public function testBulkActionReportsPartialFailures(): void {
+    $blocked = (new SegmentFactory())->withName('Blocked')->create();
+    $ok = (new SegmentFactory())->withName('OK')->create();
+    (new FormFactory())->withName('Blocked form')->withSegments([$blocked])->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$blocked->getId(), (int)$ok->getId()]],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertSame(1, $data['data']['updated']);
+    $this->assertSame(1, $data['data']['skipped']);
+    $this->assertSame((int)$blocked->getId(), $data['data']['errors'][0]['id']);
+    $blockedAfterAction = $this->segmentsRepository->findOneById($blocked->getId());
+    $okAfterAction = $this->segmentsRepository->findOneById($ok->getId());
+    $this->assertInstanceOf(SegmentEntity::class, $blockedAfterAction);
+    $this->assertInstanceOf(SegmentEntity::class, $okAfterAction);
+    $this->assertNull($blockedAfterAction->getDeletedAt());
+    $this->assertNotNull($okAfterAction->getDeletedAt());
+  }
+
+  public function testBulkActionDeletesAndEmptyTrashDeletesStaticListsOnly(): void {
+    $trashed = (new SegmentFactory())->withName('Gone')->withDeleted()->create();
+    $wpUsers = (new SegmentFactory())->withName('WP Users trashed')->withType(SegmentEntity::TYPE_WP_USERS)->withDeleted()->create();
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'empty_trash'],
+    ]);
+    $this->entityManager->clear();
+
+    $this->assertGreaterThanOrEqual(1, $data['data']['deleted']);
+    $this->assertNull($this->segmentsRepository->findOneById($trashed->getId()));
+    $this->assertInstanceOf(SegmentEntity::class, $this->segmentsRepository->findOneById($wpUsers->getId()));
+  }
+
+  public function testBulkActionRejectsInvalidInputs(): void {
+    $list = (new SegmentFactory())->create();
+
+    $this->assertSame('mailpoet_segments_invalid_bulk_action', $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'publish', 'ids' => [(int)$list->getId()]],
+    ])['code']);
+    $this->assertSame('mailpoet_segments_ids_required', $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => []],
+    ])['code']);
+  }
+}

--- a/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Segments/SegmentsEndpointsTest.php
@@ -94,6 +94,23 @@ class SegmentsEndpointsTest extends Test {
     $this->assertGreaterThanOrEqual(1, $groups['trash']);
   }
 
+  public function testGetSearchesStaticLists(): void {
+    $suffix = uniqid();
+    $matching = (new SegmentFactory())->withName("Searchable list {$suffix}")->create();
+    (new SegmentFactory())->withName("Hidden list {$suffix}")->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => "Searchable list {$suffix}",
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_column($data['data']['items'], 'id');
+    $this->assertContains((string)$matching->getId(), $ids);
+    foreach ($data['data']['items'] as $item) {
+      $this->assertStringContainsString("Searchable list {$suffix}", $item['name'] . $item['description']);
+    }
+  }
+
   public function testGetRejectsInvalidListingParams(): void {
     $this->assertSame('mailpoet_segments_invalid_group', $this->get(self::BASE_PATH, ['query' => ['group' => 'archived']])['code']);
     $this->assertSame('mailpoet_segments_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'bad_field']])['code']);
@@ -101,7 +118,6 @@ class SegmentsEndpointsTest extends Test {
     $this->assertSame('mailpoet_segments_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
     $this->assertSame('mailpoet_segments_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['per_page' => 101]])['code']);
     $this->assertSame('mailpoet_segments_invalid_offset', $this->get(self::BASE_PATH, ['query' => ['offset' => 100001]])['code']);
-    $this->assertSame('mailpoet_segments_search_not_supported', $this->get(self::BASE_PATH, ['query' => ['search' => 'hidden']])['code']);
   }
 
   public function testGetRejectsUsersWithoutPermission(): void {

--- a/mailpoet/views/segments/dynamic.html
+++ b/mailpoet/views/segments/dynamic.html
@@ -6,6 +6,7 @@
   <script type="text/javascript">
     var mailpoet_dynamic_segment_count = <%= dynamic_segment_count %>;
     var mailpoet_listing_per_page = <%= items_per_page %>;
+    var mailpoet_segments_api = <%= json_encode(api) %>;
     var mailpoet_custom_fields = <%= json_encode(custom_fields) %>;
     var mailpoet_static_segments_list = <%= json_encode(static_segments_list) %>;
     var wordpress_editable_roles_list = <%= json_encode(wordpress_editable_roles_list)  %>;

--- a/mailpoet/views/segments/static.html
+++ b/mailpoet/views/segments/static.html
@@ -5,6 +5,7 @@
 
   <script type="text/javascript">
     var mailpoet_listing_per_page = <%= items_per_page %>;
+    var mailpoet_segments_api = <%= json_encode(api) %>;
   </script>
 
   <% include 'segments/translations.html' %>


### PR DESCRIPTION
## Description

Migrates the MailPoet Lists and Segments listing pages to WordPress DataViews.

The change adds REST-backed listing and bulk-action endpoints for static lists and dynamic segments, preserves the legacy create/edit flows, and keeps existing listing behaviors such as search, sorting, pagination, trash/restore/delete, special segment restrictions, and missing-plugin handling for WooCommerce-based dynamic segments.

## Code review notes

- The new REST endpoints use the shared listing envelope expected by DataViews while keeping the existing JSON API flows for create/edit/duplicate actions.
- Missing-plugin dynamic segments keep editing disabled, but the explanatory message is rendered in the segment details instead of as an inline primary action so the DataViews actions column stays compact.

## QA notes

1. Open MailPoet > Lists and verify All/Trash tabs, search, sorting, pagination, row actions, and bulk trash/restore/delete behavior.
2. Open MailPoet > Segments and verify All/Trash tabs, search, sorting, pagination, row actions, duplicate, view subscribers, and bulk trash/restore/delete behavior.
3. On a WooCommerce-dependent dynamic segment without WooCommerce active, verify the row explains why editing is unavailable and the actions column remains compact.
4. Verify creating or editing a list or dynamic segment still returns to the listing page with the expected updated data.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7985/migrate-listssegments-listing-pages-to-dataviews

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

### Lists

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="1517" height="604" alt="Lists-before" src="https://github.com/user-attachments/assets/305ecf64-5c4d-42e2-8189-22a89c1bbd2f" />  |  <img width="1494" height="445" alt="Lists-after" src="https://github.com/user-attachments/assets/2ffc5f2e-84d5-449c-bd1c-1cd10c99e7c0" />  |


### Dynamic Segments

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
|  <img width="1514" height="477" alt="Segments-before" src="https://github.com/user-attachments/assets/2dbf610c-94a1-437c-ae91-c684ace21ca4" /> |   <img width="1511" height="553" alt="Segments-after" src="https://github.com/user-attachments/assets/e8d088ee-1bd5-4673-b580-22b90d87b325" />  |



## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/STOMAIL-7985-migrate-segments-to-dataviews)

_The latest successful build from `update/STOMAIL-7985-migrate-segments-to-dataviews` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->