### PR TITLE
Add mailpoet-beta-compat-test agent skill

### DIFF
--- a/.ai/skills/mailpoet-beta-compat-test/SKILL.md
+++ b/.ai/skills/mailpoet-beta-compat-test/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: mailpoet-beta-compat-test
+description: Use when a new WooCommerce or WordPress beta / release candidate is available and you need to test MailPoet's compatibility against it. Triggers on phrases like "test against WC beta", "test MailPoet on WP beta", "compatibility test", "new WooCommerce version", "new WordPress version".
+---
+
+# MailPoet Beta Compatibility Test
+
+## Overview
+
+Run a full compatibility test of the released MailPoet plugin against a new WooCommerce or WordPress beta / release candidate. Covers QIT automated tests, CircleCI scheduled beta runs, and manual smoke tests in the local wp-env.
+
+## Usage
+
+Invoke with the target beta version(s) as argument:
+
+```
+/mailpoet-beta-compat-test wc=10.6.0-beta.1
+/mailpoet-beta-compat-test wp=6.9-RC1
+/mailpoet-beta-compat-test wc=10.6.0-beta.1 wp=6.9-RC1
+```
+
+If neither is provided, detect the latest beta automatically:
+
+```bash
+.circleci/check_woocommerce_beta.sh
+.circleci/check_wordpress_beta.sh
+```
+
+Both scripts print a `LATEST_BETA=…` line (empty if none).
+
+## Process
+
+Follow all four steps sequentially. Report results after each step before moving to the next.
+
+### Step 1 — Download the latest stable MailPoet zip
+
+Compatibility testing must run against the _released_ plugin, not local trunk. Download from wordpress.org:
+
+```bash
+curl -L -o mailpoet/mailpoet.zip \
+  "https://downloads.wordpress.org/plugin/mailpoet.latest-stable.zip"
+```
+
+The QIT Robo tasks expect the file at `mailpoet/mailpoet.zip` (see `mailpoet/RoboFile.php:9` — `ZIP_BUILD_PATH`). Verify the download succeeded and the file is a valid zip.
+
+### Step 2 — Run QIT commands
+
+MailPoet wraps QIT in Robo tasks that take `--wp` and `--wc` version flags. Run from `mailpoet/`:
+
+```bash
+cd mailpoet
+
+# Activation test — boots WP, activates MailPoet, fails on PHP errors / hook misuse
+./do qa:qit-activation --wp=<WP_VERSION> --wc=<WC_VERSION>
+
+# WooCommerce REST API regression suite
+./do qa:qit-woo-api --wp=<WP_VERSION> --wc=<WC_VERSION>
+
+# WooCommerce E2E suite
+./do qa:qit-woo-e2e --wp=<WP_VERSION> --wc=<WC_VERSION>
+```
+
+Pass only the versions you are testing — omit flags default to `stable`. For `--wc`, use the exact beta version provided by the user first. Only if QIT rejects it, fall back to `X.Y.Z-dev` (e.g., `10.6.0-beta.1` → `10.6.0-dev`). Use `./vendor/bin/qit run:woo-api --help` from `mailpoet/` to discover the enumerated values.
+
+You must authenticate QIT once per machine:
+
+```bash
+./vendor/bin/qit partner:add --user="$QIT_PARTNER_USER" --application_password="$QIT_PARTNER_SECRET"
+```
+
+After each command completes, fetch the HTML report from the `Result Url` printed in the output:
+
+```bash
+grep "Result Url" <captured-output> | awk '{ print $3 }' | xargs curl -o /tmp/qit-report.html
+```
+
+Summarize pass/fail status and highlight any failures with details.
+
+### Step 3 — Trigger the CircleCI beta workflow and wait for results
+
+MailPoet's CircleCI config already has parameterized jobs for beta runs (`use_wordpress_beta`, `use_woocommerce_beta` — see `.circleci/config.yml:399` and `:704`). The scheduled nightly workflow picks up the latest beta automatically. To kick it manually for the version under test, trigger a pipeline with those parameters:
+
+```bash
+TOKEN=$(cat ~/.config/circleci/personal-token)
+
+curl -sX POST \
+  -H "Circle-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "branch": "trunk",
+        "parameters": {
+          "use_wordpress_beta": true,
+          "use_woocommerce_beta": true
+        }
+      }' \
+  https://circleci.com/api/v2/project/gh/mailpoet/mailpoet/pipeline
+```
+
+After triggering:
+
+1. Use the pipeline id from the response to find workflow + job ids:
+   ```bash
+   curl -sH "Circle-Token: $TOKEN" \
+     "https://circleci.com/api/v2/pipeline/<PIPELINE_ID>/workflow"
+   ```
+2. Poll the workflow until it transitions out of `running`.
+3. For any failed job, use the per-step output URLs pattern from the user's CLAUDE.md to fetch raw logs:
+   ```bash
+   curl -sH "Circle-Token: $TOKEN" \
+     "https://circleci.com/api/v1.1/project/github/mailpoet/mailpoet/<JOB_NUMBER>" \
+     | jq '.steps[].actions[] | {name, status, output_url}'
+   ```
+4. Analyze the failure logs and report what went wrong.
+5. If the failure is in plugin code, suggest or apply a fix on a feature branch.
+
+Run the equivalent for `mailpoet-premium` if WooCommerce-specific premium features (Subscriptions, Bookings, Memberships) are in scope:
+
+```bash
+curl -sX POST -H "Circle-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"branch":"trunk","parameters":{"use_wordpress_beta":true,"use_woocommerce_beta":true}}' \
+  https://circleci.com/api/v2/project/gh/mailpoet/mailpoet-premium/pipeline
+```
+
+### Step 4 — Smoke tests in local wp-env
+
+Start the local environment with the target beta installed:
+
+```bash
+pnpm env:start
+pnpm compile
+# Pin WordPress version (if testing WP beta)
+pnpm wp core update --version=<WP_VERSION> --force
+# Pin WooCommerce version (if testing WC beta)
+pnpm wp plugin update woocommerce --version=<WC_VERSION>
+pnpm wp wc update
+```
+
+Replace the local MailPoet build with the released zip from Step 1 to mirror what users actually run:
+
+```bash
+pnpm wp plugin install mailpoet/mailpoet.zip --force --activate
+```
+
+Then drive the Playwright MCP browser at `http://localhost:8888/wp-admin` (admin / password) and run these smoke tests. Watch the browser console and `pnpm env:logs` for PHP/JS errors throughout.
+
+1. **MailPoet menu loads** — Navigate to `MailPoet → Homepage`. Verify it loads without PHP/JS errors.
+2. **Subscribers list** — Open `MailPoet → Subscribers`. Verify the DataViews-based list renders, paginates, and a known subscriber is visible.
+3. **Send a standard newsletter** — `MailPoet → Emails → New → Newsletter`. Pick the block-based editor, save, send to a test segment, and confirm Mailpit (`http://localhost:8082`) captures the email.
+4. **Subscription form** — `MailPoet → Forms`. Edit a form, save. On the frontend, submit the form and confirm the new subscriber appears in the list.
+5. **Automation** — `MailPoet → Automations`. Activate a "Welcome email" automation, subscribe a new user, confirm the welcome email is delivered to Mailpit.
+6. **WooCommerce integration** (if `wc=` was set) — Place a guest order in the shop. Confirm the WC abandoned-cart / first-purchase automation fires and the customer appears in the synced WooCommerce segments.
+
+Report the result of each check. Provide a screenshot of any failure and capture the relevant entry from `pnpm env:logs`.
+
+## After testing
+
+Summarize all results in a table:
+
+| Test                                   | Status | Notes |
+| -------------------------------------- | ------ | ----- |
+| QIT Activation                         | ✅/❌  |       |
+| QIT Woo API                            | ✅/❌  |       |
+| QIT Woo E2E                            | ✅/❌  |       |
+| CircleCI: free plugin beta pipeline    | ✅/❌  |       |
+| CircleCI: premium plugin beta pipeline | ✅/❌  |       |
+| Smoke: MailPoet menu loads             | ✅/❌  |       |
+| Smoke: Subscribers list                | ✅/❌  |       |
+| Smoke: Send a standard newsletter      | ✅/❌  |       |
+| Smoke: Subscription form               | ✅/❌  |       |
+| Smoke: Automation                      | ✅/❌  |       |
+| Smoke: WooCommerce integration         | ✅/❌  |       |
+
+## Error triage
+
+When any test fails, classify each error into one of three categories and take the corresponding action:
+
+### 1. MailPoet error — fix it
+
+The error is in code from `mailpoet/` or `mailpoet-premium/` (e.g., a PHP fatal in `lib/`, a JS error from `assets/js/src/`, a failing test in `tests/`).
+
+**Action:** Open a feature branch (use the `starting-branch` skill), fix the issue, add or update a test, run `pnpm qa` and the relevant `pnpm test:*`, and open a draft PR via the `creating-pull-requests` skill. Do not commit straight to `trunk`.
+
+### 2. QIT / test environment error — report to #qit
+
+The error is in the QIT tool itself or the testing environment (QIT command crashes, Docker setup failures, infrastructure timeouts, flaky runner behavior unrelated to plugin code).
+
+**Action:** Draft a Slack message for the `#qit` channel including the QIT command, the version flags used, and the full error output. Show the draft to Pavel before sending — never post on his behalf without confirmation.
+
+### 3. WooCommerce / WordPress / other plugin error — report upstream
+
+The error is caused by WooCommerce core, WordPress core, or another bundled plugin (e.g., a WC REST API regression, a deprecation in a WP beta, a breaking change in the block editor).
+
+**Action:**
+
+1. Use the `context-a8c` MCP to identify which team owns the affected area (search Linear, Slack, GitHub for the relevant component).
+2. Draft a Slack message for `#woo-core-releases` (for WC) or the WordPress core release channel (for WP), describing:
+   - The beta version under test
+   - The specific error and which test surfaced it
+   - A ping to the responsible team identified above
+3. Show the draft to Pavel before sending.


