### PR TITLE
Stabilize trunk CI tests

### DIFF
--- a/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
+++ b/mailpoet/tests/acceptance/EmailEditor/CreateAndSendEmailUsingGutenbergCest.php
@@ -122,14 +122,16 @@ class CreateAndSendEmailUsingGutenbergCest {
     $i->closeTab();
 
     $i->wantTo('Send preview email and verify it was delivered');
+    $sendTestEmailMenuItem = '//button[@role="menuitem" and .//span[normalize-space(.)="Send a test email"]]';
+    $sendTestEmailButton = '//button[normalize-space(.)="Send test email"]';
     $i->click('.editor-preview-dropdown__toggle');
-    $i->waitForElementVisible('//span[text()="Send a test email"]');
-    $i->click('//span[text()="Send a test email"]'); // MenuItem component renders a button containing span
-    $i->waitForElementClickable('//button[text()="Send test email"]');
-    $i->click('//button[text()="Send test email"]');
+    $i->waitForElementClickable($sendTestEmailMenuItem);
+    $i->click($sendTestEmailMenuItem);
+    $i->waitForElementClickable($sendTestEmailButton);
+    $i->click($sendTestEmailButton);
     $i->waitForText('Test email sent successfully!');
     $i->click('//button[text()="Cancel"]');
-    $i->waitForElementNotVisible('//button[text()="Send test email"]');
+    $i->waitForElementNotVisible($sendTestEmailButton);
   }
 
   private function closeTemplateSelectionModal(\AcceptanceTester $i): void {

--- a/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
+++ b/mailpoet/tests/integration/Services/AuthorizedEmailsControllerTest.php
@@ -257,13 +257,37 @@ class AuthorizedEmailsControllerTest extends \MailPoetTest {
     $this->settings->set('installed_at', new Carbon());
     $this->settings->set('sender.address', 'auth@email.com');
     $this->setMailPoetSendingMethod();
-    $controller = $this->getController($authorizedEmailsFromApi = ['authorized' => ['auth@email.com']]);
+    $bridgeMock = $this->make(Bridge::class, [
+      'isMailpoetSendingServiceEnabled' => Expected::once(true),
+      'getAuthorizedEmailAddresses' => Expected::once(['authorized' => ['auth@email.com']]),
+    ]);
+    $senderDomainMock = $this->make(AuthorizedSenderDomainController::class, [
+      'shouldSkipAuthorization' => Expected::once(false),
+      'getVerifiedSenderDomainsIgnoringCache' => Expected::once([]),
+    ]);
+
+    $controller = $this->getControllerWithCustomMocks([
+      'Bridge' => $bridgeMock,
+      'AuthorizedSenderDomainController' => $senderDomainMock,
+    ]);
     $controller->checkAuthorizedEmailAddresses();
     $error = $this->settings->get(AuthorizedEmailsController::AUTHORIZED_EMAIL_ADDRESSES_ERROR_SETTING);
-    verify(count($error['invalid_senders_in_newsletters']))->equals(1);
-    verify($error['invalid_senders_in_newsletters'][0]['newsletter_id'])->equals($newsletter->getId());
-    verify($error['invalid_senders_in_newsletters'][0]['sender_address'])->equals('invalid@email.com');
-    verify($error['invalid_senders_in_newsletters'][0]['subject'])->equals('Subject');
+    if (!is_array($error)) {
+      $this->fail('Expected unauthorized sender error to be stored in settings.');
+    }
+    $invalidSenders = $error['invalid_senders_in_newsletters'] ?? null;
+    if (!is_array($invalidSenders)) {
+      $this->fail('Expected unauthorized newsletter senders to be stored in settings.');
+    }
+    $invalidSender = $invalidSenders[0] ?? null;
+    if (!is_array($invalidSender)) {
+      $this->fail('Expected unauthorized newsletter sender details to be stored in settings.');
+    }
+
+    verify(count($invalidSenders))->equals(1);
+    verify($invalidSender['newsletter_id'])->equals($newsletter->getId());
+    verify($invalidSender['sender_address'])->equals('invalid@email.com');
+    verify($invalidSender['subject'])->equals('Subject');
   }
 
   public function testItSetsFromAddressInSettings() {


### PR DESCRIPTION
## Description

Stabilizes two trunk CI failures:

- isolate the authorized-email multisite test from unrelated bridge and sender-domain state
- click the actual email-editor preview menu item button in the acceptance test

## Code review notes

The multisite integration failure reproduced only in full-suite order locally. The test now pins the service state it depends on so unrelated sender-domain or bridge state cannot suppress the expected settings error.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/trunk-ci-test-failures)

_The latest successful build from `fix/trunk-ci-test-failures` will be used. If none is available, the link won't work._