### PR TITLE
Add product types filter to order automation triggers

### DIFF
--- a/mailpoet/changelog/2026-05-02-12-15-49-added-filter-order-automation-triggers-by-product-type.md
+++ b/mailpoet/changelog/2026-05-02-12-15-49-added-filter-order-automation-triggers-by-product-type.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Filter order automation triggers by product type

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactory.php
@@ -278,6 +278,21 @@ class OrderFieldsFactory {
             'options' => $this->getProductOptions(),
           ]
         ),
+        new Field(
+          'woocommerce:order:product-types',
+          Field::TYPE_ENUM_ARRAY,
+          __('Product types', 'mailpoet'),
+          function (OrderPayload $payload) {
+            $products = $this->getProducts($payload->getOrder());
+            $types = array_map(function (WC_Product $product) {
+              return $product->get_type();
+            }, $products);
+            return array_values(array_unique($types));
+          },
+          [
+            'options' => $this->getProductTypeOptions(),
+          ]
+        ),
       ]
     );
   }
@@ -407,6 +422,17 @@ class OrderFieldsFactory {
       $title = $product['post_title'];
       return ['id' => (int)$id, 'name' => "$title (#$id)"];
     }, (array)$products);
+  }
+
+  private function getProductTypeOptions(): array {
+    if (!function_exists('wc_get_product_types')) {
+      return [];
+    }
+    $options = [];
+    foreach (wc_get_product_types() as $id => $name) {
+      $options[] = ['id' => $id, 'name' => $name];
+    }
+    return $options;
   }
 
   private function getOrderCreatedViaOptions(): array {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/Fields/OrderFieldsFactoryTest.php
@@ -538,6 +538,83 @@ class OrderFieldsFactoryTest extends \MailPoetTest {
     $this->assertContains($tagId, $value);
   }
 
+  public function testProductTypesField(): void {
+    $simple = $this->tester->createWooCommerceProduct(['name' => 'OF Simple']);
+    $grouped = new \WC_Product_Grouped();
+    $grouped->set_name('OF Grouped');
+    $grouped->save();
+
+    $fields = $this->getFieldsMap();
+    $productTypes = $fields['woocommerce:order:product-types'];
+
+    $this->assertSame('Product types', $productTypes->getName());
+    $this->assertSame('enum_array', $productTypes->getType());
+
+    $args = $productTypes->getArgs();
+    $this->assertArrayHasKey('options', $args);
+    $optionIds = array_column($args['options'], 'id');
+    // Core WooCommerce types must always be present.
+    $this->assertContains('simple', $optionIds);
+    $this->assertContains('variable', $optionIds);
+    $this->assertContains('grouped', $optionIds);
+    $this->assertContains('external', $optionIds);
+    foreach ($args['options'] as $option) {
+      $this->assertArrayHasKey('id', $option);
+      $this->assertArrayHasKey('name', $option);
+    }
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($simple);
+    $order->add_product($grouped);
+
+    $payload = new OrderPayload($order);
+    $value = $productTypes->getValue($payload);
+    $this->assertIsArray($value);
+    $this->assertEqualsCanonicalizing(['simple', 'grouped'], $value);
+  }
+
+  public function testProductTypesFieldWithVariableProduct(): void {
+    $variable = new \WC_Product_Variable();
+    $variable->set_name('OF Variable');
+    $variable->save();
+    $variation = new \WC_Product_Variation();
+    $variation->set_parent_id($variable->get_id());
+    $variation->set_name('OF Variable Variation 1');
+    $variation->save();
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($variation);
+
+    $payload = new OrderPayload($order);
+    $fields = $this->getFieldsMap();
+    $value = $fields['woocommerce:order:product-types']->getValue($payload);
+    $this->assertIsArray($value);
+    $this->assertSame(['variable'], $value);
+    $this->assertNotContains('variation', $value);
+  }
+
+  public function testProductTypesFieldDeduplicatesAcrossLineItems(): void {
+    $product1 = $this->tester->createWooCommerceProduct(['name' => 'OF Simple 1']);
+    $product2 = $this->tester->createWooCommerceProduct(['name' => 'OF Simple 2']);
+
+    $order = $this->tester->createWooCommerceOrder();
+    $order->add_product($product1);
+    $order->add_product($product2);
+
+    $payload = new OrderPayload($order);
+    $fields = $this->getFieldsMap();
+    $value = $fields['woocommerce:order:product-types']->getValue($payload);
+    $this->assertSame(['simple'], $value);
+  }
+
+  public function testProductTypesFieldEmptyOrder(): void {
+    $order = $this->tester->createWooCommerceOrder();
+    $payload = new OrderPayload($order);
+    $fields = $this->getFieldsMap();
+    $value = $fields['woocommerce:order:product-types']->getValue($payload);
+    $this->assertSame([], $value);
+  }
+
   /** @return array<string, Field> */
   private function getFieldsMap(): array {
     $factory = $this->diContainer->get(OrderSubject::class);


### PR DESCRIPTION
## Description

Adds a `Product types` filter to all order-related automation triggers (Order created, Order status changed, Order completed, Order cancelled, Order note added). Users can filter automations to fire only on orders containing — or excluding — specific product types.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7692

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="287" height="644" alt="Screenshot 2026-05-02 at 14 32 58" src="https://github.com/user-attachments/assets/fac09ffe-2534-48af-a89d-e40e7a56cc4e" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7692-automations-filter-order-product-types)

_The latest successful build from `stomail-7692-automations-filter-order-product-types` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->