### PR TITLE
Show warning banner when post notification is stuck

### DIFF
--- a/mailpoet/changelog/2026-05-03-15-14-23-added-show-a-warning-notice-on-mailpoet-admin-pages-when.md
+++ b/mailpoet/changelog/2026-05-03-15-14-23-added-show-a-warning-notice-on-mailpoet-admin-pages-when.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+A warning notice on MailPoet admin pages when a post notification is stuck (paused or invalid)

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -414,6 +414,37 @@ class NewslettersRepository extends Repository {
   }
 
   /**
+   * Notification-history newsletters whose latest sending task is paused or
+   * invalid — i.e. sending was started but is now stalled and won't progress
+   * until the user intervenes (e.g. unauthorized sender domain, deleted
+   * segment, manual pause).
+   *
+   * @return NewsletterEntity[]
+   */
+  public function findStuckNotificationHistory(int $limit = 5): array {
+    return $this->entityManager->createQueryBuilder()
+      ->select('n', 'p')
+      ->from(NewsletterEntity::class, 'n')
+      ->join('n.parent', 'p')
+      ->join('n.queues', 'q')
+      ->join('q.task', 't')
+      ->where('n.type = :type')
+      ->andWhere('n.status = :status')
+      ->andWhere('n.deletedAt IS NULL')
+      ->andWhere('p.deletedAt IS NULL')
+      ->andWhere('t.status IN (:stuckStatuses)')
+      ->setParameter('type', NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
+      ->setParameter('status', NewsletterEntity::STATUS_SENDING)
+      ->setParameter('stuckStatuses', [
+        ScheduledTaskEntity::STATUS_PAUSED,
+        ScheduledTaskEntity::STATUS_INVALID,
+      ])
+      ->orderBy('t.updatedAt', 'DESC')
+      ->setMaxResults($limit)
+      ->getQuery()->getResult();
+  }
+
+  /**
    * @return NewsletterEntity[]
    */
   public function findSendingNotificationHistoryWithoutPausedOrInvalidTask(NewsletterEntity $newsletter): array {

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -414,34 +414,55 @@ class NewslettersRepository extends Repository {
   }
 
   /**
-   * Notification-history newsletters whose latest sending task is paused or
-   * invalid — i.e. sending was started but is now stalled and won't progress
-   * until the user intervenes (e.g. unauthorized sender domain, deleted
-   * segment, manual pause).
+   * Parent post-notification newsletters that have at least one history with a
+   * paused or invalid sending task — i.e. sending was started but is now
+   * stalled and won't progress until the user intervenes (e.g. unauthorized
+   * sender domain, deleted segment, manual pause).
    *
-   * @return NewsletterEntity[]
+   * Results are deduplicated per parent so a single noisy parent (which can
+   * accumulate multiple stuck histories — see PostNotificationScheduler::
+   * createPostNotificationSendingTask) doesn't crowd out other affected
+   * parents up to $limit. `hasInvalid` is true if any of the parent's stuck
+   * histories is in the INVALID state (more severe than PAUSED).
+   *
+   * @return array<int, array{parent: NewsletterEntity, hasInvalid: bool}>
    */
-  public function findStuckNotificationHistory(int $limit = 5): array {
-    return $this->entityManager->createQueryBuilder()
-      ->select('n', 'p')
-      ->from(NewsletterEntity::class, 'n')
-      ->join('n.parent', 'p')
+  public function findStuckPostNotificationParents(int $limit = 5): array {
+    $rows = $this->entityManager->createQueryBuilder()
+      ->select(
+        'p',
+        'MAX(CASE WHEN t.status = :invalidStatus THEN 1 ELSE 0 END) AS hasInvalid',
+        'MAX(t.updatedAt) AS latestUpdate'
+      )
+      ->from(NewsletterEntity::class, 'p')
+      ->join('p.children', 'n')
       ->join('n.queues', 'q')
       ->join('q.task', 't')
-      ->where('n.type = :type')
-      ->andWhere('n.status = :status')
-      ->andWhere('n.deletedAt IS NULL')
+      ->where('p.type = :parentType')
+      ->andWhere('n.type = :historyType')
+      ->andWhere('n.status = :sendingStatus')
       ->andWhere('p.deletedAt IS NULL')
+      ->andWhere('n.deletedAt IS NULL')
       ->andWhere('t.status IN (:stuckStatuses)')
-      ->setParameter('type', NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
-      ->setParameter('status', NewsletterEntity::STATUS_SENDING)
+      ->setParameter('parentType', NewsletterEntity::TYPE_NOTIFICATION)
+      ->setParameter('historyType', NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
+      ->setParameter('sendingStatus', NewsletterEntity::STATUS_SENDING)
+      ->setParameter('invalidStatus', ScheduledTaskEntity::STATUS_INVALID)
       ->setParameter('stuckStatuses', [
         ScheduledTaskEntity::STATUS_PAUSED,
         ScheduledTaskEntity::STATUS_INVALID,
       ])
-      ->orderBy('t.updatedAt', 'DESC')
+      ->groupBy('p.id')
+      ->orderBy('latestUpdate', 'DESC')
       ->setMaxResults($limit)
       ->getQuery()->getResult();
+
+    return array_map(static function (array $row): array {
+      return [
+        'parent' => $row[0],
+        'hasInvalid' => (bool)$row['hasInvalid'],
+      ];
+    }, $rows);
   }
 
   /**

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -238,6 +238,9 @@ class PermanentNotices {
       case (SendingQueueBodyCleanupNotice::OPTION_NAME):
         $this->sendingQueueBodyCleanupNotice->disable();
         break;
+      case (StuckPostNotificationNotice::OPTION_NAME):
+        $this->stuckPostNotificationNotice->disable();
+        break;
     }
   }
 }

--- a/mailpoet/lib/Util/Notices/PermanentNotices.php
+++ b/mailpoet/lib/Util/Notices/PermanentNotices.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Menu;
 use MailPoet\Config\ServicesChecker;
 use MailPoet\Cron\CronHelper;
 use MailPoet\Mailer\MailerFactory;
+use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Services\AuthorizedSenderDomainController;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
@@ -76,6 +77,9 @@ class PermanentNotices {
   /** @var SendingQueueBodyCleanupNotice */
   private $sendingQueueBodyCleanupNotice;
 
+  /** @var StuckPostNotificationNotice */
+  private $stuckPostNotificationNotice;
+
   public function __construct(
     WPFunctions $wp,
     CronHelper $cronHelper,
@@ -87,7 +91,8 @@ class PermanentNotices {
     ServicesChecker $serviceChecker,
     MailerFactory $mailerFactory,
     SenderDomainAuthenticationNotices $senderDomainAuthenticationNotices,
-    AuthorizedSenderDomainController $senderDomainController
+    AuthorizedSenderDomainController $senderDomainController,
+    NewslettersRepository $newslettersRepository
   ) {
     $this->wp = $wp;
     $this->phpVersionWarnings = new PHPVersionWarnings();
@@ -108,6 +113,7 @@ class PermanentNotices {
     $this->databaseEngineNotice = new DatabaseEngineNotice($wp, $entityManager);
     $this->wordPressPlaygroundNotice = new WordPressPlaygroundNotice();
     $this->sendingQueueBodyCleanupNotice = new SendingQueueBodyCleanupNotice($settings, $wp);
+    $this->stuckPostNotificationNotice = new StuckPostNotificationNotice($wp, $newslettersRepository);
     $this->senderDomainAuthenticationNotices = $senderDomainAuthenticationNotices;
   }
 
@@ -175,6 +181,9 @@ class PermanentNotices {
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $this->sendingQueueBodyCleanupNotice->init(
+      Menu::isOnMailPoetAdminPage($excludeSetupWizard)
+    );
+    $this->stuckPostNotificationNotice->init(
       Menu::isOnMailPoetAdminPage($excludeSetupWizard)
     );
     $excludeDomainAuthenticationNotices = [

--- a/mailpoet/lib/Util/Notices/StuckPostNotificationNotice.php
+++ b/mailpoet/lib/Util/Notices/StuckPostNotificationNotice.php
@@ -1,0 +1,99 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class StuckPostNotificationNotice {
+
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  public function __construct(
+    WPFunctions $wp,
+    NewslettersRepository $newslettersRepository
+  ) {
+    $this->wp = $wp;
+    $this->newslettersRepository = $newslettersRepository;
+  }
+
+  public function init(bool $shouldDisplay): void {
+    if (!$shouldDisplay) {
+      return;
+    }
+    $stuck = $this->newslettersRepository->findStuckNotificationHistory();
+    if (empty($stuck)) {
+      return;
+    }
+    $this->display($stuck);
+  }
+
+  /**
+   * @param NewsletterEntity[] $stuck
+   */
+  private function display(array $stuck): void {
+    Notice::displayWarning($this->getMessage($stuck), '', '', false);
+  }
+
+  /**
+   * @param NewsletterEntity[] $stuck
+   */
+  private function getMessage(array $stuck): string {
+    $count = count($stuck);
+    $heading = sprintf(
+      '<p><b>%s</b></p>',
+      $this->wp->escHtml(_n(
+        'A post notification is stuck and may not have reached all of your subscribers.',
+        'Some post notifications are stuck and may not have reached all of your subscribers.',
+        $count,
+        'mailpoet'
+      ))
+    );
+
+    $items = '';
+    foreach ($stuck as $newsletter) {
+      $parent = $newsletter->getParent();
+      if (!$parent) {
+        continue;
+      }
+      $items .= '<li>' . $this->renderItem($newsletter, $parent) . '</li>';
+    }
+
+    return $heading . '<ul>' . $items . '</ul>';
+  }
+
+  private function renderItem(NewsletterEntity $newsletter, NewsletterEntity $parent): string {
+    $queue = $newsletter->getLatestQueue();
+    $task = $queue ? $queue->getTask() : null;
+    $isInvalid = $task && $task->getStatus() === ScheduledTaskEntity::STATUS_INVALID;
+    $reason = $isInvalid
+      ? __('flagged as invalid', 'mailpoet')
+      : __('paused', 'mailpoet');
+
+    $historyUrl = $this->wp->adminUrl(
+      'admin.php?page=mailpoet-newsletters#/notification/history/' . $parent->getId()
+    );
+
+    $line = sprintf(
+      // translators: %1$s is the post notification subject, %2$s is the status (paused / flagged as invalid)
+      __('"%1$s" is %2$s.', 'mailpoet'),
+      $this->wp->escHtml($parent->getSubject()),
+      $this->wp->escHtml($reason)
+    );
+
+    $link = sprintf(
+      ' <a href="%s">%s</a>',
+      $this->wp->escUrl($historyUrl),
+      $this->wp->escHtml(__('View sending history', 'mailpoet'))
+    );
+
+    return $line . $link;
+  }
+}

--- a/mailpoet/lib/Util/Notices/StuckPostNotificationNotice.php
+++ b/mailpoet/lib/Util/Notices/StuckPostNotificationNotice.php
@@ -3,7 +3,6 @@
 namespace MailPoet\Util\Notices;
 
 use MailPoet\Entities\NewsletterEntity;
-use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice;
@@ -28,25 +27,25 @@ class StuckPostNotificationNotice {
     if (!$shouldDisplay) {
       return;
     }
-    $stuck = $this->newslettersRepository->findStuckNotificationHistory();
-    if (empty($stuck)) {
+    $stuckParents = $this->newslettersRepository->findStuckPostNotificationParents();
+    if (empty($stuckParents)) {
       return;
     }
-    $this->display($stuck);
+    $this->display($stuckParents);
   }
 
   /**
-   * @param NewsletterEntity[] $stuck
+   * @param array<int, array{parent: NewsletterEntity, hasInvalid: bool}> $stuckParents
    */
-  private function display(array $stuck): void {
-    Notice::displayWarning($this->getMessage($stuck), '', '', false);
+  private function display(array $stuckParents): void {
+    Notice::displayWarning($this->getMessage($stuckParents), '', '', false);
   }
 
   /**
-   * @param NewsletterEntity[] $stuck
+   * @param array<int, array{parent: NewsletterEntity, hasInvalid: bool}> $stuckParents
    */
-  private function getMessage(array $stuck): string {
-    $count = count($stuck);
+  private function getMessage(array $stuckParents): string {
+    $count = count($stuckParents);
     $heading = sprintf(
       '<p><b>%s</b></p>',
       $this->wp->escHtml(_n(
@@ -58,22 +57,15 @@ class StuckPostNotificationNotice {
     );
 
     $items = '';
-    foreach ($stuck as $newsletter) {
-      $parent = $newsletter->getParent();
-      if (!$parent) {
-        continue;
-      }
-      $items .= '<li>' . $this->renderItem($newsletter, $parent) . '</li>';
+    foreach ($stuckParents as $entry) {
+      $items .= '<li>' . $this->renderItem($entry['parent'], $entry['hasInvalid']) . '</li>';
     }
 
     return $heading . '<ul>' . $items . '</ul>';
   }
 
-  private function renderItem(NewsletterEntity $newsletter, NewsletterEntity $parent): string {
-    $queue = $newsletter->getLatestQueue();
-    $task = $queue ? $queue->getTask() : null;
-    $isInvalid = $task && $task->getStatus() === ScheduledTaskEntity::STATUS_INVALID;
-    $reason = $isInvalid
+  private function renderItem(NewsletterEntity $parent, bool $hasInvalid): string {
+    $reason = $hasInvalid
       ? __('flagged as invalid', 'mailpoet')
       : __('paused', 'mailpoet');
 

--- a/mailpoet/lib/Util/Notices/StuckPostNotificationNotice.php
+++ b/mailpoet/lib/Util/Notices/StuckPostNotificationNotice.php
@@ -8,6 +8,8 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoet\WP\Notice;
 
 class StuckPostNotificationNotice {
+  const OPTION_NAME = 'mailpoet-stuck-post-notification-notice';
+  const DISMISS_NOTICE_TIMEOUT_SECONDS = WEEK_IN_SECONDS;
 
   /** @var WPFunctions */
   private $wp;
@@ -23,22 +25,27 @@ class StuckPostNotificationNotice {
     $this->newslettersRepository = $newslettersRepository;
   }
 
-  public function init(bool $shouldDisplay): void {
-    if (!$shouldDisplay) {
-      return;
+  public function init(bool $shouldDisplay): ?Notice {
+    if (!$shouldDisplay || $this->wp->getTransient(self::OPTION_NAME)) {
+      return null;
     }
     $stuckParents = $this->newslettersRepository->findStuckPostNotificationParents();
     if (empty($stuckParents)) {
-      return;
+      return null;
     }
-    $this->display($stuckParents);
+    return $this->display($stuckParents);
   }
 
   /**
    * @param array<int, array{parent: NewsletterEntity, hasInvalid: bool}> $stuckParents
    */
-  private function display(array $stuckParents): void {
-    Notice::displayWarning($this->getMessage($stuckParents), '', '', false);
+  private function display(array $stuckParents): Notice {
+    $extraClasses = 'mailpoet-dismissible-notice is-dismissible';
+    return Notice::displayWarning($this->getMessage($stuckParents), $extraClasses, self::OPTION_NAME, false);
+  }
+
+  public function disable(): void {
+    $this->wp->setTransient(self::OPTION_NAME, true, self::DISMISS_NOTICE_TIMEOUT_SECONDS);
   }
 
   /**

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -168,28 +168,57 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     verify($results[1]->getType())->equals(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
   }
 
-  public function testFindStuckNotificationHistoryReturnsPausedAndInvalidEntries() {
-    $parent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+  public function testFindStuckPostNotificationParentsReturnsOneRowPerParent() {
+    $parentPaused = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    // Multiple stuck histories under the same parent should collapse to one row
+    $this->createNotificationHistoryWithTaskStatus($parentPaused, ScheduledTaskEntity::STATUS_PAUSED);
+    $this->createNotificationHistoryWithTaskStatus($parentPaused, ScheduledTaskEntity::STATUS_PAUSED);
+    $this->createNotificationHistoryWithTaskStatus($parentPaused, ScheduledTaskEntity::STATUS_PAUSED);
 
-    $stuckPaused = $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_PAUSED);
-    $stuckInvalid = $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_INVALID);
-    // Healthy: still running (null status)
-    $this->createNotificationHistoryWithTaskStatus($parent, null);
-    // Healthy: completed
-    $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_COMPLETED);
-    // Healthy: not in sending state
-    $draft = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_DRAFT, $parent);
+    $parentInvalid = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    $this->createNotificationHistoryWithTaskStatus($parentInvalid, ScheduledTaskEntity::STATUS_INVALID);
+
+    // A parent with both paused and invalid histories should be flagged as invalid (more severe)
+    $parentMixed = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    $this->createNotificationHistoryWithTaskStatus($parentMixed, ScheduledTaskEntity::STATUS_PAUSED);
+    $this->createNotificationHistoryWithTaskStatus($parentMixed, ScheduledTaskEntity::STATUS_INVALID);
+
+    // Healthy parent: still running, completed, not-sending — must not appear
+    $parentHealthy = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    $this->createNotificationHistoryWithTaskStatus($parentHealthy, null);
+    $this->createNotificationHistoryWithTaskStatus($parentHealthy, ScheduledTaskEntity::STATUS_COMPLETED);
+    $draft = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_DRAFT, $parentHealthy);
     $this->createQueueWithTaskAndSegmentAndSubscribers($draft, ScheduledTaskEntity::STATUS_PAUSED);
 
-    $results = $this->repository->findStuckNotificationHistory();
-    $resultIds = array_map(fn(NewsletterEntity $n) => $n->getId(), $results);
+    $results = $this->repository->findStuckPostNotificationParents();
 
-    verify($resultIds)->arrayCount(2);
-    verify(in_array($stuckPaused->getId(), $resultIds, true))->true();
-    verify(in_array($stuckInvalid->getId(), $resultIds, true))->true();
+    verify($results)->arrayCount(3);
+
+    $byParentId = [];
+    foreach ($results as $row) {
+      $parentId = $row['parent']->getId();
+      $this->assertNotNull($parentId);
+      $byParentId[$parentId] = $row['hasInvalid'];
+    }
+
+    $parentPausedId = (int)$parentPaused->getId();
+    $parentInvalidId = (int)$parentInvalid->getId();
+    $parentMixedId = (int)$parentMixed->getId();
+    $parentHealthyId = (int)$parentHealthy->getId();
+
+    verify(isset($byParentId[$parentPausedId]))->true();
+    verify($byParentId[$parentPausedId])->false();
+
+    verify(isset($byParentId[$parentInvalidId]))->true();
+    verify($byParentId[$parentInvalidId])->true();
+
+    verify(isset($byParentId[$parentMixedId]))->true();
+    verify($byParentId[$parentMixedId])->true();
+
+    verify(isset($byParentId[$parentHealthyId]))->false();
   }
 
-  public function testFindStuckNotificationHistoryExcludesTrashedEntries() {
+  public function testFindStuckPostNotificationParentsExcludesTrashedEntries() {
     $parent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
     $trashedHistory = $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_PAUSED);
     $trashedHistory->setDeletedAt(new Carbon());
@@ -200,16 +229,29 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->createNotificationHistoryWithTaskStatus($trashedParent, ScheduledTaskEntity::STATUS_PAUSED);
     $this->entityManager->flush();
 
-    verify($this->repository->findStuckNotificationHistory())->arrayCount(0);
+    verify($this->repository->findStuckPostNotificationParents())->arrayCount(0);
   }
 
-  public function testFindStuckNotificationHistoryRespectsLimit() {
-    $parent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+  public function testFindStuckPostNotificationParentsRespectsLimitAcrossDistinctParents() {
+    // One noisy parent with many stuck histories — must not consume the limit
+    $noisyParent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
     for ($i = 0; $i < 4; $i++) {
-      $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_PAUSED);
+      $this->createNotificationHistoryWithTaskStatus($noisyParent, ScheduledTaskEntity::STATUS_PAUSED);
     }
 
-    verify($this->repository->findStuckNotificationHistory(2))->arrayCount(2);
+    // Three other distinct stuck parents
+    $otherParents = [];
+    for ($i = 0; $i < 3; $i++) {
+      $other = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+      $this->createNotificationHistoryWithTaskStatus($other, ScheduledTaskEntity::STATUS_PAUSED);
+      $otherParents[] = $other->getId();
+    }
+
+    $results = $this->repository->findStuckPostNotificationParents(2);
+    verify($results)->arrayCount(2);
+
+    $resultParentIds = array_map(fn(array $row) => $row['parent']->getId(), $results);
+    verify(count(array_unique($resultParentIds)))->equals(2);
   }
 
   private function createNotificationHistoryWithTaskStatus(NewsletterEntity $parent, ?string $taskStatus): NewsletterEntity {

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -168,6 +168,56 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     verify($results[1]->getType())->equals(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
   }
 
+  public function testFindStuckNotificationHistoryReturnsPausedAndInvalidEntries() {
+    $parent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+
+    $stuckPaused = $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_PAUSED);
+    $stuckInvalid = $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_INVALID);
+    // Healthy: still running (null status)
+    $this->createNotificationHistoryWithTaskStatus($parent, null);
+    // Healthy: completed
+    $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_COMPLETED);
+    // Healthy: not in sending state
+    $draft = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_DRAFT, $parent);
+    $this->createQueueWithTaskAndSegmentAndSubscribers($draft, ScheduledTaskEntity::STATUS_PAUSED);
+
+    $results = $this->repository->findStuckNotificationHistory();
+    $resultIds = array_map(fn(NewsletterEntity $n) => $n->getId(), $results);
+
+    verify($resultIds)->arrayCount(2);
+    verify(in_array($stuckPaused->getId(), $resultIds, true))->true();
+    verify(in_array($stuckInvalid->getId(), $resultIds, true))->true();
+  }
+
+  public function testFindStuckNotificationHistoryExcludesTrashedEntries() {
+    $parent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    $trashedHistory = $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_PAUSED);
+    $trashedHistory->setDeletedAt(new Carbon());
+    $this->entityManager->flush();
+
+    $trashedParent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    $trashedParent->setDeletedAt(new Carbon());
+    $this->createNotificationHistoryWithTaskStatus($trashedParent, ScheduledTaskEntity::STATUS_PAUSED);
+    $this->entityManager->flush();
+
+    verify($this->repository->findStuckNotificationHistory())->arrayCount(0);
+  }
+
+  public function testFindStuckNotificationHistoryRespectsLimit() {
+    $parent = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+    for ($i = 0; $i < 4; $i++) {
+      $this->createNotificationHistoryWithTaskStatus($parent, ScheduledTaskEntity::STATUS_PAUSED);
+    }
+
+    verify($this->repository->findStuckNotificationHistory(2))->arrayCount(2);
+  }
+
+  private function createNotificationHistoryWithTaskStatus(NewsletterEntity $parent, ?string $taskStatus): NewsletterEntity {
+    $history = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION_HISTORY, NewsletterEntity::STATUS_SENDING, $parent);
+    $this->createQueueWithTaskAndSegmentAndSubscribers($history, $taskStatus);
+    return $history;
+  }
+
   private function createNewsletter(string $type, string $status = NewsletterEntity::STATUS_DRAFT, $parent = null): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType($type);

--- a/mailpoet/tests/integration/Util/Notices/StuckPostNotificationNoticeTest.php
+++ b/mailpoet/tests/integration/Util/Notices/StuckPostNotificationNoticeTest.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Util\Notices;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoet\WP\Notice;
+
+class StuckPostNotificationNoticeTest extends \MailPoetTest {
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var NewslettersRepository&\PHPUnit\Framework\MockObject\MockObject */
+  private $newslettersRepository;
+
+  public function _before() {
+    parent::_before();
+    $this->wp = new WPFunctions();
+    $this->wp->deleteTransient(StuckPostNotificationNotice::OPTION_NAME);
+    $this->newslettersRepository = $this->createMock(NewslettersRepository::class);
+  }
+
+  public function _after() {
+    $this->wp->deleteTransient(StuckPostNotificationNotice::OPTION_NAME);
+    parent::_after();
+  }
+
+  public function testItReturnsNullWhenShouldDisplayIsFalse() {
+    $this->newslettersRepository->expects($this->never())->method('findStuckPostNotificationParents');
+    $notice = $this->createNotice();
+
+    verify($notice->init(false))->null();
+  }
+
+  public function testItReturnsNullWhenNoStuckParentsExist() {
+    $this->newslettersRepository->method('findStuckPostNotificationParents')->willReturn([]);
+    $notice = $this->createNotice();
+
+    verify($notice->init(true))->null();
+  }
+
+  public function testItRendersSingularHeadingForOneStuckParent() {
+    $this->newslettersRepository->method('findStuckPostNotificationParents')->willReturn([
+      ['parent' => $this->makeParent(1, 'Weekly digest'), 'hasInvalid' => false],
+    ]);
+    $result = $this->createNotice()->init(true);
+
+    $this->assertInstanceOf(Notice::class, $result);
+    $message = $result->getMessage();
+    verify($message)->stringContainsString('A post notification is stuck');
+    verify($message)->stringNotContainsString('Some post notifications are stuck');
+  }
+
+  public function testItRendersPluralHeadingForMultipleStuckParents() {
+    $this->newslettersRepository->method('findStuckPostNotificationParents')->willReturn([
+      ['parent' => $this->makeParent(1, 'Weekly digest'), 'hasInvalid' => false],
+      ['parent' => $this->makeParent(2, 'Daily digest'), 'hasInvalid' => true],
+    ]);
+    $result = $this->createNotice()->init(true);
+
+    $this->assertInstanceOf(Notice::class, $result);
+    $message = $result->getMessage();
+    verify($message)->stringContainsString('Some post notifications are stuck');
+    verify($message)->stringNotContainsString('A post notification is stuck');
+  }
+
+  public function testItRendersPausedAndInvalidReasons() {
+    $this->newslettersRepository->method('findStuckPostNotificationParents')->willReturn([
+      ['parent' => $this->makeParent(1, 'Paused digest'), 'hasInvalid' => false],
+      ['parent' => $this->makeParent(2, 'Invalid digest'), 'hasInvalid' => true],
+    ]);
+    $result = $this->createNotice()->init(true);
+
+    $this->assertInstanceOf(Notice::class, $result);
+    $message = $result->getMessage();
+    verify($message)->stringContainsString('"Paused digest" is paused.');
+    verify($message)->stringContainsString('"Invalid digest" is flagged as invalid.');
+  }
+
+  public function testItIncludesViewSendingHistoryLinkPerParent() {
+    $this->newslettersRepository->method('findStuckPostNotificationParents')->willReturn([
+      ['parent' => $this->makeParent(42, 'My digest'), 'hasInvalid' => false],
+    ]);
+    $result = $this->createNotice()->init(true);
+
+    $this->assertInstanceOf(Notice::class, $result);
+    $message = $result->getMessage();
+    verify($message)->stringContainsString('admin.php?page=mailpoet-newsletters#/notification/history/42');
+    verify($message)->stringContainsString('View sending history');
+  }
+
+  public function testItEscapesParentSubject() {
+    $this->newslettersRepository->method('findStuckPostNotificationParents')->willReturn([
+      ['parent' => $this->makeParent(1, '<script>alert(1)</script>'), 'hasInvalid' => false],
+    ]);
+    $result = $this->createNotice()->init(true);
+
+    $this->assertInstanceOf(Notice::class, $result);
+    $message = $result->getMessage();
+    verify($message)->stringNotContainsString('<script>alert(1)</script>');
+    verify($message)->stringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;');
+  }
+
+  public function testItReturnsNullWhenDismissed() {
+    $this->newslettersRepository->expects($this->never())->method('findStuckPostNotificationParents');
+    $notice = $this->createNotice();
+    $notice->disable();
+
+    verify($notice->init(true))->null();
+  }
+
+  public function testDisableSetsTransient() {
+    $notice = $this->createNotice();
+    verify($this->wp->getTransient(StuckPostNotificationNotice::OPTION_NAME))->false();
+
+    $notice->disable();
+
+    verify($this->wp->getTransient(StuckPostNotificationNotice::OPTION_NAME))->true();
+  }
+
+  private function createNotice(): StuckPostNotificationNotice {
+    return new StuckPostNotificationNotice($this->wp, $this->newslettersRepository);
+  }
+
+  private function makeParent(int $id, string $subject): NewsletterEntity {
+    $parent = $this->createMock(NewsletterEntity::class);
+    $parent->method('getId')->willReturn($id);
+    $parent->method('getSubject')->willReturn($subject);
+    return $parent;
+  }
+}


### PR DESCRIPTION
## Description

Add new admin notice when a post notification is paused for any reason (be it automatically due to issue, or manually by admin, as we don't have ways to differentiate these). Otherwise, there is no indication that post notifications are not sent, unless the user would viewed history of the specific post notifications.

The notice is dismissible for a week, so when this issue happens again, it will surface.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8016

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1800" height="703" alt="Screenshot 2026-05-04 at 09 59 58" src="https://github.com/user-attachments/assets/dedf2ed1-ee23-4c9f-921b-e415568528b8" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8016-show-warning-banner-when-post-notification-is-stuck)

_The latest successful build from `stomail-8016-show-warning-banner-when-post-notification-is-stuck` will be used. If none is available, the link won't work._