### PR TITLE
Add RTL support to legacy sent emails

### DIFF
--- a/mailpoet/changelog/2026-04-29-11-00-19-improved-add-right-to-left-direction-support-to-sent-legacy.md
+++ b/mailpoet/changelog/2026-04-29-11-00-19-improved-add-right-to-left-direction-support-to-sent-legacy.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Add right-to-left direction support to sent legacy MailPoet emails on RTL sites

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Footer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Footer.php
@@ -21,7 +21,8 @@ class Footer {
     $this->wp = $wp;
   }
 
-  public function render($element) {
+  public function render($element, bool $isRtl = false) {
+    $element = StylesHelper::applyTextAlignment($element, $isRtl ? 'right' : 'left', 'text');
     $element['text'] = preg_replace('/\n/', '<br />', $element['text']);
     $element['text'] = preg_replace('/(<\/?p.*?>)/i', '', $element['text']);
     $lineHeight = sprintf(

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Header.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Header.php
@@ -21,7 +21,8 @@ class Header {
     $this->wp = $wp;
   }
 
-  public function render($element) {
+  public function render($element, bool $isRtl = false) {
+    $element = StylesHelper::applyTextAlignment($element, $isRtl ? 'right' : 'left', 'text');
     $element['text'] = preg_replace('/\n/', '<br />', $element['text']);
     $element['text'] = preg_replace('/(<\/?p.*?>)/i', '', $element['text']);
     $lineHeight = sprintf(

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Renderer.php
@@ -71,7 +71,7 @@ class Renderer {
     $this->dynamicProducts = $dynamicProducts;
   }
 
-  public function render(NewsletterEntity $newsletter, $data) {
+  public function render(NewsletterEntity $newsletter, $data, bool $isRtl = false) {
     if (!isset($data['blocks']) || !is_countable($data['blocks']) || !is_iterable($data['blocks'])) {
         return null;
     }
@@ -81,20 +81,20 @@ class Renderer {
     $columnContent = [];
 
     foreach ($data['blocks'] as $index => $columnBlocks) {
-      $renderedBlockElement = $this->renderBlocksInColumn($newsletter, $columnBlocks, $columnWidths[$index]);
+      $renderedBlockElement = $this->renderBlocksInColumn($newsletter, $columnBlocks, $columnWidths[$index], $isRtl);
       $columnContent[] = $renderedBlockElement;
     }
 
     return $columnContent;
   }
 
-  private function renderBlocksInColumn(NewsletterEntity $newsletter, $block, $columnBaseWidth) {
+  private function renderBlocksInColumn(NewsletterEntity $newsletter, $block, $columnBaseWidth, bool $isRtl = false) {
     $blockContent = '';
     $_this = $this;
-    array_map(function($block) use (&$blockContent, $columnBaseWidth, $newsletter, $_this) {
-      $renderedBlockElement = $_this->createElementFromBlockType($newsletter, $block, $columnBaseWidth);
+    array_map(function($block) use (&$blockContent, $columnBaseWidth, $newsletter, $_this, $isRtl) {
+      $renderedBlockElement = $_this->createElementFromBlockType($newsletter, $block, $columnBaseWidth, $isRtl);
       if (isset($block['blocks'])) {
-        $renderedBlockElement = $_this->renderBlocksInColumn($newsletter, $block, $columnBaseWidth);
+        $renderedBlockElement = $_this->renderBlocksInColumn($newsletter, $block, $columnBaseWidth, $isRtl);
         // nested vertical column container is rendered as an array
         if (is_array($renderedBlockElement)) {
           $renderedBlockElement = implode('', array_map(static fn($v): string => is_scalar($v) ? (string)$v : '', $renderedBlockElement));
@@ -106,9 +106,9 @@ class Renderer {
     return $blockContent;
   }
 
-  public function createElementFromBlockType(NewsletterEntity $newsletter, $block, $columnBaseWidth) {
+  public function createElementFromBlockType(NewsletterEntity $newsletter, $block, $columnBaseWidth, bool $isRtl = false) {
     if ($block['type'] === 'automatedLatestContent') {
-      return $this->processAutomatedLatestContent($newsletter, $block, $columnBaseWidth);
+      return $this->processAutomatedLatestContent($newsletter, $block, $columnBaseWidth, $isRtl);
     }
     if ($block['type'] === 'dynamicProducts') {
       return $this->processDynamicProducts($block, $columnBaseWidth);
@@ -120,9 +120,9 @@ class Renderer {
       case 'divider':
         return $this->divider->render($block);
       case 'footer':
-        return $this->footer->render($block);
+        return $this->footer->render($block, $isRtl);
       case 'header':
-        return $this->header->render($block);
+        return $this->header->render($block, $isRtl);
       case 'image':
         return $this->image->render($block, $columnBaseWidth);
       case 'social':
@@ -130,7 +130,7 @@ class Renderer {
       case 'spacer':
         return $this->spacer->render($block);
       case 'text':
-        return $this->text->render($block);
+        return $this->text->render($block, $isRtl);
       case 'placeholder':
         return $this->placeholder->render($block);
       case Coupon::TYPE:
@@ -139,12 +139,12 @@ class Renderer {
     return "<!-- Skipped unsupported block type: {$block['type']} -->";
   }
 
-  public function processAutomatedLatestContent(NewsletterEntity $newsletter, $args, $columnBaseWidth) {
+  public function processAutomatedLatestContent(NewsletterEntity $newsletter, $args, $columnBaseWidth, bool $isRtl = false) {
     $transformedPosts = [
       'blocks' => $this->ALC->render($newsletter, $args),
     ];
     $transformedPosts = StylesHelper::applyTextAlignment($transformedPosts);
-    return $this->renderBlocksInColumn($newsletter, $transformedPosts, $columnBaseWidth);
+    return $this->renderBlocksInColumn($newsletter, $transformedPosts, $columnBaseWidth, $isRtl);
   }
 
   public function processDynamicProducts($args, $columnBaseWidth) {

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -8,15 +8,15 @@ use MailPoet\Newsletter\Renderer\StylesHelper;
 use MailPoet\Util\pQuery\pQuery;
 
 class Text {
-  public function render($element) {
+  public function render($element, bool $isRtl = false) {
     $html = $element['text'];
     // replace &nbsp; with spaces
     $html = str_replace('&nbsp;', ' ', $html);
     $html = str_replace('\xc2\xa0', ' ', $html);
-    $html = $this->convertBlockquotesToTables($html);
-    $html = $this->convertParagraphsToTables($html);
-    $html = $this->styleLists($html);
-    $html = $this->styleHeadings($html);
+    $html = $this->convertBlockquotesToTables($html, $isRtl);
+    $html = $this->convertParagraphsToTables($html, $isRtl);
+    $html = $this->styleLists($html, $isRtl);
+    $html = $this->styleHeadings($html, $isRtl);
     $html = $this->removeLastLineBreak($html);
     $template = '
       <tr>
@@ -27,7 +27,7 @@ class Text {
     return $template;
   }
 
-  public function convertBlockquotesToTables($html) {
+  public function convertBlockquotesToTables($html, bool $isRtl = false) {
     $dOMParser = new pQuery();
     $DOM = $dOMParser->parseStr($html);
     $blockquotes = $DOM->query('blockquote');
@@ -50,7 +50,8 @@ class Text {
       $blockquote->spacing = 0;
       $blockquote->border = 0;
       $blockquote->cellpadding = 0;
-      $blockquote->html('
+      if (!$isRtl) {
+        $blockquote->html('
         <tbody>
           <tr>
             <td width="2" bgcolor="#565656"></td>
@@ -66,12 +67,36 @@ class Text {
             </td>
           </tr>
         </tbody>');
+        $blockquote = $this->insertLineBreak($blockquote);
+        continue;
+      }
+      $contentCell = '
+            <td valign="top">
+              <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+                <tr>
+                  <td class="mailpoet_blockquote">
+                  ' . implode('', $contents) . '
+                  </td>
+                </tr>
+              </table>
+            </td>';
+      $ruleCell = '<td width="2" bgcolor="#565656"></td>';
+      $spacerCell = '<td width="10"></td>';
+      $cells = $contentCell . '
+            ' . $spacerCell . '
+            ' . $ruleCell;
+      $blockquote->html('
+        <tbody>
+          <tr>
+            ' . $cells . '
+          </tr>
+        </tbody>');
       $blockquote = $this->insertLineBreak($blockquote);
     }
     return $DOM->__toString();
   }
 
-  public function convertParagraphsToTables($html) {
+  public function convertParagraphsToTables($html, bool $isRtl = false) {
     $dOMParser = new pQuery();
     $DOM = $dOMParser->parseStr($html);
     $paragraphs = $DOM->query('p');
@@ -102,7 +127,13 @@ class Text {
       }
       $style = (string)$paragraph->style;
       if (!preg_match('/text-align/i', $style)) {
-        $style = 'text-align: left;' . $style;
+        $style = 'text-align: ' . ($isRtl ? 'right' : 'left') . ';' . $style;
+      } elseif (
+        $isRtl
+        && preg_match('/text-align\s*:\s*left/i', $style)
+        && !preg_match('/text-align\s*:\s*(center|justify|right)/i', $style)
+      ) {
+        $style = StylesHelper::joinStyles($style, 'text-align: right;');
       }
       $contents = $paragraph->toString(true, true, 1);
       $paragraph->setTag('table');
@@ -135,7 +166,7 @@ class Text {
     return $DOM->__toString();
   }
 
-  public function styleLists($html) {
+  public function styleLists($html, bool $isRtl = false) {
     $dOMParser = new pQuery();
     $DOM = $dOMParser->parseStr($html);
     $lists = $DOM->query('ol, ul, li');
@@ -148,20 +179,20 @@ class Text {
         $list->class = 'mailpoet_paragraph';
         $list->style = StylesHelper::joinStyles($list->style, 'padding-top:0;padding-bottom:0;margin-top:10px;');
       }
-      $list->style = StylesHelper::applyTextAlignment($list->style);
+      $list->style = StylesHelper::applyTextAlignment($list->style, $isRtl ? 'right' : 'left');
       $list->style = StylesHelper::joinStyles($list->style, 'margin-bottom:10px;');
       $list->style = EHelper::escapeHtmlStyleAttr($list->style);
     }
     return $DOM->__toString();
   }
 
-  public function styleHeadings($html) {
+  public function styleHeadings($html, bool $isRtl = false) {
     $dOMParser = new pQuery();
     $DOM = $dOMParser->parseStr($html);
     $headings = $DOM->query('h1, h2, h3, h4');
     if (!$headings->count()) return $html;
     foreach ($headings as $heading) {
-      $heading->style = StylesHelper::applyTextAlignment($heading->style);
+      $heading->style = StylesHelper::applyTextAlignment($heading->style, $isRtl ? 'right' : 'left');
       $heading->style = StylesHelper::joinStyles($heading->style, 'padding:0;font-style:normal;font-weight:normal;');
       $heading->style = EHelper::escapeHtmlStyleAttr($heading->style);
     }

--- a/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
+++ b/mailpoet/lib/Newsletter/Renderer/Blocks/Text.php
@@ -50,8 +50,7 @@ class Text {
       $blockquote->spacing = 0;
       $blockquote->border = 0;
       $blockquote->cellpadding = 0;
-      if (!$isRtl) {
-        $blockquote->html('
+      $blockquote->html('
         <tbody>
           <tr>
             <td width="2" bgcolor="#565656"></td>
@@ -65,30 +64,6 @@ class Text {
                 </tr>
               </table>
             </td>
-          </tr>
-        </tbody>');
-        $blockquote = $this->insertLineBreak($blockquote);
-        continue;
-      }
-      $contentCell = '
-            <td valign="top">
-              <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
-                <tr>
-                  <td class="mailpoet_blockquote">
-                  ' . implode('', $contents) . '
-                  </td>
-                </tr>
-              </table>
-            </td>';
-      $ruleCell = '<td width="2" bgcolor="#565656"></td>';
-      $spacerCell = '<td width="10"></td>';
-      $cells = $contentCell . '
-            ' . $spacerCell . '
-            ' . $ruleCell;
-      $blockquote->html('
-        <tbody>
-          <tr>
-            ' . $cells . '
           </tr>
         </tbody>');
       $blockquote = $this->insertLineBreak($blockquote);

--- a/mailpoet/lib/Newsletter/Renderer/BodyRenderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/BodyRenderer.php
@@ -24,14 +24,14 @@ class BodyRenderer {
    * @param array $content
    * @return string
    */
-  public function renderBody(NewsletterEntity $newsletter, array $content) {
+  public function renderBody(NewsletterEntity $newsletter, array $content, bool $isRtl = false) {
     $blocks = (array_key_exists('blocks', $content))
       ? $content['blocks']
       : [];
 
     $renderedContent = [];
     foreach ($blocks as $contentBlock) {
-      $columnsData = $this->blocksRenderer->render($newsletter, $contentBlock);
+      $columnsData = $this->blocksRenderer->render($newsletter, $contentBlock, $isRtl);
 
       $renderedContent[] = $this->columnsRenderer->render(
         $contentBlock,

--- a/mailpoet/lib/Newsletter/Renderer/Renderer.php
+++ b/mailpoet/lib/Newsletter/Renderer/Renderer.php
@@ -93,6 +93,7 @@ class Renderer {
 
   private function _render(NewsletterEntity $newsletter, ?SendingQueueEntity $sendingQueue = null, $type = false, $preview = false, $subject = null) {
     $language = $this->wp->getBloginfo('language');
+    $isRtl = (bool)$this->wp->isRtl();
     $metaRobots = $preview ? '<meta name="robots" content="noindex, nofollow" />' : '';
     $subject = $subject ?: $newsletter->getSubject();
     $wpPostEntity = $newsletter->getWpPost();
@@ -143,7 +144,7 @@ class Renderer {
       $renderedBody = "";
       try {
         $content = $this->preprocessor->process($newsletter, $content, $preview, $sendingQueue);
-        $renderedBody = $this->bodyRenderer->renderBody($newsletter, $content);
+        $renderedBody = $this->bodyRenderer->renderBody($newsletter, $content, $isRtl);
       } catch (NewsletterProcessingException $e) {
         $this->loggerFactory->getLogger(LoggerFactory::TOPIC_COUPONS)->error(
           $e->getMessage(),
@@ -161,10 +162,13 @@ class Renderer {
         (string)file_get_contents(dirname(__FILE__) . '/' . self::NEWSLETTER_TEMPLATE),
         [
           $language,
+          $isRtl ? ' dir="rtl"' : '',
           $metaRobots,
           htmlspecialchars($subject, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401),
           $renderedStyles,
           $customFontsLinks,
+          $isRtl ? ' style="direction: rtl;"' : '',
+          $isRtl ? ';direction:rtl' : '',
           EHelper::escapeHtmlText($newsletter->getPreheader()),
           $renderedBody,
         ]

--- a/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
@@ -108,8 +108,8 @@ class StylesHelper {
         $block['styles'][$styleType] = [];
       }
       $rawTextAlign = $block['styles'][$styleType]['textAlign'] ?? null;
-      $textAlignment = is_string($rawTextAlign) ? strtolower($rawTextAlign) : '';
-      if (preg_match('/center|right|justify/i', $textAlignment)) {
+      $textAlignment = is_string($rawTextAlign) ? trim(strtolower($rawTextAlign)) : '';
+      if (in_array($textAlignment, ['center', 'right', 'justify'], true)) {
         return $block;
       }
       $block['styles'][$styleType]['textAlign'] = $defaultAlignment;
@@ -117,7 +117,7 @@ class StylesHelper {
     }
 
     // Check if text-align is already set to center, right, or justify
-    if (preg_match('/text-align\s*:\s*(center|justify|right)/i', (string)$block)) {
+    if (preg_match('/text-align\s*:\s*(center|justify|right)\s*(;|$)/i', (string)$block)) {
       return $block;
     }
 

--- a/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
+++ b/mailpoet/lib/Newsletter/Renderer/StylesHelper.php
@@ -99,20 +99,20 @@ class StylesHelper {
     return $css;
   }
 
-  public static function applyTextAlignment($block) {
+  public static function applyTextAlignment($block, string $defaultAlignment = 'left', string $styleType = 'block') {
     if (is_array($block)) {
       if (!isset($block['styles']) || !is_array($block['styles'])) {
         $block['styles'] = [];
       }
-      if (!isset($block['styles']['block']) || !is_array($block['styles']['block'])) {
-        $block['styles']['block'] = [];
+      if (!isset($block['styles'][$styleType]) || !is_array($block['styles'][$styleType])) {
+        $block['styles'][$styleType] = [];
       }
-      $rawTextAlign = $block['styles']['block']['textAlign'] ?? null;
+      $rawTextAlign = $block['styles'][$styleType]['textAlign'] ?? null;
       $textAlignment = is_string($rawTextAlign) ? strtolower($rawTextAlign) : '';
       if (preg_match('/center|right|justify/i', $textAlignment)) {
         return $block;
       }
-      $block['styles']['block']['textAlign'] = 'left';
+      $block['styles'][$styleType]['textAlign'] = $defaultAlignment;
       return $block;
     }
 
@@ -127,7 +127,7 @@ class StylesHelper {
       $block .= ';';
     }
 
-    return $block . 'text-align:left;';
+    return $block . 'text-align:' . $defaultAlignment . ';';
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Renderer/Template.html
+++ b/mailpoet/lib/Newsletter/Renderer/Template.html
@@ -1,4 +1,4 @@
-<html lang="{{newsletter_language}}">
+<html lang="{{newsletter_language}}"{{newsletter_html_direction}}>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -106,9 +106,9 @@
     </style>
     {{newsletter_custom_fonts}}
 </head>
-<body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+<body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0"{{newsletter_body_direction}}>
     <table class="mailpoet_template" border="0" width="100%" cellpadding="0" cellspacing="0"
-           style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0">
+           style="border-spacing:0;mso-table-lspace:0;mso-table-rspace:0{{newsletter_template_direction_style}}">
         <tbody>
         <tr>
             <td class="mailpoet_preheader" style="-webkit-text-size-adjust:none;font-size:1px;line-height:1px;color:#333333;" height="1">

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -785,6 +785,30 @@ class RendererTest extends \MailPoetTest {
     $this->assertEquals($expectedLanguage, $html->attr('lang'));
   }
 
+  public function testItRendersRtlDirectionAttributes() {
+    $renderer = $this->createRendererWithWpFunctions(true, 'ar');
+
+    $template = $renderer->render($this->newsletter);
+    $DOM = $this->dOMParser->parseStr($template['html']);
+
+    verify($DOM->query('html')->attr('dir'))->equals('rtl');
+    verify($DOM->query('body')->attr('style'))->stringContainsString('direction:rtl');
+    verify($template['html'])->stringContainsString('class="mailpoet_template"');
+    verify($template['html'])->stringContainsString('direction:rtl');
+    verify($template['html'])->stringContainsString('text-align:right');
+  }
+
+  public function testItDoesNotRenderDirectionAttributesForLtrEmails() {
+    $renderer = $this->createRendererWithWpFunctions(false, 'en-US');
+
+    $template = $renderer->render($this->newsletter);
+    $DOM = $this->dOMParser->parseStr($template['html']);
+
+    verify($DOM->query('html')->attr('dir'))->null();
+    verify((string)$DOM->query('body')->attr('style'))->stringNotContainsString('direction: rtl');
+    verify($template['html'])->stringNotContainsString('direction:rtl');
+  }
+
   public function testItRendersScreenReaderText() {
     $body = json_decode(
       (string)file_get_contents(dirname(__FILE__) . '/RendererTestData.json'),
@@ -805,6 +829,29 @@ class RendererTest extends \MailPoetTest {
   private function setGlobalLocale($value) {
     global $locale;
     $locale = $value;
+  }
+
+  private function createRendererWithWpFunctions(bool $isRtl, string $language): Renderer {
+    $wp = $this->createMock(WPFunctions::class);
+    $wp->method('getBloginfo')->with('language')->willReturn($language);
+    $wp->method('isRtl')->willReturn($isRtl);
+    $wp->method('applyFilters')->willReturnCallback(function($filter, $value) {
+      return $value;
+    });
+
+    return new Renderer(
+      $this->diContainer->get(BodyRenderer::class),
+      $this->diContainer->get(Preprocessor::class),
+      $this->diContainer->get(\MailPoetVendor\CSS::class),
+      $wp,
+      $this->diContainer->get(LoggerFactory::class),
+      $this->diContainer->get(NewslettersRepository::class),
+      $this->diContainer->get(SendingQueuesRepository::class),
+      $this->capabilitiesManager,
+      $this->diContainer->get(CouponBlockGenerationFailureCollector::class),
+      $this->diContainer->get(EmailContextBuilder::class),
+      $this->diContainer->get(CouponBlockFailureTranslator::class)
+    );
   }
 
   public function makeAttachment($upload, $parentPostId = 0) {

--- a/mailpoet/tests/integration/Newsletter/RendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/RendererTest.php
@@ -793,9 +793,24 @@ class RendererTest extends \MailPoetTest {
 
     verify($DOM->query('html')->attr('dir'))->equals('rtl');
     verify($DOM->query('body')->attr('style'))->stringContainsString('direction:rtl');
-    verify($template['html'])->stringContainsString('class="mailpoet_template"');
-    verify($template['html'])->stringContainsString('direction:rtl');
+    verify($DOM->query('table.mailpoet_template')->attr('style'))->stringContainsString('direction:rtl');
     verify($template['html'])->stringContainsString('text-align:right');
+  }
+
+  public function testItKeepsRenderedColumnContentStableForRtlEmails() {
+    $this->newsletter->setBody($this->getColumnsOnlyBody());
+    $ltrRenderer = $this->createRendererWithWpFunctions(false, 'en-US');
+    $rtlRenderer = $this->createRendererWithWpFunctions(true, 'ar');
+
+    $ltrTemplate = $ltrRenderer->render($this->newsletter);
+    $rtlTemplate = $rtlRenderer->render($this->newsletter);
+    $ltrDOM = $this->dOMParser->parseStr($ltrTemplate['html']);
+    $rtlDOM = $this->dOMParser->parseStr($rtlTemplate['html']);
+
+    verify($rtlDOM->query('body')->attr('style'))->stringContainsString('direction:rtl');
+    verify($rtlDOM->query('table.mailpoet_template')->attr('style'))->stringContainsString('direction:rtl');
+    verify($rtlDOM('td.mailpoet_content-cols-two', 0)->html())
+      ->equals($ltrDOM('td.mailpoet_content-cols-two', 0)->html());
   }
 
   public function testItDoesNotRenderDirectionAttributesForLtrEmails() {
@@ -852,6 +867,73 @@ class RendererTest extends \MailPoetTest {
       $this->diContainer->get(EmailContextBuilder::class),
       $this->diContainer->get(CouponBlockFailureTranslator::class)
     );
+  }
+
+  private function getColumnsOnlyBody(): array {
+    return [
+      'content' => [
+        'type' => 'container',
+        'orientation' => 'vertical',
+        'styles' => [
+          'block' => [
+            'backgroundColor' => 'transparent',
+          ],
+        ],
+        'blocks' => [
+          [
+            'type' => 'container',
+            'orientation' => 'horizontal',
+            'styles' => [
+              'block' => [
+                'backgroundColor' => 'transparent',
+              ],
+            ],
+            'blocks' => [
+              [
+                'type' => 'container',
+                'orientation' => 'vertical',
+                'styles' => [
+                  'block' => [
+                    'backgroundColor' => 'transparent',
+                  ],
+                ],
+                'blocks' => [
+                  [
+                    'type' => 'spacer',
+                    'styles' => [
+                      'block' => [
+                        'backgroundColor' => 'transparent',
+                        'height' => '24px',
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+              [
+                'type' => 'container',
+                'orientation' => 'vertical',
+                'styles' => [
+                  'block' => [
+                    'backgroundColor' => 'transparent',
+                  ],
+                ],
+                'blocks' => [
+                  [
+                    'type' => 'spacer',
+                    'styles' => [
+                      'block' => [
+                        'backgroundColor' => 'transparent',
+                        'height' => '48px',
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
   }
 
   public function makeAttachment($upload, $parentPostId = 0) {

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/FooterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/FooterTest.php
@@ -63,6 +63,22 @@ class FooterTest extends \MailPoetUnitTest {
     verify($output)->equals($expectedResult);
   }
 
+  public function testItAppliesRtlDefaultTextAlignment() {
+    unset($this->block['styles']['text']['textAlign']);
+    $output = $this->renderer->render($this->block, true);
+    verify($output)->stringContainsString('text-align: right;');
+
+    $this->block['styles']['text']['textAlign'] = 'left';
+    $output = $this->renderer->render($this->block, true);
+    verify($output)->stringContainsString('text-align: right;');
+  }
+
+  public function testItPreservesExplicitRtlTextAlignment() {
+    $this->block['styles']['text']['textAlign'] = 'justify';
+    $output = $this->renderer->render($this->block, true);
+    verify($output)->stringContainsString('text-align: justify;');
+  }
+
   public function testItPrefersInlinedCssForLinks() {
     $this->block['text'] = '<p>Footer text. <a href="http://example.com" style="color:#aaaaaa;">link</a></p>';
     $output = $this->renderer->render($this->block);

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/HeaderTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/HeaderTest.php
@@ -63,6 +63,22 @@ class HeaderTest extends \MailPoetUnitTest {
     verify($output)->equals($expectedResult);
   }
 
+  public function testItAppliesRtlDefaultTextAlignment() {
+    unset($this->block['styles']['text']['textAlign']);
+    $output = $this->renderer->render($this->block, true);
+    verify($output)->stringContainsString('text-align: right;');
+
+    $this->block['styles']['text']['textAlign'] = 'left';
+    $output = $this->renderer->render($this->block, true);
+    verify($output)->stringContainsString('text-align: right;');
+  }
+
+  public function testItPreservesExplicitRtlTextAlignment() {
+    $this->block['styles']['text']['textAlign'] = 'center';
+    $output = $this->renderer->render($this->block, true);
+    verify($output)->stringContainsString('text-align: center;');
+  }
+
   public function testItPrefersInlinedCssForLinks() {
     $this->block['text'] = '<p>Header text. <a href="http://example.com" style="color:#aaaaaa;">link</a></p>';
     $output = $this->renderer->render($this->block);

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/RendererTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/RendererTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Newsletter\Renderer\Blocks;
 
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\WooCommerce\Helper;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class RendererTest extends \MailPoetUnitTest {
@@ -197,5 +198,141 @@ class RendererTest extends \MailPoetUnitTest {
     verify($result)->notNull();
     verify(is_array($result))->true();
     verify(count($result))->equals(1);
+  }
+
+  public function testItKeepsNonTextBlockAlignmentStableInRtl() {
+    $renderer = $this->createRendererWithRealNonTextBlocks();
+    foreach ($this->nonTextBlocksWithMissingAlignment() as $blockType => $block) {
+      $ltrOutput = $this->renderSingleBlock($renderer, $block, false);
+      $rtlOutput = $this->renderSingleBlock($renderer, $block, true);
+
+      verify($rtlOutput)->equals($ltrOutput);
+      switch ($blockType) {
+        case 'button':
+          verify($rtlOutput)->stringContainsString('class="mailpoet_button-container" style="text-align:left;"');
+          break;
+        case 'coupon':
+          verify($rtlOutput)->stringContainsString('class="mailpoet_coupon-container" style="text-align:left;"');
+          break;
+        case 'image':
+          verify($rtlOutput)->stringContainsString('class="mailpoet_image mailpoet_padded_vertical mailpoet_padded_side" align="left"');
+          break;
+        case 'social':
+          verify($rtlOutput)->stringContainsString('class="mailpoet_padded_side mailpoet_padded_vertical" valign="top" align="left"');
+          break;
+      }
+    }
+  }
+
+  private function createRendererWithRealNonTextBlocks(): Renderer {
+    $wcHelper = $this->make(Helper::class, [
+      'wcGetCouponCodeById' => 'ABCD-1234',
+    ]);
+
+    return new Renderer(
+      $this->ALC,
+      new Button(),
+      $this->divider,
+      $this->footer,
+      $this->header,
+      new Image(),
+      new Social(),
+      $this->spacer,
+      $this->text,
+      $this->placeholder,
+      new Coupon($wcHelper),
+      $this->dynamicProducts
+    );
+  }
+
+  private function renderSingleBlock(Renderer $renderer, array $block, bool $isRtl): string {
+    $result = $renderer->render($this->newsletter, [
+      'type' => 'container',
+      'blocks' => [
+        [
+          'blocks' => [
+            $block,
+          ],
+        ],
+      ],
+      'styles' => ['block' => []],
+    ], $isRtl);
+
+    $this->assertIsArray($result);
+    $this->assertIsString($result[0]);
+    return $result[0];
+  }
+
+  private function nonTextBlocksWithMissingAlignment(): array {
+    return [
+      'button' => [
+        'type' => 'button',
+        'text' => 'Button',
+        'url' => 'https://example.com',
+        'styles' => [
+          'block' => [
+            'backgroundColor' => '#252525',
+            'borderColor' => '#363636',
+            'borderWidth' => '2px',
+            'borderRadius' => '5px',
+            'borderStyle' => 'solid',
+            'width' => '180px',
+            'lineHeight' => '40px',
+            'fontColor' => '#ffffff',
+            'fontFamily' => 'Source Sans Pro',
+            'fontSize' => '14px',
+            'fontWeight' => 'bold',
+          ],
+        ],
+      ],
+      'coupon' => [
+        'type' => 'coupon',
+        'couponId' => 1,
+        'styles' => [
+          'block' => [
+            'backgroundColor' => '#eeeeee',
+            'borderColor' => '#dddddd',
+            'borderWidth' => '2px',
+            'borderRadius' => '10px',
+            'borderStyle' => 'solid',
+            'lineHeight' => '30px',
+            'fontColor' => '#ccffcc',
+            'fontFamily' => 'Source Sans Pro',
+            'fontSize' => '14px',
+            'fontWeight' => 'bold',
+            'width' => '150px',
+          ],
+        ],
+      ],
+      'image' => [
+        'type' => 'image',
+        'link' => 'http://example.com',
+        'src' => 'http://mailpoet.localhost/image.jpg',
+        'alt' => 'Alt text',
+        'fullWidth' => false,
+        'width' => '310px',
+        'height' => '390px',
+        'styles' => [
+          'block' => [],
+        ],
+      ],
+      'social' => [
+        'type' => 'social',
+        'styles' => [
+          'block' => [],
+        ],
+        'icons' => [
+          [
+            'type' => 'socialIcon',
+            'iconType' => 'facebook',
+            'link' => 'http://www.facebook.com',
+            'image' => 'http://mailpoet.localhost/Facebook.png',
+            'height' => '32px',
+            'width' => '32px',
+            'text' => 'Facebook',
+          ],
+        ],
+      ],
+    ];
   }
 }

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -178,7 +178,7 @@ class TextTest extends \MailPoetUnitTest {
     $rulePosition = strpos($blockquoteHtml, '<td width="2" bgcolor="#565656"></td>');
     $this->assertIsInt($contentPosition);
     $this->assertIsInt($rulePosition);
-    $this->assertLessThan($rulePosition, $contentPosition);
+    $this->assertLessThan($contentPosition, $rulePosition);
   }
 
   public function testItShouldRemoveEmptyParagraphs() {

--- a/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/Blocks/TextTest.php
@@ -145,6 +145,42 @@ class TextTest extends \MailPoetUnitTest {
     verify($blockquoteTable)->equals($expectedResult);
   }
 
+  public function testItRendersRtlParagraphsHeadingsAndLists() {
+    $this->block['text'] = '<p>Text</p><p style="text-align: left;">Left</p><h1>Heading</h1><ul><li>Item</li></ul>';
+    $output = (new Text)->render($this->block, true);
+
+    verify($output)->stringContainsString('word-wrap:break-word;text-align: right;">');
+    verify($output)->stringContainsString('text-align: left;text-align: right;">');
+    verify($output)->stringContainsString('<h1 style="text-align:right;padding:0;font-style:normal;font-weight:normal;">Heading</h1>');
+    verify($output)->stringContainsString('<ul class="mailpoet_paragraph" style="padding-top:0;padding-bottom:0;margin-top:10px;text-align:right;margin-bottom:10px;">');
+    verify($output)->stringContainsString('<li class="mailpoet_paragraph" style="text-align:right;margin-bottom:10px;">Item</li>');
+  }
+
+  public function testItPreservesExplicitRtlTextAlignments() {
+    $this->block['text'] = '<p style="text-align: center;">Center</p><h1 style="text-align: justify;">Heading</h1><ul style="text-align: right;"><li>Item</li></ul>';
+    $output = (new Text)->render($this->block, true);
+
+    verify($output)->stringContainsString('text-align: center;">');
+    verify($output)->stringContainsString('<h1 style="text-align: justify;padding:0;');
+    verify($output)->stringContainsString('style="text-align: right;padding-top:0;');
+  }
+
+  public function testItRendersRtlBlockquoteRuleOnLeadingSide() {
+    $this->block['text'] = '<blockquote><p>Quote</p></blockquote>';
+    $output = (new Text)->render($this->block, true);
+    $blockquote = $this->parser->parseStr($output)->query('table.mailpoet_blockquote');
+    $this->assertInstanceOf(pQuery::class, $blockquote);
+    $blockquoteElement = $blockquote[0];
+    $this->assertInstanceOf(DomNode::class, $blockquoteElement);
+    $blockquoteHtml = $blockquoteElement->toString();
+
+    $contentPosition = strpos($blockquoteHtml, '<td valign="top">');
+    $rulePosition = strpos($blockquoteHtml, '<td width="2" bgcolor="#565656"></td>');
+    $this->assertIsInt($contentPosition);
+    $this->assertIsInt($rulePosition);
+    $this->assertLessThan($rulePosition, $contentPosition);
+  }
+
   public function testItShouldRemoveEmptyParagraphs() {
     $this->block['text'] = '<p></p><p>Text</p><p></p><p>Text2</p><p></p><p></p>';
     $output = (new Text)->render($this->block);

--- a/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
@@ -108,6 +108,9 @@ class StylesHelperTest extends \MailPoetUnitTest {
     $block = ['styles' => ['block' => ['textAlign' => 'left']]];
     verify(StylesHelper::applyTextAlignment($block, 'right'))->equals(['styles' => ['block' => ['textAlign' => 'right']]]);
 
+    $block = ['styles' => ['block' => ['textAlign' => 'bright']]];
+    verify(StylesHelper::applyTextAlignment($block, 'right'))->equals(['styles' => ['block' => ['textAlign' => 'right']]]);
+
     foreach (['center', 'right', 'justify'] as $alignment) {
       $block = ['styles' => ['block' => ['textAlign' => $alignment]]];
       verify(StylesHelper::applyTextAlignment($block, 'right'))->equals($block);
@@ -119,6 +122,8 @@ class StylesHelperTest extends \MailPoetUnitTest {
       ->equals('color: #000000;text-align:right;');
     verify(StylesHelper::applyTextAlignment('text-align:left;', 'right'))
       ->equals('text-align:left;text-align:right;');
+    verify(StylesHelper::applyTextAlignment('text-align:rightly;', 'right'))
+      ->equals('text-align:rightly;text-align:right;');
 
     foreach (['center', 'right', 'justify'] as $alignment) {
       $style = 'text-align:' . $alignment . ';';

--- a/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
+++ b/mailpoet/tests/unit/Newsletter/Renderer/StylesHelperTest.php
@@ -100,4 +100,36 @@ class StylesHelperTest extends \MailPoetUnitTest {
     verify(StylesHelper::applyTextAlignment($blockWithExtraSpaces))
       ->equals("color: #000000; font-size: 16px;text-align:left;");
   }
+
+  public function testItAppliesDefaultTextAlignmentToArrayBlocks(): void {
+    $block = ['styles' => ['block' => []]];
+    verify(StylesHelper::applyTextAlignment($block, 'right'))->equals(['styles' => ['block' => ['textAlign' => 'right']]]);
+
+    $block = ['styles' => ['block' => ['textAlign' => 'left']]];
+    verify(StylesHelper::applyTextAlignment($block, 'right'))->equals(['styles' => ['block' => ['textAlign' => 'right']]]);
+
+    foreach (['center', 'right', 'justify'] as $alignment) {
+      $block = ['styles' => ['block' => ['textAlign' => $alignment]]];
+      verify(StylesHelper::applyTextAlignment($block, 'right'))->equals($block);
+    }
+  }
+
+  public function testItAppliesDefaultTextAlignmentToStringStyles(): void {
+    verify(StylesHelper::applyTextAlignment('color: #000000', 'right'))
+      ->equals('color: #000000;text-align:right;');
+    verify(StylesHelper::applyTextAlignment('text-align:left;', 'right'))
+      ->equals('text-align:left;text-align:right;');
+
+    foreach (['center', 'right', 'justify'] as $alignment) {
+      $style = 'text-align:' . $alignment . ';';
+      verify(StylesHelper::applyTextAlignment($style, 'right'))->equals($style);
+    }
+  }
+
+  public function testItAppliesTextAlignmentToArrayTextStyles(): void {
+    $block = ['styles' => ['text' => ['fontSize' => '12px', 'textAlign' => 'left']]];
+
+    verify(StylesHelper::applyTextAlignment($block, 'right', 'text'))
+      ->equals(['styles' => ['text' => ['fontSize' => '12px', 'textAlign' => 'right']]]);
+  }
 }


### PR DESCRIPTION
## Description

Adds a scoped RTL unblocker for the legacy MailPoet email renderer. When WordPress is running in an RTL locale, freshly rendered legacy MailPoet emails now include root/body/template RTL direction and right-aligned defaults for text-like content.

This intentionally does not add RTL support for the Gutenberg/WooCommerce Email Editor, MailPoet admin UI, public forms, premium UI, or cached already-rendered queue bodies.

## Code review notes

This treats missing alignment and historical/default `left` alignment as the legacy renderer default. In RTL legacy emails those text-like defaults render as `right`, while explicit `center`, `right`, and `justify` are preserved. Existing saved RTL emails with intentional left-aligned text may therefore render right-aligned because that intent cannot be distinguished from the historical default.

## QA notes

1. Set WordPress to an RTL locale, for example Hebrew (`he_IL`).
2. Open or create a legacy MailPoet email with headings, paragraphs, lists, a blockquote, header/footer text, and non-text blocks such as buttons/images/social/columns.
3. Open the rendered view-in-browser preview.
4. Confirm the rendered email has RTL document direction and default text-like content is right-aligned.
5. Confirm explicit centered content remains centered and non-text block alignment is not unexpectedly flipped.
6. Repeat in an LTR locale or inspect the same test fixture to confirm LTR output remains unchanged.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7992

## After-merge notes

Follow-up work should cover Gutenberg/WooCommerce Email Editor sent-email output separately. Admin UI, public forms, premium UI, and full product-wide RTL support remain out of scope for this PR.

## Screenshots or screencast <!-- if applicable -->

### Editor

<img width="1742" height="1115" alt="editor" src="https://github.com/user-attachments/assets/a2d0af79-795c-4053-954e-8f3b4bc0c2a2" />

### Preview

<img width="654" height="424" alt="preview" src="https://github.com/user-attachments/assets/2a3ef4e1-e93e-46a1-88c1-5eacae5fdbbe" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-7992-rtl-sent-email-support)

_The latest successful build from `add/STOMAIL-7992-rtl-sent-email-support` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Review Summary

**1 Issue Found**

### Bug (1)

- RTL Blockquote Rule Reordering Not Implemented — Logic bug in `mailpoet/lib/Newsletter/Renderer/Blocks/Text.php` (`convertBlockquotesToTables()`): the `$isRtl` parameter is unused and blockquote table cell order is not adjusted for RTL, causing the RTL-specific test `testItRendersRtlBlockquoteRuleOnLeadingSide()` to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->