### PR TITLE
Improve public API docs

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -25,30 +25,44 @@ Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by Wo
 
 ### Available API Methods
 
-- [Add List (addList)](api_methods/AddList.md)
-- [Add Subscriber (addSubscriber)](api_methods/AddSubscriber.md)
-- [Add Subscriber Field (addSubscriberField)](api_methods/AddSubscriberField.md)
-- [Add Tag (addTag)](api_methods/AddTag.md)
-- [Delete List (deleteList)](api_methods/DeleteList.md)
-- [Delete Tag (deleteTag)](api_methods/DeleteTag.md)
+#### Setup
+
+- [Is Setup Complete (isSetupComplete)](api_methods/IsSetupComplete.md)
+
+#### Lists
+
 - [Get Lists (getLists)](api_methods/GetLists.md)
+- [Add List (addList)](api_methods/AddList.md)
+- [Update List (updateList)](api_methods/UpdateList.md)
+- [Delete List (deleteList)](api_methods/DeleteList.md)
+
+#### Subscribers
+
 - [Get Subscriber (getSubscriber)](api_methods/GetSubscriber.md)
 - [Get Subscribers (getSubscribers)](api_methods/GetSubscribers.md)
 - [Get Subscribers Count (getSubscribersCount)](api_methods/GetSubscribersCount.md)
-- [Get Subscriber Fields (getSubscriberFields)](api_methods/GetSubscriberFields.md)
-- [Get Tag (getTag)](api_methods/GetTag.md)
-- [Get Tags (getTags)](api_methods/GetTags.md)
-- [Is Setup Complete (isSetupComplete)](api_methods/IsSetupComplete.md)
+- [Add Subscriber (addSubscriber)](api_methods/AddSubscriber.md)
+- [Update Subscriber (updateSubscriber)](api_methods/UpdateSubscriber.md)
 - [Subscribe to List (subscribeToList)](api_methods/SubscribeToList.md)
 - [Subscribe to Lists (subscribeToLists)](api_methods/SubscribeToLists.md)
-- [Tag Subscriber (tagSubscriber)](api_methods/TagSubscriber.md)
-- [Unsubscribe globally](api_methods/UnsubscribeGlobally.md)
 - [Unsubscribe from List (unsubscribeFromList)](api_methods/UnsubscribeFromList.md)
 - [Unsubscribe from Lists (unsubscribeFromLists)](api_methods/UnsubscribeFromLists.md)
-- [Untag Subscriber (untagSubscriber)](api_methods/UntagSubscriber.md)
-- [Update List (updateList)](api_methods/UpdateList.md)
-- [Update Subscriber (updateSubscriber)](api_methods/UpdateSubscriber.md)
+- [Unsubscribe globally (unsubscribe)](api_methods/UnsubscribeGlobally.md)
+
+#### Subscriber Fields
+
+- [Get Subscriber Fields (getSubscriberFields)](api_methods/GetSubscriberFields.md)
+- [Add Subscriber Field (addSubscriberField)](api_methods/AddSubscriberField.md)
+
+#### Tags
+
+- [Get Tag (getTag)](api_methods/GetTag.md)
+- [Get Tags (getTags)](api_methods/GetTags.md)
+- [Add Tag (addTag)](api_methods/AddTag.md)
 - [Update Tag (updateTag)](api_methods/UpdateTag.md)
+- [Delete Tag (deleteTag)](api_methods/DeleteTag.md)
+- [Tag Subscriber (tagSubscriber)](api_methods/TagSubscriber.md)
+- [Untag Subscriber (untagSubscriber)](api_methods/UntagSubscriber.md)
 
 ### Usage examples
 

--- a/doc/api_methods/AddList.md
+++ b/doc/api_methods/AddList.md
@@ -33,3 +33,23 @@ Codes description:
 | 14   | Missing list name                            |
 | 15   | Trying to create a list that already exists  |
 | 16   | The list couldn’t be created in the database |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $list = $mailpoet_api->addList([
+      'name' => 'VIP customers',
+      'description' => 'High-value customers, hand-picked.',
+    ]);
+    // $list['id'] is the new list id (string)
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet addList failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/AddSubscriber.md
+++ b/doc/api_methods/AddSubscriber.md
@@ -83,3 +83,39 @@ Codes description:
 | 17   | Welcome email failed to send.                                                         |
 | 25   | A `tags` entry resolved to an empty/missing tag name.                                 |
 | 29   | A `tags` entry referenced a tag id that does not exist.                               |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  $list_ids = [3]; // segment ids the new subscriber should be subscribed to