### PR DESCRIPTION
## Description

Adds `.ai/skills/mailpoet-beta-compat-test/SKILL.md`, a new agent skill that walks an AI agent through a full WooCommerce / WordPress beta compatibility test of MailPoet.

The skill is adapted from the equivalent skill in [`woocommerce/woocommerce-google-analytics-integration`](https://github.com/woocommerce/woocommerce-google-analytics-integration/blob/trunk/.ai/skills/woo-beta-compat-test/SKILL.md), reworked for MailPoet specifics:

- Pulls the released zip from wp.org into the path `mailpoet/RoboFile.php` already expects.
- Drives QIT through the existing `./do qa:qit-activation|qit-woo-api|qit-woo-e2e` Robo wrappers (already accept `--wp` / `--wc` flags).
- Triggers the parameterized CircleCI beta pipelines (`use_wordpress_beta`, `use_woocommerce_beta`) for both `mailpoet/mailpoet` and `mailpoet/mailpoet-premium` instead of GitHub Actions.
- Smoke-test list rewritten for MailPoet flows (menu, Subscribers DataViews, newsletter send via Mailpit, forms, automation, WooCommerce-tied automation).
- Triage routes plugin fixes through the `starting-branch` / `creating-pull-requests` skills and keeps the "draft Slack messages first" rule for `#qit` / `#woo-core-releases`.

## Code review notes

_N/A_

## QA notes

Documentation-only — the skill is loaded by AI agents (Claude Code) on demand. No plugin code, build, or runtime behavior changes. Verify by listing the file and reading the YAML frontmatter trigger phrases.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/mailpoet-beta-compat-test-skill)

_The latest successful build from `add/mailpoet-beta-compat-test-skill` will be used. If none is available, the link won't work._