### PR TITLE
`None of the conditions` in segments

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -42,6 +42,7 @@ export enum SubscriberActionTypes {
 export enum SegmentConnectTypes {
   AND = 'and',
   OR = 'or',
+  NONE = 'none',
 }
 
 export enum AnyValueTypes {

--- a/mailpoet/assets/js/src/webpack-admin-expose.js
+++ b/mailpoet/assets/js/src/webpack-admin-expose.js
@@ -34,6 +34,7 @@ export * as WordPressAPIFetch from '@wordpress/api-fetch';
 export * as WordPressData from '@wordpress/data';
 export * as WordPressDate from '@wordpress/date';
 export * as WordPressUrl from '@wordpress/url';
+export * as WordPressElement from '@wordpress/element';
 export * as WordPressI18n from '@wordpress/i18n';
 export * as WordPressIcons from '@wordpress/icons';
 export * as WordPressDataControls from '@wordpress/data-controls';

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -20,6 +20,7 @@ class DynamicSegmentFilterData {
 
   public const CONNECT_TYPE_AND = 'and';
   public const CONNECT_TYPE_OR = 'or';
+  public const CONNECT_TYPE_NONE = 'none';
 
   public const OPERATOR_ALL = 'all';
   public const OPERATOR_ANY = 'any';

--- a/mailpoet/lib/Segments/DynamicSegments/FilterHandler.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterHandler.php
@@ -35,6 +35,10 @@ class FilterHandler {
     $filterSelects = [];
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $pluginsForAllFiltersMissing = $this->segmentDependencyValidator->getMissingPluginsByAllFilters($filters);
+    if ($pluginsForAllFiltersMissing) {
+      return $queryBuilder->andWhere('1 = 0');
+    }
+    $filtersConnectOperator = $segment->getFiltersConnectOperator();
     foreach ($filters as $filter) {
       $subscribersIdsQuery = $this->entityManager
         ->getConnection()
@@ -42,7 +46,11 @@ class FilterHandler {
         ->select("DISTINCT $subscribersTable.id as inner_subscriber_id")
         ->from($subscribersTable);
       // When a required plugin is missing we want to return empty result
-      if ($pluginsForAllFiltersMissing || $this->segmentDependencyValidator->getMissingPluginsByFilter($filter)) {
+      $missingPlugins = $this->segmentDependencyValidator->getMissingPluginsByFilter($filter);
+      if ($missingPlugins && $filtersConnectOperator === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
+        return $queryBuilder->andWhere('1 = 0');
+      }
+      if ($missingPlugins) {
         $subscribersIdsQuery->andWhere('1 = 0');
       } else {
         $this->filterFactory->getFilterForFilterEntity($filter)->apply($subscribersIdsQuery, $filter);
@@ -59,16 +67,15 @@ class FilterHandler {
         )
       );
     }
-    $this->joinSubqueries($queryBuilder, $segment, $filterSelects);
+    $this->joinSubqueries($queryBuilder, $filtersConnectOperator, $filterSelects);
     return $queryBuilder;
   }
 
-  private function joinSubqueries(QueryBuilder $queryBuilder, SegmentEntity $segment, array $subQueries): QueryBuilder {
-    $filter = $segment->getDynamicFilters()->first();
-    if (!$filter) return $queryBuilder;
+  private function joinSubqueries(QueryBuilder $queryBuilder, string $filtersConnectOperator, array $subQueries): QueryBuilder {
+    if (!$subQueries) return $queryBuilder;
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
 
-    if ($segment->getFiltersConnectOperator() === DynamicSegmentFilterData::CONNECT_TYPE_OR) {
+    if ($filtersConnectOperator === DynamicSegmentFilterData::CONNECT_TYPE_OR) {
       // the final query: SELECT * FROM subscribers INNER JOIN (filter_select1 UNION filter_select2) filtered_subscribers ON filtered_subscribers.inner_subscriber_id = id
       $queryBuilder->innerJoin(
         $subscribersTable,
@@ -76,6 +83,17 @@ class FilterHandler {
         'filtered_subscribers',
         "filtered_subscribers.inner_subscriber_id = $subscribersTable.id"
       );
+      return $queryBuilder;
+    }
+
+    if ($filtersConnectOperator === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
+      $queryBuilder->leftJoin(
+        $subscribersTable,
+        sprintf('(%s)', join(' UNION ', $subQueries)),
+        'filtered_subscribers',
+        "filtered_subscribers.inner_subscriber_id = $subscribersTable.id"
+      )
+        ->andWhere('filtered_subscribers.inner_subscriber_id IS NULL');
       return $queryBuilder;
     }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
@@ -6,9 +6,13 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\FilterFactory;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
+use MailPoet\Segments\SegmentDependencyValidator;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\Common\Collections\Collection;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use MailPoetVendor\Doctrine\DBAL\Result;
 
@@ -23,6 +27,7 @@ class FilterHandlerTest extends \MailPoetTest {
     $this->tester->createWordPressUser('user-role-test1@example.com', 'editor');
     $this->tester->createWordPressUser('user-role-test2@example.com', 'administrator');
     $this->tester->createWordPressUser('user-role-test3@example.com', 'editor');
+    (new SubscriberFactory())->withEmail('user-role-test4@example.com')->create();
 
     // fetch entities
     /** @var SubscribersRepository $subscribersRepository */
@@ -43,7 +48,7 @@ class FilterHandlerTest extends \MailPoetTest {
   }
 
   public function testItAppliesFilter(): void {
-    $segment = $this->getSegment('editor');
+    $segment = $this->getSegment(['editor']);
     $statement = $this->filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
     $this->assertInstanceOf(Result::class, $statement);
     $result = $statement->fetchAll();
@@ -58,17 +63,166 @@ class FilterHandlerTest extends \MailPoetTest {
     verify($subscriber2->getEmail())->equals('user-role-test3@example.com');
   }
 
-  private function getSegment(string $role): SegmentEntity {
-    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, [
-      'wordpressRole' => $role,
+  public function testItAppliesOrConnectOperator(): void {
+    $segment = $this->getSegment(
+      ['editor', 'administrator'],
+      DynamicSegmentFilterData::CONNECT_TYPE_OR
+    );
+    $filterHandler = $this->getFilterHandlerWithoutMissingDependencies();
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    verify($this->getEmailsFromResult($result))->equals([
+      'user-role-test1@example.com',
+      'user-role-test2@example.com',
+      'user-role-test3@example.com',
     ]);
+  }
+
+  public function testItAppliesNoneConnectOperator(): void {
+    $segment = $this->getSegment(
+      ['editor', 'administrator'],
+      DynamicSegmentFilterData::CONNECT_TYPE_NONE
+    );
+    $filterHandler = $this->getFilterHandlerWithoutMissingDependencies();
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    verify($this->getEmailsFromResult($result))->equals([
+      'user-role-test4@example.com',
+    ]);
+  }
+
+  public function testItAppliesNoneConnectOperatorWithSingleFilter(): void {
+    $segment = $this->getSegment(
+      ['editor'],
+      DynamicSegmentFilterData::CONNECT_TYPE_NONE
+    );
+    $statement = $this->filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    // Editors are excluded; the administrator and the non-WP-user subscriber remain.
+    verify($this->getEmailsFromResult($result))->equals([
+      'user-role-test2@example.com',
+      'user-role-test4@example.com',
+    ]);
+  }
+
+  public function testItAppliesNoneConnectOperatorReturnsAllWhenNoSubscribersMatch(): void {
+    // No test user has the 'subscriber' role, so the inner subquery is empty and
+    // the LEFT JOIN keeps every subscriber.
+    $segment = $this->getSegment(
+      ['subscriber'],
+      DynamicSegmentFilterData::CONNECT_TYPE_NONE
+    );
+    $statement = $this->filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    verify($this->getEmailsFromResult($result))->equals([
+      'user-role-test1@example.com',
+      'user-role-test2@example.com',
+      'user-role-test3@example.com',
+      'user-role-test4@example.com',
+    ]);
+  }
+
+  public function testItReturnsEmptyResultForNoneWhenAdvancedSegmentsAreUnavailable(): void {
+    $segment = $this->getSegment(
+      ['editor', 'administrator'],
+      DynamicSegmentFilterData::CONNECT_TYPE_NONE
+    );
+    $statement = $this->filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    verify($result)->arrayCount(0);
+  }
+
+  public function testItReturnsEmptyResultForNoneWhenSingleFilterHasMissingPlugin(): void {
+    // Models the case where the segment-wide premium check passes (e.g. only
+    // one filter, or premium is active), but a specific filter's plugin
+    // dependency is missing. For NONE we cannot safely include the affected
+    // subscribers, so the whole result must be empty.
+    $segment = $this->getSegment(
+      ['editor', 'administrator'],
+      DynamicSegmentFilterData::CONNECT_TYPE_NONE
+    );
+    $segmentDependencyValidator = new class extends SegmentDependencyValidator {
+      public function __construct() {
+      }
+
+      public function getMissingPluginsByAllFilters(Collection $dynamicFilters): array {
+        return [];
+      }
+
+      public function getMissingPluginsByFilter(DynamicSegmentFilterEntity $dynamicSegmentFilter): array {
+        return ['SomePlugin'];
+      }
+    };
+    $filterHandler = new FilterHandler(
+      $this->entityManager,
+      $segmentDependencyValidator,
+      $this->diContainer->get(FilterFactory::class)
+    );
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    verify($result)->arrayCount(0);
+  }
+
+  /**
+   * @param string[] $roles
+   */
+  private function getSegment(array $roles, string $connect = DynamicSegmentFilterData::CONNECT_TYPE_AND): SegmentEntity {
     $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
-    $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $filterData);
-    $segment->addDynamicFilter($dynamicSegmentFilter);
+    foreach ($roles as $role) {
+      $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, [
+        'wordpressRole' => $role,
+        'connect' => $connect,
+      ]);
+      $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $filterData);
+      $segment->addDynamicFilter($dynamicSegmentFilter);
+      $this->entityManager->persist($dynamicSegmentFilter);
+    }
     $this->entityManager->persist($segment);
-    $this->entityManager->persist($dynamicSegmentFilter);
     $this->entityManager->flush();
     return $segment;
+  }
+
+  private function getFilterHandlerWithoutMissingDependencies(): FilterHandler {
+    $segmentDependencyValidator = new class extends SegmentDependencyValidator {
+      public function __construct() {
+      }
+
+      public function getMissingPluginsByAllFilters(Collection $dynamicFilters): array {
+        return [];
+      }
+
+      public function getMissingPluginsByFilter(DynamicSegmentFilterEntity $dynamicSegmentFilter): array {
+        return [];
+      }
+    };
+
+    return new FilterHandler(
+      $this->entityManager,
+      $segmentDependencyValidator,
+      $this->diContainer->get(FilterFactory::class)
+    );
+  }
+
+  private function getEmailsFromResult(array $result): array {
+    $emails = [];
+    foreach ($result as $subscriberData) {
+      $subscriber = $this->entityManager->find(SubscriberEntity::class, $subscriberData['id']);
+      $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+      $emails[] = $subscriber->getEmail();
+    }
+    return $emails;
   }
 
   private function getQueryBuilder(): QueryBuilder {
@@ -87,9 +241,22 @@ class FilterHandlerTest extends \MailPoetTest {
   }
 
   private function cleanWpUsers(): void {
-    $emails = ['user-role-test1@example.com', 'user-role-test2@example.com', 'user-role-test3@example.com'];
+    $emails = [
+      'user-role-test1@example.com',
+      'user-role-test2@example.com',
+      'user-role-test3@example.com',
+    ];
     foreach ($emails as $email) {
       $this->tester->deleteWordPressUser($email);
     }
+    foreach (array_merge($emails, ['user-role-test4@example.com']) as $email) {
+      $subscriber = $this->entityManager
+        ->getRepository(SubscriberEntity::class)
+        ->findOneBy(['email' => $email]);
+      if ($subscriber instanceof SubscriberEntity) {
+        $this->entityManager->remove($subscriber);
+      }
+    }
+    $this->entityManager->flush();
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/SegmentSaveControllerTest.php
@@ -79,6 +79,28 @@ class SegmentSaveControllerTest extends \MailPoetTest {
     ]);
   }
 
+  public function testItCanSaveNoneConnectOperator(): void {
+    $segmentData = [
+      'name' => 'Test Segment',
+      'description' => 'Description',
+      'filters_connect' => DynamicSegmentFilterData::CONNECT_TYPE_NONE,
+      'filters' => [[
+        'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
+        'wordpressRole' => ['subscriber'],
+        'action' => UserRole::TYPE,
+      ]],
+    ];
+
+    $segment = $this->saveController->save($segmentData);
+    $filter = $segment->getDynamicFilters()->first();
+    $this->assertInstanceOf(DynamicSegmentFilterEntity::class, $filter);
+    verify($filter->getFilterData()->getData())->equals([
+      'wordpressRole' => ['subscriber'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_NONE,
+    ]);
+  }
+
   public function testItCheckDuplicateSegment(): void {
     $name = 'Test name';
     $this->createSegment($name);


### PR DESCRIPTION
## Description

Adds backend functionality to allow using `None of the conditions` in segments. This is premium feature, so UI is added in the premium PR. 

## Code review notes

This is premium feature, so changelog is included in premium PR. 

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1045

## Linked tickets

STOMAIL-7997

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7997-none-of-the-conditions-in-segments)

_The latest successful build from `stomail-7997-none-of-the-conditions-in-segments` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR introduces the "None of the conditions" segment feature with a well-implemented backend architecture. The implementation includes:

- Proper SQL logic using LEFT JOIN with IS NULL condition to exclude matching subscribers
- Appropriate handling of missing plugin dependencies (returns empty result for NONE operator)
- Comprehensive test coverage including edge cases (no matching subscribers, missing plugins, unavailable advanced segments)
- Type-safe constant definitions in both PHP and TypeScript
- Consistent integration with existing AND/OR operator patterns

All code changes are correctly structured, properly parameterized for SQL injection prevention, and backed by adequate integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->