### PR TITLE
Translate email editor strings under the MailPoet text domain

### DIFF
--- a/mailpoet/changelog/2026-04-29-12-14-53-updated-translate-email-editor-strings-provided-by-the-woo.md
+++ b/mailpoet/changelog/2026-04-29-12-14-53-updated-translate-email-editor-strings-provided-by-the-woo.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+Translate email editor strings provided by the @woocommerce/email-editor package under the MailPoet text domain

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -54,7 +54,7 @@
     "@woocommerce/components": "^13.1.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "1.10.1",
+    "@woocommerce/email-editor": "2.0.0",
     "@wordpress/a11y": "^4.43.0",
     "@wordpress/api-fetch": "^7.43.0",
     "@wordpress/block-editor": "^15.16.0",

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -603,6 +603,14 @@ const emailEditorIntegration = Object.assign({}, wpScriptConfig, {
     // Substitute the `__i18n_text_domain__` identifier used by the
     // @woocommerce/email-editor package so its translation strings extract
     // and translate under the MailPoet text domain instead of `woocommerce`.
+    //
+    // `DefinePlugin` does a literal source-code substitution: every
+    // occurrence of the key in the bundled source is replaced by the
+    // value's JS source text verbatim. `JSON.stringify('mailpoet')`
+    // returns the seven-character string `"mailpoet"` (quotes included),
+    // which becomes a string literal in the output. Passing `'mailpoet'`
+    // directly would inject the bare identifier `mailpoet`, which
+    // webpack would then try to resolve as a variable reference.
     new webpack.DefinePlugin({
       __i18n_text_domain__: JSON.stringify('mailpoet'),
     }),

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -600,6 +600,12 @@ const emailEditorIntegration = Object.assign({}, wpScriptConfig, {
         return;
       },
     }),
+    // Substitute the `__i18n_text_domain__` identifier used by the
+    // @woocommerce/email-editor package so its translation strings extract
+    // and translate under the MailPoet text domain instead of `woocommerce`.
+    new webpack.DefinePlugin({
+      __i18n_text_domain__: JSON.stringify('mailpoet'),
+    }),
     ...(PRODUCTION_ENV ? [] : [new ForkTsCheckerWebpackPlugin()]),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.18.1)
       '@woocommerce/email-editor':
-        specifier: 1.10.1
-        version: 1.10.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
+        specifier: 2.0.0
+        version: 2.0.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/a11y':
         specifier: ^4.43.0
         version: 4.44.0
@@ -4204,8 +4204,8 @@ packages:
     peerDependencies:
       lodash: ^4.17.0
 
-  '@woocommerce/email-editor@1.10.1':
-    resolution: {integrity: sha512-4bMgD72FH885IvTakiNhX5jiAbGqqm5+OOcNXrz4NB06UU8GdYGtFO+GOE9XjPXrnD4IJAyasxdbShcJvv/OLA==}
+  '@woocommerce/email-editor@2.0.0':
+    resolution: {integrity: sha512-WQRWiPAgYjYRhQ3WyqVi6n/iC7ipaFeefc7B8swnGNIz+iBfgZ2RRtgyQf/pIPM+fA2RidxQ/YtdbrwdN+XMZA==}
 
   '@woocommerce/navigation@8.2.0':
     resolution: {integrity: sha512-joAbrzdhrnWf91kEwuNO3hzT0IiUuh8SNOs0Qbth/heZaN+SixA5yJ98UqEHNa2Mitjm5BTC4M0Qk7X+I8uUvQ==}
