### PR TITLE
Add feature-flagged timezone scheduling backend

### DIFF
--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -281,29 +281,33 @@ class NewslettersResponseBuilder {
     if ($task === null) {
       return null;
     }
+    // When $aggregateData is non-null we are looking at a time zone campaign and ALL its fields
+    // are authoritative — including a null `status`, which represents VIRTUAL_STATUS_RUNNING (a
+    // sibling batch is actively sending). Using `??` here would silently fall back to this single
+    // task's status (e.g. 'scheduled' for a future batch) and misreport the campaign.
     $aggregateData = $this->timeZoneCampaignScheduler
       ? $this->timeZoneCampaignScheduler->getAggregateQueueData($queue)
       : null;
-    $scheduledAt = $aggregateData['scheduledAt'] ?? $task->getScheduledAt();
-    $processedAt = $aggregateData['processedAt'] ?? $task->getProcessedAt();
+    $scheduledAt = $aggregateData ? $aggregateData['scheduledAt'] : $task->getScheduledAt();
+    $processedAt = $aggregateData ? $aggregateData['processedAt'] : $task->getProcessedAt();
 
     return [
       'id' => (string)$queue->getId(), // (string) for BC
       'type' => $task->getType(),
-      'status' => $aggregateData['status'] ?? $task->getStatus(),
+      'status' => $aggregateData ? $aggregateData['status'] : $task->getStatus(),
       'priority' => (string)$task->getPriority(), // (string) for BC
       'scheduled_at' => $scheduledAt ? $scheduledAt->format(self::DATE_FORMAT) : null,
       'processed_at' => $processedAt ? $processedAt->format(self::DATE_FORMAT) : null,
       'created_at' => ($createdAt = $queue->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => ($updatedAt = $queue->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $queue->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
-      'meta' => $aggregateData['meta'] ?? $queue->getMeta(),
+      'meta' => $aggregateData ? $aggregateData['meta'] : $queue->getMeta(),
       'task_id' => (string)$task->getId(), // (string) for BC
       'newsletter_id' => ($newsletter = $queue->getNewsletter()) ? (string)$newsletter->getId() : null, // (string) for BC
       'newsletter_rendered_subject' => $this->processPersonalizationTags($queue->getNewsletterRenderedSubject()),
-      'count_total' => (string)($aggregateData['countTotal'] ?? $queue->getCountTotal()), // (string) for BC
-      'count_processed' => (string)($aggregateData['countProcessed'] ?? $queue->getCountProcessed()), // (string) for BC
-      'count_to_process' => (string)($aggregateData['countToProcess'] ?? $queue->getCountToProcess()), // (string) for BC
+      'count_total' => (string)($aggregateData ? $aggregateData['countTotal'] : $queue->getCountTotal()), // (string) for BC
+      'count_processed' => (string)($aggregateData ? $aggregateData['countProcessed'] : $queue->getCountProcessed()), // (string) for BC
+      'count_to_process' => (string)($aggregateData ? $aggregateData['countToProcess'] : $queue->getCountToProcess()), // (string) for BC
     ];
   }
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/NewslettersResponseBuilder.php
@@ -10,6 +10,7 @@ use MailPoet\Logging\LoggerFactory;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url as NewsletterUrl;
@@ -48,6 +49,9 @@ class NewslettersResponseBuilder {
   /*** @var StatisticsUnsubscribesRepository */
   private $statisticsUnsubscribesRepository;
 
+  /*** @var TimeZoneCampaignScheduler|null */
+  private $timeZoneCampaignScheduler;
+
   public function __construct(
     EntityManager $entityManager,
     NewslettersRepository $newslettersRepository,
@@ -55,7 +59,8 @@ class NewslettersResponseBuilder {
     NewsletterUrl $newsletterUrl,
     SendingQueuesRepository $sendingQueuesRepository,
     LogRepository $logRepository,
-    StatisticsUnsubscribesRepository $statisticsUnsubscribesRepository
+    StatisticsUnsubscribesRepository $statisticsUnsubscribesRepository,
+    ?TimeZoneCampaignScheduler $timeZoneCampaignScheduler = null
   ) {
     $this->newslettersStatsRepository = $newslettersStatsRepository;
     $this->newslettersRepository = $newslettersRepository;
@@ -64,6 +69,7 @@ class NewslettersResponseBuilder {
     $this->sendingQueuesRepository = $sendingQueuesRepository;
     $this->logRepository = $logRepository;
     $this->statisticsUnsubscribesRepository = $statisticsUnsubscribesRepository;
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
   }
 
   public function build(NewsletterEntity $newsletter, $relations = []) {
@@ -275,23 +281,29 @@ class NewslettersResponseBuilder {
     if ($task === null) {
       return null;
     }
+    $aggregateData = $this->timeZoneCampaignScheduler
+      ? $this->timeZoneCampaignScheduler->getAggregateQueueData($queue)
+      : null;
+    $scheduledAt = $aggregateData['scheduledAt'] ?? $task->getScheduledAt();
+    $processedAt = $aggregateData['processedAt'] ?? $task->getProcessedAt();
+
     return [
       'id' => (string)$queue->getId(), // (string) for BC
       'type' => $task->getType(),
-      'status' => $task->getStatus(),
+      'status' => $aggregateData['status'] ?? $task->getStatus(),
       'priority' => (string)$task->getPriority(), // (string) for BC
-      'scheduled_at' => ($scheduledAt = $task->getScheduledAt()) ? $scheduledAt->format(self::DATE_FORMAT) : null,
-      'processed_at' => ($processedAt = $task->getProcessedAt()) ? $processedAt->format(self::DATE_FORMAT) : null,
+      'scheduled_at' => $scheduledAt ? $scheduledAt->format(self::DATE_FORMAT) : null,
+      'processed_at' => $processedAt ? $processedAt->format(self::DATE_FORMAT) : null,
       'created_at' => ($createdAt = $queue->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
       'updated_at' => ($updatedAt = $queue->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
       'deleted_at' => ($deletedAt = $queue->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
-      'meta' => $queue->getMeta(),
+      'meta' => $aggregateData['meta'] ?? $queue->getMeta(),
       'task_id' => (string)$task->getId(), // (string) for BC
       'newsletter_id' => ($newsletter = $queue->getNewsletter()) ? (string)$newsletter->getId() : null, // (string) for BC
       'newsletter_rendered_subject' => $this->processPersonalizationTags($queue->getNewsletterRenderedSubject()),
-      'count_total' => (string)$queue->getCountTotal(), // (string) for BC
-      'count_processed' => (string)$queue->getCountProcessed(), // (string) for BC
-      'count_to_process' => (string)$queue->getCountToProcess(), // (string) for BC
+      'count_total' => (string)($aggregateData['countTotal'] ?? $queue->getCountTotal()), // (string) for BC
+      'count_processed' => (string)($aggregateData['countProcessed'] ?? $queue->getCountProcessed()), // (string) for BC
+      'count_to_process' => (string)($aggregateData['countToProcess'] ?? $queue->getCountToProcess()), // (string) for BC
     ];
   }
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SendingQueuesResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SendingQueuesResponseBuilder.php
@@ -5,33 +5,49 @@ namespace MailPoet\API\JSON\ResponseBuilders;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 
 class SendingQueuesResponseBuilder {
+  private ?TimeZoneCampaignScheduler $timeZoneCampaignScheduler;
+
+  public function __construct(
+    ?TimeZoneCampaignScheduler $timeZoneCampaignScheduler = null
+  ) {
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
+  }
+
   public function build(SendingQueueEntity $sendingQueue): array {
-    if (!$sendingQueue->getTask() instanceof ScheduledTaskEntity) {
+    $task = $sendingQueue->getTask();
+    if (!$task instanceof ScheduledTaskEntity) {
       throw new \RuntimeException('Invalid state. SendingQueue has no ScheduledTask associated.');
     }
 
+    $aggregateData = $this->timeZoneCampaignScheduler
+      ? $this->timeZoneCampaignScheduler->getAggregateQueueData($sendingQueue)
+      : null;
+    $scheduledAt = $aggregateData['scheduledAt'] ?? $task->getScheduledAt();
+    $processedAt = $aggregateData['processedAt'] ?? $task->getProcessedAt();
+
     return [
       'id' => $sendingQueue->getId(),
-      'type' => $sendingQueue->getTask()->getType(),
-      'status' => $sendingQueue->getTask()->getStatus(),
-      'priority' => $sendingQueue->getTask()->getPriority(),
-      'scheduled_at' => $this->getFormattedDateOrNull($sendingQueue->getTask()->getScheduledAt()),
-      'processed_at' => $this->getFormattedDateOrNull($sendingQueue->getTask()->getProcessedAt()),
-      'created_at' => $this->getFormattedDateOrNull($sendingQueue->getTask()->getCreatedAt()),
-      'updated_at' => $this->getFormattedDateOrNull($sendingQueue->getTask()->getUpdatedAt()),
-      'deleted_at' => $this->getFormattedDateOrNull($sendingQueue->getTask()->getDeletedAt()),
-      'in_progress' => $sendingQueue->getTask()->getInProgress(),
-      'reschedule_count' => $sendingQueue->getTask()->getRescheduleCount(),
-      'meta' => $sendingQueue->getMeta(),
-      'task_id' => $sendingQueue->getTask()->getId(),
+      'type' => $task->getType(),
+      'status' => $aggregateData['status'] ?? $task->getStatus(),
+      'priority' => $task->getPriority(),
+      'scheduled_at' => $this->getFormattedDateOrNull($scheduledAt),
+      'processed_at' => $this->getFormattedDateOrNull($processedAt),
+      'created_at' => $this->getFormattedDateOrNull($task->getCreatedAt()),
+      'updated_at' => $this->getFormattedDateOrNull($task->getUpdatedAt()),
+      'deleted_at' => $this->getFormattedDateOrNull($task->getDeletedAt()),
+      'in_progress' => $task->getInProgress(),
+      'reschedule_count' => $task->getRescheduleCount(),
+      'meta' => $aggregateData['meta'] ?? $sendingQueue->getMeta(),
+      'task_id' => $task->getId(),
       'newsletter_id' => ($sendingQueue->getNewsletter() instanceof NewsletterEntity) ? $sendingQueue->getNewsletter()->getId() : null,
       'newsletter_rendered_body' => $sendingQueue->getNewsletterRenderedBody(),
       'newsletter_rendered_subject' => $sendingQueue->getNewsletterRenderedSubject(),
-      'count_total' => $sendingQueue->getCountTotal(),
-      'count_processed' => $sendingQueue->getCountProcessed(),
-      'count_to_process' => $sendingQueue->getCountToProcess(),
+      'count_total' => $aggregateData['countTotal'] ?? $sendingQueue->getCountTotal(),
+      'count_processed' => $aggregateData['countProcessed'] ?? $sendingQueue->getCountProcessed(),
+      'count_to_process' => $aggregateData['countToProcess'] ?? $sendingQueue->getCountToProcess(),
     ];
   }
 

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SendingQueuesResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SendingQueuesResponseBuilder.php
@@ -22,32 +22,34 @@ class SendingQueuesResponseBuilder {
       throw new \RuntimeException('Invalid state. SendingQueue has no ScheduledTask associated.');
     }
 
+    // When $aggregateData is non-null we are looking at a time zone campaign and ALL its fields
+    // are authoritative — including a null `status`, which represents VIRTUAL_STATUS_RUNNING (a
+    // sibling batch is actively sending). Using `??` here would silently fall back to this single
+    // task's status (e.g. 'scheduled' for a future batch) and misreport the campaign.
     $aggregateData = $this->timeZoneCampaignScheduler
       ? $this->timeZoneCampaignScheduler->getAggregateQueueData($sendingQueue)
       : null;
-    $scheduledAt = $aggregateData['scheduledAt'] ?? $task->getScheduledAt();
-    $processedAt = $aggregateData['processedAt'] ?? $task->getProcessedAt();
 
     return [
       'id' => $sendingQueue->getId(),
       'type' => $task->getType(),
-      'status' => $aggregateData['status'] ?? $task->getStatus(),
+      'status' => $aggregateData ? $aggregateData['status'] : $task->getStatus(),
       'priority' => $task->getPriority(),
-      'scheduled_at' => $this->getFormattedDateOrNull($scheduledAt),
-      'processed_at' => $this->getFormattedDateOrNull($processedAt),
+      'scheduled_at' => $this->getFormattedDateOrNull($aggregateData ? $aggregateData['scheduledAt'] : $task->getScheduledAt()),
+      'processed_at' => $this->getFormattedDateOrNull($aggregateData ? $aggregateData['processedAt'] : $task->getProcessedAt()),
       'created_at' => $this->getFormattedDateOrNull($task->getCreatedAt()),
       'updated_at' => $this->getFormattedDateOrNull($task->getUpdatedAt()),
       'deleted_at' => $this->getFormattedDateOrNull($task->getDeletedAt()),
       'in_progress' => $task->getInProgress(),
       'reschedule_count' => $task->getRescheduleCount(),
-      'meta' => $aggregateData['meta'] ?? $sendingQueue->getMeta(),
+      'meta' => $aggregateData ? $aggregateData['meta'] : $sendingQueue->getMeta(),
       'task_id' => $task->getId(),
       'newsletter_id' => ($sendingQueue->getNewsletter() instanceof NewsletterEntity) ? $sendingQueue->getNewsletter()->getId() : null,
       'newsletter_rendered_body' => $sendingQueue->getNewsletterRenderedBody(),
       'newsletter_rendered_subject' => $sendingQueue->getNewsletterRenderedSubject(),
-      'count_total' => $aggregateData['countTotal'] ?? $sendingQueue->getCountTotal(),
-      'count_processed' => $aggregateData['countProcessed'] ?? $sendingQueue->getCountProcessed(),
-      'count_to_process' => $aggregateData['countToProcess'] ?? $sendingQueue->getCountToProcess(),
+      'count_total' => $aggregateData ? $aggregateData['countTotal'] : $sendingQueue->getCountTotal(),
+      'count_processed' => $aggregateData ? $aggregateData['countProcessed'] : $sendingQueue->getCountProcessed(),
+      'count_to_process' => $aggregateData ? $aggregateData['countToProcess'] : $sendingQueue->getCountToProcess(),
     ];
   }
 

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -134,15 +134,17 @@ class SendingQueue extends APIEndpoint {
         $this->triggerSending($newsletter);
         return $this->successResponse($this->sendingQueuesResponseBuilder->build($sendingQueue));
       }
-      if ($isScheduled) {
-        if (!$this->timeZoneCampaignScheduler->canReplaceScheduledCampaign($newsletter)) {
-          throw new \Exception(
-            __('This email can no longer be edited because one or more time zone batches have already started.', 'mailpoet'),
-            Response::STATUS_BAD_REQUEST
-          );
-        }
-        $this->timeZoneCampaignScheduler->deleteScheduledCampaignQueues($newsletter);
+      // Existing time zone batches must be reconciled regardless of the new send mode (scheduled or
+      // immediate). Otherwise orphaned time zone queues survive in the DB and may later be picked up
+      // by the scheduler cron, causing duplicate sends. Both calls are no-ops when the newsletter
+      // has no time zone queues.
+      if (!$this->timeZoneCampaignScheduler->canReplaceScheduledCampaign($newsletter)) {
+        throw new \Exception(
+          __('This email can no longer be edited because one or more time zone batches have already started.', 'mailpoet'),
+          Response::STATUS_BAD_REQUEST
+        );
       }
+      $this->timeZoneCampaignScheduler->deleteScheduledCampaignQueues($newsletter);
 
       $sendingQueue = $this->sendingQueuesRepository->findOneByNewsletterAndTaskStatus($newsletter, null);
 

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -20,6 +20,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Util\License\Features\Subscribers as SubscribersFeature;
@@ -63,6 +64,9 @@ class SendingQueue extends APIEndpoint {
   /** @var CronHelper */
   private $cronHelper;
 
+  /** @var TimeZoneCampaignScheduler */
+  private $timeZoneCampaignScheduler;
+
   public function __construct(
     SubscribersFeature $subscribersFeature,
     NewslettersRepository $newsletterRepository,
@@ -74,7 +78,8 @@ class SendingQueue extends APIEndpoint {
     DaemonTrigger $actionSchedulerDaemonTriggerAction,
     NewsletterValidator $newsletterValidator,
     SendingQueuesResponseBuilder $sendingQueuesResponseBuilder,
-    CronHelper $cronHelper
+    CronHelper $cronHelper,
+    TimeZoneCampaignScheduler $timeZoneCampaignScheduler
   ) {
     $this->subscribersFeature = $subscribersFeature;
     $this->subscribersFinder = $subscribersFinder;
@@ -87,6 +92,7 @@ class SendingQueue extends APIEndpoint {
     $this->newsletterValidator = $newsletterValidator;
     $this->sendingQueuesResponseBuilder = $sendingQueuesResponseBuilder;
     $this->cronHelper = $cronHelper;
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
   }
 
   public function add($data = []) {
@@ -120,6 +126,13 @@ class SendingQueue extends APIEndpoint {
     try {
       // check that the sending method has been configured properly by verifying that default mailer can be build
       $this->mailerFactory->getDefaultMailer();
+
+      if ((bool)$newsletter->getOptionValue('isScheduled') && $this->timeZoneCampaignScheduler->isSubscriberTimeZoneMode($newsletter)) {
+        $sendingQueue = $this->timeZoneCampaignScheduler->schedule($newsletter);
+        WordPress::resetRunInterval();
+        $this->triggerSending($newsletter);
+        return $this->successResponse($this->sendingQueuesResponseBuilder->build($sendingQueue));
+      }
 
       $sendingQueue = $this->sendingQueuesRepository->findOneByNewsletterAndTaskStatus($newsletter, null);
 
@@ -190,9 +203,18 @@ class SendingQueue extends APIEndpoint {
         ($newsletter->getLatestQueue() instanceof SendingQueueEntity) ? $this->sendingQueuesResponseBuilder->build($newsletter->getLatestQueue()) : null
       );
     } catch (\Exception $e) {
+      $errorCode = APIError::UNKNOWN;
+      $statusCode = Response::STATUS_NOT_FOUND;
+      if ($e->getCode() === Response::STATUS_FORBIDDEN) {
+        $errorCode = APIError::FORBIDDEN;
+        $statusCode = Response::STATUS_FORBIDDEN;
+      } elseif ($e->getCode() === Response::STATUS_BAD_REQUEST) {
+        $errorCode = APIError::BAD_REQUEST;
+        $statusCode = Response::STATUS_BAD_REQUEST;
+      }
       return $this->errorResponse([
-        $e->getCode() => $e->getMessage(),
-      ]);
+        $errorCode => $e->getMessage(),
+      ], [], $statusCode);
     }
   }
 
@@ -211,7 +233,11 @@ class SendingQueue extends APIEndpoint {
           APIError::UNKNOWN => __('This newsletter has not been sent yet.', 'mailpoet'),
         ]);
       } else {
-        $this->sendingQueuesRepository->pause($queue);
+        if ($this->timeZoneCampaignScheduler->isTimeZoneQueue($queue)) {
+          $this->timeZoneCampaignScheduler->pauseCampaign($queue);
+        } else {
+          $this->sendingQueuesRepository->pause($queue);
+        }
         return $this->successResponse();
       }
     } else {
@@ -241,7 +267,11 @@ class SendingQueue extends APIEndpoint {
           APIError::UNKNOWN => __('This newsletter has not been sent yet.', 'mailpoet'),
         ]);
       } else {
-        $this->sendingQueuesRepository->resume($queue);
+        if ($this->timeZoneCampaignScheduler->isTimeZoneQueue($queue)) {
+          $this->timeZoneCampaignScheduler->resumeCampaign($queue);
+        } else {
+          $this->sendingQueuesRepository->resume($queue);
+        }
         $this->triggerSending($newsletter);
         return $this->successResponse();
       }

--- a/mailpoet/lib/API/JSON/v1/SendingQueue.php
+++ b/mailpoet/lib/API/JSON/v1/SendingQueue.php
@@ -127,11 +127,21 @@ class SendingQueue extends APIEndpoint {
       // check that the sending method has been configured properly by verifying that default mailer can be build
       $this->mailerFactory->getDefaultMailer();
 
-      if ((bool)$newsletter->getOptionValue('isScheduled') && $this->timeZoneCampaignScheduler->isSubscriberTimeZoneMode($newsletter)) {
+      $isScheduled = (bool)$newsletter->getOptionValue('isScheduled');
+      if ($isScheduled && $this->timeZoneCampaignScheduler->isSubscriberTimeZoneMode($newsletter)) {
         $sendingQueue = $this->timeZoneCampaignScheduler->schedule($newsletter);
         WordPress::resetRunInterval();
         $this->triggerSending($newsletter);
         return $this->successResponse($this->sendingQueuesResponseBuilder->build($sendingQueue));
+      }
+      if ($isScheduled) {
+        if (!$this->timeZoneCampaignScheduler->canReplaceScheduledCampaign($newsletter)) {
+          throw new \Exception(
+            __('This email can no longer be edited because one or more time zone batches have already started.', 'mailpoet'),
+            Response::STATUS_BAD_REQUEST
+          );
+        }
+        $this->timeZoneCampaignScheduler->deleteScheduledCampaignQueues($newsletter);
       }
 
       $sendingQueue = $this->sendingQueuesRepository->findOneByNewsletterAndTaskStatus($newsletter, null);
@@ -168,7 +178,7 @@ class SendingQueue extends APIEndpoint {
       $this->scheduledTasksRepository->flush();
 
       WordPress::resetRunInterval();
-      if ((bool)$newsletter->getOptionValue('isScheduled')) {
+      if ($isScheduled) {
         // set newsletter status
         $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);
 

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -494,6 +494,18 @@ class Populator {
         'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
       ],
       [
+        'name' => NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE,
+        'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
+      ],
+      [
+        'name' => NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE,
+        'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
+      ],
+      [
+        'name' => NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME,
+        'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
+      ],
+      [
         'name' => NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID,
         'newsletter_type' => NewsletterEntity::TYPE_RE_ENGAGEMENT,
       ],

--- a/mailpoet/lib/Cron/Workers/Scheduler.php
+++ b/mailpoet/lib/Cron/Workers/Scheduler.php
@@ -18,6 +18,7 @@ use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
@@ -71,6 +72,9 @@ class Scheduler {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var TimeZoneCampaignScheduler */
+  private $timeZoneCampaignScheduler;
+
   public function __construct(
     SubscribersFinder $subscribersFinder,
     LoggerFactory $loggerFactory,
@@ -85,7 +89,8 @@ class Scheduler {
     Security $security,
     NewsletterScheduler $scheduler,
     SubscriberSegmentRepository $subscriberSegmentRepository,
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    TimeZoneCampaignScheduler $timeZoneCampaignScheduler
   ) {
     $this->cronHelper = $cronHelper;
     $this->subscribersFinder = $subscribersFinder;
@@ -101,6 +106,7 @@ class Scheduler {
     $this->scheduler = $scheduler;
     $this->subscriberSegmentRepository = $subscriberSegmentRepository;
     $this->subscribersRepository = $subscribersRepository;
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
   }
 
   public function process($timer = false) {
@@ -122,7 +128,11 @@ class Scheduler {
       try {
         if (!$newsletter instanceof NewsletterEntity || $newsletter->getDeletedAt() !== null) {
           $this->deleteByTask($task);
-        } elseif ($newsletter->getStatus() !== NewsletterEntity::STATUS_ACTIVE && $newsletter->getStatus() !== NewsletterEntity::STATUS_SCHEDULED) {
+        } elseif (
+          $newsletter->getStatus() !== NewsletterEntity::STATUS_ACTIVE
+          && $newsletter->getStatus() !== NewsletterEntity::STATUS_SCHEDULED
+          && !($newsletter->getStatus() === NewsletterEntity::STATUS_SENDING && $this->timeZoneCampaignScheduler->isTimeZoneQueue($queue))
+        ) {
           $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
           $this->scheduledTasksRepository->flush();
           continue;
@@ -297,11 +307,13 @@ class Scheduler {
   }
 
   public function processScheduledStandardNewsletter(NewsletterEntity $newsletter, ScheduledTaskEntity $task) {
-    $segments = $newsletter->getSegmentIds();
-    $this->subscribersFinder->addSubscribersToTaskFromSegments($task, $segments, $newsletter->getFilterSegmentId());
+    $queue = $task->getSendingQueue();
+    if (!$queue || !$this->timeZoneCampaignScheduler->isTimeZoneQueue($queue)) {
+      $segments = $newsletter->getSegmentIds();
+      $this->subscribersFinder->addSubscribersToTaskFromSegments($task, $segments, $newsletter->getFilterSegmentId());
+    }
 
     $task->setStatus(null);
-    $queue = $task->getSendingQueue();
     if ($queue) {
       $this->sendingQueuesRepository->updateCounts($queue);
     }

--- a/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
+++ b/mailpoet/lib/Cron/Workers/SendingQueue/SendingQueue.php
@@ -18,6 +18,7 @@ use MailPoet\Mailer\MetaInfo;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\SubscribersFinder;
 use MailPoet\Services\AuthorizedEmailsController;
@@ -92,6 +93,9 @@ class SendingQueue {
   /** @var AuthorizedEmailsController */
   private $authorizedEmailsController;
 
+  /** @var TimeZoneCampaignScheduler|null */
+  private $timeZoneCampaignScheduler;
+
   public function __construct(
     SendingErrorHandler $errorHandler,
     SendingThrottlingHandler $throttlingHandler,
@@ -110,6 +114,7 @@ class SendingQueue {
     EntityManager $entityManager,
     StatisticsNewslettersRepository $statisticsNewslettersRepository,
     AuthorizedEmailsController $authorizedEmailsController,
+    ?TimeZoneCampaignScheduler $timeZoneCampaignScheduler = null,
     $newsletterTask = false
   ) {
     $this->errorHandler = $errorHandler;
@@ -131,6 +136,7 @@ class SendingQueue {
     $this->entityManager = $entityManager;
     $this->statisticsNewslettersRepository = $statisticsNewslettersRepository;
     $this->authorizedEmailsController = $authorizedEmailsController;
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
   }
 
   public function process($timer = false) {
@@ -685,6 +691,15 @@ class SendingQueue {
         'completed newsletter sending',
         ['newsletter_id' => $newsletter->getId(), 'task_id' => $task->getId()]
       );
+      $queue = $task->getSendingQueue();
+      if (
+        $queue
+        && $this->timeZoneCampaignScheduler
+        && $this->timeZoneCampaignScheduler->isTimeZoneQueue($queue)
+        && $this->timeZoneCampaignScheduler->hasIncompleteCampaignQueues($queue)
+      ) {
+        return;
+      }
       $this->newsletterTask->markNewsletterAsSent($newsletter);
       $this->statsNotificationsScheduler->schedule($newsletter);
     }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -627,6 +627,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscribersListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\SendingQueuesRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserController::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterCoupon::class)->setPublic(true);

--- a/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
@@ -26,6 +26,9 @@ class NewsletterOptionFieldEntity {
   public const NAME_ROLE = 'role';
   public const NAME_SCHEDULE = 'schedule';
   public const NAME_SCHEDULED_AT = 'scheduledAt';
+  public const NAME_SCHEDULE_MODE = 'scheduleMode';
+  public const NAME_SCHEDULED_LOCAL_DATE = 'scheduledLocalDate';
+  public const NAME_SCHEDULED_LOCAL_TIME = 'scheduledLocalTime';
   public const NAME_SEGMENT = 'segment';
   public const NAME_SEND_TO = 'sendTo';
   public const NAME_TIME_OF_DAY = 'timeOfDay';

--- a/mailpoet/lib/Features/FeaturesController.php
+++ b/mailpoet/lib/Features/FeaturesController.php
@@ -6,11 +6,13 @@ use MailPoetVendor\Doctrine\DBAL\Exception\TableNotFoundException;
 
 class FeaturesController {
   const FEATURE_BRAND_TEMPLATES = 'brand_templates';
+  const FEATURE_SEND_BY_TIMEZONE = 'send_by_timezone';
 
   // Define feature defaults in the array below in the following form:
   //   self::FEATURE_NAME_OF_FEATURE => true,
   private $defaults = [
     self::FEATURE_BRAND_TEMPLATES => false,
+    self::FEATURE_SEND_BY_TIMEZONE => false,
   ];
 
   /** @var array|null */

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -18,6 +18,7 @@ use MailPoet\Newsletter\Scheduler\PostNotificationScheduler;
 use MailPoet\Newsletter\Scheduler\Scheduler;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\NewsletterTemplates\NewsletterTemplatesRepository;
 use MailPoet\NotFoundException;
 use MailPoet\Services\AuthorizedEmailsController;
@@ -78,6 +79,9 @@ class NewsletterSaveController {
   /*** @var NewsletterCoupon */
   private $newsletterCoupon;
 
+  /** @var TimeZoneCampaignScheduler */
+  private $timeZoneCampaignScheduler;
+
   public function __construct(
     AuthorizedEmailsController $authorizedEmailsController,
     Emoji $emoji,
@@ -94,7 +98,8 @@ class NewsletterSaveController {
     WPFunctions $wp,
     ApiDataSanitizer $dataSanitizer,
     Scheduler $scheduler,
-    NewsletterCoupon $newsletterCoupon
+    NewsletterCoupon $newsletterCoupon,
+    TimeZoneCampaignScheduler $timeZoneCampaignScheduler
   ) {
     $this->authorizedEmailsController = $authorizedEmailsController;
     $this->emoji = $emoji;
@@ -112,6 +117,7 @@ class NewsletterSaveController {
     $this->dataSanitizer = $dataSanitizer;
     $this->scheduler = $scheduler;
     $this->newsletterCoupon = $newsletterCoupon;
+    $this->timeZoneCampaignScheduler = $timeZoneCampaignScheduler;
   }
 
   public function save(array $data = []): NewsletterEntity {
@@ -463,9 +469,27 @@ class NewsletterSaveController {
 
     // if newsletter was previously scheduled and is now unscheduled, set its status to DRAFT and delete associated queue record
     if ($newsletter->getStatus() === NewsletterEntity::STATUS_SCHEDULED && isset($options['isScheduled']) && empty($options['isScheduled'])) {
+      if ($this->timeZoneCampaignScheduler->isTimeZoneQueue($queue)) {
+        $this->timeZoneCampaignScheduler->deleteScheduledCampaignQueues($newsletter);
+        $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
+        $this->entityManager->flush();
+        return;
+      }
       $this->entityManager->remove($queue);
       $newsletter->setStatus(NewsletterEntity::STATUS_DRAFT);
     } else {
+      if ($this->timeZoneCampaignScheduler->isTimeZoneQueue($queue)) {
+        if (!$this->timeZoneCampaignScheduler->canReplaceScheduledCampaign($newsletter)) {
+          throw new InvalidStateException(__('This email can no longer be edited because one or more time zone batches have already started.', 'mailpoet'));
+        }
+        foreach ($this->timeZoneCampaignScheduler->getCampaignQueues($queue) as $campaignQueue) {
+          $campaignQueue->setNewsletterRenderedSubject(null);
+          $campaignQueue->setNewsletterRenderedBody(null);
+          $this->entityManager->persist($campaignQueue);
+        }
+        $this->entityManager->flush();
+        return;
+      }
       $queue->setNewsletterRenderedSubject(null);
       $queue->setNewsletterRenderedBody(null);
       $this->entityManager->persist($queue);

--- a/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/ScheduledTaskSubscribersRepository.php
@@ -123,6 +123,41 @@ class ScheduledTaskSubscribersRepository extends Repository {
     $stmt->executeQuery();
   }
 
+  /** @param int[] $subscriberIds */
+  public function addSubscribersByIds(ScheduledTaskEntity $task, array $subscriberIds): int {
+    $subscriberIds = array_values(array_unique(array_filter(array_map('intval', $subscriberIds))));
+    if ($subscriberIds === []) {
+      return 0;
+    }
+
+    $scheduledTaskSubscribersTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+
+    $result = $this->entityManager->getConnection()->executeQuery(
+      "INSERT IGNORE INTO $scheduledTaskSubscribersTable
+       (task_id, subscriber_id, processed)
+       SELECT DISTINCT ? as task_id, subscribers.`id` as subscriber_id, ? as processed
+       FROM $subscribersTable subscribers
+       WHERE subscribers.`deleted_at` IS NULL
+       AND subscribers.`status` = ?
+       AND subscribers.`id` IN (?)",
+      [
+        $task->getId(),
+        ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
+        SubscriberEntity::STATUS_SUBSCRIBED,
+        $subscriberIds,
+      ],
+      [
+        ParameterType::INTEGER,
+        ParameterType::INTEGER,
+        ParameterType::STRING,
+        ArrayParameterType::INTEGER,
+      ]
+    );
+
+    return (int)$result->rowCount();
+  }
+
   /** @param int[] $ids */
   public function deleteByTaskIds(array $ids): void {
     $this->entityManager->createQueryBuilder()

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -224,6 +224,7 @@ class TimeZoneCampaignScheduler {
     $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
     $newsletter = $queue->getNewsletter();
     $hasDueBatch = false;
+    $hasPendingBatch = false;
     foreach ($this->getCampaignQueues($queue) as $campaignQueue) {
       $task = $campaignQueue->getTask();
       if (!$task instanceof ScheduledTaskEntity) {
@@ -233,6 +234,7 @@ class TimeZoneCampaignScheduler {
         $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
         continue;
       }
+      $hasPendingBatch = true;
       $scheduledAt = $task->getScheduledAt();
       if ($scheduledAt && $scheduledAt > $now) {
         $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
@@ -243,7 +245,16 @@ class TimeZoneCampaignScheduler {
     }
 
     if ($newsletter instanceof NewsletterEntity) {
-      $newsletter->setStatus($hasDueBatch ? NewsletterEntity::STATUS_SENDING : NewsletterEntity::STATUS_SCHEDULED);
+      if (!$hasPendingBatch) {
+        // All batches are already completed: do not demote a finished campaign back to
+        // SCHEDULED. No task remains for the scheduler to pick up, so doing so would
+        // leave the newsletter permanently stuck in the wrong status.
+        if ($newsletter->canBeSetSent()) {
+          $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+        }
+      } else {
+        $newsletter->setStatus($hasDueBatch ? NewsletterEntity::STATUS_SENDING : NewsletterEntity::STATUS_SCHEDULED);
+      }
     }
     $this->entityManager->flush();
   }

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -1,0 +1,515 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sending;
+
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Segments\SubscribersFinder;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+class TimeZoneCampaignScheduler {
+  public const SCHEDULE_MODE_WEBSITE_TIME = 'website_time';
+  public const SCHEDULE_MODE_SUBSCRIBER_TIMEZONE = 'subscriber_timezone';
+  public const META_SEND_BY_TIMEZONE = 'sendByTimezone';
+  public const META_TIMEZONE_CAMPAIGN_ID = 'timezoneCampaignId';
+  public const META_SELECTED_LOCAL_DATE = 'selectedLocalDate';
+  public const META_SELECTED_LOCAL_TIME = 'selectedLocalTime';
+  public const META_GROUP_TIMEZONE = 'groupTimezone';
+  public const META_FALLBACK_USED = 'fallbackUsed';
+  public const META_SITE_TIMEZONE = 'siteTimezone';
+  public const META_FIRST_SCHEDULED_AT = 'firstScheduledAt';
+  public const META_LAST_SCHEDULED_AT = 'lastScheduledAt';
+  public const META_NEXT_SCHEDULED_AT = 'nextScheduledAt';
+  public const META_TIMEZONE_BREAKDOWN = 'timezoneBreakdown';
+  private const LEAD_TIME_HOURS = 24;
+
+  private CapabilitiesManager $capabilitiesManager;
+  private EntityManager $entityManager;
+  private FeaturesController $featuresController;
+  private ScheduledTasksRepository $scheduledTasksRepository;
+  private ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository;
+  private SendingQueuesRepository $sendingQueuesRepository;
+  private SubscribersFinder $subscribersFinder;
+  private SubscribersRepository $subscribersRepository;
+  private WPFunctions $wp;
+
+  public function __construct(
+    CapabilitiesManager $capabilitiesManager,
+    EntityManager $entityManager,
+    FeaturesController $featuresController,
+    ScheduledTasksRepository $scheduledTasksRepository,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
+    SubscribersFinder $subscribersFinder,
+    SubscribersRepository $subscribersRepository,
+    WPFunctions $wp
+  ) {
+    $this->capabilitiesManager = $capabilitiesManager;
+    $this->entityManager = $entityManager;
+    $this->featuresController = $featuresController;
+    $this->scheduledTasksRepository = $scheduledTasksRepository;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->subscribersFinder = $subscribersFinder;
+    $this->subscribersRepository = $subscribersRepository;
+    $this->wp = $wp;
+  }
+
+  public function isSubscriberTimeZoneMode(NewsletterEntity $newsletter): bool {
+    return $newsletter->getType() === NewsletterEntity::TYPE_STANDARD
+      && $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE) === self::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE;
+  }
+
+  /**
+   * @throws \Exception
+   */
+  public function schedule(NewsletterEntity $newsletter): SendingQueueEntity {
+    if (!$this->featuresController->isSupported(FeaturesController::FEATURE_SEND_BY_TIMEZONE)) {
+      throw new \Exception(__('Send by subscriber time zone is not available.', 'mailpoet'), 400);
+    }
+    if (!$this->isSubscriberTimeZoneMode($newsletter)) {
+      throw new \Exception(__('Send by subscriber time zone is available only for standard newsletters.', 'mailpoet'), 400);
+    }
+    $capability = $this->capabilitiesManager->getCapability('sendByTimezone');
+    if ($capability && $capability->isRestricted) {
+      throw new \Exception(__('Send by subscriber time zone requires a paid MailPoet plan.', 'mailpoet'), 403);
+    }
+    if (!$this->canReplaceScheduledCampaign($newsletter)) {
+      throw new \Exception(__('This email can no longer be edited because one or more time zone batches have already started.', 'mailpoet'), 400);
+    }
+
+    $selectedLocalDate = $this->getRequiredOption($newsletter, NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE);
+    $selectedLocalTime = $this->normalizeLocalTime($this->getRequiredOption($newsletter, NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME));
+    $this->validateLocalDate($selectedLocalDate);
+    $this->validateLocalTime($selectedLocalTime);
+
+    $subscriberIds = $this->subscribersFinder->getSubscriberIdsFromSegments($newsletter->getSegmentIds(), $newsletter->getFilterSegmentId());
+    if ($subscriberIds === []) {
+      throw new \Exception(__('There are no subscribers in that list!', 'mailpoet'));
+    }
+
+    $siteTimeZone = $this->wp->wpTimezone();
+    $siteTimeZoneName = $siteTimeZone->getName();
+    $groups = $this->groupSubscribersByTimeZone($subscriberIds, $siteTimeZoneName);
+    if ($groups === []) {
+      throw new \Exception(__('There are no subscribers in that list!', 'mailpoet'));
+    }
+
+    $schedule = $this->buildGroupSchedule($groups, $selectedLocalDate, $selectedLocalTime);
+    $this->validateLeadTime($schedule);
+
+    $campaignId = Security::generateRandomString(16);
+    $firstScheduledAt = $schedule[0]['scheduledAt']->format('Y-m-d H:i:s');
+    $lastScheduledAt = $schedule[count($schedule) - 1]['scheduledAt']->format('Y-m-d H:i:s');
+
+    $this->entityManager->beginTransaction();
+    try {
+      $this->deleteScheduledCampaignQueues($newsletter);
+      $createdQueues = [];
+
+      foreach ($schedule as $group) {
+        $task = new ScheduledTaskEntity();
+        $task->setType(SendingQueueWorker::TASK_TYPE);
+        $task->setPriority(ScheduledTaskEntity::PRIORITY_MEDIUM);
+        $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+        $task->setScheduledAt($group['scheduledAt']);
+
+        $queue = new SendingQueueEntity();
+        $queue->setNewsletter($newsletter);
+        $queue->setTask($task);
+        $queue->setMeta([
+          self::META_SEND_BY_TIMEZONE => true,
+          self::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+          self::META_SELECTED_LOCAL_DATE => $selectedLocalDate,
+          self::META_SELECTED_LOCAL_TIME => $selectedLocalTime,
+          self::META_GROUP_TIMEZONE => $group['timeZone'],
+          self::META_FALLBACK_USED => $group['fallbackUsed'],
+          self::META_SITE_TIMEZONE => $siteTimeZoneName,
+          self::META_FIRST_SCHEDULED_AT => $firstScheduledAt,
+          self::META_LAST_SCHEDULED_AT => $lastScheduledAt,
+        ]);
+
+        $this->scheduledTasksRepository->persist($task);
+        $this->sendingQueuesRepository->persist($queue);
+        $this->entityManager->flush();
+
+        $this->scheduledTaskSubscribersRepository->addSubscribersByIds($task, $group['subscriberIds']);
+        $this->sendingQueuesRepository->updateCounts($queue);
+        $createdQueues[] = $queue;
+      }
+
+      $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);
+      $this->entityManager->flush();
+      $this->entityManager->commit();
+    } catch (\Throwable $exception) {
+      $this->entityManager->rollback();
+      throw $exception;
+    }
+
+    return $createdQueues[0];
+  }
+
+  public function isTimeZoneQueue(SendingQueueEntity $queue): bool {
+    $meta = $queue->getMeta() ?? [];
+    return !empty($meta[self::META_SEND_BY_TIMEZONE]) && !empty($meta[self::META_TIMEZONE_CAMPAIGN_ID]);
+  }
+
+  public function getCampaignId(SendingQueueEntity $queue): ?string {
+    if (!$this->isTimeZoneQueue($queue)) {
+      return null;
+    }
+    $meta = $queue->getMeta() ?? [];
+    return is_string($meta[self::META_TIMEZONE_CAMPAIGN_ID] ?? null) ? $meta[self::META_TIMEZONE_CAMPAIGN_ID] : null;
+  }
+
+  /** @return SendingQueueEntity[] */
+  public function getCampaignQueues(SendingQueueEntity $queue): array {
+    $campaignId = $this->getCampaignId($queue);
+    $newsletter = $queue->getNewsletter();
+    if (!$campaignId || !$newsletter instanceof NewsletterEntity) {
+      return [$queue];
+    }
+    return $this->getCampaignQueuesById($newsletter, $campaignId);
+  }
+
+  public function hasIncompleteCampaignQueues(SendingQueueEntity $queue): bool {
+    foreach ($this->getCampaignQueues($queue) as $campaignQueue) {
+      $task = $campaignQueue->getTask();
+      if (!$task instanceof ScheduledTaskEntity) {
+        continue;
+      }
+      if (
+        !in_array(
+          $task->getStatus(),
+          [
+            ScheduledTaskEntity::STATUS_COMPLETED,
+            ScheduledTaskEntity::STATUS_CANCELLED,
+            ScheduledTaskEntity::STATUS_INVALID,
+          ],
+          true
+        )
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public function pauseCampaign(SendingQueueEntity $queue): void {
+    foreach ($this->getCampaignQueues($queue) as $campaignQueue) {
+      if ($campaignQueue->getCountProcessed() === $campaignQueue->getCountTotal()) {
+        continue;
+      }
+      $task = $campaignQueue->getTask();
+      if ($task instanceof ScheduledTaskEntity) {
+        $task->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+      }
+    }
+    $this->entityManager->flush();
+  }
+
+  public function resumeCampaign(SendingQueueEntity $queue): void {
+    $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    $newsletter = $queue->getNewsletter();
+    $hasDueBatch = false;
+    foreach ($this->getCampaignQueues($queue) as $campaignQueue) {
+      $task = $campaignQueue->getTask();
+      if (!$task instanceof ScheduledTaskEntity) {
+        continue;
+      }
+      if ($campaignQueue->getCountProcessed() === $campaignQueue->getCountTotal() && $campaignQueue->getCountTotal() > 0) {
+        $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+        continue;
+      }
+      $scheduledAt = $task->getScheduledAt();
+      if ($scheduledAt && $scheduledAt > $now) {
+        $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+      } else {
+        $task->setStatus(null);
+        $hasDueBatch = true;
+      }
+    }
+
+    if ($newsletter instanceof NewsletterEntity) {
+      $newsletter->setStatus($hasDueBatch ? NewsletterEntity::STATUS_SENDING : NewsletterEntity::STATUS_SCHEDULED);
+    }
+    $this->entityManager->flush();
+  }
+
+  /**
+   * @return array{status:?string,scheduledAt:\DateTimeInterface|null,processedAt:\DateTimeInterface|null,countTotal:int,countProcessed:int,countToProcess:int,meta:array<string,mixed>}|null
+   */
+  public function getAggregateQueueData(SendingQueueEntity $queue): ?array {
+    if (!$this->isTimeZoneQueue($queue)) {
+      return null;
+    }
+
+    $queues = $this->getCampaignQueues($queue);
+    $countTotal = 0;
+    $countProcessed = 0;
+    $countToProcess = 0;
+    $firstScheduledAt = null;
+    $lastScheduledAt = null;
+    $nextScheduledAt = null;
+    $lastProcessedAt = null;
+    $breakdown = [];
+    $statuses = [];
+    $meta = $queue->getMeta() ?? [];
+
+    foreach ($queues as $campaignQueue) {
+      $task = $campaignQueue->getTask();
+      if (!$task instanceof ScheduledTaskEntity) {
+        continue;
+      }
+      $countTotal += $campaignQueue->getCountTotal();
+      $countProcessed += $campaignQueue->getCountProcessed();
+      $countToProcess += $campaignQueue->getCountToProcess();
+      $statuses[] = $task->getStatus();
+      $scheduledAt = $task->getScheduledAt();
+      if ($scheduledAt) {
+        $firstScheduledAt = $this->minDate($firstScheduledAt, $scheduledAt);
+        $lastScheduledAt = $this->maxDate($lastScheduledAt, $scheduledAt);
+        if ($task->getStatus() === ScheduledTaskEntity::STATUS_SCHEDULED || $task->getStatus() === ScheduledTaskEntity::STATUS_PAUSED) {
+          $nextScheduledAt = $this->minDate($nextScheduledAt, $scheduledAt);
+        }
+      }
+      $processedAt = $task->getProcessedAt();
+      if ($processedAt) {
+        $lastProcessedAt = $this->maxDate($lastProcessedAt, $processedAt);
+      }
+      $queueMeta = $campaignQueue->getMeta() ?? [];
+      $breakdown[] = [
+        'timezone' => $queueMeta[self::META_GROUP_TIMEZONE] ?? null,
+        'fallback_used' => $queueMeta[self::META_FALLBACK_USED] ?? false,
+        'scheduled_at' => $scheduledAt ? $scheduledAt->format('Y-m-d H:i:s') : null,
+        'status' => $task->getStatus(),
+        'count_total' => $campaignQueue->getCountTotal(),
+        'count_processed' => $campaignQueue->getCountProcessed(),
+        'count_to_process' => $campaignQueue->getCountToProcess(),
+      ];
+    }
+
+    $meta[self::META_FIRST_SCHEDULED_AT] = $firstScheduledAt ? $firstScheduledAt->format('Y-m-d H:i:s') : null;
+    $meta[self::META_LAST_SCHEDULED_AT] = $lastScheduledAt ? $lastScheduledAt->format('Y-m-d H:i:s') : null;
+    $meta[self::META_NEXT_SCHEDULED_AT] = $nextScheduledAt ? $nextScheduledAt->format('Y-m-d H:i:s') : null;
+    $meta[self::META_TIMEZONE_BREAKDOWN] = $breakdown;
+
+    return [
+      'status' => $this->resolveAggregateStatus($statuses),
+      'scheduledAt' => $nextScheduledAt ?: $firstScheduledAt,
+      'processedAt' => $lastProcessedAt,
+      'countTotal' => $countTotal,
+      'countProcessed' => $countProcessed,
+      'countToProcess' => $countToProcess,
+      'meta' => $meta,
+    ];
+  }
+
+  private function getRequiredOption(NewsletterEntity $newsletter, string $optionName): string {
+    $value = $newsletter->getOptionValue($optionName);
+    return is_string($value) ? $value : '';
+  }
+
+  private function normalizeLocalTime(string $time): string {
+    if (strlen($time) === 5) {
+      return "{$time}:00";
+    }
+    return $time;
+  }
+
+  /**
+   * @throws \Exception
+   */
+  private function validateLocalDate(string $date): void {
+    $dateTime = \DateTimeImmutable::createFromFormat('!Y-m-d', $date);
+    if (!$dateTime || $dateTime->format('Y-m-d') !== $date) {
+      throw new \Exception(__('Please enter a valid scheduled date.', 'mailpoet'), 400);
+    }
+  }
+
+  /**
+   * @throws \Exception
+   */
+  private function validateLocalTime(string $time): void {
+    $dateTime = \DateTimeImmutable::createFromFormat('!H:i:s', $time);
+    if (
+      !$dateTime
+      || $dateTime->format('H:i:s') !== $time
+      || ((int)$dateTime->format('i')) % 15 !== 0
+      || ((int)$dateTime->format('s')) !== 0
+    ) {
+      throw new \Exception(__('Please enter a valid scheduled time.', 'mailpoet'), 400);
+    }
+  }
+
+  /**
+   * @param int[] $subscriberIds
+   * @return array<string,array{timeZone:string,fallbackUsed:bool,subscriberIds:int[]}>
+   */
+  private function groupSubscribersByTimeZone(array $subscriberIds, string $siteTimeZoneName): array {
+    $groups = [];
+    foreach (array_chunk($subscriberIds, 1000) as $idsChunk) {
+      $subscribers = $this->subscribersRepository->findBy(['id' => $idsChunk]);
+      foreach ($subscribers as $subscriber) {
+        if (!$subscriber instanceof SubscriberEntity || !$subscriber->getId()) {
+          continue;
+        }
+        $timeZone = SubscriberEntity::sanitizeTimeZone($subscriber->getTimeZone());
+        $fallbackUsed = $timeZone === null;
+        $resolvedTimeZone = $timeZone ?: $siteTimeZoneName;
+        $key = $resolvedTimeZone . ':' . (int)$fallbackUsed;
+        if (!isset($groups[$key])) {
+          $groups[$key] = [
+            'timeZone' => $resolvedTimeZone,
+            'fallbackUsed' => $fallbackUsed,
+            'subscriberIds' => [],
+          ];
+        }
+        $groups[$key]['subscriberIds'][] = (int)$subscriber->getId();
+      }
+    }
+    return $groups;
+  }
+
+  /**
+   * @param array<string,array{timeZone:string,fallbackUsed:bool,subscriberIds:int[]}> $groups
+   * @return array<int,array{timeZone:string,fallbackUsed:bool,subscriberIds:int[],scheduledAt:\DateTimeImmutable}>
+   */
+  private function buildGroupSchedule(array $groups, string $selectedLocalDate, string $selectedLocalTime): array {
+    $schedule = [];
+    foreach ($groups as $group) {
+      $scheduledAt = new \DateTimeImmutable(
+        "{$selectedLocalDate} {$selectedLocalTime}",
+        new \DateTimeZone($group['timeZone'])
+      );
+      $scheduledAt = $scheduledAt->setTimezone(new \DateTimeZone('UTC'));
+      $schedule[] = [
+        'timeZone' => $group['timeZone'],
+        'fallbackUsed' => $group['fallbackUsed'],
+        'subscriberIds' => $group['subscriberIds'],
+        'scheduledAt' => $scheduledAt,
+      ];
+    }
+    usort($schedule, function(array $a, array $b): int {
+      return $a['scheduledAt'] <=> $b['scheduledAt'];
+    });
+    return $schedule;
+  }
+
+  /**
+   * @param array<int,array{timeZone:string,fallbackUsed:bool,subscriberIds:int[],scheduledAt:\DateTimeImmutable}> $schedule
+   * @throws \Exception
+   */
+  private function validateLeadTime(array $schedule): void {
+    $earliest = $schedule[0]['scheduledAt'];
+    $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    if ($earliest <= $now) {
+      throw new \Exception(__('Subscriber time zone scheduling cannot include time zones that have already passed.', 'mailpoet'), 400);
+    }
+    if ($earliest < $now->modify('+' . self::LEAD_TIME_HOURS . ' hours')) {
+      throw new \Exception(sprintf(
+        // translators: %d is the minimum number of hours required before the first timezone batch can send.
+        __('Subscriber time zone scheduling requires at least %d hours of lead time.', 'mailpoet'),
+        self::LEAD_TIME_HOURS
+      ), 400);
+    }
+  }
+
+  public function canReplaceScheduledCampaign(NewsletterEntity $newsletter): bool {
+    foreach ($this->getTimeZoneQueuesForNewsletter($newsletter) as $queue) {
+      $task = $queue->getTask();
+      if (!$task instanceof ScheduledTaskEntity) {
+        continue;
+      }
+      if ($queue->getCountProcessed() > 0 || $task->getInProgress()) {
+        return false;
+      }
+      if (!in_array($task->getStatus(), [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED], true)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public function deleteScheduledCampaignQueues(NewsletterEntity $newsletter): void {
+    foreach ($this->getTimeZoneQueuesForNewsletter($newsletter) as $queue) {
+      $task = $queue->getTask();
+      if ($task instanceof ScheduledTaskEntity) {
+        $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($task);
+      }
+      $this->sendingQueuesRepository->remove($queue);
+      if ($task instanceof ScheduledTaskEntity) {
+        $this->scheduledTasksRepository->remove($task);
+      }
+    }
+    $this->entityManager->flush();
+  }
+
+  /** @return SendingQueueEntity[] */
+  private function getTimeZoneQueuesForNewsletter(NewsletterEntity $newsletter): array {
+    return array_values(array_filter($this->sendingQueuesRepository->findBy(['newsletter' => $newsletter]), function(SendingQueueEntity $queue): bool {
+      return $this->isTimeZoneQueue($queue);
+    }));
+  }
+
+  /** @return SendingQueueEntity[] */
+  private function getCampaignQueuesById(NewsletterEntity $newsletter, string $campaignId): array {
+    $queues = array_filter($this->getTimeZoneQueuesForNewsletter($newsletter), function(SendingQueueEntity $queue) use ($campaignId): bool {
+      return $this->getCampaignId($queue) === $campaignId;
+    });
+    usort($queues, function(SendingQueueEntity $a, SendingQueueEntity $b): int {
+      $taskA = $a->getTask();
+      $taskB = $b->getTask();
+      $scheduledA = $taskA instanceof ScheduledTaskEntity ? $taskA->getScheduledAt() : null;
+      $scheduledB = $taskB instanceof ScheduledTaskEntity ? $taskB->getScheduledAt() : null;
+      if (!$scheduledA || !$scheduledB) {
+        return (int)$a->getId() <=> (int)$b->getId();
+      }
+      return $scheduledA <=> $scheduledB;
+    });
+    return $queues;
+  }
+
+  private function resolveAggregateStatus(array $statuses): ?string {
+    if ($statuses === []) {
+      return null;
+    }
+    if (in_array(ScheduledTaskEntity::STATUS_PAUSED, $statuses, true)) {
+      return ScheduledTaskEntity::STATUS_PAUSED;
+    }
+    if (in_array(null, $statuses, true)) {
+      return null;
+    }
+    $uniqueStatuses = array_values(array_unique($statuses));
+    if ($uniqueStatuses === [ScheduledTaskEntity::STATUS_COMPLETED]) {
+      return ScheduledTaskEntity::STATUS_COMPLETED;
+    }
+    if ($uniqueStatuses === [ScheduledTaskEntity::STATUS_CANCELLED]) {
+      return ScheduledTaskEntity::STATUS_CANCELLED;
+    }
+    if ($uniqueStatuses === [ScheduledTaskEntity::STATUS_SCHEDULED]) {
+      return ScheduledTaskEntity::STATUS_SCHEDULED;
+    }
+    if (in_array(ScheduledTaskEntity::STATUS_COMPLETED, $statuses, true)) {
+      return null;
+    }
+    return $statuses[0];
+  }
+
+  private function minDate(?\DateTimeInterface $current, \DateTimeInterface $candidate): \DateTimeInterface {
+    return $current && $current <= $candidate ? $current : $candidate;
+  }
+
+  private function maxDate(?\DateTimeInterface $current, \DateTimeInterface $candidate): \DateTimeInterface {
+    return $current && $current >= $candidate ? $current : $candidate;
+  }
+}

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -14,6 +14,7 @@ use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\Security;
 use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class TimeZoneCampaignScheduler {
@@ -231,6 +232,10 @@ class TimeZoneCampaignScheduler {
         continue;
       }
       if ($campaignQueue->getCountProcessed() === $campaignQueue->getCountTotal() && $campaignQueue->getCountTotal() > 0) {
+        // Mirrors SendingQueuesRepository::resume(): when pause interrupted the worker after all
+        // recipients were processed but before STATUS_COMPLETED was set, finalize processedAt now
+        // so aggregate "processed at" reporting is not left null for this batch.
+        $task->setProcessedAt(Carbon::now()->millisecond(0));
         $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
         continue;
       }

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -83,7 +83,7 @@ class TimeZoneCampaignScheduler {
     if ($capability && $capability->isRestricted) {
       throw new \Exception(__('Send by subscriber time zone requires a paid MailPoet plan.', 'mailpoet'), 403);
     }
-    if (!$this->canReplaceScheduledCampaign($newsletter)) {
+    if (!$this->canReplaceScheduledQueues($newsletter)) {
       throw new \Exception(__('This email can no longer be edited because one or more time zone batches have already started.', 'mailpoet'), 400);
     }
 
@@ -113,7 +113,7 @@ class TimeZoneCampaignScheduler {
 
     $this->entityManager->beginTransaction();
     try {
-      $this->deleteScheduledCampaignQueues($newsletter);
+      $this->deleteReplaceableScheduledQueues($newsletter);
       $createdQueues = [];
 
       foreach ($schedule as $group) {
@@ -426,39 +426,84 @@ class TimeZoneCampaignScheduler {
 
   public function canReplaceScheduledCampaign(NewsletterEntity $newsletter): bool {
     foreach ($this->getTimeZoneQueuesForNewsletter($newsletter) as $queue) {
-      $task = $queue->getTask();
-      if (!$task instanceof ScheduledTaskEntity) {
-        continue;
-      }
-      if ($queue->getCountProcessed() > 0 || $task->getInProgress()) {
-        return false;
-      }
-      if (!in_array($task->getStatus(), [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED], true)) {
+      if (!$this->isReplaceableScheduledQueue($queue)) {
         return false;
       }
     }
     return true;
   }
 
-  public function deleteScheduledCampaignQueues(NewsletterEntity $newsletter): void {
-    foreach ($this->getTimeZoneQueuesForNewsletter($newsletter) as $queue) {
-      $task = $queue->getTask();
-      if ($task instanceof ScheduledTaskEntity) {
-        $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($task);
+  public function canReplaceScheduledQueues(NewsletterEntity $newsletter): bool {
+    foreach ($this->getQueuesForNewsletter($newsletter) as $queue) {
+      if ($this->isTerminalQueue($queue)) {
+        continue;
       }
-      $this->sendingQueuesRepository->remove($queue);
-      if ($task instanceof ScheduledTaskEntity) {
-        $this->scheduledTasksRepository->remove($task);
+      if (!$this->isReplaceableScheduledQueue($queue)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public function deleteReplaceableScheduledQueues(NewsletterEntity $newsletter): void {
+    foreach ($this->getQueuesForNewsletter($newsletter) as $queue) {
+      if ($this->isReplaceableScheduledQueue($queue)) {
+        $this->deleteQueue($queue);
       }
     }
     $this->entityManager->flush();
   }
 
+  public function deleteScheduledCampaignQueues(NewsletterEntity $newsletter): void {
+    foreach ($this->getTimeZoneQueuesForNewsletter($newsletter) as $queue) {
+      $this->deleteQueue($queue);
+    }
+    $this->entityManager->flush();
+  }
+
+  /** @return SendingQueueEntity[] */
+  private function getQueuesForNewsletter(NewsletterEntity $newsletter): array {
+    return $this->sendingQueuesRepository->findBy(['newsletter' => $newsletter]);
+  }
+
   /** @return SendingQueueEntity[] */
   private function getTimeZoneQueuesForNewsletter(NewsletterEntity $newsletter): array {
-    return array_values(array_filter($this->sendingQueuesRepository->findBy(['newsletter' => $newsletter]), function(SendingQueueEntity $queue): bool {
+    return array_values(array_filter($this->getQueuesForNewsletter($newsletter), function(SendingQueueEntity $queue): bool {
       return $this->isTimeZoneQueue($queue);
     }));
+  }
+
+  private function isReplaceableScheduledQueue(SendingQueueEntity $queue): bool {
+    $task = $queue->getTask();
+    return $task instanceof ScheduledTaskEntity
+      && $queue->getCountProcessed() === 0
+      && !$task->getInProgress()
+      && in_array($task->getStatus(), [ScheduledTaskEntity::STATUS_SCHEDULED, ScheduledTaskEntity::STATUS_PAUSED], true);
+  }
+
+  private function isTerminalQueue(SendingQueueEntity $queue): bool {
+    $task = $queue->getTask();
+    return $task instanceof ScheduledTaskEntity
+      && in_array(
+        $task->getStatus(),
+        [
+          ScheduledTaskEntity::STATUS_COMPLETED,
+          ScheduledTaskEntity::STATUS_CANCELLED,
+          ScheduledTaskEntity::STATUS_INVALID,
+        ],
+        true
+      );
+  }
+
+  private function deleteQueue(SendingQueueEntity $queue): void {
+    $task = $queue->getTask();
+    if ($task instanceof ScheduledTaskEntity) {
+      $this->scheduledTaskSubscribersRepository->deleteByScheduledTask($task);
+    }
+    $this->sendingQueuesRepository->remove($queue);
+    if ($task instanceof ScheduledTaskEntity) {
+      $this->scheduledTasksRepository->remove($task);
+    }
   }
 
   /** @return SendingQueueEntity[] */

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -206,7 +206,10 @@ class TimeZoneCampaignScheduler {
 
   public function pauseCampaign(SendingQueueEntity $queue): void {
     foreach ($this->getCampaignQueues($queue) as $campaignQueue) {
-      if ($campaignQueue->getCountProcessed() === $campaignQueue->getCountTotal()) {
+      // Mirrors the guard in resumeCampaign(): a queue is only "fully processed"
+      // when it has work to do AND all of it has been done. A zero-count queue
+      // is still pending and must be paused.
+      if ($campaignQueue->getCountTotal() > 0 && $campaignQueue->getCountProcessed() === $campaignQueue->getCountTotal()) {
         continue;
       }
       $task = $campaignQueue->getTask();

--- a/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
+++ b/mailpoet/lib/Newsletter/Sending/TimeZoneCampaignScheduler.php
@@ -524,6 +524,13 @@ class TimeZoneCampaignScheduler {
     return $queues;
   }
 
+  /**
+   * Resolves the aggregate status of a multi-batch time zone campaign from the per-batch statuses.
+   *
+   * The priority is intentionally explicit (instead of falling back to "the first status in the
+   * list") so that the result is deterministic and reflects what the campaign is doing, not the
+   * order in which batches happen to be sorted.
+   */
   private function resolveAggregateStatus(array $statuses): ?string {
     if ($statuses === []) {
       return null;
@@ -534,20 +541,16 @@ class TimeZoneCampaignScheduler {
     if (in_array(null, $statuses, true)) {
       return null;
     }
-    $uniqueStatuses = array_values(array_unique($statuses));
-    if ($uniqueStatuses === [ScheduledTaskEntity::STATUS_COMPLETED]) {
-      return ScheduledTaskEntity::STATUS_COMPLETED;
-    }
-    if ($uniqueStatuses === [ScheduledTaskEntity::STATUS_CANCELLED]) {
-      return ScheduledTaskEntity::STATUS_CANCELLED;
-    }
-    if ($uniqueStatuses === [ScheduledTaskEntity::STATUS_SCHEDULED]) {
+    if (in_array(ScheduledTaskEntity::STATUS_SCHEDULED, $statuses, true)) {
       return ScheduledTaskEntity::STATUS_SCHEDULED;
     }
     if (in_array(ScheduledTaskEntity::STATUS_COMPLETED, $statuses, true)) {
-      return null;
+      return ScheduledTaskEntity::STATUS_COMPLETED;
     }
-    return $statuses[0];
+    if (in_array(ScheduledTaskEntity::STATUS_CANCELLED, $statuses, true)) {
+      return ScheduledTaskEntity::STATUS_CANCELLED;
+    }
+    return ScheduledTaskEntity::STATUS_INVALID;
   }
 
   private function minDate(?\DateTimeInterface $current, \DateTimeInterface $candidate): \DateTimeInterface {

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -8,6 +8,7 @@ use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\InvalidStateException;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\ParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
@@ -23,14 +24,19 @@ class SubscribersFinder {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var ScheduledTaskSubscribersRepository */
+  private $scheduledTaskSubscribersRepository;
+
   public function __construct(
     SegmentSubscribersRepository $segmentSubscriberRepository,
     SegmentsRepository $segmentsRepository,
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    ScheduledTaskSubscribersRepository $scheduledTaskSubscribersRepository
   ) {
     $this->segmentSubscriberRepository = $segmentSubscriberRepository;
     $this->segmentsRepository = $segmentsRepository;
     $this->entityManager = $entityManager;
+    $this->scheduledTaskSubscribersRepository = $scheduledTaskSubscribersRepository;
   }
 
   /**
@@ -196,40 +202,9 @@ class SubscribersFinder {
     }
 
     if ($subscriberIds) {
-      $count += $this->addSubscribersToTaskByIds($task, $subscriberIds);
+      $count += $this->scheduledTaskSubscribersRepository->addSubscribersByIds($task, $subscriberIds);
     }
     return $count;
-  }
-
-  private function addSubscribersToTaskByIds(ScheduledTaskEntity $task, array $subscriberIds) {
-    $scheduledTaskSubscriberTable = $this->entityManager->getClassMetadata(ScheduledTaskSubscriberEntity::class)->getTableName();
-    $subscriberTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-
-    $connection = $this->entityManager->getConnection();
-
-    $result = $connection->executeQuery(
-      "INSERT IGNORE INTO $scheduledTaskSubscriberTable
-       (task_id, subscriber_id, processed)
-       SELECT DISTINCT ? as task_id, subscribers.`id` as subscriber_id, ? as processed
-       FROM $subscriberTable subscribers
-       WHERE subscribers.`deleted_at` IS NULL
-       AND subscribers.`status` = ?
-       AND subscribers.`id` IN (?)",
-      [
-        $task->getId(),
-        ScheduledTaskSubscriberEntity::STATUS_UNPROCESSED,
-        SubscriberEntity::STATUS_SUBSCRIBED,
-        $subscriberIds,
-      ],
-      [
-        ParameterType::INTEGER,
-        ParameterType::INTEGER,
-        ParameterType::STRING,
-        ArrayParameterType::INTEGER,
-      ]
-    );
-
-    return $result->rowCount();
   }
 
   private function unique(array $subscriberIds) {

--- a/mailpoet/lib/Segments/SubscribersFinder.php
+++ b/mailpoet/lib/Segments/SubscribersFinder.php
@@ -56,6 +56,34 @@ class SubscribersFinder {
     return $this->unique($result);
   }
 
+  /**
+   * @param int[] $newsletterSegmentsIds
+   * @return int[]
+   * @throws InvalidStateException
+   */
+  public function getSubscriberIdsFromSegments(array $newsletterSegmentsIds, ?int $filterSegmentId = null): array {
+    $result = [];
+    foreach ($newsletterSegmentsIds as $segmentId) {
+      $segment = $this->segmentsRepository->findOneById($segmentId);
+      if (!$segment instanceof SegmentEntity) {
+        continue;
+      }
+      try {
+        $result = array_merge($result, $this->segmentSubscriberRepository->getSubscriberIdsInSegment((int)$segment->getId()));
+      } catch (InvalidStateException $exception) {
+        continue;
+      }
+    }
+
+    if (is_int($filterSegmentId)) {
+      $filterSegment = $this->segmentsRepository->verifyDynamicSegmentExists($filterSegmentId);
+      $filterSubscriberIds = $this->segmentSubscriberRepository->getSubscriberIdsInSegment((int)$filterSegment->getId());
+      $result = array_intersect($result, $filterSubscriberIds);
+    }
+
+    return array_values($this->unique($result));
+  }
+
   private function findSubscribersInSegment(SegmentEntity $segment, $subscribersToProcessIds): array {
     try {
       return $this->segmentSubscriberRepository->findSubscribersIdsInSegment((int)$segment->getId(), $subscribersToProcessIds);

--- a/mailpoet/lib/Util/License/Features/CapabilitiesManager.php
+++ b/mailpoet/lib/Util/License/Features/CapabilitiesManager.php
@@ -13,12 +13,14 @@ class CapabilitiesManager {
   const MSS_DETAILED_ANALYTICS_SETTING_KEY = 'mta.mailpoet_api_key_state.data.detailed_analytics';
   const MSS_AUTOMATION_STEPS_SETTING_KEY = 'mta.mailpoet_api_key_state.data.automation_steps';
   const MSS_SEGMENT_FILTERS_SETTING_KEY = 'mta.mailpoet_api_key_state.data.segment_filters';
+  const MSS_SEND_BY_TIMEZONE_SETTING_KEY = 'mta.mailpoet_api_key_state.data.send_by_timezone';
   // Product capabilities mapping
   const MIN_TIER_LOGO_NOT_REQUIRED = 1;
   const MIN_TIER_ANALYTICS_ENABLED = 1;
   const MIN_TIER_NO_UPGRADE_PAGE = 2;
   const MIN_TIER_UNLIMITED_AUTOMATION_STEPS = 2;
   const MIN_TIER_UNLIMITED_SEGMENT_FILTERS = 2;
+  const MIN_TIER_SEND_BY_TIMEZONE_ENABLED = 1;
 
   private SettingsController $settings;
   private ServicesChecker $servicesChecker;
@@ -83,6 +85,24 @@ class CapabilitiesManager {
     return (isset($this->tier) && $this->tier >= self::MIN_TIER_ANALYTICS_ENABLED);
   }
 
+  private function isSendByTimezoneEnabled(): bool {
+    if (!$this->subscribersFeature->hasValidPremiumKey() || $this->subscribersFeature->check() || !$this->servicesChecker->isPremiumPluginActive()) {
+      return false;
+    }
+
+    $sendByTimezone = $this->settings->get(self::MSS_SEND_BY_TIMEZONE_SETTING_KEY);
+
+    if (!isset($this->tier) && !isset($sendByTimezone)) {
+      return true;
+    }
+
+    if (isset($sendByTimezone) && (bool)$sendByTimezone === true) {
+      return true;
+    }
+
+    return (isset($this->tier) && $this->tier >= self::MIN_TIER_SEND_BY_TIMEZONE_ENABLED);
+  }
+
   private function getLimit(string $settingKey, int $minTierForUnlimited): int {
     $capabilityValue = $this->settings->get($settingKey);
 
@@ -117,6 +137,7 @@ class CapabilitiesManager {
     $this->capabilities = [
       'mailpoetLogoInEmails' => new Capability('mailpoetLogoInEmails', Capability::TYPE_BOOLEAN, $this->isMailpoetLogoInEmailsRequired()),
       'detailedAnalytics' => new Capability('detailedAnalytics', Capability::TYPE_BOOLEAN, !$this->isDetailedAnalyticsEnabled()),
+      'sendByTimezone' => new Capability('sendByTimezone', Capability::TYPE_BOOLEAN, !$this->isSendByTimezoneEnabled()),
       'automationSteps' => new Capability('automationSteps', Capability::TYPE_NUMBER, $automationSteps > 0, $automationSteps),
       'segmentFilters' => new Capability('segmentFilters', Capability::TYPE_NUMBER, $segmentFilters > 0, $segmentFilters),
     ];

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -152,6 +152,10 @@ class Functions {
     return wp_timezone_string();
   }
 
+  public function wpTimezone(): \DateTimeZone {
+    return wp_timezone();
+  }
+
   public function currentUserCan($capability) {
     return current_user_can($capability);
   }

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/NewslettersResponseBuilderTest.php
@@ -10,6 +10,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Url;
@@ -108,5 +109,49 @@ class NewslettersResponseBuilderTest extends \MailPoetTest {
     /** @var string[] $renderedQueue */
     $renderedQueue = $response[0]['queue'];
     verify($renderedQueue['newsletter_rendered_subject'])->equals('Hello [mailpoet/subscriber-firstname default="subscriber"]!');
+  }
+
+  public function testItAggregatesTimeZoneCampaignQueueForListing() {
+    $em = $this->diContainer->get(EntityManager::class);
+    $responseBuilder = $this->diContainer->get(NewslettersResponseBuilder::class);
+    $campaignId = 'timezone-campaign';
+    $em->persist($newsletter = new NewsletterEntity);
+    $newsletter->setType(NewsletterEntity::TYPE_STANDARD);
+    $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);
+    $newsletter->setSubject('Subject');
+
+    $groups = [
+      ['Europe/Bratislava', '2018-10-10 10:00:00', 1],
+      ['America/New_York', '2018-10-11 10:00:00', 2],
+    ];
+    foreach ($groups as [$timeZone, $scheduledAt, $count]) {
+      $em->persist($task = new ScheduledTaskEntity());
+      $task->setType(\MailPoet\Cron\Workers\SendingQueue\SendingQueue::TASK_TYPE);
+      $task->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+      $task->setScheduledAt(new \DateTimeImmutable($scheduledAt));
+      $em->persist($queue = new SendingQueueEntity());
+      $queue->setNewsletter($newsletter);
+      $queue->setTask($task);
+      $queue->setCountTotal($count);
+      $queue->setCountToProcess($count);
+      $queue->setMeta([
+        TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+        TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+        TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => $timeZone,
+        TimeZoneCampaignScheduler::META_FALLBACK_USED => false,
+      ]);
+    }
+    $em->flush();
+
+    $response = $responseBuilder->buildForListing([$newsletter]);
+
+    /** @var array<string, mixed> $queue */
+    $queue = $response[0]['queue'];
+    verify($queue['scheduled_at'])->equals('2018-10-10 10:00:00');
+    verify($queue['count_total'])->equals('3');
+    verify($queue['count_to_process'])->equals('3');
+    $this->assertIsArray($queue['meta']);
+    $this->assertIsArray($queue['meta'][TimeZoneCampaignScheduler::META_TIMEZONE_BREAKDOWN]);
+    verify(count($queue['meta'][TimeZoneCampaignScheduler::META_TIMEZONE_BREAKDOWN]))->equals(2);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/ResponseBuilders/SendingQueuesResponseBuilderTest.php
+++ b/mailpoet/tests/integration/API/JSON/ResponseBuilders/SendingQueuesResponseBuilderTest.php
@@ -7,6 +7,7 @@ use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
@@ -61,5 +62,41 @@ class SendingQueuesResponseBuilderTest extends \MailPoetTest {
     ];
 
     $this->assertSame($expectedResult, $this->sendingQueuesResponseBuilder->build($this->sendingQueue));
+  }
+
+  public function testBuildAggregatesTimeZoneCampaignQueues() {
+    $campaignId = 'timezone-campaign';
+    $this->sendingQueue->setCountTotal(1);
+    $this->sendingQueue->setCountToProcess(1);
+    $this->sendingQueue->setMeta([
+      TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+      TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+      TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => 'Europe/Bratislava',
+      TimeZoneCampaignScheduler::META_FALLBACK_USED => false,
+    ]);
+    $secondTask = (new ScheduledTaskFactory())->create(
+      SendingQueue::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      new Carbon('2018-10-11 10:00:00')
+    );
+    $secondQueue = (new SendingQueueFactory())->create($secondTask, $this->newsletter);
+    $secondQueue->setCountTotal(2);
+    $secondQueue->setCountToProcess(2);
+    $secondQueue->setMeta([
+      TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+      TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+      TimeZoneCampaignScheduler::META_GROUP_TIMEZONE => 'America/New_York',
+      TimeZoneCampaignScheduler::META_FALLBACK_USED => false,
+    ]);
+    $this->entityManager->flush();
+
+    $result = $this->sendingQueuesResponseBuilder->build($this->sendingQueue);
+
+    verify($result['status'])->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+    verify($result['scheduled_at'])->equals('2018-10-10 10:00:00');
+    verify($result['count_total'])->equals(3);
+    verify($result['count_processed'])->equals(0);
+    verify($result['count_to_process'])->equals(3);
+    verify(count($result['meta'][TimeZoneCampaignScheduler::META_TIMEZONE_BREAKDOWN]))->equals(2);
   }
 }

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -188,6 +188,84 @@ class SendingQueueTest extends \MailPoetTest {
     verify($scheduled->format('Y-m-d H:i:s'))->equals('2030-10-10 10:00:00');
   }
 
+  public function testItReplacesOrphanedTimezoneQueuesWhenSendingImmediately(): void {
+    $segment = (new SegmentFactory())->create();
+    $subscriber = (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())
+      ->withSegments([$segment])
+      ->withSubscriber($subscriber)
+      ->create();
+
+    $campaignId = 'orphan-timezone-campaign';
+    $oldTask1 = (new ScheduledTaskFactory())->create(
+      SendingQueue::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      new \DateTimeImmutable('2030-10-09 10:00:00')
+    );
+    $oldTask2 = (new ScheduledTaskFactory())->create(
+      SendingQueue::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      new \DateTimeImmutable('2030-10-09 11:00:00')
+    );
+    $oldQueue1 = (new SendingQueueFactory())->create($oldTask1, $newsletter);
+    $oldQueue2 = (new SendingQueueFactory())->create($oldTask2, $newsletter);
+    foreach ([$oldQueue1, $oldQueue2] as $oldQueue) {
+      $oldQueue->setMeta([
+        TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+        TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+      ]);
+    }
+    $this->entityManager->flush();
+
+    $result = $this->diContainer->get(SendingQueueAPI::class)->add(['newsletter_id' => $newsletter->getId()]);
+
+    $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    verify($result->status)->equals(APIResponse::STATUS_OK);
+    verify($sendingQueuesRepository->findOneById((int)$oldQueue1->getId()))->null();
+    verify($sendingQueuesRepository->findOneById((int)$oldQueue2->getId()))->null();
+    verify($scheduledTasksRepository->findOneById((int)$oldTask1->getId()))->null();
+    verify($scheduledTasksRepository->findOneById((int)$oldTask2->getId()))->null();
+
+    $remainingQueues = $sendingQueuesRepository->findBy(['newsletter' => $newsletter]);
+    verify(count($remainingQueues))->equals(1);
+    $newQueue = $remainingQueues[0];
+    verify($newQueue->getId())->equals($result->data['id']);
+    verify($newQueue->getMeta())->null();
+    $newTask = $newQueue->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $newTask);
+    verify($newTask->getStatus())->null();
+    verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENDING);
+  }
+
+  public function testItRejectsImmediateSendWhenTimezoneBatchAlreadyStarted(): void {
+    $segment = (new SegmentFactory())->create();
+    $subscriber = (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())
+      ->withSegments([$segment])
+      ->withSubscriber($subscriber)
+      ->create();
+
+    $startedTask = (new ScheduledTaskFactory())->create(
+      SendingQueue::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      new \DateTimeImmutable('2030-10-09 10:00:00')
+    );
+    $startedQueue = (new SendingQueueFactory())->create($startedTask, $newsletter);
+    $startedQueue->setMeta([
+      TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+      TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => 'partially-started-campaign',
+    ]);
+    $startedQueue->setCountProcessed(1);
+    $this->entityManager->flush();
+
+    $result = $this->diContainer->get(SendingQueueAPI::class)->add(['newsletter_id' => $newsletter->getId()]);
+    verify($result->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+
+    $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    verify($sendingQueuesRepository->findOneById((int)$startedQueue->getId()))->notNull();
+  }
+
   public function testAddReturnsErrorIfThereAreNoSubscribersAssociatedWithTheNewsletter() {
     $sendingQueue = $this->diContainer->get(SendingQueueAPI::class);
     $expectedResult = [

--- a/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SendingQueueTest.php
@@ -9,10 +9,13 @@ use MailPoet\Cron\CronHelper;
 use MailPoet\Cron\DaemonHttpRunner;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewsletterValidator;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterOption;
@@ -137,6 +140,52 @@ class SendingQueueTest extends \MailPoetTest {
     $scheduled = $rescheduledTask->getScheduledAt();
     $this->assertInstanceOf(\DateTimeInterface::class, $scheduled);
     verify($scheduled->format('Y-m-d H:i:s'))->equals('2018-11-11 11:00:00');
+  }
+
+  public function testItReplacesTimezoneQueuesWhenSchedulingByWebsiteTime(): void {
+    $newsletter = $this->newsletter;
+    $newsletter->setStatus(NewsletterEntity::STATUS_SCHEDULED);
+    $this->entityManager->flush();
+    $this->newsletterOptionsFactory->createMultipleOptions($newsletter, [
+      NewsletterOptionFieldEntity::NAME_IS_SCHEDULED => 1,
+      NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE => TimeZoneCampaignScheduler::SCHEDULE_MODE_WEBSITE_TIME,
+      NewsletterOptionFieldEntity::NAME_SCHEDULED_AT => '2030-10-10 10:00:00',
+    ]);
+    $campaignId = 'timezone-campaign';
+    $oldTask1 = (new ScheduledTaskFactory())->create(
+      SendingQueue::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      new \DateTimeImmutable('2030-10-09 10:00:00')
+    );
+    $oldTask2 = (new ScheduledTaskFactory())->create(
+      SendingQueue::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      new \DateTimeImmutable('2030-10-09 11:00:00')
+    );
+    $oldQueue1 = (new SendingQueueFactory())->create($oldTask1, $newsletter);
+    $oldQueue2 = (new SendingQueueFactory())->create($oldTask2, $newsletter);
+    foreach ([$oldQueue1, $oldQueue2] as $oldQueue) {
+      $oldQueue->setMeta([
+        TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE => true,
+        TimeZoneCampaignScheduler::META_TIMEZONE_CAMPAIGN_ID => $campaignId,
+      ]);
+    }
+    $this->entityManager->flush();
+
+    $result = $this->diContainer->get(SendingQueueAPI::class)->add(['newsletter_id' => $newsletter->getId()]);
+
+    $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    verify($result->status)->equals(APIResponse::STATUS_OK);
+    verify($sendingQueuesRepository->findOneById((int)$oldQueue1->getId()))->null();
+    verify($sendingQueuesRepository->findOneById((int)$oldQueue2->getId()))->null();
+    verify($scheduledTasksRepository->findOneById((int)$oldTask1->getId()))->null();
+    verify($scheduledTasksRepository->findOneById((int)$oldTask2->getId()))->null();
+    $newTask = $scheduledTasksRepository->findOneById((int)$result->data['task_id']);
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $newTask);
+    $scheduled = $newTask->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduled);
+    verify($scheduled->format('Y-m-d H:i:s'))->equals('2030-10-10 10:00:00');
   }
 
   public function testAddReturnsErrorIfThereAreNoSubscribersAssociatedWithTheNewsletter() {

--- a/mailpoet/tests/integration/Config/PopulatorTest.php
+++ b/mailpoet/tests/integration/Config/PopulatorTest.php
@@ -9,7 +9,7 @@ use MailPoetTest;
 use MailPoetVendor\Doctrine\ORM\Query;
 
 class PopulatorTest extends MailPoetTest {
-  private const OPTION_FIELD_COUNT = 31;
+  private const OPTION_FIELD_COUNT = 34;
   private const TEMPLATE_COUNT = 77;
 
   public function testItInsertsOptionFields(): void {

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -360,6 +360,31 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
     }
   }
 
+  public function testPauseStillPausesQueuesWithZeroCounts(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    // Force one batch into the "both counts are zero" edge case the bug exploits.
+    $queues[0]->setCountTotal(0);
+    $queues[0]->setCountProcessed(0);
+    $this->entityManager->flush();
+
+    $scheduler->pauseCampaign($queues[0]);
+
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_PAUSED);
+    }
+  }
+
   public function testNewsletterDeleteRemovesAllSiblingQueuesAndSubscribers(): void {
     $segment = (new SegmentFactory())->create();
     (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -270,6 +270,68 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
     verify($scheduler->hasIncompleteCampaignQueues($queues[1]))->false();
   }
 
+  public function testAggregateStatusIsDeterministicAcrossMixedBatchStatuses(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    verify(count($queues))->equals(2);
+    $tasks = [];
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      $tasks[] = $task;
+    }
+
+    $assertAggregateStatus = function (string $expected) use ($scheduler, $queues): void {
+      $data = $scheduler->getAggregateQueueData($queues[0]);
+      $this->assertIsArray($data);
+      verify($data['status'])->equals($expected);
+    };
+    $assertAggregateStatusNull = function () use ($scheduler, $queues): void {
+      $data = $scheduler->getAggregateQueueData($queues[0]);
+      $this->assertIsArray($data);
+      verify($data['status'])->null();
+    };
+
+    // Mix of CANCELLED + SCHEDULED must report SCHEDULED (a batch is still pending).
+    // Previously this returned whichever status came first in the sorted queue list.
+    $tasks[0]->setStatus(ScheduledTaskEntity::STATUS_CANCELLED);
+    $tasks[1]->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->entityManager->flush();
+    $assertAggregateStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    // Order independence: the result must not depend on which batch holds CANCELLED.
+    $tasks[0]->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $tasks[1]->setStatus(ScheduledTaskEntity::STATUS_CANCELLED);
+    $this->entityManager->flush();
+    $assertAggregateStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+
+    // PAUSED dominates everything because it requires user action.
+    $tasks[0]->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+    $tasks[1]->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->entityManager->flush();
+    $assertAggregateStatus(ScheduledTaskEntity::STATUS_PAUSED);
+
+    // A null status (active sending) wins over any terminal sibling.
+    $tasks[0]->setStatus(null);
+    $tasks[1]->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->entityManager->flush();
+    $assertAggregateStatusNull();
+
+    // Purely terminal mix prefers COMPLETED (some progress was made) over CANCELLED.
+    $tasks[0]->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $tasks[1]->setStatus(ScheduledTaskEntity::STATUS_CANCELLED);
+    $this->entityManager->flush();
+    $assertAggregateStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+  }
+
   public function testPauseAndResumeAffectAllSiblings(): void {
     $segment = (new SegmentFactory())->create();
     (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Newsletter\Sending;
 
 use Codeception\Util\Stub;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -16,7 +17,9 @@ use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\NewsletterOption;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
 use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\License\Features\Data\Capability;
@@ -76,6 +79,34 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
     verify($perTimezone['America/New_York'] ?? 0)->equals(1);
     verify($perTimezone['Europe/Bratislava'] ?? 0)->equals(2);
     verify($totalSubscribers)->equals(3);
+  }
+
+  public function testItReplacesExistingWebsiteTimeQueueWhenSchedulingByTimeZone(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    $newsletter = (new NewsletterFactory())
+      ->withDefaultBody()
+      ->withSegments([$segment])
+      ->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+    $oldTask = (new ScheduledTaskFactory())->create(
+      SendingQueueWorker::TASK_TYPE,
+      ScheduledTaskEntity::STATUS_SCHEDULED,
+      $this->getUtcDateTime('+2 days')
+    );
+    $oldQueue = (new SendingQueueFactory())->create($oldTask, $newsletter);
+    $oldTaskId = (int)$oldTask->getId();
+    $oldQueueId = (int)$oldQueue->getId();
+
+    $this->getScheduler()->schedule($newsletter);
+
+    $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    verify($sendingQueuesRepository->findOneById($oldQueueId))->null();
+    verify($scheduledTasksRepository->findOneById($oldTaskId))->null();
+    foreach ($sendingQueuesRepository->findBy(['newsletter' => $newsletter]) as $queue) {
+      verify($this->getScheduler()->isTimeZoneQueue($queue))->true();
+    }
   }
 
   public function testItMarksFallbackGroupExplicitly(): void {

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -360,6 +360,38 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
     }
   }
 
+  public function testResumeDoesNotDemoteFullySentCampaign(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    // Simulate every batch having finished sending: counts equal and tasks completed,
+    // newsletter marked as SENT (the state markNewsletterAsSent leaves the campaign in).
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      $queue->setCountProcessed($queue->getCountTotal());
+      $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    }
+    $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+    $this->entityManager->flush();
+
+    $scheduler->resumeCampaign($queues[0]);
+
+    verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SENT);
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_COMPLETED);
+    }
+  }
+
   public function testPauseStillPausesQueuesWithZeroCounts(): void {
     $segment = (new SegmentFactory())->create();
     (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -392,6 +392,40 @@ class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
     }
   }
 
+  public function testResumeSetsProcessedAtWhenFinalizingFullyProcessedBatch(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    // Reproduce the race resumeCampaign() finalizes: the worker processed every recipient of one
+    // batch but the user hit pause before STATUS_COMPLETED was set, so the batch sits at PAUSED
+    // with counts equal and processedAt still null.
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    $pausedFullyProcessed = $queues[0];
+    $pausedFullyProcessedTask = $pausedFullyProcessed->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $pausedFullyProcessedTask);
+    $pausedFullyProcessed->setCountProcessed($pausedFullyProcessed->getCountTotal());
+    $pausedFullyProcessedTask->setStatus(ScheduledTaskEntity::STATUS_PAUSED);
+    $pausedFullyProcessedTask->setProcessedAt(null);
+    $this->entityManager->flush();
+    verify($pausedFullyProcessedTask->getProcessedAt())->null();
+
+    $scheduler->resumeCampaign($queues[0]);
+
+    verify($pausedFullyProcessedTask->getStatus())->equals(ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->assertInstanceOf(\DateTimeInterface::class, $pausedFullyProcessedTask->getProcessedAt());
+
+    // Aggregate reporting now reflects the finalized batch instead of leaving processedAt null.
+    $aggregate = $scheduler->getAggregateQueueData($queues[0]);
+    $this->assertIsArray($aggregate);
+    $this->assertInstanceOf(\DateTimeInterface::class, $aggregate['processedAt']);
+  }
+
   public function testPauseStillPausesQueuesWithZeroCounts(): void {
     $segment = (new SegmentFactory())->create();
     (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();

--- a/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sending/TimeZoneCampaignSchedulerTest.php
@@ -1,0 +1,365 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Sending;
+
+use Codeception\Util\Stub;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Features\FeaturesController;
+use MailPoet\Newsletter\NewsletterDeleteController;
+use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
+use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\NewsletterOption;
+use MailPoet\Test\DataFactories\Segment as SegmentFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoet\Util\License\Features\CapabilitiesManager;
+use MailPoet\Util\License\Features\Data\Capability;
+use MailPoet\WP\Functions as WPFunctions;
+
+class TimeZoneCampaignSchedulerTest extends \MailPoetTest {
+  /** @var NewsletterOption */
+  private $newsletterOptionFactory;
+
+  public function _before() {
+    parent::_before();
+    $this->newsletterOptionFactory = new NewsletterOption();
+  }
+
+  public function testItCreatesGroupedQueuesAndSnapshotsRecipients(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Time zone campaign')
+      ->withDefaultBody()
+      ->withSegments([$segment])
+      ->create();
+    $localDate = $this->getUtcDate('+3 days');
+    $this->createTimeZoneScheduleOptions($newsletter, $localDate, '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    verify(count($queues))->equals(3);
+    verify($newsletter->getStatus())->equals(NewsletterEntity::STATUS_SCHEDULED);
+
+    $totalSubscribers = 0;
+    $perTimezone = [];
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+      $meta = $queue->getMeta();
+      $this->assertIsArray($meta);
+      verify($meta[TimeZoneCampaignScheduler::META_SEND_BY_TIMEZONE])->true();
+      $tz = $meta[TimeZoneCampaignScheduler::META_GROUP_TIMEZONE];
+      $perTimezone[$tz] = ($perTimezone[$tz] ?? 0) + $queue->getCountTotal();
+      $totalSubscribers += $queue->getCountTotal();
+      if ($tz === 'America/New_York') {
+        verify($meta[TimeZoneCampaignScheduler::META_FALLBACK_USED])->false();
+        $expected = new \DateTimeImmutable("{$localDate} 12:00:00", new \DateTimeZone('America/New_York'));
+        $expected = $expected->setTimezone(new \DateTimeZone('UTC'));
+        $scheduledAt = $task->getScheduledAt();
+        $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+        verify($scheduledAt->format('Y-m-d H:i:s'))->equals($expected->format('Y-m-d H:i:s'));
+      }
+    }
+
+    verify($perTimezone['America/New_York'] ?? 0)->equals(1);
+    verify($perTimezone['Europe/Bratislava'] ?? 0)->equals(2);
+    verify($totalSubscribers)->equals(3);
+  }
+
+  public function testItMarksFallbackGroupExplicitly(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '09:00:00');
+
+    $this->getScheduler()->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    $byTimezone = [];
+    foreach ($queues as $queue) {
+      $meta = $queue->getMeta() ?? [];
+      $byTimezone[$meta[TimeZoneCampaignScheduler::META_GROUP_TIMEZONE]] = $meta;
+    }
+
+    verify($byTimezone['America/New_York'][TimeZoneCampaignScheduler::META_FALLBACK_USED])->false();
+    verify($byTimezone['Europe/Bratislava'][TimeZoneCampaignScheduler::META_FALLBACK_USED])->true();
+    verify($byTimezone['Europe/Bratislava'][TimeZoneCampaignScheduler::META_SITE_TIMEZONE])->equals('Europe/Bratislava');
+  }
+
+  public function testItRejectsRestrictedCapability(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionCode(403);
+
+    $this->getScheduler(true)->schedule($newsletter);
+  }
+
+  public function testItRejectsPastTimeZoneGroups(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('-1 day'), '12:00:00');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionCode(400);
+    $this->expectExceptionMessageMatches('/already passed/');
+
+    $this->getScheduler()->schedule($newsletter);
+  }
+
+  public function testItRejectsLeadTimeBelow24Hours(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $tooSoon = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify('+12 hours');
+    $this->createTimeZoneScheduleOptions(
+      $newsletter,
+      $tooSoon->format('Y-m-d'),
+      $this->roundDownToQuarterHour($tooSoon)->format('H:i:s')
+    );
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionCode(400);
+    $this->expectExceptionMessageMatches('/lead time/');
+
+    $this->getScheduler(false, 'UTC')->schedule($newsletter);
+  }
+
+  public function testItRejectsTimeOutsideQuarterHourBoundary(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '09:07:00');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionCode(400);
+    $this->expectExceptionMessageMatches('/scheduled time/');
+
+    $this->getScheduler()->schedule($newsletter);
+  }
+
+  public function testItRejectsTimeWithNonZeroSeconds(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '09:00:30');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionCode(400);
+    $this->expectExceptionMessageMatches('/scheduled time/');
+
+    $this->getScheduler()->schedule($newsletter);
+  }
+
+  public function testItHandlesDstAwareConversion(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    // US DST starts on 2027-03-14, so 2027-03-15 is firmly inside EDT (UTC-4).
+    $this->createTimeZoneScheduleOptions($newsletter, '2027-03-15', '09:00:00');
+
+    $this->getScheduler()->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    $task = $queues[0]->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+    $scheduledAt = $task->getScheduledAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $scheduledAt);
+    // 09:00 EDT (UTC-4) on 2027-03-15 is 13:00 UTC, not 14:00 (which would be EST UTC-5).
+    verify($scheduledAt->format('Y-m-d H:i:s'))->equals('2027-03-15 13:00:00');
+  }
+
+  public function testItRefusesReplaceWhenAQueueAlreadyStarted(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $this->getScheduler()->schedule($newsletter);
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    verify(count($queues))->greaterThanOrEqual(2);
+
+    $queues[0]->setCountProcessed(1);
+    $this->entityManager->flush();
+
+    verify($this->getScheduler()->canReplaceScheduledCampaign($newsletter))->false();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionCode(400);
+    $this->expectExceptionMessageMatches('/can no longer be edited/');
+
+    $this->getScheduler()->schedule($newsletter);
+  }
+
+  public function testHasIncompleteCampaignQueuesReportsAggregateState(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      $task->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    }
+    // Mark one as still scheduled.
+    $firstTask = $queues[0]->getTask();
+    $this->assertInstanceOf(ScheduledTaskEntity::class, $firstTask);
+    $firstTask->setStatus(ScheduledTaskEntity::STATUS_SCHEDULED);
+    $this->entityManager->flush();
+
+    verify($scheduler->hasIncompleteCampaignQueues($queues[1]))->true();
+
+    $firstTask->setStatus(ScheduledTaskEntity::STATUS_COMPLETED);
+    $this->entityManager->flush();
+
+    verify($scheduler->hasIncompleteCampaignQueues($queues[1]))->false();
+  }
+
+  public function testPauseAndResumeAffectAllSiblings(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $scheduler = $this->getScheduler();
+    $scheduler->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    $scheduler->pauseCampaign($queues[0]);
+
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_PAUSED);
+    }
+
+    $scheduler->resumeCampaign($queues[0]);
+
+    foreach ($queues as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      verify($task->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+    }
+  }
+
+  public function testNewsletterDeleteRemovesAllSiblingQueuesAndSubscribers(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('Europe/Bratislava')->create();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $this->getScheduler()->schedule($newsletter);
+
+    $sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    $scheduledTasksRepository = $this->diContainer->get(ScheduledTasksRepository::class);
+    $scheduledTaskSubscribersRepository = $this->diContainer->get(ScheduledTaskSubscribersRepository::class);
+    $newsletterId = (int)$newsletter->getId();
+
+    $queueIds = array_map(fn(SendingQueueEntity $queue): int => (int)$queue->getId(), $sendingQueuesRepository->findBy(['newsletter' => $newsletter]));
+    verify(count($queueIds))->greaterThanOrEqual(2);
+
+    $taskIds = [];
+    foreach ($sendingQueuesRepository->findBy(['newsletter' => $newsletter]) as $queue) {
+      $task = $queue->getTask();
+      $this->assertInstanceOf(ScheduledTaskEntity::class, $task);
+      $taskIds[] = (int)$task->getId();
+    }
+
+    $totalTaskSubscribers = 0;
+    foreach ($taskIds as $taskId) {
+      $totalTaskSubscribers += count($scheduledTaskSubscribersRepository->findBy(['task' => $taskId]));
+    }
+    verify($totalTaskSubscribers)->greaterThanOrEqual(2);
+
+    $this->diContainer->get(NewsletterDeleteController::class)->bulkDelete([$newsletterId]);
+
+    verify($sendingQueuesRepository->findBy(['newsletter' => $newsletterId]))->equals([]);
+    foreach ($taskIds as $taskId) {
+      verify($scheduledTasksRepository->findOneById($taskId))->null();
+      verify($scheduledTaskSubscribersRepository->findBy(['task' => $taskId]))->equals([]);
+    }
+  }
+
+  public function testItOnlyAttachesSubscribedRecipientsAtScheduleTime(): void {
+    $segment = (new SegmentFactory())->create();
+    (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    $unsubscribed = (new SubscriberFactory())->withSegments([$segment])->withTimeZone('America/New_York')->create();
+    $unsubscribed->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->entityManager->flush();
+    $newsletter = (new NewsletterFactory())->withDefaultBody()->withSegments([$segment])->create();
+    $this->createTimeZoneScheduleOptions($newsletter, $this->getUtcDate('+3 days'), '12:00:00');
+
+    $this->getScheduler()->schedule($newsletter);
+
+    $queues = $this->diContainer->get(SendingQueuesRepository::class)->findBy(['newsletter' => $newsletter]);
+    $total = 0;
+    foreach ($queues as $queue) {
+      $total += $queue->getCountTotal();
+    }
+    verify($total)->equals(1);
+  }
+
+  private function createTimeZoneScheduleOptions(NewsletterEntity $newsletter, string $localDate, string $localTime): void {
+    $this->newsletterOptionFactory->createMultipleOptions($newsletter, [
+      NewsletterOptionFieldEntity::NAME_IS_SCHEDULED => '1',
+      NewsletterOptionFieldEntity::NAME_SCHEDULE_MODE => TimeZoneCampaignScheduler::SCHEDULE_MODE_SUBSCRIBER_TIMEZONE,
+      NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_DATE => $localDate,
+      NewsletterOptionFieldEntity::NAME_SCHEDULED_LOCAL_TIME => $localTime,
+      NewsletterOptionFieldEntity::NAME_SCHEDULED_AT => $this->getUtcDateTime('+3 days')->format('Y-m-d H:i:s'),
+    ]);
+  }
+
+  private function getUtcDate(string $modifier): string {
+    return $this->getUtcDateTime($modifier)->format('Y-m-d');
+  }
+
+  private function getUtcDateTime(string $modifier): \DateTimeImmutable {
+    return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify($modifier);
+  }
+
+  private function roundDownToQuarterHour(\DateTimeImmutable $dateTime): \DateTimeImmutable {
+    $minutes = (int)$dateTime->format('i');
+    $rounded = $minutes - ($minutes % 15);
+    return $dateTime->setTime((int)$dateTime->format('H'), $rounded, 0);
+  }
+
+  private function getScheduler(bool $restricted = false, string $siteTimeZone = 'Europe/Bratislava'): TimeZoneCampaignScheduler {
+    return $this->getServiceWithOverrides(TimeZoneCampaignScheduler::class, [
+      'capabilitiesManager' => Stub::makeEmpty(CapabilitiesManager::class, [
+        'getCapability' => new Capability('sendByTimezone', Capability::TYPE_BOOLEAN, $restricted),
+      ]),
+      'featuresController' => Stub::make(FeaturesController::class, [
+        'isSupported' => true,
+      ]),
+      'wp' => Stub::make(WPFunctions::class, [
+        'wpTimezone' => new \DateTimeZone($siteTimeZone),
+      ]),
+    ]);
+  }
+}

--- a/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
+++ b/mailpoet/tests/integration/Segments/SubscribersFinderTest.php
@@ -76,7 +76,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->getId()]));
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->getId()], [$this->segment3->getId()]);
     verify($subscribers)->arrayCount(1);
     verify($subscribers)->arrayContains($this->subscriber3->getId());
@@ -90,7 +90,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->method('findSubscribersIdsInSegment')
       ->will($this->returnValue([$this->subscriber3->getId()]));
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
     $subscribers = $finder->findSubscribersInSegments([$this->subscriber3->getId()], [$this->segment3->getId(), $this->segment3->getId()]);
     verify($subscribers)->arrayCount(1);
   }
@@ -130,7 +130,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber1->getId()]));
     $this->segment2->setType(SegmentEntity::TYPE_DYNAMIC);
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
     $finder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [
@@ -152,7 +152,7 @@ class SubscribersFinderTest extends \MailPoetTest {
       ->will($this->returnValue([$this->subscriber2->getId()]));
     $this->segment3->setType(SegmentEntity::TYPE_DYNAMIC);
 
-    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager);
+    $finder = new SubscribersFinder($mock, $this->segmentsRepository, $this->entityManager, $this->scheduledTaskSubscribersRepository);
     $finder->addSubscribersToTaskFromSegments(
       $this->scheduledTask,
       [


### PR DESCRIPTION
## Description

Adds the backend building blocks for scheduling standard campaigns by subscriber time zone behind the `send_by_timezone` feature flag. This includes timezone grouping, per-timezone queue creation, aggregate queue progress data, and safe queue replacement when switching scheduling modes.

This is not yet usable end-to-end in the product UI - intentionally just a groundwork for the feature, that will ship in the future.

## Code review notes

I'll merge the PR once LLMs are happy with the code, considering this is behind feature flag and doesn't affect existing customers.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8007

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8007-add-feature-flagged-timezone-scheduling-backend)

_The latest successful build from `stomail-8007-add-feature-flagged-timezone-scheduling-backend` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->