+  $options = [
+    'send_confirmation_email' => true,
+    'schedule_welcome_email' => true,
+    'skip_subscriber_notification' => false,
+  ];
+
+  try {
+    $subscriber = $mailpoet_api->addSubscriber(
+      [
+        'email' => 'jane.doe@example.com',
+        'first_name' => 'Jane',
+        'last_name' => 'Doe',
+        'tags' => ['VIP', ['id' => 5]], // mix of names and ids
+        'cf_1' => 'New York',           // custom subscriber field
+      ],
+      $list_ids,
+      $options
+    );
+    // $subscriber['id'] is the new subscriber id
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    // 11 = missing email, 12 = subscriber exists, 5/6/7/8 = invalid list,
+    // 10 = confirmation email failed, 17 = welcome email failed, 13 = save failed
+    error_log(sprintf('MailPoet addSubscriber failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/AddSubscriber.md
+++ b/doc/api_methods/AddSubscriber.md
@@ -70,9 +70,16 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                        |
-| ---- | -------------------------------------------------- |
-| 11   | Missing email address                              |
-| 12   | Trying to create a subscriber that already exists  |
-| 13   | The subscriber couldn’t be created in the database |
-| 17   | Welcome email failed to send                       |
+| Code | Description                                                                           |
+| ---- | ------------------------------------------------------------------------------------- |
+| 5    | One or more `$list_ids` do not exist (raised when the subscriber is added to lists).  |
+| 6    | One of `$list_ids` points to a WordPress Users list.                                  |
+| 7    | One of `$list_ids` points to a WooCommerce Customers list.                            |
+| 8    | One of `$list_ids` points to a list that does not support subscribing (e.g. dynamic). |
+| 10   | Confirmation email failed to send.                                                    |
+| 11   | Missing email address.                                                                |
+| 12   | Trying to create a subscriber that already exists.                                    |
+| 13   | The subscriber couldn’t be created in the database.                                   |
+| 17   | Welcome email failed to send.                                                         |
+| 25   | A `tags` entry resolved to an empty/missing tag name.                                 |
+| 29   | A `tags` entry referenced a tag id that does not exist.                               |

--- a/doc/api_methods/AddSubscriberField.md
+++ b/doc/api_methods/AddSubscriberField.md
@@ -83,3 +83,45 @@ Codes description:
 | 1008 | Incorrect `date_type` value                                                        |
 | 1009 | Missing `values` for select or radio types                                         |
 | 1010 | Empty `value` for select or radio types                                            |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    // A simple required text field
+    $field = $mailpoet_api->addSubscriberField([
+      'name' => 'Country',
+      'type' => 'text',
+      'params' => [
+        'required' => '1',
+        'label' => 'Your country',
+        'validate' => 'alphanum',
+      ],
+    ]);
+    // $field['id'] looks like 'cf_5'
+
+    // A select field with two options
+    $select = $mailpoet_api->addSubscriberField([
+      'name' => 'T-shirt size',
+      'type' => 'select',
+      'params' => [
+        'required' => '1',
+        'values' => [
+          ['value' => 'S'],
+          ['value' => 'M', 'is_checked' => '1'],
+          ['value' => 'L'],
+        ],
+      ],
+    ]);
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    // Codes 1001-1010 cover the sanitizer's validation failures;
+    // code 1 is reserved for persistence failures.
+    error_log(sprintf('MailPoet addSubscriberField failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/AddSubscriberField.md
+++ b/doc/api_methods/AddSubscriberField.md
@@ -54,14 +54,12 @@ The common properties for all types:
 
 ## Response
 
-| Property   | Type         | Limits   | Description                                                                                       |
-| ---------- | ------------ | -------- | ------------------------------------------------------------------------------------------------- |
-| id         | string       | 11 chars | Field Id                                                                                          |
-| name       | string       | 90 chars | Human readable name. Intended to be used, as an example, as a label for form input.               |
-| type       | string       | -        | Type of the field. Possible values are: `text`, `date`, `textarea`, `radio`, `checkbox`, `select` |
-| params     | array        | -        | Contains various information, see examples below.                                                 |
-| created_at | string\|null | -        | UTC time of creation in `Y-m-d H:i:s` format                                                      |
-| updated_at | string       | -        | UTC time of last update in `Y-m-d H:i:s` format                                                   |
+| Property | Type   | Limits   | Description                                                                                       |
+| -------- | ------ | -------- | ------------------------------------------------------------------------------------------------- |
+| id       | string | 11 chars | Field id, prefixed with `cf_` (e.g. `cf_5`)                                                       |
+| name     | string | 90 chars | Human readable name. Intended to be used, as an example, as a label for form input.               |
+| type     | string | -        | Type of the field. Possible values are: `text`, `date`, `textarea`, `radio`, `checkbox`, `select` |
+| params   | array  | -        | The sanitized params, see examples above.                                                         |
 
 ## Error handling
 

--- a/doc/api_methods/AddTag.md
+++ b/doc/api_methods/AddTag.md
@@ -33,3 +33,23 @@ Codes description:
 | 25   | Missing tag name                            |
 | 26   | Trying to create a tag that already exists  |
 | 27   | The tag couldn’t be created in the database |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $tag = $mailpoet_api->addTag([
+      'name' => 'VIP',
+      'description' => 'High-value customers',
+    ]);
+    // $tag['id'] is the new tag id (string)
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet addTag failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/DeleteList.md
+++ b/doc/api_methods/DeleteList.md
@@ -25,3 +25,21 @@ Codes description:
 | 21   | List cannot be deleted because it’s used for a form             |
 | 22   | The list couldn’t be deleted from the database                  |
 | 23   | Only lists of the type 'default' can be deleted                 |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->deleteList('5'); // list id as string
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    // 18 = empty id, 5 = list not found, 20/21 = list still in use,
+    // 23 = list type is not 'default' (e.g. dynamic), 22 = delete failed
+    error_log(sprintf('MailPoet deleteList failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/DeleteTag.md
+++ b/doc/api_methods/DeleteTag.md
@@ -22,3 +22,19 @@ Codes description:
 | 28   | Tag id is empty                               |
 | 29   | Tag does not exist                            |
 | 31   | The tag couldn’t be deleted from the database |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->deleteTag('7'); // tag id as string
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet deleteTag failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/GetLists.md
+++ b/doc/api_methods/GetLists.md
@@ -43,3 +43,23 @@ In MailPoet, subscribers are organized into lists. This method returns an array 
   ],
 ]
 ```
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  $lists = $mailpoet_api->getLists();
+  // Filter out trashed lists; the API returns lists in trash with deleted_at set.
+  $active_lists = array_filter($lists, static function (array $list): bool {
+    return $list['deleted_at'] === null;
+  });
+
+  foreach ($active_lists as $list) {
+    printf("%s — %s\n", $list['id'], $list['name']);
+  }
+}
+```

--- a/doc/api_methods/GetSubscriber.md
+++ b/doc/api_methods/GetSubscriber.md
@@ -169,3 +169,28 @@ Codes description:
 | Code | Description                                  |
 | ---- | -------------------------------------------- |
 | 4    | Asking for a subscriber that does not exist. |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  // Look up by email
+  try {
+    $subscriber = $mailpoet_api->getSubscriber('jane.doe@example.com');
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    if ($e->getCode() === 4 /* SUBSCRIBER_NOT_EXISTS */) {
+      // Not found - show a sign-up prompt, etc.
+      $subscriber = null;
+    } else {
+      throw $e;
+    }
+  }
+
+  // Or by id (int or numeric string both work)
+  $subscriber = $mailpoet_api->getSubscriber(42);
+}
+```

--- a/doc/api_methods/GetSubscriber.md
+++ b/doc/api_methods/GetSubscriber.md
@@ -57,17 +57,17 @@ This method throws an `\Exception` in the event no subscriber matches the given 
 
 Each entry in `unsubscribes` describes a single unsubscribe event. `newsletterId` and `newsletterSubject` are only present when the unsubscribe is associated with a specific newsletter.
 
-| Property          | Type             | Description                                                                                                       |
-| ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- |
-| source            | string\|null     | Where the unsubscribe came from (`newsletter`, `manage`, `admin`, `mp_api`, …)                                    |
-| meta              | string\|null     | Free-form metadata stored alongside the event                                                                     |
-| createdAt         | DateTimeInterface\|null | When the unsubscribe was recorded                                                                          |
-| reason            | string\|null     | Internal reason key (e.g. `not_interested`, `spam`, `other`)                                                      |
-| reasonLabel       | string\|null     | Human-readable label for the reason; `"No reason provided"` when the reason is unspecified                        |
-| reasonText        | string\|null     | Free-form reason text submitted by the subscriber                                                                 |
-| reasonSubmittedAt | DateTimeInterface\|null | When the reason text was submitted                                                                         |
-| newsletterId      | int              | Id of the related newsletter (only present when applicable)                                                       |
-| newsletterSubject | string           | Subject of the related newsletter (only present when applicable)                                                  |
+| Property          | Type                    | Description                                                                                |
+| ----------------- | ----------------------- | ------------------------------------------------------------------------------------------ |
+| source            | string\|null            | Where the unsubscribe came from (`newsletter`, `manage`, `admin`, `mp_api`, …)             |
+| meta              | string\|null            | Free-form metadata stored alongside the event                                              |
+| createdAt         | DateTimeInterface\|null | When the unsubscribe was recorded                                                          |
+| reason            | string\|null            | Internal reason key (e.g. `not_interested`, `spam`, `other`)                               |
+| reasonLabel       | string\|null            | Human-readable label for the reason; `"No reason provided"` when the reason is unspecified |
+| reasonText        | string\|null            | Free-form reason text submitted by the subscriber                                          |
+| reasonSubmittedAt | DateTimeInterface\|null | When the reason text was submitted                                                         |
+| newsletterId      | int                     | Id of the related newsletter (only present when applicable)                                |
+| newsletterSubject | string                  | Subject of the related newsletter (only present when applicable)                           |
 
 ### Subscriber's tag
 

--- a/doc/api_methods/GetSubscriber.md
+++ b/doc/api_methods/GetSubscriber.md
@@ -2,15 +2,15 @@
 
 # Get Subscriber
 
-## `array getSubscriber(string $subscriber_email)`
+## `array getSubscriber($subscriberIdOrEmail)`
 
-This method throws an `\Exception` in the event a subscriber with a given email address doesn’t exist.
+This method throws an `\Exception` in the event no subscriber matches the given id or email.
 
 ## Arguments
 
-| Argument          | Type   | Description           |
-| ----------------- | ------ | --------------------- |
-| $subscriber_email | string | a valid email address |
+| Argument             | Type          | Description                                                          |
+| -------------------- | ------------- | -------------------------------------------------------------------- |
+| $subscriberIdOrEmail | int or string | An id (int or numeric string) or the email of an existing subscriber |
 
 ## A subscriber data structure
 
@@ -35,8 +35,11 @@ This method throws an `\Exception` in the event a subscriber with a given email 
 | unconfirmed_data         | string\|null | 65K chars | May contain serialized subscriber data in case when there are pending changes waiting for a confirmation from a subscriber     |
 | source                   | string\|null | -         | Possible values: `form`,`imported`,`administrator`,`api`,`wordpress_user`,`woocommerce_user`,`woocommerce_checkout`,`unknown`) |
 | count_confirmations      | string       | 11 chars  | Counter for confirmation emails                                                                                                |
-| subscriptions            | array        | -         | List of subcriber subscriptions                                                                                                |
-| tags                     | array        | -         | List of subcriber tags                                                                                                         |
+| unsubscribe_token        | string\|null | 15 chars  | Token used in unsubscribe links sent to the subscriber                                                                         |
+| link_token               | string\|null | 32 chars  | Token used to authenticate manage-subscription links sent to the subscriber                                                    |
+| subscriptions            | array        | -         | List of subscriber subscriptions                                                                                               |
+| unsubscribes             | array        | -         | History of unsubscribe events for the subscriber, ordered by `createdAt` desc                                                  |
+| tags                     | array        | -         | List of subscriber tags                                                                                                        |
 | cf\_{custom_field['id']} | string       | 65K chars | A custom subscriber field value (see [Get Subscriber Fields](GetSubscriberFields.md)                                           |
 
 ### Subscriber's subscription
@@ -49,6 +52,22 @@ This method throws an `\Exception` in the event a subscriber with a given email 
 | status        | string | -        | Status of a subscription for the list. Possible values: `subscribed`, `unsubscribed` |
 | created_at    | string | -        | UTC time of creation in 'Y-m-d H:i:s' format                                         |
 | updated_at    | string | -        | UTC time of last update in 'Y-m-d H:i:s' format                                      |
+
+### Subscriber's unsubscribe entry
+
+Each entry in `unsubscribes` describes a single unsubscribe event. `newsletterId` and `newsletterSubject` are only present when the unsubscribe is associated with a specific newsletter.
+
+| Property          | Type             | Description                                                                                                       |
+| ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| source            | string\|null     | Where the unsubscribe came from (`newsletter`, `manage`, `admin`, `mp_api`, …)                                    |
+| meta              | string\|null     | Free-form metadata stored alongside the event                                                                     |
+| createdAt         | DateTimeInterface\|null | When the unsubscribe was recorded                                                                          |
+| reason            | string\|null     | Internal reason key (e.g. `not_interested`, `spam`, `other`)                                                      |
+| reasonLabel       | string\|null     | Human-readable label for the reason; `"No reason provided"` when the reason is unspecified                        |
+| reasonText        | string\|null     | Free-form reason text submitted by the subscriber                                                                 |
+| reasonSubmittedAt | DateTimeInterface\|null | When the reason text was submitted                                                                         |
+| newsletterId      | int              | Id of the related newsletter (only present when applicable)                                                       |
+| newsletterSubject | string           | Subject of the related newsletter (only present when applicable)                                                  |
 
 ### Subscriber's tag
 
@@ -82,6 +101,8 @@ This method throws an `\Exception` in the event a subscriber with a given email 
   'unconfirmed_data' => NULL,
   'source' => 'woocommerce_user',
   'count_confirmations' => '0',
+  'unsubscribe_token' => 'a1b2c3d4e5f6g7h',
+  'link_token' => '0123456789abcdef0123456789abcdef',
   'subscriptions' => [
     0 => [
       'id' => '3',
@@ -98,6 +119,19 @@ This method throws an `\Exception` in the event a subscriber with a given email 
       'status' => 'unsubscribed',
       'created_at' => '2019-05-14 08:43:08',
       'updated_at' => '2019-05-14 08:43:08',
+    ],
+  ],
+  'unsubscribes' => [
+    0 => [
+      'source' => 'newsletter',
+      'meta' => NULL,
+      'createdAt' => /* DateTime */,
+      'reason' => 'not_interested',
+      'reasonLabel' => 'Not interested',
+      'reasonText' => NULL,
+      'reasonSubmittedAt' => NULL,
+      'newsletterId' => 42,
+      'newsletterSubject' => 'May newsletter',
     ],
   ],
   'tags' => [

--- a/doc/api_methods/GetSubscriberFields.md
+++ b/doc/api_methods/GetSubscriberFields.md
@@ -101,3 +101,31 @@ See also [addSubscriberField function.](AddSubscriberField.md)
 ]
 
 ```
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  $fields = $mailpoet_api->getSubscriberFields();
+
+  // Render a form with the required fields, skipping the default email field
+  // which is always required and is typically already wired up.
+  foreach ($fields as $field) {
+    if ($field['id'] === 'email') {
+      continue;
+    }
+    $required = !empty($field['params']['required']);
+    printf(
+      '<label>%s%s<input name="%s" type="%s"></label>',
+      esc_html($field['name']),
+      $required ? ' *' : '',
+      esc_attr($field['id']),
+      esc_attr(in_array($field['type'], ['text', 'date'], true) ? $field['type'] : 'text')
+    );
+  }
+}
+```

--- a/doc/api_methods/GetSubscribers.md
+++ b/doc/api_methods/GetSubscribers.md
@@ -22,4 +22,4 @@ Filter argument supports following array keys.
 | ------------ | ------------ | ----------------------------------------------------------------------------------------------------------------- |
 | status       | string       | Specific status of subscribers. One of values: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive` |
 | listId       | int          | List id or dynamic segment id                                                                                     |
-| minUpdatedAt | DateTime\int | DateTime object or timestamp of the minimal last update of subscribers                                            |
+| minUpdatedAt | DateTimeInterface\|int | A `DateTime`/`DateTimeImmutable` instance, or a unix timestamp, for the minimal last-updated time of subscribers |

--- a/doc/api_methods/GetSubscribers.md
+++ b/doc/api_methods/GetSubscribers.md
@@ -23,3 +23,28 @@ Filter argument supports following array keys.
 | status       | string       | Specific status of subscribers. One of values: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive` |
 | listId       | int          | List id or dynamic segment id                                                                                     |
 | minUpdatedAt | DateTimeInterface\|int | A `DateTime`/`DateTimeImmutable` instance, or a unix timestamp, for the minimal last-updated time of subscribers |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  // First page of all subscribed users in list 3
+  $subscribers = $mailpoet_api->getSubscribers(
+    [
+      'status' => 'subscribed',
+      'listId' => 3,
+    ],
+    100, // limit
+    0    // offset
+  );
+
+  // Subscribers updated since yesterday (any status)
+  $recent = $mailpoet_api->getSubscribers([
+    'minUpdatedAt' => new \DateTimeImmutable('-1 day'),
+  ]);
+}
+```

--- a/doc/api_methods/GetSubscribers.md
+++ b/doc/api_methods/GetSubscribers.md
@@ -18,11 +18,11 @@ This method returns a list of subscribers. To see the subscriber data structure,
 
 Filter argument supports following array keys.
 
-| Key          | Type         | Description                                                                                                       |
-| ------------ | ------------ | ----------------------------------------------------------------------------------------------------------------- |
-| status       | string       | Specific status of subscribers. One of values: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive` |
-| listId       | int          | List id or dynamic segment id                                                                                     |
-| minUpdatedAt | DateTimeInterface\|int | A `DateTime`/`DateTimeImmutable` instance, or a unix timestamp, for the minimal last-updated time of subscribers |
+| Key          | Type                   | Description                                                                                                       |
+| ------------ | ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| status       | string                 | Specific status of subscribers. One of values: `unconfirmed`, `subscribed`, `unsubscribed`, `bounced`, `inactive` |
+| listId       | int                    | List id or dynamic segment id                                                                                     |
+| minUpdatedAt | DateTimeInterface\|int | A `DateTime`/`DateTimeImmutable` instance, or a unix timestamp, for the minimal last-updated time of subscribers  |
 
 ## Example
 

--- a/doc/api_methods/GetSubscribersCount.md
+++ b/doc/api_methods/GetSubscribersCount.md
@@ -15,3 +15,22 @@ This method returns the count of subscribers by a filter.
 ### Filter
 
 To see supported filters, please check [getSubscribers()](GetSubscribers.md) documentation.
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  // Total subscribed users (no filter)
+  $total = $mailpoet_api->getSubscribersCount(['status' => 'subscribed']);
+
+  // Subscribed users in a specific list, useful for paginating getSubscribers()
+  $count_in_list = $mailpoet_api->getSubscribersCount([
+    'status' => 'subscribed',
+    'listId' => 3,
+  ]);
+}
+```

--- a/doc/api_methods/GetTag.md
+++ b/doc/api_methods/GetTag.md
@@ -26,3 +26,26 @@ Codes description:
 | Code | Description                           |
 | ---- | ------------------------------------- |
 | 29   | Asking for a tag that does not exist. |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    // By id
+    $tag = $mailpoet_api->getTag(7);
+    // ...or by exact name (case sensitivity follows the database collation)
+    $tag = $mailpoet_api->getTag('VIP');
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    if ($e->getCode() === 29 /* TAG_NOT_EXISTS */) {
+      $tag = null;
+    } else {
+      throw $e;
+    }
+  }
+}
+```

--- a/doc/api_methods/GetTags.md
+++ b/doc/api_methods/GetTags.md
@@ -37,3 +37,17 @@ In MailPoet, tags can be attached to subscribers to label them. This method retu
   ],
 ]
 ```
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  $tags = $mailpoet_api->getTags();
+  // Build a name => id map for use with tagSubscriber()
+  $tags_by_name = array_column($tags, 'id', 'name');
+}
+```

--- a/doc/api_methods/IsSetupComplete.md
+++ b/doc/api_methods/IsSetupComplete.md
@@ -13,3 +13,19 @@ It returns `false` if any of the post-install onboarding screens would show up o
 - the revenue tracking permission page.
 
 Otherwise it returns `true`.
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  if (!$mailpoet_api->isSetupComplete()) {
+    // The site admin still has post-install onboarding to do; defer any
+    // calls that would fail or behave unexpectedly until setup is finished.
+    return;
+  }
+}
+```

