### PR TITLE
New automation trigger: Customer's Saved Card Expires

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_step.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_step.scss
@@ -77,6 +77,7 @@
 }
 
 .mailpoet-automation-colored-icon {
+  align-items: center;
   border-radius: 50%;
   box-sizing: content-box;
   display: flex;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
@@ -13,6 +13,7 @@ import { step as MadeAReview } from './steps/made-a-review';
 import { step as CustomerWinBack } from './steps/customer-win-back';
 import { step as ChangeOrderStatus } from './steps/change-order-status';
 import { step as AddOrderNote } from './steps/add-order-note';
+import { step as SavedCardExpires } from './steps/saved-card-expires';
 // Insert new imports here
 
 export const initialize = (): void => {
@@ -32,5 +33,6 @@ export const initialize = (): void => {
   registerStepType(CustomerWinBack);
   registerStepType(ChangeOrderStatus);
   registerStepType(AddOrderNote);
+  registerStepType(SavedCardExpires);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/saved-card-expires/icon.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/saved-card-expires/icon.tsx
@@ -1,0 +1,5 @@
+import { Icon as WPIcon, payment } from '@wordpress/icons';
+
+export function Icon(): JSX.Element {
+  return <WPIcon icon={payment} />;
+}

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/saved-card-expires/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/saved-card-expires/index.tsx
@@ -1,0 +1,51 @@
+import { __ } from '@wordpress/i18n';
+
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+import { StepType } from '../../../../editor/store';
+import { Icon } from './icon';
+
+const keywords = [
+  // translators: noun, used as a search keyword for "Customer's saved card expires" trigger
+  __('card', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Customer's saved card expires" trigger
+  __('credit card', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Customer's saved card expires" trigger
+  __('payment', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Customer's saved card expires" trigger
+  __('expiry', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Customer's saved card expires" trigger
+  __('expiration', 'mailpoet'),
+  // translators: noun, used as a search keyword for "Customer's saved card expires" trigger
+  __('woocommerce', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:saved-card-expires',
+  group: 'triggers',
+  // translators: automation trigger title
+  title: () => __("Customer's saved card expires", 'mailpoet'),
+  description: () =>
+    __(
+      "Triggers a set number of days before a customer's saved card expires.",
+      'mailpoet',
+    ),
+  subtitle: () => <LockedBadge text={__('Premium', 'mailpoet')} />,
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => <Icon />,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_saved_card_expires',
+      }}
+    >
+      {__(
+        "The customer's saved card expires trigger is a premium feature.",
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/changelog/2026-05-02-15-06-02-added-add-customers-saved-card-expires-automation-trigge.md
+++ b/mailpoet/changelog/2026-05-02-15-06-02-added-add-customers-saved-card-expires-automation-trigge.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+(premium) Customer's saved card expires automation trigger


### PR DESCRIPTION
## Description

This is just a placeholder for a premium feature.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1051

## Linked tickets

STOMAIL-7375

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7375-trigger-credit-card-expires)

_The latest successful build from `stomail-7375-trigger-credit-card-expires` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6690)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->