### PR TITLE
Add subscriber timezone data model + save timezone from forms

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -179,6 +179,7 @@ interface Window {
     captcha_reload_title?: string;
     captcha_audio_title?: string;
     assets_url?: string;
+    collect_subscriber_timezones?: boolean | '' | '1';
     openPopup?: (formId: number | string) => boolean;
   };
   mailpoet_authorized_emails?: string[];

--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -29,6 +29,7 @@ interface JQuery {
     api_version: string;
     data: {
       recaptchaResponseToken: string;
+      mailpoet_subscriber_timezone?: string;
     };
   };
   velocity: (selector: string, options?: Record<string, unknown>) => void;

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -847,6 +847,11 @@ jQuery(($) => {
         const formData =
           form.mailpoetSerializeObject() ||
           ({} as ReturnType<JQuery['mailpoetSerializeObject']>);
+        const browserTimeZone =
+          window.Intl?.DateTimeFormat().resolvedOptions().timeZone;
+        if (browserTimeZone && formData.data) {
+          formData.data.mailpoet_subscriber_timezone = browserTimeZone;
+        }
         const size = form
           .find('.mailpoet_recaptcha')
           .attr('data-size') as ReCaptchaV2.Size;

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -847,10 +847,17 @@ jQuery(($) => {
         const formData =
           form.mailpoetSerializeObject() ||
           ({} as ReturnType<JQuery['mailpoetSerializeObject']>);
-        const browserTimeZone =
-          window.Intl?.DateTimeFormat().resolvedOptions().timeZone;
-        if (browserTimeZone && formData.data) {
-          formData.data.mailpoet_subscriber_timezone = browserTimeZone;
+        const collectSubscriberTimeZones =
+          window.MailPoetForm.collect_subscriber_timezones;
+        if (
+          collectSubscriberTimeZones !== false &&
+          collectSubscriberTimeZones !== ''
+        ) {
+          const browserTimeZone =
+            window.Intl?.DateTimeFormat().resolvedOptions().timeZone;
+          if (browserTimeZone && formData.data) {
+            formData.data.mailpoet_subscriber_timezone = browserTimeZone;
+          }
         }
         const size = form
           .find('.mailpoet_recaptcha')

--- a/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/advanced.tsx
@@ -8,6 +8,7 @@ import { Transactional } from './transactional';
 import { InactiveSubscribers } from './inactive-subscribers';
 import { SendingStatusRetention } from './sending-status-retention';
 import { SendingQueueBodyCleanup } from './sending-queue-body-cleanup';
+import { SubscriberTimeZoneData } from './subscriber-time-zone-data';
 import { ShareData } from './share-data';
 import { Libs3rdParty } from './libs-3rd-party';
 import { Captcha } from './captcha';
@@ -34,6 +35,7 @@ export function Advanced() {
       <InactiveSubscribers />
       <SendingStatusRetention />
       <SendingQueueBodyCleanup />
+      <SubscriberTimeZoneData />
       <ShareData />
       <Libs3rdParty />
       <Captcha />

--- a/mailpoet/assets/js/src/settings/pages/advanced/subscriber-time-zone-data.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/subscriber-time-zone-data.tsx
@@ -1,0 +1,40 @@
+import { t } from 'common/functions';
+import { Radio } from 'common/form/radio/radio';
+import { useSetting } from 'settings/store/hooks';
+import { Label, Inputs } from 'settings/components';
+
+export function SubscriberTimeZoneData() {
+  const [enabled, setEnabled] = useSetting(
+    'collect_subscriber_timezones',
+    'enabled',
+  );
+
+  return (
+    <>
+      <Label
+        title={t('collectSubscriberTimeZonesTitle')}
+        description={t('collectSubscriberTimeZonesDescription')}
+        htmlFor=""
+      />
+      <Inputs>
+        <Radio
+          id="collect-subscriber-timezones-enabled"
+          value="1"
+          checked={enabled === '1'}
+          onCheck={setEnabled}
+          automationId="collect-subscriber-timezones-yes"
+        />
+        <label htmlFor="collect-subscriber-timezones-enabled">{t('yes')}</label>
+        <span className="mailpoet-gap" />
+        <Radio
+          id="collect-subscriber-timezones-disabled"
+          value=""
+          checked={enabled === ''}
+          onCheck={setEnabled}
+          automationId="collect-subscriber-timezones-no"
+        />
+        <label htmlFor="collect-subscriber-timezones-disabled">{t('no')}</label>
+      </Inputs>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -136,6 +136,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
       '30',
     ),
     analytics: asObject({ enabled: disabledRadio }),
+    collect_subscriber_timezones: asObject({ enabled: enabledRadio }),
     '3rd_party_libs': asObject({ enabled: disabledRadio }),
     use_block_email_editor_for_automation_emails: asObject({
       enabled: disabledRadio,

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -69,6 +69,9 @@ export type Settings = {
   analytics: {
     enabled: '' | '1';
   };
+  collect_subscriber_timezones: {
+    enabled: '' | '1';
+  };
   captcha: {
     type: 'built-in' | 'recaptcha' | 'recaptcha-invisible' | '';
     recaptcha_site_token: string;

--- a/mailpoet/changelog/2026-05-01-14-13-13-added-start-collecting-timezone-when-subscribing-via-for.md
+++ b/mailpoet/changelog/2026-05-01-14-13-13-added-start-collecting-timezone-when-subscribing-via-for.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Start saving timezone when subscribing via form (enabled by default, with option to disable in Settings).

--- a/mailpoet/lib/Captcha/ReCaptchaHooks.php
+++ b/mailpoet/lib/Captcha/ReCaptchaHooks.php
@@ -81,13 +81,8 @@ class ReCaptchaHooks {
       'ajax_url' => $this->wp->adminUrl('admin-ajax.php'),
       'is_rtl' => (function_exists('is_rtl') && is_rtl()),
       'ajax_common_error_message' => esc_js($ajaxFailedErrorMessage),
-      'collect_subscriber_timezones' => $this->shouldCollectSubscriberTimeZones(),
+      'collect_subscriber_timezones' => $this->settings->isSettingEnabled('collect_subscriber_timezones.enabled'),
     ]);
-  }
-
-  private function shouldCollectSubscriberTimeZones(): bool {
-    $enabled = $this->settings->get('collect_subscriber_timezones.enabled');
-    return $enabled === true || $enabled === '1' || $enabled === 1;
   }
 
   public function render() {

--- a/mailpoet/lib/Captcha/ReCaptchaHooks.php
+++ b/mailpoet/lib/Captcha/ReCaptchaHooks.php
@@ -81,7 +81,13 @@ class ReCaptchaHooks {
       'ajax_url' => $this->wp->adminUrl('admin-ajax.php'),
       'is_rtl' => (function_exists('is_rtl') && is_rtl()),
       'ajax_common_error_message' => esc_js($ajaxFailedErrorMessage),
+      'collect_subscriber_timezones' => $this->shouldCollectSubscriberTimeZones(),
     ]);
+  }
+
+  private function shouldCollectSubscriberTimeZones(): bool {
+    $enabled = $this->settings->get('collect_subscriber_timezones.enabled');
+    return $enabled === true || $enabled === '1' || $enabled === 1;
   }
 
   public function render() {

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -39,6 +39,13 @@ class SubscriberEntity {
 
   public const OBSOLETE_LINK_TOKEN_LENGTH = 6;
   public const LINK_TOKEN_LENGTH = 32;
+  public const TIME_ZONE_FIELD_NAME = 'mailpoet_subscriber_timezone';
+  public const TIME_ZONE_SOURCE_FORM = 'form';
+  public const TIME_ZONE_SOURCE_SITE_FALLBACK = 'site_fallback';
+  public const TIME_ZONE_CONFIDENCE_BROWSER = 90;
+
+  /** @var array<string,bool>|null */
+  private static $validTimeZones = null;
 
   use AutoincrementedIdTrait;
   use CreatedAtTrait;
@@ -85,16 +92,40 @@ class SubscriberEntity {
   private $status = self::STATUS_UNCONFIRMED;
 
   /**
-   * @ORM\Column(type="string", nullable=true)
+   * @ORM\Column(type="string", length=64, nullable=true)
    * @var string|null
    */
   private $subscribedIp;
 
   /**
-   * @ORM\Column(type="string", nullable=true)
+   * @ORM\Column(type="string", length=32, nullable=true)
    * @var string|null
    */
   private $confirmedIp;
+
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $timeZone;
+
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   * @var string|null
+   */
+  private $timeZoneSource;
+
+  /**
+   * @ORM\Column(type="integer", nullable=true)
+   * @var int|null
+   */
+  private $timeZoneConfidence;
+
+  /**
+   * @ORM\Column(type="datetimetz", nullable=true)
+   * @var DateTimeInterface|null
+   */
+  private $timeZoneUpdatedAt;
 
   /**
    * @ORM\Column(type="datetimetz", nullable=true)
@@ -360,6 +391,59 @@ class SubscriberEntity {
    */
   public function setConfirmedIp($confirmedIp) {
     $this->confirmedIp = $confirmedIp;
+  }
+
+  public function getTimeZone(): ?string {
+    return $this->timeZone;
+  }
+
+  public function setTimeZone(?string $timeZone): void {
+    $this->timeZone = $timeZone;
+  }
+
+  public function getTimeZoneSource(): ?string {
+    return $this->timeZoneSource;
+  }
+
+  public function setTimeZoneSource(?string $timeZoneSource): void {
+    $this->timeZoneSource = $timeZoneSource;
+  }
+
+  public function getTimeZoneConfidence(): ?int {
+    return $this->timeZoneConfidence;
+  }
+
+  public function setTimeZoneConfidence(?int $timeZoneConfidence): void {
+    $this->timeZoneConfidence = $timeZoneConfidence;
+  }
+
+  public function getTimeZoneUpdatedAt(): ?DateTimeInterface {
+    return $this->timeZoneUpdatedAt;
+  }
+
+  public function setTimeZoneUpdatedAt(?DateTimeInterface $timeZoneUpdatedAt): void {
+    $this->timeZoneUpdatedAt = $timeZoneUpdatedAt;
+  }
+
+  public static function sanitizeTimeZone(?string $timeZone): ?string {
+    if (!is_string($timeZone)) {
+      return null;
+    }
+    $timeZone = trim($timeZone);
+    if ($timeZone === '' || strlen($timeZone) > 64) {
+      return null;
+    }
+    return self::isValidTimeZone($timeZone) ? $timeZone : null;
+  }
+
+  public static function isValidTimeZone(?string $timeZone): bool {
+    if (!is_string($timeZone) || $timeZone === '') {
+      return false;
+    }
+    if (self::$validTimeZones === null) {
+      self::$validTimeZones = array_fill_keys(\DateTimeZone::listIdentifiers(), true);
+    }
+    return isset(self::$validTimeZones[$timeZone]);
   }
 
   /**

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -92,13 +92,13 @@ class SubscriberEntity {
   private $status = self::STATUS_UNCONFIRMED;
 
   /**
-   * @ORM\Column(type="string", length=64, nullable=true)
+   * @ORM\Column(type="string", nullable=true)
    * @var string|null
    */
   private $subscribedIp;
 
   /**
-   * @ORM\Column(type="string", length=32, nullable=true)
+   * @ORM\Column(type="string", nullable=true)
    * @var string|null
    */
   private $confirmedIp;

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -425,7 +425,10 @@ class SubscriberEntity {
     $this->timeZoneUpdatedAt = $timeZoneUpdatedAt;
   }
 
-  public static function sanitizeTimeZone(?string $timeZone): ?string {
+  /**
+   * @param mixed $timeZone
+   */
+  public static function sanitizeTimeZone($timeZone): ?string {
     if (!is_string($timeZone)) {
       return null;
     }
@@ -436,7 +439,10 @@ class SubscriberEntity {
     return self::isValidTimeZone($timeZone) ? $timeZone : null;
   }
 
-  public static function isValidTimeZone(?string $timeZone): bool {
+  /**
+   * @param mixed $timeZone
+   */
+  public static function isValidTimeZone($timeZone): bool {
     if (!is_string($timeZone) || $timeZone === '') {
       return false;
     }

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -100,7 +100,13 @@ class AssetsController {
       'captcha_reload_title' => esc_js(__('Reload CAPTCHA', 'mailpoet')),
       'captcha_audio_title' => esc_js(__('Play CAPTCHA', 'mailpoet')),
       'assets_url' => Env::$assetsUrl,
+      'collect_subscriber_timezones' => $this->shouldCollectSubscriberTimeZones(),
     ]);
+  }
+
+  public function shouldCollectSubscriberTimeZones(): bool {
+    $enabled = $this->settings->get('collect_subscriber_timezones.enabled');
+    return $enabled === true || $enabled === '1' || $enabled === 1;
   }
 
   public function setupAdminWidgetPageDependencies() {

--- a/mailpoet/lib/Form/AssetsController.php
+++ b/mailpoet/lib/Form/AssetsController.php
@@ -100,13 +100,8 @@ class AssetsController {
       'captcha_reload_title' => esc_js(__('Reload CAPTCHA', 'mailpoet')),
       'captcha_audio_title' => esc_js(__('Play CAPTCHA', 'mailpoet')),
       'assets_url' => Env::$assetsUrl,
-      'collect_subscriber_timezones' => $this->shouldCollectSubscriberTimeZones(),
+      'collect_subscriber_timezones' => $this->settings->isSettingEnabled('collect_subscriber_timezones.enabled'),
     ]);
-  }
-
-  public function shouldCollectSubscriberTimeZones(): bool {
-    $enabled = $this->settings->get('collect_subscriber_timezones.enabled');
-    return $enabled === true || $enabled === '1' || $enabled === 1;
   }
 
   public function setupAdminWidgetPageDependencies() {

--- a/mailpoet/lib/Form/Util/Export.php
+++ b/mailpoet/lib/Form/Util/Export.php
@@ -82,15 +82,13 @@ class Export {
           Env::$assetsUrl . '/dist/js/public.js?mp_ver=' . MAILPOET_VERSION .
         '"></script>';
 
-        // (JS) variables...
-        $collectSubscriberTimeZones = SettingsController::getInstance()->get(
+        $collectSubscriberTimeZones = SettingsController::getInstance()->isSettingEnabled(
           'collect_subscriber_timezones.enabled'
         );
         $output[] = '<script type="text/javascript">';
         $output[] = '   var MailPoetForm = MailPoetForm || {';
         $output[] = '       is_rtl: ' . ((int)is_rtl()) . ",";
-        $output[] = '       collect_subscriber_timezones: ' .
-          (in_array($collectSubscriberTimeZones, [true, '1', 1], true) ? 'true' : 'false') . ',';
+        $output[] = '       collect_subscriber_timezones: ' . ($collectSubscriberTimeZones ? 'true' : 'false') . ',';
         $output[] = '       ajax_url: "' . admin_url('admin-ajax.php') . '"';
         $output[] = '   };';
         $output[] = '</script>';

--- a/mailpoet/lib/Form/Util/Export.php
+++ b/mailpoet/lib/Form/Util/Export.php
@@ -4,6 +4,7 @@ namespace MailPoet\Form\Util;
 
 use MailPoet\Config\Env;
 use MailPoet\Form\Widget;
+use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Export {
@@ -82,9 +83,14 @@ class Export {
         '"></script>';
 
         // (JS) variables...
+        $collectSubscriberTimeZones = SettingsController::getInstance()->get(
+          'collect_subscriber_timezones.enabled'
+        );
         $output[] = '<script type="text/javascript">';
         $output[] = '   var MailPoetForm = MailPoetForm || {';
         $output[] = '       is_rtl: ' . ((int)is_rtl()) . ",";
+        $output[] = '       collect_subscriber_timezones: ' .
+          (in_array($collectSubscriberTimeZones, [true, '1', 1], true) ? 'true' : 'false') . ',';
         $output[] = '       ajax_url: "' . admin_url('admin-ajax.php') . '"';
         $output[] = '   };';
         $output[] = '</script>';

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -90,6 +90,7 @@ class Widget extends \WP_Widget {
       'mailpoet_form' => [
         'ajax_url' => WPFunctions::get()->adminUrl('admin-ajax.php', 'absolute'),
         'is_rtl' => $isRtl,
+        'collect_subscriber_timezones' => $this->assetsController->shouldCollectSubscriberTimeZones(),
       ],
       'fonts_link' => $this->customFonts->generateHtmlCustomFontLink(),
       'mailpoet_public_css_url' => Env::$assetsUrl . '/dist/css/' . $this->renderer->getCssAsset('mailpoet-public.css'),

--- a/mailpoet/lib/Form/Widget.php
+++ b/mailpoet/lib/Form/Widget.php
@@ -29,6 +29,9 @@ class Widget extends \WP_Widget {
   /** @var CustomFonts */
   private $customFonts;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function __construct() {
     parent::__construct(
       'mailpoet_form',
@@ -38,7 +41,8 @@ class Widget extends \WP_Widget {
     $this->wp = new WPFunctions;
 
     $this->renderer = (new RendererFactory())->getRenderer();
-    $this->assetsController = new AssetsController($this->wp, $this->renderer, SettingsController::getInstance());
+    $this->settings = SettingsController::getInstance();
+    $this->assetsController = new AssetsController($this->wp, $this->renderer, $this->settings);
     $this->formRenderer = ContainerWrapper::getInstance()->get(FormRenderer::class);
     $this->formsRepository = ContainerWrapper::getInstance()->get(FormsRepository::class);
     $this->customFonts = ContainerWrapper::getInstance()->get(CustomFonts::class);
@@ -90,7 +94,7 @@ class Widget extends \WP_Widget {
       'mailpoet_form' => [
         'ajax_url' => WPFunctions::get()->adminUrl('admin-ajax.php', 'absolute'),
         'is_rtl' => $isRtl,
-        'collect_subscriber_timezones' => $this->assetsController->shouldCollectSubscriberTimeZones(),
+        'collect_subscriber_timezones' => $this->settings->isSettingEnabled('collect_subscriber_timezones.enabled'),
       ],
       'fonts_link' => $this->customFonts->generateHtmlCustomFontLink(),
       'mailpoet_public_css_url' => Env::$assetsUrl . '/dist/css/' . $this->renderer->getCssAsset('mailpoet-public.css'),

--- a/mailpoet/lib/Migrations/Db/Migration_20260430_120000.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260430_120000.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260430_120000 extends DbMigration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+
+    $alterations = [];
+    if (!$this->columnExists($subscribersTable, 'time_zone')) {
+      $alterations[] = 'ADD COLUMN `time_zone` varchar(64) NULL DEFAULT NULL';
+    }
+    if (!$this->columnExists($subscribersTable, 'time_zone_source')) {
+      $alterations[] = 'ADD COLUMN `time_zone_source` varchar(32) NULL DEFAULT NULL';
+    }
+    if (!$this->columnExists($subscribersTable, 'time_zone_confidence')) {
+      $alterations[] = 'ADD COLUMN `time_zone_confidence` int NULL DEFAULT NULL';
+    }
+    if (!$this->columnExists($subscribersTable, 'time_zone_updated_at')) {
+      $alterations[] = 'ADD COLUMN `time_zone_updated_at` timestamp NULL DEFAULT NULL';
+    }
+
+    if ($alterations === []) {
+      return;
+    }
+
+    $this->connection->executeStatement(
+      "ALTER TABLE `{$subscribersTable}` " . implode(', ', $alterations)
+    );
+  }
+}

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -211,6 +211,16 @@ class SettingsController {
     return $this->get($key, 'unset') !== 'unset';
   }
 
+  /**
+   * Returns true if the setting value is a truthy boolean. Settings are persisted as
+   * strings, integers, or booleans depending on how they were written, so this helper
+   * normalizes the check across all three representations.
+   */
+  public function isSettingEnabled(string $key): bool {
+    $value = $this->get($key);
+    return $value === true || $value === '1' || $value === 1;
+  }
+
   private function ensureLoaded() {
     if ($this->loaded) {
       return;

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -87,6 +87,9 @@ class SettingsController {
         'analytics' => [
           'enabled' => false,
         ],
+        'collect_subscriber_timezones' => [
+          'enabled' => true,
+        ],
         'display_nps_poll' => true,
         'deactivate_subscriber_after_inactive_days' => self::DEFAULT_DEACTIVATE_SUBSCRIBER_AFTER_INACTIVE_DAYS,
         'delete_unconfirmed_subscribers_after_days' => self::DEFAULT_DELETE_UNCONFIRMED_SUBSCRIBERS_AFTER_DAYS,

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -235,12 +235,14 @@ class SubscriberSaveController {
     if (isset($data['subscribed_ip'])) $subscriber->setSubscribedIp($data['subscribed_ip']);
     if (isset($data['confirmed_ip'])) $subscriber->setConfirmedIp($data['confirmed_ip']);
     if (isset($data['is_woocommerce_user'])) $subscriber->setIsWoocommerceUser((bool)$data['is_woocommerce_user']);
-    $timeZone = SubscriberEntity::sanitizeTimeZone($data[SubscriberEntity::TIME_ZONE_FIELD_NAME] ?? null);
-    if ($timeZone !== null) {
-      $subscriber->setTimeZone($timeZone);
-      $subscriber->setTimeZoneSource(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
-      $subscriber->setTimeZoneConfidence(SubscriberEntity::TIME_ZONE_CONFIDENCE_BROWSER);
-      $subscriber->setTimeZoneUpdatedAt(Carbon::now()->millisecond(0));
+    if ($this->shouldCollectSubscriberTimeZones()) {
+      $timeZone = SubscriberEntity::sanitizeTimeZone($data[SubscriberEntity::TIME_ZONE_FIELD_NAME] ?? null);
+      if ($timeZone !== null) {
+        $subscriber->setTimeZone($timeZone);
+        $subscriber->setTimeZoneSource(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
+        $subscriber->setTimeZoneConfidence(SubscriberEntity::TIME_ZONE_CONFIDENCE_BROWSER);
+        $subscriber->setTimeZoneUpdatedAt(Carbon::now()->millisecond(0));
+      }
     }
     $createdAt = isset($data['created_at']) ? Carbon::createFromFormat('Y-m-d H:i:s', $data['created_at']) : null;
     if ($createdAt) $subscriber->setCreatedAt($createdAt);
@@ -377,5 +379,10 @@ class SubscriberSaveController {
     foreach ($removedTags as $subscriberTag) {
       $this->wp->doAction('mailpoet_subscriber_tag_removed', $subscriberTag);
     }
+  }
+
+  private function shouldCollectSubscriberTimeZones(): bool {
+    $enabled = $this->settings->get('collect_subscriber_timezones.enabled');
+    return $enabled === true || $enabled === '1' || $enabled === 1;
   }
 }

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -235,7 +235,7 @@ class SubscriberSaveController {
     if (isset($data['subscribed_ip'])) $subscriber->setSubscribedIp($data['subscribed_ip']);
     if (isset($data['confirmed_ip'])) $subscriber->setConfirmedIp($data['confirmed_ip']);
     if (isset($data['is_woocommerce_user'])) $subscriber->setIsWoocommerceUser((bool)$data['is_woocommerce_user']);
-    if ($this->shouldCollectSubscriberTimeZones()) {
+    if ($this->settings->isSettingEnabled('collect_subscriber_timezones.enabled')) {
       $timeZone = SubscriberEntity::sanitizeTimeZone($data[SubscriberEntity::TIME_ZONE_FIELD_NAME] ?? null);
       if ($timeZone !== null) {
         $subscriber->setTimeZone($timeZone);
@@ -379,10 +379,5 @@ class SubscriberSaveController {
     foreach ($removedTags as $subscriberTag) {
       $this->wp->doAction('mailpoet_subscriber_tag_removed', $subscriberTag);
     }
-  }
-
-  private function shouldCollectSubscriberTimeZones(): bool {
-    $enabled = $this->settings->get('collect_subscriber_timezones.enabled');
-    return $enabled === true || $enabled === '1' || $enabled === 1;
   }
 }

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -235,6 +235,13 @@ class SubscriberSaveController {
     if (isset($data['subscribed_ip'])) $subscriber->setSubscribedIp($data['subscribed_ip']);
     if (isset($data['confirmed_ip'])) $subscriber->setConfirmedIp($data['confirmed_ip']);
     if (isset($data['is_woocommerce_user'])) $subscriber->setIsWoocommerceUser((bool)$data['is_woocommerce_user']);
+    $timeZone = SubscriberEntity::sanitizeTimeZone($data[SubscriberEntity::TIME_ZONE_FIELD_NAME] ?? null);
+    if ($timeZone !== null) {
+      $subscriber->setTimeZone($timeZone);
+      $subscriber->setTimeZoneSource(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
+      $subscriber->setTimeZoneConfidence(SubscriberEntity::TIME_ZONE_CONFIDENCE_BROWSER);
+      $subscriber->setTimeZoneUpdatedAt(Carbon::now()->millisecond(0));
+    }
     $createdAt = isset($data['created_at']) ? Carbon::createFromFormat('Y-m-d H:i:s', $data['created_at']) : null;
     if ($createdAt) $subscriber->setCreatedAt($createdAt);
     $confirmedAt = isset($data['confirmed_at']) ? Carbon::createFromFormat('Y-m-d H:i:s', $data['confirmed_at']) : null;

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -120,6 +120,8 @@ class SubscriberSubscribeController {
       return $meta;
     }
 
+    $submittedTimeZone = SubscriberEntity::sanitizeTimeZone($data[SubscriberEntity::TIME_ZONE_FIELD_NAME] ?? null);
+
     // only accept fields defined in the form
     $formFieldIds = array_filter(array_map(function (array $formField): ?string {
       if (!isset($formField['id'])) {
@@ -128,6 +130,9 @@ class SubscriberSubscribeController {
       return is_numeric($formField['id']) ? "cf_{$formField['id']}" : $formField['id'];
     }, $form->getBlocksByTypes(FormEntity::FORM_FIELD_TYPES)));
     $data = array_intersect_key($data, array_flip($formFieldIds));
+    if ($submittedTimeZone !== null) {
+      $data[SubscriberEntity::TIME_ZONE_FIELD_NAME] = $submittedTimeZone;
+    }
 
     // make sure we don't allow too many subscriptions with the same ip address
     $timeout = $this->throttling->throttle();

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -481,7 +481,7 @@ class Pages {
   public function saveUnsubscribeReason(string $reason, ?string $reasonText): bool {
     if (
       $this->isPreview()
-      || !$this->isSettingEnabled('subscription.unsubscribe_survey.enabled')
+      || !$this->settings->isSettingEnabled('subscription.unsubscribe_survey.enabled')
       || !($this->subscriber instanceof SubscriberEntity)
       || $this->subscriber->getStatus() !== SubscriberEntity::STATUS_UNSUBSCRIBED
     ) {
@@ -494,7 +494,7 @@ class Pages {
       $queueId,
       $reason,
       $reasonText,
-      $this->isSettingEnabled('subscription.unsubscribe_survey.allow_other_text')
+      $this->settings->isSettingEnabled('subscription.unsubscribe_survey.allow_other_text')
     );
 
     return $result instanceof StatisticsUnsubscribeEntity;
@@ -515,7 +515,7 @@ class Pages {
   private function shouldRenderUnsubscribeReasonSurvey(): bool {
     if (
       $this->isPreview()
-      || !$this->isSettingEnabled('subscription.unsubscribe_survey.enabled')
+      || !$this->settings->isSettingEnabled('subscription.unsubscribe_survey.enabled')
       || !($this->subscriber instanceof SubscriberEntity)
       || $this->subscriber->getStatus() !== SubscriberEntity::STATUS_UNSUBSCRIBED
     ) {
@@ -528,7 +528,7 @@ class Pages {
 
   private function renderUnsubscribeReasonSurvey(): string {
     $queueId = isset($this->data['queueId']) ? (int)$this->data['queueId'] : null;
-    $allowOtherText = $this->isSettingEnabled('subscription.unsubscribe_survey.allow_other_text');
+    $allowOtherText = $this->settings->isSettingEnabled('subscription.unsubscribe_survey.allow_other_text');
     $reasons = $this->unsubscribeReasonTracker->getReasonLabels();
 
     return $this->templateRenderer->render('subscription/unsubscribe_reason.html', [
@@ -538,11 +538,6 @@ class Pages {
       'otherReason' => StatisticsUnsubscribeEntity::REASON_OTHER,
       'nonce' => $this->wp->wpCreateNonce('mailpoet_unsubscribe_reason'),
     ]);
-  }
-
-  private function isSettingEnabled(string $key): bool {
-    $value = $this->settings->get($key);
-    return $value === true || $value === '1' || $value === 1;
   }
 
   private function isUnsubscribeReasonSaved(): bool {

--- a/mailpoet/tests/DataFactories/Subscriber.php
+++ b/mailpoet/tests/DataFactories/Subscriber.php
@@ -230,6 +230,11 @@ class Subscriber {
     return $this;
   }
 
+  public function withTimeZone(string $timeZone): self {
+    $this->data['timeZone'] = $timeZone;
+    return $this;
+  }
+
   /**
    * @return $this
    */
@@ -282,6 +287,7 @@ class Subscriber {
     if (isset($this->data['wp_user_id'])) $subscriber->setWpUserId($this->data['wp_user_id']);
     if (isset($this->data['subscribedIp'])) $subscriber->setSubscribedIp($this->data['subscribedIp']);
     if (isset($this->data['confirmedIp'])) $subscriber->setConfirmedIp($this->data['confirmedIp']);
+    if (isset($this->data['timeZone'])) $subscriber->setTimeZone($this->data['timeZone']);
     if (isset($this->data['unconfirmedData'])) $subscriber->setUnconfirmedData($this->data['unconfirmedData']);
     if (isset($this->data['createdAt'])) $subscriber->setCreatedAt($this->data['createdAt']);
     if (isset($this->data['source'])) {

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20260430_120000_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20260430_120000_Test.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Migrations\Db;
+
+require_once __DIR__ . '/../../../../lib/Migrations/Db/Migration_20260430_120000.php';
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrations\Db\Migration_20260430_120000;
+
+//phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
+class Migration_20260430_120000_Test extends \MailPoetTest {
+  private const COLUMNS = [
+    'time_zone_updated_at',
+    'time_zone_confidence',
+    'time_zone_source',
+    'time_zone',
+  ];
+
+  /** @var Migration_20260430_120000 */
+  private $migration;
+
+  /** @var string */
+  private $tableName;
+
+  public function _before() {
+    parent::_before();
+    $this->migration = new Migration_20260430_120000($this->diContainer);
+    $this->tableName = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+
+    foreach (self::COLUMNS as $column) {
+      if ($this->columnExists($column)) {
+        $this->entityManager->getConnection()->executeStatement("ALTER TABLE `{$this->tableName}` DROP COLUMN `{$column}`");
+      }
+    }
+  }
+
+  public function testItAddsSubscriberTimeZoneColumns(): void {
+    $this->migration->run();
+
+    foreach (self::COLUMNS as $column) {
+      verify($this->columnExists($column))->true();
+    }
+  }
+
+  public function testItCanBeRerunSafely(): void {
+    $this->migration->run();
+    $this->migration->run();
+
+    foreach (self::COLUMNS as $column) {
+      verify($this->columnExists($column))->true();
+    }
+  }
+
+  private function columnExists(string $column): bool {
+    if (!in_array($column, self::COLUMNS, true)) {
+      throw new \InvalidArgumentException('Unsupported column name.');
+    }
+
+    return (bool)$this->entityManager->getConnection()
+      ->fetchAssociative("SHOW COLUMNS FROM `{$this->tableName}` LIKE '{$column}'");
+  }
+}

--- a/mailpoet/tests/integration/Settings/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsControllerTest.php
@@ -47,6 +47,10 @@ class SettingsControllerTest extends \MailPoetTest {
     $this->assertFalse($this->controller->get('subscription.unsubscribe_survey.allow_other_text'));
   }
 
+  public function testItEnablesSubscriberTimeZoneCollectionByDefault(): void {
+    $this->assertTrue($this->controller->get('collect_subscriber_timezones.enabled'));
+  }
+
   public function testItCanFetchValuesFromDB() {
     $this->assertNull($this->controller->fetch('test_key'));
     $this->assertNull($this->controller->fetch('test_key.sub_key'));

--- a/mailpoet/tests/integration/Settings/SettingsControllerTest.php
+++ b/mailpoet/tests/integration/Settings/SettingsControllerTest.php
@@ -143,6 +143,35 @@ class SettingsControllerTest extends \MailPoetTest {
     $this->assertTrue($this->controller->hasSavedValue('test_key'));
   }
 
+  public function testItChecksIfSettingIsEnabledAcrossStoredRepresentations(): void {
+    // Settings may be persisted as string, integer, or boolean depending on how
+    // they were written, so the helper must accept all three truthy forms.
+    $this->controller->set('truthy_bool', true);
+    $this->controller->set('truthy_string', '1');
+    $this->controller->set('truthy_int', 1);
+    $this->controller->set('falsy_bool', false);
+    $this->controller->set('falsy_string', '');
+    $this->controller->set('falsy_int', 0);
+    $this->controller->set('falsy_zero_string', '0');
+
+    $this->assertTrue($this->controller->isSettingEnabled('truthy_bool'));
+    $this->assertTrue($this->controller->isSettingEnabled('truthy_string'));
+    $this->assertTrue($this->controller->isSettingEnabled('truthy_int'));
+    $this->assertFalse($this->controller->isSettingEnabled('falsy_bool'));
+    $this->assertFalse($this->controller->isSettingEnabled('falsy_string'));
+    $this->assertFalse($this->controller->isSettingEnabled('falsy_int'));
+    $this->assertFalse($this->controller->isSettingEnabled('falsy_zero_string'));
+    $this->assertFalse($this->controller->isSettingEnabled('unknown_key'));
+  }
+
+  public function testItChecksIfNestedSettingIsEnabled(): void {
+    $this->controller->set('group.enabled', '1');
+    $this->assertTrue($this->controller->isSettingEnabled('group.enabled'));
+
+    $this->controller->set('group.enabled', '');
+    $this->assertFalse($this->controller->isSettingEnabled('group.enabled'));
+  }
+
   public function testItSkipsDbWriteWhenValueUnchanged() {
     // Same scalar value — second set() should skip DB write
     $this->controller->set('skip_test', 1);

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Settings\SettingsController;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -21,11 +22,16 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
   /** @var SubscriberSegmentRepository */
   private $subscriberSegmentRepository;
 
+  /** @var SettingsController */
+  private $settings;
+
   public function _before() {
     parent::_before();
     $this->saveController = $this->diContainer->get(SubscriberSaveController::class);
     $this->segmentsRepository = $this->diContainer->get(SegmentsRepository::class);
     $this->subscriberSegmentRepository = $this->diContainer->get(SubscriberSegmentRepository::class);
+    $this->settings = $this->diContainer->get(SettingsController::class);
+    $this->settings->set('collect_subscriber_timezones', ['enabled' => '1']);
   }
 
   public function testItCreatesNewSubscriber(): void {
@@ -68,6 +74,34 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     verify($subscriber->getSegments())->arrayCount(2);
     verify($subscriber->getSubscriberSegments())->arrayCount(2);
     verify($subscriber->getSubscriberTags())->arrayCount(2);
+  }
+
+  public function testItSavesSubscriberTimeZoneWhenCollectionIsEnabled(): void {
+    $subscriber = $this->saveController->save([
+      'email' => 'timezone-enabled@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      SubscriberEntity::TIME_ZONE_FIELD_NAME => 'Europe/Prague',
+    ]);
+
+    verify($subscriber->getTimeZone())->equals('Europe/Prague');
+    verify($subscriber->getTimeZoneSource())->equals(SubscriberEntity::TIME_ZONE_SOURCE_FORM);
+    verify($subscriber->getTimeZoneConfidence())->equals(SubscriberEntity::TIME_ZONE_CONFIDENCE_BROWSER);
+    verify($subscriber->getTimeZoneUpdatedAt())->notNull();
+  }
+
+  public function testItDoesNotSaveSubscriberTimeZoneWhenCollectionIsDisabled(): void {
+    $this->settings->set('collect_subscriber_timezones', ['enabled' => '']);
+
+    $subscriber = $this->saveController->save([
+      'email' => 'timezone-disabled@test.com',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      SubscriberEntity::TIME_ZONE_FIELD_NAME => 'Europe/Prague',
+    ]);
+
+    verify($subscriber->getTimeZone())->null();
+    verify($subscriber->getTimeZoneSource())->null();
+    verify($subscriber->getTimeZoneConfidence())->null();
+    verify($subscriber->getTimeZoneUpdatedAt())->null();
   }
 
   public function testItCanUpdateASubscriber(): void {

--- a/mailpoet/tests/unit/Subscribers/SubscriberTimeZoneTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberTimeZoneTest.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Subscribers;
+
+use MailPoet\Entities\SubscriberEntity;
+
+class SubscriberTimeZoneTest extends \MailPoetUnitTest {
+  public function testItAcceptsValidIanaTimeZones(): void {
+    verify(SubscriberEntity::sanitizeTimeZone('Europe/Bratislava'))->equals('Europe/Bratislava');
+    verify(SubscriberEntity::isValidTimeZone('America/New_York'))->true();
+  }
+
+  public function testItRejectsInvalidTimeZones(): void {
+    verify(SubscriberEntity::sanitizeTimeZone('Not/AZone'))->null();
+    verify(SubscriberEntity::sanitizeTimeZone(''))->null();
+    verify(SubscriberEntity::isValidTimeZone(null))->false();
+  }
+}

--- a/mailpoet/tests/unit/Subscribers/SubscriberTimeZoneTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberTimeZoneTest.php
@@ -15,4 +15,13 @@ class SubscriberTimeZoneTest extends \MailPoetUnitTest {
     verify(SubscriberEntity::sanitizeTimeZone(''))->null();
     verify(SubscriberEntity::isValidTimeZone(null))->false();
   }
+
+  public function testItRejectsNonStringInputWithoutThrowing(): void {
+    verify(SubscriberEntity::sanitizeTimeZone(['Europe/Prague']))->null();
+    verify(SubscriberEntity::sanitizeTimeZone(123))->null();
+    verify(SubscriberEntity::sanitizeTimeZone(true))->null();
+    verify(SubscriberEntity::sanitizeTimeZone(null))->null();
+    verify(SubscriberEntity::isValidTimeZone(['Europe/Prague']))->false();
+    verify(SubscriberEntity::isValidTimeZone(123))->false();
+  }
 }

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -120,6 +120,8 @@
   'libs3rdPartyDescription': __('E.g. Google Fonts in the Form and Email editor and WordPress.com to get help. When disabled, you can still reach support at [link]www.mailpoet.com/support/[/link].'),
   'useBlockEditorForAutomationTitle': __('Use block email editor for automation emails'),
   'useBlockEditorForAutomationDescription': __('Use the alpha block email editor for creating and editing automation newsletters. Note: newsletters created with this editor will not be visible in the classic editor.'),
+  'collectSubscriberTimeZonesTitle': __("Collect subscribers' time zones"),
+  'collectSubscriberTimeZonesDescription': __("Collect subscribers' browser time zones from MailPoet forms. This is used to send newsletters based on each subscriber's local time."),
   'shareDataTitle': __('Share anonymous data'),
   'shareDataDescription': __('Share anonymous data and help us improve the plugin. We appreciate your help!'),
   'captchaTitle': __('Protect your MailPoet forms against spam signups'),


### PR DESCRIPTION
## Description

Start saving timezone reported by browser when submitting a subscription form. Enabled by default, with option to disable in settings. 

## Code review notes

The migration explicitly didn't add any index so it's near-instant on MySQL 8+. 

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8005

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="611" height="99" alt="Screenshot 2026-05-01 at 16 05 12" src="https://github.com/user-attachments/assets/157088c1-36f3-45ee-8b24-c1482184ff1d" />
.
<img width="578" height="157" alt="Screenshot 2026-05-01 at 16 06 47" src="https://github.com/user-attachments/assets/1688d359-84bd-444d-bb70-c92a60fd68f3" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8005-add-subscriber-timezone-data-model)

_The latest successful build from `stomail-8005-add-subscriber-timezone-data-model` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->