### PR TITLE
Duplicate automation

### DIFF
--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -180,6 +180,7 @@ export function AutomationListing(): JSX.Element {
     loadLegacyAutomations,
     restoreAutomation,
     restoreLegacyAutomation,
+    duplicateAutomation,
     trashAutomation,
     trashLegacyAutomation,
     deleteAutomation,
@@ -356,6 +357,13 @@ export function AutomationListing(): JSX.Element {
     [restoreAutomation, restoreLegacyAutomation],
   );
 
+  const duplicate = useCallback(
+    (automation: AutomationItem): void => {
+      void (duplicateAutomation(automation) as Promise<void>);
+    },
+    [duplicateAutomation],
+  );
+
   const runPendingAction = useCallback((): void => {
     if (!pendingAction) return;
     pendingAction.targets.forEach((automation) => {
@@ -404,6 +412,16 @@ export function AutomationListing(): JSX.Element {
         },
       },
       {
+        id: 'duplicate',
+        label: __('Duplicate', 'mailpoet'),
+        supportsBulk: false,
+        isEligible: (item) =>
+          !item.isLegacy && item.status !== AutomationStatus.TRASH,
+        callback: (targets) => {
+          if (targets[0]) duplicate(targets[0]);
+        },
+      },
+      {
         id: 'trash',
         label: _x('Trash', 'verb', 'mailpoet'),
         supportsBulk: false,
@@ -436,7 +454,7 @@ export function AutomationListing(): JSX.Element {
         },
       },
     ],
-    [restore],
+    [duplicate, restore],
   );
 
   const emptyLabel =

--- a/mailpoet/changelog/2026-04-29-19-02-37-added-add-a-duplicate-action-to-automation-listings.md
+++ b/mailpoet/changelog/2026-04-29-19-02-37-added-add-a-duplicate-action-to-automation-listings.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Duplicate action for automations.

--- a/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
@@ -44,6 +44,9 @@ class DuplicateAutomationController {
       $this->wordPress->wpGetCurrentUser()
     );
     $duplicate->setStatus(Automation::STATUS_DRAFT);
+    foreach ($automation->getAllMetas() as $key => $value) {
+      $duplicate->setMeta((string)$key, $value);
+    }
 
     $steps = $duplicate->getSteps();
     foreach ($steps as $id => $step) {
@@ -97,7 +100,8 @@ class DuplicateAutomationController {
         array_map(function (NextStep $nextStep) use ($newIds): NextStep {
           $nextStepId = $nextStep->getId();
           return new NextStep($nextStepId ? $newIds[$nextStepId] : null);
-        }, $step->getNextSteps())
+        }, $step->getNextSteps()),
+        $step->getFilters()
       );
     }
     return $newSteps;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -590,7 +590,7 @@ class SendEmailAction implements Action {
 
   public function onDuplicate(Step $step): Step {
     $args = $step->getArgs();
-    $emailId = (int)$args['email_id'];
+    $emailId = (int)($args['email_id'] ?? 0);
     if (!$emailId) {
       // if the email is not yet designed, we don't need to duplicate it
       return $step;

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationsDuplicateEndpointTest.php
@@ -4,8 +4,14 @@ namespace MailPoet\REST\Automation\Automations;
 
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
+use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\REST\Automation\AutomationTest;
 
 require_once __DIR__ . '/../AutomationTest.php';
@@ -121,5 +127,116 @@ class AutomationsDuplicateEndpointTest extends AutomationTest {
     $automation = $this->automationStorage->getAutomation($id);
     $this->assertInstanceOf(Automation::class, $automation);
     $this->assertTrue($automation->equals($expectedAutomation));
+  }
+
+  public function testItDuplicatesAutomationEmailWhenDuplicatingAutomation(): void {
+    $newslettersRepository = $this->diContainer->get(NewslettersRepository::class);
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+    $newsletter->setSubject('Original email');
+    $newsletter->setSenderName('Sender');
+    $newsletter->setSenderAddress('sender@example.com');
+    $newslettersRepository->persist($newsletter);
+    $newslettersRepository->flush();
+    $originalNewsletterId = $newsletter->getId();
+    $this->assertIsInt($originalNewsletterId);
+
+    $automationId = $this->automationStorage->createAutomation(
+      new Automation(
+        'Testing automation with email',
+        [
+          'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('send-email')]),
+          'send-email' => new Step(
+            'send-email',
+            Step::TYPE_ACTION,
+            'mailpoet:send-email',
+            [
+              'email_id' => $originalNewsletterId,
+              'subject' => 'Original email',
+              'sender_name' => 'Sender',
+              'sender_address' => 'sender@example.com',
+            ],
+            []
+          ),
+        ],
+        wp_get_current_user()
+      )
+    );
+
+    $data = $this->post(sprintf(self::ENDPOINT_PATH, $automationId));
+
+    $sendEmailStep = $this->getStepByKey($data['data']['steps'], 'mailpoet:send-email');
+    $this->assertIsArray($sendEmailStep);
+    $duplicatedNewsletterId = (int)$sendEmailStep['args']['email_id'];
+    $this->assertNotSame($originalNewsletterId, $duplicatedNewsletterId);
+    $this->assertSame('Copy of Original email', $sendEmailStep['args']['subject']);
+
+    $duplicatedNewsletter = $newslettersRepository->findOneBy(['id' => $duplicatedNewsletterId]);
+    $this->assertInstanceOf(NewsletterEntity::class, $duplicatedNewsletter);
+    $this->assertSame('Copy of Original email', $duplicatedNewsletter->getSubject());
+    $this->assertSame(NewsletterEntity::STATUS_ACTIVE, $duplicatedNewsletter->getStatus());
+
+    $originalNewsletter = $newslettersRepository->findOneBy(['id' => $originalNewsletterId]);
+    $this->assertInstanceOf(NewsletterEntity::class, $originalNewsletter);
+    $this->assertSame('Original email', $originalNewsletter->getSubject());
+  }
+
+  public function testItPreservesMetaAndStepFiltersWhenDuplicatingAutomation(): void {
+    $filters = new Filters(
+      Filters::OPERATOR_AND,
+      [
+        new FilterGroup(
+          'group-1',
+          FilterGroup::OPERATOR_AND,
+          [
+            new Filter(
+              'filter-1',
+              'string',
+              'mailpoet:subscriber:email',
+              'contains',
+              ['value' => 'example.com']
+            ),
+          ]
+        ),
+      ]
+    );
+    $automation = new Automation(
+      'Testing automation with meta and filters',
+      [
+        'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('delay')]),
+        'delay' => new Step(
+          'delay',
+          Step::TYPE_ACTION,
+          'core:delay',
+          [
+            'delay' => 1,
+            'delay_type' => 'HOURS',
+          ],
+          [],
+          $filters
+        ),
+      ],
+      wp_get_current_user()
+    );
+    $automation->setMeta('mailpoet:run-once-per-subscriber', true);
+    $automationId = $this->automationStorage->createAutomation($automation);
+
+    $data = $this->post(sprintf(self::ENDPOINT_PATH, $automationId));
+
+    $this->assertSame(['mailpoet:run-once-per-subscriber' => true], $data['data']['meta']);
+
+    $delayStep = $this->getStepByKey($data['data']['steps'], 'core:delay');
+    $this->assertIsArray($delayStep);
+    $this->assertSame($filters->toArray(), $delayStep['filters']);
+  }
+
+  private function getStepByKey(array $steps, string $key): ?array {
+    foreach ($steps as $step) {
+      if ($step['key'] === $key) {
+        return $step;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Description

Add option to duplicate automation.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7993

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->


<img width="1448" height="689" alt="Screenshot 2026-04-29 at 21 24 14" src="https://github.com/user-attachments/assets/f1a6e603-f931-47e2-8bf8-98ab3cd18494" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7993-duplicate-automations)

_The latest successful build from `stomail-7993-duplicate-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->