### PR TITLE
Update email editor dependency to 2.13.0

### DIFF
--- a/mailpoet/changelog/2026-05-04-10-05-52-improved-improve-rtl-language-support-in-the-block-email-ed.md
+++ b/mailpoet/changelog/2026-05-04-10-05-52-improved-improve-rtl-language-support-in-the-block-email-ed.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improve RTL language support in the block email editor

--- a/mailpoet/composer.json
+++ b/mailpoet/composer.json
@@ -6,7 +6,7 @@
     "dragonmantank/cron-expression": "^3.3",
     "mixpanel/mixpanel-php": "2.*",
     "woocommerce/action-scheduler": "3.9.2",
-    "woocommerce/email-editor": "2.12.0"
+    "woocommerce/email-editor": "2.13.0"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/mailpoet/composer.lock
+++ b/mailpoet/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4e1f9cb901874a9ade4e43fbf5980d3",
+    "content-hash": "83dc6912ee72af67396c96cffa1f9fed",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -285,16 +285,16 @@
         },
         {
             "name": "woocommerce/email-editor",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/email-editor.git",
-                "reference": "7d2dfa8649f49879523413f1e0124786a60d9fc5"
+                "reference": "bdd2aeaa5f2852b0ef1a6b84da1cff2990c13f40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/7d2dfa8649f49879523413f1e0124786a60d9fc5",
-                "reference": "7d2dfa8649f49879523413f1e0124786a60d9fc5",
+                "url": "https://api.github.com/repos/woocommerce/email-editor/zipball/bdd2aeaa5f2852b0ef1a6b84da1cff2990c13f40",
+                "reference": "bdd2aeaa5f2852b0ef1a6b84da1cff2990c13f40",
                 "shasum": ""
             },
             "require": {
@@ -336,9 +336,9 @@
             ],
             "description": "Email editor based on WordPress Gutenberg package.",
             "support": {
-                "source": "https://github.com/woocommerce/email-editor/tree/2.12.0"
+                "source": "https://github.com/woocommerce/email-editor/tree/2.13.0"
             },
-            "time": "2026-04-27T10:07:06+00:00"
+            "time": "2026-05-04T09:48:24+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Description

Updates `woocommerce/email-editor` from `2.12.0` to `2.13.0` so MailPoet consumes the released block email editor RTL renderer support.

## Code review notes

The WooCommerce package release was completed in https://github.com/woocommerce/woocommerce/pull/64561 and published to Packagist as `woocommerce/email-editor` `2.13.0`.

## QA notes

On an RTL WordPress site, create or edit a MailPoet email with the block email editor and send/render a preview. Verify core text, button, list, table, quote, column, and product-related blocks render with RTL direction and expected alignment in the email output.

## Linked PRs

https://github.com/woocommerce/woocommerce/pull/64561

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-7992/add-rtl-right-to-left-language-support-across-mailpoet


## Screenshots or screencast <!-- if applicable -->

<img width="1556" height="984" alt="Screenshot 2026-05-04 at 12 49 29" src="https://github.com/user-attachments/assets/c5bb95ae-19e6-4cf5-91f7-e490dc58ce20" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:chore/STOMAIL-7992-update-email-editor-2-13-0)

_The latest successful build from `chore/STOMAIL-7992-update-email-editor-2-13-0` will be used. If none is available, the link won't work._