### PR TITLE
Add bulk confirmation email resend

### DIFF
--- a/mailpoet/assets/js/src/common/button/button.tsx
+++ b/mailpoet/assets/js/src/common/button/button.tsx
@@ -39,6 +39,7 @@ export function Button({
   target,
   automationId,
   className,
+  'aria-describedby': ariaDescribedBy,
 }: Props) {
   const Element = href ? 'a' : 'button';
   return (
@@ -64,6 +65,7 @@ export function Button({
       data-automation-id={automationId}
       data-tip={dataTip}
       data-tooltip-id={dataFor}
+      aria-describedby={ariaDescribedBy}
     >
       {iconStart}
       {children && <span>{children}</span>}

--- a/mailpoet/assets/js/src/common/modal/frame.tsx
+++ b/mailpoet/assets/js/src/common/modal/frame.tsx
@@ -4,12 +4,16 @@ import classnames from 'classnames';
 type Props = {
   fullScreen?: boolean;
   className?: string;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
   children: ReactNode;
 };
 
 export function ModalFrame({
   fullScreen = false,
   className = '',
+  ariaLabel = undefined,
+  ariaLabelledBy = undefined,
   children,
 }: Props) {
   return (
@@ -20,6 +24,8 @@ export function ModalFrame({
         className,
       )}
       role="dialog"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       tabIndex={-1}
     >
       {children}

--- a/mailpoet/assets/js/src/common/modal/header.tsx
+++ b/mailpoet/assets/js/src/common/modal/header.tsx
@@ -2,12 +2,15 @@ import { Heading } from '../typography/heading/heading';
 
 type Props = {
   title: string;
+  id?: string;
 };
 
-export function ModalHeader({ title }: Props) {
+export function ModalHeader({ title, id = undefined }: Props) {
   return (
     <div className="mailpoet-modal-header">
-      <Heading level={3}>{title}</Heading>
+      <Heading id={id} level={3}>
+        {title}
+      </Heading>
     </div>
   );
 }

--- a/mailpoet/assets/js/src/common/modal/modal.tsx
+++ b/mailpoet/assets/js/src/common/modal/modal.tsx
@@ -1,6 +1,7 @@
-import { ReactNode } from 'react';
+import { ReactNode, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { noop } from 'lodash';
+import { __ } from '@wordpress/i18n';
 
 import { ModalFrame } from './frame';
 import { ModalHeader } from './header';
@@ -16,6 +17,8 @@ type Props = {
   fullScreen?: boolean;
   contentClassName?: string;
   overlayClassName?: string;
+  ariaLabel?: string;
+  closeButtonLabel?: string;
   children: ReactNode;
 };
 
@@ -28,8 +31,15 @@ export function Modal({
   fullScreen = false,
   contentClassName = '',
   overlayClassName = '',
+  ariaLabel = undefined,
+  closeButtonLabel = __('Close modal', 'mailpoet'),
   children,
 }: Props) {
+  const generatedTitleId = useId();
+  const titleId = title
+    ? `mailpoet-modal-title-${generatedTitleId}`
+    : undefined;
+
   return createPortal(
     <ModalOverlay
       isDismissible={isDismissible}
@@ -38,14 +48,20 @@ export function Modal({
       shouldCloseOnClickOutside={shouldCloseOnClickOutside}
       className={overlayClassName}
     >
-      <ModalFrame className={contentClassName} fullScreen={fullScreen}>
-        {title && <ModalHeader title={title} />}
+      <ModalFrame
+        className={contentClassName}
+        fullScreen={fullScreen}
+        ariaLabel={ariaLabel}
+        ariaLabelledBy={ariaLabel ? undefined : titleId}
+      >
+        {title && <ModalHeader id={titleId} title={title} />}
         {isDismissible && (
           <button
             type="button"
             onClick={onRequestClose}
             className="mailpoet-modal-close"
             data-automation-id="mailpoet-modal-close"
+            aria-label={closeButtonLabel}
           >
             {modalCloseIcon}
           </button>

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -136,6 +136,7 @@ interface Window {
   mailpoet_date_format: string;
   mailpoet_listing_per_page: string;
   mailpoet_signup_confirmation_enabled: boolean;
+  mailpoet_bulk_confirmation_resend_limit: number;
   mailpoet_3rd_party_libs_enabled: string;
   mailpoet_analytics_enabled: boolean;
   mailpoet_datetime_format: string;

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -135,6 +135,7 @@ interface Window {
   mailpoet_time_format: string;
   mailpoet_date_format: string;
   mailpoet_listing_per_page: string;
+  mailpoet_signup_confirmation_enabled: boolean;
   mailpoet_3rd_party_libs_enabled: string;
   mailpoet_analytics_enabled: boolean;
   mailpoet_datetime_format: string;

--- a/mailpoet/assets/js/src/listing/bulk-actions.jsx
+++ b/mailpoet/assets/js/src/listing/bulk-actions.jsx
@@ -40,7 +40,7 @@ class ListingBulkActions extends Component {
     }
 
     const selectedIds =
-      this.props.selection !== 'all' ? this.props.selected_ids : [];
+      this.props.selection === 'all' ? 'all' : this.props.selected_ids;
 
     const data = action.getData !== undefined ? action.getData() : {};
 

--- a/mailpoet/assets/js/src/listing/bulk-actions.jsx
+++ b/mailpoet/assets/js/src/listing/bulk-actions.jsx
@@ -28,9 +28,7 @@ class ListingBulkActions extends Component {
       const submitModal = () => this.handleApplyAction(actionName);
       const closeModal = () => {
         this.setState({ extra: false }, () => {
-          if (this.triggerElement) {
-            this.triggerElement.focus();
-          }
+          this.restoreTriggerElementFocus();
         });
       };
       this.setState({
@@ -69,9 +67,7 @@ class ListingBulkActions extends Component {
         extra: false,
       },
       () => {
-        if (this.triggerElement) {
-          this.triggerElement.focus();
-        }
+        this.restoreTriggerElementFocus();
       },
     );
   }
@@ -88,6 +84,14 @@ class ListingBulkActions extends Component {
       }
     }
     return null;
+  }
+
+  restoreTriggerElementFocus() {
+    const { triggerElement } = this;
+    this.triggerElement = null;
+    if (triggerElement && document.contains(triggerElement)) {
+      triggerElement.focus();
+    }
   }
 
   render() {

--- a/mailpoet/assets/js/src/listing/bulk-actions.jsx
+++ b/mailpoet/assets/js/src/listing/bulk-actions.jsx
@@ -10,20 +10,29 @@ class ListingBulkActions extends Component {
     this.state = {
       extra: false,
     };
+    this.isSubmittingAction = false;
+    this.triggerElement = null;
     this.handleApplyAction = this.handleApplyAction.bind(this);
   }
 
-  handleApplyAction(actionName) {
+  handleApplyAction(actionName, triggerElement = null) {
     const action = this.getSelectedAction(actionName);
 
-    if (action === null) {
+    if (action === null || this.isSubmittingAction) {
       return;
     }
 
     // action on select callback
     if (action.onSelect !== undefined && !this.state.extra) {
+      this.triggerElement = triggerElement;
       const submitModal = () => this.handleApplyAction(actionName);
-      const closeModal = () => this.setState({ extra: false });
+      const closeModal = () => {
+        this.setState({ extra: false }, () => {
+          if (this.triggerElement) {
+            this.triggerElement.focus();
+          }
+        });
+      };
       this.setState({
         extra: action.onSelect(submitModal, closeModal, this.props),
       });
@@ -43,15 +52,28 @@ class ListingBulkActions extends Component {
     }
 
     if (data.action) {
+      this.isSubmittingAction = true;
       const promise = this.props.onBulkAction(selectedIds, data);
       if (promise !== false) {
         promise.then(onSuccess);
+        promise.always(() => {
+          this.isSubmittingAction = false;
+        });
+      } else {
+        this.isSubmittingAction = false;
       }
     }
 
-    this.setState({
-      extra: false,
-    });
+    this.setState(
+      {
+        extra: false,
+      },
+      () => {
+        if (this.triggerElement) {
+          this.triggerElement.focus();
+        }
+      },
+    );
   }
 
   getSelectedAction(actionName) {
@@ -90,7 +112,7 @@ class ListingBulkActions extends Component {
               key={`action-${action.name}`}
               onClick={(e) => {
                 e.preventDefault();
-                return this.handleApplyAction(action.name);
+                return this.handleApplyAction(action.name, e.currentTarget);
               }}
             >
               {action.label}

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -410,8 +410,16 @@ class ListingComponent extends Component {
         }
       })
       .fail((response) => {
-        if (response.errors.length > 0) {
+        if (response && response.errors && response.errors.length > 0) {
           this.context.notices.apiError(response, { scroll: true });
+        } else {
+          MailPoet.Notice.error(
+            __(
+              'The bulk action could not be completed. Please try again.',
+              'mailpoet',
+            ),
+            { scroll: true },
+          );
         }
       });
   };
@@ -580,6 +588,18 @@ class ListingComponent extends Component {
 
     // bulk actions
     let bulkActions = this.props.bulk_actions || [];
+    bulkActions = bulkActions.filter(
+      (action) =>
+        action.display === undefined ||
+        action.display({
+          group: this.state.group,
+          filter: this.state.filter,
+          search: this.state.search,
+          count: this.state.count,
+          selection: this.state.selection,
+          selected_ids: this.state.selected_ids,
+        }),
+    );
 
     if (this.state.group === 'trash' && bulkActions.length > 0) {
       bulkActions = [

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -1,6 +1,7 @@
 import jQuery from 'jquery';
 import { Component } from 'react';
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import _ from 'underscore';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
@@ -410,6 +411,35 @@ class ListingComponent extends Component {
         }
       })
       .fail((response) => {
+        if (this.isComponentMounted) {
+          this.setState({ loading: false });
+        }
+        if (
+          data.action === 'resendConfirmationEmails' &&
+          response &&
+          response.errors &&
+          response.errors.some(
+            (error) => error.error === 'confirmation_disabled',
+          )
+        ) {
+          this.context.notices.error(
+            <p>
+              {createInterpolateElement(
+                __(
+                  'Sign-up confirmation is disabled in your <link>MailPoet settings</link>. Please enable it to resend confirmation emails or update your subscriber’s status manually.',
+                  'mailpoet',
+                ),
+                {
+                  link: (
+                    <a href="admin.php?page=mailpoet-settings#/signup"> </a>
+                  ),
+                },
+              )}
+            </p>,
+            { scroll: true },
+          );
+          return;
+        }
         if (response && response.errors && response.errors.length > 0) {
           this.context.notices.apiError(response, { scroll: true });
         } else {

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -1,9 +1,10 @@
 import classnames from 'classnames';
 import jQuery from 'jquery';
+import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { __ } from '@wordpress/i18n';
 
-import { Button, SegmentTags, SubscriberTags } from 'common';
+import { Button, Checkbox, SegmentTags, SubscriberTags } from 'common';
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal';
@@ -44,6 +45,15 @@ type Subscriber = {
 };
 
 type Response = {
+  data?: {
+    selected_count: number;
+    eligible_count: number;
+    queued_count: number;
+    skipped_count: number;
+    skipped_by_reason: Record<string, number>;
+    task_id: number | null;
+    message: string;
+  };
   meta: {
     count: number;
     segment: string;
@@ -53,6 +63,9 @@ type Response = {
 };
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
+const bulkConfirmationResendLimit = 20;
+const bulkConfirmationCheckboxId = 'bulk-resend-confirmation-checkbox-input';
+const bulkConfirmationConfirmHelpId = 'bulk-resend-confirmation-confirm-help';
 
 const getColumns = () => [
   {
@@ -190,6 +203,187 @@ const createModal = (submitModal, closeModal, field, title) => (
   </Modal>
 );
 
+const getFocusableElements = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => element.offsetParent !== null);
+
+const trapModalTabFocus = (event: KeyboardEvent, container: HTMLElement) => {
+  if (event.key !== 'Tab') {
+    return;
+  }
+
+  const focusableElements = getFocusableElements(container);
+
+  if (focusableElements.length === 0) {
+    return;
+  }
+
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  if (event.shiftKey && document.activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+  } else if (!event.shiftKey && document.activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+};
+
+function BulkResendConfirmationEmailsModal({
+  submitModal,
+  closeModal,
+  count,
+}: {
+  submitModal: () => void;
+  closeModal: () => void;
+  count: number;
+}) {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const modalContentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    document.getElementById(bulkConfirmationCheckboxId)?.focus();
+  }, []);
+
+  useEffect(() => {
+    const modalFrame = modalContentRef.current?.closest<HTMLElement>(
+      '.mailpoet-modal-frame',
+    );
+    if (!modalFrame) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      trapModalTabFocus(event, modalFrame);
+    };
+    modalFrame.addEventListener('keydown', handleKeyDown);
+    return () => modalFrame.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const handleSubmit = () => {
+    if (!isChecked || isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+    submitModal();
+  };
+
+  return (
+    <Modal
+      title={__('Resend confirmation emails', 'mailpoet')}
+      onRequestClose={closeModal}
+      isDismissible
+    >
+      <div ref={modalContentRef}>
+        <p>
+          {__(
+            'You selected %1$s subscribers. MailPoet will queue confirmation emails for up to %2$s eligible unconfirmed subscribers.',
+            'mailpoet',
+          )
+            .replace('%1$s', Number(count).toLocaleString())
+            .replace('%2$s', bulkConfirmationResendLimit.toLocaleString())}
+        </p>
+        <p>
+          {__(
+            'Subscribers who reached the resend limit, were emailed recently, are too old, or are no longer unconfirmed will be skipped.',
+            'mailpoet',
+          )}
+        </p>
+        <Checkbox
+          id={bulkConfirmationCheckboxId}
+          automationId="bulk-resend-confirmation-checkbox"
+          checked={isChecked}
+          disabled={isSubmitting}
+          onCheck={(checked) => setIsChecked(checked)}
+          isFullWidth
+        >
+          {__(
+            'I understand these confirmation emails will be queued and only sent to eligible unconfirmed subscribers.',
+            'mailpoet',
+          )}
+        </Checkbox>
+        <p id={bulkConfirmationConfirmHelpId} className="description">
+          {__('Confirm the checkbox to queue confirmation emails.', 'mailpoet')}
+        </p>
+        <span className="mailpoet-gap-half" />
+        <Button
+          onClick={handleSubmit}
+          dimension="small"
+          isDisabled={!isChecked || isSubmitting}
+          withSpinner={isSubmitting}
+          aria-describedby={bulkConfirmationConfirmHelpId}
+          automationId="bulk-resend-confirmation-confirm"
+        >
+          {__('Queue emails', 'mailpoet')}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+const showBulkResendConfirmationNotice = (response: Response) => {
+  const data = response.data;
+  if (!data) {
+    MailPoet.Notice.success(__('Confirmation emails were queued.', 'mailpoet'));
+    return;
+  }
+
+  const queuedCount = Number(data.queued_count);
+  const skippedCount = Number(data.skipped_count);
+  let message;
+
+  if (queuedCount === 0) {
+    message = __(
+      'No confirmation emails were queued. No selected subscribers were eligible.',
+      'mailpoet',
+    );
+  } else if (queuedCount === 1 && skippedCount === 1) {
+    message = __(
+      'Confirmation emails were queued for 1 subscriber. 1 selected subscriber was skipped.',
+      'mailpoet',
+    );
+  } else if (queuedCount === 1 && skippedCount > 0) {
+    message = __(
+      'Confirmation emails were queued for 1 subscriber. %1$s selected subscribers were skipped.',
+      'mailpoet',
+    ).replace('%1$s', skippedCount.toLocaleString());
+  } else if (skippedCount === 1) {
+    message = __(
+      'Confirmation emails were queued for %1$s subscribers. 1 selected subscriber was skipped.',
+      'mailpoet',
+    ).replace('%1$s', queuedCount.toLocaleString());
+  } else if (skippedCount > 0) {
+    message = __(
+      'Confirmation emails were queued for %1$s subscribers. %2$s selected subscribers were skipped.',
+      'mailpoet',
+    )
+      .replace('%1$s', queuedCount.toLocaleString())
+      .replace('%2$s', skippedCount.toLocaleString());
+  } else if (queuedCount === 1) {
+    message = __(
+      'Confirmation emails were queued for 1 subscriber.',
+      'mailpoet',
+    );
+  } else {
+    message = __(
+      'Confirmation emails were queued for %1$s subscribers.',
+      'mailpoet',
+    ).replace('%1$s', queuedCount.toLocaleString());
+  }
+
+  MailPoet.Notice.success(message, {
+    onOpen: (element) => {
+      element.attr('role', 'status');
+      element.attr('aria-live', 'polite');
+    },
+  });
+};
+
 const getBulkActions = () => {
   const bulkActions = [
     {
@@ -320,6 +514,7 @@ const getBulkActions = () => {
     {
       name: 'unsubscribe',
       label: __('Unsubscribe', 'mailpoet'),
+      display: ({ group }) => group !== 'unsubscribed',
       onSelect: (submitModal, closeModal, bulkActionProps) => {
         const count =
           bulkActionProps.selection !== 'all'
@@ -349,6 +544,25 @@ const getBulkActions = () => {
           </Modal>
         );
       },
+    },
+    {
+      name: 'resendConfirmationEmails',
+      label: __('Resend confirmation emails', 'mailpoet'),
+      display: ({ group }) => group === 'unconfirmed',
+      onSelect: (submitModal, closeModal, bulkActionProps) => {
+        const count =
+          bulkActionProps.selection !== 'all'
+            ? bulkActionProps.selected_ids.length
+            : bulkActionProps.count;
+        return (
+          <BulkResendConfirmationEmailsModal
+            submitModal={submitModal}
+            closeModal={closeModal}
+            count={count}
+          />
+        );
+      },
+      onSuccess: showBulkResendConfirmationNotice,
     },
     {
       name: 'addTag',
@@ -417,15 +631,6 @@ const getBulkActions = () => {
       },
     },
   ];
-
-  // Filter out 'unsubscribe' action if we're in the unsubscribed group
-  const url = window.location.href;
-  const match = url.match(/group\[(.*?)\]/);
-  const group = match ? match[1] : null;
-
-  if (group === 'unsubscribed') {
-    return bulkActions.filter((action) => action.name !== 'unsubscribe');
-  }
 
   return bulkActions;
 };

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -1,10 +1,17 @@
 import classnames from 'classnames';
 import jQuery from 'jquery';
-import { useEffect, useRef, useState } from 'react';
+import {
+  Button as WordPressButton,
+  CheckboxControl,
+  Modal as WordPressModal,
+  __experimentalText as Text,
+  __experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useEffect, useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
-import { Button, Checkbox, SegmentTags, SubscriberTags } from 'common';
+import { Button, SegmentTags, SubscriberTags } from 'common';
 import { Listing } from 'listing/listing.jsx';
 import { MailPoet } from 'mailpoet';
 import { Modal } from 'common/modal/modal';
@@ -203,36 +210,6 @@ const createModal = (submitModal, closeModal, field, title) => (
   </Modal>
 );
 
-const getFocusableElements = (container: HTMLElement) =>
-  Array.from(
-    container.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ),
-  ).filter((element) => element.offsetParent !== null);
-
-const trapModalTabFocus = (event: KeyboardEvent, container: HTMLElement) => {
-  if (event.key !== 'Tab') {
-    return;
-  }
-
-  const focusableElements = getFocusableElements(container);
-
-  if (focusableElements.length === 0) {
-    return;
-  }
-
-  const firstElement = focusableElements[0];
-  const lastElement = focusableElements[focusableElements.length - 1];
-
-  if (event.shiftKey && document.activeElement === firstElement) {
-    event.preventDefault();
-    lastElement.focus();
-  } else if (!event.shiftKey && document.activeElement === lastElement) {
-    event.preventDefault();
-    firstElement.focus();
-  }
-};
-
 function BulkResendConfirmationEmailsModal({
   submitModal,
   closeModal,
@@ -244,25 +221,9 @@ function BulkResendConfirmationEmailsModal({
 }) {
   const [isChecked, setIsChecked] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const modalContentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     document.getElementById(bulkConfirmationCheckboxId)?.focus();
-  }, []);
-
-  useEffect(() => {
-    const modalFrame = modalContentRef.current?.closest<HTMLElement>(
-      '.mailpoet-modal-frame',
-    );
-    if (!modalFrame) {
-      return undefined;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      trapModalTabFocus(event, modalFrame);
-    };
-    modalFrame.addEventListener('keydown', handleKeyDown);
-    return () => modalFrame.removeEventListener('keydown', handleKeyDown);
   }, []);
 
   const handleSubmit = () => {
@@ -274,55 +235,57 @@ function BulkResendConfirmationEmailsModal({
   };
 
   return (
-    <Modal
+    <WordPressModal
       title={__('Resend confirmation emails', 'mailpoet')}
       onRequestClose={closeModal}
-      isDismissible
     >
-      <div ref={modalContentRef}>
-        <p>
+      <VStack spacing={3}>
+        <Text as="p">
           {__(
             'You selected %1$s subscribers. MailPoet will queue confirmation emails for up to %2$s eligible unconfirmed subscribers.',
             'mailpoet',
           )
             .replace('%1$s', Number(count).toLocaleString())
             .replace('%2$s', bulkConfirmationResendLimit.toLocaleString())}
-        </p>
-        <p>
+        </Text>
+        <Text as="p">
           {__(
             'Subscribers who reached the resend limit, were emailed recently, are too old, or are no longer unconfirmed will be skipped.',
             'mailpoet',
           )}
-        </p>
-        <Checkbox
-          id={bulkConfirmationCheckboxId}
-          automationId="bulk-resend-confirmation-checkbox"
-          checked={isChecked}
-          disabled={isSubmitting}
-          onCheck={(checked) => setIsChecked(checked)}
-          isFullWidth
-        >
+        </Text>
+        <div data-automation-id="bulk-resend-confirmation-checkbox">
+          <CheckboxControl
+            id={bulkConfirmationCheckboxId}
+            label={__(
+              'I confirm these subscribers asked to join and can be sent a confirmation email.',
+              'mailpoet',
+            )}
+            checked={isChecked}
+            disabled={isSubmitting}
+            onChange={(checked) => setIsChecked(checked)}
+          />
+        </div>
+        <Text as="p" id={bulkConfirmationConfirmHelpId} className="description">
           {__(
-            'I understand these confirmation emails will be queued and only sent to eligible unconfirmed subscribers.',
+            'Confirm that these subscribers asked to join to queue confirmation emails.',
             'mailpoet',
           )}
-        </Checkbox>
-        <p id={bulkConfirmationConfirmHelpId} className="description">
-          {__('Confirm the checkbox to queue confirmation emails.', 'mailpoet')}
-        </p>
-        <span className="mailpoet-gap-half" />
-        <Button
-          onClick={handleSubmit}
-          dimension="small"
-          isDisabled={!isChecked || isSubmitting}
-          withSpinner={isSubmitting}
-          aria-describedby={bulkConfirmationConfirmHelpId}
-          automationId="bulk-resend-confirmation-confirm"
-        >
-          {__('Queue emails', 'mailpoet')}
-        </Button>
-      </div>
-    </Modal>
+        </Text>
+        <div>
+          <WordPressButton
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={!isChecked || isSubmitting}
+            isBusy={isSubmitting}
+            aria-describedby={bulkConfirmationConfirmHelpId}
+            data-automation-id="bulk-resend-confirmation-confirm"
+          >
+            {__('Queue emails', 'mailpoet')}
+          </WordPressButton>
+        </div>
+      </VStack>
+    </WordPressModal>
   );
 }
 
@@ -335,48 +298,59 @@ const showBulkResendConfirmationNotice = (response: Response) => {
 
   const queuedCount = Number(data.queued_count);
   const skippedCount = Number(data.skipped_count);
-  let message;
 
   if (queuedCount === 0) {
-    message = __(
-      'No confirmation emails were queued. No selected subscribers were eligible.',
-      'mailpoet',
+    MailPoet.Notice.success(
+      __(
+        'No confirmation email resend job was queued. No selected subscribers were currently eligible.',
+        'mailpoet',
+      ),
     );
-  } else if (queuedCount === 1 && skippedCount === 1) {
-    message = __(
-      'Confirmation emails were queued for 1 subscriber. 1 selected subscriber was skipped.',
-      'mailpoet',
-    );
-  } else if (queuedCount === 1 && skippedCount > 0) {
-    message = __(
-      'Confirmation emails were queued for 1 subscriber. %1$s selected subscribers were skipped.',
-      'mailpoet',
-    ).replace('%1$s', skippedCount.toLocaleString());
-  } else if (skippedCount === 1) {
-    message = __(
-      'Confirmation emails were queued for %1$s subscribers. 1 selected subscriber was skipped.',
-      'mailpoet',
-    ).replace('%1$s', queuedCount.toLocaleString());
-  } else if (skippedCount > 0) {
-    message = __(
-      'Confirmation emails were queued for %1$s subscribers. %2$s selected subscribers were skipped.',
-      'mailpoet',
-    )
-      .replace('%1$s', queuedCount.toLocaleString())
-      .replace('%2$s', skippedCount.toLocaleString());
-  } else if (queuedCount === 1) {
-    message = __(
-      'Confirmation emails were queued for 1 subscriber.',
-      'mailpoet',
-    );
-  } else {
-    message = __(
-      'Confirmation emails were queued for %1$s subscribers.',
-      'mailpoet',
-    ).replace('%1$s', queuedCount.toLocaleString());
+    return;
   }
 
-  MailPoet.Notice.success(message, {
+  const messageParts = [
+    String(
+      sprintf(
+        /* translators: %d is the number of subscribers. */
+        _n(
+          'A resend job was queued for up to %d eligible subscriber.',
+          'A resend job was queued for up to %d eligible subscribers.',
+          queuedCount,
+          'mailpoet',
+        ),
+        queuedCount,
+      ),
+    ),
+  ];
+
+  if (skippedCount > 0) {
+    messageParts.push(
+      String(
+        sprintf(
+          /* translators: %d is the number of subscribers. */
+          _n(
+            '%d selected subscriber was not queued because they were ineligible or beyond the batch limit.',
+            '%d selected subscribers were not queued because they were ineligible or beyond the batch limit.',
+            skippedCount,
+            'mailpoet',
+          ),
+          skippedCount,
+        ),
+      ),
+    );
+  }
+
+  messageParts.push(
+    String(
+      __(
+        'The background job may still skip queued subscribers if they become ineligible before it runs.',
+        'mailpoet',
+      ),
+    ),
+  );
+
+  MailPoet.Notice.success(messageParts.join(' '), {
     onOpen: (element) => {
       element.attr('role', 'status');
       element.attr('aria-live', 'polite');
@@ -548,7 +522,8 @@ const getBulkActions = () => {
     {
       name: 'resendConfirmationEmails',
       label: __('Resend confirmation emails', 'mailpoet'),
-      display: ({ group }) => group === 'unconfirmed',
+      display: ({ group }) =>
+        group === 'unconfirmed' && window.mailpoet_signup_confirmation_enabled,
       onSelect: (submitModal, closeModal, bulkActionProps) => {
         const count =
           bulkActionProps.selection !== 'all'

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -73,7 +73,6 @@ const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
 const bulkConfirmationResendLimit =
   window.mailpoet_bulk_confirmation_resend_limit;
 const bulkConfirmationCheckboxId = 'bulk-resend-confirmation-checkbox-input';
-const bulkConfirmationConfirmHelpId = 'bulk-resend-confirmation-confirm-help';
 
 const getColumns = () => [
   {
@@ -244,7 +243,7 @@ function BulkResendConfirmationEmailsModal({
         <Text as="p">
           {sprintf(
             __(
-              'You selected %1$s subscribers. MailPoet will queue confirmation emails for up to %2$s eligible unconfirmed subscribers.',
+              'You selected %1$s subscribers. MailPoet can resend confirmation emails to up to %2$s of them at a time.',
               'mailpoet',
             ),
             Number(count).toLocaleString(),
@@ -253,7 +252,7 @@ function BulkResendConfirmationEmailsModal({
         </Text>
         <Text as="p">
           {__(
-            'Subscribers who reached the resend limit, were emailed recently, are too old, or are no longer unconfirmed will be skipped.',
+            'Some subscribers may be skipped if they already received too many confirmation emails, got one recently, or were added too long ago.',
             'mailpoet',
           )}
         </Text>
@@ -261,7 +260,7 @@ function BulkResendConfirmationEmailsModal({
           <CheckboxControl
             id={bulkConfirmationCheckboxId}
             label={__(
-              'I confirm these subscribers asked to join and can be sent a confirmation email.',
+              'I confirm these subscribers asked to join my list.',
               'mailpoet',
             )}
             checked={isChecked}
@@ -269,22 +268,15 @@ function BulkResendConfirmationEmailsModal({
             onChange={(checked) => setIsChecked(checked)}
           />
         </div>
-        <Text as="p" id={bulkConfirmationConfirmHelpId} className="description">
-          {__(
-            'Confirm that these subscribers asked to join to queue confirmation emails.',
-            'mailpoet',
-          )}
-        </Text>
         <div>
           <WordPressButton
             variant="primary"
             onClick={handleSubmit}
             disabled={!isChecked || isSubmitting}
             isBusy={isSubmitting}
-            aria-describedby={bulkConfirmationConfirmHelpId}
             data-automation-id="bulk-resend-confirmation-confirm"
           >
-            {__('Queue emails', 'mailpoet')}
+            {__('Resend emails', 'mailpoet')}
           </WordPressButton>
         </div>
       </VStack>
@@ -295,7 +287,9 @@ function BulkResendConfirmationEmailsModal({
 const showBulkResendConfirmationNotice = (response: Response) => {
   const data = response.data;
   if (!data) {
-    MailPoet.Notice.success(__('Confirmation emails were queued.', 'mailpoet'));
+    MailPoet.Notice.success(
+      __('Confirmation emails are being resent.', 'mailpoet'),
+    );
     return;
   }
 
@@ -305,7 +299,7 @@ const showBulkResendConfirmationNotice = (response: Response) => {
   if (queuedCount === 0) {
     MailPoet.Notice.success(
       __(
-        'No confirmation email resend job was queued. No selected subscribers were currently eligible.',
+        'No confirmation emails were resent. The selected subscribers could not receive another confirmation email right now.',
         'mailpoet',
       ),
     );
@@ -317,8 +311,8 @@ const showBulkResendConfirmationNotice = (response: Response) => {
       sprintf(
         /* translators: %d is the number of subscribers. */
         _n(
-          'A resend job was queued for up to %d eligible subscriber.',
-          'A resend job was queued for up to %d eligible subscribers.',
+          'MailPoet is resending confirmation emails to %d subscriber.',
+          'MailPoet is resending confirmation emails to %d subscribers.',
           queuedCount,
           'mailpoet',
         ),
@@ -333,8 +327,8 @@ const showBulkResendConfirmationNotice = (response: Response) => {
         sprintf(
           /* translators: %d is the number of subscribers. */
           _n(
-            '%d selected subscriber was not queued because they were ineligible or beyond the batch limit.',
-            '%d selected subscribers were not queued because they were ineligible or beyond the batch limit.',
+            '%d selected subscriber was skipped.',
+            '%d selected subscribers were skipped.',
             skippedCount,
             'mailpoet',
           ),
@@ -343,15 +337,6 @@ const showBulkResendConfirmationNotice = (response: Response) => {
       ),
     );
   }
-
-  messageParts.push(
-    String(
-      __(
-        'The background job may still skip queued subscribers if they become ineligible before it runs.',
-        'mailpoet',
-      ),
-    ),
-  );
 
   MailPoet.Notice.success(messageParts.join(' '), {
     onOpen: (element) => {

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -70,7 +70,8 @@ type Response = {
 };
 
 const mailpoetTrackingEnabled = MailPoet.trackingConfig.emailTrackingEnabled;
-const bulkConfirmationResendLimit = 20;
+const bulkConfirmationResendLimit =
+  window.mailpoet_bulk_confirmation_resend_limit;
 const bulkConfirmationCheckboxId = 'bulk-resend-confirmation-checkbox-input';
 const bulkConfirmationConfirmHelpId = 'bulk-resend-confirmation-confirm-help';
 
@@ -241,12 +242,14 @@ function BulkResendConfirmationEmailsModal({
     >
       <VStack spacing={3}>
         <Text as="p">
-          {__(
-            'You selected %1$s subscribers. MailPoet will queue confirmation emails for up to %2$s eligible unconfirmed subscribers.',
-            'mailpoet',
-          )
-            .replace('%1$s', Number(count).toLocaleString())
-            .replace('%2$s', bulkConfirmationResendLimit.toLocaleString())}
+          {sprintf(
+            __(
+              'You selected %1$s subscribers. MailPoet will queue confirmation emails for up to %2$s eligible unconfirmed subscribers.',
+              'mailpoet',
+            ),
+            Number(count).toLocaleString(),
+            bulkConfirmationResendLimit.toLocaleString(),
+          )}
         </Text>
         <Text as="p">
           {__(

--- a/mailpoet/changelog/2026-04-29-09-16-29-added-add-a-controlled-bulk-resend-action-for-confirmati.md
+++ b/mailpoet/changelog/2026-04-29-09-16-29-added-add-a-controlled-bulk-resend-action-for-confirmati.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add a controlled bulk resend action for confirmation emails to unconfirmed subscribers

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -20,6 +20,7 @@ use MailPoet\Listing;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\Track\Unsubscribes;
+use MailPoet\Subscribers\BulkConfirmationEmailResender;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\SubscriberListingRepository;
 use MailPoet\Subscribers\SubscriberSaveController;
@@ -70,6 +71,9 @@ class Subscribers extends APIEndpoint {
   /** @var Unsubscribes */
   private $unsubscribesTracker;
 
+  /** @var BulkConfirmationEmailResender */
+  private $bulkConfirmationEmailResender;
+
   public function __construct(
     Listing\Handler $listingHandler,
     ConfirmationEmailMailer $confirmationEmailMailer,
@@ -81,7 +85,8 @@ class Subscribers extends APIEndpoint {
     SubscriberSaveController $saveController,
     SubscriberSubscribeController $subscribeController,
     SettingsController $settings,
-    Unsubscribes $unsubscribesTracker
+    Unsubscribes $unsubscribesTracker,
+    BulkConfirmationEmailResender $bulkConfirmationEmailResender
   ) {
     $this->listingHandler = $listingHandler;
     $this->confirmationEmailMailer = $confirmationEmailMailer;
@@ -94,6 +99,7 @@ class Subscribers extends APIEndpoint {
     $this->subscribeController = $subscribeController;
     $this->settings = $settings;
     $this->unsubscribesTracker = $unsubscribesTracker;
+    $this->bulkConfirmationEmailResender = $bulkConfirmationEmailResender;
   }
 
   public function get($data = []) {
@@ -243,6 +249,21 @@ class Subscribers extends APIEndpoint {
         if ($this->confirmationEmailMailer->sendConfirmationEmail($subscriber)) {
           return $this->successResponse();
         } else {
+          $reason = $this->subscribersRepository->getAdminConfirmationEmailResendIneligibilityReason(
+            $subscriber,
+            ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS,
+            \MailPoetVendor\Carbon\Carbon::now()->subDays(ConfirmationEmailMailer::ADMIN_CONFIRMATION_RESEND_INTERVAL_DAYS)->millisecond(0)
+          );
+          if ($reason === 'max_confirmations_reached') {
+            return $this->errorResponse([
+              APIError::BAD_REQUEST => __('The maximum number of confirmation emails has already been reached for this subscriber.', 'mailpoet'),
+            ], [], Response::STATUS_BAD_REQUEST);
+          }
+          if ($reason === 'recently_sent') {
+            return $this->errorResponse([
+              APIError::BAD_REQUEST => __('A confirmation email was sent recently. Please wait before resending it.', 'mailpoet'),
+            ], [], Response::STATUS_BAD_REQUEST);
+          }
           return $this->errorResponse([
             APIError::UNKNOWN => __('There was a problem with your sending method. Please check if your sending method is properly configured.', 'mailpoet'),
           ]);
@@ -261,6 +282,25 @@ class Subscribers extends APIEndpoint {
 
   public function bulkAction($data = []) {
     $definition = $this->listingHandler->getListingDefinition($data['listing']);
+    if (($data['action'] ?? null) === 'resendConfirmationEmails') {
+      if (!$this->bulkConfirmationEmailResender->canCurrentUserResend()) {
+        return $this->errorResponse([
+          APIError::FORBIDDEN => __('You do not have permission to resend confirmation emails.', 'mailpoet'),
+        ], [], Response::STATUS_FORBIDDEN);
+      }
+      if ($definition->getGroup() !== SubscriberEntity::STATUS_UNCONFIRMED) {
+        return $this->badRequest([
+          'invalid_group' => __('Confirmation emails can be resent in bulk only from the Unconfirmed subscribers view.', 'mailpoet'),
+        ]);
+      }
+      if (!$this->bulkConfirmationEmailResender->isSignupConfirmationEnabled()) {
+        return $this->errorResponse([
+          'confirmation_disabled' => $this->bulkConfirmationEmailResender->getConfirmationDisabledMessage(),
+        ], [], Response::STATUS_BAD_REQUEST);
+      }
+      return $this->successResponse($this->bulkConfirmationEmailResender->queue($definition, $data));
+    }
+
     $ids = $this->subscriberListingRepository->getActionableIds($definition);
 
     $count = 0;

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -246,14 +246,11 @@ class Subscribers extends APIEndpoint {
       try {
         // Per-list confirmation settings are not resolved for manual resends;
         // the global default is used to avoid ambiguity across multiple segments.
-        if ($this->confirmationEmailMailer->sendConfirmationEmail($subscriber)) {
+        $result = $this->confirmationEmailMailer->sendAdminConfirmationEmail($subscriber);
+        if ($result['status'] === 'sent') {
           return $this->successResponse();
         } else {
-          $reason = $this->subscribersRepository->getAdminConfirmationEmailResendIneligibilityReason(
-            $subscriber,
-            ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS,
-            \MailPoetVendor\Carbon\Carbon::now()->subDays(ConfirmationEmailMailer::ADMIN_CONFIRMATION_RESEND_INTERVAL_DAYS)->millisecond(0)
-          );
+          $reason = $result['reason'] ?? null;
           if ($reason === 'max_confirmations_reached') {
             return $this->errorResponse([
               APIError::BAD_REQUEST => __('The maximum number of confirmation emails has already been reached for this subscriber.', 'mailpoet'),

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Form\Block;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Segments\SegmentsSimpleListRepository;
+use MailPoet\Settings\SettingsController;
 
 class Subscribers {
   /** @var PageRenderer */
@@ -29,13 +30,17 @@ class Subscribers {
   /** @var CustomFieldsResponseBuilder */
   private $customFieldsResponseBuilder;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function __construct(
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
     Block\Date $dateBlock,
     SegmentsSimpleListRepository $segmentsListRepository,
     CustomFieldsRepository $customFieldsRepository,
-    CustomFieldsResponseBuilder $customFieldsResponseBuilder
+    CustomFieldsResponseBuilder $customFieldsResponseBuilder,
+    SettingsController $settings
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
@@ -43,6 +48,7 @@ class Subscribers {
     $this->segmentsListRepository = $segmentsListRepository;
     $this->customFieldsRepository = $customFieldsRepository;
     $this->customFieldsResponseBuilder = $customFieldsResponseBuilder;
+    $this->settings = $settings;
   }
 
   public function render() {
@@ -67,6 +73,9 @@ class Subscribers {
 
     $data['date_formats'] = $this->dateBlock->getDateFormats();
     $data['month_names'] = $this->dateBlock->getMonthNames();
+    $data['signup_confirmation_enabled'] = (bool)$this->settings->get(
+      'signup_confirmation.enabled'
+    );
     $this->pageRenderer->displayPage('subscribers/subscribers.html', $data);
   }
 }

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -10,6 +10,7 @@ use MailPoet\Form\Block;
 use MailPoet\Listing\PageLimit;
 use MailPoet\Segments\SegmentsSimpleListRepository;
 use MailPoet\Settings\SettingsController;
+use MailPoet\Subscribers\BulkConfirmationEmailResender;
 
 class Subscribers {
   /** @var PageRenderer */
@@ -76,6 +77,7 @@ class Subscribers {
     $data['signup_confirmation_enabled'] = (bool)$this->settings->get(
       'signup_confirmation.enabled'
     );
+    $data['bulk_confirmation_resend_limit'] = BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT;
     $this->pageRenderer->displayPage('subscribers/subscribers.html', $data);
   }
 }

--- a/mailpoet/lib/Cron/Daemon.php
+++ b/mailpoet/lib/Cron/Daemon.php
@@ -119,5 +119,6 @@ class Daemon {
     yield $this->workersFactory->createMixpanelWorker();
     yield $this->workersFactory->createTracksWorker();
     yield $this->workersFactory->createStatisticsExportWorker();
+    yield $this->workersFactory->createBulkConfirmationEmailResendWorker();
   }
 }

--- a/mailpoet/lib/Cron/Workers/BulkConfirmationEmailResend.php
+++ b/mailpoet/lib/Cron/Workers/BulkConfirmationEmailResend.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Logging\LogRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Subscribers\BulkConfirmationEmailResender;
+use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Tasks\Subscribers\BatchIterator;
+use MailPoetVendor\Carbon\Carbon;
+
+class BulkConfirmationEmailResend extends SimpleWorker {
+  const TASK_TYPE = 'bulk_confirmation_email_resend';
+  const AUTOMATIC_SCHEDULING = false;
+  const SUPPORT_MULTIPLE_INSTANCES = false;
+  const BATCH_SIZE = 20;
+
+  private const AUDIT_LOG_MESSAGE_COMPLETED = 'Bulk confirmation email resend completed.';
+  private const LOG_LEVEL_INFO = 200;
+
+  /** @var ConfirmationEmailMailer */
+  private $confirmationEmailMailer;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  public function __construct(
+    ConfirmationEmailMailer $confirmationEmailMailer,
+    SubscribersRepository $subscribersRepository,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    LogRepository $logRepository
+  ) {
+    $this->confirmationEmailMailer = $confirmationEmailMailer;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->logRepository = $logRepository;
+    parent::__construct();
+  }
+
+  public function processTaskStrategy(ScheduledTaskEntity $task, $timer) {
+    $subscriberBatches = new BatchIterator($task->getId(), self::BATCH_SIZE);
+    $sentCount = 0;
+    $failedCount = 0;
+    $skippedByReason = [];
+    $oldestLifecycleDate = Carbon::now()->subDays(BulkConfirmationEmailResender::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS)->millisecond(0);
+
+    foreach ($subscriberBatches as $subscriberIds) {
+      $this->cronHelper->enforceExecutionLimit($timer);
+      $sentIds = [];
+      foreach ($subscriberIds as $subscriberId) {
+        $subscriber = $this->subscribersRepository->findOneById((int)$subscriberId);
+        if (!$subscriber instanceof SubscriberEntity) {
+          $this->saveSkipped($task, (int)$subscriberId, 'not_found', $skippedByReason);
+          $failedCount++;
+          continue;
+        }
+
+        try {
+          $result = $this->confirmationEmailMailer->sendAdminConfirmationEmail($subscriber, $oldestLifecycleDate);
+        } catch (\Throwable $throwable) {
+          $this->scheduledTaskSubscribersRepository->saveError($task, (int)$subscriberId, 'send_failed:mailer_error');
+          $failedCount++;
+          continue;
+        }
+
+        if ($result['status'] === 'sent') {
+          $sentIds[] = (int)$subscriberId;
+          $sentCount++;
+        } elseif ($result['status'] === 'skipped') {
+          $this->saveSkipped($task, (int)$subscriberId, $result['reason'] ?? 'not_found', $skippedByReason);
+          $failedCount++;
+        } else {
+          $this->scheduledTaskSubscribersRepository->saveError($task, (int)$subscriberId, 'send_failed:' . ($result['reason'] ?? 'sending_method'));
+          $failedCount++;
+        }
+      }
+
+      $this->scheduledTaskSubscribersRepository->updateProcessedSubscribers($task, $sentIds);
+    }
+
+    $meta = $task->getMeta() ?? [];
+    $meta['sent_count'] = $sentCount;
+    $meta['failed_count'] = $failedCount;
+    $meta['skipped_by_reason'] = $skippedByReason;
+    $task->setMeta($meta);
+    $this->scheduledTasksRepository->persist($task);
+    $this->scheduledTasksRepository->flush();
+    $this->saveCompletionAuditLog($task, $sentCount, $failedCount, $skippedByReason);
+    return true;
+  }
+
+  /**
+   * @param array<string, int> $skippedByReason
+   */
+  private function saveSkipped(ScheduledTaskEntity $task, int $subscriberId, string $reason, array &$skippedByReason): void {
+    $skippedByReason[$reason] = ($skippedByReason[$reason] ?? 0) + 1;
+    $this->scheduledTaskSubscribersRepository->saveError($task, $subscriberId, 'skipped:' . $reason);
+  }
+
+  /**
+   * @param array<string, int> $skippedByReason
+   */
+  private function saveCompletionAuditLog(ScheduledTaskEntity $task, int $sentCount, int $failedCount, array $skippedByReason): void {
+    $log = new LogEntity();
+    $log->setName(LoggerFactory::TOPIC_CRON);
+    $log->setLevel(self::LOG_LEVEL_INFO);
+    $log->setMessage(self::AUDIT_LOG_MESSAGE_COMPLETED);
+    $log->setRawMessage(self::AUDIT_LOG_MESSAGE_COMPLETED);
+    $log->setContext([
+      'action' => 'bulk_confirmation_email_resend_completed',
+      'task_id' => $task->getId(),
+      'sent_count' => $sentCount,
+      'failed_count' => $failedCount,
+      'skipped_by_reason' => $skippedByReason,
+      'final_status' => ScheduledTaskEntity::STATUS_COMPLETED,
+    ]);
+    $this->logRepository->saveLog($log);
+  }
+}

--- a/mailpoet/lib/Cron/Workers/WorkersFactory.php
+++ b/mailpoet/lib/Cron/Workers/WorkersFactory.php
@@ -38,6 +38,7 @@ class WorkersFactory {
     SendingQueueBodyCleanup::TASK_TYPE,
     Tracks::TASK_TYPE,
     StatisticsExport::TASK_TYPE,
+    BulkConfirmationEmailResend::TASK_TYPE,
   ];
 
   /** @var ContainerWrapper */
@@ -195,5 +196,10 @@ class WorkersFactory {
   /** @return StatisticsExport */
   public function createStatisticsExportWorker() {
     return $this->container->get(StatisticsExport::class);
+  }
+
+  /** @return BulkConfirmationEmailResend */
+  public function createBulkConfirmationEmailResendWorker() {
+    return $this->container->get(BulkConfirmationEmailResend::class);
   }
 }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -314,6 +314,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Cron\ActionScheduler\Actions\DaemonTrigger::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SendingQueue\SendingErrorHandler::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\SendingQueue\SendingThrottlingHandler::class)->setPublic(true);
+    $container->autowire(\MailPoet\Cron\Workers\BulkConfirmationEmailResend::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\StatsNotifications\Scheduler::class);
     $container->autowire(\MailPoet\Cron\Workers\StatsNotifications\StatsNotificationsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository::class)->setPublic(true);
@@ -471,6 +472,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Subscribers
     $container->autowire(\MailPoet\Subscribers\NewSubscriberNotificationMailer::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\ConfirmationEmailMailer::class)->setPublic(true);
+    $container->autowire(\MailPoet\Subscribers\BulkConfirmationEmailResender::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\RequiredCustomFieldValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscriberActions::class)->setPublic(true);
     $container->autowire(\MailPoet\Subscribers\SubscribersEmailCountsController::class);

--- a/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
+++ b/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Subscribers;
+
+use MailPoet\Cron\Workers\BulkConfirmationEmailResend;
+use MailPoet\Entities\LogEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Listing\ListingDefinition;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Logging\LogRepository;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Util\Helpers;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class BulkConfirmationEmailResender {
+  public const BULK_CONFIRMATION_RESEND_LIMIT = 20;
+  public const RECENT_CONFIRMATION_RESEND_INTERVAL_DAYS = 7;
+  public const BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS = 90;
+
+  private const AUDIT_LOG_MESSAGE_QUEUED = 'Bulk confirmation email resend queued.';
+  private const LOG_LEVEL_INFO = 200;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var SettingsController */
+  private $settings;
+
+  /** @var SubscriberListingRepository */
+  private $subscriberListingRepository;
+
+  /** @var LogRepository */
+  private $logRepository;
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  public function __construct(
+    WPFunctions $wp,
+    SettingsController $settings,
+    SubscriberListingRepository $subscriberListingRepository,
+    LogRepository $logRepository,
+    EntityManager $entityManager
+  ) {
+    $this->wp = $wp;
+    $this->settings = $settings;
+    $this->subscriberListingRepository = $subscriberListingRepository;
+    $this->logRepository = $logRepository;
+    $this->entityManager = $entityManager;
+  }
+
+  public function canCurrentUserResend(): bool {
+    return $this->wp->currentUserCan('manage_options');
+  }
+
+  public function isSignupConfirmationEnabled(): bool {
+    return (bool)$this->settings->get('signup_confirmation.enabled', true);
+  }
+
+  public function getConfirmationDisabledMessage(): string {
+    $errorMessage = __('Sign-up confirmation is disabled in your [link]MailPoet settings[/link]. Please enable it to resend confirmation emails or update your subscriber’s status manually.', 'mailpoet');
+    return Helpers::replaceLinkTags($errorMessage, 'admin.php?page=mailpoet-settings#/signup');
+  }
+
+  /**
+   * @param array<string, mixed> $requestData
+   * @return array{selected_count: int, eligible_count: int, queued_count: int, skipped_count: int, skipped_by_reason: array<string, int>, task_id: int|null, message: string}
+   */
+  public function queue(ListingDefinition $definition, array $requestData): array {
+    $now = Carbon::now()->millisecond(0);
+    $queueData = $this->subscriberListingRepository->getConfirmationEmailResendQueueData(
+      $definition,
+      (clone $now)->subDays(self::RECENT_CONFIRMATION_RESEND_INTERVAL_DAYS),
+      (clone $now)->subDays(self::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS),
+      ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS,
+      self::BULK_CONFIRMATION_RESEND_LIMIT
+    );
+
+    $queuedIds = $queueData['queued_ids'];
+    $task = null;
+    if ($queuedIds) {
+      $task = $this->createTask($queuedIds, $queueData, $requestData, $now);
+    } else {
+      $this->saveQueueAuditLog(null, $queueData, $requestData);
+    }
+
+    $queuedCount = count($queuedIds);
+    return [
+      'selected_count' => $queueData['selected_count'],
+      'eligible_count' => $queueData['eligible_count'],
+      'queued_count' => $queuedCount,
+      'skipped_count' => max(0, $queueData['selected_count'] - $queuedCount),
+      'skipped_by_reason' => $queueData['skipped_by_reason'],
+      'task_id' => $task instanceof ScheduledTaskEntity ? $task->getId() : null,
+      'message' => $queuedCount > 0
+        ? __('Confirmation emails were queued.', 'mailpoet')
+        : __('No eligible subscribers were queued for confirmation email resend.', 'mailpoet'),
+    ];
+  }
+
+  /**
+   * @param int[] $queuedIds
+   * @param array{selected_count: int, eligible_count: int, queued_ids: int[], skipped_by_reason: array<string, int>} $queueData
+   * @param array<string, mixed> $requestData
+   */
+  private function createTask(array $queuedIds, array $queueData, array $requestData, Carbon $now): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($task, $queuedIds, $queueData, $requestData, $now) {
+      $task->setType(BulkConfirmationEmailResend::TASK_TYPE);
+      $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+      $task->setScheduledAt($now);
+      $task->setPriority(ScheduledTaskEntity::PRIORITY_HIGH);
+      $task->setMeta([
+        'requested_by' => (int)$this->wp->getCurrentUserId(),
+        'selected_count' => $queueData['selected_count'],
+        'eligible_count' => $queueData['eligible_count'],
+        'queued_count' => count($queuedIds),
+        'skipped_by_reason' => $queueData['skipped_by_reason'],
+        'constants' => $this->getAuditConstants(),
+        'request' => $this->getRequestSummary($requestData),
+      ]);
+      $entityManager->persist($task);
+
+      foreach ($queuedIds as $subscriberId) {
+        $subscriberReference = $entityManager->getReference(SubscriberEntity::class, $subscriberId);
+        if (!$subscriberReference instanceof SubscriberEntity) {
+          throw new \RuntimeException(sprintf('Subscriber %d not found.', $subscriberId));
+        }
+        $entityManager->persist(new ScheduledTaskSubscriberEntity(
+          $task,
+          $subscriberReference
+        ));
+      }
+
+      $entityManager->flush();
+      $this->saveQueueAuditLog($task, $queueData, $requestData);
+    });
+
+    return $task;
+  }
+
+  /**
+   * @param array{selected_count: int, eligible_count: int, queued_ids: int[], skipped_by_reason: array<string, int>} $queueData
+   * @param array<string, mixed> $requestData
+   */
+  private function saveQueueAuditLog(?ScheduledTaskEntity $task, array $queueData, array $requestData): void {
+    $log = new LogEntity();
+    $log->setName(LoggerFactory::TOPIC_API);
+    $log->setLevel(self::LOG_LEVEL_INFO);
+    $log->setMessage(self::AUDIT_LOG_MESSAGE_QUEUED);
+    $log->setRawMessage(self::AUDIT_LOG_MESSAGE_QUEUED);
+    $log->setContext([
+      'action' => 'bulk_confirmation_email_resend_queued',
+      'requested_by' => (int)$this->wp->getCurrentUserId(),
+      'task_id' => $task instanceof ScheduledTaskEntity ? $task->getId() : null,
+      'selected_count' => $queueData['selected_count'],
+      'eligible_count' => $queueData['eligible_count'],
+      'queued_count' => count($queueData['queued_ids']),
+      'skipped_by_reason' => $queueData['skipped_by_reason'],
+      'constants' => $this->getAuditConstants(),
+      'request' => $this->getRequestSummary($requestData),
+    ]);
+    $this->logRepository->saveLog($log);
+  }
+
+  /**
+   * @return array<string, int>
+   */
+  private function getAuditConstants(): array {
+    return [
+      'bulk_confirmation_resend_limit' => self::BULK_CONFIRMATION_RESEND_LIMIT,
+      'recent_confirmation_resend_interval_days' => self::RECENT_CONFIRMATION_RESEND_INTERVAL_DAYS,
+      'bulk_confirmation_max_subscriber_age_days' => self::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS,
+      'max_confirmation_emails' => ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS,
+    ];
+  }
+
+  /**
+   * @param array<string, mixed> $requestData
+   * @return array<string, mixed>
+   */
+  private function getRequestSummary(array $requestData): array {
+    $listing = isset($requestData['listing']) && is_array($requestData['listing']) ? $requestData['listing'] : [];
+    return [
+      'group' => $listing['group'] ?? null,
+      'has_selection' => !empty($listing['selection']),
+      'selection_count' => isset($listing['selection']) && is_array($listing['selection']) ? count($listing['selection']) : 0,
+      'has_search' => !empty($listing['search']),
+      'filter_keys' => isset($listing['filter']) && is_array($listing['filter']) ? array_keys($listing['filter']) : [],
+    ];
+  }
+}

--- a/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
+++ b/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
@@ -77,7 +77,8 @@ class BulkConfirmationEmailResender {
       (clone $now)->subDays(self::RECENT_CONFIRMATION_RESEND_INTERVAL_DAYS),
       (clone $now)->subDays(self::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS),
       ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS,
-      self::BULK_CONFIRMATION_RESEND_LIMIT
+      self::BULK_CONFIRMATION_RESEND_LIMIT,
+      $this->hasExplicitSelection($requestData)
     );
 
     $queuedIds = $queueData['queued_ids'];
@@ -192,5 +193,13 @@ class BulkConfirmationEmailResender {
       'has_search' => !empty($listing['search']),
       'filter_keys' => isset($listing['filter']) && is_array($listing['filter']) ? array_keys($listing['filter']) : [],
     ];
+  }
+
+  /**
+   * @param array<string, mixed> $requestData
+   */
+  private function hasExplicitSelection(array $requestData): bool {
+    $listing = isset($requestData['listing']) && is_array($requestData['listing']) ? $requestData['listing'] : [];
+    return array_key_exists('selection', $listing);
   }
 }

--- a/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
+++ b/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
@@ -128,9 +128,6 @@ class BulkConfirmationEmailResender {
 
       foreach ($queuedIds as $subscriberId) {
         $subscriberReference = $entityManager->getReference(SubscriberEntity::class, $subscriberId);
-        if (!$subscriberReference instanceof SubscriberEntity) {
-          throw new \RuntimeException(sprintf('Subscriber %d not found.', $subscriberId));
-        }
         $entityManager->persist(new ScheduledTaskSubscriberEntity(
           $task,
           $subscriberReference

--- a/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
+++ b/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
@@ -127,6 +127,7 @@ class BulkConfirmationEmailResender {
       $entityManager->persist($task);
 
       foreach ($queuedIds as $subscriberId) {
+        /** @var SubscriberEntity $subscriberReference */
         $subscriberReference = $entityManager->getReference(SubscriberEntity::class, $subscriberId);
         $entityManager->persist(new ScheduledTaskSubscriberEntity(
           $task,

--- a/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
+++ b/mailpoet/lib/Subscribers/BulkConfirmationEmailResender.php
@@ -98,8 +98,11 @@ class BulkConfirmationEmailResender {
       'skipped_by_reason' => $queueData['skipped_by_reason'],
       'task_id' => $task instanceof ScheduledTaskEntity ? $task->getId() : null,
       'message' => $queuedCount > 0
-        ? __('Confirmation emails were queued.', 'mailpoet')
-        : __('No eligible subscribers were queued for confirmation email resend.', 'mailpoet'),
+        ? __('Confirmation emails are being resent.', 'mailpoet')
+        : __(
+          'No confirmation emails were resent. The selected subscribers could not receive another confirmation email right now.',
+          'mailpoet'
+        ),
     ];
   }
 

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -24,6 +24,7 @@ use MailPoetVendor\Carbon\Carbon;
 class ConfirmationEmailMailer {
 
   const MAX_CONFIRMATION_EMAILS = 3;
+  const ADMIN_CONFIRMATION_RESEND_INTERVAL_DAYS = 7;
   protected const WC_CONFIRMATION_UNAVAILABLE = 'unavailable';
   protected const WC_CONFIRMATION_SENT = 'sent';
   protected const WC_CONFIRMATION_FAILED = 'failed';
@@ -60,15 +61,15 @@ class ConfirmationEmailMailer {
 
   public function __construct(
     MailerFactory $mailerFactory,
-    WPFunctions $wp,
     SettingsController $settings,
     SubscribersRepository $subscribersRepository,
     SubscriptionUrlFactory $subscriptionUrlFactory,
     ConfirmationEmailCustomizer $confirmationEmailCustomizer,
-    NewslettersRepository $newslettersRepository
+    NewslettersRepository $newslettersRepository,
+    ?WPFunctions $wp = null
   ) {
     $this->mailerFactory = $mailerFactory;
-    $this->wp = $wp;
+    $this->wp = $wp ?? new WPFunctions();
     $this->settings = $settings;
     $this->mailerMetaInfo = new MetaInfo;
     $this->subscriptionUrlFactory = $subscriptionUrlFactory;
@@ -252,7 +253,9 @@ class ConfirmationEmailMailer {
           return $sent;
         }
       );
-    } else if (
+    }
+
+    if (
       !$this->wp->isUserLoggedIn()
       && $subscriber->getConfirmationsCount() >= self::MAX_CONFIRMATION_EMAILS
     ) {
@@ -268,6 +271,56 @@ class ConfirmationEmailMailer {
     $this->sentEmails[$subscriber->getId()] = true;
 
     return true;
+  }
+
+  /**
+   * @return array{status: 'sent'|'skipped'|'send_failed', reason?: string}
+   * @throws \Exception if unable to send the email.
+   */
+  public function sendAdminConfirmationEmail(SubscriberEntity $subscriber, ?\DateTimeInterface $oldestLifecycleDate = null): array {
+    $signupConfirmation = $this->settings->get('signup_confirmation');
+    if ((bool)$signupConfirmation['enabled'] === false) {
+      return ['status' => 'skipped', 'reason' => 'confirmation_disabled'];
+    }
+
+    $claim = $this->subscribersRepository->claimAdminConfirmationEmailResend(
+      $subscriber,
+      self::MAX_CONFIRMATION_EMAILS,
+      Carbon::now()->subDays(self::ADMIN_CONFIRMATION_RESEND_INTERVAL_DAYS)->millisecond(0),
+      $oldestLifecycleDate
+    );
+    if (!$claim['claimed']) {
+      return ['status' => 'skipped', 'reason' => $claim['reason'] ?? 'not_found'];
+    }
+
+    try {
+      $sent = $this->sendConfirmationEmailMessage($subscriber, $signupConfirmation);
+    } catch (\Throwable $throwable) {
+      $this->releaseAdminConfirmationEmailClaim($subscriber, $claim);
+      throw $throwable;
+    }
+
+    if (!$sent) {
+      $this->releaseAdminConfirmationEmailClaim($subscriber, $claim);
+      return ['status' => 'send_failed', 'reason' => 'sending_method'];
+    }
+
+    $this->subscribersRepository->refresh($subscriber);
+    $this->sentEmails[$subscriber->getId()] = true;
+    return ['status' => 'sent'];
+  }
+
+  /** @param array{claim_time?: string, previous_last_confirmation_email_sent_at?: string|null, previous_count_confirmations?: int} $claim */
+  private function releaseAdminConfirmationEmailClaim(SubscriberEntity $subscriber, array $claim): void {
+    if (!isset($claim['claim_time'], $claim['previous_count_confirmations'])) {
+      return;
+    }
+    $this->subscribersRepository->releaseAdminConfirmationEmailResendClaim(
+      $subscriber,
+      (string)$claim['claim_time'],
+      $claim['previous_last_confirmation_email_sent_at'] ?? null,
+      (int)$claim['previous_count_confirmations']
+    );
   }
 
   /**

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -305,7 +305,7 @@ class ConfirmationEmailMailer {
       return ['status' => 'send_failed', 'reason' => 'sending_method'];
     }
 
-    $this->subscribersRepository->refresh($subscriber);
+    $this->completeAdminConfirmationEmailClaim($subscriber, $claim);
     $this->sentEmails[$subscriber->getId()] = true;
     return ['status' => 'sent'];
   }
@@ -316,6 +316,19 @@ class ConfirmationEmailMailer {
       return;
     }
     $this->subscribersRepository->releaseAdminConfirmationEmailResendClaim(
+      $subscriber,
+      (string)$claim['claim_time'],
+      $claim['previous_last_confirmation_email_sent_at'] ?? null,
+      (int)$claim['previous_count_confirmations']
+    );
+  }
+
+  /** @param array{claim_time?: string, previous_last_confirmation_email_sent_at?: string|null, previous_count_confirmations?: int} $claim */
+  private function completeAdminConfirmationEmailClaim(SubscriberEntity $subscriber, array $claim): void {
+    if (!isset($claim['claim_time'], $claim['previous_count_confirmations'])) {
+      return;
+    }
+    $this->subscribersRepository->completeAdminConfirmationEmailResendClaim(
       $subscriber,
       (string)$claim['claim_time'],
       $claim['previous_last_confirmation_email_sent_at'] ?? null,

--- a/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
+++ b/mailpoet/lib/Subscribers/ConfirmationEmailMailer.php
@@ -382,10 +382,10 @@ class ConfirmationEmailMailer {
   }
 
   private function recordSuccessfulConfirmationSend(SubscriberEntity $subscriber): void {
-    if (!$this->wp->isUserLoggedIn()) {
-      $subscriber->setConfirmationsCount($subscriber->getConfirmationsCount() + 1);
+    if ($this->wp->isUserLoggedIn()) {
+      return;
     }
-    $subscriber->setLastConfirmationEmailSentAt(Carbon::now()->millisecond(0));
+    $subscriber->setConfirmationsCount($subscriber->getConfirmationsCount() + 1);
     $this->subscribersRepository->persist($subscriber);
     $this->subscribersRepository->flush();
   }

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -4,12 +4,16 @@ namespace MailPoet\Subscribers;
 
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoet\Listing\ListingDefinition;
 use MailPoet\Listing\ListingRepository;
 use MailPoet\Segments\DynamicSegments\FilterHandler;
 use MailPoet\Segments\SegmentSubscribersRepository;
 use MailPoet\Util\Helpers;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder as DBALQueryBuilder;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\Query\Expr\Join;
@@ -28,6 +32,16 @@ class SubscriberListingRepository extends ListingRepository {
   private const ENGAGEMENT_SCORE_GOOD_MIN = 20;
   private const ENGAGEMENT_SCORE_GOOD_MAX = 50;
   private const ENGAGEMENT_SCORE_EXCELLENT_MIN = 50;
+  private const BULK_RESEND_REASONS = [
+    'batch_limit',
+    'not_unconfirmed',
+    'deleted',
+    'max_confirmations_reached',
+    'recently_sent',
+    'too_old',
+    'outside_scope',
+    'not_found',
+  ];
 
   private static $supportedStatuses = [
     SubscriberEntity::STATUS_SUBSCRIBED,
@@ -110,6 +124,271 @@ class SubscriberListingRepository extends ListingRepository {
     $idsStatement = $subscribersIdsQuery->execute();
     $result = $idsStatement->fetchAll();
     return array_column($result, 'id');
+  }
+
+  /**
+   * @return array{selected_count: int, eligible_count: int, queued_ids: int[], skipped_by_reason: array<string, int>}
+   */
+  public function getConfirmationEmailResendQueueData(
+    ListingDefinition $definition,
+    \DateTimeInterface $recentCutoff,
+    \DateTimeInterface $oldestLifecycleDate,
+    int $maxConfirmationEmails,
+    int $limit
+  ): array {
+    $selectedIds = $this->normalizeSelectedIds($definition->getSelection());
+    $skippedByReason = array_fill_keys(self::BULK_RESEND_REASONS, 0);
+    $base = $this->createBulkResendBaseQuery($definition);
+    $idColumn = $base['id_column'];
+
+    if ($selectedIds) {
+      $selectedCount = count($selectedIds);
+      $skippedByReason = $this->getExplicitSelectionScopeSkippedCounts($selectedIds, $skippedByReason);
+      $scopeSkippedCount = $skippedByReason['deleted'] + $skippedByReason['not_unconfirmed'] + $skippedByReason['not_found'];
+      $base['query']->andWhere("$idColumn IN (:selected_ids)")
+        ->setParameter('selected_ids', $selectedIds, ArrayParameterType::INTEGER);
+    } else {
+      $selectedCount = $this->countBulkResendQuery($base['query'], $idColumn);
+      $scopeSkippedCount = 0;
+    }
+
+    $inScopeCount = $this->countBulkResendQuery($base['query'], $idColumn);
+    $skippedByReason['max_confirmations_reached'] = $this->countBulkResendQuery(
+      $this->addMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
+      $idColumn
+    );
+    $skippedByReason['recently_sent'] = $this->countBulkResendQuery(
+      $this->addRecentPredicate(
+        $this->addBelowMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
+        $idColumn,
+        $recentCutoff
+      ),
+      $idColumn
+    );
+    $skippedByReason['too_old'] = $this->countBulkResendQuery(
+      $this->addTooOldPredicate(
+        $this->addNotRecentPredicate(
+          $this->addBelowMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
+          $idColumn,
+          $recentCutoff
+        ),
+        $idColumn,
+        $oldestLifecycleDate
+      ),
+      $idColumn
+    );
+
+    $eligibleQuery = $this->addEligiblePredicates(clone $base['query'], $idColumn, $recentCutoff, $oldestLifecycleDate, $maxConfirmationEmails);
+    $eligibleCount = $this->countBulkResendQuery($eligibleQuery, $idColumn);
+    $queuedIds = $this->fetchBulkResendIds($eligibleQuery, $idColumn, $limit);
+    $skippedByReason['batch_limit'] = max(0, $eligibleCount - count($queuedIds));
+
+    if ($selectedIds) {
+      $skippedByReason['outside_scope'] += max(0, $selectedCount - $inScopeCount - $scopeSkippedCount);
+    }
+
+    return [
+      'selected_count' => $selectedCount,
+      'eligible_count' => $eligibleCount,
+      'queued_ids' => $queuedIds,
+      'skipped_by_reason' => $skippedByReason,
+    ];
+  }
+
+  /**
+   * @param int[] $selectedIds
+   * @param array<string, int> $skippedByReason
+   * @return array<string, int>
+   */
+  private function getExplicitSelectionScopeSkippedCounts(array $selectedIds, array $skippedByReason): array {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $rows = $this->entityManager->getConnection()->executeQuery(
+      "SELECT `id`, `status`, `deleted_at`
+       FROM $subscribersTable
+       WHERE `id` IN (:selected_ids)",
+      ['selected_ids' => $selectedIds],
+      ['selected_ids' => ArrayParameterType::INTEGER]
+    )->fetchAllAssociative();
+
+    $existingIds = [];
+    foreach ($rows as $row) {
+      $existingIds[] = $this->toInt($row['id'] ?? 0);
+      if (!empty($row['deleted_at'])) {
+        $skippedByReason['deleted']++;
+      } elseif (($row['status'] ?? null) !== SubscriberEntity::STATUS_UNCONFIRMED) {
+        $skippedByReason['not_unconfirmed']++;
+      }
+    }
+    $skippedByReason['not_found'] = count(array_diff($selectedIds, $existingIds));
+
+    return $skippedByReason;
+  }
+
+  /**
+   * @return array{query: DBALQueryBuilder, id_column: string}
+   */
+  private function createBulkResendBaseQuery(ListingDefinition $definition): array {
+    $dynamicSegment = $this->getDynamicSegmentFromFilters($definition);
+    if ($dynamicSegment instanceof SegmentEntity) {
+      $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+      $query = $this->entityManager->getConnection()->createQueryBuilder()
+        ->select("DISTINCT $subscribersTable.id")
+        ->from($subscribersTable);
+      $query = $this->applyConstraintsForDynamicSegment($query, $definition, $dynamicSegment);
+      return ['query' => $query, 'id_column' => "$subscribersTable.id"];
+    }
+
+    $query = $this->entityManager->getConnection()->createQueryBuilder();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $query->select('DISTINCT s.id')
+      ->from($subscribersTable, 's');
+
+    $this->applyBulkResendListingConstraints($query, $definition);
+    return ['query' => $query, 'id_column' => 's.id'];
+  }
+
+  private function applyBulkResendListingConstraints(DBALQueryBuilder $query, ListingDefinition $definition): void {
+    $group = $definition->getGroup();
+    if ($group === 'trash') {
+      $query->andWhere('s.deleted_at IS NOT NULL');
+    } else {
+      $query->andWhere('s.deleted_at IS NULL');
+    }
+    if ($group && in_array($group, self::$supportedStatuses, true)) {
+      $query->andWhere('s.status = :listing_status')
+        ->setParameter('listing_status', $group);
+    }
+
+    $search = $definition->getSearch();
+    if ($search && strlen(trim($search)) > 0) {
+      $search = Helpers::escapeSearch($search);
+      $query
+        ->andWhere('s.email LIKE :search OR s.first_name LIKE :search OR s.last_name LIKE :search')
+        ->setParameter('search', "%$search%");
+    }
+
+    $filters = $definition->getFilters();
+    if (isset($filters['segment'])) {
+      if ($filters['segment'] === self::FILTER_WITHOUT_LIST) {
+        $this->segmentSubscribersRepository->addConstraintsForSubscribersWithoutSegmentToDBAL($query);
+      } else {
+        $segment = $this->entityManager->find(SegmentEntity::class, (int)$filters['segment']);
+        if ($segment instanceof SegmentEntity && $segment->isStatic()) {
+          $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+          $query->join('s', $subscriberSegmentsTable, 'ss', 'ss.subscriber_id = s.id AND ss.segment_id = :segment_id')
+            ->setParameter('segment_id', $segment->getId(), ParameterType::INTEGER);
+        }
+      }
+    }
+
+    if (isset($filters['tag'])) {
+      $tag = $this->entityManager->find(TagEntity::class, (int)$filters['tag']);
+      if ($tag instanceof TagEntity) {
+        $subscriberTagsTable = $this->entityManager->getClassMetadata(SubscriberTagEntity::class)->getTableName();
+        $query->join('s', $subscriberTagsTable, 'st', 'st.subscriber_id = s.id AND st.tag_id = :tag_id')
+          ->setParameter('tag_id', $tag->getId(), ParameterType::INTEGER);
+      }
+    }
+  }
+
+  private function countBulkResendQuery(DBALQueryBuilder $query, string $idColumn): int {
+    $countQuery = clone $query;
+    $countQuery->select("COUNT(DISTINCT $idColumn)");
+    return $this->toInt($countQuery->executeQuery()->fetchOne());
+  }
+
+  /**
+   * @return int[]
+   */
+  private function fetchBulkResendIds(DBALQueryBuilder $query, string $idColumn, int $limit): array {
+    $query->select("DISTINCT $idColumn AS id")
+      ->orderBy($idColumn, 'ASC')
+      ->setMaxResults($limit);
+    return array_map(function($id): int {
+      return $this->toInt($id);
+    }, $query->executeQuery()->fetchFirstColumn());
+  }
+
+  private function addEligiblePredicates(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $recentCutoff, \DateTimeInterface $oldestLifecycleDate, int $maxConfirmationEmails): DBALQueryBuilder {
+    return $this->addNotTooOldPredicate(
+      $this->addNotRecentPredicate(
+        $this->addBelowMaxConfirmationPredicate($query, $idColumn, $maxConfirmationEmails),
+        $idColumn,
+        $recentCutoff
+      ),
+      $idColumn,
+      $oldestLifecycleDate
+    );
+  }
+
+  private function addBelowMaxConfirmationPredicate(DBALQueryBuilder $query, string $idColumn, int $maxConfirmationEmails): DBALQueryBuilder {
+    $query->andWhere($this->column($idColumn, 'count_confirmations') . ' < :max_confirmation_emails')
+      ->setParameter('max_confirmation_emails', $maxConfirmationEmails, ParameterType::INTEGER);
+    return $query;
+  }
+
+  private function addMaxConfirmationPredicate(DBALQueryBuilder $query, string $idColumn, int $maxConfirmationEmails): DBALQueryBuilder {
+    $query->andWhere($this->column($idColumn, 'count_confirmations') . ' >= :max_confirmation_emails')
+      ->setParameter('max_confirmation_emails', $maxConfirmationEmails, ParameterType::INTEGER);
+    return $query;
+  }
+
+  private function addRecentPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $recentCutoff): DBALQueryBuilder {
+    $query->andWhere($this->column($idColumn, 'last_confirmation_email_sent_at') . ' IS NOT NULL')
+      ->andWhere($this->column($idColumn, 'last_confirmation_email_sent_at') . ' > :recent_cutoff')
+      ->setParameter('recent_cutoff', $recentCutoff->format('Y-m-d H:i:s'), ParameterType::STRING);
+    return $query;
+  }
+
+  private function addNotRecentPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $recentCutoff): DBALQueryBuilder {
+    $column = $this->column($idColumn, 'last_confirmation_email_sent_at');
+    $query->andWhere("($column IS NULL OR $column <= :recent_cutoff)")
+      ->setParameter('recent_cutoff', $recentCutoff->format('Y-m-d H:i:s'), ParameterType::STRING);
+    return $query;
+  }
+
+  private function addTooOldPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $oldestLifecycleDate): DBALQueryBuilder {
+    $query->andWhere('COALESCE(' . $this->column($idColumn, 'last_subscribed_at') . ', ' . $this->column($idColumn, 'created_at') . ') < :oldest_lifecycle_date')
+      ->setParameter('oldest_lifecycle_date', $oldestLifecycleDate->format('Y-m-d H:i:s'), ParameterType::STRING);
+    return $query;
+  }
+
+  private function addNotTooOldPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $oldestLifecycleDate): DBALQueryBuilder {
+    $query->andWhere('COALESCE(' . $this->column($idColumn, 'last_subscribed_at') . ', ' . $this->column($idColumn, 'created_at') . ') >= :oldest_lifecycle_date')
+      ->setParameter('oldest_lifecycle_date', $oldestLifecycleDate->format('Y-m-d H:i:s'), ParameterType::STRING);
+    return $query;
+  }
+
+  private function column(string $idColumn, string $column): string {
+    if ($idColumn === 's.id') {
+      return "s.$column";
+    }
+    $table = substr($idColumn, 0, -3);
+    return "$table.$column";
+  }
+
+  /**
+   * @param mixed[] $ids
+   * @return int[]
+   */
+  private function normalizeSelectedIds(array $ids): array {
+    $ids = array_map(function($id): int {
+      return $this->toInt($id);
+    }, $ids);
+    $ids = array_filter($ids, static function(int $id): bool {
+      return $id > 0;
+    });
+    return array_values(array_unique($ids));
+  }
+
+  private function toInt($value): int {
+    if (is_int($value)) {
+      return $value;
+    }
+    if (is_string($value) || is_float($value) || is_bool($value)) {
+      return (int)$value;
+    }
+    return 0;
   }
 
   protected function applySelectClause(QueryBuilder $queryBuilder) {

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -257,7 +257,7 @@ class SubscriberListingRepository extends ListingRepository {
     if ($search && strlen(trim($search)) > 0) {
       $search = Helpers::escapeSearch($search);
       $query
-        ->andWhere('s.email LIKE :search OR s.first_name LIKE :search OR s.last_name LIKE :search')
+        ->andWhere('(s.email LIKE :search OR s.first_name LIKE :search OR s.last_name LIKE :search)')
         ->setParameter('search', "%$search%");
     }
 

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -134,14 +134,25 @@ class SubscriberListingRepository extends ListingRepository {
     \DateTimeInterface $recentCutoff,
     \DateTimeInterface $oldestLifecycleDate,
     int $maxConfirmationEmails,
-    int $limit
+    int $limit,
+    bool $hasExplicitSelection = false
   ): array {
     $selectedIds = $this->normalizeSelectedIds($definition->getSelection());
     $skippedByReason = array_fill_keys(self::BULK_RESEND_REASONS, 0);
     $base = $this->createBulkResendBaseQuery($definition);
     $idColumn = $base['id_column'];
 
-    if ($selectedIds) {
+    if ($hasExplicitSelection) {
+      if (!$selectedIds) {
+        $selectedCount = count($definition->getSelection());
+        $skippedByReason['not_found'] = $selectedCount;
+        return [
+          'selected_count' => $selectedCount,
+          'eligible_count' => 0,
+          'queued_ids' => [],
+          'skipped_by_reason' => $skippedByReason,
+        ];
+      }
       $selectedCount = count($selectedIds);
       $skippedByReason = $this->getExplicitSelectionScopeSkippedCounts($selectedIds, $skippedByReason);
       $scopeSkippedCount = $skippedByReason['deleted'] + $skippedByReason['not_unconfirmed'] + $skippedByReason['not_found'];
@@ -152,7 +163,7 @@ class SubscriberListingRepository extends ListingRepository {
       $scopeSkippedCount = 0;
     }
 
-    $inScopeCount = $this->countBulkResendQuery($base['query'], $idColumn);
+    $inScopeCount = $hasExplicitSelection ? $this->countBulkResendQuery($base['query'], $idColumn) : $selectedCount;
     $skippedByReason['max_confirmations_reached'] = $this->countBulkResendQuery(
       $this->addMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
       $idColumn
@@ -289,6 +300,91 @@ class SubscriberListingRepository extends ListingRepository {
           ->setParameter('tag_id', $tag->getId(), ParameterType::INTEGER);
       }
     }
+
+    if (isset($filters['minUpdatedAt']) && $filters['minUpdatedAt'] instanceof \DateTimeInterface) {
+      $query->andWhere('s.updated_at >= :updated_at')
+        ->setParameter('updated_at', $filters['minUpdatedAt']->format('Y-m-d H:i:s'), ParameterType::STRING);
+    }
+
+    $statusInclude = $this->sanitizeStatusFilter($filters['statusInclude'] ?? []);
+    if ($statusInclude) {
+      $query->andWhere('s.status IN (:status_include)')
+        ->setParameter('status_include', $statusInclude, ArrayParameterType::STRING);
+    }
+
+    $statusExclude = $this->sanitizeStatusFilter($filters['statusExclude'] ?? []);
+    if ($statusExclude) {
+      $query->andWhere('s.status NOT IN (:status_exclude)')
+        ->setParameter('status_exclude', $statusExclude, ArrayParameterType::STRING);
+    }
+
+    $createdAtFrom = $filters['createdAtFrom'] ?? null;
+    if ($createdAtFrom && is_string($createdAtFrom) && $this->isValidDateTime($createdAtFrom)) {
+      $query->andWhere('s.created_at >= :created_at_from')
+        ->setParameter('created_at_from', $createdAtFrom, ParameterType::STRING);
+    }
+
+    $createdAtTo = $filters['createdAtTo'] ?? null;
+    if ($createdAtTo && is_string($createdAtTo) && $this->isValidDateTime($createdAtTo)) {
+      $query->andWhere('s.created_at <= :created_at_to')
+        ->setParameter('created_at_to', $createdAtTo, ParameterType::STRING);
+    }
+
+    $engagementScoreInclude = $filters['engagementScoreInclude'] ?? [];
+    if (!empty($engagementScoreInclude)) {
+      $conditions = $this->getEngagementScoreConditions(is_array($engagementScoreInclude) ? $engagementScoreInclude : [$engagementScoreInclude]);
+      if ($conditions) {
+        $query->andWhere('(' . implode(' OR ', $conditions) . ')');
+      }
+    }
+
+    $engagementScoreExclude = $filters['engagementScoreExclude'] ?? [];
+    if (!empty($engagementScoreExclude)) {
+      foreach (is_array($engagementScoreExclude) ? $engagementScoreExclude : [$engagementScoreExclude] as $score) {
+        if ($score === self::ENGAGEMENT_SCORE_UNKNOWN) {
+          $query->andWhere('s.engagement_score IS NOT NULL');
+        } elseif ($score === self::ENGAGEMENT_SCORE_LOW) {
+          $query->andWhere(sprintf('(s.engagement_score >= %d OR s.engagement_score IS NULL)', self::ENGAGEMENT_SCORE_LOW_MAX));
+        } elseif ($score === self::ENGAGEMENT_SCORE_GOOD) {
+          $query->andWhere(sprintf('(s.engagement_score < %d OR s.engagement_score >= %d OR s.engagement_score IS NULL)', self::ENGAGEMENT_SCORE_GOOD_MIN, self::ENGAGEMENT_SCORE_GOOD_MAX));
+        } elseif ($score === self::ENGAGEMENT_SCORE_EXCELLENT) {
+          $query->andWhere(sprintf('(s.engagement_score < %d OR s.engagement_score IS NULL)', self::ENGAGEMENT_SCORE_EXCELLENT_MIN));
+        }
+      }
+    }
+  }
+
+  /**
+   * @param mixed $statuses
+   * @return string[]
+   */
+  private function sanitizeStatusFilter($statuses): array {
+    $statuses = is_array($statuses) ? $statuses : [$statuses];
+    $statuses = array_filter($statuses, function($status) {
+      return is_string($status) && in_array($status, self::$supportedStatuses, true);
+    });
+    return array_values(array_unique($statuses));
+  }
+
+  /**
+   * @param mixed[] $scores
+   * @return string[]
+   */
+  private function getEngagementScoreConditions(array $scores): array {
+    $conditions = [];
+    if (in_array(self::ENGAGEMENT_SCORE_UNKNOWN, $scores, true)) {
+      $conditions[] = '(s.engagement_score IS NULL)';
+    }
+    if (in_array(self::ENGAGEMENT_SCORE_LOW, $scores, true)) {
+      $conditions[] = sprintf('(s.engagement_score < %d)', self::ENGAGEMENT_SCORE_LOW_MAX);
+    }
+    if (in_array(self::ENGAGEMENT_SCORE_GOOD, $scores, true)) {
+      $conditions[] = sprintf('(s.engagement_score >= %d AND s.engagement_score < %d)', self::ENGAGEMENT_SCORE_GOOD_MIN, self::ENGAGEMENT_SCORE_GOOD_MAX);
+    }
+    if (in_array(self::ENGAGEMENT_SCORE_EXCELLENT, $scores, true)) {
+      $conditions[] = sprintf('(s.engagement_score >= %d)', self::ENGAGEMENT_SCORE_EXCELLENT_MIN);
+    }
+    return $conditions;
   }
 
   private function countBulkResendQuery(DBALQueryBuilder $query, string $idColumn): int {

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -159,38 +159,21 @@ class SubscriberListingRepository extends ListingRepository {
       $base['query']->andWhere("$idColumn IN (:selected_ids)")
         ->setParameter('selected_ids', $selectedIds, ArrayParameterType::INTEGER);
     } else {
-      $selectedCount = $this->countBulkResendQuery($base['query'], $idColumn);
+      $selectedCount = 0;
       $scopeSkippedCount = 0;
     }
 
-    $inScopeCount = $hasExplicitSelection ? $this->countBulkResendQuery($base['query'], $idColumn) : $selectedCount;
-    $skippedByReason['max_confirmations_reached'] = $this->countBulkResendQuery(
-      $this->addMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
-      $idColumn
-    );
-    $skippedByReason['recently_sent'] = $this->countBulkResendQuery(
-      $this->addRecentPredicate(
-        $this->addBelowMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
-        $idColumn,
-        $recentCutoff
-      ),
-      $idColumn
-    );
-    $skippedByReason['too_old'] = $this->countBulkResendQuery(
-      $this->addTooOldPredicate(
-        $this->addNotRecentPredicate(
-          $this->addBelowMaxConfirmationPredicate(clone $base['query'], $idColumn, $maxConfirmationEmails),
-          $idColumn,
-          $recentCutoff
-        ),
-        $idColumn,
-        $oldestLifecycleDate
-      ),
-      $idColumn
-    );
+    $counts = $this->getBulkResendEligibilityCounts(clone $base['query'], $idColumn, $recentCutoff, $oldestLifecycleDate, $maxConfirmationEmails);
+    $inScopeCount = $counts['in_scope_count'];
+    if (!$hasExplicitSelection) {
+      $selectedCount = $inScopeCount;
+    }
+    $skippedByReason['max_confirmations_reached'] = $counts['max_confirmations_reached'];
+    $skippedByReason['recently_sent'] = $counts['recently_sent'];
+    $skippedByReason['too_old'] = $counts['too_old'];
+    $eligibleCount = $counts['eligible'];
 
     $eligibleQuery = $this->addEligiblePredicates(clone $base['query'], $idColumn, $recentCutoff, $oldestLifecycleDate, $maxConfirmationEmails);
-    $eligibleCount = $this->countBulkResendQuery($eligibleQuery, $idColumn);
     $queuedIds = $this->fetchBulkResendIds($eligibleQuery, $idColumn, $limit);
     $skippedByReason['batch_limit'] = max(0, $eligibleCount - count($queuedIds));
 
@@ -387,10 +370,46 @@ class SubscriberListingRepository extends ListingRepository {
     return $conditions;
   }
 
-  private function countBulkResendQuery(DBALQueryBuilder $query, string $idColumn): int {
+  /**
+   * @return array{in_scope_count: int, max_confirmations_reached: int, recently_sent: int, too_old: int, eligible: int}
+   */
+  private function getBulkResendEligibilityCounts(
+    DBALQueryBuilder $query,
+    string $idColumn,
+    \DateTimeInterface $recentCutoff,
+    \DateTimeInterface $oldestLifecycleDate,
+    int $maxConfirmationEmails
+  ): array {
     $countQuery = clone $query;
-    $countQuery->select("COUNT(DISTINCT $idColumn)");
-    return $this->toInt($countQuery->executeQuery()->fetchOne());
+    $countConfirmationColumn = $this->column($idColumn, 'count_confirmations');
+    $lastConfirmationEmailSentAtColumn = $this->column($idColumn, 'last_confirmation_email_sent_at');
+    $lifecycleDateExpression = 'COALESCE(' . $this->column($idColumn, 'last_subscribed_at') . ', ' . $this->column($idColumn, 'created_at') . ')';
+    $belowMaxConfirmations = "$countConfirmationColumn < :max_confirmation_emails";
+    $maxConfirmationsReached = "$countConfirmationColumn >= :max_confirmation_emails";
+    $recentlySent = "$lastConfirmationEmailSentAtColumn IS NOT NULL AND $lastConfirmationEmailSentAtColumn > :recent_cutoff";
+    $notRecentlySent = "($lastConfirmationEmailSentAtColumn IS NULL OR $lastConfirmationEmailSentAtColumn <= :recent_cutoff)";
+    $tooOld = "$lifecycleDateExpression < :oldest_lifecycle_date";
+    $notTooOld = "$lifecycleDateExpression >= :oldest_lifecycle_date";
+
+    $countQuery->select(implode(', ', [
+      "COUNT(DISTINCT $idColumn) AS in_scope_count",
+      "COUNT(DISTINCT CASE WHEN $maxConfirmationsReached THEN $idColumn END) AS max_confirmations_reached",
+      "COUNT(DISTINCT CASE WHEN $belowMaxConfirmations AND $recentlySent THEN $idColumn END) AS recently_sent",
+      "COUNT(DISTINCT CASE WHEN $belowMaxConfirmations AND $notRecentlySent AND $tooOld THEN $idColumn END) AS too_old",
+      "COUNT(DISTINCT CASE WHEN $belowMaxConfirmations AND $notRecentlySent AND $notTooOld THEN $idColumn END) AS eligible",
+    ]))
+      ->setParameter('max_confirmation_emails', $maxConfirmationEmails, ParameterType::INTEGER)
+      ->setParameter('recent_cutoff', $recentCutoff->format('Y-m-d H:i:s'), ParameterType::STRING)
+      ->setParameter('oldest_lifecycle_date', $oldestLifecycleDate->format('Y-m-d H:i:s'), ParameterType::STRING);
+
+    $row = $countQuery->executeQuery()->fetchAssociative() ?: [];
+    return [
+      'in_scope_count' => $this->toInt($row['in_scope_count'] ?? 0),
+      'max_confirmations_reached' => $this->toInt($row['max_confirmations_reached'] ?? 0),
+      'recently_sent' => $this->toInt($row['recently_sent'] ?? 0),
+      'too_old' => $this->toInt($row['too_old'] ?? 0),
+      'eligible' => $this->toInt($row['eligible'] ?? 0),
+    ];
   }
 
   /**
@@ -423,29 +442,10 @@ class SubscriberListingRepository extends ListingRepository {
     return $query;
   }
 
-  private function addMaxConfirmationPredicate(DBALQueryBuilder $query, string $idColumn, int $maxConfirmationEmails): DBALQueryBuilder {
-    $query->andWhere($this->column($idColumn, 'count_confirmations') . ' >= :max_confirmation_emails')
-      ->setParameter('max_confirmation_emails', $maxConfirmationEmails, ParameterType::INTEGER);
-    return $query;
-  }
-
-  private function addRecentPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $recentCutoff): DBALQueryBuilder {
-    $query->andWhere($this->column($idColumn, 'last_confirmation_email_sent_at') . ' IS NOT NULL')
-      ->andWhere($this->column($idColumn, 'last_confirmation_email_sent_at') . ' > :recent_cutoff')
-      ->setParameter('recent_cutoff', $recentCutoff->format('Y-m-d H:i:s'), ParameterType::STRING);
-    return $query;
-  }
-
   private function addNotRecentPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $recentCutoff): DBALQueryBuilder {
     $column = $this->column($idColumn, 'last_confirmation_email_sent_at');
     $query->andWhere("($column IS NULL OR $column <= :recent_cutoff)")
       ->setParameter('recent_cutoff', $recentCutoff->format('Y-m-d H:i:s'), ParameterType::STRING);
-    return $query;
-  }
-
-  private function addTooOldPredicate(DBALQueryBuilder $query, string $idColumn, \DateTimeInterface $oldestLifecycleDate): DBALQueryBuilder {
-    $query->andWhere('COALESCE(' . $this->column($idColumn, 'last_subscribed_at') . ', ' . $this->column($idColumn, 'created_at') . ') < :oldest_lifecycle_date')
-      ->setParameter('oldest_lifecycle_date', $oldestLifecycleDate->format('Y-m-d H:i:s'), ParameterType::STRING);
     return $query;
   }
 

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -397,6 +397,39 @@ class SubscribersRepository extends Repository {
     $this->entityManager->refresh($subscriber);
   }
 
+  public function completeAdminConfirmationEmailResendClaim(
+    SubscriberEntity $subscriber,
+    string $claimTime,
+    ?string $previousLastConfirmationEmailSentAt,
+    int $previousCountConfirmations
+  ): void {
+    if (!$subscriber->getId()) {
+      return;
+    }
+
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE $subscriberTable
+       SET `last_confirmation_email_sent_at` = :previous_last_confirmation_email_sent_at
+       WHERE `id` = :id
+       AND `last_confirmation_email_sent_at` = :claim_time
+       AND `count_confirmations` = :claimed_count_confirmations",
+      [
+        'id' => $subscriber->getId(),
+        'claim_time' => $claimTime,
+        'previous_last_confirmation_email_sent_at' => $previousLastConfirmationEmailSentAt,
+        'claimed_count_confirmations' => $previousCountConfirmations + 1,
+      ],
+      [
+        'id' => ParameterType::INTEGER,
+        'claim_time' => ParameterType::STRING,
+        'previous_last_confirmation_email_sent_at' => $previousLastConfirmationEmailSentAt === null ? ParameterType::NULL : ParameterType::STRING,
+        'claimed_count_confirmations' => ParameterType::INTEGER,
+      ]
+    );
+    $this->entityManager->refresh($subscriber);
+  }
+
   public function getAdminConfirmationEmailResendIneligibilityReason(
     SubscriberEntity $subscriber,
     int $maxConfirmationEmails,

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -295,23 +295,34 @@ class SubscribersRepository extends Repository {
       return ['claimed' => false, 'reason' => $reason];
     }
 
+    $previousCountConfirmations = $this->toInt($row['count_confirmations'] ?? 0);
+    $previousLastConfirmationEmailSentAt = $this->toStringOrNull($row['last_confirmation_email_sent_at'] ?? null);
     $claimTime = Carbon::now()->millisecond(0)->format('Y-m-d H:i:s');
     $ageCondition = $oldestLifecycleDate instanceof DateTimeInterface
       ? 'AND COALESCE(`last_subscribed_at`, `created_at`) >= :oldest_lifecycle_date'
       : '';
+    $lastConfirmationEmailSentAtCondition = $previousLastConfirmationEmailSentAt === null
+      ? 'AND `last_confirmation_email_sent_at` IS NULL'
+      : 'AND `last_confirmation_email_sent_at` = :previous_last_confirmation_email_sent_at';
     $parameters = [
       'id' => $subscriber->getId(),
       'status' => SubscriberEntity::STATUS_UNCONFIRMED,
       'max_confirmation_emails' => $maxConfirmationEmails,
       'recent_cutoff' => $recentCutoff->format('Y-m-d H:i:s'),
       'claim_time' => $claimTime,
+      'previous_count_confirmations' => $previousCountConfirmations,
     ];
     $types = [
       'id' => ParameterType::INTEGER,
       'max_confirmation_emails' => ParameterType::INTEGER,
       'recent_cutoff' => ParameterType::STRING,
       'claim_time' => ParameterType::STRING,
+      'previous_count_confirmations' => ParameterType::INTEGER,
     ];
+    if ($previousLastConfirmationEmailSentAt !== null) {
+      $parameters['previous_last_confirmation_email_sent_at'] = $previousLastConfirmationEmailSentAt;
+      $types['previous_last_confirmation_email_sent_at'] = ParameterType::STRING;
+    }
     if ($oldestLifecycleDate instanceof DateTimeInterface) {
       $parameters['oldest_lifecycle_date'] = $oldestLifecycleDate->format('Y-m-d H:i:s');
       $types['oldest_lifecycle_date'] = ParameterType::STRING;
@@ -326,6 +337,8 @@ class SubscribersRepository extends Repository {
        AND `deleted_at` IS NULL
        AND `count_confirmations` < :max_confirmation_emails
        AND (`last_confirmation_email_sent_at` IS NULL OR `last_confirmation_email_sent_at` <= :recent_cutoff)
+       AND `count_confirmations` = :previous_count_confirmations
+       $lastConfirmationEmailSentAtCondition
        $ageCondition",
       $parameters,
       $types
@@ -343,8 +356,8 @@ class SubscribersRepository extends Repository {
     return [
       'claimed' => true,
       'claim_time' => $claimTime,
-      'previous_last_confirmation_email_sent_at' => $this->toStringOrNull($row['last_confirmation_email_sent_at'] ?? null),
-      'previous_count_confirmations' => $this->toInt($row['count_confirmations'] ?? 0),
+      'previous_last_confirmation_email_sent_at' => $previousLastConfirmationEmailSentAt,
+      'previous_count_confirmations' => $previousCountConfirmations,
     ];
   }
 

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -274,6 +274,196 @@ class SubscribersRepository extends Repository {
     return true;
   }
 
+  /**
+   * @return array{claimed: bool, reason?: string, claim_time?: string, previous_last_confirmation_email_sent_at?: string|null, previous_count_confirmations?: int}
+   */
+  public function claimAdminConfirmationEmailResend(
+    SubscriberEntity $subscriber,
+    int $maxConfirmationEmails,
+    DateTimeInterface $recentCutoff,
+    ?DateTimeInterface $oldestLifecycleDate = null
+  ): array {
+    if (!$subscriber->getId()) {
+      return ['claimed' => false, 'reason' => 'not_found'];
+    }
+
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $row = $this->getConfirmationResendState($subscriberTable, (int)$subscriber->getId());
+    $reason = $this->getConfirmationResendIneligibilityReasonFromRow($row, $maxConfirmationEmails, $recentCutoff, $oldestLifecycleDate);
+    if ($reason !== null) {
+      $this->entityManager->refresh($subscriber);
+      return ['claimed' => false, 'reason' => $reason];
+    }
+
+    $claimTime = Carbon::now()->millisecond(0)->format('Y-m-d H:i:s');
+    $ageCondition = $oldestLifecycleDate instanceof DateTimeInterface
+      ? 'AND COALESCE(`last_subscribed_at`, `created_at`) >= :oldest_lifecycle_date'
+      : '';
+    $parameters = [
+      'id' => $subscriber->getId(),
+      'status' => SubscriberEntity::STATUS_UNCONFIRMED,
+      'max_confirmation_emails' => $maxConfirmationEmails,
+      'recent_cutoff' => $recentCutoff->format('Y-m-d H:i:s'),
+      'claim_time' => $claimTime,
+    ];
+    $types = [
+      'id' => ParameterType::INTEGER,
+      'max_confirmation_emails' => ParameterType::INTEGER,
+      'recent_cutoff' => ParameterType::STRING,
+      'claim_time' => ParameterType::STRING,
+    ];
+    if ($oldestLifecycleDate instanceof DateTimeInterface) {
+      $parameters['oldest_lifecycle_date'] = $oldestLifecycleDate->format('Y-m-d H:i:s');
+      $types['oldest_lifecycle_date'] = ParameterType::STRING;
+    }
+
+    $claimedRows = (int)$this->entityManager->getConnection()->executeStatement(
+      "UPDATE $subscriberTable
+       SET `count_confirmations` = `count_confirmations` + 1,
+         `last_confirmation_email_sent_at` = :claim_time
+       WHERE `id` = :id
+       AND `status` = :status
+       AND `deleted_at` IS NULL
+       AND `count_confirmations` < :max_confirmation_emails
+       AND (`last_confirmation_email_sent_at` IS NULL OR `last_confirmation_email_sent_at` <= :recent_cutoff)
+       $ageCondition",
+      $parameters,
+      $types
+    );
+
+    $this->entityManager->refresh($subscriber);
+    if ($claimedRows !== 1) {
+      $row = $this->getConfirmationResendState($subscriberTable, (int)$subscriber->getId());
+      return [
+        'claimed' => false,
+        'reason' => $this->getConfirmationResendIneligibilityReasonFromRow($row, $maxConfirmationEmails, $recentCutoff, $oldestLifecycleDate) ?? 'not_found',
+      ];
+    }
+
+    return [
+      'claimed' => true,
+      'claim_time' => $claimTime,
+      'previous_last_confirmation_email_sent_at' => $this->toStringOrNull($row['last_confirmation_email_sent_at'] ?? null),
+      'previous_count_confirmations' => $this->toInt($row['count_confirmations'] ?? 0),
+    ];
+  }
+
+  public function releaseAdminConfirmationEmailResendClaim(
+    SubscriberEntity $subscriber,
+    string $claimTime,
+    ?string $previousLastConfirmationEmailSentAt,
+    int $previousCountConfirmations
+  ): void {
+    if (!$subscriber->getId()) {
+      return;
+    }
+
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE $subscriberTable
+       SET `count_confirmations` = :previous_count_confirmations,
+         `last_confirmation_email_sent_at` = :previous_last_confirmation_email_sent_at
+       WHERE `id` = :id
+       AND `last_confirmation_email_sent_at` = :claim_time
+       AND `count_confirmations` = :claimed_count_confirmations",
+      [
+        'id' => $subscriber->getId(),
+        'claim_time' => $claimTime,
+        'previous_last_confirmation_email_sent_at' => $previousLastConfirmationEmailSentAt,
+        'previous_count_confirmations' => $previousCountConfirmations,
+        'claimed_count_confirmations' => $previousCountConfirmations + 1,
+      ],
+      [
+        'id' => ParameterType::INTEGER,
+        'claim_time' => ParameterType::STRING,
+        'previous_last_confirmation_email_sent_at' => $previousLastConfirmationEmailSentAt === null ? ParameterType::NULL : ParameterType::STRING,
+        'previous_count_confirmations' => ParameterType::INTEGER,
+        'claimed_count_confirmations' => ParameterType::INTEGER,
+      ]
+    );
+    $this->entityManager->refresh($subscriber);
+  }
+
+  public function getAdminConfirmationEmailResendIneligibilityReason(
+    SubscriberEntity $subscriber,
+    int $maxConfirmationEmails,
+    DateTimeInterface $recentCutoff,
+    ?DateTimeInterface $oldestLifecycleDate = null
+  ): ?string {
+    if (!$subscriber->getId()) {
+      return 'not_found';
+    }
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $row = $this->getConfirmationResendState($subscriberTable, (int)$subscriber->getId());
+    return $this->getConfirmationResendIneligibilityReasonFromRow($row, $maxConfirmationEmails, $recentCutoff, $oldestLifecycleDate);
+  }
+
+  /**
+   * @return array<string, mixed>|false
+   */
+  private function getConfirmationResendState(string $subscriberTable, int $subscriberId) {
+    return $this->entityManager->getConnection()->executeQuery(
+      "SELECT `id`, `status`, `deleted_at`, `count_confirmations`, `last_confirmation_email_sent_at`,
+         COALESCE(`last_subscribed_at`, `created_at`) AS lifecycle_date
+       FROM $subscriberTable
+       WHERE `id` = :id",
+      ['id' => $subscriberId],
+      ['id' => ParameterType::INTEGER]
+    )->fetchAssociative();
+  }
+
+  /**
+   * @param array<string, mixed>|false $row
+   */
+  private function getConfirmationResendIneligibilityReasonFromRow(
+    $row,
+    int $maxConfirmationEmails,
+    DateTimeInterface $recentCutoff,
+    ?DateTimeInterface $oldestLifecycleDate
+  ): ?string {
+    if (!$row) {
+      return 'not_found';
+    }
+    if (!empty($row['deleted_at'])) {
+      return 'deleted';
+    }
+    if (($row['status'] ?? null) !== SubscriberEntity::STATUS_UNCONFIRMED) {
+      return 'not_unconfirmed';
+    }
+    if ($this->toInt($row['count_confirmations'] ?? 0) >= $maxConfirmationEmails) {
+      return 'max_confirmations_reached';
+    }
+    $lastConfirmationEmailSentAt = $this->toStringOrNull($row['last_confirmation_email_sent_at'] ?? null);
+    if ($lastConfirmationEmailSentAt !== null && strtotime($lastConfirmationEmailSentAt) > $recentCutoff->getTimestamp()) {
+      return 'recently_sent';
+    }
+    $lifecycleDate = $this->toStringOrNull($row['lifecycle_date'] ?? null);
+    if ($oldestLifecycleDate instanceof DateTimeInterface && $lifecycleDate !== null && strtotime($lifecycleDate) < $oldestLifecycleDate->getTimestamp()) {
+      return 'too_old';
+    }
+    return null;
+  }
+
+  private function toInt($value): int {
+    if (is_int($value)) {
+      return $value;
+    }
+    if (is_string($value) || is_float($value) || is_bool($value)) {
+      return (int)$value;
+    }
+    return 0;
+  }
+
+  private function toStringOrNull($value): ?string {
+    if ($value === null || $value === '') {
+      return null;
+    }
+    if (is_scalar($value)) {
+      return (string)$value;
+    }
+    return null;
+  }
+
   private function releasePublicConfirmationEmailClaim(string $subscriberTable, int $subscriberId): void {
     $this->entityManager->getConnection()->executeStatement(
       "UPDATE $subscriberTable

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Test\Acceptance;
 use DateTime;
 use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Test\DataFactories\Settings;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoet\Test\DataFactories\Tag;
 use PHPUnit\Framework\Assert;
@@ -142,6 +143,9 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailActionVisibility(\AcceptanceTester $i) {
     $i->wantTo('Show the bulk confirmation resend action only for unconfirmed subscribers');
 
+    $settings = new Settings();
+    $settings->withConfirmationEmailEnabled();
+
     $subscribers = [
       'all' => (new Subscriber())
         ->withEmail('bulk-resend-all@example.com')
@@ -194,6 +198,12 @@ class SubscribersListingCest {
     $this->openSubscribersGroup($i, 'unconfirmed');
     $this->selectSubscriberForBulkAction($i, $unconfirmedSubscriber);
     $i->seeElement("[data-automation-id='action-resendConfirmationEmails']");
+
+    $settings->withConfirmationEmailDisabled();
+    $this->openSubscribersGroup($i, 'unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $unconfirmedSubscriber);
+    $i->dontSeeElement("[data-automation-id='action-resendConfirmationEmails']");
+    $settings->withConfirmationEmailEnabled();
   }
 
   public function bulkResendConfirmationEmailModalAndNotice(\AcceptanceTester $i) {
@@ -222,11 +232,9 @@ class SubscribersListingCest {
       'bulk-resend-confirmation-checkbox-input',
       $i->executeJS('return document.activeElement.id;')
     );
-    $i->seeElement('.mailpoet-modal-frame[role="dialog"][aria-labelledby]');
-    $i->seeElement(
-      "[data-automation-id='mailpoet-modal-close'][aria-label='Close modal']"
-    );
-    $modalTitleId = $i->grabAttributeFrom('.mailpoet-modal-frame', 'aria-labelledby');
+    $i->seeElement('div[role="dialog"][aria-labelledby]');
+    $i->seeElement('div[role="dialog"] button[aria-label="Close"]');
+    $modalTitleId = $i->grabAttributeFrom('div[role="dialog"]', 'aria-labelledby');
     Assert::assertSame(
       'Resend confirmation emails',
       $i->executeJS(
@@ -234,7 +242,7 @@ class SubscribersListingCest {
       )
     );
     $i->see(
-      'I understand these confirmation emails will be queued and only sent to eligible unconfirmed subscribers.',
+      'I confirm these subscribers asked to join and can be sent a confirmation email.',
       "[data-automation-id='bulk-resend-confirmation-checkbox']"
     );
     $i->seeElement("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
@@ -244,7 +252,7 @@ class SubscribersListingCest {
     );
 
     $i->pressKey('#bulk-resend-confirmation-checkbox-input', WebDriverKeys::ESCAPE);
-    $i->waitForElementNotVisible('.mailpoet-modal-frame');
+    $i->waitForElementNotVisible('div[role="dialog"]');
     Assert::assertSame(
       'action-resendConfirmationEmails',
       $i->executeJS('return document.activeElement.getAttribute("data-automation-id");')
@@ -255,7 +263,7 @@ class SubscribersListingCest {
     $i->dontSeeElement("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
     $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
 
-    $i->waitForText('Confirmation emails were queued for 1 subscriber. 1 selected subscriber was skipped.');
+    $i->waitForText('A resend job was queued for up to 1 eligible subscriber. 1 selected subscriber was not queued because they were ineligible or beyond the batch limit.');
   }
 
   public function bulkResendConfirmationEmailPreventsDuplicateSubmits(\AcceptanceTester $i) {
@@ -313,7 +321,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailSelectAllKeepsListingScope(\AcceptanceTester $i) {
     $i->wantTo('Queue bulk confirmation resends for all pages without sending an explicit empty selection');
 
-    for ($index = 1; $index <= 11; $index++) {
+    for ($index = 1; $index <= 31; $index++) {
       (new Subscriber())
         ->withEmail(sprintf('bulk-resend-all-pages-%02d@example.com', $index))
         ->withStatus('unconfirmed')
@@ -348,10 +356,10 @@ class SubscribersListingCest {
           window.mailpoetBulkResendListingGroup = request.data.listing.group;
           return jQuery.Deferred().resolve({
             data: {
-              selected_count: 11,
-              eligible_count: 11,
-              queued_count: 11,
-              skipped_count: 0,
+              selected_count: 31,
+              eligible_count: 31,
+              queued_count: 20,
+              skipped_count: 11,
               skipped_by_reason: {},
               task_id: 1,
               message: 'Confirmation emails were queued.'
@@ -494,7 +502,7 @@ class SubscribersListingCest {
     $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
     $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
 
-    $i->waitForText('No confirmation emails were queued. No selected subscribers were eligible.');
+    $i->waitForText('No confirmation email resend job was queued. No selected subscribers were currently eligible.');
   }
 
   public function searchInTrashWithNoResultsStaysInTrash(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -222,6 +222,17 @@ class SubscribersListingCest {
       'bulk-resend-confirmation-checkbox-input',
       $i->executeJS('return document.activeElement.id;')
     );
+    $i->seeElement('.mailpoet-modal-frame[role="dialog"][aria-labelledby]');
+    $i->seeElement(
+      "[data-automation-id='mailpoet-modal-close'][aria-label='Close modal']"
+    );
+    $modalTitleId = $i->grabAttributeFrom('.mailpoet-modal-frame', 'aria-labelledby');
+    Assert::assertSame(
+      'Resend confirmation emails',
+      $i->executeJS(
+        'return document.getElementById(' . json_encode($modalTitleId) . ').textContent;'
+      )
+    );
     $i->see(
       'I understand these confirmation emails will be queued and only sent to eligible unconfirmed subscribers.',
       "[data-automation-id='bulk-resend-confirmation-checkbox']"
@@ -297,6 +308,174 @@ class SubscribersListingCest {
         }
       });
     JS);
+  }
+
+  public function bulkResendConfirmationEmailSelectAllKeepsListingScope(\AcceptanceTester $i) {
+    $i->wantTo('Queue bulk confirmation resends for all pages without sending an explicit empty selection');
+
+    for ($index = 1; $index <= 11; $index++) {
+      (new Subscriber())
+        ->withEmail(sprintf('bulk-resend-all-pages-%02d@example.com', $index))
+        ->withStatus('unconfirmed')
+        ->create();
+    }
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->changeGroupInListingFilter('unconfirmed');
+    $i->waitForText('bulk-resend-all-pages-01@example.com');
+    $i->click("[data-automation-id='select_all']");
+    $i->waitForText('Select all items on all pages');
+    $i->click('Select all items on all pages');
+    $i->waitForElement('tbody .mailpoet-form-checkbox.mailpoet-disabled');
+    $this->openBulkResendConfirmationModal($i);
+    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+
+    $i->executeJS(<<<'JS'
+      window.mailpoetBulkResendRequestHasListingSelection = null;
+      window.mailpoetBulkResendListingGroup = null;
+      window.mailpoetOriginalAjaxPost = MailPoet.Ajax.post;
+      MailPoet.Ajax.post = function(request) {
+        if (
+          request.action === 'bulkAction'
+          && request.data
+          && request.data.action === 'resendConfirmationEmails'
+        ) {
+          window.mailpoetBulkResendRequestHasListingSelection = Object.prototype.hasOwnProperty.call(
+            request.data.listing,
+            'selection'
+          );
+          window.mailpoetBulkResendListingGroup = request.data.listing.group;
+          return jQuery.Deferred().resolve({
+            data: {
+              selected_count: 11,
+              eligible_count: 11,
+              queued_count: 11,
+              skipped_count: 0,
+              skipped_by_reason: {},
+              task_id: 1,
+              message: 'Confirmation emails were queued.'
+            }
+          }).promise();
+        }
+        return window.mailpoetOriginalAjaxPost.apply(this, arguments);
+      };
+    JS);
+
+    $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
+    $i->waitForJS(
+      'return window.mailpoetBulkResendRequestHasListingSelection !== null;'
+    );
+    Assert::assertFalse(
+      $i->executeJS('return window.mailpoetBulkResendRequestHasListingSelection;')
+    );
+    Assert::assertSame(
+      'unconfirmed',
+      $i->executeJS('return window.mailpoetBulkResendListingGroup;')
+    );
+
+    $i->executeJS('MailPoet.Ajax.post = window.mailpoetOriginalAjaxPost;');
+  }
+
+  public function bulkResendConfirmationEmailFailureClearsLoading(\AcceptanceTester $i) {
+    $i->wantTo('Clear the subscribers listing loading state after a failed bulk confirmation resend');
+
+    $subscriber = (new Subscriber())
+      ->withEmail('bulk-resend-failed@example.com')
+      ->withStatus('unconfirmed')
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->changeGroupInListingFilter('unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $subscriber);
+    $this->openBulkResendConfirmationModal($i);
+    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+
+    $i->executeJS(<<<'JS'
+      window.mailpoetOriginalAjaxPost = MailPoet.Ajax.post;
+      MailPoet.Ajax.post = function(request) {
+        if (
+          request.action === 'bulkAction'
+          && request.data
+          && request.data.action === 'resendConfirmationEmails'
+        ) {
+          return jQuery.Deferred().reject({
+            errors: [
+              {
+                error: 'forced_failure',
+                message: 'Forced bulk resend failure.'
+              }
+            ]
+          }).promise();
+        }
+        return window.mailpoetOriginalAjaxPost.apply(this, arguments);
+      };
+    JS);
+
+    $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
+    $i->waitForText('Forced bulk resend failure.');
+    $i->waitForElementNotVisible(\AcceptanceTester::LISTING_LOADING_SELECTOR);
+
+    $i->executeJS('MailPoet.Ajax.post = window.mailpoetOriginalAjaxPost;');
+  }
+
+  public function bulkResendConfirmationEmailSettingsErrorShowsSafeLink(\AcceptanceTester $i) {
+    $i->wantTo('Show the confirmation-disabled error with a safe settings link');
+
+    $subscriber = (new Subscriber())
+      ->withEmail('bulk-resend-settings-link@example.com')
+      ->withStatus('unconfirmed')
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->changeGroupInListingFilter('unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $subscriber);
+    $this->openBulkResendConfirmationModal($i);
+    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+
+    $i->executeJS(<<<'JS'
+      window.mailpoetOriginalAjaxPost = MailPoet.Ajax.post;
+      MailPoet.Ajax.post = function(request) {
+        if (
+          request.action === 'bulkAction'
+          && request.data
+          && request.data.action === 'resendConfirmationEmails'
+        ) {
+          return jQuery.Deferred().reject({
+            errors: [
+              {
+                error: 'confirmation_disabled',
+                message: [
+                  'Sign-up confirmation is disabled in your ',
+                  '<a href="admin.php?page=mailpoet-settings#/signup">',
+                  'MailPoet settings',
+                  '</a>. Please enable it to resend confirmation emails ',
+                  'or update your subscriber’s status manually.'
+                ].join('')
+              }
+            ]
+          }).promise();
+        }
+        return window.mailpoetOriginalAjaxPost.apply(this, arguments);
+      };
+    JS);
+
+    $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
+    $i->waitForText('Sign-up confirmation is disabled in your');
+    Assert::assertSame(
+      'admin.php?page=mailpoet-settings#/signup',
+      $i->executeJS(
+        'return document.querySelector(".mailpoet_notice.error a").getAttribute("href");'
+      )
+    );
+    Assert::assertStringNotContainsString(
+      '&lt;a',
+      $i->executeJS('return document.querySelector(".mailpoet_notice.error").innerHTML;')
+    );
+
+    $i->executeJS('MailPoet.Ajax.post = window.mailpoetOriginalAjaxPost;');
   }
 
   public function bulkResendConfirmationEmailShowsZeroEligibleNotice(\AcceptanceTester $i) {

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -3,9 +3,11 @@
 namespace MailPoet\Test\Acceptance;
 
 use DateTime;
+use Facebook\WebDriver\WebDriverKeys;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Test\DataFactories\Subscriber;
 use MailPoet\Test\DataFactories\Tag;
+use PHPUnit\Framework\Assert;
 
 class SubscribersListingCest {
   public function subscribersListing(\AcceptanceTester $i) {
@@ -83,7 +85,7 @@ class SubscribersListingCest {
 
     $i->waitForText($maxConfirmationsEmail);
     $i->moveMouseOver(['xpath' => '//*[text()="' . $maxConfirmationsEmail . '"]//ancestor::tr']);
-    // Admins can resend confirmation emails even when the subscriber reached the limit
+    // The backend enforces resend limits when admins use this row action.
     $i->see('Resend confirmation email', '//*[text()="' . $maxConfirmationsEmail . '"]//ancestor::tr');
 
     $i->clickItemRowActionByItemName($allowedEmail, 'Resend confirmation email');
@@ -137,6 +139,186 @@ class SubscribersListingCest {
     $i->dontSee('Unsubscribed', "[data-automation-id='listing_item_{$subscriber4->getId()}']");
   }
 
+  public function bulkResendConfirmationEmailActionVisibility(\AcceptanceTester $i) {
+    $i->wantTo('Show the bulk confirmation resend action only for unconfirmed subscribers');
+
+    $subscribers = [
+      'all' => (new Subscriber())
+        ->withEmail('bulk-resend-all@example.com')
+        ->withStatus('unconfirmed')
+        ->create(),
+      'subscribed' => (new Subscriber())
+        ->withEmail('bulk-resend-subscribed@example.com')
+        ->withStatus('subscribed')
+        ->create(),
+      'unsubscribed' => (new Subscriber())
+        ->withEmail('bulk-resend-unsubscribed@example.com')
+        ->withStatus('unsubscribed')
+        ->create(),
+      'inactive' => (new Subscriber())
+        ->withEmail('bulk-resend-inactive@example.com')
+        ->withStatus('inactive')
+        ->create(),
+      'bounced' => (new Subscriber())
+        ->withEmail('bulk-resend-bounced@example.com')
+        ->withStatus('bounced')
+        ->create(),
+      'trash' => (new Subscriber())
+        ->withEmail('bulk-resend-trash@example.com')
+        ->withDeletedAt(new DateTime())
+        ->create(),
+    ];
+    $unconfirmedSubscriber = (new Subscriber())
+      ->withEmail('bulk-resend-unconfirmed@example.com')
+      ->withStatus('unconfirmed')
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+
+    $this->selectSubscriberForBulkAction($i, $subscribers['all']);
+    $i->dontSeeElement("[data-automation-id='action-resendConfirmationEmails']");
+
+    foreach (['subscribed', 'unsubscribed', 'inactive', 'bounced'] as $group) {
+      $this->openSubscribersGroup($i, $group);
+      $this->selectSubscriberForBulkAction($i, $subscribers[$group]);
+      $i->dontSeeElement("[data-automation-id='action-resendConfirmationEmails']");
+    }
+
+    $this->openSubscribersGroup($i, 'trash');
+    $i->waitForElement("tbody [data-automation-id^='listing-row-checkbox-']");
+    $i->click("tbody [data-automation-id^='listing-row-checkbox-']");
+    $i->waitForElement("[data-automation-id='listing-bulk-actions']");
+    $i->dontSeeElement("[data-automation-id='action-resendConfirmationEmails']");
+
+    $this->openSubscribersGroup($i, 'unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $unconfirmedSubscriber);
+    $i->seeElement("[data-automation-id='action-resendConfirmationEmails']");
+  }
+
+  public function bulkResendConfirmationEmailModalAndNotice(\AcceptanceTester $i) {
+    $i->wantTo('Queue bulk confirmation email resends with a gated accessible modal');
+
+    $eligibleSubscriber = (new Subscriber())
+      ->withEmail('bulk-resend-eligible@example.com')
+      ->withStatus('unconfirmed')
+      ->withCountConfirmations(0)
+      ->create();
+    $skippedSubscriber = (new Subscriber())
+      ->withEmail('bulk-resend-skipped@example.com')
+      ->withStatus('unconfirmed')
+      ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->changeGroupInListingFilter('unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $eligibleSubscriber);
+    $this->selectSubscriberForBulkAction($i, $skippedSubscriber);
+    $this->openBulkResendConfirmationModal($i);
+
+    $i->waitForElement('#bulk-resend-confirmation-checkbox-input');
+    Assert::assertSame(
+      'bulk-resend-confirmation-checkbox-input',
+      $i->executeJS('return document.activeElement.id;')
+    );
+    $i->see(
+      'I understand these confirmation emails will be queued and only sent to eligible unconfirmed subscribers.',
+      "[data-automation-id='bulk-resend-confirmation-checkbox']"
+    );
+    $i->seeElement("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
+    Assert::assertSame(
+      'bulk-resend-confirmation-confirm-help',
+      $i->grabAttributeFrom("[data-automation-id='bulk-resend-confirmation-confirm']", 'aria-describedby')
+    );
+
+    $i->pressKey('#bulk-resend-confirmation-checkbox-input', WebDriverKeys::ESCAPE);
+    $i->waitForElementNotVisible('.mailpoet-modal-frame');
+    Assert::assertSame(
+      'action-resendConfirmationEmails',
+      $i->executeJS('return document.activeElement.getAttribute("data-automation-id");')
+    );
+
+    $this->openBulkResendConfirmationModal($i);
+    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $i->dontSeeElement("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
+    $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
+
+    $i->waitForText('Confirmation emails were queued for 1 subscriber. 1 selected subscriber was skipped.');
+  }
+
+  public function bulkResendConfirmationEmailPreventsDuplicateSubmits(\AcceptanceTester $i) {
+    $i->wantTo('Prevent duplicate bulk confirmation resend requests while queueing is pending');
+
+    $subscriber = (new Subscriber())
+      ->withEmail('bulk-resend-pending@example.com')
+      ->withStatus('unconfirmed')
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->changeGroupInListingFilter('unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $subscriber);
+    $this->openBulkResendConfirmationModal($i);
+    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+
+    $i->executeJS(<<<'JS'
+      window.mailpoetBulkResendRequests = 0;
+      window.mailpoetBulkResendDeferred = jQuery.Deferred();
+      window.mailpoetOriginalAjaxPost = MailPoet.Ajax.post;
+      MailPoet.Ajax.post = function(request) {
+        if (
+          request.action === 'bulkAction'
+          && request.data
+          && request.data.action === 'resendConfirmationEmails'
+        ) {
+          window.mailpoetBulkResendRequests += 1;
+          return window.mailpoetBulkResendDeferred.promise();
+        }
+        return window.mailpoetOriginalAjaxPost.apply(this, arguments);
+      };
+    JS);
+
+    $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
+    $i->click("[data-automation-id='action-resendConfirmationEmails']");
+    Assert::assertSame(1, $i->executeJS('return window.mailpoetBulkResendRequests;'));
+
+    $i->executeJS(<<<'JS'
+      MailPoet.Ajax.post = window.mailpoetOriginalAjaxPost;
+      window.mailpoetBulkResendDeferred.resolve({
+        data: {
+          selected_count: 1,
+          eligible_count: 1,
+          queued_count: 1,
+          skipped_count: 0,
+          skipped_by_reason: {},
+          task_id: 1,
+          message: 'Confirmation emails were queued.'
+        }
+      });
+    JS);
+  }
+
+  public function bulkResendConfirmationEmailShowsZeroEligibleNotice(\AcceptanceTester $i) {
+    $i->wantTo('Show a zero eligible notice for bulk confirmation resends');
+
+    $subscriber = (new Subscriber())
+      ->withEmail('bulk-resend-zero@example.com')
+      ->withStatus('unconfirmed')
+      ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
+      ->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Subscribers');
+    $i->changeGroupInListingFilter('unconfirmed');
+    $this->selectSubscriberForBulkAction($i, $subscriber);
+    $this->openBulkResendConfirmationModal($i);
+    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
+
+    $i->waitForText('No confirmation emails were queued. No selected subscribers were eligible.');
+  }
+
   public function searchInTrashWithNoResultsStaysInTrash(\AcceptanceTester $i) {
     $i->wantTo('Verify that searching in Trash with no results does not redirect to All');
 
@@ -159,5 +341,23 @@ class SubscribersListingCest {
     // Should stay in trash — not redirect to All
     $i->waitForText('No items found.');
     $i->seeInCurrentURL(urlencode('group[trash]'));
+  }
+
+  private function selectSubscriberForBulkAction(\AcceptanceTester $i, $subscriber): void {
+    $i->waitForText($subscriber->getEmail());
+    $i->click("[data-automation-id='listing-row-checkbox-{$subscriber->getId()}']");
+    $i->waitForElement("[data-automation-id='listing-bulk-actions']");
+  }
+
+  private function openBulkResendConfirmationModal(\AcceptanceTester $i): void {
+    $i->waitForElement("[data-automation-id='action-resendConfirmationEmails']");
+    $i->click("[data-automation-id='action-resendConfirmationEmails']");
+    $i->waitForElement("[data-automation-id='bulk-resend-confirmation-checkbox']");
+  }
+
+  private function openSubscribersGroup(\AcceptanceTester $i, string $group): void {
+    $i->amOnPage('/wp-admin/admin.php?page=mailpoet-subscribers#/group[' . $group . ']');
+    $i->waitForElement('#search_input');
+    $i->waitForElementNotVisible(\AcceptanceTester::LISTING_LOADING_SELECTOR);
   }
 }

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -470,10 +470,9 @@ class SubscribersListingCest {
         'return document.querySelector(".mailpoet_notice.error a").getAttribute("href");'
       )
     );
-    Assert::assertStringNotContainsString(
-      '&lt;a',
-      $i->executeJS('return document.querySelector(".mailpoet_notice.error").innerHTML;')
-    );
+    $noticeHtml = $i->executeJS('return document.querySelector(".mailpoet_notice.error").innerHTML;');
+    Assert::assertIsString($noticeHtml);
+    Assert::assertStringNotContainsString('&lt;a', $noticeHtml);
 
     $i->executeJS('MailPoet.Ajax.post = window.mailpoetOriginalAjaxPost;');
   }

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -243,14 +243,10 @@ class SubscribersListingCest {
       )
     );
     $i->see(
-      'I confirm these subscribers asked to join and can be sent a confirmation email.',
+      'I confirm these subscribers asked to join my list.',
       "[data-automation-id='bulk-resend-confirmation-checkbox']"
     );
     $i->seeElement("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
-    Assert::assertSame(
-      'bulk-resend-confirmation-confirm-help',
-      $i->grabAttributeFrom("[data-automation-id='bulk-resend-confirmation-confirm']", 'aria-describedby')
-    );
 
     $i->pressKey('#bulk-resend-confirmation-checkbox-input', WebDriverKeys::ESCAPE);
     $i->waitForElementNotVisible('div[role="dialog"]');
@@ -260,11 +256,13 @@ class SubscribersListingCest {
     );
 
     $this->openBulkResendConfirmationModal($i);
-    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $this->confirmBulkResendConfirmationEmailRequest($i);
     $i->dontSeeElement("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
     $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
 
-    $i->waitForText('A resend job was queued for up to 1 eligible subscriber. 1 selected subscriber was not queued because they were ineligible or beyond the batch limit.');
+    $i->waitForText(
+      'MailPoet is resending confirmation emails to 1 subscriber. 1 selected subscriber was skipped.'
+    );
   }
 
   public function bulkResendConfirmationEmailPreventsDuplicateSubmits(\AcceptanceTester $i) {
@@ -281,7 +279,7 @@ class SubscribersListingCest {
     $i->changeGroupInListingFilter('unconfirmed');
     $this->selectSubscriberForBulkAction($i, $subscriber);
     $this->openBulkResendConfirmationModal($i);
-    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $this->confirmBulkResendConfirmationEmailRequest($i);
 
     $i->executeJS(<<<'JS'
       window.mailpoetBulkResendRequests = 0;
@@ -314,7 +312,7 @@ class SubscribersListingCest {
           skipped_count: 0,
           skipped_by_reason: {},
           task_id: 1,
-          message: 'Confirmation emails were queued.'
+          message: 'Confirmation emails are being resent.'
         }
       });
     JS);
@@ -340,7 +338,7 @@ class SubscribersListingCest {
     $i->click('Select all items on all pages');
     $i->waitForElement('tbody .mailpoet-form-checkbox.mailpoet-disabled');
     $this->openBulkResendConfirmationModal($i);
-    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $this->confirmBulkResendConfirmationEmailRequest($i);
 
     $i->executeJS(<<<'JS'
       window.mailpoetBulkResendRequestHasListingSelection = null;
@@ -365,7 +363,7 @@ class SubscribersListingCest {
               skipped_count: 11,
               skipped_by_reason: {},
               task_id: 1,
-              message: 'Confirmation emails were queued.'
+              message: 'Confirmation emails are being resent.'
             }
           }).promise();
         }
@@ -402,7 +400,7 @@ class SubscribersListingCest {
     $i->changeGroupInListingFilter('unconfirmed');
     $this->selectSubscriberForBulkAction($i, $subscriber);
     $this->openBulkResendConfirmationModal($i);
-    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $this->confirmBulkResendConfirmationEmailRequest($i);
 
     $i->executeJS(<<<'JS'
       window.mailpoetOriginalAjaxPost = MailPoet.Ajax.post;
@@ -446,7 +444,7 @@ class SubscribersListingCest {
     $i->changeGroupInListingFilter('unconfirmed');
     $this->selectSubscriberForBulkAction($i, $subscriber);
     $this->openBulkResendConfirmationModal($i);
-    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $this->confirmBulkResendConfirmationEmailRequest($i);
 
     $i->executeJS(<<<'JS'
       window.mailpoetOriginalAjaxPost = MailPoet.Ajax.post;
@@ -505,10 +503,12 @@ class SubscribersListingCest {
     $i->changeGroupInListingFilter('unconfirmed');
     $this->selectSubscriberForBulkAction($i, $subscriber);
     $this->openBulkResendConfirmationModal($i);
-    $i->click("[data-automation-id='bulk-resend-confirmation-checkbox']");
+    $this->confirmBulkResendConfirmationEmailRequest($i);
     $i->click("[data-automation-id='bulk-resend-confirmation-confirm']");
 
-    $i->waitForText('No confirmation email resend job was queued. No selected subscribers were currently eligible.');
+    $i->waitForText(
+      'No confirmation emails were resent. The selected subscribers could not receive another confirmation email right now.'
+    );
   }
 
   public function searchInTrashWithNoResultsStaysInTrash(\AcceptanceTester $i) {
@@ -545,6 +545,11 @@ class SubscribersListingCest {
     $i->waitForElement("[data-automation-id='action-resendConfirmationEmails']");
     $i->click("[data-automation-id='action-resendConfirmationEmails']");
     $i->waitForElement("[data-automation-id='bulk-resend-confirmation-checkbox']");
+  }
+
+  private function confirmBulkResendConfirmationEmailRequest(\AcceptanceTester $i): void {
+    $i->checkOption('#bulk-resend-confirmation-checkbox-input');
+    $i->waitForElementNotVisible("[data-automation-id='bulk-resend-confirmation-confirm']:disabled");
   }
 
   private function openSubscribersGroup(\AcceptanceTester $i, string $group): void {

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -209,6 +209,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailModalAndNotice(\AcceptanceTester $i) {
     $i->wantTo('Queue bulk confirmation email resends with a gated accessible modal');
 
+    (new Settings())->withConfirmationEmailEnabled();
     $eligibleSubscriber = (new Subscriber())
       ->withEmail('bulk-resend-eligible@example.com')
       ->withStatus('unconfirmed')
@@ -269,6 +270,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailPreventsDuplicateSubmits(\AcceptanceTester $i) {
     $i->wantTo('Prevent duplicate bulk confirmation resend requests while queueing is pending');
 
+    (new Settings())->withConfirmationEmailEnabled();
     $subscriber = (new Subscriber())
       ->withEmail('bulk-resend-pending@example.com')
       ->withStatus('unconfirmed')
@@ -321,6 +323,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailSelectAllKeepsListingScope(\AcceptanceTester $i) {
     $i->wantTo('Queue bulk confirmation resends for all pages without sending an explicit empty selection');
 
+    (new Settings())->withConfirmationEmailEnabled();
     for ($index = 1; $index <= 31; $index++) {
       (new Subscriber())
         ->withEmail(sprintf('bulk-resend-all-pages-%02d@example.com', $index))
@@ -388,6 +391,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailFailureClearsLoading(\AcceptanceTester $i) {
     $i->wantTo('Clear the subscribers listing loading state after a failed bulk confirmation resend');
 
+    (new Settings())->withConfirmationEmailEnabled();
     $subscriber = (new Subscriber())
       ->withEmail('bulk-resend-failed@example.com')
       ->withStatus('unconfirmed')
@@ -431,6 +435,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailSettingsErrorShowsSafeLink(\AcceptanceTester $i) {
     $i->wantTo('Show the confirmation-disabled error with a safe settings link');
 
+    (new Settings())->withConfirmationEmailEnabled();
     $subscriber = (new Subscriber())
       ->withEmail('bulk-resend-settings-link@example.com')
       ->withStatus('unconfirmed')
@@ -488,6 +493,7 @@ class SubscribersListingCest {
   public function bulkResendConfirmationEmailShowsZeroEligibleNotice(\AcceptanceTester $i) {
     $i->wantTo('Show a zero eligible notice for bulk confirmation resends');
 
+    (new Settings())->withConfirmationEmailEnabled();
     $subscriber = (new Subscriber())
       ->withEmail('bulk-resend-zero@example.com')
       ->withStatus('unconfirmed')

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -869,6 +869,45 @@ class SubscribersTest extends \MailPoetTest {
     verify($this->countBulkConfirmationEmailResendTasks())->equals(0);
   }
 
+  public function testBulkConfirmationEmailResendCountsExplicitSelectionOutsideActiveScope(): void {
+    wp_set_current_user(1);
+    $segment = (new SegmentFactory())
+      ->withName('Bulk resend scoped segment')
+      ->create();
+    $inScope = (new SubscriberFactory())
+      ->withEmail('bulk-resend-in-segment@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withSegments([$segment])
+      ->create();
+    $outsideScope = (new SubscriberFactory())
+      ->withEmail('bulk-resend-outside-segment@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'filter' => [
+          'segment' => (string)$segment->getId(),
+        ],
+        'selection' => [
+          $inScope->getId(),
+          $outsideScope->getId(),
+        ],
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['selected_count'])->equals(2);
+    verify($response->data['eligible_count'])->equals(1);
+    verify($response->data['queued_count'])->equals(1);
+    verify($response->data['skipped_count'])->equals(1);
+    verify($response->data['skipped_by_reason']['outside_scope'])->equals(1);
+    verify($response->data['skipped_by_reason']['not_found'])->equals(0);
+    verify($this->getTaskSubscriberIds((int)$response->data['task_id']))->equals([$inScope->getId()]);
+  }
+
   public function testBulkConfirmationEmailResendHonorsListingFiltersAndEligibilityBoundaries(): void {
     wp_set_current_user(1);
     $now = Carbon::now()->millisecond(0);

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -908,6 +908,38 @@ class SubscribersTest extends \MailPoetTest {
     verify($this->getTaskSubscriberIds((int)$response->data['task_id']))->equals([$inScope->getId()]);
   }
 
+  public function testBulkConfirmationEmailResendSearchStaysWithinListingScope(): void {
+    wp_set_current_user(1);
+    $inScope = (new SubscriberFactory())
+      ->withEmail('bulk-resend-search-match@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('bulk-resend-search-subscribed@mailpoet.com')
+      ->withFirstName('bulk-resend-search-match')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('bulk-resend-search-deleted@mailpoet.com')
+      ->withLastName('bulk-resend-search-match')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withDeletedAt(Carbon::now())
+      ->create();
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'search' => 'bulk-resend-search-match',
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['selected_count'])->equals(1);
+    verify($response->data['queued_count'])->equals(1);
+    verify($this->getTaskSubscriberIds((int)$response->data['task_id']))->equals([$inScope->getId()]);
+  }
+
   public function testBulkConfirmationEmailResendHonorsListingFiltersAndEligibilityBoundaries(): void {
     wp_set_current_user(1);
     $now = Carbon::now()->millisecond(0);

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -770,6 +770,194 @@ class SubscribersTest extends \MailPoetTest {
       ->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT);
   }
 
+  public function testBulkConfirmationEmailResendRejectsUsersWithoutManageOptions(): void {
+    wp_set_current_user(0);
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'selection' => [$this->subscriber1->getId()],
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_FORBIDDEN);
+    verify($response->errors[0]['error'])->equals(Error::FORBIDDEN);
+    verify($this->countBulkConfirmationEmailResendTasks())->equals(0);
+  }
+
+  public function testBulkConfirmationEmailResendDoesNotTreatMalformedExplicitSelectionAsSelectAll(): void {
+    wp_set_current_user(1);
+    (new SubscriberFactory())
+      ->withEmail('valid-unselected@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'selection' => ['not-an-id', 0, -10],
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['selected_count'])->equals(3);
+    verify($response->data['eligible_count'])->equals(0);
+    verify($response->data['queued_count'])->equals(0);
+    verify($response->data['task_id'])->null();
+    verify($response->data['skipped_by_reason']['not_found'])->equals(3);
+    verify($this->countBulkConfirmationEmailResendTasks())->equals(0);
+  }
+
+  public function testBulkConfirmationEmailResendSelectAllQueuesFirstTwentyEligibleIds(): void {
+    wp_set_current_user(1);
+    $this->subscriber1->setConfirmationsCount(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
+    $this->subscribersRepository->flush();
+
+    $eligibleIds = [];
+    for ($i = 0; $i < BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT + 3; $i++) {
+      $eligibleIds[] = (new SubscriberFactory())
+        ->withEmail("select-all-$i@mailpoet.com")
+        ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+        ->withCreatedAt(Carbon::now()->subDays(10))
+        ->withLastSubscribedAt(Carbon::now()->subDays(10))
+        ->create()
+        ->getId();
+    }
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'offset' => 20,
+        'limit' => 20,
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['eligible_count'])->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT + 3);
+    verify($response->data['queued_count'])->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT);
+    verify($response->data['skipped_by_reason']['batch_limit'])->equals(3);
+    verify($this->getTaskSubscriberIds((int)$response->data['task_id']))
+      ->equals(array_slice($eligibleIds, 0, BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT));
+  }
+
+  public function testBulkConfirmationEmailResendReturnsSuccessForZeroEligibleSelection(): void {
+    wp_set_current_user(1);
+    $maxed = (new SubscriberFactory())
+      ->withEmail('zero-eligible@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
+      ->create();
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'selection' => [$maxed->getId()],
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['selected_count'])->equals(1);
+    verify($response->data['eligible_count'])->equals(0);
+    verify($response->data['queued_count'])->equals(0);
+    verify($response->data['task_id'])->null();
+    verify($response->data['skipped_by_reason']['max_confirmations_reached'])->equals(1);
+    verify($response->data['skipped_count'])->equals(1);
+    verify($this->countBulkConfirmationEmailResendTasks())->equals(0);
+  }
+
+  public function testBulkConfirmationEmailResendHonorsListingFiltersAndEligibilityBoundaries(): void {
+    wp_set_current_user(1);
+    $now = Carbon::now()->millisecond(0);
+    $matching = (new SubscriberFactory())
+      ->withEmail('filtered-matching@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt($now->copy()->subDays(10))
+      ->withUpdatedAt($now->copy()->subHour())
+      ->withEngagementScore(35)
+      ->withLastConfirmationEmailSentAt($now->copy()->subDays(BulkConfirmationEmailResender::RECENT_CONFIRMATION_RESEND_INTERVAL_DAYS))
+      ->withLastSubscribedAt($now->copy()->subDays(BulkConfirmationEmailResender::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS))
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('filtered-old-updated@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt($now->copy()->subDays(10))
+      ->withUpdatedAt($now->copy()->subDays(3))
+      ->withEngagementScore(35)
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('filtered-created-before@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt($now->copy()->subDays(40))
+      ->withUpdatedAt($now->copy()->subHour())
+      ->withEngagementScore(35)
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('filtered-low-score@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt($now->copy()->subDays(10))
+      ->withUpdatedAt($now->copy()->subHour())
+      ->withEngagementScore(10)
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('too-recent-boundary@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt($now->copy()->subDays(10))
+      ->withUpdatedAt($now->copy()->subHour())
+      ->withEngagementScore(35)
+      ->withLastConfirmationEmailSentAt($now->copy()->subDays(BulkConfirmationEmailResender::RECENT_CONFIRMATION_RESEND_INTERVAL_DAYS)->addHour())
+      ->create();
+    (new SubscriberFactory())
+      ->withEmail('too-old-boundary@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt($now->copy()->subDays(10))
+      ->withUpdatedAt($now->copy()->subHour())
+      ->withEngagementScore(35)
+      ->withLastSubscribedAt($now->copy()->subDays(BulkConfirmationEmailResender::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS)->subSecond())
+      ->create();
+
+    Carbon::setTestNow($now);
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'filter' => [
+          'minUpdatedAt' => $now->copy()->subDay(),
+          'statusInclude' => [SubscriberEntity::STATUS_UNCONFIRMED],
+          'statusExclude' => [SubscriberEntity::STATUS_SUBSCRIBED],
+          'createdAtFrom' => $now->copy()->subDays(20)->format('Y-m-d H:i:s'),
+          'createdAtTo' => $now->copy()->format('Y-m-d H:i:s'),
+          'engagementScoreInclude' => ['good'],
+          'engagementScoreExclude' => ['low'],
+        ],
+      ],
+    ]);
+    Carbon::setTestNow();
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['queued_count'])->equals(1);
+    verify($response->data['skipped_by_reason']['recently_sent'])->equals(1);
+    verify($response->data['skipped_by_reason']['too_old'])->equals(1);
+    verify($this->getTaskSubscriberIds((int)$response->data['task_id']))->equals([$matching->getId()]);
+
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'filter' => [
+          'statusExclude' => [SubscriberEntity::STATUS_UNCONFIRMED],
+        ],
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['queued_count'])->equals(0);
+    verify($response->data['task_id'])->null();
+  }
+
   public function testBulkConfirmationEmailResendRejectsInvalidScopeAndDisabledConfirmation() {
     wp_set_current_user(1);
     $response = $this->endpoint->bulkAction([
@@ -1125,6 +1313,31 @@ class SubscribersTest extends \MailPoetTest {
     $response = $this->endpoint->sendConfirmationEmail(['id' => $this->subscriber1->getId()]);
     verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
     verify($response->errors[0]['message'])->equals('Sign-up confirmation is disabled in your <a href="admin.php?page=mailpoet-settings#/signup">MailPoet settings</a>. Please enable it to resend confirmation emails or update your subscriber’s status manually.');
+  }
+
+  private function countBulkConfirmationEmailResendTasks(): int {
+    return (int)$this->entityManager->getRepository(ScheduledTaskEntity::class)->count([
+      'type' => BulkConfirmationEmailResend::TASK_TYPE,
+    ]);
+  }
+
+  /**
+   * @return int[]
+   */
+  private function getTaskSubscriberIds(int $taskId): array {
+    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    return array_map(function($id): int {
+      if (!is_scalar($id)) {
+        return 0;
+      }
+      return (int)$id;
+    }, $this->entityManager->getConnection()->executeQuery(
+      "SELECT `subscriber_id`
+       FROM $scheduledTaskSubscribersTable
+       WHERE `task_id` = :task_id
+       ORDER BY `subscriber_id` ASC",
+      ['task_id' => $taskId]
+    )->fetchFirstColumn());
   }
 
   public function testItKeepsSpecialSegmentsUnchangedAfterSaving() {

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -12,20 +12,25 @@ use MailPoet\API\JSON\v1\Subscribers;
 use MailPoet\Captcha\CaptchaConstants;
 use MailPoet\Captcha\CaptchaSession;
 use MailPoet\Config\Populator;
+use MailPoet\Cron\Workers\BulkConfirmationEmailResend;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\FormEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Form\Util\FieldNameObfuscator;
 use MailPoet\Listing\Handler;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 use MailPoet\Statistics\Track\Unsubscribes;
+use MailPoet\Subscribers\BulkConfirmationEmailResender;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberListingRepository;
@@ -100,7 +105,8 @@ class SubscribersTest extends \MailPoetTest {
       $container->get(SubscriberSaveController::class),
       $container->get(SubscriberSubscribeController::class),
       $container->get(SettingsController::class),
-      $container->get(Unsubscribes::class)
+      $container->get(Unsubscribes::class),
+      $container->get(BulkConfirmationEmailResender::class)
     );
     $this->obfuscatedEmail = $obfuscator->obfuscate('email');
     $this->obfuscatedSegments = $obfuscator->obfuscate('segments');
@@ -687,6 +693,101 @@ class SubscribersTest extends \MailPoetTest {
     }
   }
 
+  public function testItQueuesBulkConfirmationEmailResendsWithEligibilityCounts() {
+    wp_set_current_user(1);
+    $eligibleIds = [];
+    for ($i = 0; $i < BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT + 2; $i++) {
+      $eligibleIds[] = (new SubscriberFactory())
+        ->withEmail("eligible-$i@mailpoet.com")
+        ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+        ->withCreatedAt(Carbon::now()->subDays(10))
+        ->withLastSubscribedAt(Carbon::now()->subDays(10))
+        ->create()
+        ->getId();
+    }
+    $recent = (new SubscriberFactory())
+      ->withEmail('recent@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withLastConfirmationEmailSentAt(Carbon::now()->subDays(6))
+      ->create();
+    $tooOld = (new SubscriberFactory())
+      ->withEmail('old@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCreatedAt(Carbon::now()->subDays(BulkConfirmationEmailResender::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS + 1))
+      ->withLastSubscribedAt(Carbon::now()->subDays(BulkConfirmationEmailResender::BULK_CONFIRMATION_MAX_SUBSCRIBER_AGE_DAYS + 1))
+      ->create();
+    $maxed = (new SubscriberFactory())
+      ->withEmail('maxed@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
+      ->create();
+    $subscribed = (new SubscriberFactory())
+      ->withEmail('subscribed@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $deleted = (new SubscriberFactory())
+      ->withEmail('deleted@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withDeletedAt(Carbon::now())
+      ->create();
+
+    $selection = array_merge($eligibleIds, [
+      $recent->getId(),
+      $tooOld->getId(),
+      $maxed->getId(),
+      $subscribed->getId(),
+      $deleted->getId(),
+      99999999,
+    ]);
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => [
+        'group' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'selection' => $selection,
+      ],
+    ]);
+
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['selected_count'])->equals(count($selection));
+    verify($response->data['eligible_count'])->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT + 2);
+    verify($response->data['queued_count'])->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT);
+    verify($response->data['skipped_by_reason']['batch_limit'])->equals(2);
+    verify($response->data['skipped_by_reason']['recently_sent'])->equals(1);
+    verify($response->data['skipped_by_reason']['too_old'])->equals(1);
+    verify($response->data['skipped_by_reason']['max_confirmations_reached'])->equals(1);
+    verify($response->data['skipped_by_reason']['not_unconfirmed'])->equals(1);
+    verify($response->data['skipped_by_reason']['deleted'])->equals(1);
+    verify($response->data['skipped_by_reason']['not_found'])->equals(1);
+    verify($response->data['task_id'])->notNull();
+
+    $task = $this->diContainer->get(ScheduledTasksRepository::class)->findOneById((int)$response->data['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    verify($task->getType())->equals(BulkConfirmationEmailResend::TASK_TYPE);
+    $taskMeta = $task->getMeta();
+    $this->assertIsArray($taskMeta);
+    verify($taskMeta['queued_count'])->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT);
+    verify($this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->count(['task' => $task]))
+      ->equals(BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT);
+  }
+
+  public function testBulkConfirmationEmailResendRejectsInvalidScopeAndDisabledConfirmation() {
+    wp_set_current_user(1);
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => ['group' => SubscriberEntity::STATUS_SUBSCRIBED],
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['error'])->equals('invalid_group');
+
+    $this->settings->set('signup_confirmation.enabled', false);
+    $response = $this->endpoint->bulkAction([
+      'action' => 'resendConfirmationEmails',
+      'listing' => ['group' => SubscriberEntity::STATUS_UNCONFIRMED],
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['error'])->equals('confirmation_disabled');
+  }
+
   public function testItFailsWithEmailFilled() {
     $response = $this->endpoint->subscribe([
       'form_id' => $this->form->getId(),
@@ -1015,7 +1116,8 @@ class SubscribersTest extends \MailPoetTest {
     $this->subscriber1->setConfirmationsCount(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
     $this->entityManager->flush();
     $response = $this->endpoint->sendConfirmationEmail(['id' => $this->subscriber1->getId()]);
-    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['message'])->equals('The maximum number of confirmation emails has already been reached for this subscriber.');
   }
 
   public function testItDisplaysProperErrorMessageWhenConfirmationEmailsAreDisabled() {

--- a/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonHttpRunnerTest.php
@@ -325,6 +325,7 @@ class DaemonHttpRunnerTest extends \MailPoetTest {
       'createMixpanelWorker' => $worker,
       'createTracksWorker' => $worker,
       'createStatisticsExportWorker' => $worker,
+      'createBulkConfirmationEmailResendWorker' => $worker,
       ]);
   }
 }

--- a/mailpoet/tests/integration/Cron/DaemonTest.php
+++ b/mailpoet/tests/integration/Cron/DaemonTest.php
@@ -125,6 +125,7 @@ class DaemonTest extends \MailPoetTest {
       'createMixpanelWorker' => $this->createSimpleWorkerMock(),
       'createTracksWorker' => $this->createSimpleWorkerMock(),
       'createStatisticsExportWorker' => $this->createSimpleWorkerMock(),
+      'createBulkConfirmationEmailResendWorker' => $this->createSimpleWorkerMock(),
       ]);
   }
 

--- a/mailpoet/tests/integration/Cron/Workers/BulkConfirmationEmailResendTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BulkConfirmationEmailResendTest.php
@@ -2,11 +2,16 @@
 
 namespace MailPoet\Cron\Workers;
 
+use Codeception\Stub;
+use MailPoet\Entities\LogEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Logging\LoggerFactory;
+use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -44,5 +49,113 @@ class BulkConfirmationEmailResendTest extends \MailPoetTest {
     verify($taskMeta['failed_count'])->equals(1);
     verify($taskMeta['skipped_by_reason']['max_confirmations_reached'])->equals(1);
     verify($this->diContainer->get(ScheduledTaskSubscribersRepository::class)->countUnprocessed($task))->equals(0);
+  }
+
+  public function testItRecordsSentFailedSkippedCountsAndIgnoresUnrelatedTasks(): void {
+    $sent = (new SubscriberFactory())
+      ->withEmail('bulk-sent@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    $sendFailed = (new SubscriberFactory())
+      ->withEmail('bulk-send-failed@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    $skipped = (new SubscriberFactory())
+      ->withEmail('bulk-skipped@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+    $unrelated = (new SubscriberFactory())
+      ->withEmail('bulk-unrelated@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->create();
+
+    $task = $this->createTaskWithSubscribers([$sent, $sendFailed, $skipped]);
+    $unrelatedTask = $this->createTaskWithSubscribers([$unrelated]);
+    $unrelatedTaskSubscriber = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findOneBy([
+      'task' => $unrelatedTask,
+      'subscriber' => $unrelated,
+    ]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $unrelatedTaskSubscriber);
+
+    $mailer = Stub::makeEmpty(ConfirmationEmailMailer::class, [
+      'sendAdminConfirmationEmail' => function(SubscriberEntity $subscriber): array {
+        if ($subscriber->getEmail() === 'bulk-sent@mailpoet.com') {
+          return ['status' => 'sent'];
+        }
+        if ($subscriber->getEmail() === 'bulk-send-failed@mailpoet.com') {
+          return ['status' => 'send_failed', 'reason' => 'sending_method'];
+        }
+        return ['status' => 'skipped', 'reason' => 'recently_sent'];
+      },
+    ], $this);
+    $worker = new BulkConfirmationEmailResend(
+      $mailer,
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(ScheduledTaskSubscribersRepository::class),
+      $this->diContainer->get(LogRepository::class)
+    );
+
+    verify($worker->processTaskStrategy($task, microtime(true)))->true();
+
+    $this->entityManager->refresh($task);
+    $this->entityManager->refresh($unrelatedTaskSubscriber);
+    $sentTaskSubscriber = $this->getTaskSubscriber($task, $sent);
+    $sendFailedTaskSubscriber = $this->getTaskSubscriber($task, $sendFailed);
+    $skippedTaskSubscriber = $this->getTaskSubscriber($task, $skipped);
+
+    verify($sentTaskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
+    verify($sentTaskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_OK);
+    verify($sendFailedTaskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
+    verify($sendFailedTaskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
+    verify($sendFailedTaskSubscriber->getError())->equals('send_failed:sending_method');
+    verify($skippedTaskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
+    verify($skippedTaskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
+    verify($skippedTaskSubscriber->getError())->equals('skipped:recently_sent');
+    verify($unrelatedTaskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED);
+
+    $taskMeta = $task->getMeta();
+    $this->assertIsArray($taskMeta);
+    verify($taskMeta['sent_count'])->equals(1);
+    verify($taskMeta['failed_count'])->equals(2);
+    verify($taskMeta['skipped_by_reason']['recently_sent'])->equals(1);
+
+    $completionLog = $this->entityManager->getRepository(LogEntity::class)->findOneBy([
+      'name' => LoggerFactory::TOPIC_CRON,
+      'message' => 'Bulk confirmation email resend completed.',
+    ]);
+    $this->assertInstanceOf(LogEntity::class, $completionLog);
+    $context = $completionLog->getContext();
+    $this->assertIsArray($context);
+    verify($context['sent_count'])->equals(1);
+    verify($context['failed_count'])->equals(2);
+    verify($context['skipped_by_reason']['recently_sent'])->equals(1);
+  }
+
+  /**
+   * @param SubscriberEntity[] $subscribers
+   */
+  private function createTaskWithSubscribers(array $subscribers): ScheduledTaskEntity {
+    $task = new ScheduledTaskEntity();
+    $task->setType(BulkConfirmationEmailResend::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING);
+    $task->setScheduledAt(Carbon::now());
+    $this->entityManager->persist($task);
+    $this->entityManager->flush();
+
+    foreach ($subscribers as $subscriber) {
+      $this->entityManager->persist(new ScheduledTaskSubscriberEntity($task, $subscriber));
+    }
+    $this->entityManager->flush();
+
+    return $task;
+  }
+
+  private function getTaskSubscriber(ScheduledTaskEntity $task, SubscriberEntity $subscriber): ScheduledTaskSubscriberEntity {
+    $taskSubscriber = $this->entityManager->getRepository(ScheduledTaskSubscriberEntity::class)->findOneBy([
+      'task' => $task,
+      'subscriber' => $subscriber,
+    ]);
+    $this->assertInstanceOf(ScheduledTaskSubscriberEntity::class, $taskSubscriber);
+    return $taskSubscriber;
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/BulkConfirmationEmailResendTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/BulkConfirmationEmailResendTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Cron\Workers;
+
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\ScheduledTaskSubscriberEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class BulkConfirmationEmailResendTest extends \MailPoetTest {
+  public function testItMarksIneligibleSubscribersAsSkipped(): void {
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('maxed-confirmation@mailpoet.com')
+      ->withStatus(SubscriberEntity::STATUS_UNCONFIRMED)
+      ->withCountConfirmations(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS)
+      ->create();
+
+    $task = new ScheduledTaskEntity();
+    $task->setType(BulkConfirmationEmailResend::TASK_TYPE);
+    $task->setStatus(ScheduledTaskEntity::VIRTUAL_STATUS_RUNNING);
+    $task->setScheduledAt(Carbon::now());
+    $this->entityManager->persist($task);
+    $this->entityManager->flush();
+
+    $taskSubscriber = new ScheduledTaskSubscriberEntity($task, $subscriber);
+    $this->entityManager->persist($taskSubscriber);
+    $this->entityManager->flush();
+
+    $worker = $this->diContainer->get(BulkConfirmationEmailResend::class);
+    verify($worker->supportsMultipleInstances())->false();
+    verify($worker->scheduleAutomatically())->false();
+    verify($worker->processTaskStrategy($task, microtime(true)))->true();
+
+    $this->entityManager->refresh($taskSubscriber);
+    $this->entityManager->refresh($task);
+    verify($taskSubscriber->getProcessed())->equals(ScheduledTaskSubscriberEntity::STATUS_PROCESSED);
+    verify($taskSubscriber->getFailed())->equals(ScheduledTaskSubscriberEntity::FAIL_STATUS_FAILED);
+    verify($taskSubscriber->getError())->equals('skipped:max_confirmations_reached');
+    $taskMeta = $task->getMeta();
+    $this->assertIsArray($taskMeta);
+    verify($taskMeta['failed_count'])->equals(1);
+    verify($taskMeta['skipped_by_reason']['max_confirmations_reached'])->equals(1);
+    verify($this->diContainer->get(ScheduledTaskSubscribersRepository::class)->countUnprocessed($task))->equals(0);
+  }
+}

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -241,10 +241,13 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     verify($result['reason'] ?? null)->equals('max_confirmations_reached');
   }
 
-  public function testItRecordsAndThrottlesAdminConfirmationEmailsForLoggedInUser() {
+  public function testItRecordsAdminConfirmationEmailWithoutUpdatingPublicTimestamp() {
     wp_set_current_user(1);
     verify((new WPFunctions)->isUserLoggedIn())->true();
+    $previousSentAt = Carbon::now()->subDays(8)->millisecond(0);
     $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscriber->setConfirmationsCount(1);
+    $this->subscriber->setLastConfirmationEmailSentAt($previousSentAt);
     $this->subscribersRepository->flush();
 
     $mailer = Stub::makeEmpty(Mailer::class, [
@@ -265,14 +268,10 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
 
     verify($sender->sendAdminConfirmationEmail($this->subscriber)['status'])->equals('sent');
     $this->subscribersRepository->refresh($this->subscriber);
-    verify($this->subscriber->getConfirmationsCount())->equals(1);
-    verify($this->subscriber->getLastConfirmationEmailSentAt())->notNull();
-
-    $result = $sender->sendAdminConfirmationEmail($this->subscriber);
-    verify($result['status'])->equals('skipped');
-    verify($result['reason'] ?? null)->equals('recently_sent');
-    $this->subscribersRepository->refresh($this->subscriber);
-    verify($this->subscriber->getConfirmationsCount())->equals(1);
+    verify($this->subscriber->getConfirmationsCount())->equals(2);
+    $lastConfirmationEmailSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
+    $this->assertNotNull($lastConfirmationEmailSentAt);
+    verify($lastConfirmationEmailSentAt->format('Y-m-d H:i:s'))->equals($previousSentAt->format('Y-m-d H:i:s'));
   }
 
   public function testGenericConfirmationEmailKeepsApiCompatibilityWithoutAdminThrottle(): void {
@@ -295,7 +294,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     verify($sender->sendConfirmationEmail($this->subscriber))->true();
@@ -374,7 +374,8 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
-      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+      $this->diContainer->get(ConfirmationEmailCustomizer::class),
+      $this->diContainer->get(NewslettersRepository::class)
     );
 
     try {

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -275,9 +275,10 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
 
   public function testGenericConfirmationEmailKeepsApiCompatibilityWithoutAdminThrottle(): void {
     wp_set_current_user(1);
+    $previousSentAt = Carbon::now()->subDay()->millisecond(0);
     $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
     $this->subscriber->setConfirmationsCount(1);
-    $this->subscriber->setLastConfirmationEmailSentAt(Carbon::now()->subDay());
+    $this->subscriber->setLastConfirmationEmailSentAt($previousSentAt);
     $this->subscribersRepository->flush();
 
     $mailer = Stub::makeEmpty(Mailer::class, [
@@ -300,7 +301,7 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     verify($this->subscriber->getConfirmationsCount())->equals(1);
     $lastConfirmationEmailSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
     $this->assertNotNull($lastConfirmationEmailSentAt);
-    $this->assertGreaterThan(Carbon::now()->subMinute()->getTimestamp(), $lastConfirmationEmailSentAt->getTimestamp());
+    verify($lastConfirmationEmailSentAt->format('Y-m-d H:i:s'))->equals($previousSentAt->format('Y-m-d H:i:s'));
   }
 
   public function testAdminConfirmationEmailReleaseDoesNotEraseNewerClaim(): void {

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -83,7 +83,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $subscriptionUrlFactoryMock,
@@ -104,6 +103,9 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
   }
 
   public function testItThrowsExceptionWhenConfirmationEmailCannotBeSent() {
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->flush();
+
     $mailer = Stub::makeEmpty(Mailer::class, [
       'send' =>
         Stub\Expected::once(function () {
@@ -115,7 +117,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -130,6 +131,9 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
 
   public function testSendConfirmationEmailThrowsAndLogHardErrorWhenSendReturnsFalse() {
     MailerLog::resetMailerLog();
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->flush();
+
     $mailer = Stub::makeEmpty(Mailer::class, [
       'send' => ['response' => false, 'error' => new MailerError(MailerError::OPERATION_SEND, MailerError::LEVEL_HARD, 'Error message')],
     ], $this);
@@ -138,7 +142,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -160,6 +163,9 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
 
   public function testSendConfirmationEmailThrowsAndIgnoresSoftErrorWhenSendReturnsFalse() {
     MailerLog::resetMailerLog();
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->flush();
+
     $mailer = Stub::makeEmpty(Mailer::class, [
       'send' => ['response' => false, 'error' => new MailerError(MailerError::OPERATION_SEND, MailerError::LEVEL_SOFT, 'Error message')],
     ], $this);
@@ -168,7 +174,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -197,7 +202,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -210,20 +214,20 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $settings->set(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING, null);
   }
 
-  public function testItLimitsNumberOfConfirmationEmailsForNotLoggedInUser() {
+  public function testItDoesNotSendAdminConfirmationEmailWhenMaxCountIsReached() {
     wp_set_current_user(0);
     verify((new WPFunctions)->isUserLoggedIn())->false();
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscriber->setConfirmationsCount(ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS);
+    $this->subscribersRepository->flush();
 
     $mailer = Stub::makeEmpty(Mailer::class, [
-      'send' => function() {
-        return ['response' => true];
-      },
+      'send' => Stub\Expected::never(),
     ], $this);
     $mailerFactory = $this->createMock(MailerFactory::class);
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -231,26 +235,24 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(NewslettersRepository::class)
     );
 
-    for ($i = 0; $i < $sender::MAX_CONFIRMATION_EMAILS; $i++) {
-      verify($sender->sendConfirmationEmail($this->subscriber))->equals(true);
-    }
     verify($sender->sendConfirmationEmail($this->subscriber))->equals(false);
   }
 
-  public function testItDoesNotLimitNumberOfConfirmationEmailsForLoggedInUser() {
+  public function testItRecordsAndThrottlesAdminConfirmationEmailsForLoggedInUser() {
     wp_set_current_user(1);
     verify((new WPFunctions)->isUserLoggedIn())->true();
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscribersRepository->flush();
 
     $mailer = Stub::makeEmpty(Mailer::class, [
-      'send' => function() {
+      'send' => Stub\Expected::once(function() {
         return ['response' => true];
-      },
+      }),
     ], $this);
     $mailerFactory = $this->createMock(MailerFactory::class);
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -258,13 +260,14 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(NewslettersRepository::class)
     );
 
-    for ($i = 0; $i < $sender::MAX_CONFIRMATION_EMAILS; $i++) {
-      verify($sender->sendConfirmationEmail($this->subscriber))->equals(true);
-    }
     verify($sender->sendConfirmationEmail($this->subscriber))->equals(true);
     $this->subscribersRepository->refresh($this->subscriber);
-    verify($this->subscriber->getConfirmationsCount())->equals(0);
+    verify($this->subscriber->getConfirmationsCount())->equals(1);
     verify($this->subscriber->getLastConfirmationEmailSentAt())->notNull();
+
+    verify($sender->sendConfirmationEmail($this->subscriber))->equals(false);
+    $this->subscribersRepository->refresh($this->subscriber);
+    verify($this->subscriber->getConfirmationsCount())->equals(1);
   }
 
   public function testItLimitsAndRecordsPublicConfirmationEmailsForLoggedInUsers() {
@@ -282,7 +285,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -315,7 +317,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -353,7 +354,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new ConfirmationEmailMailer(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -379,7 +379,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new class(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -408,7 +407,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
     $sender = new class(
       $mailerFactory,
-      $this->diContainer->get(WPFunctions::class),
       $this->diContainer->get(SettingsController::class),
       $this->diContainer->get(SubscribersRepository::class),
       $this->diContainer->get(SubscriptionUrlFactory::class),
@@ -477,7 +475,6 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
 
     $sender = new ConfirmationEmailMailer(
       $this->createMock(MailerFactory::class),
-      $this->diContainer->get(WPFunctions::class),
       $settings,
       $this->diContainer->get(SubscribersRepository::class),
       $subscriptionUrlFactoryMock,

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -236,7 +236,9 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(NewslettersRepository::class)
     );
 
-    verify($sender->sendConfirmationEmail($this->subscriber))->equals(false);
+    $result = $sender->sendAdminConfirmationEmail($this->subscriber);
+    verify($result['status'])->equals('skipped');
+    verify($result['reason'] ?? null)->equals('max_confirmations_reached');
   }
 
   public function testItRecordsAndThrottlesAdminConfirmationEmailsForLoggedInUser() {

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -346,6 +346,50 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
     verify($lastConfirmationEmailSentAt->format('Y-m-d H:i:s'))->equals($newerClaimTime);
   }
 
+  public function testFailedAdminConfirmationEmailReleasesClaimedCountAndTimestamp(): void {
+    wp_set_current_user(1);
+    $previousSentAt = Carbon::now()->subDays(8)->millisecond(0);
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscriber->setConfirmationsCount(1);
+    $this->subscriber->setLastConfirmationEmailSentAt($previousSentAt);
+    $this->subscribersRepository->flush();
+
+    $mailer = Stub::makeEmpty(Mailer::class, [
+      'send' => Stub\Expected::once(function() use ($previousSentAt) {
+        $this->subscribersRepository->refresh($this->subscriber);
+        verify($this->subscriber->getConfirmationsCount())->equals(2);
+        $claimedSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
+        $this->assertNotNull($claimedSentAt);
+        $this->assertNotSame($previousSentAt->format('Y-m-d H:i:s'), $claimedSentAt->format('Y-m-d H:i:s'));
+        throw new \Exception('send error');
+      }),
+    ], $this);
+    $mailerFactory = $this->createMock(MailerFactory::class);
+    $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
+    $sender = new ConfirmationEmailMailer(
+      $mailerFactory,
+      $this->diContainer->get(SettingsController::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(SubscriptionUrlFactory::class),
+      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+    );
+
+    try {
+      $sender->sendAdminConfirmationEmail($this->subscriber);
+      $this->fail('Expected admin confirmation send to fail.');
+    } catch (\Exception $e) {
+      verify($e->getMessage())->equals(
+        __('There was an error when sending a confirmation email for your subscription. Please contact the website owner.', 'mailpoet')
+      );
+    }
+
+    $this->subscribersRepository->refresh($this->subscriber);
+    verify($this->subscriber->getConfirmationsCount())->equals(1);
+    $lastConfirmationEmailSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
+    $this->assertNotNull($lastConfirmationEmailSentAt);
+    verify($lastConfirmationEmailSentAt->format('Y-m-d H:i:s'))->equals($previousSentAt->format('Y-m-d H:i:s'));
+  }
+
   public function testItLimitsAndRecordsPublicConfirmationEmailsForLoggedInUsers() {
     wp_set_current_user(1);
     verify((new WPFunctions)->isUserLoggedIn())->true();

--- a/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
+++ b/mailpoet/tests/integration/Subscribers/ConfirmationEmailMailerTest.php
@@ -17,6 +17,7 @@ use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
 
 class ConfirmationEmailMailerTest extends \MailPoetTest {
 
@@ -260,14 +261,89 @@ class ConfirmationEmailMailerTest extends \MailPoetTest {
       $this->diContainer->get(NewslettersRepository::class)
     );
 
-    verify($sender->sendConfirmationEmail($this->subscriber))->equals(true);
+    verify($sender->sendAdminConfirmationEmail($this->subscriber)['status'])->equals('sent');
     $this->subscribersRepository->refresh($this->subscriber);
     verify($this->subscriber->getConfirmationsCount())->equals(1);
     verify($this->subscriber->getLastConfirmationEmailSentAt())->notNull();
 
-    verify($sender->sendConfirmationEmail($this->subscriber))->equals(false);
+    $result = $sender->sendAdminConfirmationEmail($this->subscriber);
+    verify($result['status'])->equals('skipped');
+    verify($result['reason'] ?? null)->equals('recently_sent');
     $this->subscribersRepository->refresh($this->subscriber);
     verify($this->subscriber->getConfirmationsCount())->equals(1);
+  }
+
+  public function testGenericConfirmationEmailKeepsApiCompatibilityWithoutAdminThrottle(): void {
+    wp_set_current_user(1);
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscriber->setConfirmationsCount(1);
+    $this->subscriber->setLastConfirmationEmailSentAt(Carbon::now()->subDay());
+    $this->subscribersRepository->flush();
+
+    $mailer = Stub::makeEmpty(Mailer::class, [
+      'send' => Stub\Expected::once(function() {
+        return ['response' => true];
+      }),
+    ], $this);
+    $mailerFactory = $this->createMock(MailerFactory::class);
+    $mailerFactory->method('getDefaultMailer')->willReturn($mailer);
+    $sender = new ConfirmationEmailMailer(
+      $mailerFactory,
+      $this->diContainer->get(SettingsController::class),
+      $this->diContainer->get(SubscribersRepository::class),
+      $this->diContainer->get(SubscriptionUrlFactory::class),
+      $this->diContainer->get(ConfirmationEmailCustomizer::class)
+    );
+
+    verify($sender->sendConfirmationEmail($this->subscriber))->true();
+    $this->subscribersRepository->refresh($this->subscriber);
+    verify($this->subscriber->getConfirmationsCount())->equals(1);
+    $lastConfirmationEmailSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
+    $this->assertNotNull($lastConfirmationEmailSentAt);
+    $this->assertGreaterThan(Carbon::now()->subMinute()->getTimestamp(), $lastConfirmationEmailSentAt->getTimestamp());
+  }
+
+  public function testAdminConfirmationEmailReleaseDoesNotEraseNewerClaim(): void {
+    $this->subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+    $this->subscriber->setConfirmationsCount(1);
+    $this->subscriber->setLastConfirmationEmailSentAt(Carbon::now()->subDays(8));
+    $this->subscribersRepository->flush();
+
+    $claim = $this->subscribersRepository->claimAdminConfirmationEmailResend(
+      $this->subscriber,
+      ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS,
+      Carbon::now()->subDays(ConfirmationEmailMailer::ADMIN_CONFIRMATION_RESEND_INTERVAL_DAYS)->millisecond(0)
+    );
+    $this->assertTrue($claim['claimed']);
+    $this->assertArrayHasKey('claim_time', $claim);
+    $this->assertArrayHasKey('previous_count_confirmations', $claim);
+
+    $newerClaimTime = Carbon::now()->addSecond()->millisecond(0)->format('Y-m-d H:i:s');
+    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE $subscriberTable
+       SET `count_confirmations` = :count_confirmations,
+         `last_confirmation_email_sent_at` = :last_confirmation_email_sent_at
+       WHERE `id` = :id",
+      [
+        'count_confirmations' => 3,
+        'last_confirmation_email_sent_at' => $newerClaimTime,
+        'id' => $this->subscriber->getId(),
+      ]
+    );
+
+    $this->subscribersRepository->releaseAdminConfirmationEmailResendClaim(
+      $this->subscriber,
+      (string)$claim['claim_time'],
+      $claim['previous_last_confirmation_email_sent_at'] ?? null,
+      (int)$claim['previous_count_confirmations']
+    );
+
+    $this->subscribersRepository->refresh($this->subscriber);
+    verify($this->subscriber->getConfirmationsCount())->equals(3);
+    $lastConfirmationEmailSentAt = $this->subscriber->getLastConfirmationEmailSentAt();
+    $this->assertNotNull($lastConfirmationEmailSentAt);
+    verify($lastConfirmationEmailSentAt->format('Y-m-d H:i:s'))->equals($newerClaimTime);
   }
 
   public function testItLimitsAndRecordsPublicConfirmationEmailsForLoggedInUsers() {

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -9,6 +9,7 @@
     var mailpoet_custom_fields = <%= json_encode(custom_fields) %>;
     var mailpoet_month_names = <%= json_encode(month_names) %>;
     var mailpoet_date_formats = <%= json_encode(date_formats) %>;
+    var mailpoet_signup_confirmation_enabled = <%= json_encode(signup_confirmation_enabled) %>;
   </script>
 
   <%= localize({

--- a/mailpoet/views/subscribers/subscribers.html
+++ b/mailpoet/views/subscribers/subscribers.html
@@ -10,6 +10,7 @@
     var mailpoet_month_names = <%= json_encode(month_names) %>;
     var mailpoet_date_formats = <%= json_encode(date_formats) %>;
     var mailpoet_signup_confirmation_enabled = <%= json_encode(signup_confirmation_enabled) %>;
+    var mailpoet_bulk_confirmation_resend_limit = <%= json_encode(bulk_confirmation_resend_limit) %>;
   </script>
 
   <%= localize({


### PR DESCRIPTION
## Description

Adds a controlled bulk action for resending confirmation emails to selected unconfirmed subscribers. The action queues eligible subscribers in capped batches, skips ineligible selections, and keeps the UI clear about queued jobs versus final delivery.

Eligibility is checked before queueing and again in the background worker, so the success notice intentionally describes a queued resend job rather than guaranteed delivered emails.

Request-level gates:

- The current user must be able to `manage_options`, usually Administrator.
- Sign-up confirmation must be enabled.
- The bulk action must target the Unconfirmed subscribers group.
- The bulk action button is hidden when sign-up confirmation is disabled.

Subscriber eligibility:

- The subscriber must be in the current listing scope.
- The subscriber must have fewer than 3 confirmation emails sent.
- The subscriber must not have received a confirmation email in the last 7 days.
- The subscriber must not be older than 90 days.
- Only the first 20 eligible subscribers are queued per bulk action.

## Code review notes

_N/A_

## QA notes

1. Enable sign-up confirmation in MailPoet settings.
2. Open Subscribers, switch to Unconfirmed, select one or more subscribers, and confirm that `Resend confirmation emails` appears in bulk actions.
3. Open the modal and confirm the button stays disabled until the checkbox confirming that subscribers asked to join is checked.
4. Queue the resend and confirm the notice explains how many subscribers were queued or skipped.
5. Select all unconfirmed subscribers across pages and confirm only up to 20 eligible subscribers are queued.
6. Disable sign-up confirmation in MailPoet settings, return to the Unconfirmed subscribers list, select subscribers, and confirm the bulk resend action is hidden.

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7995/bulk-resend-confirmation-email-to-unconfirmed-subscribers

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="2029" height="1011" alt="Screenshot 2026-04-29 at 12 26 29" src="https://github.com/user-attachments/assets/71f19f7a-421d-41f3-85ff-e0930f3f759d" />

----

<img width="797" height="263" alt="Screenshot 2026-04-29 at 13 06 53" src="https://github.com/user-attachments/assets/a2553a90-c3e9-4bcd-8ac3-0e149ebbd572" />

----

<img width="1629" height="73" alt="Screenshot 2026-04-29 at 12 57 08" src="https://github.com/user-attachments/assets/dbbc6b68-2819-4871-975e-466982cf4824" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-7995-bulk-resend-confirmation-email)

_The latest successful build from `add/STOMAIL-7995-bulk-resend-confirmation-email` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 1 Issue Found

### Bug: Silent Failure in releaseAdminConfirmationEmailResendClaim

**Location:** mailpoet/lib/Subscribers/SubscribersRepository.php::releaseAdminConfirmationEmailResendClaim()

**Issue:** The method performs a guarded UPDATE to revert a claimed resend but does not check the number of affected rows or otherwise log/notify when the UPDATE affects 0 rows. It returns void and silently ignores failed releases.

**Impact:** If the guarded UPDATE doesn't match (e.g., due to a concurrent newer claim or subscriber state change), the release will not be applied and callers are not informed. This can leave count_confirmations and last_confirmation_email_sent_at in an incorrect state, causing data integrity and throttling inaccuracies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->