### PR TITLE
Add cast.string baseline entry for SystemReportCollector

### DIFF
--- a/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-7-baseline.neon
@@ -1076,6 +1076,11 @@ parameters:
 			path: ../../lib/SystemReport/SystemReportCollector.php
 
 		-
+			identifier: cast.string
+			count: 1
+			path: ../../lib/SystemReport/SystemReportCollector.php
+
+		-
 			identifier: argument.type
 			count: 1
 			path: ../../lib/Tags/RestApi/Endpoints/TagsBulkDeleteEndpoint.php

--- a/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-8-baseline.neon
@@ -1066,6 +1066,11 @@ parameters:
 			path: ../../lib/SystemReport/SystemReportCollector.php
 
 		-
+			identifier: cast.string
+			count: 1
+			path: ../../lib/SystemReport/SystemReportCollector.php
+
+		-
 			identifier: argument.type
 			count: 1
 			path: ../../lib/Tags/RestApi/Endpoints/TagsBulkDeleteEndpoint.php


### PR DESCRIPTION
## Description

Mini follow-up to STOMAIL-7987 (PHPStan 2.x upgrade). A new
`cast.string` error in `lib/SystemReport/SystemReportCollector.php`
surfaces on trunk from code that landed concurrently with the PHPStan
upgrade. Because the upgrade PR was not rebased before merge, the
regenerated baselines did not capture this error.

This PR adds a single entry to both PHP 7 and PHP 8 baselines.

```yaml
-
    identifier: cast.string
    count: 1
    path: ../../lib/SystemReport/SystemReportCollector.php
```

## Code review notes

The actual line is `$latestVersion = (string)$pluginUpdate['new_version'];`
in `getActivePluginsData()`. PHPStan 2.x cannot prove that
`$pluginUpdate['new_version']` is a value safely castable to string, since
the array shape is not declared. A proper fix would tighten the input type
or add an `is_string` guard before the cast — out of scope for this
unblock-CI mini PR. The entry is added to the existing baseline so a
later cleanup ticket can address the cast.string identifier as a category.

## QA notes

Verified locally on macOS / PHP 8.3.21 host:

- `cd mailpoet/tasks/phpstan && php -d memory_limit=-1 vendor/bin/phpstan analyse <paths>`
  → `[OK] No errors`
- `ANALYSIS_PHP_VERSION=70400 php -d memory_limit=-1 vendor/bin/phpstan analyse <paths>`
  → `[OK] No errors`

## Linked PRs

_N/A_

## Linked tickets

closes STOMAIL-7987

## After-merge notes

_N/A_

## Tasks

- [x] I added sufficient test coverage — covered by the static analyzer itself

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7987-phpstan-baseline-after-merge)

_The latest successful build from `fix/stomail-7987-phpstan-baseline-after-merge` will be used. If none is available, the link won't work._