--- a/doc/api_methods/IsSetupComplete.md
+++ b/doc/api_methods/IsSetupComplete.md
@@ -6,4 +6,10 @@
 
 This method checks if the MailPoet is set up.
 
-It returns `false` if either Welcome Wizard, or WooCommerce setup, or MailPoet 2 migration is shown on the next MailPoet page visit. Otherwise it returns `true`.
+It returns `false` if any of the post-install onboarding screens would show up on the next MailPoet page visit:
+
+- the Welcome Wizard,
+- the WooCommerce list-import page,
+- the revenue tracking permission page.
+
+Otherwise it returns `true`.

--- a/doc/api_methods/SubscribeToList.md
+++ b/doc/api_methods/SubscribeToList.md
@@ -7,3 +7,22 @@
 This method allows adding an existing subscriber into a list, and handles confirmation email and admin notification email sending.
 
 This method works exactly the same as [Subscribe to lists](SubscribeToLists.md). The only difference is the second argument which is a single list id.
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->subscribeToList(
+      'jane.doe@example.com', // subscriber id or email
+      3                       // single list id
+    );
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet subscribeToList failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/SubscribeToLists.md
+++ b/doc/api_methods/SubscribeToLists.md
@@ -43,13 +43,14 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                             |
-| ---- | ------------------------------------------------------- |
-| 3    | No lists provided                                       |
-| 4    | Invalid subscriber that does not exist                  |
-| 5    | Invalid list that does not exist                        |
-| 6    | Trying to subscribe to a WordPress Users list           |
-| 7    | Trying to subscribe to a WooCommerce Customers list     |
-| 8    | Trying to subscribe to a list that doesn’t support that |
-| 10   | Confirmation email failed to send                       |
-| 17   | Welcome email failed to send                            |
+| Code | Description                                                          |
+| ---- | -------------------------------------------------------------------- |
+| 3    | No lists provided                                                    |
+| 4    | Invalid subscriber that does not exist                               |
+| 5    | Invalid list that does not exist                                     |
+| 6    | Trying to subscribe to a WordPress Users list                        |
+| 7    | Trying to subscribe to a WooCommerce Customers list                  |
+| 8    | Trying to subscribe to a list that doesn’t support that              |
+| 10   | Confirmation email failed to send                                    |
+| 13   | Failed to save the subscriber's status when transitioning to the list |
+| 17   | Welcome email failed to send                                         |

