### PR TITLE
Allow bulk actions in automations

### DIFF
--- a/mailpoet/assets/js/src/automation/listing/index.tsx
+++ b/mailpoet/assets/js/src/automation/listing/index.tsx
@@ -2,7 +2,7 @@ import {
   __experimentalConfirmDialog as ConfirmDialog,
   TabPanel,
 } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import {
   DataViews,
   filterSortAndPaginate,
@@ -10,6 +10,7 @@ import {
   Action,
 } from '@wordpress/dataviews';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { storeName } from './store/constants';
@@ -27,8 +28,10 @@ type Group =
   | AutomationStatus.DRAFT
   | AutomationStatus.TRASH;
 
+type AutomationBulkAction = 'duplicate' | 'trash' | 'restore' | 'delete';
+
 type PendingAction = {
-  action: 'trash' | 'delete';
+  action: Extract<AutomationBulkAction, 'trash' | 'delete'>;
   targets: AutomationItem[];
 } | null;
 
@@ -149,6 +152,81 @@ function getActionCopy(pendingAction: PendingAction): {
   };
 }
 
+function getAutomationActionTargets(
+  action: AutomationBulkAction,
+  targets: AutomationItem[],
+): AutomationItem[] {
+  switch (action) {
+    case 'duplicate':
+      return targets.filter(
+        (item) => !item.isLegacy && item.status !== AutomationStatus.TRASH,
+      );
+    case 'trash':
+      return targets.filter((item) => item.status !== AutomationStatus.TRASH);
+    case 'restore':
+    case 'delete':
+      return targets.filter((item) => item.status === AutomationStatus.TRASH);
+    default:
+      return [];
+  }
+}
+
+function getBulkActionSuccessMessage(
+  action: AutomationBulkAction,
+  count: number,
+): string {
+  if (action === 'duplicate') {
+    return sprintf(
+      // translators: %d is the number of automations.
+      _n(
+        '%d automation was duplicated.',
+        '%d automations were duplicated.',
+        count,
+        'mailpoet',
+      ),
+      count,
+    );
+  }
+  if (action === 'trash') {
+    return sprintf(
+      // translators: %d is the number of automations.
+      _n(
+        '%d automation was moved to the trash.',
+        '%d automations were moved to the trash.',
+        count,
+        'mailpoet',
+      ),
+      count,
+    );
+  }
+  if (action === 'restore') {
+    return sprintf(
+      // translators: %d is the number of automations.
+      _n(
+        '%d automation was restored from the trash.',
+        '%d automations were restored from the trash.',
+        count,
+        'mailpoet',
+      ),
+      count,
+    );
+  }
+  return sprintf(
+    // translators: %d is the number of automations.
+    _n(
+      '%d automation was permanently deleted.',
+      '%d automations were permanently deleted.',
+      count,
+      'mailpoet',
+    ),
+    count,
+  );
+}
+
+const createSuccessNotice = (content: string): void => {
+  void dispatch(noticesStore).createSuccessNotice(content);
+};
+
 export function AutomationListingHeader(): JSX.Element {
   return (
     <PageHeader heading={__('Automations', 'mailpoet')}>
@@ -168,6 +246,7 @@ export function AutomationListing(): JSX.Element {
   const [view, setView] = useState<View>(() =>
     getViewFromSearch(new URLSearchParams(location.search)),
   );
+  const [selection, setSelection] = useState<string[]>([]);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
   const latestGroupRef = useRef(group);
   const latestViewRef = useRef(view);
@@ -200,11 +279,17 @@ export function AutomationListing(): JSX.Element {
   useEffect(() => {
     const nextSearch = new URLSearchParams(location.search);
     const nextGroup = getGroupFromSearch(nextSearch);
+    let selectionShouldBeCleared = false;
     if (nextGroup !== latestGroupRef.current) {
       setGroup(nextGroup);
+      selectionShouldBeCleared = true;
     }
     if (!viewMatchesSearch(latestViewRef.current, nextSearch)) {
       setView(getViewFromSearch(nextSearch));
+      selectionShouldBeCleared = true;
+    }
+    if (selectionShouldBeCleared) {
+      setSelection([]);
     }
   }, [location.search]);
 
@@ -249,6 +334,7 @@ export function AutomationListing(): JSX.Element {
 
   const handleViewChange = useCallback(
     (nextView: View) => {
+      setSelection([]);
       setView(nextView);
       updateUrlSearchString(group, nextView);
     },
@@ -262,6 +348,7 @@ export function AutomationListing(): JSX.Element {
 
     const nextView = { ...view, page: 1 };
     setGroup(nextGroup);
+    setSelection([]);
     setView(nextView);
     updateUrlSearchString(nextGroup, nextView);
   };
@@ -347,44 +434,75 @@ export function AutomationListing(): JSX.Element {
     [groupedAutomations],
   );
 
-  const restore = useCallback(
-    (automation: AutomationItem): void => {
-      const action = automation.isLegacy
-        ? restoreLegacyAutomation
-        : restoreAutomation;
-      void (action(automation, AutomationStatus.DRAFT) as Promise<void>);
-    },
-    [restoreAutomation, restoreLegacyAutomation],
-  );
+  const runAutomationAction = useCallback(
+    async (
+      action: AutomationBulkAction,
+      targets: AutomationItem[],
+    ): Promise<void> => {
+      const actionTargets = getAutomationActionTargets(action, targets);
+      if (actionTargets.length === 0) return;
 
-  const duplicate = useCallback(
-    (automation: AutomationItem): void => {
-      void (duplicateAutomation(automation) as Promise<void>);
+      const showsIndividualNotices = actionTargets.length === 1;
+      const noticeOptions = { showSuccessNotice: showsIndividualNotices };
+
+      await Promise.all(
+        actionTargets.map((automation) => {
+          if (action === 'duplicate') {
+            return duplicateAutomation(
+              automation,
+              noticeOptions,
+            ) as Promise<void>;
+          }
+          if (action === 'trash') {
+            const selectedAction = automation.isLegacy
+              ? trashLegacyAutomation
+              : trashAutomation;
+            return selectedAction(automation, noticeOptions) as Promise<void>;
+          }
+          if (action === 'restore') {
+            return automation.isLegacy
+              ? (restoreLegacyAutomation(
+                  automation,
+                  noticeOptions,
+                ) as Promise<void>)
+              : (restoreAutomation(
+                  automation,
+                  AutomationStatus.DRAFT,
+                  noticeOptions,
+                ) as Promise<void>);
+          }
+
+          const selectedAction = automation.isLegacy
+            ? deleteLegacyAutomation
+            : deleteAutomation;
+          return selectedAction(automation, noticeOptions) as Promise<void>;
+        }),
+      );
+
+      if (!showsIndividualNotices) {
+        createSuccessNotice(
+          getBulkActionSuccessMessage(action, actionTargets.length),
+        );
+      }
+
+      setSelection([]);
     },
-    [duplicateAutomation],
+    [
+      deleteAutomation,
+      deleteLegacyAutomation,
+      duplicateAutomation,
+      restoreAutomation,
+      restoreLegacyAutomation,
+      trashAutomation,
+      trashLegacyAutomation,
+    ],
   );
 
   const runPendingAction = useCallback((): void => {
     if (!pendingAction) return;
-    pendingAction.targets.forEach((automation) => {
-      let selectedAction = automation.isLegacy
-        ? deleteLegacyAutomation
-        : deleteAutomation;
-      if (pendingAction.action === 'trash') {
-        selectedAction = automation.isLegacy
-          ? trashLegacyAutomation
-          : trashAutomation;
-      }
-      void (selectedAction(automation) as Promise<void>);
-    });
+    void runAutomationAction(pendingAction.action, pendingAction.targets);
     setPendingAction(null);
-  }, [
-    deleteAutomation,
-    deleteLegacyAutomation,
-    pendingAction,
-    trashAutomation,
-    trashLegacyAutomation,
-  ]);
+  }, [pendingAction, runAutomationAction]);
 
   const actions = useMemo<Action<AutomationItem>[]>(
     () => [
@@ -414,47 +532,49 @@ export function AutomationListing(): JSX.Element {
       {
         id: 'duplicate',
         label: __('Duplicate', 'mailpoet'),
-        supportsBulk: false,
+        supportsBulk: true,
         isEligible: (item) =>
           !item.isLegacy && item.status !== AutomationStatus.TRASH,
         callback: (targets) => {
-          if (targets[0]) duplicate(targets[0]);
+          void runAutomationAction('duplicate', targets);
         },
       },
       {
         id: 'trash',
         label: _x('Trash', 'verb', 'mailpoet'),
-        supportsBulk: false,
+        supportsBulk: true,
         isEligible: (item) => item.status !== AutomationStatus.TRASH,
         callback: (targets) => {
-          if (targets.length > 0) {
-            setPendingAction({ action: 'trash', targets });
+          const actionTargets = getAutomationActionTargets('trash', targets);
+          if (actionTargets.length > 0) {
+            setPendingAction({ action: 'trash', targets: actionTargets });
           }
         },
       },
       {
         id: 'restore',
         label: __('Restore', 'mailpoet'),
-        supportsBulk: false,
+        supportsBulk: true,
         isEligible: (item) => item.status === AutomationStatus.TRASH,
         callback: (targets) => {
-          if (targets[0]) restore(targets[0]);
+          void runAutomationAction('restore', targets);
         },
       },
       {
         id: 'delete',
         label: __('Delete permanently', 'mailpoet'),
-        supportsBulk: false,
+        supportsBulk: true,
         isDestructive: true,
         isEligible: (item) => item.status === AutomationStatus.TRASH,
         callback: (targets) => {
-          if (targets.length > 0) {
-            setPendingAction({ action: 'delete', targets });
+          const actionTargets = getAutomationActionTargets('delete', targets);
+          if (actionTargets.length > 0) {
+            setPendingAction({ action: 'delete', targets: actionTargets });
           }
         },
       },
     ],
-    [duplicate, restore],
+    [runAutomationAction],
   );
 
   const emptyLabel =
@@ -490,6 +610,8 @@ export function AutomationListing(): JSX.Element {
               getItemId={(item) =>
                 `${item.isLegacy ? 'legacy' : 'automation'}-${item.id}`
               }
+              selection={selection}
+              onChangeSelection={setSelection}
               isLoading={!automations}
               empty={<div>{emptyLabel}</div>}
             >

--- a/mailpoet/assets/js/src/automation/listing/store/actions.tsx
+++ b/mailpoet/assets/js/src/automation/listing/store/actions.tsx
@@ -7,10 +7,17 @@ import { Automation, AutomationStatus } from '../automation';
 import { UndoTrashButton } from '../components/actions';
 import { getAutomationEditorUrl } from '../urls';
 
+type NoticeOptions = {
+  showSuccessNotice?: boolean;
+};
+
 const createSuccessNotice = (content: string, options?: unknown) =>
   dispatch(noticesStore).createSuccessNotice(content, options);
 
 const removeNotice = (id: string) => dispatch(noticesStore).removeNotice(id);
+
+const shouldShowSuccessNotice = (options?: NoticeOptions): boolean =>
+  options?.showSuccessNotice !== false;
 
 export function* loadAutomations() {
   const data = yield apiFetch({
@@ -23,16 +30,24 @@ export function* loadAutomations() {
   } as const;
 }
 
-export function* duplicateAutomation(automation: Automation) {
+export function* duplicateAutomation(
+  automation: Automation,
+  options?: NoticeOptions,
+) {
   const data = yield apiFetch({
     path: `/automations/${automation.id}/duplicate`,
     method: 'POST',
   });
 
-  void createSuccessNotice(
-    // translators: %s is the automation name
-    sprintf(__('Automation "%s" was duplicated.', 'mailpoet'), automation.name),
-  );
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(
+      // translators: %s is the automation name
+      sprintf(
+        __('Automation "%s" was duplicated.', 'mailpoet'),
+        automation.name,
+      ),
+    );
+  }
 
   return {
     type: 'ADD_AUTOMATION',
@@ -40,7 +55,10 @@ export function* duplicateAutomation(automation: Automation) {
   } as const;
 }
 
-export function* trashAutomation(automation: Automation) {
+export function* trashAutomation(
+  automation: Automation,
+  options?: NoticeOptions,
+) {
   const data = yield apiFetch({
     path: `/automations/${automation.id}`,
     method: 'PUT',
@@ -53,18 +71,20 @@ export function* trashAutomation(automation: Automation) {
     __('Automation "%s" was moved to the trash.', 'mailpoet'),
     automation.name,
   );
-  void createSuccessNotice(message, {
-    id: `automation-trashed-${automation.id}`,
-    __unstableHTML: (
-      <p>
-        {message}{' '}
-        <UndoTrashButton
-          automation={automation}
-          previousStatus={automation.status}
-        />
-      </p>
-    ),
-  });
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(message, {
+      id: `automation-trashed-${automation.id}`,
+      __unstableHTML: (
+        <p>
+          {message}{' '}
+          <UndoTrashButton
+            automation={automation}
+            previousStatus={automation.status}
+          />
+        </p>
+      ),
+    });
+  }
 
   return {
     type: 'UPDATE_AUTOMATION',
@@ -75,6 +95,7 @@ export function* trashAutomation(automation: Automation) {
 export function* restoreAutomation(
   automation: Automation,
   status: AutomationStatus,
+  options?: NoticeOptions,
 ) {
   const data = yield apiFetch({
     path: `/automations/${automation.id}`,
@@ -90,16 +111,18 @@ export function* restoreAutomation(
     __('Automation "%s" was restored from the trash.', 'mailpoet'),
     automation.name,
   );
-  void createSuccessNotice(message, {
-    __unstableHTML: (
-      <p>
-        {message}{' '}
-        <Button variant="link" href={getAutomationEditorUrl(automation)}>
-          {__('Edit automation', 'mailpoet')}
-        </Button>
-      </p>
-    ),
-  });
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(message, {
+      __unstableHTML: (
+        <p>
+          {message}{' '}
+          <Button variant="link" href={getAutomationEditorUrl(automation)}>
+            {__('Edit automation', 'mailpoet')}
+          </Button>
+        </p>
+      ),
+    });
+  }
 
   return {
     type: 'UPDATE_AUTOMATION',
@@ -107,21 +130,26 @@ export function* restoreAutomation(
   } as const;
 }
 
-export function* deleteAutomation(automation: Automation) {
+export function* deleteAutomation(
+  automation: Automation,
+  options?: NoticeOptions,
+) {
   yield apiFetch({
     path: `/automations/${automation.id}`,
     method: 'DELETE',
   });
 
-  void createSuccessNotice(
-    sprintf(
-      __(
-        'Automation "%s" and all associated data were permanently deleted.',
-        'mailpoet',
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(
+      sprintf(
+        __(
+          'Automation "%s" and all associated data were permanently deleted.',
+          'mailpoet',
+        ),
+        automation.name,
       ),
-      automation.name,
-    ),
-  );
+    );
+  }
 
   return {
     type: 'DELETE_AUTOMATION',

--- a/mailpoet/assets/js/src/automation/listing/store/legacy-actions.tsx
+++ b/mailpoet/assets/js/src/automation/listing/store/legacy-actions.tsx
@@ -7,10 +7,17 @@ import { getDescription } from './legacy-description';
 import { AutomationItem } from './types';
 import { Automation, AutomationStatus } from '../automation';
 
+type NoticeOptions = {
+  showSuccessNotice?: boolean;
+};
+
 const createSuccessNotice = (content: string, options?: unknown) =>
   dispatch(noticesStore).createSuccessNotice(content, options);
 
 const removeNotice = (id: string) => dispatch(noticesStore).removeNotice(id);
+
+const shouldShowSuccessNotice = (options?: NoticeOptions): boolean =>
+  options?.showSuccessNotice !== false;
 
 const mapToAutomation = (item: ListingItem): AutomationItem => ({
   id: item.id,
@@ -55,7 +62,10 @@ export function* loadLegacyAutomations() {
   } as const;
 }
 
-export function* trashLegacyAutomation(automation: Automation) {
+export function* trashLegacyAutomation(
+  automation: Automation,
+  options?: NoticeOptions,
+) {
   yield AwaitPromise(
     legacyApiFetch({
       endpoint: 'newsletters',
@@ -64,12 +74,14 @@ export function* trashLegacyAutomation(automation: Automation) {
     }),
   );
 
-  void createSuccessNotice(
-    sprintf(
-      __('Automation "%s" was moved to the trash.', 'mailpoet'),
-      automation.name,
-    ),
-  );
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(
+      sprintf(
+        __('Automation "%s" was moved to the trash.', 'mailpoet'),
+        automation.name,
+      ),
+    );
+  }
 
   return {
     type: 'UPDATE_LEGACY_AUTOMATION_STATUS',
@@ -78,7 +90,10 @@ export function* trashLegacyAutomation(automation: Automation) {
   } as const;
 }
 
-export function* restoreLegacyAutomation(automation: Automation) {
+export function* restoreLegacyAutomation(
+  automation: Automation,
+  options?: NoticeOptions,
+) {
   const data: { data: ListingItem } = yield AwaitPromise(
     legacyApiFetch({
       endpoint: 'newsletters',
@@ -89,12 +104,14 @@ export function* restoreLegacyAutomation(automation: Automation) {
 
   void removeNotice(`automation-trashed-${automation.id}`);
 
-  void createSuccessNotice(
-    sprintf(
-      __('Automation "%s" was restored from the trash.', 'mailpoet'),
-      automation.name,
-    ),
-  );
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(
+      sprintf(
+        __('Automation "%s" was restored from the trash.', 'mailpoet'),
+        automation.name,
+      ),
+    );
+  }
 
   return {
     type: 'UPDATE_LEGACY_AUTOMATION_STATUS',
@@ -103,7 +120,10 @@ export function* restoreLegacyAutomation(automation: Automation) {
   } as const;
 }
 
-export function* deleteLegacyAutomation(automation: Automation) {
+export function* deleteLegacyAutomation(
+  automation: Automation,
+  options?: NoticeOptions,
+) {
   yield AwaitPromise(
     legacyApiFetch({
       endpoint: 'newsletters',
@@ -112,15 +132,17 @@ export function* deleteLegacyAutomation(automation: Automation) {
     }),
   );
 
-  void createSuccessNotice(
-    sprintf(
-      __(
-        'Automation "%s" and all associated data were permanently deleted.',
-        'mailpoet',
+  if (shouldShowSuccessNotice(options)) {
+    void createSuccessNotice(
+      sprintf(
+        __(
+          'Automation "%s" and all associated data were permanently deleted.',
+          'mailpoet',
+        ),
+        automation.name,
       ),
-      automation.name,
-    ),
-  );
+    );
+  }
 
   return {
     type: 'DELETE_LEGACY_AUTOMATION',

--- a/mailpoet/changelog/2026-04-29-19-40-29-added-add-bulk-actions-for-automations.md
+++ b/mailpoet/changelog/2026-04-29-19-40-29-added-add-bulk-actions-for-automations.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Bulk actions for automations.

--- a/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
+++ b/mailpoet/tests/acceptance/Automation/AutomationListingCest.php
@@ -6,8 +6,11 @@ use AcceptanceTester;
 use DateTimeImmutable;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Test\DataFactories;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\CssSelector\XPath\Translator;
 
 class AutomationListingCest {
@@ -150,6 +153,71 @@ class AutomationListingCest {
     $productPurchasedInCategoryRow = $this->getAutomationRow('Product purchased in category');
     $i->see('Product purchased in category', $productPurchasedInCategoryRow);
     $i->see('Email sent when a customer buys a product in category: Uncategorized.', $productPurchasedInCategoryRow);
+  }
+
+  public function bulkAutomationActions(AcceptanceTester $i): void {
+    $i->wantTo('Duplicate, trash, restore, and delete automations in bulk');
+    $uniqueId = uniqid();
+    $automation1Name = 'Bulk automation 1 ' . $uniqueId;
+    $automation2Name = 'Bulk automation 2 ' . $uniqueId;
+
+    $automation1 = (new DataFactories\Automation())->withName($automation1Name)->create();
+    $automation2 = (new DataFactories\Automation())->withName($automation2Name)->create();
+
+    $i->login();
+    $i->amOnMailpoetPage('Automation');
+    $i->waitForText($automation1Name, 20, '[data-automation-id="automation_listing"]');
+    $i->waitForText($automation2Name, 20, '[data-automation-id="automation_listing"]');
+
+    $i->wantTo('Bulk duplicate selected automations');
+    $i->checkWooTableCheckboxForItemName($automation1Name);
+    $i->checkWooTableCheckboxForItemName($automation2Name);
+    $i->selectListingBulkAction('Duplicate');
+    $i->waitForText('2 automations were duplicated.');
+    $i->waitForText('Copy of ' . $automation1Name, 20, '[data-automation-id="automation_listing"]');
+    $i->waitForText('Copy of ' . $automation2Name, 20, '[data-automation-id="automation_listing"]');
+
+    $i->wantTo('Bulk trash selected automations');
+    $i->checkWooTableCheckboxForItemName($automation1Name);
+    $i->checkWooTableCheckboxForItemName($automation2Name);
+    $i->selectListingBulkAction('Trash');
+    $i->waitForText('Are you sure you want to move the automations');
+    $i->clickModalButton('Yes, move to trash');
+    $i->waitForText('2 automations were moved to the trash.');
+
+    $i->wantTo('Bulk restore selected automations from trash');
+    $i->changeWooTableTab('trash');
+    $i->waitForText($automation1Name, 20, '[data-automation-id="automation_listing"]');
+    $i->waitForText($automation2Name, 20, '[data-automation-id="automation_listing"]');
+    $i->checkWooTableCheckboxForItemName($automation1Name);
+    $i->checkWooTableCheckboxForItemName($automation2Name);
+    $i->selectListingBulkAction('Restore');
+    $i->waitForText('2 automations were restored from the trash.');
+    $i->waitForText('Trash is empty.', 20, '[data-automation-id="automation_listing"]');
+
+    $i->wantTo('Bulk delete selected automations permanently');
+    $i->changeWooTableTab('all');
+    $i->waitForText($automation1Name, 20, '[data-automation-id="automation_listing"]');
+    $i->waitForText($automation2Name, 20, '[data-automation-id="automation_listing"]');
+    $i->checkWooTableCheckboxForItemName($automation1Name);
+    $i->checkWooTableCheckboxForItemName($automation2Name);
+    $i->selectListingBulkAction('Trash');
+    $i->clickModalButton('Yes, move to trash');
+    $i->waitForText('2 automations were moved to the trash.');
+    $i->changeWooTableTab('trash');
+    $i->waitForText($automation1Name, 20, '[data-automation-id="automation_listing"]');
+    $i->checkWooTableCheckboxForItemName($automation1Name);
+    $i->checkWooTableCheckboxForItemName($automation2Name);
+    $i->selectListingBulkAction('Delete permanently');
+    $i->waitForText('Are you sure you want to permanently delete');
+    $i->clickModalButton('Yes, permanently delete');
+    $i->waitForText('2 automations were permanently deleted.');
+    $i->waitForText('Trash is empty.', 20, '[data-automation-id="automation_listing"]');
+
+    $automationStorage = ContainerWrapper::getInstance()->get(AutomationStorage::class);
+    Assert::assertNull($automationStorage->getAutomation($automation1->getId()));
+    Assert::assertNull($automationStorage->getAutomation($automation2->getId()));
+    $i->seeNoJSErrors();
   }
 
   private function getAutomationRow(string $automationName): string {


### PR DESCRIPTION
## Description

Allow bulk `Trash`, `Restore`, `Delete permanently` and `Duplicate` actions in automations.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8001

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1160" height="553" alt="Screenshot 2026-04-29 at 21 55 51" src="https://github.com/user-attachments/assets/d1196f1a-e670-4f22-bd50-f20ebbf81f50" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8001-allow-bulk-actions-in-automations)

_The latest successful build from `stomail-8001-allow-bulk-actions-in-automations` will be used. If none is available, the link won't work._