### PR TITLE
Add custom fields management

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_custom-fields-form.scss
+++ b/mailpoet/assets/css/src/components-plugin/_custom-fields-form.scss
@@ -1,0 +1,71 @@
+.mailpoet-custom-fields-form-modal {
+  max-width: 560px;
+  width: calc(100vw - 32px);
+}
+
+.mailpoet-custom-fields-form-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mailpoet-custom-fields-form-options-label {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.mailpoet-custom-fields-form-option {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding-left: 2px;
+
+  &.is-dragging {
+    opacity: 0.65;
+  }
+
+  &.is-drag-over {
+    box-shadow: inset 0 2px 0 #007cba;
+  }
+
+  .components-base-control {
+    margin-bottom: 0;
+  }
+
+  .components-base-control__field {
+    margin-bottom: 0;
+  }
+
+  .components-checkbox-control {
+    padding-top: 0;
+  }
+}
+
+.mailpoet-custom-fields-form-option-drag-handle {
+  align-items: center;
+  align-self: center;
+  cursor: grab;
+  display: flex;
+  height: 36px;
+  justify-content: center;
+  min-width: 28px;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  .dashicon {
+    margin: 0;
+  }
+}
+
+.mailpoet-custom-fields-form-option-input {
+  flex: 1;
+}
+
+.mailpoet-custom-fields-form-error {
+  color: #cc1818;
+}

--- a/mailpoet/assets/css/src/components-plugin/_custom-fields-form.scss
+++ b/mailpoet/assets/css/src/components-plugin/_custom-fields-form.scss
@@ -24,11 +24,8 @@
   padding-left: 2px;
 
   &.is-dragging {
-    opacity: 0.65;
-  }
-
-  &.is-drag-over {
-    box-shadow: inset 0 2px 0 #007cba;
+    background: #fff;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   }
 
   .components-base-control {

--- a/mailpoet/assets/css/src/components-plugin/_custom-fields-form.scss
+++ b/mailpoet/assets/css/src/components-plugin/_custom-fields-form.scss
@@ -26,6 +26,9 @@
   &.is-dragging {
     background: #fff;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    /* The Modal overlay sits at z-index 9999999, so the dragged option
+       must outrank it (react-beautiful-dnd's default of 5000 is too low). */
+    z-index: 10000000 !important;
   }
 
   .components-base-control {

--- a/mailpoet/assets/css/src/components-plugin/_import-export.scss
+++ b/mailpoet/assets/css/src/components-plugin/_import-export.scss
@@ -9,10 +9,14 @@
 }
 
 .subscribers_data {
-  overflow: auto;
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow: auto hidden;
+  width: 100%;
 
   table {
-    width: auto;
+    table-layout: auto;
+    width: max-content;
   }
 
   td {

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -4,6 +4,49 @@
   }
 }
 
+.mailpoet-subscribers-page-header {
+  align-items: center;
+
+  .mailpoet-page-header-content {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    width: 100%;
+  }
+}
+
+.mailpoet-subscribers-heading-actions {
+  align-items: center;
+  display: inline-flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: space-between;
+}
+
+.mailpoet-subscribers-heading-primary-actions,
+.mailpoet-subscribers-heading-management-actions {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+@include respond-to(small-screen) {
+  .mailpoet-subscribers-page-header {
+    .mailpoet-page-header-content {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+
+  .mailpoet-subscribers-heading-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
 .mailpoet-subscriber-stats-heading {
   margin-bottom: $grid-gap;
 }

--- a/mailpoet/assets/css/src/mailpoet-custom-fields.scss
+++ b/mailpoet/assets/css/src/mailpoet-custom-fields.scss
@@ -1,0 +1,15 @@
+#mailpoet_custom_fields_container .components-notice {
+  margin: 8px 0 0;
+}
+
+.mailpoet-custom-fields-dataviews {
+  margin-top: 8px;
+
+  .dataviews-wrapper {
+    min-height: 200px;
+  }
+}
+
+.mailpoet-custom-fields-dataviews__toolbar {
+  padding: 8px;
+}

--- a/mailpoet/assets/css/src/mailpoet-custom-fields.scss
+++ b/mailpoet/assets/css/src/mailpoet-custom-fields.scss
@@ -28,3 +28,75 @@
   gap: 8px;
   padding: 8px;
 }
+
+.mailpoet-custom-fields-form-modal {
+  max-width: 560px;
+  width: calc(100vw - 32px);
+}
+
+.mailpoet-custom-fields-form-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mailpoet-custom-fields-form-options-label {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.mailpoet-custom-fields-form-option {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding-left: 2px;
+
+  &.is-dragging {
+    opacity: 0.65;
+  }
+
+  &.is-drag-over {
+    box-shadow: inset 0 2px 0 #007cba;
+  }
+
+  .components-base-control {
+    margin-bottom: 0;
+  }
+
+  .components-base-control__field {
+    margin-bottom: 0;
+  }
+
+  .components-checkbox-control {
+    padding-top: 0;
+  }
+}
+
+.mailpoet-custom-fields-form-option-drag-handle {
+  align-items: center;
+  align-self: center;
+  cursor: grab;
+  display: flex;
+  height: 36px;
+  justify-content: center;
+  min-width: 28px;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  .dashicon {
+    margin: 0;
+  }
+}
+
+.mailpoet-custom-fields-form-option-input {
+  flex: 1;
+}
+
+.mailpoet-custom-fields-form-error {
+  color: #cc1818;
+}

--- a/mailpoet/assets/css/src/mailpoet-custom-fields.scss
+++ b/mailpoet/assets/css/src/mailpoet-custom-fields.scss
@@ -1,3 +1,5 @@
+@import 'components-plugin/custom-fields-form';
+
 #mailpoet_custom_fields_container .components-notice {
   margin: 8px 0 0;
 }
@@ -27,76 +29,4 @@
   flex-wrap: wrap;
   gap: 8px;
   padding: 8px;
-}
-
-.mailpoet-custom-fields-form-modal {
-  max-width: 560px;
-  width: calc(100vw - 32px);
-}
-
-.mailpoet-custom-fields-form-options {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.mailpoet-custom-fields-form-options-label {
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.4;
-  text-transform: uppercase;
-}
-
-.mailpoet-custom-fields-form-option {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  margin-bottom: 8px;
-  padding-left: 2px;
-
-  &.is-dragging {
-    opacity: 0.65;
-  }
-
-  &.is-drag-over {
-    box-shadow: inset 0 2px 0 #007cba;
-  }
-
-  .components-base-control {
-    margin-bottom: 0;
-  }
-
-  .components-base-control__field {
-    margin-bottom: 0;
-  }
-
-  .components-checkbox-control {
-    padding-top: 0;
-  }
-}
-
-.mailpoet-custom-fields-form-option-drag-handle {
-  align-items: center;
-  align-self: center;
-  cursor: grab;
-  display: flex;
-  height: 36px;
-  justify-content: center;
-  min-width: 28px;
-
-  &:active {
-    cursor: grabbing;
-  }
-
-  .dashicon {
-    margin: 0;
-  }
-}
-
-.mailpoet-custom-fields-form-option-input {
-  flex: 1;
-}
-
-.mailpoet-custom-fields-form-error {
-  color: #cc1818;
 }

--- a/mailpoet/assets/css/src/mailpoet-custom-fields.scss
+++ b/mailpoet/assets/css/src/mailpoet-custom-fields.scss
@@ -2,8 +2,19 @@
   margin: 8px 0 0;
 }
 
-.mailpoet-custom-fields-dataviews {
+.mailpoet-custom-fields-dataviews__tabs {
   margin-top: 8px;
+
+  > [role='tablist'] {
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    margin: 0;
+    padding: 0 8px;
+  }
+}
+
+.mailpoet-custom-fields-dataviews {
+  margin-top: 0;
 
   .dataviews-wrapper {
     min-height: 200px;
@@ -11,5 +22,9 @@
 }
 
 .mailpoet-custom-fields-dataviews__toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 8px;
 }

--- a/mailpoet/assets/css/src/mailpoet-plugin.scss
+++ b/mailpoet/assets/css/src/mailpoet-plugin.scss
@@ -63,6 +63,7 @@
 @import 'components-plugin/automatic-emails';
 @import 'components-plugin/browser-preview';
 @import 'components-plugin/common';
+@import 'components-plugin/custom-fields-form';
 @import 'components-plugin/legacy-modal';
 @import 'components-plugin/inline-notice';
 @import 'components-plugin/notice';

--- a/mailpoet/assets/js/src/common/page-header/page-header.tsx
+++ b/mailpoet/assets/js/src/common/page-header/page-header.tsx
@@ -23,7 +23,7 @@ export function PageHeader({
       <FlexBlock>
         <Flex direction="row" gap="4px">
           {headingPrefix}
-          <FlexBlock>
+          <FlexBlock className="mailpoet-page-header-content">
             <h1 className="wp-heading-inline">{heading}</h1> {children}
           </FlexBlock>
         </Flex>

--- a/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
@@ -1,6 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import type { CustomField, CustomFieldListMeta } from './types';
+import type {
+  CustomField,
+  CustomFieldListGroup,
+  CustomFieldListMeta,
+} from './types';
 
 type WindowApi = {
   mailpoet_custom_fields_api: {
@@ -27,6 +31,7 @@ type ListParams = {
   order?: 'asc' | 'desc';
   page?: number;
   per_page?: number;
+  group?: 'all' | 'trash';
 };
 
 type ApiEnvelope<T> = {
@@ -36,11 +41,13 @@ type ApiEnvelope<T> = {
 type ListResponse = ApiEnvelope<{
   items: CustomField[];
   meta: CustomFieldListMeta;
+  groups: CustomFieldListGroup[];
 }>;
 
 export async function getCustomFields(params: ListParams = {}): Promise<{
   items: CustomField[];
   meta: CustomFieldListMeta;
+  groups: CustomFieldListGroup[];
 }> {
   ensureInitialized();
   const response = await apiFetch<ListResponse>({
@@ -48,6 +55,25 @@ export async function getCustomFields(params: ListParams = {}): Promise<{
     method: 'GET',
   });
   return response.data;
+}
+
+export type CustomFieldBulkAction =
+  | 'trash'
+  | 'restore'
+  | 'delete'
+  | 'empty_trash';
+
+export async function bulkAction(
+  action: CustomFieldBulkAction,
+  ids: number[] = [],
+): Promise<number> {
+  ensureInitialized();
+  const response = await apiFetch<ApiEnvelope<{ count: number }>>({
+    path: '/mailpoet/v1/custom-fields/bulk-action',
+    method: 'POST',
+    data: action === 'empty_trash' ? { action } : { action, ids },
+  });
+  return response.data.count;
 }
 
 export function getSubscribersListingUrl(): string {

--- a/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
@@ -2,6 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import type {
   CustomField,
+  CustomFieldPayload,
   CustomFieldListGroup,
   CustomFieldListMeta,
 } from './types';
@@ -44,6 +45,8 @@ type ListResponse = ApiEnvelope<{
   groups: CustomFieldListGroup[];
 }>;
 
+type ItemResponse = ApiEnvelope<CustomField>;
+
 export async function getCustomFields(params: ListParams = {}): Promise<{
   items: CustomField[];
   meta: CustomFieldListMeta;
@@ -53,6 +56,18 @@ export async function getCustomFields(params: ListParams = {}): Promise<{
   const response = await apiFetch<ListResponse>({
     path: addQueryArgs('/mailpoet/v1/custom-fields', params),
     method: 'GET',
+  });
+  return response.data;
+}
+
+export async function createCustomField(
+  data: CustomFieldPayload,
+): Promise<CustomField> {
+  ensureInitialized();
+  const response = await apiFetch<ItemResponse>({
+    path: '/mailpoet/v1/custom-fields',
+    method: 'POST',
+    data,
   });
   return response.data;
 }

--- a/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
@@ -85,6 +85,15 @@ export async function updateCustomField(
   return response.data;
 }
 
+export async function duplicateCustomField(id: number): Promise<CustomField> {
+  ensureInitialized();
+  const response = await apiFetch<ItemResponse>({
+    path: `/mailpoet/v1/custom-fields/${id}/duplicate`,
+    method: 'POST',
+  });
+  return response.data;
+}
+
 export type CustomFieldBulkAction =
   | 'trash'
   | 'restore'

--- a/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
@@ -1,0 +1,58 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import type { CustomField, CustomFieldListMeta } from './types';
+
+type WindowApi = {
+  mailpoet_custom_fields_api: {
+    root: string;
+    nonce: string;
+  };
+  mailpoet_custom_fields_subscribers_listing_url: string;
+};
+
+declare const window: Window & WindowApi;
+
+let initialized = false;
+function ensureInitialized(): void {
+  if (initialized) return;
+  const config = window.mailpoet_custom_fields_api;
+  apiFetch.use(apiFetch.createRootURLMiddleware(`${config.root}/`));
+  apiFetch.use(apiFetch.createNonceMiddleware(config.nonce));
+  initialized = true;
+}
+
+type ListParams = {
+  search?: string;
+  orderby?: string;
+  order?: 'asc' | 'desc';
+  page?: number;
+  per_page?: number;
+};
+
+type ApiEnvelope<T> = {
+  data: T;
+};
+
+type ListResponse = ApiEnvelope<{
+  items: CustomField[];
+  meta: CustomFieldListMeta;
+}>;
+
+export async function getCustomFields(params: ListParams = {}): Promise<{
+  items: CustomField[];
+  meta: CustomFieldListMeta;
+}> {
+  ensureInitialized();
+  const response = await apiFetch<ListResponse>({
+    path: addQueryArgs('/mailpoet/v1/custom-fields', params),
+    method: 'GET',
+  });
+  return response.data;
+}
+
+export function getSubscribersListingUrl(): string {
+  return (
+    window.mailpoet_custom_fields_subscribers_listing_url ??
+    '?page=mailpoet-subscribers'
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/api.ts
@@ -72,6 +72,19 @@ export async function createCustomField(
   return response.data;
 }
 
+export async function updateCustomField(
+  id: number,
+  data: CustomFieldPayload,
+): Promise<CustomField> {
+  ensureInitialized();
+  const response = await apiFetch<ItemResponse>({
+    path: `/mailpoet/v1/custom-fields/${id}`,
+    method: 'PUT',
+    data,
+  });
+  return response.data;
+}
+
 export type CustomFieldBulkAction =
   | 'trash'
   | 'restore'

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { __, sprintf } from '@wordpress/i18n';
 import {
   Button,
@@ -225,6 +226,23 @@ export function CustomFieldFormFields({
   disabled = false,
   onChange,
 }: Props): JSX.Element {
+  // Render the dragged option via a portal to <body> so it escapes the modal's
+  // overflow:hidden + transform stacking context (which would otherwise clip
+  // and mis-position the lifted item that uses position:fixed).
+  const dragPortalRef = useRef<HTMLDivElement | null>(null);
+  if (typeof document !== 'undefined' && !dragPortalRef.current) {
+    dragPortalRef.current = document.createElement('div');
+    dragPortalRef.current.className = 'mailpoet-custom-fields-form-drag-portal';
+  }
+  useEffect(() => {
+    const portal = dragPortalRef.current;
+    if (!portal) return undefined;
+    document.body.appendChild(portal);
+    return () => {
+      document.body.removeChild(portal);
+    };
+  }, []);
+
   const dateFormatOptions = useMemo(
     () =>
       (dateSettings.dateFormats[data.dateType] ?? []).map((format) => ({
@@ -393,61 +411,69 @@ export function CustomFieldFormFields({
                         index={index}
                         isDragDisabled={disabled}
                       >
-                        {(draggableProvided, snapshot) => (
-                          <div
-                            ref={draggableProvided.innerRef}
-                            {...draggableProvided.draggableProps}
-                            className={`mailpoet-custom-fields-form-option ${
-                              snapshot.isDragging ? 'is-dragging' : ''
-                            }`}
-                          >
+                        {(draggableProvided, snapshot) => {
+                          const child = (
                             <div
-                              {...draggableProvided.dragHandleProps}
-                              aria-label={__('Drag to reorder', 'mailpoet')}
-                              className="mailpoet-custom-fields-form-option-drag-handle"
+                              ref={draggableProvided.innerRef}
+                              {...draggableProvided.draggableProps}
+                              className={`mailpoet-custom-fields-form-option ${
+                                snapshot.isDragging ? 'is-dragging' : ''
+                              }`}
                             >
-                              <Dashicon icon="menu" />
-                            </div>
-                            <div className="mailpoet-custom-fields-form-option-input">
-                              <TextControl
-                                label={sprintf(
-                                  __('Option %d', 'mailpoet'),
-                                  index + 1,
-                                )}
-                                hideLabelFromVision
-                                value={option.value}
-                                onChange={(value) =>
-                                  setOption(option.id, { value })
-                                }
-                                disabled={disabled}
-                                __nextHasNoMarginBottom
-                              />
-                            </div>
-                            <div>
-                              <CheckboxControl
-                                label={__('Default', 'mailpoet')}
-                                checked={option.isChecked}
-                                onChange={() =>
-                                  setOption(option.id, {
-                                    isChecked: !option.isChecked,
-                                  })
-                                }
-                                disabled={disabled}
-                                __nextHasNoMarginBottom
-                              />
-                            </div>
-                            <div>
-                              <Button
-                                variant="tertiary"
-                                onClick={() => removeOption(option.id)}
-                                disabled={disabled || data.options.length === 1}
-                                __next40pxDefaultSize
+                              <div
+                                {...draggableProvided.dragHandleProps}
+                                aria-label={__('Drag to reorder', 'mailpoet')}
+                                className="mailpoet-custom-fields-form-option-drag-handle"
                               >
-                                {__('Remove', 'mailpoet')}
-                              </Button>
+                                <Dashicon icon="menu" />
+                              </div>
+                              <div className="mailpoet-custom-fields-form-option-input">
+                                <TextControl
+                                  label={sprintf(
+                                    __('Option %d', 'mailpoet'),
+                                    index + 1,
+                                  )}
+                                  hideLabelFromVision
+                                  value={option.value}
+                                  onChange={(value) =>
+                                    setOption(option.id, { value })
+                                  }
+                                  disabled={disabled}
+                                  __nextHasNoMarginBottom
+                                />
+                              </div>
+                              <div>
+                                <CheckboxControl
+                                  label={__('Default', 'mailpoet')}
+                                  checked={option.isChecked}
+                                  onChange={() =>
+                                    setOption(option.id, {
+                                      isChecked: !option.isChecked,
+                                    })
+                                  }
+                                  disabled={disabled}
+                                  __nextHasNoMarginBottom
+                                />
+                              </div>
+                              <div>
+                                <Button
+                                  variant="tertiary"
+                                  onClick={() => removeOption(option.id)}
+                                  disabled={
+                                    disabled || data.options.length === 1
+                                  }
+                                  __next40pxDefaultSize
+                                >
+                                  {__('Remove', 'mailpoet')}
+                                </Button>
+                              </div>
                             </div>
-                          </div>
-                        )}
+                          );
+                          if (snapshot.isDragging && dragPortalRef.current) {
+                            return createPortal(child, dragPortalRef.current);
+                          }
+                          return child;
+                        }}
                       </Draggable>
                     ))}
                     {droppableProvided.placeholder}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import {
   Button,
@@ -9,6 +9,12 @@ import {
   ToggleControl,
   __experimentalSpacer as Spacer,
 } from '@wordpress/components';
+import {
+  DragDropContext,
+  Draggable,
+  type DropResult,
+} from 'react-beautiful-dnd';
+import { StrictModeDroppable as Droppable } from 'form-editor/utils/strict-mode-droppable';
 import type {
   CustomField,
   CustomFieldDateSettings,
@@ -219,9 +225,6 @@ export function CustomFieldFormFields({
   disabled = false,
   onChange,
 }: Props): JSX.Element {
-  const [draggedOptionId, setDraggedOptionId] = useState<string | null>(null);
-  const [dragOverOptionId, setDragOverOptionId] = useState<string | null>(null);
-
   const dateFormatOptions = useMemo(
     () =>
       (dateSettings.dateFormats[data.dateType] ?? []).map((format) => ({
@@ -277,25 +280,18 @@ export function CustomFieldFormFields({
     });
   };
 
-  const reorderOptions = (sourceId: string, targetId: string): void => {
-    if (sourceId === targetId) {
+  const onDragEnd = (result: DropResult): void => {
+    if (!result.destination) {
       return;
     }
-
-    const sourceIndex = data.options.findIndex(
-      (option) => option.id === sourceId,
-    );
-    const targetIndex = data.options.findIndex(
-      (option) => option.id === targetId,
-    );
-
-    if (sourceIndex === -1 || targetIndex === -1) {
+    const from = Number(result.source.index);
+    const to = Number(result.destination.index);
+    if (from === to) {
       return;
     }
-
     const options = [...data.options];
-    const [movedOption] = options.splice(sourceIndex, 1);
-    options.splice(targetIndex, 0, movedOption);
+    const [movedOption] = options.splice(from, 1);
+    options.splice(to, 0, movedOption);
     updateData({ options });
   };
 
@@ -383,100 +379,82 @@ export function CustomFieldFormFields({
             <div className="mailpoet-custom-fields-form-options-label">
               {__('Options', 'mailpoet')}
             </div>
-            {data.options.map((option, index) => (
-              <div
-                key={option.id}
-                className={`mailpoet-custom-fields-form-option ${
-                  draggedOptionId === option.id ? 'is-dragging' : ''
-                } ${dragOverOptionId === option.id ? 'is-drag-over' : ''}`}
-                onDragOver={(event) => {
-                  if (!draggedOptionId || disabled) {
-                    return;
-                  }
-                  event.preventDefault();
-                  const { dataTransfer } = event;
-                  dataTransfer.dropEffect = 'move';
-                  setDragOverOptionId(option.id);
-                }}
-                onDragLeave={() => {
-                  if (dragOverOptionId === option.id) {
-                    setDragOverOptionId(null);
-                  }
-                }}
-                onDrop={(event) => {
-                  event.preventDefault();
-                  const sourceId =
-                    draggedOptionId || event.dataTransfer.getData('text/plain');
-                  reorderOptions(sourceId, option.id);
-                  setDraggedOptionId(null);
-                  setDragOverOptionId(null);
-                }}
-              >
-                <div
-                  aria-label={__('Drag to reorder', 'mailpoet')}
-                  className="mailpoet-custom-fields-form-option-drag-handle"
-                  draggable={!disabled}
-                  onDragStart={(event) => {
-                    if (disabled) {
-                      event.preventDefault();
-                      return;
-                    }
-                    setDraggedOptionId(option.id);
-                    const { dataTransfer } = event;
-                    dataTransfer.effectAllowed = 'move';
-                    dataTransfer.setData('text/plain', option.id);
-
-                    const row = event.currentTarget.closest(
-                      '.mailpoet-custom-fields-form-option',
-                    );
-                    if (row instanceof HTMLElement) {
-                      dataTransfer.setDragImage(row, 18, 18);
-                    }
-                  }}
-                  onDragEnd={() => {
-                    setDraggedOptionId(null);
-                    setDragOverOptionId(null);
-                  }}
-                  role="button"
-                  tabIndex={disabled ? -1 : 0}
-                >
-                  <Dashicon icon="menu" />
-                </div>
-                <div className="mailpoet-custom-fields-form-option-input">
-                  <TextControl
-                    label={sprintf(__('Option %d', 'mailpoet'), index + 1)}
-                    hideLabelFromVision
-                    value={option.value}
-                    onChange={(value) => setOption(option.id, { value })}
-                    disabled={disabled}
-                    __nextHasNoMarginBottom
-                  />
-                </div>
-                <div>
-                  <CheckboxControl
-                    label={__('Default', 'mailpoet')}
-                    checked={option.isChecked}
-                    onChange={() =>
-                      setOption(option.id, {
-                        isChecked: !option.isChecked,
-                      })
-                    }
-                    disabled={disabled}
-                    __nextHasNoMarginBottom
-                  />
-                </div>
-                <div>
-                  <Button
-                    variant="tertiary"
-                    onClick={() => removeOption(option.id)}
-                    disabled={disabled || data.options.length === 1}
-                    __next40pxDefaultSize
+            <DragDropContext onDragEnd={onDragEnd}>
+              <Droppable droppableId="custom-field-options">
+                {(droppableProvided) => (
+                  <div
+                    ref={droppableProvided.innerRef}
+                    {...droppableProvided.droppableProps}
                   >
-                    {__('Remove', 'mailpoet')}
-                  </Button>
-                </div>
-              </div>
-            ))}
+                    {data.options.map((option, index) => (
+                      <Draggable
+                        key={option.id}
+                        draggableId={option.id}
+                        index={index}
+                        isDragDisabled={disabled}
+                      >
+                        {(draggableProvided, snapshot) => (
+                          <div
+                            ref={draggableProvided.innerRef}
+                            {...draggableProvided.draggableProps}
+                            className={`mailpoet-custom-fields-form-option ${
+                              snapshot.isDragging ? 'is-dragging' : ''
+                            }`}
+                          >
+                            <div
+                              {...draggableProvided.dragHandleProps}
+                              aria-label={__('Drag to reorder', 'mailpoet')}
+                              className="mailpoet-custom-fields-form-option-drag-handle"
+                            >
+                              <Dashicon icon="menu" />
+                            </div>
+                            <div className="mailpoet-custom-fields-form-option-input">
+                              <TextControl
+                                label={sprintf(
+                                  __('Option %d', 'mailpoet'),
+                                  index + 1,
+                                )}
+                                hideLabelFromVision
+                                value={option.value}
+                                onChange={(value) =>
+                                  setOption(option.id, { value })
+                                }
+                                disabled={disabled}
+                                __nextHasNoMarginBottom
+                              />
+                            </div>
+                            <div>
+                              <CheckboxControl
+                                label={__('Default', 'mailpoet')}
+                                checked={option.isChecked}
+                                onChange={() =>
+                                  setOption(option.id, {
+                                    isChecked: !option.isChecked,
+                                  })
+                                }
+                                disabled={disabled}
+                                __nextHasNoMarginBottom
+                              />
+                            </div>
+                            <div>
+                              <Button
+                                variant="tertiary"
+                                onClick={() => removeOption(option.id)}
+                                disabled={disabled || data.options.length === 1}
+                                __next40pxDefaultSize
+                              >
+                                {__('Remove', 'mailpoet')}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    ))}
+                    {droppableProvided.placeholder}
+                  </div>
+                )}
+              </Droppable>
+            </DragDropContext>
             <Button
               variant="secondary"
               onClick={() =>

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
@@ -10,6 +10,7 @@ import {
   __experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import type {
+  CustomField,
   CustomFieldDateSettings,
   CustomFieldPayload,
   CustomFieldType,
@@ -58,11 +59,43 @@ const validationOptions = [
   { label: __('Phone number', 'mailpoet'), value: 'phone' },
 ];
 
+const customFieldTypes = fieldTypeOptions.map((option) => option.value);
+
 function createOption(value = ''): CustomFieldFormOption {
   return {
     id: `${Date.now()}-${Math.random()}`,
     value,
     isChecked: false,
+  };
+}
+
+function isCustomFieldType(type: string): type is CustomFieldType {
+  return customFieldTypes.includes(type as CustomFieldType);
+}
+
+function getStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  fallback = '',
+): string {
+  const value = params[key];
+  return typeof value === 'string' ? value : fallback;
+}
+
+function isTruthyParam(value: unknown): boolean {
+  return value === true || value === '1' || value === 1;
+}
+
+function getOptionValue(value: unknown, index: number): CustomFieldFormOption {
+  if (!value || typeof value !== 'object') {
+    return createOption(sprintf(__('Option %d', 'mailpoet'), index + 1));
+  }
+
+  const option = value as Record<string, unknown>;
+  return {
+    id: `${Date.now()}-${index}-${Math.random()}`,
+    value: getStringParam(option, 'value'),
+    isChecked: isTruthyParam(option.is_checked),
   };
 }
 
@@ -83,6 +116,38 @@ export function getInitialCustomFieldFormData(
     dateType,
     dateFormat,
     defaultToday: false,
+  };
+}
+
+export function getCustomFieldFormDataFromCustomField(
+  customField: CustomField,
+  dateSettings: CustomFieldDateSettings,
+): CustomFieldFormData {
+  const initialData = getInitialCustomFieldFormData(dateSettings);
+  const type = isCustomFieldType(customField.type) ? customField.type : 'text';
+  const params = customField.params;
+  const values = Array.isArray(params.values)
+    ? params.values.map(getOptionValue).filter((option) => option.value !== '')
+    : [];
+  const dateType = getStringParam(params, 'date_type', initialData.dateType);
+
+  return {
+    ...initialData,
+    name: customField.name,
+    type,
+    label: getStringParam(params, 'label', customField.label),
+    required: isTruthyParam(params.required),
+    validate: getStringParam(params, 'validate'),
+    checkboxValue: values[0]?.value ?? '',
+    checkboxChecked: values[0]?.isChecked ?? false,
+    options: values.length > 0 ? values : initialData.options,
+    dateType,
+    dateFormat: getStringParam(
+      params,
+      'date_format',
+      dateSettings.dateFormats[dateType]?.[0] ?? initialData.dateFormat,
+    ),
+    defaultToday: isTruthyParam(params.is_default_today),
   };
 }
 

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-field-form-fields.tsx
@@ -1,0 +1,481 @@
+import { useMemo, useState } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+  Button,
+  CheckboxControl,
+  Dashicon,
+  SelectControl,
+  TextControl,
+  ToggleControl,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import type {
+  CustomFieldDateSettings,
+  CustomFieldPayload,
+  CustomFieldType,
+} from './types';
+
+export type CustomFieldFormOption = {
+  id: string;
+  value: string;
+  isChecked: boolean;
+};
+
+export type CustomFieldFormData = {
+  name: string;
+  type: CustomFieldType;
+  label: string;
+  required: boolean;
+  validate: string;
+  checkboxValue: string;
+  checkboxChecked: boolean;
+  options: CustomFieldFormOption[];
+  dateType: string;
+  dateFormat: string;
+  defaultToday: boolean;
+};
+
+type Props = {
+  data: CustomFieldFormData;
+  dateSettings: CustomFieldDateSettings;
+  disabled?: boolean;
+  onChange: (data: CustomFieldFormData) => void;
+};
+
+const fieldTypeOptions: Array<{ label: string; value: CustomFieldType }> = [
+  { label: __('Text', 'mailpoet'), value: 'text' },
+  { label: __('Textarea', 'mailpoet'), value: 'textarea' },
+  { label: __('Radio buttons', 'mailpoet'), value: 'radio' },
+  { label: __('Checkbox', 'mailpoet'), value: 'checkbox' },
+  { label: __('Select', 'mailpoet'), value: 'select' },
+  { label: __('Date', 'mailpoet'), value: 'date' },
+];
+
+const validationOptions = [
+  { label: __('None', 'mailpoet'), value: '' },
+  { label: __('Numbers only', 'mailpoet'), value: 'number' },
+  { label: __('Alphanumeric', 'mailpoet'), value: 'alphanum' },
+  { label: __('Phone number', 'mailpoet'), value: 'phone' },
+];
+
+function createOption(value = ''): CustomFieldFormOption {
+  return {
+    id: `${Date.now()}-${Math.random()}`,
+    value,
+    isChecked: false,
+  };
+}
+
+export function getInitialCustomFieldFormData(
+  dateSettings: CustomFieldDateSettings,
+): CustomFieldFormData {
+  const dateType = dateSettings.dateTypes[0]?.value ?? 'year_month_day';
+  const dateFormat = dateSettings.dateFormats[dateType]?.[0] ?? 'MM/DD/YYYY';
+  return {
+    name: '',
+    type: 'text',
+    label: '',
+    required: false,
+    validate: '',
+    checkboxValue: '',
+    checkboxChecked: false,
+    options: [createOption(__('Option 1', 'mailpoet'))],
+    dateType,
+    dateFormat,
+    defaultToday: false,
+  };
+}
+
+export function buildCustomFieldPayload(
+  data: CustomFieldFormData,
+): CustomFieldPayload {
+  const params: Record<string, unknown> = {
+    label: data.label.trim() || data.name.trim(),
+    required: data.required ? '1' : '',
+  };
+
+  if (data.type === 'text' || data.type === 'textarea') {
+    params.validate = data.validate;
+    if (data.type === 'textarea') {
+      params.lines = '1';
+    }
+  }
+
+  if (data.type === 'checkbox') {
+    params.values = [
+      {
+        value: data.checkboxValue.trim(),
+        is_checked: data.checkboxChecked ? '1' : '',
+      },
+    ];
+  }
+
+  if (data.type === 'radio' || data.type === 'select') {
+    params.values = data.options.map((option) => ({
+      value: option.value.trim(),
+      is_checked: option.isChecked ? '1' : '',
+    }));
+  }
+
+  if (data.type === 'date') {
+    params.date_type = data.dateType;
+    params.date_format = data.dateFormat;
+    params.is_default_today = data.defaultToday ? '1' : '';
+  }
+
+  return {
+    name: data.name.trim(),
+    type: data.type,
+    params,
+  };
+}
+
+export function validateCustomFieldFormData(
+  data: CustomFieldFormData,
+): string | null {
+  if (!data.name.trim()) {
+    return __('Field name is required.', 'mailpoet');
+  }
+  if (data.type === 'checkbox' && !data.checkboxValue.trim()) {
+    return __('Checkbox value is required.', 'mailpoet');
+  }
+  if (
+    (data.type === 'radio' || data.type === 'select') &&
+    data.options.some((option) => !option.value.trim())
+  ) {
+    return __('Every option needs a value.', 'mailpoet');
+  }
+  return null;
+}
+
+export function CustomFieldFormFields({
+  data,
+  dateSettings,
+  disabled = false,
+  onChange,
+}: Props): JSX.Element {
+  const [draggedOptionId, setDraggedOptionId] = useState<string | null>(null);
+  const [dragOverOptionId, setDragOverOptionId] = useState<string | null>(null);
+
+  const dateFormatOptions = useMemo(
+    () =>
+      (dateSettings.dateFormats[data.dateType] ?? []).map((format) => ({
+        label: format,
+        value: format,
+      })),
+    [data.dateType, dateSettings.dateFormats],
+  );
+
+  const updateData = (updates: Partial<CustomFieldFormData>): void => {
+    onChange({
+      ...data,
+      ...updates,
+    });
+  };
+
+  const setType = (type: CustomFieldType): void => {
+    const dateType = dateSettings.dateTypes[0]?.value ?? 'year_month_day';
+    onChange({
+      ...data,
+      type,
+      required: false,
+      validate: '',
+      checkboxValue: '',
+      checkboxChecked: false,
+      options: [createOption(__('Option 1', 'mailpoet'))],
+      dateType,
+      dateFormat: dateSettings.dateFormats[dateType]?.[0] ?? 'MM/DD/YYYY',
+      defaultToday: false,
+    });
+  };
+
+  const setOption = (
+    id: string,
+    updates: Partial<Pick<CustomFieldFormOption, 'value' | 'isChecked'>>,
+  ): void => {
+    updateData({
+      options: data.options.map((option) => {
+        if (option.id !== id) {
+          return updates.isChecked ? { ...option, isChecked: false } : option;
+        }
+        return { ...option, ...updates };
+      }),
+    });
+  };
+
+  const removeOption = (id: string): void => {
+    if (data.options.length === 1) {
+      return;
+    }
+    updateData({
+      options: data.options.filter((option) => option.id !== id),
+    });
+  };
+
+  const reorderOptions = (sourceId: string, targetId: string): void => {
+    if (sourceId === targetId) {
+      return;
+    }
+
+    const sourceIndex = data.options.findIndex(
+      (option) => option.id === sourceId,
+    );
+    const targetIndex = data.options.findIndex(
+      (option) => option.id === targetId,
+    );
+
+    if (sourceIndex === -1 || targetIndex === -1) {
+      return;
+    }
+
+    const options = [...data.options];
+    const [movedOption] = options.splice(sourceIndex, 1);
+    options.splice(targetIndex, 0, movedOption);
+    updateData({ options });
+  };
+
+  return (
+    <>
+      <SelectControl
+        label={__('Field type', 'mailpoet')}
+        value={data.type}
+        options={fieldTypeOptions}
+        onChange={(value) => setType(value as CustomFieldType)}
+        disabled={disabled}
+        __nextHasNoMarginBottom
+      />
+      <Spacer marginTop={4} />
+      <TextControl
+        label={__('Field name', 'mailpoet')}
+        value={data.name}
+        onChange={(name) => {
+          onChange({
+            ...data,
+            name,
+            label: data.label === data.name ? name : data.label,
+          });
+        }}
+        disabled={disabled}
+        __nextHasNoMarginBottom
+      />
+      <Spacer marginTop={4} />
+      <TextControl
+        label={__('Label', 'mailpoet')}
+        value={data.label}
+        placeholder={data.name}
+        onChange={(label) => updateData({ label })}
+        disabled={disabled}
+        __nextHasNoMarginBottom
+      />
+      <Spacer marginTop={4} />
+      <ToggleControl
+        label={__('Mandatory field', 'mailpoet')}
+        checked={data.required}
+        onChange={(required) => updateData({ required })}
+        disabled={disabled}
+        __nextHasNoMarginBottom
+      />
+
+      {(data.type === 'text' || data.type === 'textarea') && (
+        <>
+          <Spacer marginTop={4} />
+          <SelectControl
+            label={__('Validate for', 'mailpoet')}
+            value={data.validate}
+            options={validationOptions}
+            onChange={(validate) => updateData({ validate })}
+            disabled={disabled}
+            __nextHasNoMarginBottom
+          />
+        </>
+      )}
+
+      {data.type === 'checkbox' && (
+        <>
+          <Spacer marginTop={4} />
+          <ToggleControl
+            label={__('Checked by default', 'mailpoet')}
+            checked={data.checkboxChecked}
+            onChange={(checkboxChecked) => updateData({ checkboxChecked })}
+            disabled={disabled}
+            __nextHasNoMarginBottom
+          />
+          <Spacer marginTop={4} />
+          <TextControl
+            label={__('Checkbox value', 'mailpoet')}
+            value={data.checkboxValue}
+            onChange={(checkboxValue) => updateData({ checkboxValue })}
+            disabled={disabled}
+            __nextHasNoMarginBottom
+          />
+        </>
+      )}
+
+      {(data.type === 'radio' || data.type === 'select') && (
+        <>
+          <Spacer marginTop={4} />
+          <div className="mailpoet-custom-fields-form-options">
+            <div className="mailpoet-custom-fields-form-options-label">
+              {__('Options', 'mailpoet')}
+            </div>
+            {data.options.map((option, index) => (
+              <div
+                key={option.id}
+                className={`mailpoet-custom-fields-form-option ${
+                  draggedOptionId === option.id ? 'is-dragging' : ''
+                } ${dragOverOptionId === option.id ? 'is-drag-over' : ''}`}
+                onDragOver={(event) => {
+                  if (!draggedOptionId || disabled) {
+                    return;
+                  }
+                  event.preventDefault();
+                  const { dataTransfer } = event;
+                  dataTransfer.dropEffect = 'move';
+                  setDragOverOptionId(option.id);
+                }}
+                onDragLeave={() => {
+                  if (dragOverOptionId === option.id) {
+                    setDragOverOptionId(null);
+                  }
+                }}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  const sourceId =
+                    draggedOptionId || event.dataTransfer.getData('text/plain');
+                  reorderOptions(sourceId, option.id);
+                  setDraggedOptionId(null);
+                  setDragOverOptionId(null);
+                }}
+              >
+                <div
+                  aria-label={__('Drag to reorder', 'mailpoet')}
+                  className="mailpoet-custom-fields-form-option-drag-handle"
+                  draggable={!disabled}
+                  onDragStart={(event) => {
+                    if (disabled) {
+                      event.preventDefault();
+                      return;
+                    }
+                    setDraggedOptionId(option.id);
+                    const { dataTransfer } = event;
+                    dataTransfer.effectAllowed = 'move';
+                    dataTransfer.setData('text/plain', option.id);
+
+                    const row = event.currentTarget.closest(
+                      '.mailpoet-custom-fields-form-option',
+                    );
+                    if (row instanceof HTMLElement) {
+                      dataTransfer.setDragImage(row, 18, 18);
+                    }
+                  }}
+                  onDragEnd={() => {
+                    setDraggedOptionId(null);
+                    setDragOverOptionId(null);
+                  }}
+                  role="button"
+                  tabIndex={disabled ? -1 : 0}
+                >
+                  <Dashicon icon="menu" />
+                </div>
+                <div className="mailpoet-custom-fields-form-option-input">
+                  <TextControl
+                    label={sprintf(__('Option %d', 'mailpoet'), index + 1)}
+                    hideLabelFromVision
+                    value={option.value}
+                    onChange={(value) => setOption(option.id, { value })}
+                    disabled={disabled}
+                    __nextHasNoMarginBottom
+                  />
+                </div>
+                <div>
+                  <CheckboxControl
+                    label={__('Default', 'mailpoet')}
+                    checked={option.isChecked}
+                    onChange={() =>
+                      setOption(option.id, {
+                        isChecked: !option.isChecked,
+                      })
+                    }
+                    disabled={disabled}
+                    __nextHasNoMarginBottom
+                  />
+                </div>
+                <div>
+                  <Button
+                    variant="tertiary"
+                    onClick={() => removeOption(option.id)}
+                    disabled={disabled || data.options.length === 1}
+                    __next40pxDefaultSize
+                  >
+                    {__('Remove', 'mailpoet')}
+                  </Button>
+                </div>
+              </div>
+            ))}
+            <Button
+              variant="secondary"
+              onClick={() =>
+                updateData({
+                  options: [
+                    ...data.options,
+                    createOption(
+                      sprintf(
+                        __('Option %d', 'mailpoet'),
+                        data.options.length + 1,
+                      ),
+                    ),
+                  ],
+                })
+              }
+              disabled={disabled}
+              __next40pxDefaultSize
+            >
+              {__('Add option', 'mailpoet')}
+            </Button>
+          </div>
+        </>
+      )}
+
+      {data.type === 'date' && (
+        <>
+          <Spacer marginTop={4} />
+          <ToggleControl
+            label={__('Default to today', 'mailpoet')}
+            checked={data.defaultToday}
+            onChange={(defaultToday) => updateData({ defaultToday })}
+            disabled={disabled}
+            __nextHasNoMarginBottom
+          />
+          <Spacer marginTop={4} />
+          <SelectControl
+            label={__('Date type', 'mailpoet')}
+            value={data.dateType}
+            options={dateSettings.dateTypes}
+            onChange={(dateType) =>
+              updateData({
+                dateType,
+                dateFormat:
+                  dateSettings.dateFormats[dateType]?.[0] ?? 'MM/DD/YYYY',
+              })
+            }
+            disabled={disabled}
+            __nextHasNoMarginBottom
+          />
+          {dateFormatOptions.length > 1 && (
+            <>
+              <Spacer marginTop={4} />
+              <SelectControl
+                label={__('Date format', 'mailpoet')}
+                value={data.dateFormat}
+                options={dateFormatOptions}
+                onChange={(dateFormat) => updateData({ dateFormat })}
+                disabled={disabled}
+                __nextHasNoMarginBottom
+              />
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-form.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-form.tsx
@@ -12,27 +12,32 @@ import type {
   CustomField,
   CustomFieldDateSettings,
 } from './types';
-import { createCustomField } from './api';
+import { createCustomField, updateCustomField } from './api';
 import {
   buildCustomFieldPayload,
   CustomFieldFormFields,
+  getCustomFieldFormDataFromCustomField,
   getInitialCustomFieldFormData,
   validateCustomFieldFormData,
 } from './custom-field-form-fields';
 
 type Props = {
+  customField?: CustomField;
   dateSettings: CustomFieldDateSettings;
   onClose: () => void;
   onSuccess: (customField: CustomField) => void;
 };
 
 export function CustomFieldsForm({
+  customField,
   dateSettings,
   onClose,
   onSuccess,
 }: Props): JSX.Element {
   const [data, setData] = useState(() =>
-    getInitialCustomFieldFormData(dateSettings),
+    customField
+      ? getCustomFieldFormDataFromCustomField(customField, dateSettings)
+      : getInitialCustomFieldFormData(dateSettings),
   );
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +53,12 @@ export function CustomFieldsForm({
     setIsSaving(true);
     setError(null);
     try {
-      onSuccess(await createCustomField(buildCustomFieldPayload(data)));
+      const payload = buildCustomFieldPayload(data);
+      onSuccess(
+        customField
+          ? await updateCustomField(customField.id, payload)
+          : await createCustomField(payload),
+      );
     } catch (err) {
       const apiError = err as ApiErrorResponse;
       setError(
@@ -62,7 +72,11 @@ export function CustomFieldsForm({
 
   return (
     <Modal
-      title={__('Add new custom field', 'mailpoet')}
+      title={
+        customField
+          ? __('Edit custom field', 'mailpoet')
+          : __('Add new custom field', 'mailpoet')
+      }
       onRequestClose={onClose}
       className="mailpoet-custom-fields-form-modal"
       focusOnMount
@@ -103,7 +117,9 @@ export function CustomFieldsForm({
               disabled={isSaving}
               __next40pxDefaultSize
             >
-              {__('Create custom field', 'mailpoet')}
+              {customField
+                ? __('Save custom field', 'mailpoet')
+                : __('Create custom field', 'mailpoet')}
             </Button>
           </FlexItem>
         </Flex>

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-form.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-form.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Modal,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import type {
+  ApiErrorResponse,
+  CustomField,
+  CustomFieldDateSettings,
+} from './types';
+import { createCustomField } from './api';
+import {
+  buildCustomFieldPayload,
+  CustomFieldFormFields,
+  getInitialCustomFieldFormData,
+  validateCustomFieldFormData,
+} from './custom-field-form-fields';
+
+type Props = {
+  dateSettings: CustomFieldDateSettings;
+  onClose: () => void;
+  onSuccess: (customField: CustomField) => void;
+};
+
+export function CustomFieldsForm({
+  dateSettings,
+  onClose,
+  onSuccess,
+}: Props): JSX.Element {
+  const [data, setData] = useState(() =>
+    getInitialCustomFieldFormData(dateSettings),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const validationError = validateCustomFieldFormData(data);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      onSuccess(await createCustomField(buildCustomFieldPayload(data)));
+    } catch (err) {
+      const apiError = err as ApiErrorResponse;
+      setError(
+        apiError?.message ||
+          __('Something went wrong. Please try again.', 'mailpoet'),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={__('Add new custom field', 'mailpoet')}
+      onRequestClose={onClose}
+      className="mailpoet-custom-fields-form-modal"
+      focusOnMount
+    >
+      <form onSubmit={handleSubmit}>
+        <CustomFieldFormFields
+          data={data}
+          dateSettings={dateSettings}
+          disabled={isSaving}
+          onChange={setData}
+        />
+
+        {error && (
+          <>
+            <Spacer marginTop={4} />
+            <div className="mailpoet-custom-fields-form-error" role="alert">
+              {error}
+            </div>
+          </>
+        )}
+        <Spacer marginTop={6} />
+        <Flex justify="flex-end" gap={3}>
+          <FlexItem>
+            <Button
+              variant="tertiary"
+              onClick={onClose}
+              disabled={isSaving}
+              __next40pxDefaultSize
+            >
+              {__('Cancel', 'mailpoet')}
+            </Button>
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant="primary"
+              type="submit"
+              isBusy={isSaving}
+              disabled={isSaving}
+              __next40pxDefaultSize
+            >
+              {__('Create custom field', 'mailpoet')}
+            </Button>
+          </FlexItem>
+        </Flex>
+      </form>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -240,6 +240,9 @@ export function CustomFieldsPage() {
       {
         id: 'edit',
         label: __('Edit', 'mailpoet'),
+        isPrimary: true,
+        icon: 'edit',
+        supportsBulk: false,
         isEligible: (item) => !item.deleted_at,
         callback: (selected) => {
           const [customField] = selected;

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -9,6 +9,7 @@ import { listFields } from './fields';
 import {
   bulkAction,
   type CustomFieldBulkAction,
+  duplicateCustomField,
   getCustomFields,
   getSubscribersListingUrl,
 } from './api';
@@ -213,6 +214,27 @@ export function CustomFieldsPage() {
     [loadCustomFields],
   );
 
+  const handleDuplicate = useCallback(async (customField: CustomField) => {
+    try {
+      const duplicate = await duplicateCustomField(customField.id);
+      setSelection([]);
+      setGroup('all');
+      setGlobalSuccess(
+        sprintf(
+          __('Custom field "%s" duplicated.', 'mailpoet'),
+          duplicate.name,
+        ),
+      );
+      setRefreshToken((current) => current + 1);
+    } catch (err) {
+      const apiError = err as ApiErrorResponse;
+      setGlobalError(
+        apiError?.message ||
+          __('The custom field could not be duplicated.', 'mailpoet'),
+      );
+    }
+  }, []);
+
   const actions = useMemo<Action<CustomField>[]>(
     () => [
       {
@@ -223,6 +245,17 @@ export function CustomFieldsPage() {
           const [customField] = selected;
           if (customField) {
             setEditingCustomField(customField);
+          }
+        },
+      },
+      {
+        id: 'duplicate',
+        label: __('Duplicate', 'mailpoet'),
+        isEligible: (item) => !item.deleted_at,
+        callback: (selected) => {
+          const [customField] = selected;
+          if (customField) {
+            void handleDuplicate(customField);
           }
         },
       },
@@ -264,7 +297,7 @@ export function CustomFieldsPage() {
         },
       },
     ],
-    [handleBulkAction],
+    [handleBulkAction, handleDuplicate],
   );
 
   const paginationInfo = useMemo(

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -1,9 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice, TabPanel } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
+import {
+  type LoadListing,
+  useDataViewsQuery,
+} from 'common/dataviews/use-dataviews-query';
+import type { ListingGroup } from 'common/dataviews/types';
 import { CustomFieldsForm } from './custom-fields-form';
 import { listFields } from './fields';
 import {
@@ -17,8 +22,6 @@ import type {
   ApiErrorResponse,
   CustomField,
   CustomFieldDateSettings,
-  CustomFieldListGroup,
-  CustomFieldListMeta,
 } from './types';
 
 type Group = 'all' | 'trash';
@@ -98,69 +101,43 @@ export function CustomFieldsPage() {
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
   const [editingCustomField, setEditingCustomField] =
     useState<CustomField | null>(null);
-  const [refreshToken, setRefreshToken] = useState(0);
-  const [view, setView] = useState<View>(DEFAULT_VIEW);
-  const [items, setItems] = useState<CustomField[]>([]);
-  const [meta, setMeta] = useState<CustomFieldListMeta>({
-    count: 0,
-    pages: 0,
-  });
-  const [groups, setGroups] = useState<CustomFieldListGroup[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
-  const latestRequestIdRef = useRef(0);
 
-  const loadCustomFields = useCallback(async () => {
-    const requestId = latestRequestIdRef.current + 1;
-    latestRequestIdRef.current = requestId;
-    setIsLoading(true);
-    try {
-      const requestedPage = view.page ?? 1;
+  const load = useCallback<LoadListing<CustomField>>(
+    async (params) => {
       const result = await getCustomFields({
-        search: view.search || '',
-        orderby: view.sort?.field ?? 'name',
-        order: view.sort?.direction ?? 'asc',
-        page: requestedPage,
-        per_page: view.perPage ?? 20,
+        search: typeof params.search === 'string' ? params.search : '',
+        orderby: params.orderby ?? 'name',
+        order: params.order ?? 'asc',
+        page: params.page,
+        per_page: params.per_page,
         group,
       });
+      return {
+        items: result.items,
+        meta: result.meta,
+        groups: result.groups as ListingGroup[],
+      };
+    },
+    [group],
+  );
 
-      if (requestId !== latestRequestIdRef.current) {
-        return;
-      }
-
-      const lastValidPage = Math.max(1, result.meta.pages);
-      if (requestedPage > lastValidPage) {
-        setView((currentView) => ({
-          ...currentView,
-          page: lastValidPage,
-        }));
-        return;
-      }
-
-      setItems(result.items);
-      setMeta(result.meta);
-      setGroups(result.groups);
-    } catch (err) {
-      if (requestId !== latestRequestIdRef.current) {
-        return;
-      }
-      const apiError = err as ApiErrorResponse;
-      setGlobalError(
-        apiError?.message || __('Failed to load custom fields.', 'mailpoet'),
-      );
-    } finally {
-      if (requestId === latestRequestIdRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, [group, view.search, view.sort, view.page, view.perPage]);
-
-  useEffect(() => {
-    void loadCustomFields();
-  }, [loadCustomFields, refreshToken]);
+  const {
+    view,
+    setView,
+    items,
+    meta,
+    groups,
+    isLoading,
+    error: loadError,
+    refresh,
+    clearError: clearLoadError,
+  } = useDataViewsQuery<CustomField>({
+    initialView: DEFAULT_VIEW,
+    load,
+  });
 
   const handleBulkAction = useCallback(
     async (
@@ -202,7 +179,7 @@ export function CustomFieldsPage() {
         const updatedCount = await bulkAction(action, ids);
         setSelection([]);
         setGlobalSuccess(bulkActionSuccessMessage(action, updatedCount));
-        void loadCustomFields();
+        refresh();
       } catch (err) {
         const apiError = err as ApiErrorResponse;
         setGlobalError(
@@ -211,29 +188,32 @@ export function CustomFieldsPage() {
         );
       }
     },
-    [loadCustomFields],
+    [refresh],
   );
 
-  const handleDuplicate = useCallback(async (customField: CustomField) => {
-    try {
-      const duplicate = await duplicateCustomField(customField.id);
-      setSelection([]);
-      setGroup('all');
-      setGlobalSuccess(
-        sprintf(
-          __('Custom field "%s" duplicated.', 'mailpoet'),
-          duplicate.name,
-        ),
-      );
-      setRefreshToken((current) => current + 1);
-    } catch (err) {
-      const apiError = err as ApiErrorResponse;
-      setGlobalError(
-        apiError?.message ||
-          __('The custom field could not be duplicated.', 'mailpoet'),
-      );
-    }
-  }, []);
+  const handleDuplicate = useCallback(
+    async (customField: CustomField) => {
+      try {
+        const duplicate = await duplicateCustomField(customField.id);
+        setSelection([]);
+        setGroup('all');
+        setGlobalSuccess(
+          sprintf(
+            __('Custom field "%s" duplicated.', 'mailpoet'),
+            duplicate.name,
+          ),
+        );
+        refresh();
+      } catch (err) {
+        const apiError = err as ApiErrorResponse;
+        setGlobalError(
+          apiError?.message ||
+            __('The custom field could not be duplicated.', 'mailpoet'),
+        );
+      }
+    },
+    [refresh],
+  );
 
   const actions = useMemo<Action<CustomField>[]>(
     () => [
@@ -310,8 +290,10 @@ export function CustomFieldsPage() {
 
   const groupCounts = useMemo(() => {
     const counts: Record<Group, number | null> = { all: null, trash: null };
-    groups.forEach((entry) => {
-      counts[entry.name] = entry.count;
+    (groups ?? []).forEach((entry) => {
+      if (entry.name === 'all' || entry.name === 'trash') {
+        counts[entry.name] = entry.count;
+      }
     });
     return counts;
   }, [groups]);
@@ -365,7 +347,7 @@ export function CustomFieldsPage() {
     setGroup('all');
     setSelection([]);
     setView((currentView) => ({ ...currentView, page: 1 }));
-    setRefreshToken((current) => current + 1);
+    refresh();
   };
 
   const handleEditSuccess = (customField: CustomField): void => {
@@ -373,7 +355,7 @@ export function CustomFieldsPage() {
     setGlobalSuccess(
       sprintf(__('Custom field "%s" updated.', 'mailpoet'), customField.name),
     );
-    setRefreshToken((current) => current + 1);
+    refresh();
   };
 
   return (
@@ -399,6 +381,13 @@ export function CustomFieldsPage() {
         </button>
       </PageHeader>
 
+      {loadError && (
+        <Notice status="error" onRemove={clearLoadError}>
+          {loadError === 'Failed to load data.'
+            ? __('Failed to load custom fields.', 'mailpoet')
+            : loadError}
+        </Notice>
+      )}
       {globalError && (
         <Notice status="error" onRemove={() => setGlobalError(null)}>
           {globalError}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -4,6 +4,7 @@ import { Notice, TabPanel } from '@wordpress/components';
 import { DataViews, View, Action } from '@wordpress/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
+import { CustomFieldsForm } from './custom-fields-form';
 import { listFields } from './fields';
 import {
   bulkAction,
@@ -14,11 +15,19 @@ import {
 import type {
   ApiErrorResponse,
   CustomField,
+  CustomFieldDateSettings,
   CustomFieldListGroup,
   CustomFieldListMeta,
 } from './types';
 
 type Group = 'all' | 'trash';
+
+declare global {
+  interface Window {
+    mailpoet_custom_fields_date_types?: CustomFieldDateSettings['dateTypes'];
+    mailpoet_custom_fields_date_formats?: CustomFieldDateSettings['dateFormats'];
+  }
+}
 
 const DEFAULT_VIEW: View = {
   type: 'table',
@@ -85,6 +94,8 @@ function bulkActionSuccessMessage(
 
 export function CustomFieldsPage() {
   const [group, setGroup] = useState<Group>('all');
+  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const [refreshToken, setRefreshToken] = useState(0);
   const [view, setView] = useState<View>(DEFAULT_VIEW);
   const [items, setItems] = useState<CustomField[]>([]);
   const [meta, setMeta] = useState<CustomFieldListMeta>({
@@ -146,7 +157,7 @@ export function CustomFieldsPage() {
 
   useEffect(() => {
     void loadCustomFields();
-  }, [loadCustomFields]);
+  }, [loadCustomFields, refreshToken]);
 
   const handleBulkAction = useCallback(
     async (
@@ -289,6 +300,25 @@ export function CustomFieldsPage() {
       ? __('Trash is empty.', 'mailpoet')
       : __('No custom fields yet.', 'mailpoet');
 
+  const dateSettings = useMemo<CustomFieldDateSettings>(
+    () => ({
+      dateTypes: window.mailpoet_custom_fields_date_types ?? [],
+      dateFormats: window.mailpoet_custom_fields_date_formats ?? {},
+    }),
+    [],
+  );
+
+  const handleCreateSuccess = (customField: CustomField): void => {
+    setIsCreateFormOpen(false);
+    setGlobalSuccess(
+      sprintf(__('Custom field "%s" created.', 'mailpoet'), customField.name),
+    );
+    setGroup('all');
+    setSelection([]);
+    setView((currentView) => ({ ...currentView, page: 1 }));
+    setRefreshToken((current) => current + 1);
+  };
+
   return (
     <>
       <TopBarWithBoundary />
@@ -301,7 +331,16 @@ export function CustomFieldsPage() {
             aria-label={__('Back to subscribers list', 'mailpoet')}
           />
         }
-      />
+      >
+        <button
+          type="button"
+          className="page-title-action"
+          onClick={() => setIsCreateFormOpen(true)}
+          data-automation-id="add-new-custom-field-button"
+        >
+          {__('Add new custom field', 'mailpoet')}
+        </button>
+      </PageHeader>
 
       {globalError && (
         <Notice status="error" onRemove={() => setGlobalError(null)}>
@@ -366,6 +405,14 @@ export function CustomFieldsPage() {
           </div>
         )}
       </TabPanel>
+
+      {isCreateFormOpen && (
+        <CustomFieldsForm
+          dateSettings={dateSettings}
+          onClose={() => setIsCreateFormOpen(false)}
+          onSuccess={handleCreateSuccess}
+        />
+      )}
     </>
   );
 }

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -1,16 +1,24 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { __ } from '@wordpress/i18n';
-import { Notice } from '@wordpress/components';
-import { DataViews, View } from '@wordpress/dataviews';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { Notice, TabPanel } from '@wordpress/components';
+import { DataViews, View, Action } from '@wordpress/dataviews';
 import { BackButton, PageHeader } from 'common/page-header';
 import { TopBarWithBoundary } from 'common/top-bar/top-bar';
 import { listFields } from './fields';
-import { getCustomFields, getSubscribersListingUrl } from './api';
+import {
+  bulkAction,
+  type CustomFieldBulkAction,
+  getCustomFields,
+  getSubscribersListingUrl,
+} from './api';
 import type {
   ApiErrorResponse,
   CustomField,
+  CustomFieldListGroup,
   CustomFieldListMeta,
 } from './types';
+
+type Group = 'all' | 'trash';
 
 const DEFAULT_VIEW: View = {
   type: 'table',
@@ -29,15 +37,65 @@ const DEFAULT_VIEW: View = {
   showTitle: true,
 };
 
+function bulkActionSuccessMessage(
+  action: CustomFieldBulkAction,
+  count: number,
+): string {
+  if (action === 'trash') {
+    return count === 1
+      ? __('1 custom field was moved to the trash.', 'mailpoet')
+      : sprintf(
+          /* translators: %d is the number of custom fields */
+          _n(
+            '%d custom field was moved to the trash.',
+            '%d custom fields were moved to the trash.',
+            count,
+            'mailpoet',
+          ),
+          count,
+        );
+  }
+  if (action === 'restore') {
+    return count === 1
+      ? __('1 custom field has been restored from the trash.', 'mailpoet')
+      : sprintf(
+          /* translators: %d is the number of custom fields */
+          _n(
+            '%d custom field has been restored from the trash.',
+            '%d custom fields have been restored from the trash.',
+            count,
+            'mailpoet',
+          ),
+          count,
+        );
+  }
+  return count === 1
+    ? __('1 custom field was permanently deleted.', 'mailpoet')
+    : sprintf(
+        /* translators: %d is the number of custom fields */
+        _n(
+          '%d custom field was permanently deleted.',
+          '%d custom fields were permanently deleted.',
+          count,
+          'mailpoet',
+        ),
+        count,
+      );
+}
+
 export function CustomFieldsPage() {
+  const [group, setGroup] = useState<Group>('all');
   const [view, setView] = useState<View>(DEFAULT_VIEW);
   const [items, setItems] = useState<CustomField[]>([]);
   const [meta, setMeta] = useState<CustomFieldListMeta>({
     count: 0,
     pages: 0,
   });
+  const [groups, setGroups] = useState<CustomFieldListGroup[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [selection, setSelection] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
+  const [globalSuccess, setGlobalSuccess] = useState<string | null>(null);
   const latestRequestIdRef = useRef(0);
 
   const loadCustomFields = useCallback(async () => {
@@ -52,6 +110,7 @@ export function CustomFieldsPage() {
         order: view.sort?.direction ?? 'asc',
         page: requestedPage,
         per_page: view.perPage ?? 20,
+        group,
       });
 
       if (requestId !== latestRequestIdRef.current) {
@@ -69,6 +128,7 @@ export function CustomFieldsPage() {
 
       setItems(result.items);
       setMeta(result.meta);
+      setGroups(result.groups);
     } catch (err) {
       if (requestId !== latestRequestIdRef.current) {
         return;
@@ -82,16 +142,152 @@ export function CustomFieldsPage() {
         setIsLoading(false);
       }
     }
-  }, [view.search, view.sort, view.page, view.perPage]);
+  }, [group, view.search, view.sort, view.page, view.perPage]);
 
   useEffect(() => {
     void loadCustomFields();
   }, [loadCustomFields]);
 
+  const handleBulkAction = useCallback(
+    async (
+      action: CustomFieldBulkAction,
+      ids: number[],
+      count = ids.length,
+    ) => {
+      if (count === 0) return;
+
+      if (action === 'delete' || action === 'empty_trash') {
+        const confirmMessage =
+          action === 'empty_trash'
+            ? sprintf(
+                /* translators: %d is the number of custom fields */
+                _n(
+                  'Permanently delete %d custom field from the trash? It will be removed from subscribers, forms, and dynamic segments.',
+                  'Permanently delete %d custom fields from the trash? They will be removed from subscribers, forms, and dynamic segments.',
+                  count,
+                  'mailpoet',
+                ),
+                count,
+              )
+            : sprintf(
+                /* translators: %d is the number of custom fields */
+                _n(
+                  'Permanently delete %d custom field? It will be removed from subscribers, forms, and dynamic segments.',
+                  'Permanently delete %d custom fields? They will be removed from subscribers, forms, and dynamic segments.',
+                  count,
+                  'mailpoet',
+                ),
+                count,
+              );
+        // eslint-disable-next-line no-alert
+        if (!window.confirm(confirmMessage)) {
+          return;
+        }
+      }
+      try {
+        const updatedCount = await bulkAction(action, ids);
+        setSelection([]);
+        setGlobalSuccess(bulkActionSuccessMessage(action, updatedCount));
+        void loadCustomFields();
+      } catch (err) {
+        const apiError = err as ApiErrorResponse;
+        setGlobalError(
+          apiError?.message ||
+            __('The bulk action could not be completed.', 'mailpoet'),
+        );
+      }
+    },
+    [loadCustomFields],
+  );
+
+  const actions = useMemo<Action<CustomField>[]>(
+    () => [
+      {
+        id: 'trash',
+        label: __('Move to trash', 'mailpoet'),
+        supportsBulk: true,
+        isEligible: (item) => !item.deleted_at,
+        callback: (selected) => {
+          void handleBulkAction(
+            'trash',
+            selected.map((customField) => customField.id),
+          );
+        },
+      },
+      {
+        id: 'restore',
+        label: __('Restore', 'mailpoet'),
+        supportsBulk: true,
+        isEligible: (item) => !!item.deleted_at,
+        callback: (selected) => {
+          void handleBulkAction(
+            'restore',
+            selected.map((customField) => customField.id),
+          );
+        },
+      },
+      {
+        id: 'delete',
+        label: __('Delete permanently', 'mailpoet'),
+        supportsBulk: true,
+        isDestructive: true,
+        isEligible: (item) => !!item.deleted_at,
+        callback: (selected) => {
+          void handleBulkAction(
+            'delete',
+            selected.map((customField) => customField.id),
+          );
+        },
+      },
+    ],
+    [handleBulkAction],
+  );
+
   const paginationInfo = useMemo(
     () => ({ totalItems: meta.count, totalPages: meta.pages }),
     [meta],
   );
+
+  const groupCounts = useMemo(() => {
+    const counts: Record<Group, number | null> = { all: null, trash: null };
+    groups.forEach((entry) => {
+      counts[entry.name] = entry.count;
+    });
+    return counts;
+  }, [groups]);
+
+  const tabs = useMemo(
+    () =>
+      (
+        [
+          { name: 'all', label: __('All', 'mailpoet') },
+          { name: 'trash', label: __('Trash', 'mailpoet') },
+        ] as Array<{ name: Group; label: string }>
+      ).map((tab) => ({
+        name: tab.name,
+        title:
+          groupCounts[tab.name] === null
+            ? tab.label
+            : `${tab.label} (${groupCounts[tab.name]})`,
+        className: `mailpoet-dataviews-group-${tab.name}`,
+      })),
+    [groupCounts],
+  );
+
+  const handleTabSelect = (tabName: string): void => {
+    if (tabName !== 'all' && tabName !== 'trash') return;
+    if (tabName === group) return;
+    setGroup(tabName);
+    setSelection([]);
+    setGlobalError(null);
+    setGlobalSuccess(null);
+    setView((currentView) => ({ ...currentView, page: 1 }));
+  };
+
+  const emptyLabel =
+    group === 'trash'
+      ? __('Trash is empty.', 'mailpoet')
+      : __('No custom fields yet.', 'mailpoet');
 
   return (
     <>
@@ -112,26 +308,64 @@ export function CustomFieldsPage() {
           {globalError}
         </Notice>
       )}
+      {globalSuccess && (
+        <Notice status="success" onRemove={() => setGlobalSuccess(null)}>
+          {globalSuccess}
+        </Notice>
+      )}
 
-      <div className="mailpoet-custom-fields-dataviews">
-        <DataViews<CustomField>
-          data={items}
-          fields={listFields}
-          view={view}
-          onChangeView={setView}
-          paginationInfo={paginationInfo}
-          defaultLayouts={{ table: {} }}
-          getItemId={(item) => String(item.id)}
-          isLoading={isLoading}
-          empty={<div>{__('No custom fields yet.', 'mailpoet')}</div>}
-        >
-          <div className="mailpoet-custom-fields-dataviews__toolbar">
-            <DataViews.Search label={__('Search custom fields', 'mailpoet')} />
+      <TabPanel
+        className="mailpoet-custom-fields-dataviews__tabs"
+        activeClass="is-active"
+        tabs={tabs}
+        initialTabName={group}
+        onSelect={handleTabSelect}
+      >
+        {() => (
+          <div className="mailpoet-custom-fields-dataviews">
+            <DataViews<CustomField>
+              data={items}
+              fields={listFields}
+              view={view}
+              onChangeView={setView}
+              actions={actions}
+              paginationInfo={paginationInfo}
+              defaultLayouts={{ table: {} }}
+              getItemId={(item) => String(item.id)}
+              selection={selection}
+              onChangeSelection={setSelection}
+              isLoading={isLoading}
+              empty={<div>{emptyLabel}</div>}
+            >
+              <div className="mailpoet-custom-fields-dataviews__toolbar">
+                <DataViews.Search
+                  label={__('Search custom fields', 'mailpoet')}
+                />
+              </div>
+              {group === 'trash' && (groupCounts.trash ?? 0) > 0 && (
+                <div className="mailpoet-custom-fields-dataviews__toolbar">
+                  <button
+                    type="button"
+                    className="button"
+                    data-automation-id="empty_trash_custom_fields"
+                    onClick={() => {
+                      void handleBulkAction(
+                        'empty_trash',
+                        [],
+                        groupCounts.trash ?? 0,
+                      );
+                    }}
+                  >
+                    {__('Empty Trash', 'mailpoet')}
+                  </button>
+                </div>
+              )}
+              <DataViews.Layout />
+              <DataViews.Footer />
+            </DataViews>
           </div>
-          <DataViews.Layout />
-          <DataViews.Footer />
-        </DataViews>
-      </div>
+        )}
+      </TabPanel>
     </>
   );
 }

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -95,6 +95,8 @@ function bulkActionSuccessMessage(
 export function CustomFieldsPage() {
   const [group, setGroup] = useState<Group>('all');
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const [editingCustomField, setEditingCustomField] =
+    useState<CustomField | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
   const [view, setView] = useState<View>(DEFAULT_VIEW);
   const [items, setItems] = useState<CustomField[]>([]);
@@ -214,6 +216,17 @@ export function CustomFieldsPage() {
   const actions = useMemo<Action<CustomField>[]>(
     () => [
       {
+        id: 'edit',
+        label: __('Edit', 'mailpoet'),
+        isEligible: (item) => !item.deleted_at,
+        callback: (selected) => {
+          const [customField] = selected;
+          if (customField) {
+            setEditingCustomField(customField);
+          }
+        },
+      },
+      {
         id: 'trash',
         label: __('Move to trash', 'mailpoet'),
         supportsBulk: true,
@@ -319,6 +332,14 @@ export function CustomFieldsPage() {
     setRefreshToken((current) => current + 1);
   };
 
+  const handleEditSuccess = (customField: CustomField): void => {
+    setEditingCustomField(null);
+    setGlobalSuccess(
+      sprintf(__('Custom field "%s" updated.', 'mailpoet'), customField.name),
+    );
+    setRefreshToken((current) => current + 1);
+  };
+
   return (
     <>
       <TopBarWithBoundary />
@@ -411,6 +432,15 @@ export function CustomFieldsPage() {
           dateSettings={dateSettings}
           onClose={() => setIsCreateFormOpen(false)}
           onSuccess={handleCreateSuccess}
+        />
+      )}
+
+      {editingCustomField && (
+        <CustomFieldsForm
+          customField={editingCustomField}
+          dateSettings={dateSettings}
+          onClose={() => setEditingCustomField(null)}
+          onSuccess={handleEditSuccess}
         />
       )}
     </>

--- a/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/custom-fields-page.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { DataViews, View } from '@wordpress/dataviews';
+import { BackButton, PageHeader } from 'common/page-header';
+import { TopBarWithBoundary } from 'common/top-bar/top-bar';
+import { listFields } from './fields';
+import { getCustomFields, getSubscribersListingUrl } from './api';
+import type {
+  ApiErrorResponse,
+  CustomField,
+  CustomFieldListMeta,
+} from './types';
+
+const DEFAULT_VIEW: View = {
+  type: 'table',
+  perPage: 20,
+  page: 1,
+  sort: { field: 'name', direction: 'asc' },
+  fields: [
+    'label',
+    'type',
+    'subscribers_count',
+    'forms_count',
+    'dynamic_segments_count',
+    'created_at',
+  ],
+  titleField: 'name',
+  showTitle: true,
+};
+
+export function CustomFieldsPage() {
+  const [view, setView] = useState<View>(DEFAULT_VIEW);
+  const [items, setItems] = useState<CustomField[]>([]);
+  const [meta, setMeta] = useState<CustomFieldListMeta>({
+    count: 0,
+    pages: 0,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const latestRequestIdRef = useRef(0);
+
+  const loadCustomFields = useCallback(async () => {
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
+    setIsLoading(true);
+    try {
+      const requestedPage = view.page ?? 1;
+      const result = await getCustomFields({
+        search: view.search || '',
+        orderby: view.sort?.field ?? 'name',
+        order: view.sort?.direction ?? 'asc',
+        page: requestedPage,
+        per_page: view.perPage ?? 20,
+      });
+
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
+
+      const lastValidPage = Math.max(1, result.meta.pages);
+      if (requestedPage > lastValidPage) {
+        setView((currentView) => ({
+          ...currentView,
+          page: lastValidPage,
+        }));
+        return;
+      }
+
+      setItems(result.items);
+      setMeta(result.meta);
+    } catch (err) {
+      if (requestId !== latestRequestIdRef.current) {
+        return;
+      }
+      const apiError = err as ApiErrorResponse;
+      setGlobalError(
+        apiError?.message || __('Failed to load custom fields.', 'mailpoet'),
+      );
+    } finally {
+      if (requestId === latestRequestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [view.search, view.sort, view.page, view.perPage]);
+
+  useEffect(() => {
+    void loadCustomFields();
+  }, [loadCustomFields]);
+
+  const paginationInfo = useMemo(
+    () => ({ totalItems: meta.count, totalPages: meta.pages }),
+    [meta],
+  );
+
+  return (
+    <>
+      <TopBarWithBoundary />
+      <PageHeader
+        heading={__('Custom Fields', 'mailpoet')}
+        headingPrefix={
+          <BackButton
+            href={getSubscribersListingUrl()}
+            label={__('Subscribers', 'mailpoet')}
+            aria-label={__('Back to subscribers list', 'mailpoet')}
+          />
+        }
+      />
+
+      {globalError && (
+        <Notice status="error" onRemove={() => setGlobalError(null)}>
+          {globalError}
+        </Notice>
+      )}
+
+      <div className="mailpoet-custom-fields-dataviews">
+        <DataViews<CustomField>
+          data={items}
+          fields={listFields}
+          view={view}
+          onChangeView={setView}
+          paginationInfo={paginationInfo}
+          defaultLayouts={{ table: {} }}
+          getItemId={(item) => String(item.id)}
+          isLoading={isLoading}
+          empty={<div>{__('No custom fields yet.', 'mailpoet')}</div>}
+        >
+          <div className="mailpoet-custom-fields-dataviews__toolbar">
+            <DataViews.Search label={__('Search custom fields', 'mailpoet')} />
+          </div>
+          <DataViews.Layout />
+          <DataViews.Footer />
+        </DataViews>
+      </div>
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
@@ -1,0 +1,81 @@
+import { __ } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { createElement } from 'react';
+import type { Field } from '@wordpress/dataviews';
+import type { CustomField } from './types';
+
+const FIELD_TYPE_LABELS: Record<string, string> = {
+  text: __('Text', 'mailpoet'),
+  textarea: __('Textarea', 'mailpoet'),
+  radio: __('Radio buttons', 'mailpoet'),
+  checkbox: __('Checkbox', 'mailpoet'),
+  select: __('Select', 'mailpoet'),
+  date: __('Date', 'mailpoet'),
+};
+
+export const listFields: Field<CustomField>[] = [
+  {
+    id: 'name',
+    label: __('Name', 'mailpoet'),
+    type: 'text',
+    enableGlobalSearch: true,
+    enableSorting: true,
+  },
+  {
+    id: 'label',
+    label: __('Label', 'mailpoet'),
+    type: 'text',
+    enableGlobalSearch: false,
+    enableSorting: false,
+    render: ({ item }) => createElement('span', null, item.label || '—'),
+  },
+  {
+    id: 'type',
+    label: __('Type', 'mailpoet'),
+    type: 'text',
+    enableGlobalSearch: false,
+    enableSorting: true,
+    render: ({ item }) =>
+      createElement('span', null, FIELD_TYPE_LABELS[item.type] ?? item.type),
+  },
+  {
+    id: 'subscribers_count',
+    label: __('Subscribers', 'mailpoet'),
+    type: 'integer',
+    enableGlobalSearch: false,
+    enableSorting: true,
+    render: ({ item }) =>
+      createElement('span', null, item.subscribers_count.toLocaleString()),
+  },
+  {
+    id: 'forms_count',
+    label: __('Forms', 'mailpoet'),
+    type: 'integer',
+    enableGlobalSearch: false,
+    enableSorting: false,
+    render: ({ item }) =>
+      createElement('span', null, item.forms_count.toLocaleString()),
+  },
+  {
+    id: 'dynamic_segments_count',
+    label: __('Segments', 'mailpoet'),
+    type: 'integer',
+    enableGlobalSearch: false,
+    enableSorting: false,
+    render: ({ item }) =>
+      createElement('span', null, item.dynamic_segments_count.toLocaleString()),
+  },
+  {
+    id: 'created_at',
+    label: __('Created', 'mailpoet'),
+    type: 'datetime',
+    enableGlobalSearch: false,
+    enableSorting: true,
+    render: ({ item }) =>
+      createElement(
+        'span',
+        null,
+        item.created_at ? dateI18n('M j, Y', item.created_at, undefined) : '',
+      ),
+  },
+];

--- a/mailpoet/assets/js/src/subscribers/custom-fields/index.tsx
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/index.tsx
@@ -1,0 +1,21 @@
+import { createRoot } from 'react-dom/client';
+import { GlobalContext, useGlobalContextValue } from 'context';
+import { registerTranslations, ErrorBoundary } from 'common';
+import { CustomFieldsPage } from './custom-fields-page';
+
+function App() {
+  return (
+    <GlobalContext.Provider value={useGlobalContextValue(window)}>
+      <ErrorBoundary>
+        <CustomFieldsPage />
+      </ErrorBoundary>
+    </GlobalContext.Provider>
+  );
+}
+
+const container = document.getElementById('mailpoet_custom_fields_container');
+if (container) {
+  registerTranslations();
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
@@ -1,0 +1,25 @@
+export type CustomField = {
+  id: number;
+  name: string;
+  label: string;
+  type: string;
+  params: Record<string, unknown>;
+  subscribers_count: number;
+  forms_count: number;
+  dynamic_segments_count: number;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type CustomFieldListMeta = {
+  count: number;
+  pages: number;
+};
+
+export type ApiErrorResponse = {
+  code: string;
+  message: string;
+  data?: {
+    status?: number;
+  };
+};

--- a/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
@@ -12,6 +12,25 @@ export type CustomField = {
   deleted_at: string | null;
 };
 
+export type CustomFieldType =
+  | 'text'
+  | 'textarea'
+  | 'radio'
+  | 'checkbox'
+  | 'select'
+  | 'date';
+
+export type CustomFieldPayload = {
+  name: string;
+  type: CustomFieldType;
+  params: Record<string, unknown>;
+};
+
+export type CustomFieldDateSettings = {
+  dateTypes: Array<{ label: string; value: string }>;
+  dateFormats: Record<string, string[]>;
+};
+
 export type CustomFieldListMeta = {
   count: number;
   pages: number;

--- a/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/types.ts
@@ -9,11 +9,18 @@ export type CustomField = {
   dynamic_segments_count: number;
   created_at: string | null;
   updated_at: string | null;
+  deleted_at: string | null;
 };
 
 export type CustomFieldListMeta = {
   count: number;
   pages: number;
+};
+
+export type CustomFieldListGroup = {
+  name: 'all' | 'trash';
+  label: string;
+  count: number;
 };
 
 export type ApiErrorResponse = {

--- a/mailpoet/assets/js/src/subscribers/heading.tsx
+++ b/mailpoet/assets/js/src/subscribers/heading.tsx
@@ -14,50 +14,59 @@ export function SubscribersHeading() {
     <>
       <CompensateScreenOptions />
       <TopBarWithBoundary />
-      <PageHeader heading={__('Subscribers', 'mailpoet')}>
-        <Link
-          className="page-title-action"
-          to={
-            {
-              pathname: '/new',
-              state: {
-                backUrl: location?.pathname,
-              },
-            } as To
-          }
-        >
-          <span data-automation-id="add-new-subscribers-button">
-            {__('Add new subscriber', 'mailpoet')}
+      <PageHeader
+        className="mailpoet-subscribers-page-header"
+        heading={__('Subscribers', 'mailpoet')}
+      >
+        <span className="mailpoet-subscribers-heading-actions">
+          <span className="mailpoet-subscribers-heading-primary-actions">
+            <Link
+              className="page-title-action"
+              to={
+                {
+                  pathname: '/new',
+                  state: {
+                    backUrl: location?.pathname,
+                  },
+                } as To
+              }
+            >
+              <span data-automation-id="add-new-subscribers-button">
+                {__('Add new subscriber', 'mailpoet')}
+              </span>
+            </Link>
+            <a
+              className="page-title-action"
+              href="?page=mailpoet-import"
+              data-automation-id="import-subscribers-button"
+            >
+              {__('Import', 'mailpoet')}
+            </a>
+            <a
+              id="mailpoet_export_button"
+              className="page-title-action"
+              href="?page=mailpoet-export"
+            >
+              {__('Export', 'mailpoet')}
+            </a>
           </span>
-        </Link>
-        <a
-          className="page-title-action not-small-screen"
-          href="?page=mailpoet-import"
-          data-automation-id="import-subscribers-button"
-        >
-          {__('Import', 'mailpoet')}
-        </a>
-        <a
-          id="mailpoet_export_button"
-          className="page-title-action not-small-screen"
-          href="?page=mailpoet-export"
-        >
-          {__('Export', 'mailpoet')}
-        </a>
-        <a
-          className="page-title-action not-small-screen"
-          href="?page=mailpoet-tags"
-          data-automation-id="manage-tags-button"
-        >
-          {__('Tags', 'mailpoet')}
-        </a>
-        <a
-          className="page-title-action not-small-screen"
-          href="?page=mailpoet-custom-fields"
-          data-automation-id="manage-custom-fields-button"
-        >
-          {__('Custom fields', 'mailpoet')}
-        </a>
+          <span className="mailpoet-subscribers-heading-management-actions">
+            <a
+              className="page-title-action"
+              href="?page=mailpoet-tags"
+              data-automation-id="manage-tags-button"
+            >
+              {__('Tags', 'mailpoet')}
+            </a>
+            <a
+              className="page-title-action"
+              href="?page=mailpoet-custom-fields"
+              data-automation-id="manage-custom-fields-button"
+            >
+              {__('Custom fields', 'mailpoet')}
+            </a>
+          </span>
+        </span>
       </PageHeader>
       <div className="mailpoet-segment-subscriber-count">
         <SubscribersInPlan

--- a/mailpoet/assets/js/src/subscribers/heading.tsx
+++ b/mailpoet/assets/js/src/subscribers/heading.tsx
@@ -51,6 +51,13 @@ export function SubscribersHeading() {
         >
           {__('Tags', 'mailpoet')}
         </a>
+        <a
+          className="page-title-action not-small-screen"
+          href="?page=mailpoet-custom-fields"
+          data-automation-id="manage-custom-fields-button"
+        >
+          {__('Custom fields', 'mailpoet')}
+        </a>
       </PageHeader>
       <div className="mailpoet-segment-subscriber-count">
         <SubscribersInPlan

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { PreviousNextStepButtons } from './previous-next-step-buttons.jsx';
@@ -10,6 +10,8 @@ import { ExistingSubscribersStatus } from './step-data-manipulation/existing-sub
 import { UpdateExistingSubscribers } from './step-data-manipulation/update-existing-subscribers.jsx';
 import { doImport } from './step-data-manipulation/do-import.jsx';
 import { AssignTags } from './step-data-manipulation/assign-tags';
+import { CreateCustomFieldModal } from './step-data-manipulation/create-custom-field-modal';
+import { addCustomFieldColumn } from './step-data-manipulation/generate-column-selection.jsx';
 
 function getPreviousStepLink(importData, subscribersLimitForValidation) {
   if (importData === undefined) {
@@ -38,6 +40,26 @@ export function StepDataManipulation({
   const [existingSubscribersStatus, setExistingSubscribersStatus] =
     useState('dontUpdate');
   const [selectedTags, setSelectedTags] = useState([]);
+  const [customFieldSelectElement, setCustomFieldSelectElement] =
+    useState(null);
+  const customFieldDateSettings = useMemo(
+    () => ({
+      dateTypes: window.mailpoet_import_custom_fields_date_types ?? [],
+      dateFormats: window.mailpoet_import_custom_fields_date_formats ?? {},
+    }),
+    [],
+  );
+  const handleCreateCustomField = useCallback((selectElement) => {
+    setCustomFieldSelectElement(selectElement);
+  }, []);
+  const handleCustomFieldCreated = (customField) => {
+    if (!customFieldSelectElement) {
+      return;
+    }
+    addCustomFieldColumn(customFieldSelectElement, customField);
+    setCustomFieldSelectElement(null);
+  };
+
   useEffect(() => {
     if (typeof stepMethodSelectionData === 'undefined') {
       navigate('/step_method_selection', { replace: true });
@@ -69,6 +91,7 @@ export function StepDataManipulation({
         subscribersCount={stepMethodSelectionData.subscribersCount}
         subscribers={stepMethodSelectionData.subscribers}
         header={stepMethodSelectionData.header}
+        onCreateCustomField={handleCreateCustomField}
       />
       <div className="mailpoet-settings-grid">
         <SelectSegment setSelectedSegments={setSelectedSegments} />
@@ -102,6 +125,13 @@ export function StepDataManipulation({
           isLastStep
         />
       </div>
+      {customFieldSelectElement && (
+        <CreateCustomFieldModal
+          dateSettings={customFieldDateSettings}
+          onClose={() => setCustomFieldSelectElement(null)}
+          onSuccess={handleCustomFieldCreated}
+        />
+      )}
     </div>
   );
 }

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-custom-field-modal.tsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-custom-field-modal.tsx
@@ -1,0 +1,143 @@
+import { FormEvent, useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Modal,
+  __experimentalSpacer as Spacer,
+} from '@wordpress/components';
+import { MailPoet } from 'mailpoet';
+import type {
+  CustomField,
+  CustomFieldDateSettings,
+  CustomFieldPayload,
+} from '../../../custom-fields/types';
+import {
+  buildCustomFieldPayload,
+  CustomFieldFormFields,
+  getInitialCustomFieldFormData,
+  validateCustomFieldFormData,
+} from '../../../custom-fields/custom-field-form-fields';
+
+type Props = {
+  dateSettings: CustomFieldDateSettings;
+  onClose: () => void;
+  onSuccess: (customField: CustomField) => void;
+};
+
+type ApiErrorResponse = {
+  errors?: Array<{ message?: string }>;
+  message?: string;
+};
+
+type SaveCustomFieldResponse = {
+  data: CustomField;
+};
+
+function createCustomField(data: CustomFieldPayload): Promise<CustomField> {
+  return new Promise((resolve, reject) => {
+    void MailPoet.Ajax.post<SaveCustomFieldResponse>({
+      api_version: window.mailpoet_api_version,
+      endpoint: 'customFields',
+      action: 'save',
+      data,
+    })
+      .done((response) => resolve(response.data))
+      .fail((response: ApiErrorResponse) => reject(response));
+  });
+}
+
+function getApiErrorMessage(error: ApiErrorResponse): string {
+  return (
+    error?.errors?.[0]?.message ||
+    error?.message ||
+    MailPoet.I18n.t('customFieldCreateError') ||
+    __('Custom field could not be created', 'mailpoet')
+  );
+}
+
+export function CreateCustomFieldModal({
+  dateSettings,
+  onClose,
+  onSuccess,
+}: Props): JSX.Element {
+  const [data, setData] = useState(() =>
+    getInitialCustomFieldFormData(dateSettings),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const validationError = validateCustomFieldFormData(data);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      onSuccess(await createCustomField(buildCustomFieldPayload(data)));
+    } catch (err) {
+      setError(getApiErrorMessage(err as ApiErrorResponse));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={MailPoet.I18n.t('addNewField')}
+      onRequestClose={onClose}
+      className="mailpoet-custom-fields-form-modal"
+      focusOnMount
+    >
+      <form
+        onSubmit={handleSubmit}
+        data-automation-id="create_custom_field_form"
+      >
+        <CustomFieldFormFields
+          data={data}
+          dateSettings={dateSettings}
+          disabled={isSaving}
+          onChange={setData}
+        />
+
+        {error && (
+          <>
+            <Spacer marginTop={4} />
+            <div className="mailpoet-custom-fields-form-error" role="alert">
+              {error}
+            </div>
+          </>
+        )}
+        <Spacer marginTop={6} />
+        <Flex justify="flex-end" gap={3}>
+          <FlexItem>
+            <Button
+              variant="tertiary"
+              onClick={onClose}
+              disabled={isSaving}
+              __next40pxDefaultSize
+            >
+              {__('Cancel', 'mailpoet')}
+            </Button>
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant="primary"
+              type="submit"
+              isBusy={isSaving}
+              disabled={isSaving}
+              __next40pxDefaultSize
+            >
+              {__('Create custom field', 'mailpoet')}
+            </Button>
+          </FlexItem>
+        </Flex>
+      </form>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-custom-field-modal.tsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/create-custom-field-modal.tsx
@@ -8,10 +8,11 @@ import {
   __experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { MailPoet } from 'mailpoet';
+import { createCustomField } from '../../../custom-fields/api';
 import type {
+  ApiErrorResponse,
   CustomField,
   CustomFieldDateSettings,
-  CustomFieldPayload,
 } from '../../../custom-fields/types';
 import {
   buildCustomFieldPayload,
@@ -26,31 +27,8 @@ type Props = {
   onSuccess: (customField: CustomField) => void;
 };
 
-type ApiErrorResponse = {
-  errors?: Array<{ message?: string }>;
-  message?: string;
-};
-
-type SaveCustomFieldResponse = {
-  data: CustomField;
-};
-
-function createCustomField(data: CustomFieldPayload): Promise<CustomField> {
-  return new Promise((resolve, reject) => {
-    void MailPoet.Ajax.post<SaveCustomFieldResponse>({
-      api_version: window.mailpoet_api_version,
-      endpoint: 'customFields',
-      action: 'save',
-      data,
-    })
-      .done((response) => resolve(response.data))
-      .fail((response: ApiErrorResponse) => reject(response));
-  });
-}
-
 function getApiErrorMessage(error: ApiErrorResponse): string {
   return (
-    error?.errors?.[0]?.message ||
     error?.message ||
     MailPoet.I18n.t('customFieldCreateError') ||
     __('Custom field could not be created', 'mailpoet')

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/generate-column-selection.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/generate-column-selection.jsx
@@ -1,7 +1,84 @@
 import jQuery from 'jquery';
 import { MailPoet } from 'mailpoet';
 
-export const generateColumnSelection = () => {
+const getCustomFieldsGroup = () => {
+  let customFieldsGroup = window.mailpoetColumnsSelect2.find(
+    (group) => group.name === MailPoet.I18n.t('userColumns'),
+  );
+
+  if (!customFieldsGroup) {
+    const label = MailPoet.I18n.t('userColumns');
+    customFieldsGroup = {
+      name: label,
+      text: label,
+      children: [],
+    };
+    window.mailpoetColumnsSelect2.push(customFieldsGroup);
+  }
+
+  return customFieldsGroup;
+};
+
+const getColumnData = (customField) => ({
+  id: customField.id,
+  name: customField.name,
+  text: customField.name, // Required for select2 default functionality
+  type: customField.type,
+  params: customField.params,
+  custom: true,
+});
+
+export const addCustomFieldColumn = (selectElement, customField) => {
+  const newColumnData = getColumnData(customField);
+  const customFieldsGroup = getCustomFieldsGroup();
+  customFieldsGroup.children.push(newColumnData);
+  window.mailpoetColumns.push(newColumnData);
+  const newColumnId = `${newColumnData.id}`;
+
+  const select2Config = {
+    data: window.mailpoetColumnsSelect2,
+    width: '15em',
+  };
+
+  jQuery('select.mailpoet_subscribers_column_data_match').each(
+    (index, element) => {
+      const $element = jQuery(element);
+
+      if (element === selectElement) {
+        $element.find(`option[value="${newColumnId}"]`).remove();
+        $element.append(
+          new Option(newColumnData.text, newColumnId, true, true),
+        );
+        $element.data('column-id', newColumnData.id);
+        $element.attr('data-column-id', newColumnData.id);
+        $element.val(newColumnId).trigger('change');
+        $element.trigger({
+          type: 'select2:select',
+          params: {
+            data: {
+              ...newColumnData,
+              id: newColumnId,
+            },
+          },
+        });
+        $element
+          .next('.select2-container')
+          .find('.select2-selection__rendered')
+          .text(newColumnData.text)
+          .attr('title', newColumnData.text);
+        return;
+      }
+
+      const currentValue = $element.data('column-id');
+      $element.html('').select2('destroy').select2(select2Config);
+      $element.data('column-id', currentValue);
+      $element.attr('data-column-id', currentValue);
+      $element.val(`${currentValue}`).trigger('change');
+    },
+  );
+};
+
+export const generateColumnSelection = (onCreateCustomField) => {
   const select2Config = {
     data: window.mailpoetColumnsSelect2,
     width: '15em',
@@ -15,62 +92,7 @@ export const generateColumnSelection = () => {
       if (selectedOptionId === 'create') {
         selectEvent.preventDefault();
         jQuery(selectElement).select2('close');
-        MailPoet.Modal.popup({
-          title: MailPoet.I18n.t('addNewField'),
-          template: jQuery('#form_template_field_form').html(),
-        });
-        jQuery('#form_field_new')
-          .parsley()
-          .on('form:submit', () => {
-            // get data
-            const data = jQuery('#form_field_new').mailpoetSerializeObject();
-
-            // save custom field
-            MailPoet.Ajax.post({
-              api_version: window.mailpoet_api_version,
-              endpoint: 'customFields',
-              action: 'save',
-              data,
-            })
-              .done((response) => {
-                const newColumnData = {
-                  id: response.data.id,
-                  name: response.data.name,
-                  text: response.data.name, // Required for select2 default functionality
-                  type: response.data.type,
-                  params: response.data.params,
-                  custom: true,
-                };
-                // if this is the first custom column, create an "optgroup"
-                if (window.mailpoetColumnsSelect2.length === 2) {
-                  window.mailpoetColumnsSelect2.push({
-                    name: MailPoet.I18n.t('userColumns'),
-                    children: [],
-                  });
-                }
-                window.mailpoetColumnsSelect2[2].children.push(newColumnData);
-                window.mailpoetColumns.push(newColumnData);
-                jQuery('select.mailpoet_subscribers_column_data_match').each(
-                  () => {
-                    jQuery(selectElement)
-                      .html('')
-                      .select2('destroy')
-                      .select2(select2Config);
-                  },
-                );
-                jQuery(selectElement).data('column-id', newColumnData.id);
-                // close popup
-                MailPoet.Modal.close();
-              })
-              .fail((response) => {
-                if (response.errors.length > 0) {
-                  MailPoet.Notice.showApiErrorNotice(response, {
-                    positionAfter: '#field_name',
-                  });
-                }
-              });
-            return false;
-          });
+        onCreateCustomField(selectElement);
       } else {
         // CHANGE COLUMN
         // check for duplicate values in all select options

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/generate-column-selection.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/generate-column-selection.jsx
@@ -95,28 +95,32 @@ export const generateColumnSelection = (onCreateCustomField) => {
         onCreateCustomField(selectElement);
       } else {
         // CHANGE COLUMN
-        // check for duplicate values in all select options
-        jQuery('select.mailpoet_subscribers_column_data_match').each(() => {
-          const element = selectElement;
-          const elementId = jQuery(element).val();
-          // if another column has the same value and it's not an 'ignore',
-          // prompt user
-          if (elementId === selectedOptionId && elementId !== 'ignore') {
-            if (
-              // eslint-disable-next-line no-restricted-globals, no-alert
-              confirm(
-                `${MailPoet.I18n.t(
-                  'selectedValueAlreadyMatched',
-                )} ${MailPoet.I18n.t('confirmCorrespondingColumn')}`,
-              )
-            ) {
-              jQuery(element).data('column-id', 'ignore');
-            } else {
-              selectEvent.preventDefault();
-              jQuery(selectElement).select2('close');
+        // check for duplicate values in all other select options
+        jQuery('select.mailpoet_subscribers_column_data_match').each(
+          (index, element) => {
+            if (element === selectElement) {
+              return;
             }
-          }
-        });
+            const elementId = jQuery(element).val();
+            // if another column has the same value and it's not an 'ignore',
+            // prompt user
+            if (elementId === selectedOptionId && elementId !== 'ignore') {
+              if (
+                // eslint-disable-next-line no-restricted-globals, no-alert
+                confirm(
+                  `${MailPoet.I18n.t(
+                    'selectedValueAlreadyMatched',
+                  )} ${MailPoet.I18n.t('confirmCorrespondingColumn')}`,
+                )
+              ) {
+                jQuery(element).data('column-id', 'ignore');
+              } else {
+                selectEvent.preventDefault();
+                jQuery(selectElement).select2('close');
+              }
+            }
+          },
+        );
       }
     })
     .on('select2:select', (selectEvent) => {

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-table.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-table.jsx
@@ -13,10 +13,11 @@ function ColumnDataMatch({ header = [], subscribers }) {
     <tr>
       <th>{MailPoet.I18n.t('matchData')}</th>
       {matchedColumnTypes.map((columnType, i) => (
-        <th
-          // eslint-disable-next-line react/no-array-index-key
-          key={columnType.column_id + i}
-        >
+        // A stable index keeps the underlying <select> (and its select2 binding)
+        // intact when matchColumns reclassifies a column after a custom field is
+        // created mid-flow.
+        // eslint-disable-next-line react/no-array-index-key
+        <th key={i}>
           {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <select
             className="mailpoet_subscribers_column_data_match"

--- a/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-table.jsx
+++ b/mailpoet/assets/js/src/subscribers/import-export/import/step-data-manipulation/match-table.jsx
@@ -123,10 +123,15 @@ Subscribers.propTypes = {
   ).isRequired,
 };
 
-function MatchTable({ subscribersCount = 0, subscribers = [], header = [] }) {
+function MatchTable({
+  subscribersCount = 0,
+  subscribers = [],
+  header = [],
+  onCreateCustomField,
+}) {
   useLayoutEffect(() => {
-    generateColumnSelection();
-  });
+    generateColumnSelection(onCreateCustomField);
+  }, [onCreateCustomField]);
 
   return (
     <div className="subscribers_data">
@@ -159,6 +164,7 @@ MatchTable.propTypes = {
     ),
   ),
   header: PropTypes.arrayOf(PropTypes.string),
+  onCreateCustomField: PropTypes.func.isRequired,
 };
 
 export { MatchTable };

--- a/mailpoet/changelog/2026-05-04-06-28-30-added-add-custom-fields-management-for-subscribers.md
+++ b/mailpoet/changelog/2026-05-04-06-28-30-added-add-custom-fields-management-for-subscribers.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Add custom fields management for subscribers

--- a/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
+++ b/mailpoet/lib/API/JSON/ResponseBuilders/SubscribersResponseBuilder.php
@@ -137,7 +137,7 @@ class SubscribersResponseBuilder {
   }
 
   private function buildCustomFields(SubscriberEntity $subscriberEntity, array $data): array {
-    $customFields = $this->customFieldsRepository->findAll();
+    $customFields = $this->customFieldsRepository->findAllActive();
 
     foreach ($customFields as $customField) {
       $subscriberCustomField = $this->subscriberCustomFieldRepository->findOneBy(

--- a/mailpoet/lib/API/JSON/v1/CustomFields.php
+++ b/mailpoet/lib/API/JSON/v1/CustomFields.php
@@ -36,7 +36,7 @@ class CustomFields extends APIEndpoint {
   }
 
   public function getAll() {
-    $collection = $this->customFieldsRepository->findBy([], ['createdAt' => 'asc']);
+    $collection = $this->customFieldsRepository->findAllActive();
     return $this->successResponse($this->customFieldsResponseBuilder->buildBatch($collection));
   }
 

--- a/mailpoet/lib/API/MP/v1/CustomFields.php
+++ b/mailpoet/lib/API/MP/v1/CustomFields.php
@@ -48,7 +48,7 @@ class CustomFields {
       ],
     ];
 
-    $customFields = $this->customFieldsRepository->findAll();
+    $customFields = $this->customFieldsRepository->findAllActive();
     foreach ($customFields as $customField) {
       $result = [
         'id' => 'cf_' . $customField->getId(),

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -50,6 +50,12 @@ class AssetsController {
     $this->wp->wpEnqueueStyle('mailpoet_tags', $this->getCssUrl('mailpoet-tags.css'));
   }
 
+  public function setupCustomFieldsDependencies(): void {
+    $this->enqueueJsEntrypoint('custom_fields');
+    $this->setupDataViewsDependencies();
+    $this->wp->wpEnqueueStyle('mailpoet_custom_fields', $this->getCssUrl('mailpoet-custom-fields.css'));
+  }
+
   /**
    * Enqueue the WordPress component + DataViews styles required by listings
    * that render `@wordpress/dataviews`. Listings already shipped via the

--- a/mailpoet/lib/AdminPages/Pages/CustomFields.php
+++ b/mailpoet/lib/AdminPages/Pages/CustomFields.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
+use MailPoet\Form\Block\Date;
 use MailPoet\WP\Functions as WPFunctions;
 
 class CustomFields {
@@ -16,23 +17,36 @@ class CustomFields {
   /** @var WPFunctions */
   private $wp;
 
+  /** @var Date */
+  private $dateBlock;
+
   public function __construct(
     AssetsController $assetsController,
     PageRenderer $pageRenderer,
-    WPFunctions $wp
+    WPFunctions $wp,
+    Date $dateBlock
   ) {
     $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
     $this->wp = $wp;
+    $this->dateBlock = $dateBlock;
   }
 
   public function render(): void {
     $this->assetsController->setupCustomFieldsDependencies();
+    $dateTypes = $this->dateBlock->getDateTypes();
     $this->pageRenderer->displayPage('subscribers/custom_fields.html', [
       'api' => [
         'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
         'nonce' => $this->wp->wpCreateNonce('wp_rest'),
       ],
+      'date_types' => array_map(function ($label, $value) {
+        return [
+          'label' => $label,
+          'value' => $value,
+        ];
+      }, $dateTypes, array_keys($dateTypes)),
+      'date_formats' => $this->dateBlock->getDateFormats(),
       'subscribers_listing_url' => $this->wp->escUrlRaw($this->wp->adminUrl('admin.php?page=mailpoet-subscribers')),
     ]);
   }

--- a/mailpoet/lib/AdminPages/Pages/CustomFields.php
+++ b/mailpoet/lib/AdminPages/Pages/CustomFields.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\AdminPages\Pages;
+
+use MailPoet\AdminPages\AssetsController;
+use MailPoet\AdminPages\PageRenderer;
+use MailPoet\WP\Functions as WPFunctions;
+
+class CustomFields {
+  /** @var AssetsController */
+  private $assetsController;
+
+  /** @var PageRenderer */
+  private $pageRenderer;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    AssetsController $assetsController,
+    PageRenderer $pageRenderer,
+    WPFunctions $wp
+  ) {
+    $this->assetsController = $assetsController;
+    $this->pageRenderer = $pageRenderer;
+    $this->wp = $wp;
+  }
+
+  public function render(): void {
+    $this->assetsController->setupCustomFieldsDependencies();
+    $this->pageRenderer->displayPage('subscribers/custom_fields.html', [
+      'api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
+      'subscribers_listing_url' => $this->wp->escUrlRaw($this->wp->adminUrl('admin.php?page=mailpoet-subscribers')),
+    ]);
+  }
+}

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -102,7 +102,7 @@ class DynamicSegments {
     ]);
     $data['items_per_page'] = $this->listingPageLimit->getLimitPerPage('segments');
 
-    $customFields = $this->customFieldsRepository->findBy([], ['name' => 'asc']);
+    $customFields = $this->customFieldsRepository->findBy(['deletedAt' => null], ['name' => 'asc']);
     $data['custom_fields'] = $this->customFieldsResponseBuilder->buildBatch($customFields);
 
     $wpRoles = $this->wp->getEditableRoles();

--- a/mailpoet/lib/AdminPages/Pages/FormEditor.php
+++ b/mailpoet/lib/AdminPages/Pages/FormEditor.php
@@ -240,7 +240,7 @@ class FormEditor {
       $idParam = $_GET['id'] ?? null;
       $form = $this->getFormData(is_numeric($idParam) ? (int)$idParam : 0);
     }
-    $customFields = $this->customFieldsRepository->findAll();
+    $customFields = $this->customFieldsRepository->findAllActive();
     if (!$form instanceof FormEntity) {
       throw new NotFoundException('Form does not exist');
     }

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -63,7 +63,7 @@ class Subscribers {
         $field['params']['values'] = $values;
       }
       return $field;
-    }, $this->customFieldsRepository->findAll());
+    }, $this->customFieldsRepository->findAllActive());
 
     $data['date_formats'] = $this->dateBlock->getDateFormats();
     $data['month_names'] = $this->dateBlock->getMonthNames();

--- a/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
+++ b/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
@@ -25,8 +25,15 @@ class SubscribersImport {
   public function render() {
     $import = new ImportExportFactory(ImportExportFactory::IMPORT_ACTION);
     $data = $import->bootstrap();
+    $dateTypes = $this->dateBlock->getDateTypes();
     $data = array_merge($data, [
-      'date_types' => $this->dateBlock->getDateTypes(),
+      'date_types' => $dateTypes,
+      'custom_fields_date_types' => array_map(function ($label, $value) {
+        return [
+          'label' => $label,
+          'value' => $value,
+        ];
+      }, $dateTypes, array_keys($dateTypes)),
       'date_formats' => $this->dateBlock->getDateFormats(),
       'month_names' => $this->dateBlock->getMonthNames(),
       'role_based_emails' => json_encode(Validator::ROLE_EMAILS),

--- a/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
+++ b/mailpoet/lib/AdminPages/Pages/SubscribersImport.php
@@ -6,6 +6,7 @@ use MailPoet\AdminPages\PageRenderer;
 use MailPoet\Form\Block;
 use MailPoet\Services\Validator;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
+use MailPoet\WP\Functions as WPFunctions;
 
 class SubscribersImport {
   /** @var PageRenderer */
@@ -14,12 +15,17 @@ class SubscribersImport {
   /** @var Block\Date */
   private $dateBlock;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
     PageRenderer $pageRenderer,
-    Block\Date $dateBlock
+    Block\Date $dateBlock,
+    WPFunctions $wp
   ) {
     $this->pageRenderer = $pageRenderer;
     $this->dateBlock = $dateBlock;
+    $this->wp = $wp;
   }
 
   public function render() {
@@ -37,6 +43,10 @@ class SubscribersImport {
       'date_formats' => $this->dateBlock->getDateFormats(),
       'month_names' => $this->dateBlock->getMonthNames(),
       'role_based_emails' => json_encode(Validator::ROLE_EMAILS),
+      'custom_fields_api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
     ]);
     $this->pageRenderer->displayPage('subscribers/importExport/import.html', $data);
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberCustomFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberCustomFieldsFactory.php
@@ -31,7 +31,7 @@ class SubscriberCustomFieldsFactory {
   public function getFields(): array {
     return array_map(function (CustomFieldEntity $customField) {
       return $this->getField($customField);
-    }, $this->customFieldsRepository->findAll());
+    }, $this->customFieldsRepository->findAllActive());
   }
 
   private function getField(CustomFieldEntity $customField): Field {

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -14,6 +14,7 @@ use MailPoet\Automation\Integrations\MailPoet\MailPoetIntegration;
 use MailPoet\Automation\Integrations\WooCommerce\WooCommerceIntegration;
 use MailPoet\Cron\CronTrigger;
 use MailPoet\Cron\DaemonActionSchedulerRunner;
+use MailPoet\CustomFields\RestApi\Api as CustomFieldsRestApi;
 use MailPoet\EmailEditor\Integrations\MailPoet\Blocks\BlockTypesController;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEditorIntegration;
 use MailPoet\EmailEditor\Integrations\MailPoet\Logger;
@@ -115,6 +116,9 @@ class Initializer {
   /** @var TagsRestApi */
   private $tagsRestApi;
 
+  /** @var CustomFieldsRestApi */
+  private $customFieldsRestApi;
+
   /** @var FormsRestApi */
   private $formsRestApi;
 
@@ -183,6 +187,7 @@ class Initializer {
     MailpoetEmailEditorIntegration $mailpoetEmailEditorIntegration,
     Url $urlHelper,
     TagsRestApi $tagsRestApi,
+    CustomFieldsRestApi $customFieldsRestApi,
     FormsRestApi $formsRestApi,
     SegmentsRestApi $segmentsRestApi
   ) {
@@ -218,6 +223,7 @@ class Initializer {
     $this->blockTypesController = $blockTypesController;
     $this->urlHelper = $urlHelper;
     $this->tagsRestApi = $tagsRestApi;
+    $this->customFieldsRestApi = $customFieldsRestApi;
     $this->formsRestApi = $formsRestApi;
     $this->segmentsRestApi = $segmentsRestApi;
 
@@ -387,6 +393,7 @@ class Initializer {
       $this->postEditorBlock->init();
       $this->automationEngine->initialize();
       $this->tagsRestApi->initialize();
+      $this->customFieldsRestApi->initialize();
       $this->formsRestApi->initialize();
       $this->segmentsRestApi->initialize();
       $this->blockTypesController->initialize();

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -8,6 +8,7 @@ use MailPoet\AdminPages\Pages\AutomationEditor;
 use MailPoet\AdminPages\Pages\AutomationFlowEmbed;
 use MailPoet\AdminPages\Pages\AutomationPreviewEmbed;
 use MailPoet\AdminPages\Pages\AutomationTemplates;
+use MailPoet\AdminPages\Pages\CustomFields as CustomFieldsPage;
 use MailPoet\AdminPages\Pages\DynamicSegments;
 use MailPoet\AdminPages\Pages\ExperimentalFeatures;
 use MailPoet\AdminPages\Pages\FormEditor;
@@ -48,6 +49,7 @@ class Menu {
   const IMPORT_PAGE_SLUG = 'mailpoet-import';
   const EXPORT_PAGE_SLUG = 'mailpoet-export';
   const TAGS_PAGE_SLUG = 'mailpoet-tags';
+  const CUSTOM_FIELDS_PAGE_SLUG = 'mailpoet-custom-fields';
   const LISTS_PAGE_SLUG = 'mailpoet-lists';
   const SEGMENTS_PAGE_SLUG = 'mailpoet-segments';
   const SETTINGS_PAGE_SLUG = 'mailpoet-settings';
@@ -399,6 +401,19 @@ class Menu {
       ]
     );
 
+    // custom fields
+    $this->wp->addSubmenuPage(
+      self::SUBSCRIBERS_PAGE_SLUG,
+      $this->setPageTitle(__('Custom Fields', 'mailpoet')),
+      esc_html__('Custom Fields', 'mailpoet'),
+      AccessControl::PERMISSION_MANAGE_FORMS,
+      self::CUSTOM_FIELDS_PAGE_SLUG,
+      [
+        $this,
+        'customFields',
+      ]
+    );
+
     // Lists page
     $listsPage = $this->wp->addSubmenuPage(
       self::MAIN_PAGE_SLUG,
@@ -732,6 +747,10 @@ class Menu {
 
   public function tags() {
     $this->container->get(TagsPage::class)->render();
+  }
+
+  public function customFields() {
+    $this->container->get(CustomFieldsPage::class)->render();
   }
 
   public function formEditor() {

--- a/mailpoet/lib/Config/Menu.php
+++ b/mailpoet/lib/Config/Menu.php
@@ -406,7 +406,7 @@ class Menu {
       self::SUBSCRIBERS_PAGE_SLUG,
       $this->setPageTitle(__('Custom Fields', 'mailpoet')),
       esc_html__('Custom Fields', 'mailpoet'),
-      AccessControl::PERMISSION_MANAGE_FORMS,
+      AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
       self::CUSTOM_FIELDS_PAGE_SLUG,
       [
         $this,

--- a/mailpoet/lib/CustomFields/ApiDataSanitizer.php
+++ b/mailpoet/lib/CustomFields/ApiDataSanitizer.php
@@ -94,6 +94,9 @@ class ApiDataSanitizer {
   private function getExtraParamsForText($params) {
     if (isset($params['validate'])) {
       $validate = trim(strtolower($params['validate']));
+      if ($validate === '') {
+        return [];
+      }
       if (in_array($validate, ['number', 'alphanum', 'phone'], true)) {
         return ['validate' => $validate];
       }
@@ -128,7 +131,7 @@ class ApiDataSanitizer {
         $dateFormat = $inputDateFormat;
         break;
       case 'year_month':
-        if (!in_array($inputDateFormat, ['YYYY/MM', 'MM/YY'], true)) {
+        if (!in_array($inputDateFormat, ['YYYY/MM', 'MM/YYYY', 'MM/YY'], true)) {
           throw new InvalidArgumentException(__('Invalid date_format for year_month', 'mailpoet'), self::ERROR_INVALID_DATE_FORMAT);
         }
         $dateFormat = $inputDateFormat;
@@ -148,6 +151,7 @@ class ApiDataSanitizer {
     return [
       'date_type' => $dateType,
       'date_format' => $dateFormat,
+      'is_default_today' => !empty($params['is_default_today']) ? '1' : '',
     ];
   }
 

--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -29,6 +29,10 @@ class CustomFieldsRepository extends Repository {
   /**
    * @param array $data
    * @return CustomFieldEntity
+   *
+   * Updates the entity in place and does not touch `deletedAt`. Callers that
+   * accept ids from outside (REST endpoints, etc.) must reject trashed fields
+   * before calling this — otherwise the field stays trashed despite the update.
    */
   public function createOrUpdate($data) {
     // set name as label by default

--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -9,6 +9,7 @@ use MailPoet\Entities\FormEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
@@ -59,14 +60,127 @@ class CustomFieldsRepository extends Repository {
       ->createQueryBuilder()
       ->select('*')
       ->from($customFieldsTable)
+      ->where('deleted_at IS NULL')
       ->execute();
 
     return $query->fetchAllAssociative();
   }
 
   /**
-   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int} $args
-   * @return array{items: array<int, array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface}>, total: int}
+   * @return CustomFieldEntity[]
+   */
+  public function findAllActive(): array {
+    return $this->findBy(['deletedAt' => null], ['createdAt' => 'asc']);
+  }
+
+  public function deleteCustomField(CustomFieldEntity $customField): void {
+    $this->bulkTrash([(int)$customField->getId()]);
+  }
+
+  /**
+   * @param array<int|null> $ids
+   */
+  public function bulkTrash(array $ids): int {
+    $ids = $this->normalizeIds($ids);
+    if (!$ids) {
+      return 0;
+    }
+
+    $result = $this->entityManager->createQueryBuilder()
+      ->update(CustomFieldEntity::class, 'cf')
+      ->set('cf.deletedAt', 'CURRENT_TIMESTAMP()')
+      ->where('cf.id IN (:ids)')
+      ->andWhere('cf.deletedAt IS NULL')
+      ->setParameter('ids', $ids)
+      ->getQuery()->execute();
+
+    $this->refreshAll(function (CustomFieldEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
+    return $result;
+  }
+
+  /**
+   * @param array<int|null> $ids
+   */
+  public function bulkRestore(array $ids): int {
+    $ids = $this->normalizeIds($ids);
+    if (!$ids) {
+      return 0;
+    }
+
+    $result = $this->entityManager->createQueryBuilder()
+      ->update(CustomFieldEntity::class, 'cf')
+      ->set('cf.deletedAt', ':deletedAt')
+      ->where('cf.id IN (:ids)')
+      ->andWhere('cf.deletedAt IS NOT NULL')
+      ->setParameter('deletedAt', null)
+      ->setParameter('ids', $ids)
+      ->getQuery()->execute();
+
+    $this->refreshAll(function (CustomFieldEntity $entity) use ($ids) {
+      return in_array($entity->getId(), $ids, true);
+    });
+    return $result;
+  }
+
+  /**
+   * Permanently deletes trashed custom fields and removes references from
+   * subscriber values, forms, and dynamic segments.
+   *
+   * @param array<int|null> $ids
+   * @return int Number of custom fields deleted.
+   */
+  public function bulkDelete(array $ids): int {
+    $ids = $this->normalizeIds($ids);
+    if (!$ids) {
+      return 0;
+    }
+    $ids = $this->findTrashedIds($ids);
+    return $this->deleteTrashedByIds($ids);
+  }
+
+  public function emptyTrash(): int {
+    return $this->deleteTrashedByIds($this->findTrashedIds());
+  }
+
+  /**
+   * @param int[] $ids
+   */
+  private function deleteTrashedByIds(array $ids): int {
+    if (!$ids) {
+      return 0;
+    }
+    $deleted = 0;
+    $this->entityManager->transactional(function (EntityManager $entityManager) use ($ids, &$deleted): void {
+      $this->removeCustomFieldsFromForms($ids);
+      $this->removeCustomFieldsFromDynamicSegments($ids);
+
+      $subscriberCustomFieldTable = $entityManager->getClassMetadata(SubscriberCustomFieldEntity::class)->getTableName();
+      $entityManager->getConnection()->executeStatement(
+        "DELETE FROM $subscriberCustomFieldTable WHERE custom_field_id IN (:ids)",
+        ['ids' => $ids],
+        ['ids' => ArrayParameterType::INTEGER]
+      );
+
+      $customFieldsTable = $entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+      $deleted = (int)$entityManager->getConnection()->executeStatement(
+        "DELETE FROM $customFieldsTable WHERE id IN (:ids)",
+        ['ids' => $ids],
+        ['ids' => ArrayParameterType::INTEGER]
+      );
+    });
+
+    $this->entityManager->clear(CustomFieldEntity::class);
+    $this->entityManager->clear(SubscriberCustomFieldEntity::class);
+    $this->entityManager->clear(FormEntity::class);
+    $this->entityManager->clear(DynamicSegmentFilterEntity::class);
+    return $deleted;
+  }
+
+  /**
+   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int, group?: string} $args
+   * @return array{items: array<int, array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface, deleted_at: ?\DateTimeInterface}>, total: int, groups: array<int, array{name: string, label: string, count: int}>}
    */
   public function listWithCounts(array $args = []): array {
     $search = isset($args['search']) ? trim((string)$args['search']) : '';
@@ -74,6 +188,7 @@ class CustomFieldsRepository extends Repository {
     $order = isset($args['order']) && strtolower((string)$args['order']) === 'desc' ? 'DESC' : 'ASC';
     $page = isset($args['page']) ? max(1, (int)$args['page']) : 1;
     $perPage = isset($args['per_page']) ? max(1, min(100, (int)$args['per_page'])) : 25;
+    $group = isset($args['group']) && $args['group'] === 'trash' ? 'trash' : 'all';
 
     $sortable = [
       'name' => 'cf.name',
@@ -84,7 +199,7 @@ class CustomFieldsRepository extends Repository {
     $orderByExpr = $sortable[$orderby] ?? $sortable['name'];
 
     $qb = $this->entityManager->createQueryBuilder()
-      ->select('cf.id AS id, cf.name AS name, cf.type AS type, cf.params AS params, cf.createdAt AS created_at, cf.updatedAt AS updated_at, COUNT(DISTINCT s.id) AS subscribersCount')
+      ->select('cf.id AS id, cf.name AS name, cf.type AS type, cf.params AS params, cf.createdAt AS created_at, cf.updatedAt AS updated_at, cf.deletedAt AS deleted_at, COUNT(DISTINCT s.id) AS subscribersCount')
       ->from(CustomFieldEntity::class, 'cf')
       ->leftJoin(SubscriberCustomFieldEntity::class, 'scf', 'WITH', 'scf.customField = cf')
       ->leftJoin('scf.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
@@ -102,8 +217,9 @@ class CustomFieldsRepository extends Repository {
       $qb->andWhere('cf.name LIKE :search')
         ->setParameter('search', '%' . $search . '%');
     }
+    $this->applyGroup($qb, $group);
 
-    /** @var array<array{id: int, name: string, type: string, params: mixed, created_at: mixed, updated_at: mixed, subscribersCount: int|string}> $rows */
+    /** @var array<array{id: int, name: string, type: string, params: mixed, created_at: mixed, updated_at: mixed, deleted_at: mixed, subscribersCount: int|string}> $rows */
     $rows = $qb->getQuery()->getArrayResult();
 
     $countQb = $this->entityManager->createQueryBuilder()
@@ -113,7 +229,9 @@ class CustomFieldsRepository extends Repository {
       $countQb->andWhere('cf.name LIKE :search')
         ->setParameter('search', '%' . $search . '%');
     }
+    $this->applyGroup($countQb, $group);
     $total = (int)$countQb->getQuery()->getSingleScalarResult();
+    $groups = $this->getGroups();
 
     $customFieldIds = array_map('intval', array_column($rows, 'id'));
     $formsCounts = $this->getFormCountsByCustomFieldIds($customFieldIds);
@@ -126,6 +244,7 @@ class CustomFieldsRepository extends Repository {
       $label = isset($params['label']) && is_scalar($params['label']) ? (string)$params['label'] : (string)$row['name'];
       $createdAt = $row['created_at'] ?? null;
       $updatedAt = $row['updated_at'] ?? null;
+      $deletedAt = $row['deleted_at'] ?? null;
       $items[] = [
         'id' => $id,
         'name' => (string)$row['name'],
@@ -137,10 +256,87 @@ class CustomFieldsRepository extends Repository {
         'dynamic_segments_count' => $dynamicSegmentsCounts[$id] ?? 0,
         'created_at' => $createdAt instanceof \DateTimeInterface ? $createdAt : null,
         'updated_at' => $updatedAt instanceof \DateTimeInterface ? $updatedAt : null,
+        'deleted_at' => $deletedAt instanceof \DateTimeInterface ? $deletedAt : null,
       ];
     }
 
-    return ['items' => $items, 'total' => $total];
+    return ['items' => $items, 'total' => $total, 'groups' => $groups];
+  }
+
+  /**
+   * @return array<int, array{name: string, label: string, count: int}>
+   */
+  private function getGroups(): array {
+    $activeCount = $this->countByDeletedAt(false);
+    $trashedCount = $this->countByDeletedAt(true);
+    return [
+      [
+        'name' => 'all',
+        'label' => __('All', 'mailpoet'),
+        'count' => $activeCount,
+      ],
+      [
+        'name' => 'trash',
+        'label' => __('Trash', 'mailpoet'),
+        'count' => $trashedCount,
+      ],
+    ];
+  }
+
+  private function countByDeletedAt(bool $trashed): int {
+    $queryBuilder = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(cf.id)')
+      ->from(CustomFieldEntity::class, 'cf');
+    $this->applyGroup($queryBuilder, $trashed ? 'trash' : 'all');
+    return (int)$queryBuilder->getQuery()->getSingleScalarResult();
+  }
+
+  private function applyGroup(\MailPoetVendor\Doctrine\ORM\QueryBuilder $queryBuilder, string $group): void {
+    if ($group === 'trash') {
+      $queryBuilder->andWhere('cf.deletedAt IS NOT NULL');
+    } else {
+      $queryBuilder->andWhere('cf.deletedAt IS NULL');
+    }
+  }
+
+  /**
+   * @param array<int|null> $ids
+   * @return int[]
+   */
+  private function normalizeIds(array $ids): array {
+    return array_values(array_filter(array_map(
+      static function ($id): int {
+        return (int)$id;
+      },
+      $ids
+    )));
+  }
+
+  /**
+   * @param int[]|null $ids
+   * @return int[]
+   */
+  private function findTrashedIds(?array $ids = null): array {
+    $customFieldsTable = $this->entityManager->getClassMetadata(CustomFieldEntity::class)->getTableName();
+    $queryBuilder = $this->entityManager->getConnection()
+      ->createQueryBuilder()
+      ->select('id')
+      ->from($customFieldsTable)
+      ->where('deleted_at IS NOT NULL');
+    if ($ids !== null) {
+      $queryBuilder
+        ->andWhere('id IN (:ids)')
+        ->setParameter('ids', $ids, ArrayParameterType::INTEGER);
+    }
+    $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+    $trashedIds = [];
+    foreach ($rows as $row) {
+      $id = $row['id'] ?? null;
+      if (is_int($id) || is_string($id)) {
+        $trashedIds[] = (int)$id;
+      }
+    }
+    return $trashedIds;
   }
 
   /**
@@ -176,6 +372,83 @@ class CustomFieldsRepository extends Repository {
     }
 
     return $counts;
+  }
+
+  /**
+   * @param int[] $customFieldIds
+   */
+  private function removeCustomFieldsFromForms(array $customFieldIds): void {
+    $customFieldIdsLookup = array_flip($customFieldIds);
+    /** @var FormEntity[] $forms */
+    $forms = $this->entityManager->createQueryBuilder()
+      ->select('f')
+      ->from(FormEntity::class, 'f')
+      ->getQuery()
+      ->getResult();
+
+    foreach ($forms as $form) {
+      $body = $form->getBody();
+      if (!is_array($body)) {
+        continue;
+      }
+      $updatedBody = $this->removeCustomFieldBlocks($body, $customFieldIdsLookup);
+      if ($updatedBody !== $body) {
+        $form->setBody($updatedBody);
+      }
+    }
+  }
+
+  /**
+   * @param array<mixed, mixed> $blocks
+   * @param array<int, int> $customFieldIdsLookup
+   * @return array<int, mixed>
+   */
+  private function removeCustomFieldBlocks(array $blocks, array $customFieldIdsLookup): array {
+    $updated = [];
+    foreach ($blocks as $block) {
+      if (!is_array($block)) {
+        $updated[] = $block;
+        continue;
+      }
+
+      $rawCustomFieldId = $block['id'] ?? null;
+      $customFieldId = is_int($rawCustomFieldId) || is_string($rawCustomFieldId) ? (int)$rawCustomFieldId : 0;
+      $type = isset($block['type']) && is_string($block['type']) ? $block['type'] : null;
+      if ($type !== null && in_array($type, FormEntity::FORM_FIELD_TYPES, true) && isset($customFieldIdsLookup[$customFieldId])) {
+        continue;
+      }
+
+      if (isset($block['body']) && is_array($block['body'])) {
+        $block['body'] = $this->removeCustomFieldBlocks($block['body'], $customFieldIdsLookup);
+      }
+      $updated[] = $block;
+    }
+    return $updated;
+  }
+
+  /**
+   * @param int[] $customFieldIds
+   */
+  private function removeCustomFieldsFromDynamicSegments(array $customFieldIds): void {
+    $customFieldIdsLookup = array_flip($customFieldIds);
+    /** @var DynamicSegmentFilterEntity[] $filters */
+    $filters = $this->entityManager->createQueryBuilder()
+      ->select('dsf')
+      ->from(DynamicSegmentFilterEntity::class, 'dsf')
+      ->where('dsf.filterData.action = :action')
+      ->setParameter('action', MailPoetCustomFields::TYPE)
+      ->getQuery()
+      ->getResult();
+
+    foreach ($filters as $filter) {
+      $customFieldIdParam = $filter->getFilterData()->getParam('custom_field_id');
+      if (!is_int($customFieldIdParam) && !is_string($customFieldIdParam)) {
+        continue;
+      }
+      if (isset($customFieldIdsLookup[(int)$customFieldIdParam])) {
+        $this->entityManager->remove($filter);
+      }
+    }
   }
 
   /**

--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -77,6 +77,17 @@ class CustomFieldsRepository extends Repository {
     $this->bulkTrash([(int)$customField->getId()]);
   }
 
+  public function hasSubscriberValues(int $customFieldId): bool {
+    $count = (int)$this->entityManager->createQueryBuilder()
+      ->select('COUNT(scf.id)')
+      ->from(SubscriberCustomFieldEntity::class, 'scf')
+      ->where('scf.customField = :id')
+      ->setParameter('id', $customFieldId)
+      ->setMaxResults(1)
+      ->getQuery()->getSingleScalarResult();
+    return $count > 0;
+  }
+
   /**
    * @param array<int|null> $ids
    */

--- a/mailpoet/lib/CustomFields/CustomFieldsRepository.php
+++ b/mailpoet/lib/CustomFields/CustomFieldsRepository.php
@@ -4,11 +4,23 @@ namespace MailPoet\CustomFields;
 
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\FormEntity;
+use MailPoet\Entities\SegmentEntity;
+use MailPoet\Entities\SubscriberCustomFieldEntity;
+use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 /**
  * @extends Repository<CustomFieldEntity>
  */
 class CustomFieldsRepository extends Repository {
+  public function __construct(
+    EntityManager $entityManager
+  ) {
+    parent::__construct($entityManager);
+  }
+
   protected function getEntityClassName() {
     return CustomFieldEntity::class;
   }
@@ -50,5 +62,164 @@ class CustomFieldsRepository extends Repository {
       ->execute();
 
     return $query->fetchAllAssociative();
+  }
+
+  /**
+   * @param array{search?: string, orderby?: string, order?: string, page?: int, per_page?: int} $args
+   * @return array{items: array<int, array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface}>, total: int}
+   */
+  public function listWithCounts(array $args = []): array {
+    $search = isset($args['search']) ? trim((string)$args['search']) : '';
+    $orderby = isset($args['orderby']) && is_string($args['orderby']) ? $args['orderby'] : 'name';
+    $order = isset($args['order']) && strtolower((string)$args['order']) === 'desc' ? 'DESC' : 'ASC';
+    $page = isset($args['page']) ? max(1, (int)$args['page']) : 1;
+    $perPage = isset($args['per_page']) ? max(1, min(100, (int)$args['per_page'])) : 25;
+
+    $sortable = [
+      'name' => 'cf.name',
+      'type' => 'cf.type',
+      'created_at' => 'cf.createdAt',
+      'subscribers_count' => 'subscribersCount',
+    ];
+    $orderByExpr = $sortable[$orderby] ?? $sortable['name'];
+
+    $qb = $this->entityManager->createQueryBuilder()
+      ->select('cf.id AS id, cf.name AS name, cf.type AS type, cf.params AS params, cf.createdAt AS created_at, cf.updatedAt AS updated_at, COUNT(DISTINCT s.id) AS subscribersCount')
+      ->from(CustomFieldEntity::class, 'cf')
+      ->leftJoin(SubscriberCustomFieldEntity::class, 'scf', 'WITH', 'scf.customField = cf')
+      ->leftJoin('scf.subscriber', 's', 'WITH', 's.deletedAt IS NULL')
+      ->groupBy('cf.id')
+      ->orderBy($orderByExpr, $order);
+
+    if ($orderby !== 'name') {
+      $qb->addOrderBy('cf.name', 'ASC');
+    }
+    $qb->addOrderBy('cf.id', 'ASC')
+      ->setFirstResult(($page - 1) * $perPage)
+      ->setMaxResults($perPage);
+
+    if ($search !== '') {
+      $qb->andWhere('cf.name LIKE :search')
+        ->setParameter('search', '%' . $search . '%');
+    }
+
+    /** @var array<array{id: int, name: string, type: string, params: mixed, created_at: mixed, updated_at: mixed, subscribersCount: int|string}> $rows */
+    $rows = $qb->getQuery()->getArrayResult();
+
+    $countQb = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(cf.id)')
+      ->from(CustomFieldEntity::class, 'cf');
+    if ($search !== '') {
+      $countQb->andWhere('cf.name LIKE :search')
+        ->setParameter('search', '%' . $search . '%');
+    }
+    $total = (int)$countQb->getQuery()->getSingleScalarResult();
+
+    $customFieldIds = array_map('intval', array_column($rows, 'id'));
+    $formsCounts = $this->getFormCountsByCustomFieldIds($customFieldIds);
+    $dynamicSegmentsCounts = $this->getDynamicSegmentCountsByCustomFieldIds($customFieldIds);
+
+    $items = [];
+    foreach ($rows as $row) {
+      $id = (int)$row['id'];
+      $params = is_array($row['params']) ? $row['params'] : [];
+      $label = isset($params['label']) && is_scalar($params['label']) ? (string)$params['label'] : (string)$row['name'];
+      $createdAt = $row['created_at'] ?? null;
+      $updatedAt = $row['updated_at'] ?? null;
+      $items[] = [
+        'id' => $id,
+        'name' => (string)$row['name'],
+        'label' => $label,
+        'type' => (string)$row['type'],
+        'params' => $params,
+        'subscribers_count' => (int)$row['subscribersCount'],
+        'forms_count' => $formsCounts[$id] ?? 0,
+        'dynamic_segments_count' => $dynamicSegmentsCounts[$id] ?? 0,
+        'created_at' => $createdAt instanceof \DateTimeInterface ? $createdAt : null,
+        'updated_at' => $updatedAt instanceof \DateTimeInterface ? $updatedAt : null,
+      ];
+    }
+
+    return ['items' => $items, 'total' => $total];
+  }
+
+  /**
+   * @param int[] $customFieldIds
+   * @return array<int, int>
+   */
+  private function getFormCountsByCustomFieldIds(array $customFieldIds): array {
+    if (!$customFieldIds) {
+      return [];
+    }
+
+    $customFieldIdsLookup = array_flip($customFieldIds);
+    $counts = array_fill_keys($customFieldIds, 0);
+    /** @var FormEntity[] $forms */
+    $forms = $this->entityManager->createQueryBuilder()
+      ->select('f')
+      ->from(FormEntity::class, 'f')
+      ->where('f.deletedAt IS NULL')
+      ->getQuery()
+      ->getResult();
+
+    foreach ($forms as $form) {
+      $formCustomFieldIds = [];
+      foreach ($form->getBlocksByTypes(FormEntity::FORM_FIELD_TYPES) as $block) {
+        $customFieldId = isset($block['id']) ? (int)$block['id'] : 0;
+        if (isset($customFieldIdsLookup[$customFieldId])) {
+          $formCustomFieldIds[$customFieldId] = true;
+        }
+      }
+      foreach (array_keys($formCustomFieldIds) as $customFieldId) {
+        $counts[$customFieldId]++;
+      }
+    }
+
+    return $counts;
+  }
+
+  /**
+   * @param int[] $customFieldIds
+   * @return array<int, int>
+   */
+  private function getDynamicSegmentCountsByCustomFieldIds(array $customFieldIds): array {
+    if (!$customFieldIds) {
+      return [];
+    }
+
+    $customFieldIdsLookup = array_flip($customFieldIds);
+    $segmentIdsByCustomFieldId = array_fill_keys($customFieldIds, []);
+    /** @var DynamicSegmentFilterEntity[] $filters */
+    $filters = $this->entityManager->createQueryBuilder()
+      ->select('dsf')
+      ->from(DynamicSegmentFilterEntity::class, 'dsf')
+      ->join('dsf.segment', 's')
+      ->where('s.deletedAt IS NULL')
+      ->andWhere('dsf.filterData.action = :action')
+      ->setParameter('action', MailPoetCustomFields::TYPE)
+      ->getQuery()
+      ->getResult();
+
+    foreach ($filters as $filter) {
+      $customFieldIdParam = $filter->getFilterData()->getParam('custom_field_id');
+      if (!is_int($customFieldIdParam) && !is_string($customFieldIdParam)) {
+        continue;
+      }
+      $customFieldId = (int)$customFieldIdParam;
+      if (!isset($customFieldIdsLookup[$customFieldId])) {
+        continue;
+      }
+      $segment = $filter->getSegment();
+      if (!$segment instanceof SegmentEntity) {
+        continue;
+      }
+      $segmentIdsByCustomFieldId[$customFieldId][(int)$segment->getId()] = true;
+    }
+
+    $counts = [];
+    foreach ($segmentIdsByCustomFieldId as $customFieldId => $segmentIds) {
+      $counts[$customFieldId] = count($segmentIds);
+    }
+    return $counts;
   }
 }

--- a/mailpoet/lib/CustomFields/RestApi/Api.php
+++ b/mailpoet/lib/CustomFields/RestApi/Api.php
@@ -3,6 +3,7 @@
 namespace MailPoet\CustomFields\RestApi;
 
 use MailPoet\API\REST\API as RestApi;
+use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -24,6 +25,7 @@ class Api {
   public function initialize(): void {
     $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
       $this->api->registerGetRoute('custom-fields', CustomFieldsGetEndpoint::class);
+      $this->api->registerPostRoute('custom-fields/bulk-action', CustomFieldsBulkActionEndpoint::class);
     });
   }
 }

--- a/mailpoet/lib/CustomFields/RestApi/Api.php
+++ b/mailpoet/lib/CustomFields/RestApi/Api.php
@@ -5,6 +5,7 @@ namespace MailPoet\CustomFields\RestApi;
 use MailPoet\API\REST\API as RestApi;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint;
+use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPostEndpoint;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Api {
@@ -25,6 +26,7 @@ class Api {
   public function initialize(): void {
     $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
       $this->api->registerGetRoute('custom-fields', CustomFieldsGetEndpoint::class);
+      $this->api->registerPostRoute('custom-fields', CustomFieldsPostEndpoint::class);
       $this->api->registerPostRoute('custom-fields/bulk-action', CustomFieldsBulkActionEndpoint::class);
     });
   }

--- a/mailpoet/lib/CustomFields/RestApi/Api.php
+++ b/mailpoet/lib/CustomFields/RestApi/Api.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi;
+
+use MailPoet\API\REST\API as RestApi;
+use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Api {
+  /** @var RestApi */
+  private $api;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    RestApi $api,
+    WPFunctions $wp
+  ) {
+    $this->api = $api;
+    $this->wp = $wp;
+  }
+
+  public function initialize(): void {
+    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
+      $this->api->registerGetRoute('custom-fields', CustomFieldsGetEndpoint::class);
+    });
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Api.php
+++ b/mailpoet/lib/CustomFields/RestApi/Api.php
@@ -6,6 +6,7 @@ use MailPoet\API\REST\API as RestApi;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPostEndpoint;
+use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPutEndpoint;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Api {
@@ -27,6 +28,7 @@ class Api {
     $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
       $this->api->registerGetRoute('custom-fields', CustomFieldsGetEndpoint::class);
       $this->api->registerPostRoute('custom-fields', CustomFieldsPostEndpoint::class);
+      $this->api->registerPutRoute('custom-fields/(?P<id>\d+)', CustomFieldsPutEndpoint::class);
       $this->api->registerPostRoute('custom-fields/bulk-action', CustomFieldsBulkActionEndpoint::class);
     });
   }

--- a/mailpoet/lib/CustomFields/RestApi/Api.php
+++ b/mailpoet/lib/CustomFields/RestApi/Api.php
@@ -4,6 +4,7 @@ namespace MailPoet\CustomFields\RestApi;
 
 use MailPoet\API\REST\API as RestApi;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint;
+use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsDuplicateEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPostEndpoint;
 use MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPutEndpoint;
@@ -29,6 +30,7 @@ class Api {
       $this->api->registerGetRoute('custom-fields', CustomFieldsGetEndpoint::class);
       $this->api->registerPostRoute('custom-fields', CustomFieldsPostEndpoint::class);
       $this->api->registerPutRoute('custom-fields/(?P<id>\d+)', CustomFieldsPutEndpoint::class);
+      $this->api->registerPostRoute('custom-fields/(?P<id>\d+)/duplicate', CustomFieldsDuplicateEndpoint::class);
       $this->api->registerPostRoute('custom-fields/bulk-action', CustomFieldsBulkActionEndpoint::class);
     });
   }

--- a/mailpoet/lib/CustomFields/RestApi/CustomFieldApiException.php
+++ b/mailpoet/lib/CustomFields/RestApi/CustomFieldApiException.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi;
+
+use MailPoet\API\REST\ApiException;
+use Throwable;
+
+class CustomFieldApiException extends ApiException {
+  /**
+   * @param array<string, string> $errors
+   */
+  public function __construct(
+    string $message,
+    int $statusCode = 400,
+    string $errorCode = 'mailpoet_custom_fields_error',
+    array $errors = [],
+    ?Throwable $previous = null
+  ) {
+    parent::__construct($message, $statusCode, $errorCode, $errors, $previous);
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsBulkActionEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsBulkActionEndpoint.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\CustomFields\RestApi\CustomFieldApiException;
+use MailPoet\Validator\Builder;
+
+class CustomFieldsBulkActionEndpoint extends CustomFieldsEndpoint {
+  private const ACTION_TRASH = 'trash';
+  private const ACTION_RESTORE = 'restore';
+  private const ACTION_DELETE = 'delete';
+  private const ACTION_EMPTY_TRASH = 'empty_trash';
+
+  private const SUPPORTED_ACTIONS = [
+    self::ACTION_TRASH,
+    self::ACTION_RESTORE,
+    self::ACTION_DELETE,
+    self::ACTION_EMPTY_TRASH,
+  ];
+
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  public function __construct(
+    CustomFieldsRepository $customFieldsRepository
+  ) {
+    $this->customFieldsRepository = $customFieldsRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $action = is_string($request->getParam('action')) ? (string)$request->getParam('action') : '';
+    if (!in_array($action, self::SUPPORTED_ACTIONS, true)) {
+      throw new CustomFieldApiException(
+        // translators: %s is the list of supported bulk actions.
+        sprintf(__('Unsupported bulk action. Allowed values are: %s.', 'mailpoet'), implode(', ', self::SUPPORTED_ACTIONS)),
+        400,
+        'mailpoet_custom_fields_invalid_bulk_action'
+      );
+    }
+
+    $ids = $this->getIds($request, $action);
+    $count = 0;
+    if ($action === self::ACTION_TRASH) {
+      $count = $this->customFieldsRepository->bulkTrash($ids);
+    } elseif ($action === self::ACTION_RESTORE) {
+      $count = $this->customFieldsRepository->bulkRestore($ids);
+    } elseif ($action === self::ACTION_DELETE) {
+      $count = $this->customFieldsRepository->bulkDelete($ids);
+    } elseif ($action === self::ACTION_EMPTY_TRASH) {
+      $count = $this->customFieldsRepository->emptyTrash();
+    }
+
+    return new Response([
+      'action' => $action,
+      'count' => $count,
+    ]);
+  }
+
+  /**
+   * @return int[]
+   */
+  private function getIds(Request $request, string $action): array {
+    if ($action === self::ACTION_EMPTY_TRASH) {
+      return [];
+    }
+
+    $rawIds = $request->getParam('ids');
+    if (!is_array($rawIds) || $rawIds === []) {
+      throw new CustomFieldApiException(
+        __('At least one custom field id is required.', 'mailpoet'),
+        400,
+        'mailpoet_custom_fields_ids_required'
+      );
+    }
+
+    $ids = array_values(array_filter(
+      array_map(
+        static function ($id): int {
+          return is_int($id) || is_string($id) ? (int)$id : 0;
+        },
+        $rawIds
+      ),
+      static function (int $id): bool {
+        return $id > 0;
+      }
+    ));
+    if ($ids === []) {
+      throw new CustomFieldApiException(
+        __('At least one custom field id is required.', 'mailpoet'),
+        400,
+        'mailpoet_custom_fields_ids_required'
+      );
+    }
+    return $ids;
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'action' => Builder::string()->required(),
+      'ids' => Builder::array(Builder::integer()),
+    ];
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsDuplicateEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsDuplicateEndpoint.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\CustomFields\RestApi\CustomFieldApiException;
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Validator\Builder;
+
+class CustomFieldsDuplicateEndpoint extends CustomFieldsEndpoint {
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  public function __construct(
+    CustomFieldsRepository $customFieldsRepository
+  ) {
+    $this->customFieldsRepository = $customFieldsRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $customField = $this->customFieldsRepository->findOneById($this->getId($request));
+    if (!$customField instanceof CustomFieldEntity || $customField->getDeletedAt() !== null) {
+      throw new CustomFieldApiException(
+        __('The custom field does not exist.', 'mailpoet'),
+        404,
+        'mailpoet_custom_fields_not_found'
+      );
+    }
+
+    $params = $customField->getParams() ?: [];
+    $params['label'] = $this->getDuplicateLabel($params, $customField->getName());
+    $duplicate = $this->customFieldsRepository->createOrUpdate([
+      'name' => $this->getDuplicateName($customField->getName()),
+      'type' => $customField->getType(),
+      'params' => $params,
+    ]);
+
+    return new Response($this->buildItem($duplicate), 201);
+  }
+
+  private function getId(Request $request): int {
+    $rawId = $request->getParam('id');
+    return (int)(is_scalar($rawId) ? $rawId : 0);
+  }
+
+  private function getDuplicateName(string $name): string {
+    /* translators: %s is the original custom field name. */
+    $candidate = sprintf(__('%s copy', 'mailpoet'), $name);
+    $suffix = 2;
+    while ($this->customFieldsRepository->findOneBy(['name' => $candidate]) instanceof CustomFieldEntity) {
+      /* translators: %1$s is the original custom field name, %2$d is the copy number. */
+      $candidate = sprintf(__('%1$s copy %2$d', 'mailpoet'), $name, $suffix);
+      $suffix++;
+    }
+    return $candidate;
+  }
+
+  private function getDuplicateLabel(array $params, string $fallback): string {
+    $label = isset($params['label']) && is_scalar($params['label']) ? (string)$params['label'] : $fallback;
+    /* translators: %s is the original custom field label. */
+    return sprintf(__('%s copy', 'mailpoet'), $label);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsDuplicateEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsDuplicateEndpoint.php
@@ -8,6 +8,7 @@ use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\CustomFields\RestApi\CustomFieldApiException;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Validator\Builder;
+use MailPoetVendor\Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 class CustomFieldsDuplicateEndpoint extends CustomFieldsEndpoint {
   /** @var CustomFieldsRepository */
@@ -31,11 +32,29 @@ class CustomFieldsDuplicateEndpoint extends CustomFieldsEndpoint {
 
     $params = $customField->getParams() ?: [];
     $params['label'] = $this->getDuplicateLabel($params, $customField->getName());
-    $duplicate = $this->customFieldsRepository->createOrUpdate([
-      'name' => $this->getDuplicateName($customField->getName()),
-      'type' => $customField->getType(),
-      'params' => $params,
-    ]);
+
+    $attempts = 0;
+    while (true) {
+      try {
+        $duplicate = $this->customFieldsRepository->createOrUpdate([
+          'name' => $this->getDuplicateName($customField->getName()),
+          'type' => $customField->getType(),
+          'params' => $params,
+        ]);
+        break;
+      } catch (UniqueConstraintViolationException $exception) {
+        // A concurrent duplicate request picked the same candidate name. Recompute and retry.
+        if (++$attempts >= 3) {
+          throw new CustomFieldApiException(
+            __('A custom field with this name already exists.', 'mailpoet'),
+            409,
+            'mailpoet_custom_fields_duplicate',
+            [],
+            $exception
+          );
+        }
+      }
+    }
 
     return new Response($this->buildItem($duplicate), 201);
   }

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
@@ -4,6 +4,7 @@ namespace MailPoet\CustomFields\RestApi\Endpoints;
 
 use MailPoet\API\REST\Endpoint;
 use MailPoet\Config\AccessControl;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\WP\Functions as WPFunctions;
 
 abstract class CustomFieldsEndpoint extends Endpoint {
@@ -11,6 +12,24 @@ abstract class CustomFieldsEndpoint extends Endpoint {
 
   public function checkPermissions(): bool {
     return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_FORMS);
+  }
+
+  protected function buildItem(CustomFieldEntity $customField): array {
+    $params = $customField->getParams();
+    $label = isset($params['label']) && is_scalar($params['label']) ? (string)$params['label'] : $customField->getName();
+    return [
+      'id' => (int)$customField->getId(),
+      'name' => $customField->getName(),
+      'label' => $label,
+      'type' => $customField->getType(),
+      'params' => $params,
+      'subscribers_count' => 0,
+      'forms_count' => 0,
+      'dynamic_segments_count' => 0,
+      'created_at' => ($createdAt = $customField->getCreatedAt()) ? $createdAt->format(self::DATE_FORMAT) : null,
+      'updated_at' => ($updatedAt = $customField->getUpdatedAt()) ? $updatedAt->format(self::DATE_FORMAT) : null,
+      'deleted_at' => ($deletedAt = $customField->getDeletedAt()) ? $deletedAt->format(self::DATE_FORMAT) : null,
+    ];
   }
 
   /**

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
@@ -14,7 +14,7 @@ abstract class CustomFieldsEndpoint extends Endpoint {
   }
 
   /**
-   * @param array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface} $row
+   * @param array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface, deleted_at: ?\DateTimeInterface} $row
    */
   protected function buildItemFromRow(array $row): array {
     return [
@@ -28,6 +28,7 @@ abstract class CustomFieldsEndpoint extends Endpoint {
       'dynamic_segments_count' => (int)$row['dynamic_segments_count'],
       'created_at' => $row['created_at'] instanceof \DateTimeInterface ? $row['created_at']->format(self::DATE_FORMAT) : null,
       'updated_at' => $row['updated_at'] instanceof \DateTimeInterface ? $row['updated_at']->format(self::DATE_FORMAT) : null,
+      'deleted_at' => $row['deleted_at'] instanceof \DateTimeInterface ? $row['deleted_at']->format(self::DATE_FORMAT) : null,
     ];
   }
 }

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi\Endpoints;
+
+use MailPoet\API\REST\Endpoint;
+use MailPoet\Config\AccessControl;
+use MailPoet\WP\Functions as WPFunctions;
+
+abstract class CustomFieldsEndpoint extends Endpoint {
+  private const DATE_FORMAT = 'Y-m-d H:i:s';
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_FORMS);
+  }
+
+  /**
+   * @param array{id: int, name: string, label: string, type: string, params: array, subscribers_count: int, forms_count: int, dynamic_segments_count: int, created_at: ?\DateTimeInterface, updated_at: ?\DateTimeInterface} $row
+   */
+  protected function buildItemFromRow(array $row): array {
+    return [
+      'id' => (int)$row['id'],
+      'name' => (string)$row['name'],
+      'label' => (string)$row['label'],
+      'type' => (string)$row['type'],
+      'params' => $row['params'],
+      'subscribers_count' => (int)$row['subscribers_count'],
+      'forms_count' => (int)$row['forms_count'],
+      'dynamic_segments_count' => (int)$row['dynamic_segments_count'],
+      'created_at' => $row['created_at'] instanceof \DateTimeInterface ? $row['created_at']->format(self::DATE_FORMAT) : null,
+      'updated_at' => $row['updated_at'] instanceof \DateTimeInterface ? $row['updated_at']->format(self::DATE_FORMAT) : null,
+    ];
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsEndpoint.php
@@ -11,7 +11,7 @@ abstract class CustomFieldsEndpoint extends Endpoint {
   private const DATE_FORMAT = 'Y-m-d H:i:s';
 
   public function checkPermissions(): bool {
-    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_FORMS);
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_MANAGE_SUBSCRIBERS);
   }
 
   protected function buildItem(CustomFieldEntity $customField): array {

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsGetEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsGetEndpoint.php
@@ -23,6 +23,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
     $order = is_string($request->getParam('order')) ? (string)$request->getParam('order') : 'asc';
     $page = is_numeric($request->getParam('page')) ? max(1, (int)$request->getParam('page')) : 1;
     $perPage = is_numeric($request->getParam('per_page')) ? max(1, min(100, (int)$request->getParam('per_page'))) : 25;
+    $group = is_string($request->getParam('group')) ? (string)$request->getParam('group') : 'all';
 
     $result = $this->customFieldsRepository->listWithCounts([
       'search' => $search,
@@ -30,6 +31,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
       'order' => $order,
       'page' => $page,
       'per_page' => $perPage,
+      'group' => $group,
     ]);
 
     $items = array_map([$this, 'buildItemFromRow'], $result['items']);
@@ -41,6 +43,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
         'count' => $result['total'],
         'pages' => $pages,
       ],
+      'groups' => $result['groups'],
     ]);
   }
 
@@ -51,6 +54,7 @@ class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
       'order' => Builder::string(),
       'page' => Builder::integer(),
       'per_page' => Builder::integer(),
+      'group' => Builder::string(),
     ];
   }
 }

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsGetEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsGetEndpoint.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Validator\Builder;
+
+class CustomFieldsGetEndpoint extends CustomFieldsEndpoint {
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  public function __construct(
+    CustomFieldsRepository $customFieldsRepository
+  ) {
+    $this->customFieldsRepository = $customFieldsRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $search = is_string($request->getParam('search')) ? (string)$request->getParam('search') : '';
+    $orderby = is_string($request->getParam('orderby')) ? (string)$request->getParam('orderby') : 'name';
+    $order = is_string($request->getParam('order')) ? (string)$request->getParam('order') : 'asc';
+    $page = is_numeric($request->getParam('page')) ? max(1, (int)$request->getParam('page')) : 1;
+    $perPage = is_numeric($request->getParam('per_page')) ? max(1, min(100, (int)$request->getParam('per_page'))) : 25;
+
+    $result = $this->customFieldsRepository->listWithCounts([
+      'search' => $search,
+      'orderby' => $orderby,
+      'order' => $order,
+      'page' => $page,
+      'per_page' => $perPage,
+    ]);
+
+    $items = array_map([$this, 'buildItemFromRow'], $result['items']);
+    $pages = $result['total'] === 0 ? 0 : (int)ceil($result['total'] / max(1, $perPage));
+
+    return new Response([
+      'items' => $items,
+      'meta' => [
+        'count' => $result['total'],
+        'pages' => $pages,
+      ],
+    ]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'search' => Builder::string(),
+      'orderby' => Builder::string(),
+      'order' => Builder::string(),
+      'page' => Builder::integer(),
+      'per_page' => Builder::integer(),
+    ];
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPostEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPostEndpoint.php
@@ -10,6 +10,7 @@ use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\CustomFields\RestApi\CustomFieldApiException;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Validator\Builder;
+use MailPoetVendor\Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 class CustomFieldsPostEndpoint extends CustomFieldsEndpoint {
   /** @var CustomFieldsRepository */
@@ -48,7 +49,18 @@ class CustomFieldsPostEndpoint extends CustomFieldsEndpoint {
       );
     }
 
-    $customField = $this->customFieldsRepository->createOrUpdate($data);
+    try {
+      $customField = $this->customFieldsRepository->createOrUpdate($data);
+    } catch (UniqueConstraintViolationException $exception) {
+      // Concurrent request created a field with the same name between the duplicate-name check and the insert.
+      throw new CustomFieldApiException(
+        __('A custom field with this name already exists.', 'mailpoet'),
+        409,
+        'mailpoet_custom_fields_duplicate',
+        [],
+        $exception
+      );
+    }
     return new Response($this->buildItem($customField), 201);
   }
 

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPostEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPostEndpoint.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi\Endpoints;
+
+use InvalidArgumentException;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\CustomFields\ApiDataSanitizer;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\CustomFields\RestApi\CustomFieldApiException;
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Validator\Builder;
+
+class CustomFieldsPostEndpoint extends CustomFieldsEndpoint {
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  /** @var ApiDataSanitizer */
+  private $apiDataSanitizer;
+
+  public function __construct(
+    CustomFieldsRepository $customFieldsRepository,
+    ApiDataSanitizer $apiDataSanitizer
+  ) {
+    $this->customFieldsRepository = $customFieldsRepository;
+    $this->apiDataSanitizer = $apiDataSanitizer;
+  }
+
+  public function handle(Request $request): Response {
+    try {
+      $data = $this->apiDataSanitizer->sanitize($this->getRequestData($request));
+    } catch (InvalidArgumentException $exception) {
+      throw new CustomFieldApiException(
+        $exception->getMessage(),
+        400,
+        'mailpoet_custom_fields_invalid_data',
+        [],
+        $exception
+      );
+    }
+
+    $existing = $this->customFieldsRepository->findOneBy(['name' => $data['name']]);
+    if ($existing instanceof CustomFieldEntity) {
+      throw new CustomFieldApiException(
+        __('A custom field with this name already exists.', 'mailpoet'),
+        409,
+        'mailpoet_custom_fields_duplicate'
+      );
+    }
+
+    $customField = $this->customFieldsRepository->createOrUpdate($data);
+    return new Response($this->buildItem($customField), 201);
+  }
+
+  /**
+   * @return array{name: string, type: string, params: array}
+   */
+  private function getRequestData(Request $request): array {
+    $rawName = $request->getParam('name');
+    $rawType = $request->getParam('type');
+    $rawParams = $request->getParam('params');
+    return [
+      'name' => sanitize_text_field(is_scalar($rawName) ? (string)$rawName : ''),
+      'type' => sanitize_key(is_scalar($rawType) ? (string)$rawType : ''),
+      'params' => is_array($rawParams) ? $this->sanitizeParams($rawParams) : [],
+    ];
+  }
+
+  private function sanitizeParams(array $params): array {
+    $sanitized = [];
+    foreach ($params as $key => $value) {
+      if (is_array($value)) {
+        $sanitized[$key] = $this->sanitizeParams($value);
+      } elseif (is_scalar($value)) {
+        $sanitized[$key] = sanitize_text_field((string)$value);
+      }
+    }
+    return $sanitized;
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'name' => Builder::string()->required()->minLength(1),
+      'type' => Builder::string()->required()->minLength(1),
+      'params' => Builder::object(),
+    ];
+  }
+}

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPutEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPutEndpoint.php
@@ -10,6 +10,7 @@ use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\CustomFields\RestApi\CustomFieldApiException;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Validator\Builder;
+use MailPoetVendor\Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 class CustomFieldsPutEndpoint extends CustomFieldsEndpoint {
   /** @var CustomFieldsRepository */
@@ -59,7 +60,18 @@ class CustomFieldsPutEndpoint extends CustomFieldsEndpoint {
     }
 
     $data['id'] = $id;
-    $customField = $this->customFieldsRepository->createOrUpdate($data);
+    try {
+      $customField = $this->customFieldsRepository->createOrUpdate($data);
+    } catch (UniqueConstraintViolationException $exception) {
+      // Concurrent request renamed another field to this name between the duplicate-name check and the update.
+      throw new CustomFieldApiException(
+        __('A custom field with this name already exists.', 'mailpoet'),
+        409,
+        'mailpoet_custom_fields_duplicate',
+        [],
+        $exception
+      );
+    }
     return new Response($this->buildItem($customField));
   }
 

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPutEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPutEndpoint.php
@@ -38,8 +38,21 @@ class CustomFieldsPutEndpoint extends CustomFieldsEndpoint {
       );
     }
 
+    $requestData = $this->getRequestData($request);
+    if (
+      $requestData['type'] !== ''
+      && $requestData['type'] !== $customField->getType()
+      && $this->customFieldsRepository->hasSubscriberValues($id)
+    ) {
+      throw new CustomFieldApiException(
+        __('The custom field type cannot be changed because subscribers have values stored for this field.', 'mailpoet'),
+        409,
+        'mailpoet_custom_fields_type_locked'
+      );
+    }
+
     try {
-      $data = $this->apiDataSanitizer->sanitize($this->getRequestData($request));
+      $data = $this->apiDataSanitizer->sanitize($requestData);
     } catch (InvalidArgumentException $exception) {
       throw new CustomFieldApiException(
         $exception->getMessage(),

--- a/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPutEndpoint.php
+++ b/mailpoet/lib/CustomFields/RestApi/Endpoints/CustomFieldsPutEndpoint.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\CustomFields\RestApi\Endpoints;
+
+use InvalidArgumentException;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\CustomFields\ApiDataSanitizer;
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\CustomFields\RestApi\CustomFieldApiException;
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Validator\Builder;
+
+class CustomFieldsPutEndpoint extends CustomFieldsEndpoint {
+  /** @var CustomFieldsRepository */
+  private $customFieldsRepository;
+
+  /** @var ApiDataSanitizer */
+  private $apiDataSanitizer;
+
+  public function __construct(
+    CustomFieldsRepository $customFieldsRepository,
+    ApiDataSanitizer $apiDataSanitizer
+  ) {
+    $this->customFieldsRepository = $customFieldsRepository;
+    $this->apiDataSanitizer = $apiDataSanitizer;
+  }
+
+  public function handle(Request $request): Response {
+    $id = $this->getId($request);
+    $customField = $this->customFieldsRepository->findOneById($id);
+    if (!$customField instanceof CustomFieldEntity || $customField->getDeletedAt() !== null) {
+      throw new CustomFieldApiException(
+        __('The custom field does not exist.', 'mailpoet'),
+        404,
+        'mailpoet_custom_fields_not_found'
+      );
+    }
+
+    try {
+      $data = $this->apiDataSanitizer->sanitize($this->getRequestData($request));
+    } catch (InvalidArgumentException $exception) {
+      throw new CustomFieldApiException(
+        $exception->getMessage(),
+        400,
+        'mailpoet_custom_fields_invalid_data',
+        [],
+        $exception
+      );
+    }
+
+    $existing = $this->customFieldsRepository->findOneBy(['name' => $data['name']]);
+    if ($existing instanceof CustomFieldEntity && $existing->getId() !== $id) {
+      throw new CustomFieldApiException(
+        __('A custom field with this name already exists.', 'mailpoet'),
+        409,
+        'mailpoet_custom_fields_duplicate'
+      );
+    }
+
+    $data['id'] = $id;
+    $customField = $this->customFieldsRepository->createOrUpdate($data);
+    return new Response($this->buildItem($customField));
+  }
+
+  private function getId(Request $request): int {
+    $rawId = $request->getParam('id');
+    return (int)(is_scalar($rawId) ? $rawId : 0);
+  }
+
+  /**
+   * @return array{name: string, type: string, params: array}
+   */
+  private function getRequestData(Request $request): array {
+    $rawName = $request->getParam('name');
+    $rawType = $request->getParam('type');
+    $rawParams = $request->getParam('params');
+    return [
+      'name' => sanitize_text_field(is_scalar($rawName) ? (string)$rawName : ''),
+      'type' => sanitize_key(is_scalar($rawType) ? (string)$rawType : ''),
+      'params' => is_array($rawParams) ? $this->sanitizeParams($rawParams) : [],
+    ];
+  }
+
+  private function sanitizeParams(array $params): array {
+    $sanitized = [];
+    foreach ($params as $key => $value) {
+      if (is_array($value)) {
+        $sanitized[$key] = $this->sanitizeParams($value);
+      } elseif (is_scalar($value)) {
+        $sanitized[$key] = sanitize_text_field((string)$value);
+      }
+    }
+    return $sanitized;
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+      'name' => Builder::string()->required()->minLength(1),
+      'type' => Builder::string()->required()->minLength(1),
+      'params' => Builder::object(),
+    ];
+  }
+}

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -714,6 +714,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagsBulkDeleteEndpoint::class)->setPublic(true);
     // Custom fields REST API
     $container->autowire(\MailPoet\CustomFields\RestApi\Api::class)->setPublic(true);
+    $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsDuplicateEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPostEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPutEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -715,6 +715,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Custom fields REST API
     $container->autowire(\MailPoet\CustomFields\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint::class)->setPublic(true);
     // Forms REST API
     $container->autowire(\MailPoet\Form\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\RestApi\Endpoints\FormsListingEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -715,6 +715,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Custom fields REST API
     $container->autowire(\MailPoet\CustomFields\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPostEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint::class)->setPublic(true);
     // Forms REST API
     $container->autowire(\MailPoet\Form\RestApi\Api::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -54,6 +54,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersExport::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\SubscribersImport::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Tags::class)->setPublic(true);
+    $container->autowire(\MailPoet\AdminPages\Pages\CustomFields::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\WelcomeWizard::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\WooCommerceSetup::class)->setPublic(true);
     $container->autowire(\MailPoet\AdminPages\Pages\Landingpage::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -716,6 +716,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\CustomFields\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPostEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsBulkActionEndpoint::class)->setPublic(true);
     // Forms REST API
     $container->autowire(\MailPoet\Form\RestApi\Api::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -711,6 +711,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagPutEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagDeleteEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Tags\RestApi\Endpoints\TagsBulkDeleteEndpoint::class)->setPublic(true);
+    // Custom fields REST API
+    $container->autowire(\MailPoet\CustomFields\RestApi\Api::class)->setPublic(true);
+    $container->autowire(\MailPoet\CustomFields\RestApi\Endpoints\CustomFieldsGetEndpoint::class)->setPublic(true);
     // Forms REST API
     $container->autowire(\MailPoet\Form\RestApi\Api::class)->setPublic(true);
     $container->autowire(\MailPoet\Form\RestApi\Endpoints\FormsListingEndpoint::class)->setPublic(true);

--- a/mailpoet/lib/Entities/CustomFieldEntity.php
+++ b/mailpoet/lib/Entities/CustomFieldEntity.php
@@ -4,6 +4,7 @@ namespace MailPoet\Entities;
 
 use MailPoet\Doctrine\EntityTraits\AutoincrementedIdTrait;
 use MailPoet\Doctrine\EntityTraits\CreatedAtTrait;
+use MailPoet\Doctrine\EntityTraits\DeletedAtTrait;
 use MailPoet\Doctrine\EntityTraits\UpdatedAtTrait;
 use MailPoetVendor\Doctrine\ORM\Mapping as ORM;
 use MailPoetVendor\Symfony\Component\Validator\Constraints as Assert;
@@ -22,6 +23,7 @@ class CustomFieldEntity {
 
   use AutoincrementedIdTrait;
   use CreatedAtTrait;
+  use DeletedAtTrait;
   use UpdatedAtTrait;
 
   /**

--- a/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php
@@ -147,7 +147,6 @@ class Migration_20221028_105818 extends DbMigration {
       'params longtext NOT NULL,',
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
-      'deleted_at timestamp NULL,',
       'PRIMARY KEY  (id),',
       'UNIQUE KEY name (name)',
     ];

--- a/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20221028_105818.php
@@ -147,6 +147,7 @@ class Migration_20221028_105818 extends DbMigration {
       'params longtext NOT NULL,',
       'created_at timestamp NULL,', // must be NULL, see comment at the top
       'updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,',
+      'deleted_at timestamp NULL,',
       'PRIMARY KEY  (id),',
       'UNIQUE KEY name (name)',
     ];

--- a/mailpoet/lib/Migrations/Db/Migration_20260430_103000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260430_103000_Db.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\CustomFieldEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260430_103000_Db extends DbMigration {
+  public function run(): void {
+    $customFieldsTable = $this->getTableName(CustomFieldEntity::class);
+    if (!$this->columnExists($customFieldsTable, 'deleted_at')) {
+      $this->connection->executeQuery(
+        "ALTER TABLE `{$customFieldsTable}`
+          ADD COLUMN `deleted_at` TIMESTAMP NULL DEFAULT NULL"
+      );
+    }
+  }
+}

--- a/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
+++ b/mailpoet/lib/Newsletter/Shortcodes/ShortcodesHelper.php
@@ -141,7 +141,7 @@ class ShortcodesHelper {
   }
 
   public function getCustomFields(): array {
-    $customFields = $this->customFieldsRepository->findAll();
+    $customFields = $this->customFieldsRepository->findAllActive();
     return array_map(function($customField) {
       return [
         'text' => $customField->getName(),

--- a/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
@@ -242,7 +242,7 @@ class Export {
    */
   public function getSubscriberCustomFields(): array {
     $result = [];
-    foreach ($this->customFieldsRepository->findAll() as $customField) {
+    foreach ($this->customFieldsRepository->findAllActive() as $customField) {
       $result[(int)$customField->getId()] = $customField->getName();
     }
     return $result;

--- a/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Import/Import.php
@@ -581,7 +581,7 @@ class Import {
     // check if custom fields exist in the database
     $subscribersCustomFieldsIds = array_map(function(CustomFieldEntity $customField): int {
       return (int)$customField->getId();
-    }, $this->customFieldsRepository->findByIds($subscribersCustomFieldsIds));
+    }, $this->customFieldsRepository->findBy(['id' => $subscribersCustomFieldsIds, 'deletedAt' => null]));
     if (!$subscribersCustomFieldsIds) {
       return;
     }

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
@@ -125,7 +125,7 @@ class SubscriberExporter {
       return $this->customFields;
     }
 
-    $fields = $this->customFieldsRepository->findAll();
+    $fields = $this->customFieldsRepository->findAllActive();
     foreach ($fields as $field) {
       $fieldId = $field->getId();
       if ($fieldId !== null) {

--- a/mailpoet/lib/Subscribers/RequiredCustomFieldValidator.php
+++ b/mailpoet/lib/Subscribers/RequiredCustomFieldValidator.php
@@ -55,9 +55,9 @@ class RequiredCustomFieldValidator {
       if (!$ids) {
         return [];
       }
-      $requiredCustomFields = $this->customFieldRepository->findByIds($ids);
+      $requiredCustomFields = $this->customFieldRepository->findBy(['id' => $ids, 'deletedAt' => null]);
     } else {
-      $requiredCustomFields = $this->customFieldRepository->findAll();
+      $requiredCustomFields = $this->customFieldRepository->findAllActive();
     }
 
     foreach ($requiredCustomFields as $customField) {

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -313,7 +313,7 @@ class SubscriberSaveController {
       return;
     }
 
-    $customFields = $this->customFieldsRepository->findBy(['id' => array_keys($customFieldsMap)]);
+    $customFields = $this->customFieldsRepository->findBy(['id' => array_keys($customFieldsMap), 'deletedAt' => null]);
     foreach ($customFields as $customField) {
       $this->subscriberCustomFieldRepository->createOrUpdate($subscriber, $customField, $customFieldsMap[$customField->getId()]);
     }

--- a/mailpoet/lib/Subscription/Manage.php
+++ b/mailpoet/lib/Subscription/Manage.php
@@ -213,7 +213,7 @@ class Manage {
    */
   private function getMandatory(): array {
     $mandatory = [];
-    $requiredCustomFields = $this->customFieldsRepository->findAll();
+    $requiredCustomFields = $this->customFieldsRepository->findAllActive();
     foreach ($requiredCustomFields as $customField) {
       $params = $customField->getParams();
       if (

--- a/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
+++ b/mailpoet/lib/Subscription/ManageSubscriptionFormRenderer.php
@@ -145,7 +145,7 @@ class ManageSubscriptionFormRenderer {
       }
 
       return $customField;
-    }, $this->customFieldsRepository->findAll());
+    }, $this->customFieldsRepository->findAllActive());
   }
 
   private function getBasicFields(SubscriberEntity $subscriber): array {

--- a/mailpoet/tests/DataFactories/DynamicSegment.php
+++ b/mailpoet/tests/DataFactories/DynamicSegment.php
@@ -3,8 +3,10 @@
 namespace MailPoet\Test\DataFactories;
 
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Segments\DynamicSegments\Filters\MailPoetCustomFields;
 use MailPoet\Segments\DynamicSegments\Filters\SubscriberScore;
 use MailPoet\Segments\DynamicSegments\Filters\UserRole;
 use MailPoet\Segments\DynamicSegments\SegmentSaveController;
@@ -33,6 +35,16 @@ class DynamicSegment extends Segment {
     $this->filterData['value'] = $score;
     $this->filterData['operator'] = $operator;
     $this->filterData['action'] = SubscriberScore::TYPE;
+    return $this;
+  }
+
+  public function withCustomFieldFilter(CustomFieldEntity $customField) {
+    $this->filterData['segmentType'] = 'userRole';
+    $this->filterData['action'] = MailPoetCustomFields::TYPE;
+    $this->filterData['custom_field_id'] = $customField->getId();
+    $this->filterData['custom_field_type'] = $customField->getType();
+    $this->filterData['operator'] = DynamicSegmentFilterData::IS_NOT_BLANK;
+    $this->filterData['value'] = '';
     return $this;
   }
 

--- a/mailpoet/tests/integration/CustomFields/CustomFieldsRepositoryTest.php
+++ b/mailpoet/tests/integration/CustomFields/CustomFieldsRepositoryTest.php
@@ -3,18 +3,27 @@
 namespace MailPoet\Test\CustomFields;
 
 use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\FormEntity;
+use MailPoet\Entities\SubscriberCustomFieldEntity;
+use MailPoet\Form\FormsRepository;
 use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
 use MailPoet\Test\DataFactories\DynamicSegment as DynamicSegmentFactory;
 use MailPoet\Test\DataFactories\Form as FormFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
 
 class CustomFieldsRepositoryTest extends \MailPoetTest {
   /** @var CustomFieldsRepository */
   private $repository;
 
+  /** @var EntityManager */
+  private $orm;
+
   public function _before() {
     parent::_before();
     $this->repository = $this->diContainer->get(CustomFieldsRepository::class);
+    $this->orm = $this->diContainer->get(EntityManager::class);
   }
 
   public function testListWithCountsReturnsCustomFieldsWithUsageCounts(): void {
@@ -78,11 +87,131 @@ class CustomFieldsRepositoryTest extends \MailPoetTest {
     $this->assertSame(['Customers', 'Prospects'], array_column($page1['items'], 'name'));
   }
 
+  public function testListWithCountsSupportsTrashGroup(): void {
+    $active = (new CustomFieldFactory())->withName('Active')->create();
+    $trashed = (new CustomFieldFactory())->withName('Trashed')->create();
+
+    $this->repository->bulkTrash([(int)$trashed->getId()]);
+
+    $activeResult = $this->repository->listWithCounts();
+    $this->assertSame(1, $activeResult['total']);
+    $this->assertSame('Active', $activeResult['items'][0]['name']);
+    $this->assertSame(1, $this->getGroupCount($activeResult['groups'], 'all'));
+    $this->assertSame(1, $this->getGroupCount($activeResult['groups'], 'trash'));
+
+    $trashResult = $this->repository->listWithCounts(['group' => 'trash']);
+    $this->assertSame(1, $trashResult['total']);
+    $this->assertSame('Trashed', $trashResult['items'][0]['name']);
+    $this->assertNotNull($trashResult['items'][0]['deleted_at']);
+
+    $activeIds = array_map('intval', array_column($this->repository->findAllAsArray(), 'id'));
+    $this->assertContains((int)$active->getId(), $activeIds);
+    $this->assertNotContains((int)$trashed->getId(), $activeIds);
+  }
+
+  public function testBulkTrashAndRestoreCustomFields(): void {
+    $customField = (new CustomFieldFactory())->withName('Restorable')->create();
+
+    $this->assertSame(1, $this->repository->bulkTrash([(int)$customField->getId()]));
+    $trashedField = $this->repository->findOneById($customField->getId());
+    $this->assertNotNull($trashedField);
+    $this->assertNotNull($trashedField->getDeletedAt());
+
+    $this->assertSame(1, $this->repository->bulkRestore([(int)$customField->getId()]));
+    $restoredField = $this->repository->findOneById($customField->getId());
+    $this->assertNotNull($restoredField);
+    $this->assertNull($restoredField->getDeletedAt());
+  }
+
+  public function testBulkDeleteRemovesTrashedCustomFieldsAndUsageReferences(): void {
+    $subscriber = (new SubscriberFactory())->withEmail('subscriber@example.com')->create();
+    $alpha = (new CustomFieldFactory())
+      ->withName('Alpha')
+      ->withSubscriber($subscriber->getId(), 'value')
+      ->create();
+    $beta = (new CustomFieldFactory())
+      ->withName('Beta')
+      ->withSubscriber($subscriber->getId(), 'value')
+      ->create();
+    $gamma = (new CustomFieldFactory())->withName('Gamma')->create();
+
+    $form = (new FormFactory())
+      ->withName('Form with custom fields')
+      ->withCustomField($alpha)
+      ->withCustomField($beta)
+      ->create();
+    (new DynamicSegmentFactory())->withCustomFieldFilter($alpha)->create();
+    (new DynamicSegmentFactory())->withCustomFieldFilter($beta)->create();
+
+    $this->repository->bulkTrash([(int)$alpha->getId(), (int)$beta->getId()]);
+    $deleted = $this->repository->bulkDelete([(int)$alpha->getId(), (int)$beta->getId(), (int)$gamma->getId()]);
+
+    $this->assertSame(2, $deleted);
+    $this->assertNull($this->repository->findOneById($alpha->getId()));
+    $this->assertNull($this->repository->findOneById($beta->getId()));
+    $this->assertNotNull($this->repository->findOneById($gamma->getId()));
+    $this->assertSame(0, $this->countSubscriberCustomFieldValues([(int)$alpha->getId(), (int)$beta->getId()]));
+    $this->assertSame(0, $this->countDynamicSegmentFilters([(int)$alpha->getId(), (int)$beta->getId()]));
+
+    /** @var FormsRepository $formsRepository */
+    $formsRepository = $this->diContainer->get(FormsRepository::class);
+    $refreshedForm = $formsRepository->findOneById($form->getId());
+    $this->assertInstanceOf(FormEntity::class, $refreshedForm);
+    $formCustomFieldIds = array_map('intval', array_column($refreshedForm->getBlocksByTypes(FormEntity::FORM_FIELD_TYPES), 'id'));
+    $this->assertNotContains((int)$alpha->getId(), $formCustomFieldIds);
+    $this->assertNotContains((int)$beta->getId(), $formCustomFieldIds);
+  }
+
+  public function testEmptyTrashPermanentlyDeletesTrashedCustomFields(): void {
+    $trashed = (new CustomFieldFactory())->withName('Trashed')->create();
+    $active = (new CustomFieldFactory())->withName('Active')->create();
+    $this->repository->bulkTrash([(int)$trashed->getId()]);
+
+    $this->assertSame(1, $this->repository->emptyTrash());
+
+    $this->assertNull($this->repository->findOneById($trashed->getId()));
+    $this->assertNotNull($this->repository->findOneById($active->getId()));
+  }
+
   /**
    * @param array<int, array{name: string}> $items
    * @return array<string, array>
    */
   private function indexByName(array $items): array {
     return array_column($items, null, 'name');
+  }
+
+  /**
+   * @param array<int, array{name: string, count: int}> $groups
+   */
+  private function getGroupCount(array $groups, string $name): int {
+    foreach ($groups as $group) {
+      if ($group['name'] === $name) {
+        return $group['count'];
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * @param int[] $customFieldIds
+   */
+  private function countSubscriberCustomFieldValues(array $customFieldIds): int {
+    return count($this->orm->getRepository(SubscriberCustomFieldEntity::class)->findBy(['customField' => $customFieldIds]));
+  }
+
+  /**
+   * @param int[] $customFieldIds
+   */
+  private function countDynamicSegmentFilters(array $customFieldIds): int {
+    $filters = $this->orm->getRepository(DynamicSegmentFilterEntity::class)->findAll();
+    $count = 0;
+    foreach ($filters as $filter) {
+      $customFieldId = $filter->getFilterData()->getParam('custom_field_id');
+      if ((is_int($customFieldId) || is_string($customFieldId)) && in_array((int)$customFieldId, $customFieldIds, true)) {
+        $count++;
+      }
+    }
+    return $count;
   }
 }

--- a/mailpoet/tests/integration/CustomFields/CustomFieldsRepositoryTest.php
+++ b/mailpoet/tests/integration/CustomFields/CustomFieldsRepositoryTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\CustomFields;
+
+use MailPoet\CustomFields\CustomFieldsRepository;
+use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
+use MailPoet\Test\DataFactories\DynamicSegment as DynamicSegmentFactory;
+use MailPoet\Test\DataFactories\Form as FormFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+class CustomFieldsRepositoryTest extends \MailPoetTest {
+  /** @var CustomFieldsRepository */
+  private $repository;
+
+  public function _before() {
+    parent::_before();
+    $this->repository = $this->diContainer->get(CustomFieldsRepository::class);
+  }
+
+  public function testListWithCountsReturnsCustomFieldsWithUsageCounts(): void {
+    $subscriberA = (new SubscriberFactory())->withEmail('a@example.com')->create();
+    $subscriberB = (new SubscriberFactory())->withEmail('b@example.com')->create();
+    $deletedSubscriber = (new SubscriberFactory())
+      ->withEmail('deleted@example.com')
+      ->withDeletedAt(new \DateTimeImmutable())
+      ->create();
+
+    $alpha = (new CustomFieldFactory())
+      ->withName('Alpha')
+      ->withParams(['label' => 'Alpha label'])
+      ->withSubscriber($subscriberA->getId(), 'value')
+      ->withSubscriber($subscriberB->getId(), 'value')
+      ->withSubscriber($deletedSubscriber->getId(), 'deleted value')
+      ->create();
+    $beta = (new CustomFieldFactory())
+      ->withName('Beta')
+      ->withSubscriber($subscriberB->getId(), 'value')
+      ->create();
+    (new CustomFieldFactory())->withName('Gamma')->create();
+
+    (new FormFactory())->withName('Alpha form')->withCustomField($alpha)->create();
+    (new FormFactory())->withName('Both fields form')->withCustomField($alpha)->withCustomField($beta)->create();
+    (new FormFactory())->withName('Deleted form')->withCustomField($alpha)->withDeleted()->create();
+
+    (new DynamicSegmentFactory())->withCustomFieldFilter($alpha)->create();
+    (new DynamicSegmentFactory())->withCustomFieldFilter($alpha)->create();
+    (new DynamicSegmentFactory())->withCustomFieldFilter($beta)->withDeleted()->create();
+
+    $result = $this->repository->listWithCounts();
+    $this->assertSame(3, $result['total']);
+    $items = $this->indexByName($result['items']);
+
+    $this->assertSame('Alpha label', $items['Alpha']['label']);
+    $this->assertSame(2, $items['Alpha']['subscribers_count']);
+    $this->assertSame(2, $items['Alpha']['forms_count']);
+    $this->assertSame(2, $items['Alpha']['dynamic_segments_count']);
+    $this->assertSame(1, $items['Beta']['subscribers_count']);
+    $this->assertSame(1, $items['Beta']['forms_count']);
+    $this->assertSame(0, $items['Beta']['dynamic_segments_count']);
+    $this->assertSame(0, $items['Gamma']['subscribers_count']);
+  }
+
+  public function testListWithCountsSupportsSearchSortAndPagination(): void {
+    (new CustomFieldFactory())->withName('Customers')->create();
+    (new CustomFieldFactory())->withName('Prospects')->create();
+    (new CustomFieldFactory())->withName('VIP')->create();
+
+    $result = $this->repository->listWithCounts(['search' => 'Pro']);
+    $this->assertSame(1, $result['total']);
+    $this->assertSame('Prospects', $result['items'][0]['name']);
+
+    $desc = $this->repository->listWithCounts(['orderby' => 'name', 'order' => 'desc']);
+    $this->assertSame(['VIP', 'Prospects', 'Customers'], array_column($desc['items'], 'name'));
+
+    $page1 = $this->repository->listWithCounts(['per_page' => 2, 'page' => 1, 'orderby' => 'name', 'order' => 'asc']);
+    $this->assertSame(3, $page1['total']);
+    $this->assertCount(2, $page1['items']);
+    $this->assertSame(['Customers', 'Prospects'], array_column($page1['items'], 'name'));
+  }
+
+  /**
+   * @param array<int, array{name: string}> $items
+   * @return array<string, array>
+   */
+  private function indexByName(array $items): array {
+    return array_column($items, null, 'name');
+  }
+}

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\CustomFields;
+
+use MailPoet\REST\Test;
+use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
+use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
+
+require_once __DIR__ . '/../Test.php';
+
+class CustomFieldsEndpointsTest extends Test {
+  private const BASE_PATH = '/mailpoet/v1/custom-fields';
+
+  public function _before() {
+    parent::_before();
+    wp_set_current_user(1);
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+  }
+
+  public function testGetReturnsCustomFieldsWithCounts(): void {
+    $subscriber = (new SubscriberFactory())->withEmail('x@example.com')->create();
+    (new CustomFieldFactory())
+      ->withName('Favorite color')
+      ->withParams(['label' => 'Color'])
+      ->withSubscriber($subscriber->getId(), 'blue')
+      ->create();
+    (new CustomFieldFactory())->withName('Birthday')->create();
+
+    $payload = $this->getListingPayload($this->get(self::BASE_PATH));
+    $items = $payload['items'];
+    $this->assertCount(2, $items);
+    $this->assertSame(2, $payload['meta']['count']);
+    $this->assertSame(1, $payload['meta']['pages']);
+
+    $byName = array_column($items, null, 'name');
+    $favoriteColor = $byName['Favorite color'] ?? null;
+    $birthday = $byName['Birthday'] ?? null;
+    $this->assertIsArray($favoriteColor);
+    $this->assertIsArray($birthday);
+    $this->assertSame('Color', $favoriteColor['label']);
+    $this->assertSame(1, $favoriteColor['subscribers_count']);
+    $this->assertSame(0, $birthday['subscribers_count']);
+  }
+
+  public function testGetSupportsSearchAndPagination(): void {
+    (new CustomFieldFactory())->withName('Customers')->create();
+    (new CustomFieldFactory())->withName('Prospective')->create();
+    (new CustomFieldFactory())->withName('VIP')->create();
+
+    $data = $this->getListingPayload($this->get(self::BASE_PATH, ['query' => ['search' => 'Pro']]));
+    $this->assertSame(1, $data['meta']['count']);
+    $this->assertSame('Prospective', $data['items'][0]['name']);
+
+    $page1 = $this->getListingPayload($this->get(self::BASE_PATH, ['query' => ['per_page' => 2, 'page' => 1, 'orderby' => 'name', 'order' => 'asc']]));
+    $this->assertCount(2, $page1['items']);
+    $this->assertSame(2, $page1['meta']['pages']);
+  }
+
+  public function testGetRejectsGuest(): void {
+    wp_set_current_user(0);
+    $data = $this->get(self::BASE_PATH);
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  /**
+   * @param mixed $response
+   * @return array{items: array<int, array<int|string, mixed>>, meta: array<int|string, mixed>}
+   */
+  private function getListingPayload($response): array {
+    $this->assertIsArray($response);
+    $data = $response['data'] ?? null;
+    $this->assertIsArray($data);
+    $items = $data['items'] ?? null;
+    $meta = $data['meta'] ?? null;
+    $this->assertIsArray($items);
+    $this->assertIsArray($meta);
+
+    $normalizedItems = [];
+    foreach ($items as $item) {
+      $this->assertIsArray($item);
+      $normalizedItems[] = $item;
+    }
+
+    return [
+      'items' => $normalizedItems,
+      'meta' => $meta,
+    ];
+  }
+}

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -225,6 +225,52 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame(409, $data['data']['status']);
   }
 
+  public function testPutRejectsTypeChangeWhenSubscriberValuesExist(): void {
+    $subscriber = (new SubscriberFactory())->withEmail('locked@example.com')->create();
+    $field = (new CustomFieldFactory())
+      ->withName('Locked field')
+      ->withType('text')
+      ->withSubscriber($subscriber->getId(), 'value')
+      ->create();
+
+    $data = $this->put(self::BASE_PATH . '/' . $field->getId(), [
+      'json' => [
+        'name' => 'Locked field',
+        'type' => 'date',
+        'params' => [
+          'label' => 'Locked field',
+        ],
+      ],
+    ]);
+
+    $this->assertSame('mailpoet_custom_fields_type_locked', $data['code']);
+    $this->assertSame(409, $data['data']['status']);
+
+    $entity = $this->repository->findOneById($field->getId());
+    $this->assertNotNull($entity);
+    $this->assertSame('text', $entity->getType());
+  }
+
+  public function testPutAllowsTypeChangeWhenNoSubscriberValues(): void {
+    $field = (new CustomFieldFactory())
+      ->withName('Empty field')
+      ->withType('text')
+      ->create();
+
+    $data = $this->put(self::BASE_PATH . '/' . $field->getId(), [
+      'json' => [
+        'name' => 'Empty field',
+        'type' => 'textarea',
+        'params' => [
+          'label' => 'Empty field',
+        ],
+      ],
+    ]);
+
+    $this->assertArrayHasKey('data', $data);
+    $this->assertSame('textarea', $data['data']['type']);
+  }
+
   public function testPutRejectsMissingCustomField(): void {
     $data = $this->put(self::BASE_PATH . '/999999', [
       'json' => [

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -73,6 +73,99 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame('rest_forbidden', $data['code']);
   }
 
+  public function testPostCreatesCustomField(): void {
+    $data = $this->post(self::BASE_PATH, [
+      'json' => [
+        'name' => 'Favorite trail',
+        'type' => 'select',
+        'params' => [
+          'label' => 'Favorite trail label',
+          'required' => '1',
+          'values' => [
+            ['value' => 'Alpine Loop'],
+            ['value' => 'River Walk', 'is_checked' => '1'],
+          ],
+        ],
+      ],
+    ]);
+
+    $customField = $data['data'];
+    $this->assertSame('Favorite trail', $customField['name']);
+    $this->assertSame('select', $customField['type']);
+    $this->assertSame('Favorite trail label', $customField['label']);
+    $this->assertSame('1', $customField['params']['required']);
+    $this->assertSame('River Walk', $customField['params']['values'][1]['value']);
+
+    $entity = $this->repository->findOneById($customField['id']);
+    $this->assertNotNull($entity);
+    $this->assertSame('Favorite trail', $entity->getName());
+  }
+
+  public function testPostCreatesDateCustomField(): void {
+    $data = $this->post(self::BASE_PATH, [
+      'json' => [
+        'name' => 'Anniversary',
+        'type' => 'date',
+        'params' => [
+          'date_type' => 'year_month',
+          'date_format' => 'MM/YYYY',
+          'is_default_today' => '1',
+        ],
+      ],
+    ]);
+
+    $customField = $data['data'];
+    $this->assertSame('date', $customField['type']);
+    $this->assertSame('year_month', $customField['params']['date_type']);
+    $this->assertSame('MM/YYYY', $customField['params']['date_format']);
+    $this->assertSame('1', $customField['params']['is_default_today']);
+  }
+
+  public function testPostRejectsDuplicateCustomFieldName(): void {
+    (new CustomFieldFactory())->withName('Duplicate')->create();
+
+    $data = $this->post(self::BASE_PATH, [
+      'json' => [
+        'name' => 'Duplicate',
+        'type' => 'text',
+        'params' => [
+          'label' => 'Duplicate',
+        ],
+      ],
+    ]);
+
+    $this->assertSame('mailpoet_custom_fields_duplicate', $data['code']);
+    $this->assertSame(409, $data['data']['status']);
+  }
+
+  public function testPostRejectsInvalidCustomFieldData(): void {
+    $data = $this->post(self::BASE_PATH, [
+      'json' => [
+        'name' => 'Bad field',
+        'type' => 'select',
+        'params' => [
+          'values' => [],
+        ],
+      ],
+    ]);
+
+    $this->assertSame('mailpoet_custom_fields_invalid_data', $data['code']);
+    $this->assertSame(400, $data['data']['status']);
+  }
+
+  public function testPostRejectsGuest(): void {
+    wp_set_current_user(0);
+
+    $data = $this->post(self::BASE_PATH, [
+      'json' => [
+        'name' => 'Guest field',
+        'type' => 'text',
+      ],
+    ]);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
   public function testGetSupportsTrashGroup(): void {
     $active = (new CustomFieldFactory())->withName('Active')->create();
     $trashed = (new CustomFieldFactory())->withName('Trashed')->create();

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -254,6 +254,64 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame('rest_forbidden', $data['code']);
   }
 
+  public function testPostDuplicatesCustomField(): void {
+    $field = (new CustomFieldFactory())
+      ->withName('Favorite trail')
+      ->withType('select')
+      ->withParams([
+        'label' => 'Favorite trail label',
+        'required' => '1',
+        'values' => [
+          ['value' => 'Alpine Loop'],
+          ['value' => 'River Walk', 'is_checked' => '1'],
+        ],
+      ])
+      ->create();
+
+    $data = $this->post(self::BASE_PATH . '/' . $field->getId() . '/duplicate');
+
+    $duplicate = $data['data'];
+    $this->assertNotSame((int)$field->getId(), $duplicate['id']);
+    $this->assertSame('Favorite trail copy', $duplicate['name']);
+    $this->assertSame('select', $duplicate['type']);
+    $this->assertSame('Favorite trail label copy', $duplicate['label']);
+    $this->assertSame('1', $duplicate['params']['required']);
+    $this->assertSame('River Walk', $duplicate['params']['values'][1]['value']);
+    $this->assertSame(0, $duplicate['subscribers_count']);
+
+    $entity = $this->repository->findOneById($duplicate['id']);
+    $this->assertNotNull($entity);
+    $this->assertSame('Favorite trail copy', $entity->getName());
+  }
+
+  public function testPostDuplicateGeneratesUniqueName(): void {
+    $field = (new CustomFieldFactory())->withName('Favorite trail')->create();
+    (new CustomFieldFactory())->withName('Favorite trail copy')->create();
+
+    $data = $this->post(self::BASE_PATH . '/' . $field->getId() . '/duplicate');
+
+    $this->assertSame('Favorite trail copy 2', $data['data']['name']);
+  }
+
+  public function testPostDuplicateRejectsTrashedCustomField(): void {
+    $field = (new CustomFieldFactory())->withName('Trashed duplicate')->create();
+    $this->repository->bulkTrash([(int)$field->getId()]);
+
+    $data = $this->post(self::BASE_PATH . '/' . $field->getId() . '/duplicate');
+
+    $this->assertSame('mailpoet_custom_fields_not_found', $data['code']);
+    $this->assertSame(404, $data['data']['status']);
+  }
+
+  public function testPostDuplicateRejectsGuest(): void {
+    $field = (new CustomFieldFactory())->withName('Guest duplicate')->create();
+    wp_set_current_user(0);
+
+    $data = $this->post(self::BASE_PATH . '/' . $field->getId() . '/duplicate');
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
   public function testGetSupportsTrashGroup(): void {
     $active = (new CustomFieldFactory())->withName('Active')->create();
     $trashed = (new CustomFieldFactory())->withName('Trashed')->create();

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Test\REST\CustomFields;
 
+use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\REST\Test;
 use MailPoet\Test\DataFactories\CustomField as CustomFieldFactory;
 use MailPoet\Test\DataFactories\Subscriber as SubscriberFactory;
@@ -11,8 +12,12 @@ require_once __DIR__ . '/../Test.php';
 class CustomFieldsEndpointsTest extends Test {
   private const BASE_PATH = '/mailpoet/v1/custom-fields';
 
+  /** @var CustomFieldsRepository */
+  private $repository;
+
   public function _before() {
     parent::_before();
+    $this->repository = $this->diContainer->get(CustomFieldsRepository::class);
     wp_set_current_user(1);
   }
 
@@ -44,6 +49,8 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame('Color', $favoriteColor['label']);
     $this->assertSame(1, $favoriteColor['subscribers_count']);
     $this->assertSame(0, $birthday['subscribers_count']);
+    $this->assertSame(2, $this->getGroupCount($payload['groups'], 'all'));
+    $this->assertSame(0, $this->getGroupCount($payload['groups'], 'trash'));
   }
 
   public function testGetSupportsSearchAndPagination(): void {
@@ -66,9 +73,104 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame('rest_forbidden', $data['code']);
   }
 
+  public function testGetSupportsTrashGroup(): void {
+    $active = (new CustomFieldFactory())->withName('Active')->create();
+    $trashed = (new CustomFieldFactory())->withName('Trashed')->create();
+    $this->repository->bulkTrash([(int)$trashed->getId()]);
+
+    $activePayload = $this->getListingPayload($this->get(self::BASE_PATH));
+    $this->assertSame(1, $activePayload['meta']['count']);
+    $this->assertSame((int)$active->getId(), $activePayload['items'][0]['id']);
+
+    $trashPayload = $this->getListingPayload($this->get(self::BASE_PATH, ['query' => ['group' => 'trash']]));
+    $this->assertSame(1, $trashPayload['meta']['count']);
+    $this->assertSame((int)$trashed->getId(), $trashPayload['items'][0]['id']);
+    $this->assertNotNull($trashPayload['items'][0]['deleted_at']);
+  }
+
+  public function testBulkActionTrashesRestoresAndDeletesCustomFields(): void {
+    $a = (new CustomFieldFactory())->withName('A')->create();
+    $b = (new CustomFieldFactory())->withName('B')->create();
+    $c = (new CustomFieldFactory())->withName('C')->create();
+
+    $trash = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$a->getId(), (int)$b->getId()]],
+    ]);
+    $this->assertSame('trash', $trash['data']['action']);
+    $this->assertSame(2, $trash['data']['count']);
+    $trashedA = $this->repository->findOneById($a->getId());
+    $trashedB = $this->repository->findOneById($b->getId());
+    $this->assertNotNull($trashedA);
+    $this->assertNotNull($trashedB);
+    $this->assertNotNull($trashedA->getDeletedAt());
+    $this->assertNotNull($trashedB->getDeletedAt());
+
+    $restore = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'restore', 'ids' => [(int)$b->getId()]],
+    ]);
+    $this->assertSame('restore', $restore['data']['action']);
+    $this->assertSame(1, $restore['data']['count']);
+    $restoredB = $this->repository->findOneById($b->getId());
+    $this->assertNotNull($restoredB);
+    $this->assertNull($restoredB->getDeletedAt());
+
+    $delete = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'delete', 'ids' => [(int)$a->getId(), (int)$b->getId()]],
+    ]);
+    $this->assertSame('delete', $delete['data']['action']);
+    $this->assertSame(1, $delete['data']['count']);
+
+    $this->assertNull($this->repository->findOneById($a->getId()));
+    $this->assertNotNull($this->repository->findOneById($b->getId()));
+    $this->assertNotNull($this->repository->findOneById($c->getId()));
+  }
+
+  public function testEmptyTrashDeletesTrashedCustomFields(): void {
+    $a = (new CustomFieldFactory())->withName('A')->create();
+    $b = (new CustomFieldFactory())->withName('B')->create();
+    $c = (new CustomFieldFactory())->withName('C')->create();
+    $this->repository->bulkTrash([(int)$a->getId(), (int)$b->getId()]);
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'empty_trash'],
+    ]);
+    $this->assertSame('empty_trash', $data['data']['action']);
+    $this->assertSame(2, $data['data']['count']);
+
+    $this->assertNull($this->repository->findOneById($a->getId()));
+    $this->assertNull($this->repository->findOneById($b->getId()));
+    $this->assertNotNull($this->repository->findOneById($c->getId()));
+  }
+
+  public function testBulkActionRejectsInvalidPayload(): void {
+    $invalidAction = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'unknown', 'ids' => [1]],
+    ]);
+    $this->assertSame('mailpoet_custom_fields_invalid_bulk_action', $invalidAction['code']);
+
+    $missingIds = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash'],
+    ]);
+    $this->assertSame('mailpoet_custom_fields_ids_required', $missingIds['code']);
+  }
+
+  public function testBulkActionRejectsGuest(): void {
+    $customField = (new CustomFieldFactory())->withName('Keep')->create();
+    wp_set_current_user(0);
+
+    $data = $this->post(self::BASE_PATH . '/bulk-action', [
+      'json' => ['action' => 'trash', 'ids' => [(int)$customField->getId()]],
+    ]);
+    $this->assertSame('rest_forbidden', $data['code']);
+
+    $field = $this->repository->findOneById($customField->getId());
+    $this->assertNotNull($field);
+    $this->assertNull($field->getDeletedAt());
+  }
+
   /**
    * @param mixed $response
-   * @return array{items: array<int, array<int|string, mixed>>, meta: array<int|string, mixed>}
+   * @return array{items: array<int, array<int|string, mixed>>, meta: array<int|string, mixed>, groups: array<int, array<int|string, mixed>>}
    */
   private function getListingPayload($response): array {
     $this->assertIsArray($response);
@@ -76,18 +178,39 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertIsArray($data);
     $items = $data['items'] ?? null;
     $meta = $data['meta'] ?? null;
+    $groups = $data['groups'] ?? null;
     $this->assertIsArray($items);
     $this->assertIsArray($meta);
+    $this->assertIsArray($groups);
 
     $normalizedItems = [];
     foreach ($items as $item) {
       $this->assertIsArray($item);
       $normalizedItems[] = $item;
     }
+    $normalizedGroups = [];
+    foreach ($groups as $group) {
+      $this->assertIsArray($group);
+      $normalizedGroups[] = $group;
+    }
 
     return [
       'items' => $normalizedItems,
       'meta' => $meta,
+      'groups' => $normalizedGroups,
     ];
+  }
+
+  /**
+   * @param array<int, array<int|string, mixed>> $groups
+   */
+  private function getGroupCount(array $groups, string $name): int {
+    foreach ($groups as $group) {
+      if (($group['name'] ?? null) === $name) {
+        $count = $group['count'] ?? null;
+        return is_int($count) || is_string($count) ? (int)$count : 0;
+      }
+    }
+    return 0;
   }
 }

--- a/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/CustomFields/CustomFieldsEndpointsTest.php
@@ -166,6 +166,94 @@ class CustomFieldsEndpointsTest extends Test {
     $this->assertSame('rest_forbidden', $data['code']);
   }
 
+  public function testPutUpdatesCustomField(): void {
+    $field = (new CustomFieldFactory())
+      ->withName('Favorite trail')
+      ->withType('select')
+      ->withParams([
+        'label' => 'Favorite trail',
+        'values' => [
+          ['value' => 'Alpine Loop'],
+          ['value' => 'River Walk'],
+        ],
+      ])
+      ->create();
+
+    $data = $this->put(self::BASE_PATH . '/' . $field->getId(), [
+      'json' => [
+        'name' => 'Preferred trail',
+        'type' => 'radio',
+        'params' => [
+          'label' => 'Preferred trail label',
+          'required' => '1',
+          'values' => [
+            ['value' => 'Forest Path', 'is_checked' => '1'],
+            ['value' => 'Mountain Pass'],
+          ],
+        ],
+      ],
+    ]);
+
+    $customField = $data['data'];
+    $this->assertSame((int)$field->getId(), $customField['id']);
+    $this->assertSame('Preferred trail', $customField['name']);
+    $this->assertSame('radio', $customField['type']);
+    $this->assertSame('Preferred trail label', $customField['label']);
+    $this->assertSame('Forest Path', $customField['params']['values'][0]['value']);
+
+    $entity = $this->repository->findOneById($field->getId());
+    $this->assertNotNull($entity);
+    $this->assertSame('Preferred trail', $entity->getName());
+    $this->assertSame('radio', $entity->getType());
+  }
+
+  public function testPutRejectsDuplicateCustomFieldName(): void {
+    (new CustomFieldFactory())->withName('Existing')->create();
+    $field = (new CustomFieldFactory())->withName('Editable')->create();
+
+    $data = $this->put(self::BASE_PATH . '/' . $field->getId(), [
+      'json' => [
+        'name' => 'Existing',
+        'type' => 'text',
+        'params' => [
+          'label' => 'Existing',
+        ],
+      ],
+    ]);
+
+    $this->assertSame('mailpoet_custom_fields_duplicate', $data['code']);
+    $this->assertSame(409, $data['data']['status']);
+  }
+
+  public function testPutRejectsMissingCustomField(): void {
+    $data = $this->put(self::BASE_PATH . '/999999', [
+      'json' => [
+        'name' => 'Missing',
+        'type' => 'text',
+        'params' => [
+          'label' => 'Missing',
+        ],
+      ],
+    ]);
+
+    $this->assertSame('mailpoet_custom_fields_not_found', $data['code']);
+    $this->assertSame(404, $data['data']['status']);
+  }
+
+  public function testPutRejectsGuest(): void {
+    $field = (new CustomFieldFactory())->withName('Keep')->create();
+    wp_set_current_user(0);
+
+    $data = $this->put(self::BASE_PATH . '/' . $field->getId(), [
+      'json' => [
+        'name' => 'Guest update',
+        'type' => 'text',
+      ],
+    ]);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
   public function testGetSupportsTrashGroup(): void {
     $active = (new CustomFieldFactory())->withName('Active')->create();
     $trashed = (new CustomFieldFactory())->withName('Trashed')->create();

--- a/mailpoet/tests/unit/CustomFields/ApiDataSanitizerTest.php
+++ b/mailpoet/tests/unit/CustomFields/ApiDataSanitizerTest.php
@@ -109,6 +109,11 @@ class ApiDataSanitizerTest extends \MailPoetUnitTest {
     verify($result['params']['validate'])->same('alphanum');
   }
 
+  public function testItIgnoresEmptyValidate() {
+    $result = $this->sanitizer->sanitize(['name' => 'Name', 'type' => 'text', 'params' => ['validate' => '']]);
+    verify($result['params'])->arrayHasNotKey('validate');
+  }
+
   public function testItThrowsIfNoValuesInRadio() {
     $this->expectException(InvalidArgumentException::class);
     $this->sanitizer->sanitize([
@@ -232,13 +237,23 @@ class ApiDataSanitizerTest extends \MailPoetUnitTest {
     $result = $this->sanitizer->sanitize([
       'name' => 'Name',
       'type' => 'date',
-      'params' => ['date_format' => 'MM/DD/YYYY', 'date_type' => 'year_month_day'],
+      'params' => ['date_format' => 'MM/DD/YYYY', 'date_type' => 'year_month_day', 'is_default_today' => '1'],
     ]);
     verify($result['params'])->equals([
       'date_format' => 'MM/DD/YYYY',
       'date_type' => 'year_month_day',
+      'is_default_today' => '1',
       'label' => 'Name',
       'required' => '',
     ]);
+  }
+
+  public function testSanitizeYearMonthDateFormat() {
+    $result = $this->sanitizer->sanitize([
+      'name' => 'Name',
+      'type' => 'date',
+      'params' => ['date_format' => 'MM/YYYY', 'date_type' => 'year_month'],
+    ]);
+    verify($result['params']['date_format'])->same('MM/YYYY');
   }
 }

--- a/mailpoet/views/subscribers/custom_fields.html
+++ b/mailpoet/views/subscribers/custom_fields.html
@@ -6,5 +6,7 @@
 <script type="text/javascript">
   var mailpoet_custom_fields_api = <%= json_encode(api) %>;
   var mailpoet_custom_fields_subscribers_listing_url = <%= json_encode(subscribers_listing_url) %>;
+  var mailpoet_custom_fields_date_types = <%= json_encode(date_types) %>;
+  var mailpoet_custom_fields_date_formats = <%= json_encode(date_formats) %>;
 </script>
 <% endblock %>

--- a/mailpoet/views/subscribers/custom_fields.html
+++ b/mailpoet/views/subscribers/custom_fields.html
@@ -1,0 +1,10 @@
+<% extends 'layout.html' %>
+
+<% block content %>
+<div id="mailpoet_custom_fields_container"></div>
+
+<script type="text/javascript">
+  var mailpoet_custom_fields_api = <%= json_encode(api) %>;
+  var mailpoet_custom_fields_subscribers_listing_url = <%= json_encode(subscribers_listing_url) %>;
+</script>
+<% endblock %>

--- a/mailpoet/views/subscribers/importExport/import.html
+++ b/mailpoet/views/subscribers/importExport/import.html
@@ -31,7 +31,9 @@
     importData = {},
     mailpoetColumnsSelect2 = JSON.parse("<%=subscriberFieldsSelect2|escape('js')%>"),
     mailpoetColumns = JSON.parse("<%=subscriberFields|escape('js')%>"),
-    mailpoetSegments = JSON.parse("<%=segments|escape('js')%>");
+    mailpoetSegments = JSON.parse("<%=segments|escape('js')%>"),
+    mailpoet_import_custom_fields_date_types = <%= json_encode(custom_fields_date_types) %>,
+    mailpoet_import_custom_fields_date_formats = <%= json_encode(date_formats) %>;
 </script>
 
 <%= localize({

--- a/mailpoet/views/subscribers/importExport/import.html
+++ b/mailpoet/views/subscribers/importExport/import.html
@@ -33,7 +33,8 @@
     mailpoetColumns = JSON.parse("<%=subscriberFields|escape('js')%>"),
     mailpoetSegments = JSON.parse("<%=segments|escape('js')%>"),
     mailpoet_import_custom_fields_date_types = <%= json_encode(custom_fields_date_types) %>,
-    mailpoet_import_custom_fields_date_formats = <%= json_encode(date_formats) %>;
+    mailpoet_import_custom_fields_date_formats = <%= json_encode(date_formats) %>,
+    mailpoet_custom_fields_api = <%= json_encode(custom_fields_api) %>;
 </script>
 
 <%= localize({

--- a/mailpoet/views/subscribers/importExport/import/step_data_manipulation.html
+++ b/mailpoet/views/subscribers/importExport/import/step_data_manipulation.html
@@ -36,7 +36,5 @@
       </form>
     </script>
 
-    <!-- New custom field logic -->
-    <% include 'form/custom_fields_legacy.html' %>
   </div>
 </div>

--- a/mailpoet/webpack.config.js
+++ b/mailpoet/webpack.config.js
@@ -266,6 +266,7 @@ const adminConfig = {
     form_editor: 'form-editor/form-editor.jsx',
     settings: 'settings/index.tsx',
     tags: 'subscribers/tags/index.tsx',
+    custom_fields: 'subscribers/custom-fields/index.tsx',
   },
   plugins: [
     ...baseConfig.plugins,


### PR DESCRIPTION
## Description

Add a custom fields management screen for subscribers, including create, edit, duplicate, trash, restore, and permanent delete flows. The subscriber listing now links to custom fields, and the import flow reuses the custom field form when creating fields while matching columns.

Trashing a custom field hides it from: the subscriber edit screen, subscription preference pages, the manage-subscription form, CSV + GDPR exports, newsletter shortcodes, dynamic-segment filter dropdowns, the automation field registry, required-field validation, and subscriber save/import. Permanent delete cleans up subscriber values, form references, and dynamic-segment filters.

## API behaviour change

`MP\v1\CustomFields::getCustomFields()` and `API\JSON\v1\CustomFields::getAll()` no longer return trashed fields. This is a contract change for third-party integrations that consume these endpoints.

## QA notes

1. Open Subscribers and confirm Tags and Custom fields are visible as management actions, including on a narrow viewport.
2. Open Custom fields and verify listing, search, add, edit, duplicate, move to trash, restore, and permanent delete flows.
3. In Import subscribers, paste a CSV with extra columns, choose Create new field from a column matcher, create fields of several types, and confirm the created fields can be selected for import.
4. Complete an import with custom field columns and confirm the imported subscriber stores the expected custom field values.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8002

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1493" height="801" alt="Screenshot 2026-04-30 at 15 43 38" src="https://github.com/user-attachments/assets/352ae7f3-dea3-465b-b38a-a93db83b8dc3" />

---

<img width="563" height="576" alt="Screenshot 2026-04-30 at 15 44 15" src="https://github.com/user-attachments/assets/5884e282-585e-4fb0-89e8-a69dcaced8d9" />

---

<img width="1283" height="227" alt="Screenshot 2026-04-30 at 15 50 18" src="https://github.com/user-attachments/assets/da2264c2-6ba6-4699-85cb-50032b78eb36" />




## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8002-custom-fields-crud)

_The latest successful build from `add/STOMAIL-8002-custom-fields-crud` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->