--- a/doc/api_methods/SubscribeToLists.md
+++ b/doc/api_methods/SubscribeToLists.md
@@ -54,3 +54,28 @@ Codes description:
 | 10   | Confirmation email failed to send                                    |
 | 13   | Failed to save the subscriber's status when transitioning to the list |
 | 17   | Welcome email failed to send                                         |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    // Add an existing subscriber to two lists, suppressing the admin
+    // notification email but keeping confirmation/welcome emails on.
+    $subscriber = $mailpoet_api->subscribeToLists(
+      'jane.doe@example.com',
+      [3, 7],
+      ['skip_subscriber_notification' => true]
+    );
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    // Common codes: 4 (subscriber not found), 5 (list not found),
+    // 6/7/8 (list type not allowed), 10 (confirmation send failed),
+    // 17 (welcome send failed).
+    error_log(sprintf('MailPoet subscribeToLists failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/SubscribeToLists.md
+++ b/doc/api_methods/SubscribeToLists.md
@@ -43,17 +43,17 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                                          |
-| ---- | -------------------------------------------------------------------- |
-| 3    | No lists provided                                                    |
-| 4    | Invalid subscriber that does not exist                               |
-| 5    | Invalid list that does not exist                                     |
-| 6    | Trying to subscribe to a WordPress Users list                        |
-| 7    | Trying to subscribe to a WooCommerce Customers list                  |
-| 8    | Trying to subscribe to a list that doesn’t support that              |
-| 10   | Confirmation email failed to send                                    |
+| Code | Description                                                           |
+| ---- | --------------------------------------------------------------------- |
+| 3    | No lists provided                                                     |
+| 4    | Invalid subscriber that does not exist                                |
+| 5    | Invalid list that does not exist                                      |
+| 6    | Trying to subscribe to a WordPress Users list                         |
+| 7    | Trying to subscribe to a WooCommerce Customers list                   |
+| 8    | Trying to subscribe to a list that doesn’t support that               |
+| 10   | Confirmation email failed to send                                     |
 | 13   | Failed to save the subscriber's status when transitioning to the list |
-| 17   | Welcome email failed to send                                         |
+| 17   | Welcome email failed to send                                          |
 
 ## Example
 

--- a/doc/api_methods/TagSubscriber.md
+++ b/doc/api_methods/TagSubscriber.md
@@ -34,3 +34,23 @@ Codes description:
 | 4    | The subscriber does not exist.          |
 | 25   | Missing tag name (empty string passed). |
 | 29   | A tag referenced by id does not exist.  |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    // Use an existing tag id (must exist), or pass a name to auto-create one.
+    $mailpoet_api->tagSubscriber('jane.doe@example.com', 'VIP');
+    // Idempotent: a second call with the same tag is a no-op and does not
+    // re-fire the `mailpoet_subscriber_tag_added` action.
+    $mailpoet_api->tagSubscriber('jane.doe@example.com', 'VIP');
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet tagSubscriber failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UnsubscribeFromList.md
+++ b/doc/api_methods/UnsubscribeFromList.md
@@ -7,3 +7,22 @@
 This method removes a subscriber from given list.
 
 This method works exactly the same as [Unsubscribe from Lists](UnsubscribeFromLists.md). The only difference is the second argument which is a single list id.
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->unsubscribeFromList(
+      'jane.doe@example.com', // subscriber id or email
+      3                       // single list id
+    );
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet unsubscribeFromList failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UnsubscribeFromLists.md
+++ b/doc/api_methods/UnsubscribeFromLists.md
@@ -27,11 +27,11 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                         |
-| ---- | --------------------------------------------------- |
-| 3    | No lists provided                                   |
-| 4    | Invalid subscriber that does not exist              |
-| 5    | Invalid list that does not exist                    |
-| 6    | Trying to subscribe to a WordPress Users list       |
-| 7    | Trying to subscribe to a WooCommerce Customers list |
-| 10   | Confirmation email failed to send                   |
+| Code | Description                                                 |
+| ---- | ----------------------------------------------------------- |
+| 3    | No lists provided                                           |
+| 4    | Invalid subscriber that does not exist                      |
+| 5    | Invalid list that does not exist                            |
+| 6    | Trying to unsubscribe from a WordPress Users list           |
+| 7    | Trying to unsubscribe from a WooCommerce Customers list     |
+| 8    | Trying to unsubscribe from a list that doesn’t support that |

--- a/doc/api_methods/UnsubscribeFromLists.md
+++ b/doc/api_methods/UnsubscribeFromLists.md
@@ -35,3 +35,25 @@ Codes description:
 | 6    | Trying to unsubscribe from a WordPress Users list           |
 | 7    | Trying to unsubscribe from a WooCommerce Customers list     |
 | 8    | Trying to unsubscribe from a list that doesn’t support that |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->unsubscribeFromLists(
+      'jane.doe@example.com',
+      [3, 7] // list ids
+    );
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    // Note: this only removes the per-list subscription. To unsubscribe
+    // the subscriber from everything and flip their global status, use
+    // unsubscribe() (see UnsubscribeGlobally.md).
+    error_log(sprintf('MailPoet unsubscribeFromLists failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UnsubscribeGlobally.md
+++ b/doc/api_methods/UnsubscribeGlobally.md
@@ -27,3 +27,23 @@ Codes description:
 | ---- | -------------------------------------------- |
 | 4    | Invalid subscriber that does not exist       |
 | 24   | Subscriber already has 'unsubscribed' status |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->unsubscribe('jane.doe@example.com');
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    if ($e->getCode() === 24 /* SUBSCRIBER_ALREADY_UNSUBSCRIBED */) {
+      // Already unsubscribed - safe to ignore depending on the use case.
+      return;
+    }
+    error_log(sprintf('MailPoet unsubscribe failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UntagSubscriber.md
+++ b/doc/api_methods/UntagSubscriber.md
@@ -34,3 +34,22 @@ Codes description:
 | 4    | The subscriber does not exist.          |
 | 25   | Missing tag name (empty string passed). |
 | 29   | The tag does not exist.                 |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $mailpoet_api->untagSubscriber('jane.doe@example.com', 'VIP');
+    // Idempotent: calling again when the tag isn't attached is a no-op
+    // and does not re-fire `mailpoet_subscriber_tag_removed`.
+    $mailpoet_api->untagSubscriber('jane.doe@example.com', 'VIP');
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet untagSubscriber failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UpdateList.md
+++ b/doc/api_methods/UpdateList.md
@@ -37,3 +37,23 @@ Codes description:
 | 18   | Missing list id                                 |
 | 19   | The list couldn’t be updated in the database    |
 | 23   | Only lists of the type 'default' can be updated |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    $list = $mailpoet_api->updateList([
+      'id' => '5',                       // required
+      'name' => 'VIP customers (renamed)',
+      'description' => 'High-value customers, hand-picked.',
+    ]);
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet updateList failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UpdateSubscriber.md
+++ b/doc/api_methods/UpdateSubscriber.md
@@ -41,3 +41,29 @@ Codes description:
 | 13   | The subscriber couldn’t be updated in the database.      |
 | 25   | A `tags` entry resolved to an empty/missing tag name.    |
 | 29   | A `tags` entry referenced a tag id that does not exist.  |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    // Update the name and replace the entire tag set with two tags.
+    $subscriber = $mailpoet_api->updateSubscriber('jane.doe@example.com', [
+      'first_name' => 'Janet',
+      'tags' => ['VIP', 'Newsletter'],
+      'cf_1' => 'San Francisco',
+    ]);
+
+    // To leave tags untouched, simply omit the 'tags' key.
+    $mailpoet_api->updateSubscriber($subscriber['id'], [
+      'last_name' => 'Doe-Smith',
+    ]);
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet updateSubscriber failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/doc/api_methods/UpdateSubscriber.md
+++ b/doc/api_methods/UpdateSubscriber.md
@@ -35,7 +35,9 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                        |
-| ---- | -------------------------------------------------- |
-| 4    | Updating a subscriber that does not exist.         |
-| 13   | The subscriber couldn’t be updated in the database |
+| Code | Description                                              |
+| ---- | -------------------------------------------------------- |
+| 4    | Updating a subscriber that does not exist.               |
+| 13   | The subscriber couldn’t be updated in the database.      |
+| 25   | A `tags` entry resolved to an empty/missing tag name.    |
+| 29   | A `tags` entry referenced a tag id that does not exist.  |

--- a/doc/api_methods/UpdateSubscriber.md
+++ b/doc/api_methods/UpdateSubscriber.md
@@ -35,12 +35,12 @@ An exception of base class `\Exception` can be thrown when something unexpected 
 
 Codes description:
 
-| Code | Description                                              |
-| ---- | -------------------------------------------------------- |
-| 4    | Updating a subscriber that does not exist.               |
-| 13   | The subscriber couldn’t be updated in the database.      |
-| 25   | A `tags` entry resolved to an empty/missing tag name.    |
-| 29   | A `tags` entry referenced a tag id that does not exist.  |
+| Code | Description                                             |
+| ---- | ------------------------------------------------------- |
+| 4    | Updating a subscriber that does not exist.              |
+| 13   | The subscriber couldn’t be updated in the database.     |
+| 25   | A `tags` entry resolved to an empty/missing tag name.   |
+| 29   | A `tags` entry referenced a tag id that does not exist. |
 
 ## Example
 

--- a/doc/api_methods/UpdateTag.md
+++ b/doc/api_methods/UpdateTag.md
@@ -36,3 +36,29 @@ Codes description:
 | 28   | Missing tag id                                       |
 | 29   | The tag was not found by id                          |
 | 30   | The tag couldn’t be updated in the database          |
+
+## Example
+
+```php
+<?php
+
+if (class_exists(\MailPoet\API\API::class)) {
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+  try {
+    // Rename the tag without touching the description
+    $tag = $mailpoet_api->updateTag([
+      'id' => '7',
+      'name' => 'VIP (legacy)',
+    ]);
+
+    // Clear the description by passing an empty string
+    $mailpoet_api->updateTag([
+      'id' => '7',
+      'description' => '',
+    ]);
+  } catch (\MailPoet\API\MP\v1\APIException $e) {
+    error_log(sprintf('MailPoet updateTag failed [%d]: %s', $e->getCode(), $e->getMessage()));
+  }
+}
+```

--- a/mailpoet/changelog/2026-05-01-12-08-49-improved-improved-public-api-documentation-and-added-exampl.md
+++ b/mailpoet/changelog/2026-05-01-12-08-49-improved-improved-public-api-documentation-and-added-exampl.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improved public API documentation, and added examples

--- a/mailpoet/lib/API/MP/v1/CustomFields.php
+++ b/mailpoet/lib/API/MP/v1/CustomFields.php
@@ -63,8 +63,14 @@ class CustomFields {
   }
 
   public function addSubscriberField(array $data = []): array {
+    // Run sanitize() OUTSIDE the try/catch so its InvalidArgumentException
+    // propagates to API::addSubscriberField, which maps it to an APIException
+    // carrying the original sanitizer code (1001-1010). Wrapping it here would
+    // collapse every validation error into FAILED_TO_SAVE_SUBSCRIBER_FIELD (1)
+    // and make the documented sanitizer codes unreachable.
+    $sanitized = $this->customFieldsDataSanitizer->sanitize($data);
     try {
-      $customField = $this->customFieldsRepository->createOrUpdate($this->customFieldsDataSanitizer->sanitize($data));
+      $customField = $this->customFieldsRepository->createOrUpdate($sanitized);
     } catch (\Exception $e) {
       throw new APIException('Failed to save a new subscriber field ' . $e->getMessage(), APIException::FAILED_TO_SAVE_SUBSCRIBER_FIELD);
     }

--- a/mailpoet/lib/API/MP/v1/Segments.php
+++ b/mailpoet/lib/API/MP/v1/Segments.php
@@ -152,11 +152,15 @@ class Segments {
   }
 
   /**
-   * Throws an exception when the segment's name is invalid
+   * Throws an exception when the segment's name is invalid.
+   * Validates against the sanitized name so whitespace-only inputs that
+   * collapse to empty after sanitize_text_field() are rejected up front
+   * instead of being silently saved as an empty list name.
    * @return void
    */
   private function validateSegmentName(array $data): void {
-    if (empty($data['name'])) {
+    $name = isset($data['name']) && is_string($data['name']) ? sanitize_text_field($data['name']) : '';
+    if ($name === '') {
       throw new APIException(
         __('List name is required.', 'mailpoet'),
         APIException::LIST_NAME_REQUIRED
@@ -164,7 +168,7 @@ class Segments {
     }
 
     $segmentId = isset($data['id']) ? (int)$data['id'] : null;
-    if (!$this->segmentsRepository->isNameUnique($data['name'], $segmentId)) {
+    if (!$this->segmentsRepository->isNameUnique($name, $segmentId)) {
       throw new APIException(
         __('This list already exists.', 'mailpoet'),
         APIException::LIST_EXISTS

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -435,9 +435,9 @@ class Subscribers {
    * @param array $filter {
    *     Filters to retrieve subscribers.
    *
-   *     @type string        $status       One of values: subscribed, unconfirmed, unsubscribed, inactive, bounced
-   *     @type int           $listId       id of a list or dynamic segment
-   *     @type \DateTime|int $minUpdatedAt DateTime object or timestamp of last update of subscriber.
+   *     @type string                 $status       One of values: subscribed, unconfirmed, unsubscribed, inactive, bounced
+   *     @type int                    $listId       id of a list or dynamic segment
+   *     @type \DateTimeInterface|int $minUpdatedAt DateTime/DateTimeImmutable instance or timestamp of last update of subscriber.
    * }
    */
   private function buildListingDefinition(array $filter, int $limit = 50, int $offset = 0): ListingDefinition {
@@ -449,7 +449,7 @@ class Subscribers {
     }
     // Set filtering by minimal updatedAt
     if (isset($filter['minUpdatedAt'])) {
-      if ($filter['minUpdatedAt'] instanceof \DateTime) {
+      if ($filter['minUpdatedAt'] instanceof \DateTimeInterface) {
         $listingFilters['minUpdatedAt'] = $filter['minUpdatedAt'];
       } elseif (is_int($filter['minUpdatedAt'])) {
         $listingFilters['minUpdatedAt'] = Carbon::createFromTimestamp($filter['minUpdatedAt']);


### PR DESCRIPTION
## Description

1. **Doc accuracy** — fixed discrepancies in 7 endpoint docs (missing/cascading error codes on `addSubscriber`, `subscribeToLists`, `unsubscribeFromLists`, `updateSubscriber`; outdated method signatures and response shape on `getSubscriber`; obsolete MP2 migration reference on `isSetupComplete`; non-existent timestamps in the `addSubscriberField` response).
2. **Bug fixes** — three small fixes the audit turned up:
    - `addList`/`updateList` accepted whitespace-only names that silently sanitized to empty.
    - `getSubscribers`' `minUpdatedAt` filter silently dropped `DateTimeImmutable` (only `DateTime` was matched).
    - `addSubscriberField`'s sanitizer error codes (1001–1010) were unreachable because an over-broad catch (`\Exception`) collapsed them all to code 1; fixing it makes runtime match the documented codes.
3. **README regrouped** — endpoint index grouped by area (Setup, Lists, Subscribers, Subscriber Fields, Tags) instead of one alphabetical bullet list.
4. **Examples** — every endpoint doc now includes a runnable PHP snippet matching the style in `UsageExamples.md`.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8003

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8003-improve-public-api-docs)

_The latest successful build from `stomail-8003-improve-public-api-docs` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 3 Bugs**

1. **Bug (Validation)**: Whitespace-only list names not rejected
2. **Bug (Type Compatibility)**: DateTimeImmutable not accepted for minUpdatedAt filter
3. **Bug (Error Handling)**: Sanitizer error codes collapsed to code 1 instead of preserved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->