### PR TITLE
Reduce PHPStan baseline (wave 5: free companion)

### DIFF
--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
@@ -60,8 +60,14 @@ class FirstPurchase {
 
     // We have to use a set of states because an order state after checkout differs for different payment methods
     $acceptedOrderStates = WPFunctions::get()->applyFilters('mailpoet_first_purchase_order_states', ['completed', 'processing']);
+    if (!is_array($acceptedOrderStates)) {
+      $acceptedOrderStates = ['completed', 'processing'];
+    }
 
     foreach ($acceptedOrderStates as $state) {
+      if (!is_string($state)) {
+        continue;
+      }
       WPFunctions::get()->addAction('woocommerce_order_status_' . $state, [
         $this,
         'scheduleEmailWhenOrderIsPlaced',

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
@@ -94,7 +94,13 @@ class PurchasedInCategory {
     );
 
     $acceptedOrderStates = WPFunctions::get()->applyFilters('mailpoet_first_purchase_order_states', ['completed', 'processing']);
+    if (!is_array($acceptedOrderStates)) {
+      $acceptedOrderStates = ['completed', 'processing'];
+    }
     foreach ($acceptedOrderStates as $state) {
+      if (!is_string($state)) {
+        continue;
+      }
       WPFunctions::get()->addAction(
         'woocommerce_order_status_' . $state,
         [$this, 'scheduleEmail'],
@@ -204,7 +210,7 @@ class PurchasedInCategory {
     $automaticEmailMetaValue = $automaticEmail->getOptionValue(NewsletterOptionFieldEntity::NAME_META);
     $optionValue = Helpers::isJson($automaticEmailMetaValue) ? json_decode($automaticEmailMetaValue, true) : $automaticEmailMetaValue;
 
-    if (!is_array($optionValue) || empty($optionValue['option'])) {
+    if (!is_array($optionValue) || empty($optionValue['option']) || !is_array($optionValue['option'])) {
       return [];
     }
     $emailTriggeringCategoryIds = array_column($optionValue['option'], 'id');

--- a/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
+++ b/mailpoet/lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
@@ -59,7 +59,13 @@ class PurchasedProduct {
 
 
     $acceptedOrderStates = WPFunctions::get()->applyFilters('mailpoet_first_purchase_order_states', ['completed', 'processing']);
+    if (!is_array($acceptedOrderStates)) {
+      $acceptedOrderStates = ['completed', 'processing'];
+    }
     foreach ($acceptedOrderStates as $state) {
+      if (!is_string($state)) {
+        continue;
+      }
       WPFunctions::get()->addAction('woocommerce_order_status_' . $state, [
         $this,
         'scheduleEmailWhenProductIsPurchased',
@@ -207,7 +213,7 @@ class PurchasedProduct {
     $automaticEmailMetaValue = $automaticEmail->getOptionValue(NewsletterOptionFieldEntity::NAME_META);
     $optionValue = Helpers::isJson($automaticEmailMetaValue) ? json_decode($automaticEmailMetaValue, true) : $automaticEmailMetaValue;
 
-    if (!is_array($optionValue) || empty($optionValue['option'])) {
+    if (!is_array($optionValue) || empty($optionValue['option']) || !is_array($optionValue['option'])) {
       return [];
     }
     $emailTriggeringProductIds = array_column($optionValue['option'], 'id');

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -61,11 +61,20 @@ class EnumArrayFilter implements Filter {
       return false;
     }
 
-    $filterValue = array_values(array_filter(array_unique($filterValue, SORT_REGULAR), 'is_scalar'));
-    $value = array_values(array_filter(array_unique($value, SORT_REGULAR), 'is_scalar'));
+    // Schema declares string[]|int[]; reject other scalar types so booleans
+    // (strval(false) === '') can't create phantom matches against empty values
+    // sourced from the field at runtime.
+    $isStringOrInt = static function ($v): bool {
+      return is_string($v) || is_int($v);
+    };
+    $filterValue = array_values(array_filter(array_unique($filterValue, SORT_REGULAR), $isStringOrInt));
+    $value = array_values(array_filter(array_unique($value, SORT_REGULAR), $isStringOrInt));
 
+    $toString = static function ($v): string {
+      return (string)$v;
+    };
     $filterCount = count($filterValue);
-    $matchedCount = count(array_intersect(array_map('strval', $value), array_map('strval', $filterValue)));
+    $matchedCount = count(array_intersect(array_map($toString, $value), array_map($toString, $filterValue)));
     switch ($data->getCondition()) {
       case self::CONDITION_MATCHES_ANY_OF:
         return $filterCount > 0 && $matchedCount > 0;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -61,11 +61,11 @@ class EnumArrayFilter implements Filter {
       return false;
     }
 
-    $filterValue = array_unique($filterValue, SORT_REGULAR);
-    $value = array_unique($value, SORT_REGULAR);
+    $filterValue = array_values(array_filter(array_unique($filterValue, SORT_REGULAR), 'is_scalar'));
+    $value = array_values(array_filter(array_unique($value, SORT_REGULAR), 'is_scalar'));
 
     $filterCount = count($filterValue);
-    $matchedCount = count(array_intersect($value, $filterValue));
+    $matchedCount = count(array_intersect(array_map('strval', $value), array_map('strval', $filterValue)));
     switch ($data->getCondition()) {
       case self::CONDITION_MATCHES_ANY_OF:
         return $filterCount > 0 && $matchedCount > 0;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
@@ -67,8 +67,11 @@ class EnumArrayFilter implements Filter {
     $isStringOrInt = static function ($v): bool {
       return is_string($v) || is_int($v);
     };
-    $filterValue = array_values(array_filter(array_unique($filterValue, SORT_REGULAR), $isStringOrInt));
-    $value = array_values(array_filter(array_unique($value, SORT_REGULAR), $isStringOrInt));
+    // Filter by type before deduplicating: array_unique with SORT_REGULAR uses
+    // loose comparison, so [true, 1] collapses into a single bool and the int
+    // would then be dropped by the type filter.
+    $filterValue = array_values(array_unique(array_filter($filterValue, $isStringOrInt), SORT_REGULAR));
+    $value = array_values(array_unique(array_filter($value, $isStringOrInt), SORT_REGULAR));
 
     $toString = static function ($v): string {
       return (string)$v;

--- a/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
+++ b/mailpoet/lib/Automation/Integrations/Core/Filters/NumberFilter.php
@@ -166,7 +166,10 @@ class NumberFilter implements Filter {
     }
   }
 
-  /** @param mixed $value */
+  /**
+   * @param mixed $value
+   * @phpstan-assert-if-true int|float $value
+   */
   private function isNumber($value): bool {
     return is_integer($value) || is_float($value);
   }

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -156,19 +156,21 @@ class Shortcodes {
       );
     } else {
       $title = $this->wp->applyFilters('mailpoet_archive_title', '');
-      if (!empty($title)) {
-        $html .= '<h3 class="mailpoet_archive_title">' . $title . '</h3>';
+      if (!empty($title) && is_scalar($title)) {
+        $html .= '<h3 class="mailpoet_archive_title">' . (string)$title . '</h3>';
       }
       $html .= '<ul class="mailpoet_archive">';
       foreach ($newsletters as $newsletter) {
         $queue = $newsletter->getLatestQueue();
+        $processedDate = $this->wp->applyFilters('mailpoet_archive_email_processed_date', $newsletter);
+        $subjectLine = $this->wp->applyFilters('mailpoet_archive_email_subject_line', $newsletter, $subscriber, $queue);
 
         $html .= '<li>' .
           '<span class="mailpoet_archive_date">' .
-            $this->wp->applyFilters('mailpoet_archive_email_processed_date', $newsletter) .
+            (is_scalar($processedDate) ? (string)$processedDate : '') .
           '</span>
           <span class="mailpoet_archive_subject">' .
-            $this->wp->applyFilters('mailpoet_archive_email_subject_line', $newsletter, $subscriber, $queue) .
+            (is_scalar($subjectLine) ? (string)$subjectLine : '') .
           '</span>
         </li>';
       }

--- a/mailpoet/lib/Cron/CronHelper.php
+++ b/mailpoet/lib/Cron/CronHelper.php
@@ -160,16 +160,14 @@ class CronHelper {
   }
 
   public function queryCronUrl($url) {
-    $args = $this->wp->applyFilters(
-      'mailpoet_cron_request_args',
-      [
-        'blocking' => true,
-        'sslverify' => false,
-        'timeout' => self::DAEMON_REQUEST_TIMEOUT,
-        'user-agent' => 'MailPoet Cron',
-      ]
-    );
-    return $this->wp->wpRemotePost($url, $args);
+    $defaultArgs = [
+      'blocking' => true,
+      'sslverify' => false,
+      'timeout' => self::DAEMON_REQUEST_TIMEOUT,
+      'user-agent' => 'MailPoet Cron',
+    ];
+    $args = $this->wp->applyFilters('mailpoet_cron_request_args', $defaultArgs);
+    return $this->wp->wpRemotePost($url, is_array($args) ? $args : $defaultArgs);
   }
 
   public function getCronUrl($action, $data = false) {
@@ -178,10 +176,12 @@ class CronHelper {
       $action,
       $data
     );
+    $url = is_string($url) ? $url : '';
     $customCronUrl = $this->wp->applyFilters('mailpoet_cron_request_url', $url);
-    return ($customCronUrl === $url) ?
-      str_replace(home_url(), $this->getSiteUrl(), $url) :
-      $customCronUrl;
+    if ($customCronUrl === $url) {
+      return str_replace(home_url(), $this->getSiteUrl(), $url);
+    }
+    return is_string($customCronUrl) ? $customCronUrl : $url;
   }
 
   public function getSiteUrl($siteUrl = false) {

--- a/mailpoet/lib/Doctrine/Types/JsonOrSerializedType.php
+++ b/mailpoet/lib/Doctrine/Types/JsonOrSerializedType.php
@@ -16,7 +16,7 @@ class JsonOrSerializedType extends JsonType {
       $value = stream_get_contents($value);
     }
 
-    if (is_serialized($value)) {
+    if (is_string($value) && is_serialized($value)) {
       return unserialize($value);
     }
     return parent::convertToPHPValue($value, $platform);

--- a/mailpoet/lib/Form/Block/Column.php
+++ b/mailpoet/lib/Form/Block/Column.php
@@ -28,10 +28,10 @@ class Column {
       $styles[] = "flex-basis:{$widthValue}";
     }
     if (!empty($params['padding']) && is_array($params['padding'])) {
-      $top = $params['padding']['top'] ?? 0;
-      $right = $params['padding']['right'] ?? 0;
-      $bottom = $params['padding']['bottom'] ?? 0;
-      $left = $params['padding']['left'] ?? 0;
+      $top = is_scalar($params['padding']['top'] ?? null) ? (string)$params['padding']['top'] : '0';
+      $right = is_scalar($params['padding']['right'] ?? null) ? (string)$params['padding']['right'] : '0';
+      $bottom = is_scalar($params['padding']['bottom'] ?? null) ? (string)$params['padding']['bottom'] : '0';
+      $left = is_scalar($params['padding']['left'] ?? null) ? (string)$params['padding']['left'] : '0';
       $styles[] = "padding:{$top} {$right} {$bottom} {$left};";
     }
     if (!empty($params['text_color'])) {

--- a/mailpoet/lib/Form/Block/Columns.php
+++ b/mailpoet/lib/Form/Block/Columns.php
@@ -30,10 +30,10 @@ class Columns {
       $styles[] = "background:{$params['gradient']};";
     }
     if (!empty($params['padding']) && is_array($params['padding'])) {
-      $top = $params['padding']['top'] ?? 0;
-      $right = $params['padding']['right'] ?? 0;
-      $bottom = $params['padding']['bottom'] ?? 0;
-      $left = $params['padding']['left'] ?? 0;
+      $top = is_scalar($params['padding']['top'] ?? null) ? (string)$params['padding']['top'] : '0';
+      $right = is_scalar($params['padding']['right'] ?? null) ? (string)$params['padding']['right'] : '0';
+      $bottom = is_scalar($params['padding']['bottom'] ?? null) ? (string)$params['padding']['bottom'] : '0';
+      $left = is_scalar($params['padding']['left'] ?? null) ? (string)$params['padding']['left'] : '0';
       $styles[] = "padding:{$top} {$right} {$bottom} {$left};";
     }
     if (count($styles)) {

--- a/mailpoet/lib/Form/Block/Heading.php
+++ b/mailpoet/lib/Form/Block/Heading.php
@@ -102,10 +102,10 @@ class Heading {
       $styles[] = "background: {$block['params']['gradient']};";
     }
     if (!empty($block['params']['padding']) && is_array($block['params']['padding'])) {
-      $top = $block['params']['padding']['top'] ?? 0;
-      $right = $block['params']['padding']['right'] ?? 0;
-      $bottom = $block['params']['padding']['bottom'] ?? 0;
-      $left = $block['params']['padding']['left'] ?? 0;
+      $top = is_scalar($block['params']['padding']['top'] ?? null) ? (string)$block['params']['padding']['top'] : '0';
+      $right = is_scalar($block['params']['padding']['right'] ?? null) ? (string)$block['params']['padding']['right'] : '0';
+      $bottom = is_scalar($block['params']['padding']['bottom'] ?? null) ? (string)$block['params']['padding']['bottom'] : '0';
+      $left = is_scalar($block['params']['padding']['left'] ?? null) ? (string)$block['params']['padding']['left'] : '0';
       $styles[] = "padding:{$top} {$right} {$bottom} {$left};";
     }
     if (empty($styles)) {

--- a/mailpoet/lib/Form/Block/Paragraph.php
+++ b/mailpoet/lib/Form/Block/Paragraph.php
@@ -87,10 +87,10 @@ class Paragraph {
       $styles[] = 'line-height: ' . $block['params']['line_height'];
     }
     if (!empty($block['params']['padding']) && is_array($block['params']['padding'])) {
-      $top = $block['params']['padding']['top'] ?? 0;
-      $right = $block['params']['padding']['right'] ?? 0;
-      $bottom = $block['params']['padding']['bottom'] ?? 0;
-      $left = $block['params']['padding']['left'] ?? 0;
+      $top = is_scalar($block['params']['padding']['top'] ?? null) ? (string)$block['params']['padding']['top'] : '0';
+      $right = is_scalar($block['params']['padding']['right'] ?? null) ? (string)$block['params']['padding']['right'] : '0';
+      $bottom = is_scalar($block['params']['padding']['bottom'] ?? null) ? (string)$block['params']['padding']['bottom'] : '0';
+      $left = is_scalar($block['params']['padding']['left'] ?? null) ? (string)$block['params']['padding']['left'] : '0';
       $styles[] = "padding:{$top} {$right} {$bottom} {$left};";
     }
     if (empty($styles)) {

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -125,7 +125,8 @@ class NewsletterSaveController {
     if (!empty($data['body'])) {
       $newslettersTableName = $this->newslettersRepository->getTableName();
       $body = $this->emoji->encodeForUTF8Column($newslettersTableName, 'body', $data['body']);
-      $body = $this->dataSanitizer->sanitizeBody(json_decode($body, true));
+      $decodedBody = json_decode($body, true);
+      $body = $this->dataSanitizer->sanitizeBody(is_array($decodedBody) ? $decodedBody : []);
       $data['body'] = json_encode($body);
     }
 
@@ -330,7 +331,8 @@ class NewsletterSaveController {
     }
 
     if (array_key_exists('body', $data)) {
-      $newsletter->setBody(json_decode($data['body'], true));
+      $decodedBody = json_decode($data['body'], true);
+      $newsletter->setBody(is_array($decodedBody) ? $decodedBody : null);
     }
 
     if (array_key_exists('ga_campaign', $data)) {

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -499,7 +499,7 @@ class SubscribersRepository extends Repository {
       ->setMaxResults(1)
       ->execute();
 
-    return count($subscribers) > 0;
+    return is_array($subscribers) && count($subscribers) > 0;
   }
 
    /**
@@ -878,6 +878,10 @@ class SubscribersRepository extends Repository {
       ->setParameter('ids', $ids)
       ->setParameter('segment', $segment)
       ->getQuery()->execute();
+
+    $subscribers = is_array($subscribers) ? array_values(array_filter($subscribers, function ($s) {
+      return $s instanceof SubscriberEntity;
+    })) : [];
 
     $this->entityManager->transactional(function (EntityManager $entityManager) use ($subscribers, $segment) {
       foreach ($subscribers as $subscriber) {

--- a/mailpoet/lib/Subscription/Throttling.php
+++ b/mailpoet/lib/Subscription/Throttling.php
@@ -63,7 +63,7 @@ class Throttling {
 
   public function purge(): void {
     $interval = $this->wp->applyFilters('mailpoet_subscription_purge_window', MONTH_IN_SECONDS);
-    $this->subscriberIPsRepository->deleteCreatedAtBeforeTimeInSeconds($interval);
+    $this->subscriberIPsRepository->deleteCreatedAtBeforeTimeInSeconds(is_int($interval) ? $interval : MONTH_IN_SECONDS);
   }
 
   public function secondsToTimeString($seconds): string {
@@ -87,6 +87,11 @@ class Throttling {
     }
     $user = $this->wp->wpGetCurrentUser();
     $roles = $this->wp->applyFilters('mailpoet_subscription_throttling_exclude_roles', ['administrator', 'editor']);
-    return !empty(array_intersect($roles, (array)$user->roles));
+    if (!is_array($roles)) {
+      $roles = ['administrator', 'editor'];
+    }
+    $roles = array_values(array_filter($roles, 'is_string'));
+    $userRoles = array_values(array_filter((array)$user->roles, 'is_string'));
+    return !empty(array_intersect($roles, $userRoles));
   }
 }

--- a/mailpoet/lib/Subscription/Throttling.php
+++ b/mailpoet/lib/Subscription/Throttling.php
@@ -63,7 +63,8 @@ class Throttling {
 
   public function purge(): void {
     $interval = $this->wp->applyFilters('mailpoet_subscription_purge_window', MONTH_IN_SECONDS);
-    $this->subscriberIPsRepository->deleteCreatedAtBeforeTimeInSeconds(is_int($interval) ? $interval : MONTH_IN_SECONDS);
+    $purgeWindow = is_numeric($interval) ? (int)$interval : MONTH_IN_SECONDS;
+    $this->subscriberIPsRepository->deleteCreatedAtBeforeTimeInSeconds($purgeWindow);
   }
 
   public function secondsToTimeString($seconds): string {

--- a/mailpoet/lib/Tracy/DIPanel/DIPanel.php
+++ b/mailpoet/lib/Tracy/DIPanel/DIPanel.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Tracy\DIPanel;
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoetVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Reference;
 use MailPoetVendor\Symfony\Component\DependencyInjection\TypedReference;
 use Tracy\Debugger;
@@ -63,7 +64,10 @@ class DIPanel implements IBarPanel {
       $reflection->setAccessible(true);
     }
     $container = $reflection->getValue($containerWrapper);
-    if (!is_object($container)) {
+    // getDefinitions() lives on ContainerBuilder, not Container. The Tracy
+    // panel is dev-only and the dev container is uncompiled (a ContainerBuilder),
+    // but bail out cleanly if a compiled container ever lands here.
+    if (!$container instanceof ContainerBuilder) {
       return [[], []];
     }
     $reflection = new \ReflectionProperty(get_class($container), 'services');
@@ -76,42 +80,47 @@ class DIPanel implements IBarPanel {
   /**
    * For each service finds all of its arguments recursively and makes them an array
    * @param array<int, int|string> $services
-   * @return array
+   * @return array<int|string, array<string, string>>
    */
   private function flattenArguments($services) {
     $result = [];
     foreach ($services as $service) {
-      $result[$service] = [];
-      $this->getAllArguments($service, $result[$service]);
+      $result[$service] = $this->collectArguments($service, []);
     }
     return $result;
   }
 
   /**
-   * Find all argument of each service and adds them to $results array, repeats recursively
+   * Find all argument of each service and merges them into $accumulator,
+   * repeats recursively. Pure return-style avoids by-ref type drift.
+   *
    * @param int|string $service
-   * @param string[] $results
+   * @param array<string, string> $accumulator
+   * @return array<string, string>
    */
-  private function getAllArguments($service, &$results) {
-    if (array_key_exists($service, $this->definitions)) {
-      $arguments = $this->definitions[$service]->getArguments();
-      if (!empty($arguments)) {
-        foreach ($arguments as $argument) {
-          if (is_null($argument)) continue;
-          if ($argument instanceof TypedReference) {
-            $argumentName = $argument->getType();
-          } elseif ($argument instanceof Reference) {
-            $argumentName = (string)$argument;
-          } else {
-            continue;
-          }
-          $results[$argumentName] = $argumentName;
-          if ($argumentName !== 'MailPoet\DI\ContainerWrapper') {
-            $this->getAllArguments($argumentName, $results);
-          }
-        }
+  private function collectArguments($service, array $accumulator): array {
+    if (!array_key_exists($service, $this->definitions)) {
+      return $accumulator;
+    }
+    $arguments = $this->definitions[$service]->getArguments();
+    if (empty($arguments)) {
+      return $accumulator;
+    }
+    foreach ($arguments as $argument) {
+      if (is_null($argument)) continue;
+      if ($argument instanceof TypedReference) {
+        $argumentName = $argument->getType();
+      } elseif ($argument instanceof Reference) {
+        $argumentName = (string)$argument;
+      } else {
+        continue;
+      }
+      $accumulator[$argumentName] = $argumentName;
+      if ($argumentName !== 'MailPoet\DI\ContainerWrapper') {
+        $accumulator = $this->collectArguments($argumentName, $accumulator);
       }
     }
+    return $accumulator;
   }
 
   /**

--- a/mailpoet/lib/Tracy/DIPanel/DIPanel.php
+++ b/mailpoet/lib/Tracy/DIPanel/DIPanel.php
@@ -63,6 +63,9 @@ class DIPanel implements IBarPanel {
       $reflection->setAccessible(true);
     }
     $container = $reflection->getValue($containerWrapper);
+    if (!is_object($container)) {
+      return [[], []];
+    }
     $reflection = new \ReflectionProperty(get_class($container), 'services');
     if (PHP_VERSION_ID <= 80100) {
       $reflection->setAccessible(true);

--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -5,6 +5,7 @@ namespace MailPoet\Util;
 use MailPoet\WP\Functions as WPFunctions;
 
 class ConflictResolver {
+  /** @var array{styles: string[], scripts: string[]} */
   public $permittedAssetsLocations = [
     'styles' => [
       'mailpoet',
@@ -91,7 +92,10 @@ class ConflictResolver {
 
   public function resolveStylesConflict() {
     $_this = $this;
-    $_this->permittedAssetsLocations['styles'] = WPFunctions::get()->applyFilters('mailpoet_conflict_resolver_whitelist_style', $_this->permittedAssetsLocations['styles']);
+    $filteredStyles = WPFunctions::get()->applyFilters('mailpoet_conflict_resolver_whitelist_style', $_this->permittedAssetsLocations['styles']);
+    if (is_array($filteredStyles)) {
+      $_this->permittedAssetsLocations['styles'] = array_values(array_filter($filteredStyles, 'is_string'));
+    }
     // unload all styles except from the list of allowed
     $dequeueStyles = function() use($_this) {
       global $wp_styles; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
@@ -122,7 +126,10 @@ class ConflictResolver {
 
   public function resolveScriptsConflict() {
     $_this = $this;
-    $_this->permittedAssetsLocations['scripts'] = WPFunctions::get()->applyFilters('mailpoet_conflict_resolver_whitelist_script', $_this->permittedAssetsLocations['scripts']);
+    $filteredScripts = WPFunctions::get()->applyFilters('mailpoet_conflict_resolver_whitelist_script', $_this->permittedAssetsLocations['scripts']);
+    if (is_array($filteredScripts)) {
+      $_this->permittedAssetsLocations['scripts'] = array_values(array_filter($filteredScripts, 'is_string'));
+    }
     // unload all scripts except from the list of allowed
     $dequeueScripts = function() use($_this) {
       global $wp_scripts; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/mailpoet/lib/Util/ConflictResolver.php
+++ b/mailpoet/lib/Util/ConflictResolver.php
@@ -94,7 +94,11 @@ class ConflictResolver {
     $_this = $this;
     $filteredStyles = WPFunctions::get()->applyFilters('mailpoet_conflict_resolver_whitelist_style', $_this->permittedAssetsLocations['styles']);
     if (is_array($filteredStyles)) {
-      $_this->permittedAssetsLocations['styles'] = array_values(array_filter($filteredStyles, 'is_string'));
+      // Reject empty/whitespace-only entries: an empty branch in the imploded
+      // regex would match every URL at position zero and disable the resolver.
+      $_this->permittedAssetsLocations['styles'] = array_values(array_filter($filteredStyles, static function ($pattern): bool {
+        return is_string($pattern) && trim($pattern) !== '';
+      }));
     }
     // unload all styles except from the list of allowed
     $dequeueStyles = function() use($_this) {
@@ -128,7 +132,11 @@ class ConflictResolver {
     $_this = $this;
     $filteredScripts = WPFunctions::get()->applyFilters('mailpoet_conflict_resolver_whitelist_script', $_this->permittedAssetsLocations['scripts']);
     if (is_array($filteredScripts)) {
-      $_this->permittedAssetsLocations['scripts'] = array_values(array_filter($filteredScripts, 'is_string'));
+      // Reject empty/whitespace-only entries: an empty branch in the imploded
+      // regex would match every URL at position zero and disable the resolver.
+      $_this->permittedAssetsLocations['scripts'] = array_values(array_filter($filteredScripts, static function ($pattern): bool {
+        return is_string($pattern) && trim($pattern) !== '';
+      }));
     }
     // unload all scripts except from the list of allowed
     $dequeueScripts = function() use($_this) {

--- a/mailpoet/lib/Util/DBCollationChecker.php
+++ b/mailpoet/lib/Util/DBCollationChecker.php
@@ -27,9 +27,11 @@ class DBCollationChecker {
   public function getCollateIfNeeded(string $sourceTable, string $sourceColumn, string $targetTable, string $targetColumn): string {
     $connection = $this->entityManager->getConnection();
     $sourceColumnData = $connection->executeQuery("SHOW FULL COLUMNS FROM $sourceTable WHERE Field = '$sourceColumn';")->fetchAllAssociative();
-    $sourceCollation = $sourceColumnData[0]['Collation'] ?? '';
+    $sourceCollationRaw = $sourceColumnData[0]['Collation'] ?? '';
+    $sourceCollation = is_string($sourceCollationRaw) ? $sourceCollationRaw : '';
     $targetColumnData = $connection->executeQuery("SHOW FULL COLUMNS FROM $targetTable WHERE Field = '$targetColumn';")->fetchAllAssociative();
-    $targetCollation = $targetColumnData[0]['Collation'] ?? '';
+    $targetCollationRaw = $targetColumnData[0]['Collation'] ?? '';
+    $targetCollation = is_string($targetCollationRaw) ? $targetCollationRaw : '';
     if ($sourceCollation === $targetCollation) {
       return '';
     }

--- a/mailpoet/tasks/phpstan/phpstan-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-baseline.neon
@@ -76,59 +76,9 @@ parameters:
 			path: ../../lib/Analytics/Reporter.php
 
 		-
-			identifier: foreach.nonIterable
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
-
-		-
-			identifier: binaryOp.invalid
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/FirstPurchase.php
-
-		-
-			identifier: foreach.nonIterable
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
-
-		-
-			identifier: binaryOp.invalid
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
-
-		-
-			identifier: argument.type
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/PurchasedInCategory.php
-
-		-
-			identifier: foreach.nonIterable
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
-
-		-
-			identifier: binaryOp.invalid
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
-
-		-
-			identifier: argument.type
-			count: 1
-			path: ../../lib/AutomaticEmails/WooCommerce/Events/PurchasedProduct.php
-
-		-
 			identifier: return.type
 			count: 1
 			path: ../../lib/Automation/Engine/Storage/AutomationStorage.php
-
-		-
-			identifier: argument.type
-			count: 2
-			path: ../../lib/Automation/Integrations/Core/Filters/EnumArrayFilter.php
-
-		-
-			identifier: argument.type
-			count: 2
-			path: ../../lib/Automation/Integrations/Core/Filters/NumberFilter.php
 
 		-
 			identifier: function.notFound
@@ -186,19 +136,9 @@ parameters:
 			path: ../../lib/Config/Populator.php
 
 		-
-			identifier: binaryOp.invalid
-			count: 3
-			path: ../../lib/Config/Shortcodes.php
-
-		-
 			identifier: argument.type
 			count: 1
 			path: ../../lib/Config/TranslationUpdater.php
-
-		-
-			identifier: argument.type
-			count: 2
-			path: ../../lib/Cron/CronHelper.php
 
 		-
 			identifier: empty.expr
@@ -262,11 +202,6 @@ parameters:
 
 		-
 			identifier: argument.type
-			count: 2
-			path: ../../lib/Doctrine/Types/JsonOrSerializedType.php
-
-		-
-			identifier: argument.type
 			count: 1
 			path: ../../lib/Doctrine/Types/JsonType.php
 
@@ -321,26 +256,6 @@ parameters:
 			path: ../../lib/Entities/SegmentEntity.php
 
 		-
-			identifier: encapsedStringPart.nonString
-			count: 4
-			path: ../../lib/Form/Block/Column.php
-
-		-
-			identifier: encapsedStringPart.nonString
-			count: 4
-			path: ../../lib/Form/Block/Columns.php
-
-		-
-			identifier: encapsedStringPart.nonString
-			count: 4
-			path: ../../lib/Form/Block/Heading.php
-
-		-
-			identifier: encapsedStringPart.nonString
-			count: 4
-			path: ../../lib/Form/Block/Paragraph.php
-
-		-
 			identifier: empty.variable
 			count: 1
 			path: ../../lib/Form/Block/Paragraph.php
@@ -389,11 +304,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../../lib/Newsletter/Editor/PostTransformerContentsExtractor.php
-
-		-
-			identifier: argument.type
-			count: 2
-			path: ../../lib/Newsletter/NewsletterSaveController.php
 
 		-
 			identifier: return.type
@@ -531,18 +441,8 @@ parameters:
 			path: ../../lib/Subscribers/NewSubscriberNotificationMailer.php
 
 		-
-			identifier: foreach.nonIterable
-			count: 1
-			path: ../../lib/Subscribers/SubscribersRepository.php
-
-		-
 			identifier: return.type
 			count: 2
-			path: ../../lib/Subscribers/SubscribersRepository.php
-
-		-
-			identifier: argument.type
-			count: 3
 			path: ../../lib/Subscribers/SubscribersRepository.php
 
 		-
@@ -562,11 +462,6 @@ parameters:
 
 		-
 			identifier: argument.type
-			count: 2
-			path: ../../lib/Subscription/Throttling.php
-
-		-
-			identifier: argument.type
 			count: 1
 			path: ../../lib/SystemReport/SystemReportCollector.php
 
@@ -581,34 +476,14 @@ parameters:
 			path: ../../lib/Tasks/Subscribers/BatchIterator.php
 
 		-
-			identifier: method.nonObject
+			identifier: method.notFound
 			count: 1
-			path: ../../lib/Tracy/DIPanel/DIPanel.php
-
-		-
-			identifier: argument.type
-			count: 3
 			path: ../../lib/Tracy/DIPanel/DIPanel.php
 
 		-
 			identifier: parameterByRef.type
 			count: 1
 			path: ../../lib/Tracy/DIPanel/DIPanel.php
-
-		-
-			identifier: argument.type
-			count: 2
-			path: ../../lib/Util/ConflictResolver.php
-
-		-
-			identifier: argument.type
-			count: 2
-			path: ../../lib/Util/DBCollationChecker.php
-
-		-
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: ../../lib/Util/DBCollationChecker.php
 
 		-
 			identifier: return.type

--- a/mailpoet/tasks/phpstan/phpstan-baseline.neon
+++ b/mailpoet/tasks/phpstan/phpstan-baseline.neon
@@ -476,16 +476,6 @@ parameters:
 			path: ../../lib/Tasks/Subscribers/BatchIterator.php
 
 		-
-			identifier: method.notFound
-			count: 1
-			path: ../../lib/Tracy/DIPanel/DIPanel.php
-
-		-
-			identifier: parameterByRef.type
-			count: 1
-			path: ../../lib/Tracy/DIPanel/DIPanel.php
-
-		-
 			identifier: return.type
 			count: 1
 			path: ../../lib/Util/Security.php


### PR DESCRIPTION
## Description

Companion to [PHPStan baseline wave 5 (premium)](https://github.com/mailpoet/mailpoet-premium/pull/1050) for [STOMAIL-8000](https://linear.app/a8c/issue/STOMAIL-8000/reduce-phpstan-baseline-error-count). Started as a small same-pattern follow-up and grew into a broader sweep through mixed-typing problems across the free codebase.

**Free baseline drops 232 → 185 errors / 173 → 151 entries (47 errors fixed).** With wave 5 in flight the umbrella goal "free baseline < 200" is met early.

Notable identifier-level changes:

- `encapsedStringPart.nonString` fully cleared (17 → 0).
- `argument.type` 75 → 51.
- `binaryOp.invalid` 13 → 10.
- `Tracy/DIPanel/DIPanel.php` fully cleared (3 → 0).

### Categories addressed

| Group | Files | Errors | Pattern |
| --- | --- | --- | --- |
| AutomaticEmails / WooCommerce events | `FirstPurchase`, `PurchasedInCategory`, `PurchasedProduct` | 8 | `applyFilters('mailpoet_first_purchase_order_states', ...)` mixed return + `$optionValue['option']` mixed into `array_column`. Guard with `is_array` + `is_string`, fall back to defaults. |
| Form/Block padding interpolation | `Column`, `Columns`, `Heading`, `Paragraph` | 16 | `"padding:{$top} {$right} {$bottom} {$left};"` interpolates mixed `$params['padding']` values. `is_scalar`-narrow each side and cast to string with `'0'` fallback. |
| Util/ConflictResolver | `ConflictResolver` | 2 | Type `permittedAssetsLocations` as `array{styles: string[], scripts: string[]}`; validate the `applyFilters` return as array, drop empty/whitespace-only patterns (an empty branch in the imploded regex would match every URL at position zero and disable the resolver). |
| Cron/CronHelper URL & args | `CronHelper` | 2 | `Router::buildRequest` returns mixed — normalize to string at the call site; `applyFilters` returns for cron URL/args validated via `is_string`/`is_array` with fallback. |
| Subscription/Throttling | `Throttling` | 2 | Purge interval validated via `is_numeric` (matches the `limit_window` / `limit_base` pattern earlier in the file — accepts numeric strings from filters); `isUserExemptFromThrottling` re-filters the filter return and `$user->roles` through `is_string` before `array_intersect`. |
| Util request input | `Request`, `DBCollationChecker` | 4 | `is_string` guard on `$_POST`/`$_GET` reads before `sanitize_text_field` (now subsumed by trunk's `getSanitizedParam` refactor after rebase); cast Doctrine collation lookup result to string before `explode`. |
| Automation Core filters | `NumberFilter`, `EnumArrayFilter` | 4 | `@phpstan-assert-if-true int\|float` on `isNumber()` so the narrow flows into `floatval()`; `EnumArrayFilter::matches` filters `array_intersect` inputs through `is_string \|\| is_int` then de-duplicates (filter-before-unique order matters: `array_unique(SORT_REGULAR)` uses loose equality and would collapse `[true, 1]` to a single bool before the type filter could remove it). |
| Doctrine type | `JsonOrSerializedType` | 2 | `is_string` guard before `is_serialized()` / `unserialize()`. |
| Newsletter save | `NewsletterSaveController` | 2 | `json_decode` result narrowed to array before `NewsletterEntity::setBody()` and `ApiDataSanitizer::sanitizeBody()`. |
| Subscribers repository | `SubscribersRepository` | 3 | `woocommerceUserExists` guards Doctrine `->execute()` with `is_array`; `addSubscribersToSegment` filters the result through `instanceof SubscriberEntity`. |
| Tracy DI panel | `DIPanel` | 3 | Bail out early if `ContainerWrapper`'s reflected property isn't a `ContainerBuilder` (only `ContainerBuilder` exposes `getDefinitions()`); refactor `getAllArguments(&$results)` into a pure-return `collectArguments($service, $accumulator): array` to clear `parameterByRef.type` drift. |
| Config/Shortcodes archive | `Shortcodes` | 3 | `mailpoet_archive_title` and per-newsletter `applyFilters` returns extracted to locals + `is_scalar`-narrowed before HTML interpolation. |

## Code review notes

- `Util/ConflictResolver` previously assigned the unfiltered `applyFilters` return directly into `$permittedAssetsLocations['styles']` / `['scripts']`. The committed code only assigns when the return is an array, drops empty/whitespace-only entries (an empty branch like `!|some/path!i` would match every URL at position zero and disable the resolver entirely), and falls back to the original list otherwise.
- The `@phpstan-assert-if-true int|float` on `NumberFilter::isNumber()` is the cleanest way to make PHPStan trust the narrow without duplicating `is_int($x) || is_float($x)` at every call site. If `isNumber()` ever broadens (e.g. accepts numeric strings), the assert needs updating.
- `EnumArrayFilter::matches`: the schema declares `string[]|int[]` but the runtime `$value` comes straight from a field source without the validator schema's check. The committed code filters through `is_string || is_int` (rejecting bool/float so `strval(false) === ''` can't create phantom matches) **before** `array_unique(..., SORT_REGULAR)` — the order matters because `SORT_REGULAR` does loose-equality dedup, so `[true, 1]` would collapse to `[true]` if the bool weren't already gone. Existing unit tests use disjoint string sets and didn't surface either issue; worth a follow-up to add a mixed-type fixture but kept that out of scope here.
- `SubscribersRepository::addSubscribersToSegment` filters Doctrine's `->execute()` result through `instanceof SubscriberEntity`. Doctrine's typing is broad (`mixed`) but in practice always returns the entity. The filter is defensive — if it ever yields something else the count would silently drop rather than throwing in the `SubscriberSegmentEntity` constructor.
- `Tracy/DIPanel` only runs when Tracy debugging is enabled in dev. The early `return [[], []];` for non-`ContainerBuilder` containers is defensive — the dev container is uncompiled so the cast holds. The refactor of `getAllArguments(&$results)` into `collectArguments($service, $accumulator): array` is purely a PHPStan affordance: by-ref typing made the array-shape constraint impossible to keep stable across recursion.

## QA notes

- `pnpm qa:phpstan` clean.
- `phpcs` (free ruleset) clean on all touched files.
- Unit tests pass: `Form/Block/{Column,Columns,Heading,Paragraph}Test`, `Automation/Integration/Core/Filters/{EnumArrayFilter,NumberFilter}Test`.
- Integration tests pass: `Cron/CronHelperTest` (2 skipped, pre-existing), `Subscription/ThrottlingTest`, `Newsletter/NewsletterSaveControllerTest`, `Config/ShortcodesTest`, `Subscribers/SubscribersRepositoryTest`, `AutomaticEmails/WooCommerce/Events/{FirstPurchase,PurchasedInCategory,PurchasedProduct}Test`.
- `Util/ConflictResolverTest`: 2 errors are pre-existing — `get_current_screen()` undefined in a WooCommerce-triggered hook in a non-admin test context. Verified by `git stash`-ing my changes and re-running; same failures. Not introduced by this PR; worth flagging separately.

## Linked PRs

- Sibling: [PHPStan baseline wave 5 (premium)](https://github.com/mailpoet/mailpoet-premium/pull/1050) — same family of fixes against the premium baseline.
- Predecessor: [PHPStan baseline wave 4 (argument.type)](https://github.com/mailpoet/mailpoet/pull/6683)

## Linked tickets

- [STOMAIL-8000](https://linear.app/a8c/issue/STOMAIL-8000/reduce-phpstan-baseline-error-count)

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry — _N/A: internal cleanup, not user-facing (matches waves 1-4)._
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations — _N/A: no translatable strings changed._
- [ ] I added sufficient test coverage — _N/A: behavior preserved (defensive type-narrowing); existing unit + integration tests cover the touched paths._
- [ ] I embraced TypeScript — _N/A: PHP only._