@@ -4336,13 +4336,6 @@ packages:
   '@wordpress/commands@0.29.0':
     resolution: {integrity: sha512-HqTrYfQw/5cdT2hPgmuKW6gugnt1Pqtg9zjRHUa+D4ME7mjR4dYQoHRgnFM+hm8OOuEZRVBsa1kYO3t3041Jew==}
     engines: {node: '>=12'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
-  '@wordpress/commands@1.39.0':
-    resolution: {integrity: sha512-zNFvNyfv+/mLFa+kPcAtrdPscj2XT+9eVMzS9jN645hcFQZdep6YhSGkaK6jVw9Vu+qTsw04o31Q8PaWejI9Mw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -4488,10 +4481,6 @@ packages:
     resolution: {integrity: sha512-sDgRPjNBToRKgYrpwvMRv2Yc7/17+sp8hm/rRnbubwb+d/DbGkK4Tc/r4sNLSZCqUAtcBXq9uk1lzvhge3QUSg==}
     engines: {node: '>=12'}
 
-  '@wordpress/dom-ready@4.39.0':
-    resolution: {integrity: sha512-qHhRnlSK0E2GTMo1D2gOtcr9FW11HG8X8lZLkmf3N0zhjem+MP7G15jFB7wophpypL3plnBHMxiDD6qUHh9dSg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/dom-ready@4.44.0':
     resolution: {integrity: sha512-YSiDpmelYLgFu0/Mki9OogEDO5t8Dr1pZnJU/RYRC7aawWGxidgNr0hael+9jO6pLAd+3LiAEV5cAvLg0V1pZQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -4592,10 +4581,6 @@ packages:
     resolution: {integrity: sha512-ndHLf9fNpUofYTMvFo49JHaYcbQKbTJ/08v6lQkNH5Y2pMJniIM4NcDz5Dsi/IgmhBy3ZiZJO6VAdNhRQ5iY1A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/global-styles-engine@1.6.0':
-    resolution: {integrity: sha512-SlV6RwNrnbh3/0fE6kRdTZLt7Fj02sTNEnEMq1rKpr+P5i8ZYFXZj5nW2Mb4lPpLNCQ2DiKxDpo6TEtscrBnUw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/global-styles-ui@1.11.0':
     resolution: {integrity: sha512-tokz38jpAB3wB8hgPlfmH3d0c4Tn7dDVD5m8w0XNWYnNRAhW2FAzPbSRx0FksNRZrNheAvu0d9tOYtzhYRWm5w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -4641,12 +4626,6 @@ packages:
   '@wordpress/icons@10.32.0':
     resolution: {integrity: sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/icons@11.6.0':
-    resolution: {integrity: sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/icons@12.2.0':
     resolution: {integrity: sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==}
@@ -4913,10 +4892,6 @@ packages:
   '@wordpress/style-engine@1.41.0':
     resolution: {integrity: sha512-aM5bbJn6m8SHRotCoh/fSGuIB0MQJoVFBjpzIDoUDQ1KlO7CbY+fj9daDV1FZPMNv0h0ZEFWZ+y7Gv/CERypMA==}
     engines: {node: '>=12'}
-
-  '@wordpress/style-engine@2.39.0':
-    resolution: {integrity: sha512-UhQ8rzIfdWYV0uITZOWl1G1HI+9ay679Ig+9W7qcGjp8Okwl4XyMF+B7f1jtqjbAhq45spzUgPs1d3+F4aiWYA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/style-engine@2.44.0':
     resolution: {integrity: sha512-VTjiY2hWVg8jmudRrxcKqjHmlCbPBWztBakBwNQgfcQ8Mp3ohZHR1WRJyX6ZE4ujpyH5iEFOw98jPAEqPwkvmQ==}
@@ -17304,24 +17279,24 @@ snapshots:
       moment-timezone: 0.5.45
       qs: 6.15.0
 
-  '@woocommerce/email-editor@1.10.1(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
+  '@woocommerce/email-editor@2.0.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/base-styles': 6.20.0
       '@wordpress/block-editor': 15.17.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/block-library': 9.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/blocks': 15.17.0(react@18.3.1)
-      '@wordpress/commands': 1.39.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.44.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/components': 32.6.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/core-data': 7.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/data': 10.44.0(react@18.3.1)
       '@wordpress/data-controls': 4.44.0(react@18.3.1)
-      '@wordpress/dom-ready': 4.39.0
+      '@wordpress/dom-ready': 4.44.0
       '@wordpress/editor': 14.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/element': 6.44.0
       '@wordpress/format-library': 5.44.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))
-      '@wordpress/global-styles-engine': 1.6.0(react@18.3.1)
+      '@wordpress/global-styles-engine': 1.11.0(react@18.3.1)
       '@wordpress/hooks': 4.44.0
       '@wordpress/html-entities': 4.44.0
       '@wordpress/i18n': 6.17.0
@@ -17333,7 +17308,7 @@ snapshots:
       '@wordpress/notices': 5.44.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.44.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.44.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.39.0
+      '@wordpress/priority-queue': 3.44.0
       '@wordpress/private-apis': 1.44.0
       '@wordpress/rich-text': 7.44.0(react@18.3.1)
       '@wordpress/url': 4.44.0
@@ -17756,26 +17731,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'
-      - supports-color
-
-  '@wordpress/commands@1.39.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/components': 32.6.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.44.0(react@18.3.1)
-      '@wordpress/element': 6.44.0
-      '@wordpress/i18n': 6.17.0
-      '@wordpress/icons': 11.6.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.44.0(react@18.3.1)
-      '@wordpress/private-apis': 1.44.0
-      clsx: 2.1.1
-      cmdk: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
       - supports-color
 
   '@wordpress/commands@1.44.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -18259,8 +18214,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
 
-  '@wordpress/dom-ready@4.39.0': {}
-
   '@wordpress/dom-ready@4.44.0': {}
 
   '@wordpress/dom@3.58.0':
@@ -18641,20 +18594,6 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@wordpress/global-styles-engine@1.6.0(react@18.3.1)':
-    dependencies:
-      '@wordpress/blocks': 15.17.0(react@18.3.1)
-      '@wordpress/data': 10.44.0(react@18.3.1)
-      '@wordpress/i18n': 6.17.0
-      '@wordpress/style-engine': 2.39.0
-      colord: 2.9.3
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-    transitivePeerDependencies:
-      - react
-
   '@wordpress/global-styles-ui@1.11.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/a11y': 4.44.0
@@ -18735,12 +18674,6 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
     transitivePeerDependencies:
       - react
-
-  '@wordpress/icons@11.6.0(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.44.0
-      '@wordpress/primitives': 4.44.0(react@18.3.1)
-      react: 18.3.1
 
   '@wordpress/icons@12.2.0(react@18.3.1)':
     dependencies:
@@ -19298,10 +19231,6 @@ snapshots:
   '@wordpress/style-engine@1.41.0':
     dependencies:
       '@babel/runtime': 7.29.2
-      change-case: 4.1.2
-
-  '@wordpress/style-engine@2.39.0':
-    dependencies:
       change-case: 4.1.2
 
   '@wordpress/style-engine@2.44.0':


### PR DESCRIPTION
## Description

The new block-based email editor pulls most of its UI from the `@woocommerce/email-editor` NPM package. Until now, every translation call inside that package hardcoded the `woocommerce` text domain, which meant MailPoet couldn't extract or translate those strings under its own domain — they only translated when WooCommerce was installed and its language pack happened to cover them.

[woocommerce/woocommerce#64356](https://github.com/woocommerce/woocommerce/pull/64356) (shipped in [`@woocommerce/email-editor@2.0.0`](https://www.npmjs.com/package/@woocommerce/email-editor/v/2.0.0)) replaces the hardcoded domain with a `__i18n_text_domain__` identifier that consumers substitute at bundle time via `webpack.DefinePlugin`. The package falls back to `'woocommerce'` at runtime when the identifier isn't substituted, so consumers that don't update their build still get a working editor.

This PR:

1. Adds the `webpack.DefinePlugin` substitution to MailPoet's `email_editor_integration` webpack config so the package's strings extract under the `mailpoet` text domain.
2. Bumps `@woocommerce/email-editor` from `1.10.1` to `2.0.0`.

## Code review notes

- The `DefinePlugin` entry sits inside the `emailEditorIntegration` config only — other webpack configs in this file don't bundle the `@woocommerce/email-editor` package, so they don't need the substitution.
- The `2.0.0` major bump is the upstream package signalling the breaking change from hardcoded `'woocommerce'` to the variable text domain. With the `DefinePlugin` already in place, the bump is a no-op for runtime behaviour and just changes which domain extraction picks up.

## QA notes

End-to-end pipeline verified locally against `@woocommerce/email-editor@2.0.0`:

- Bundle: **0** unresolved `__i18n_text_domain__` references in the rebuilt `email_editor_integration.js`; upstream calls land under `"mailpoet"` (e.g. `__('Personalization Tags', "mailpoet")`, `__('This is the Content block.', "mailpoet")`, `__('Close editor', "mailpoet")`). The package's runtime fallback branch is dead-code-eliminated by the consumer's minifier — only the JSDoc comment remains.
- `./do translations:build` extracts **256** `email_editor_integration` entries under the `mailpoet` domain in `lang/mailpoet.pot`.
- Editor opens cleanly in `wp-env` (existing newsletter post) — Gutenberg toolbar (Block Inserter, Undo, Redo, Document Overview, Save/Save and continue, View, Styles, Settings, Options) renders, editor canvas renders, sidebar tabs (Actions / Settings / Content) render. **0** browser console errors. **0** new entries in `wp-content/debug.log` related to the bump (only pre-existing Mockery deprecations and a session warning).

Reviewer can reproduce the bundle check with: `cd mailpoet && pnpm install && pnpm compile:js && grep -c '__i18n_text_domain__' assets/dist/js/email_editor_integration/email_editor_integration.js` (the expected count is `1`, matching the JSDoc comment of the upstream runtime fallback).

## Linked PRs

- [woocommerce/woocommerce#64356](https://github.com/woocommerce/woocommerce/pull/64356) — upstream `__i18n_text_domain__` support (merged, shipped in `@woocommerce/email-editor@2.0.0`)
- [mailpoet/mailpoet#6638](https://github.com/mailpoet/mailpoet/pull/6638) — STOMAIL-7971, the script-translations wiring this PR builds on (merged)

## Linked tickets

- [STOMAIL-7524](https://linear.app/a8c/issue/STOMAIL-7524/update-translations-domain-in-the-email-editor-packages)

## After-merge notes

The `lang/mailpoet.pot` push to Transifex happens as part of the regular release pipeline — no manual action required at merge time. Translators will see the **256** newly-domained `email_editor_integration` entries (`Personalization Tags`, `Start with an email preset`, `This is the Content block.`, etc.) on the next release cycle. Until those translations land in language packs, the strings fall back to the `woocommerce` runtime default the upstream package ships, so the editor still loads in non-English locales — just without MailPoet-owned translations for those specific strings.

## Screenshots or screencast

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/stomail-7524-email-editor-text-domain)

_The latest successful build from `update/stomail-7524-email-editor-text-domain` will be used. If none is available, the link won't work._