### PR TITLE
Stabilize DataViews acceptance clicks

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -149,11 +149,14 @@ class AcceptanceTester extends \Codeception\Actor {
     // open it first and then click the matching role="menuitem".
     $dataViewsActionsToggleXpath = ['xpath' => '//tr[.//*[normalize-space(text())="' . $itemName . '"]]//button[@aria-label="Actions" and @aria-haspopup="menu"]'];
     $dataViewsMenuItemXpath = ['xpath' => '//*[@role="menuitem" and normalize-space(.)="' . $link . '"]'];
+    $lastException = null;
 
     for ($x = 1; $x <= 3; $x++) {
       try {
+        $i->scrollListingRowIntoViewByItemName($itemName);
         $i->moveMouseOver($rowCellXpath);
       } catch (Exception $hoverException) {
+        $lastException = $hoverException;
         $this->wait(1);
         continue;
       }
@@ -164,6 +167,7 @@ class AcceptanceTester extends \Codeception\Actor {
         $i->click($legacyActionXpath);
         return;
       } catch (Exception $legacyException) {
+        $lastException = $legacyException;
         // ignore and fall through to DataViews variants
       }
 
@@ -173,6 +177,7 @@ class AcceptanceTester extends \Codeception\Actor {
         $i->click($dataViewsPrimaryXpath);
         return;
       } catch (Exception $primaryException) {
+        $lastException = $primaryException;
         // ignore and try the dropdown menu
       }
 
@@ -184,10 +189,13 @@ class AcceptanceTester extends \Codeception\Actor {
         $i->click($dataViewsMenuItemXpath);
         return;
       } catch (Exception $menuException) {
+        $lastException = $menuException;
         $this->wait(1);
         continue;
       }
     }
+
+    throw $lastException;
   }
 
   public function clickWooTableActionByItemName($itemName, $actionLinkText) {
@@ -213,6 +221,7 @@ class AcceptanceTester extends \Codeception\Actor {
       return;
     } catch (Exception $exception) {
       $dataViewsActionsToggleXpath = ['xpath' => '//tr[.//*[normalize-space(text())="' . $itemName . '"]]//button[@aria-label="Actions" and @aria-haspopup="menu"]'];
+      $i->scrollListingRowIntoViewByItemName($itemName);
       $i->waitForElementClickable($dataViewsActionsToggleXpath);
       $i->click($dataViewsActionsToggleXpath);
     }
@@ -1057,7 +1066,21 @@ class AcceptanceTester extends \Codeception\Actor {
   public function checkWooTableCheckboxForItemName(string $itemName): void {
     $i = $this;
     $xpath = ['xpath' => '//tr[.//*[normalize-space(text())="' . $itemName . '"]]//input[@type="checkbox"]'];
+    $i->scrollListingRowIntoViewByItemName($itemName);
     $i->click($xpath);
+  }
+
+  private function scrollListingRowIntoViewByItemName(string $itemName): void {
+    $encodedItemName = json_encode($itemName);
+    $this->executeJS(
+      <<<JS
+      const itemName = {$encodedItemName};
+      const rows = Array.from(document.querySelectorAll('tr'));
+      const row = rows.find((tableRow) => Array.from(tableRow.querySelectorAll('*')).some((element) => element.textContent.trim() === itemName));
+      if (row) row.scrollIntoView({ block: 'center', inline: 'nearest' });
+      JS
+    );
+    $this->wait(0.1);
   }
 
   public function selectListingBulkAction(string $actionName): void {


### PR DESCRIPTION
## Description

Stabilizes acceptance-test helpers for DataViews-backed listings. Sticky DataViews footers can cover row actions and checkboxes in CI, so the helper now centers the target row before clicking and rethrows the last click failure when all retries fail.

## Code review notes

This is intentionally scoped to acceptance-test helpers; no production behavior changes.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stabilize-dataviews-acceptance-clicks)

_The latest successful build from `fix/stabilize-dataviews-acceptance-clicks` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

This PR fixes acceptance test flakiness by addressing issues where sticky DataViews footers cover row actions and checkboxes during CI runs. The changes include:

1. **Bug Fix - Test Stability**: Adds row centering via a new `scrollListingRowIntoViewByItemName()` private helper method to ensure UI elements are properly positioned before interaction.

2. **Bug Fix - Error Visibility**: Modifies `clickItemRowActionByItemName()` to track and rethrow the last encountered exception after all retry attempts are exhausted, improving error diagnostics instead of silently failing.

All modifications are scoped to acceptance test helpers only, with no impact on production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->