### PR TITLE
Hide the "Nice job!" success tag for newsletters whose sending is paused or still in progress

### DIFF
--- a/mailpoet/assets/js/src/newsletters/listings/statistics.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/statistics.jsx
@@ -108,6 +108,11 @@ function Statistics({
     newsletter.statistics.opened >= minNewsletterOpens &&
     !tooEarlyForStats;
 
+  // only celebrate once the queue actually finished sending — otherwise
+  // a paused or stalled queue at X/Y < total still shows "Nice job!"
+  const showJustSentTag =
+    tooEarlyForStats && newsletter.queue.status === 'completed';
+
   const wrapContentInLink = (content, idPrefix) =>
     wrapInLink(content, params, `${idPrefix}-${newsletter.id}`, totalSent);
 
@@ -125,7 +130,7 @@ function Statistics({
   const content = (
     <>
       {openedClickedAndRevenueStats}
-      {tooEarlyForStats &&
+      {showJustSentTag &&
         wrapContentInLink(
           <Tag
             className="mailpoet-listing-stats-too-early"

--- a/mailpoet/changelog/2026-05-03-12-36-43-fixed-hide-the-nice-job-success-tag-for-newsletters-whos.md
+++ b/mailpoet/changelog/2026-05-03-12-36-43-fixed-hide-the-nice-job-success-tag-for-newsletters-whos.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Hide the "Nice job!" success tag for newsletters whose sending is paused or still in progress

--- a/mailpoet/tests/acceptance/Newsletters/NewsletterCreationCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/NewsletterCreationCest.php
@@ -77,7 +77,6 @@ class NewsletterCreationCest {
     $i->click('Send');
 
     // step 5 - verify recently sent newsletter tab and sent newsletter
-    $niceJobText = 'Nice job! Check back in 6 hour(s) for more stats.';
     $i->waitForText('Emails');
     $i->waitForText('The newsletter is being sent...');
     $i->reloadPage();
@@ -93,7 +92,8 @@ class NewsletterCreationCest {
     $i->selectOptionInSelect2($segmentName);
     $i->click('Send');
     $i->waitForText('Newsletters');
-    $i->waitForText($niceJobText);
+    $i->waitForText('Pause');
+    $i->dontSee('Nice job');
   }
 
   public function createNewsletterWhenKeyPendingApproval(\AcceptanceTester $i, Scenario $scenario) {


### PR DESCRIPTION
## Description

The green `Nice job! Check back in 10 hour(s) for more stats.` message can appear while an email is still stuck at `0 / X`, which makes the send look successful even though it is paused or not sending.

The success message should only appear once sending is actually complete.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8015

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8015-show-nice-job-only-after-sending-completes)

_The latest successful build from `stomail-8015-show-nice-job-only-after-sending-completes` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**1 issue found**

**Suggestion:**
The variable name `tooEarlyForStats` is semantically misleading. When this variable evaluates to `true`, it leads to displaying the "Nice job!" success banner (gated additionally by `newsletter.queue.status === 'completed'`), but the name implies stats should be hidden. Consider renaming to `showSuccessBanner` or `isNewsletterRecentlyCompleted` for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->