### PR TITLE
Segment by product variation

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product-variation.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product-variation.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { filter } from 'lodash/fp';
 import { Select } from 'common/form/select/select';
@@ -61,8 +61,13 @@ export function PurchasedProductVariationFields({
   const [isLoadingVariations, setIsLoadingVariations] =
     useState<boolean>(false);
   const [hasInitialized, setHasInitialized] = useState<boolean>(false);
+  // Tracks the latest in-flight variations request so out-of-order
+  // responses from rapid parent changes don't overwrite newer state.
+  const variationsRequestIdRef = useRef(0);
 
   const loadVariationsByProduct = useCallback((productId: string) => {
+    variationsRequestIdRef.current += 1;
+    const requestId = variationsRequestIdRef.current;
     setIsLoadingVariations(true);
     void MailPoet.Ajax.post({
       api_version: MailPoet.apiVersion,
@@ -71,6 +76,7 @@ export function PurchasedProductVariationFields({
       data: { product_id: productId },
     })
       .then((response: VariationsResponse) => {
+        if (requestId !== variationsRequestIdRef.current) return;
         setVariations(
           response.data.variations.map((variation) => ({
             value: variation.id,
@@ -78,10 +84,15 @@ export function PurchasedProductVariationFields({
           })),
         );
       })
-      .always(() => setIsLoadingVariations(false));
+      .always(() => {
+        if (requestId !== variationsRequestIdRef.current) return;
+        setIsLoadingVariations(false);
+      });
   }, []);
 
   const loadVariationsByVariation = useCallback((variationId: string) => {
+    variationsRequestIdRef.current += 1;
+    const requestId = variationsRequestIdRef.current;
     setIsLoadingVariations(true);
     void MailPoet.Ajax.post({
       api_version: MailPoet.apiVersion,
@@ -90,6 +101,7 @@ export function PurchasedProductVariationFields({
       data: { variation_id: variationId },
     })
       .then((response: VariationsResponse) => {
+        if (requestId !== variationsRequestIdRef.current) return;
         if (response.data.product) {
           setParentProductId(response.data.product.id);
         }
@@ -100,7 +112,10 @@ export function PurchasedProductVariationFields({
           })),
         );
       })
-      .always(() => setIsLoadingVariations(false));
+      .always(() => {
+        if (requestId !== variationsRequestIdRef.current) return;
+        setIsLoadingVariations(false);
+      });
   }, []);
 
   useEffect(() => {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product-variation.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product-variation.tsx
@@ -1,0 +1,203 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import { filter } from 'lodash/fp';
+import { Select } from 'common/form/select/select';
+import { MailPoet } from 'mailpoet';
+import { ReactSelect } from 'common/form/react-select/react-select';
+import { storeName } from '../../../store';
+import {
+  AnyValueTypes,
+  FilterProps,
+  SelectOption,
+  WindowProducts,
+  WooCommerceFormItem,
+} from '../../../types';
+
+type VariationsResponse = {
+  data: {
+    product: { id: string; name: string } | null;
+    variations: { id: string; name: string }[];
+  };
+};
+
+export function validatePurchasedProductVariation(
+  formItems: WooCommerceFormItem,
+): boolean {
+  return (
+    Array.isArray(formItems.variation_ids) &&
+    formItems.variation_ids.length > 0 &&
+    !!formItems.operator
+  );
+}
+
+export function PurchasedProductVariationFields({
+  filterIndex,
+}: FilterProps): JSX.Element {
+  const segment: WooCommerceFormItem = useSelect(
+    (select) => select(storeName).getSegmentFilter(filterIndex),
+    [filterIndex],
+  );
+  const { updateSegmentFilter } = useDispatch(storeName);
+
+  const variableProducts: WindowProducts = useSelect(
+    (select) => select(storeName).getVariableProducts(),
+    [],
+  );
+
+  const variableProductOptions = useMemo(
+    () =>
+      variableProducts.map((product) => ({
+        value: product.id,
+        label: product.name,
+      })),
+    [variableProducts],
+  );
+
+  const [parentProductId, setParentProductId] = useState<string | undefined>(
+    undefined,
+  );
+  const [variations, setVariations] = useState<SelectOption[]>([]);
+  const [isLoadingVariations, setIsLoadingVariations] =
+    useState<boolean>(false);
+  const [hasInitialized, setHasInitialized] = useState<boolean>(false);
+
+  const loadVariationsByProduct = useCallback((productId: string) => {
+    setIsLoadingVariations(true);
+    void MailPoet.Ajax.post({
+      api_version: MailPoet.apiVersion,
+      endpoint: 'woocommerce_product_variations',
+      action: 'getVariations',
+      data: { product_id: productId },
+    })
+      .then((response: VariationsResponse) => {
+        setVariations(
+          response.data.variations.map((variation) => ({
+            value: variation.id,
+            label: variation.name,
+          })),
+        );
+      })
+      .always(() => setIsLoadingVariations(false));
+  }, []);
+
+  const loadVariationsByVariation = useCallback((variationId: string) => {
+    setIsLoadingVariations(true);
+    void MailPoet.Ajax.post({
+      api_version: MailPoet.apiVersion,
+      endpoint: 'woocommerce_product_variations',
+      action: 'getVariations',
+      data: { variation_id: variationId },
+    })
+      .then((response: VariationsResponse) => {
+        if (response.data.product) {
+          setParentProductId(response.data.product.id);
+        }
+        setVariations(
+          response.data.variations.map((variation) => ({
+            value: variation.id,
+            label: variation.name,
+          })),
+        );
+      })
+      .always(() => setIsLoadingVariations(false));
+  }, []);
+
+  useEffect(() => {
+    if (
+      segment.operator !== AnyValueTypes.ALL &&
+      segment.operator !== AnyValueTypes.ANY &&
+      segment.operator !== AnyValueTypes.NONE
+    ) {
+      void updateSegmentFilter({ operator: AnyValueTypes.ANY }, filterIndex);
+    }
+  }, [updateSegmentFilter, segment.operator, filterIndex]);
+
+  useEffect(() => {
+    if (hasInitialized) return;
+    setHasInitialized(true);
+    if (
+      Array.isArray(segment.variation_ids) &&
+      segment.variation_ids.length > 0
+    ) {
+      loadVariationsByVariation(segment.variation_ids[0]);
+    }
+  }, [hasInitialized, segment.variation_ids, loadVariationsByVariation]);
+
+  const handleParentChange = (option: SelectOption | null): void => {
+    const newParentId = option ? option.value : undefined;
+    setParentProductId(newParentId);
+    setVariations([]);
+    void updateSegmentFilter({ variation_ids: [] }, filterIndex);
+    if (newParentId) {
+      loadVariationsByProduct(newParentId);
+    }
+  };
+
+  const selectedVariations = filter((option) => {
+    if (
+      !Array.isArray(segment.variation_ids) ||
+      segment.variation_ids.length === 0
+    ) {
+      return false;
+    }
+    return segment.variation_ids.indexOf(option.value) !== -1;
+  }, variations);
+
+  const selectedParent = parentProductId
+    ? variableProductOptions.find((opt) => opt.value === parentProductId) ||
+      null
+    : null;
+
+  return (
+    <>
+      <Select
+        key="select-operator"
+        value={segment.operator}
+        isMinWidth
+        onChange={(e): void => {
+          void updateSegmentFilter({ operator: e.target.value }, filterIndex);
+        }}
+        automationId="select-operator"
+      >
+        <option value={AnyValueTypes.ANY}>{MailPoet.I18n.t('anyOf')}</option>
+        <option value={AnyValueTypes.ALL}>{MailPoet.I18n.t('allOf')}</option>
+        <option value={AnyValueTypes.NONE}>{MailPoet.I18n.t('noneOf')}</option>
+      </Select>
+      <ReactSelect
+        dimension="small"
+        isClearable
+        key="select-variable-product"
+        placeholder={MailPoet.I18n.t('selectWooVariableProduct')}
+        options={variableProductOptions}
+        value={selectedParent}
+        onChange={(option: SelectOption | null): void =>
+          handleParentChange(option)
+        }
+        automationId="select-variable-product"
+      />
+      <ReactSelect
+        isMulti
+        dimension="small"
+        key="select-product-variations"
+        placeholder={
+          isLoadingVariations
+            ? __('Loading variations…', 'mailpoet')
+            : MailPoet.I18n.t('selectWooPurchasedProductVariation')
+        }
+        isDisabled={!parentProductId || isLoadingVariations}
+        options={variations}
+        value={selectedVariations}
+        onChange={(options: SelectOption[]): void => {
+          void updateSegmentFilter(
+            {
+              variation_ids: (options || []).map((x: SelectOption) => x.value),
+            },
+            filterIndex,
+          );
+        }}
+        automationId="select-product-variations"
+      />
+    </>
+  );
+}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce-options.ts
@@ -11,6 +11,7 @@ export enum WooCommerceActionTypes {
   PURCHASED_TAG = 'purchasedTag',
   PURCHASE_DATE = 'purchaseDate',
   PURCHASED_PRODUCT = 'purchasedProduct',
+  PURCHASED_PRODUCT_VARIATION = 'purchasedProductVariation',
   PURCHASED_WITH_ATTRIBUTE = 'purchasedWithAttribute',
   TOTAL_SPENT = 'totalSpent',
   AVERAGE_SPENT = 'averageSpent',
@@ -83,6 +84,11 @@ export const WooCommerceOptions = [
   {
     value: WooCommerceActionTypes.PURCHASED_PRODUCT,
     label: __('purchased product', 'mailpoet'),
+    group: SegmentTypes.WooCommerce,
+  },
+  {
+    value: WooCommerceActionTypes.PURCHASED_PRODUCT_VARIATION,
+    label: __('purchased product variation', 'mailpoet'),
     group: SegmentTypes.WooCommerce,
   },
   {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/woocommerce.tsx
@@ -11,6 +11,10 @@ import {
   validatePurchasedProduct,
 } from './fields/woocommerce/purchased-product';
 import {
+  PurchasedProductVariationFields,
+  validatePurchasedProductVariation,
+} from './fields/woocommerce/purchased-product-variation';
+import {
   PurchasedCategoryFields,
   validatePurchasedCategory,
 } from './fields/woocommerce/purchased-category';
@@ -71,6 +75,9 @@ export function validateWooCommerce(formItems: WooCommerceFormItem): boolean {
   }
   if (formItems.action === WooCommerceActionTypes.PURCHASED_PRODUCT) {
     return validatePurchasedProduct(formItems);
+  }
+  if (formItems.action === WooCommerceActionTypes.PURCHASED_PRODUCT_VARIATION) {
+    return validatePurchasedProductVariation(formItems);
   }
   if (formItems.action === WooCommerceActionTypes.CUSTOMER_IN_COUNTRY) {
     return validateCustomerInCountry(formItems);
@@ -136,6 +143,8 @@ const componentsMap = {
   [WooCommerceActionTypes.NUMBER_OF_REVIEWS]: NumberOfReviewsFields,
   [WooCommerceActionTypes.PURCHASE_DATE]: DateFieldsDefaultBefore,
   [WooCommerceActionTypes.PURCHASED_PRODUCT]: PurchasedProductFields,
+  [WooCommerceActionTypes.PURCHASED_PRODUCT_VARIATION]:
+    PurchasedProductVariationFields,
   [WooCommerceActionTypes.PURCHASED_CATEGORY]: PurchasedCategoryFields,
   [WooCommerceActionTypes.PURCHASED_WITH_ATTRIBUTE]:
     PurchasedWithAttributeFields,

--- a/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/initial-state.ts
@@ -25,6 +25,7 @@ export function getSegmentInitialState() {
 export const getInitialState = (): StateType => ({
   automations: window.mailpoet_automations,
   products: window.mailpoet_products,
+  variableProducts: window.mailpoet_variable_products || [],
   staticSegmentsList: window.mailpoet_static_segments_list,
   membershipPlans: window.mailpoet_membership_plans,
   subscriptionProducts: window.mailpoet_subscription_products,

--- a/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/store/selectors.ts
@@ -27,6 +27,8 @@ import {
 } from '../types';
 
 export const getProducts = (state: StateType): WindowProducts => state.products;
+export const getVariableProducts = (state: StateType): WindowProducts =>
+  state.variableProducts;
 export const getMembershipPlans = (state: StateType): WindowMembershipPlans =>
   state.membershipPlans;
 export const getSubscriptionProducts = (

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -136,6 +136,7 @@ export enum CountType {
 export interface WooCommerceFormItem extends FormItem {
   category_ids?: string[];
   product_ids?: string[];
+  variation_ids?: string[];
   operator?: string;
   number_of_orders_type?: string;
   number_of_orders_count?: number;
@@ -316,6 +317,7 @@ export type StaticSegment = {
 export interface SegmentFormDataWindow extends Window {
   wordpress_editable_roles_list: WindowEditableRoles;
   mailpoet_products: WindowProducts;
+  mailpoet_variable_products: WindowProducts;
   mailpoet_membership_plans: WindowMembershipPlans;
   mailpoet_subscription_products: WindowSubscriptionProducts;
   mailpoet_product_attributes: WindowProductAttributes;
@@ -344,6 +346,7 @@ export type DynamicSegmentGroup = {
 
 export interface StateType {
   products: WindowProducts;
+  variableProducts: WindowProducts;
   membershipPlans: WindowMembershipPlans;
   subscriptionProducts: WindowSubscriptionProducts;
   wordpressRoles: WindowEditableRoles;

--- a/mailpoet/changelog/2026-05-04-10-35-55-added-woocommerce-dynamic-segment-filter-for-product-var.md
+++ b/mailpoet/changelog/2026-05-04-10-35-55-added-woocommerce-dynamic-segment-filter-for-product-var.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+WooCommerce dynamic segment filter for product variations

--- a/mailpoet/changelog/2026-05-04-13-27-04-fixed-match-purchased-product-across-orders-for-the-all-.md
+++ b/mailpoet/changelog/2026-05-04-13-27-04-fixed-match-purchased-product-across-orders-for-the-all-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Match purchased product across orders for the all-of operator in WooCommerce dynamic segments

--- a/mailpoet/lib/API/JSON/v1/WoocommerceProductVariations.php
+++ b/mailpoet/lib/API/JSON/v1/WoocommerceProductVariations.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\JSON\v1;
+
+use MailPoet\API\JSON\Endpoint as APIEndpoint;
+use MailPoet\API\JSON\SuccessResponse;
+use MailPoet\Config\AccessControl;
+use MailPoet\WooCommerce\Helper;
+use WC_Product_Variable;
+use WC_Product_Variation;
+
+class WoocommerceProductVariations extends APIEndpoint {
+  /** @var Helper */
+  private $wooHelper;
+
+  public $permissions = [
+    'global' => AccessControl::PERMISSION_MANAGE_SEGMENTS,
+  ];
+
+  public function __construct(
+    Helper $wooHelper
+  ) {
+    $this->wooHelper = $wooHelper;
+  }
+
+  public function getVariations(array $data = []): SuccessResponse {
+    $emptyResponse = ['product' => null, 'variations' => []];
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return $this->successResponse($emptyResponse);
+    }
+
+    $product = null;
+    if (isset($data['product_id'])) {
+      $candidate = $this->wooHelper->wcGetProduct((int)$data['product_id']);
+      if ($candidate instanceof WC_Product_Variable) {
+        $product = $candidate;
+      }
+    } elseif (isset($data['variation_id'])) {
+      $variation = $this->wooHelper->wcGetProduct((int)$data['variation_id']);
+      if ($variation instanceof WC_Product_Variation) {
+        $parent = $this->wooHelper->wcGetProduct($variation->get_parent_id());
+        if ($parent instanceof WC_Product_Variable) {
+          $product = $parent;
+        }
+      }
+    }
+
+    if (!$product instanceof WC_Product_Variable) {
+      return $this->successResponse($emptyResponse);
+    }
+
+    $variations = [];
+    foreach ($product->get_children() as $variationId) {
+      $variation = $this->wooHelper->wcGetProduct($variationId);
+      if (!$variation instanceof WC_Product_Variation) {
+        continue;
+      }
+      $attributesSummary = $this->wooHelper->wcGetFormattedVariation($variation, true);
+      $variations[] = [
+        'id' => (string)$variation->get_id(),
+        'name' => $attributesSummary !== '' ? $attributesSummary : $variation->get_name(),
+      ];
+    }
+
+    return $this->successResponse([
+      'product' => [
+        'id' => (string)$product->get_id(),
+        'name' => $product->get_name(),
+      ],
+      'variations' => $variations,
+    ]);
+  }
+}

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -168,6 +168,9 @@ class DynamicSegments {
     $data['product_tags'] = $this->wpPostListLoader->getWooCommerceTags();
 
     $data['products'] = $this->wpPostListLoader->getProducts();
+    $data['variable_products'] = $this->woocommerceHelper->isWooCommerceActive()
+      ? $this->wpPostListLoader->getVariableProducts()
+      : [];
     $data['membership_plans'] = $this->wpPostListLoader->getMembershipPlans();
     $data['subscription_products'] = $this->wpPostListLoader->getSubscriptionProducts();
     $wcCountries = $this->woocommerceHelper->isWooCommerceActive() ? $this->woocommerceHelper->getAllowedCountries() : [];

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -100,6 +100,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\API\JSON\v1\StatisticsExport::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\SubscriberStats::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Subscribers::class)->setPublic(true);
+    $container->autowire(\MailPoet\API\JSON\v1\WoocommerceProductVariations::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\WoocommerceSettings::class)->setPublic(true);
     $container->autowire(\MailPoet\API\JSON\v1\Captcha::class)->setPublic(true);
     $container->autowire(\MailPoet\Util\APIPermissionHelper::class)->setPublic(true);

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -537,6 +537,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct::class)->setPublic(true);
+    $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceProductVariation::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue::class)->setPublic(true);

--- a/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
@@ -23,4 +23,5 @@ class InvalidFilterException extends InvalidStateException {
   const MISSING_PLAN_ID = 16;
   const MISSING_SINGLE_ORDER_VALUE_FIELDS = 17;
   const MISSING_AVERAGE_SPENT_FIELDS = 18;
+  const MISSING_VARIATION_ID = 19;
 };

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -28,6 +28,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProductVariation;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
@@ -414,6 +415,15 @@ class FilterDataMapper {
       }
       $filterData['operator'] = $data['operator'];
       $filterData['product_ids'] = $data['product_ids'];
+    } elseif ($data['action'] === WooCommerceProductVariation::ACTION_PRODUCT_VARIATION) {
+      if (!isset($data['variation_ids']) || !is_array($data['variation_ids']) || count($data['variation_ids']) === 0) {
+        throw new InvalidFilterException('Missing variation', InvalidFilterException::MISSING_VARIATION_ID);
+      }
+      if (!isset($data['operator'])) {
+        throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
+      }
+      $filterData['operator'] = $data['operator'];
+      $filterData['variation_ids'] = $data['variation_ids'];
     } elseif ($data['action'] === WooCommerceCountry::ACTION_CUSTOMER_COUNTRY) {
       if (!isset($data['country_code'])) {
         throw new InvalidFilterException('Missing country', InvalidFilterException::MISSING_COUNTRY);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -419,7 +419,13 @@ class FilterDataMapper {
       if (!isset($data['variation_ids']) || !is_array($data['variation_ids']) || count($data['variation_ids']) === 0) {
         throw new InvalidFilterException('Missing variation', InvalidFilterException::MISSING_VARIATION_ID);
       }
-      if (!isset($data['operator'])) {
+      if (
+        !isset($data['operator']) || !in_array($data['operator'], [
+          DynamicSegmentFilterData::OPERATOR_ANY,
+          DynamicSegmentFilterData::OPERATOR_ALL,
+          DynamicSegmentFilterData::OPERATOR_NONE,
+        ], true)
+      ) {
         throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
       }
       $filterData['operator'] = $data['operator'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterFactory.php
@@ -29,6 +29,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceMembership;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfReviews;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProductVariation;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchaseDate;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
@@ -51,6 +52,9 @@ class FilterFactory {
 
   /** @var WooCommerceProduct */
   private $wooCommerceProduct;
+
+  /** @var WooCommerceProductVariation */
+  private $wooCommerceProductVariation;
 
   /** @var WooCommerceCategory */
   private $wooCommerceCategory;
@@ -166,7 +170,8 @@ class FilterFactory {
     AutomationsEvents $automationsEvents,
     EmailsReceived $emailsReceived,
     NumberOfClicks $numberOfClicks,
-    WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute
+    WooCommercePurchasedWithAttribute $wooCommercePurchasedWithAttribute,
+    WooCommerceProductVariation $wooCommerceProductVariation
   ) {
     $this->emailAction = $emailAction;
     $this->userRole = $userRole;
@@ -200,6 +205,7 @@ class FilterFactory {
     $this->numberOfClicks = $numberOfClicks;
     $this->wooCommercePurchasedWithAttribute = $wooCommercePurchasedWithAttribute;
     $this->wooCommerceTag = $wooCommerceTag;
+    $this->wooCommerceProductVariation = $wooCommerceProductVariation;
   }
 
   public function getFilterForFilterEntity(DynamicSegmentFilterEntity $filter): Filter {
@@ -281,6 +287,8 @@ class FilterFactory {
   private function wooCommerce(?string $action) {
     if ($action === WooCommerceProduct::ACTION_PRODUCT) {
       return $this->wooCommerceProduct;
+    } elseif ($action === WooCommerceProductVariation::ACTION_PRODUCT_VARIATION) {
+      return $this->wooCommerceProductVariation;
     } elseif (in_array($action, WooCommerceNumberOfOrders::ACTIONS)) {
       return $this->wooCommerceNumberOfOrders;
     } elseif ($action === WooCommerceTotalSpent::ACTION_TOTAL_SPENT) {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -52,13 +52,23 @@ class WooCommerceProduct implements Filter {
       $this->applyProductJoin($queryBuilder, $orderStatsAlias);
       $queryBuilder->andWhere("product.product_id IN (:products_{$parameterSuffix})");
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
-      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-      $this->applyProductJoin($queryBuilder, $orderStatsAlias);
-      $queryBuilder->andWhere("product.product_id IN (:products_{$parameterSuffix})")
-        ->groupBy("{$subscribersTable}.id, $orderStatsAlias.order_id")
-        ->having("COUNT($orderStatsAlias.order_id) = :count" . $parameterSuffix)
-        ->setParameter('count' . $parameterSuffix, count($productIds));
-
+      $subQueryCount = 1;
+      foreach ($productIds as $productId) {
+        $uniqueParameterSuffix = Security::generateRandomString();
+        $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+        $subOrderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+        $this->applyProductJoin($subQuery, $subOrderStatsAlias);
+        $subQuery->andWhere("product.product_id = :product_{$uniqueParameterSuffix}");
+        $subQuery->setParameter("product_{$uniqueParameterSuffix}", $productId);
+        $alias = sprintf('productSubQuery%d', $subQueryCount);
+        $queryBuilder->innerJoin(
+          $subscribersTable,
+          sprintf('(%s)', $this->filterHelper->getInterpolatedSQL($subQuery)),
+          $alias,
+          "$subscribersTable.id = $alias.id"
+        );
+        $subQueryCount++;
+      }
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
       // subQuery with subscriber ids that bought products
       $subQuery = $this->createQueryBuilder($subscribersTable);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProductVariation.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProductVariation.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\DynamicSegmentFilterEntity;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Util\Security;
+use MailPoet\WooCommerce\Helper;
+use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
+use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+use WC_Product;
+use WC_Product_Variation;
+
+class WooCommerceProductVariation implements Filter {
+  const ACTION_PRODUCT_VARIATION = 'purchasedProductVariation';
+
+  /** @var EntityManager */
+  private $entityManager;
+
+  /** @var WooFilterHelper */
+  private $wooFilterHelper;
+
+  /** @var FilterHelper */
+  private $filterHelper;
+
+  /** @var Helper */
+  private $wooHelper;
+
+  public function __construct(
+    EntityManager $entityManager,
+    FilterHelper $filterHelper,
+    Helper $wooHelper,
+    WooFilterHelper $wooFilterHelper
+  ) {
+    $this->entityManager = $entityManager;
+    $this->wooFilterHelper = $wooFilterHelper;
+    $this->filterHelper = $filterHelper;
+    $this->wooHelper = $wooHelper;
+  }
+
+  public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
+    $filterData = $filter->getFilterData();
+    $operator = $filterData->getOperator();
+    $variationIds = $filterData->getParam('variation_ids');
+    $variationIds = is_array($variationIds) ? $variationIds : [];
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
+
+    if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
+      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->applyProductJoin($queryBuilder, $orderStatsAlias);
+      $queryBuilder->andWhere("product.variation_id IN (:variations_{$parameterSuffix})");
+    } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
+      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->applyProductJoin($queryBuilder, $orderStatsAlias);
+      $queryBuilder->andWhere("product.variation_id IN (:variations_{$parameterSuffix})")
+        ->groupBy("{$subscribersTable}.id, $orderStatsAlias.order_id")
+        ->having("COUNT(DISTINCT product.variation_id) = :count" . $parameterSuffix)
+        ->setParameter('count' . $parameterSuffix, count($variationIds));
+    } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
+      $subQuery = $this->createQueryBuilder($subscribersTable);
+      $subQuery->select("DISTINCT $subscribersTable.id");
+      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+      $subQuery = $this->applyProductJoin($subQuery, $orderStatsAlias);
+      $subQuery->andWhere("product.variation_id IN (:variations_{$parameterSuffix})");
+      $queryBuilder->where("{$subscribersTable}.id NOT IN ({$this->filterHelper->getInterpolatedSQL($subQuery)})");
+    }
+    return $queryBuilder
+      ->setParameter("variations_{$parameterSuffix}", $variationIds, ArrayParameterType::STRING);
+  }
+
+  private function applyProductJoin(QueryBuilder $queryBuilder, string $orderStatsAlias): QueryBuilder {
+    global $wpdb;
+    return $queryBuilder->innerJoin(
+      $orderStatsAlias,
+      $wpdb->prefix . 'wc_order_product_lookup',
+      'product',
+      "$orderStatsAlias.order_id = product.order_id"
+    );
+  }
+
+  private function createQueryBuilder(string $table): QueryBuilder {
+    return $this->entityManager->getConnection()
+      ->createQueryBuilder()
+      ->from($table);
+  }
+
+  public function getLookupData(DynamicSegmentFilterData $filterData): array {
+    $lookupData = ['variations' => []];
+    if (!$this->wooHelper->isWooCommerceActive()) {
+      return $lookupData;
+    }
+    $variationIds = $filterData->getArrayParam('variation_ids');
+    foreach ($variationIds as $variationId) {
+      $variation = $this->wooHelper->wcGetProduct($variationId);
+      if (!$variation instanceof WC_Product) {
+        continue;
+      }
+      $lookupData['variations'][$variationId] = $this->formatVariationLabel($variation);
+    }
+
+    return $lookupData;
+  }
+
+  private function formatVariationLabel(WC_Product $variation): string {
+    if (!$variation instanceof WC_Product_Variation) {
+      return $variation->get_name();
+    }
+    $parent = $this->wooHelper->wcGetProduct($variation->get_parent_id());
+    $parentName = $parent instanceof WC_Product ? $parent->get_name() : $variation->get_name();
+    $attributesSummary = $this->wooHelper->wcGetFormattedVariation($variation, true);
+    return $attributesSummary === '' ? $parentName : sprintf('%s — %s', $parentName, $attributesSummary);
+  }
+}

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProductVariation.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProductVariation.php
@@ -53,12 +53,23 @@ class WooCommerceProductVariation implements Filter {
       $this->applyProductJoin($queryBuilder, $orderStatsAlias);
       $queryBuilder->andWhere("product.variation_id IN (:variations_{$parameterSuffix})");
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
-      $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-      $this->applyProductJoin($queryBuilder, $orderStatsAlias);
-      $queryBuilder->andWhere("product.variation_id IN (:variations_{$parameterSuffix})")
-        ->groupBy("{$subscribersTable}.id, $orderStatsAlias.order_id")
-        ->having("COUNT(DISTINCT product.variation_id) = :count" . $parameterSuffix)
-        ->setParameter('count' . $parameterSuffix, count($variationIds));
+      $subQueryCount = 1;
+      foreach ($variationIds as $variationId) {
+        $uniqueParameterSuffix = Security::generateRandomString();
+        $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
+        $subOrderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+        $this->applyProductJoin($subQuery, $subOrderStatsAlias);
+        $subQuery->andWhere("product.variation_id = :variation_{$uniqueParameterSuffix}");
+        $subQuery->setParameter("variation_{$uniqueParameterSuffix}", $variationId);
+        $alias = sprintf('variationSubQuery%d', $subQueryCount);
+        $queryBuilder->innerJoin(
+          $subscribersTable,
+          sprintf('(%s)', $this->filterHelper->getInterpolatedSQL($subQuery)),
+          $alias,
+          "$subscribersTable.id = $alias.id"
+        );
+        $subQueryCount++;
+      }
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_NONE) {
       $subQuery = $this->createQueryBuilder($subscribersTable);
       $subQuery->select("DISTINCT $subscribersTable.id");

--- a/mailpoet/lib/WP/AutocompletePostListLoader.php
+++ b/mailpoet/lib/WP/AutocompletePostListLoader.php
@@ -25,6 +25,24 @@ class AutocompletePostListLoader {
     return $this->formatPosts($products);
   }
 
+  public function getVariableProducts() {
+    global $wpdb;
+
+    $products = $wpdb->get_results($wpdb->prepare(
+      "SELECT DISTINCT p.ID, p.post_title
+        FROM {$wpdb->posts} p
+        INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+        INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = %s
+        INNER JOIN {$wpdb->terms} t ON t.term_id = tt.term_id AND t.slug = %s
+        WHERE p.post_type = %s
+        ORDER BY p.post_title ASC;",
+      'product_type',
+      'variable',
+      'product'
+    ));
+    return $this->formatPosts($products);
+  }
+
   public function getMembershipPlans() {
     global $wpdb;
     $products = $wpdb->get_results($wpdb->prepare(

--- a/mailpoet/lib/WooCommerce/Helper.php
+++ b/mailpoet/lib/WooCommerce/Helper.php
@@ -100,6 +100,10 @@ class Helper {
     return wc_get_products($args);
   }
 
+  public function wcGetFormattedVariation(\WC_Product_Variation $variation, bool $flat = false, bool $includeNames = true, bool $skipAttributesInName = false): string {
+    return wc_get_formatted_variation($variation, $flat, $includeNames, $skipAttributesInName);
+  }
+
   public function wcGetPageId(string $page): ?int {
     if ($this->isWooCommerceActive()) {
       return (int)wc_get_page_id($page);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -20,6 +20,7 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCategory;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceCountry;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceNumberOfOrders;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProduct;
+use MailPoet\Segments\DynamicSegments\Filters\WooCommerceProductVariation;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSingleOrderValue;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceSubscription;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
@@ -285,6 +286,50 @@ class FilterDataMapperTest extends \MailPoetTest {
     $this->mapper->map(['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       'action' => WooCommerceProduct::ACTION_PRODUCT,
+    ]]]);
+  }
+
+  public function testItMapsWooCommerceProductVariation(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => WooCommerceProductVariation::ACTION_PRODUCT_VARIATION,
+      'variation_ids' => ['20', '21'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'noise' => 'noise',
+    ]]];
+    $filters = $this->mapper->map($data);
+    verify($filters)->isArray();
+    verify($filters)->arrayCount(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_WOOCOMMERCE);
+    verify($filter->getAction())->equals(WooCommerceProductVariation::ACTION_PRODUCT_VARIATION);
+    verify($filter->getData())->equals([
+      'variation_ids' => ['20', '21'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+    ]);
+  }
+
+  public function testItChecksWooCommerceProductVariationIds(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing variation');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_VARIATION_ID);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => WooCommerceProductVariation::ACTION_PRODUCT_VARIATION,
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+    ]]]);
+  }
+
+  public function testItChecksWooCommerceProductVariationOperator(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing operator');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_OPERATOR);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => WooCommerceProductVariation::ACTION_PRODUCT_VARIATION,
+      'variation_ids' => ['20'],
     ]]]);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -333,6 +333,18 @@ class FilterDataMapperTest extends \MailPoetTest {
     ]]]);
   }
 
+  public function testItChecksWooCommerceProductVariationOperatorIsValid(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionMessage('Missing operator');
+    $this->expectExceptionCode(InvalidFilterException::MISSING_OPERATOR);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => WooCommerceProductVariation::ACTION_PRODUCT_VARIATION,
+      'variation_ids' => ['20'],
+      'operator' => 'invalid-operator',
+    ]]]);
+  }
+
   public function testItCreatesEmailOpens(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -33,6 +33,7 @@ class WooCommerceProductTest extends \MailPoetTest {
     $customerId2 = $this->tester->createCustomer('customer2@example.com');
     $customerIdOnHold = $this->tester->createCustomer('customer-on-hold@example.com');
     $customerIdPendingPayment = $this->tester->createCustomer('customer-pending-payment@example.com');
+    $customerIdMulti = $this->tester->createCustomer('customer-multi-orders@example.com');
 
     $this->createSubscriber('a1@example.com');
     $this->createSubscriber('a2@example.com');
@@ -48,10 +49,21 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->addToOrder(3, $this->orderIds[2], $this->productIds[0], $customerIdOnHold);
     $this->orderIds[] = $this->createOrder($customerIdPendingPayment, Carbon::now(), 'wc-pending');
     $this->addToOrder(4, $this->orderIds[3], $this->productIds[0], $customerIdPendingPayment);
+
+    // customer-multi-orders bought product[0] and product[1] in two separate completed orders.
+    // This exercises the "all of" operator across orders.
+    $this->orderIds[] = $this->createOrder($customerIdMulti, Carbon::now());
+    $this->addToOrder(5, $this->orderIds[4], $this->productIds[0], $customerIdMulti);
+    $this->orderIds[] = $this->createOrder($customerIdMulti, Carbon::now());
+    $this->addToOrder(6, $this->orderIds[5], $this->productIds[1], $customerIdMulti);
   }
 
   public function testItGetsSubscribersThatPurchasedAnyProducts(): void {
-    $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
+    $expectedEmails = [
+      'customer1@example.com',
+      'customer2@example.com',
+      'customer-multi-orders@example.com',
+    ];
     $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ANY);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
@@ -71,11 +83,14 @@ class WooCommerceProductTest extends \MailPoetTest {
   }
 
   public function testItGetsSubscribersThatPurchasedAllProducts(): void {
+    // customer-multi-orders bought product[0] and product[1] in two separate orders.
+    // The "all of" operator must match across orders, not require both in the same order.
+    $expectedEmails = ['customer-multi-orders@example.com'];
     $segmentFilterData = $this->getSegmentFilterData($this->productIds, DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
-    verify($emails)->arrayCount(0);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
 
-    $expectedEmails = ['customer1@example.com'];
+    $expectedEmails = ['customer1@example.com', 'customer-multi-orders@example.com'];
     $segmentFilterData = $this->getSegmentFilterData([$this->productIds[0]], DynamicSegmentFilterData::OPERATOR_ALL);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductVariationTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductVariationTest.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+use MailPoet\Entities\DynamicSegmentFilterData;
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoetVendor\Carbon\Carbon;
+
+/**
+ * @group woo
+ */
+class WooCommerceProductVariationTest extends \MailPoetTest {
+  /** @var WooCommerceProductVariation */
+  private $wooCommerceProductVariationFilter;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var int[] */
+  private $productIds = [];
+
+  /** @var int[] */
+  private $variationIds = [];
+
+  /** @var int[] */
+  private $orderIds = [];
+
+  public function _before(): void {
+    $this->wooCommerceProductVariationFilter = $this->diContainer->get(WooCommerceProductVariation::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+
+    $this->cleanUp();
+
+    $customerId1 = $this->tester->createCustomer('customer1@example.com');
+    $customerId2 = $this->tester->createCustomer('customer2@example.com');
+    $customerIdOnHold = $this->tester->createCustomer('customer-on-hold@example.com');
+
+    $this->createSubscriber('a1@example.com');
+    $this->createSubscriber('a2@example.com');
+
+    $this->productIds[] = $this->createProduct('variableProduct1');
+    $this->productIds[] = $this->createProduct('variableProduct2');
+
+    $this->variationIds[] = $this->createVariation($this->productIds[0], 'variableProduct1 - red');
+    $this->variationIds[] = $this->createVariation($this->productIds[0], 'variableProduct1 - blue');
+    $this->variationIds[] = $this->createVariation($this->productIds[1], 'variableProduct2 - small');
+
+    $this->orderIds[] = $this->createOrder($customerId1, Carbon::now());
+    $this->addToOrder(1, $this->orderIds[0], $this->productIds[0], $this->variationIds[0], $customerId1);
+    $this->orderIds[] = $this->createOrder($customerId2, Carbon::now());
+    $this->addToOrder(2, $this->orderIds[1], $this->productIds[0], $this->variationIds[1], $customerId2);
+    $this->orderIds[] = $this->createOrder($customerIdOnHold, Carbon::now(), 'wc-on-hold');
+    $this->addToOrder(3, $this->orderIds[2], $this->productIds[0], $this->variationIds[0], $customerIdOnHold);
+  }
+
+  public function testItGetsSubscribersThatPurchasedAnyVariation(): void {
+    $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
+    $segmentFilterData = $this->getSegmentFilterData(
+      [$this->variationIds[0], $this->variationIds[1]],
+      DynamicSegmentFilterData::OPERATOR_ANY
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductVariationFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  public function testItGetsSubscribersThatPurchasedNoneOfVariations(): void {
+    $expectedEmails = [
+      'a1@example.com',
+      'a2@example.com',
+      'customer-on-hold@example.com',
+      'customer2@example.com',
+    ];
+    $segmentFilterData = $this->getSegmentFilterData(
+      [$this->variationIds[0]],
+      DynamicSegmentFilterData::OPERATOR_NONE
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductVariationFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  public function testItGetsSubscribersThatPurchasedAllVariations(): void {
+    $segmentFilterData = $this->getSegmentFilterData(
+      [$this->variationIds[0], $this->variationIds[1]],
+      DynamicSegmentFilterData::OPERATOR_ALL
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductVariationFilter);
+    verify($emails)->arrayCount(0);
+
+    $expectedEmails = ['customer1@example.com'];
+    $segmentFilterData = $this->getSegmentFilterData(
+      [$this->variationIds[0]],
+      DynamicSegmentFilterData::OPERATOR_ALL
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductVariationFilter);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
+  }
+
+  public function testItRetrievesLookupData(): void {
+    $segmentFilterData = $this->getSegmentFilterData(
+      [$this->variationIds[0], 999999],
+      DynamicSegmentFilterData::OPERATOR_ANY
+    );
+    $lookupData = $this->wooCommerceProductVariationFilter->getLookupData($segmentFilterData);
+    verify($lookupData)->arrayHasKey('variations');
+    verify($lookupData['variations'])->arrayHasKey($this->variationIds[0]);
+  }
+
+  private function getSegmentFilterData(array $variationIds, string $operator): DynamicSegmentFilterData {
+    $filterData = [
+      'variation_ids' => $variationIds,
+      'operator' => $operator,
+    ];
+
+    return new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceProductVariation::ACTION_PRODUCT_VARIATION,
+      $filterData
+    );
+  }
+
+  private function createOrder(int $customerId, Carbon $createdAt, string $status = 'wc-completed'): int {
+    $order = $this->tester->createWooCommerceOrder();
+    $order->set_customer_id($customerId);
+    $order->set_date_created($createdAt->toDateTimeString());
+    $order->set_status($status);
+    $order->save();
+    $this->tester->updateWooOrderStats($order->get_id());
+
+    return $order->get_id();
+  }
+
+  private function createProduct(string $name): int {
+    $productData = [
+      'post_type' => 'product',
+      'post_status' => 'publish',
+      'post_title' => $name,
+    ];
+    $productId = wp_insert_post($productData);
+    $this->assertIsInt($productId);
+    return $productId;
+  }
+
+  private function createVariation(int $parentId, string $name): int {
+    $variationData = [
+      'post_type' => 'product_variation',
+      'post_status' => 'publish',
+      'post_title' => $name,
+      'post_parent' => $parentId,
+    ];
+    $variationId = wp_insert_post($variationData);
+    $this->assertIsInt($variationId);
+    return $variationId;
+  }
+
+  private function addToOrder(int $orderItemId, int $orderId, int $productId, int $variationId, int $customerId): void {
+    global $wpdb;
+    $this->connection->executeQuery("
+      INSERT INTO {$wpdb->prefix}wc_order_product_lookup (order_item_id, order_id, product_id, customer_id, variation_id, product_qty, date_created)
+      VALUES ({$orderItemId}, {$orderId}, {$productId}, {$customerId}, {$variationId}, 1, now())
+    ");
+  }
+
+  private function createSubscriber(string $email): SubscriberEntity {
+    $subscriber = new SubscriberEntity();
+    $subscriber->setEmail($email);
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+    return $subscriber;
+  }
+
+  public function _after(): void {
+    parent::_after();
+    $this->cleanUp();
+  }
+
+  private function cleanUp(): void {
+    global $wpdb;
+
+    foreach ($this->variationIds as $variationId) {
+      wp_delete_post($variationId, true);
+    }
+    foreach ($this->productIds as $productId) {
+      wp_delete_post($productId, true);
+    }
+    $this->variationIds = [];
+    $this->productIds = [];
+
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_customer_lookup");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_stats");
+    $this->connection->executeQuery("TRUNCATE TABLE {$wpdb->prefix}wc_order_product_lookup");
+  }
+}

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductVariationTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductVariationTest.php
@@ -35,6 +35,7 @@ class WooCommerceProductVariationTest extends \MailPoetTest {
     $customerId1 = $this->tester->createCustomer('customer1@example.com');
     $customerId2 = $this->tester->createCustomer('customer2@example.com');
     $customerIdOnHold = $this->tester->createCustomer('customer-on-hold@example.com');
+    $customerIdMulti = $this->tester->createCustomer('customer-multi-orders@example.com');
 
     $this->createSubscriber('a1@example.com');
     $this->createSubscriber('a2@example.com');
@@ -52,10 +53,21 @@ class WooCommerceProductVariationTest extends \MailPoetTest {
     $this->addToOrder(2, $this->orderIds[1], $this->productIds[0], $this->variationIds[1], $customerId2);
     $this->orderIds[] = $this->createOrder($customerIdOnHold, Carbon::now(), 'wc-on-hold');
     $this->addToOrder(3, $this->orderIds[2], $this->productIds[0], $this->variationIds[0], $customerIdOnHold);
+
+    // customer-multi-orders bought variation[0] and variation[1] in two separate completed orders.
+    // This exercises the "all of" operator across orders.
+    $this->orderIds[] = $this->createOrder($customerIdMulti, Carbon::now());
+    $this->addToOrder(4, $this->orderIds[3], $this->productIds[0], $this->variationIds[0], $customerIdMulti);
+    $this->orderIds[] = $this->createOrder($customerIdMulti, Carbon::now());
+    $this->addToOrder(5, $this->orderIds[4], $this->productIds[0], $this->variationIds[1], $customerIdMulti);
   }
 
   public function testItGetsSubscribersThatPurchasedAnyVariation(): void {
-    $expectedEmails = ['customer1@example.com', 'customer2@example.com'];
+    $expectedEmails = [
+      'customer1@example.com',
+      'customer2@example.com',
+      'customer-multi-orders@example.com',
+    ];
     $segmentFilterData = $this->getSegmentFilterData(
       [$this->variationIds[0], $this->variationIds[1]],
       DynamicSegmentFilterData::OPERATOR_ANY
@@ -80,14 +92,17 @@ class WooCommerceProductVariationTest extends \MailPoetTest {
   }
 
   public function testItGetsSubscribersThatPurchasedAllVariations(): void {
+    // customer-multi-orders bought variation[0] and variation[1] in two separate orders.
+    // The "all of" operator must match across orders, not require both in the same order.
+    $expectedEmails = ['customer-multi-orders@example.com'];
     $segmentFilterData = $this->getSegmentFilterData(
       [$this->variationIds[0], $this->variationIds[1]],
       DynamicSegmentFilterData::OPERATOR_ALL
     );
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductVariationFilter);
-    verify($emails)->arrayCount(0);
+    $this->assertEqualsCanonicalizing($expectedEmails, $emails);
 
-    $expectedEmails = ['customer1@example.com'];
+    $expectedEmails = ['customer1@example.com', 'customer-multi-orders@example.com'];
     $segmentFilterData = $this->getSegmentFilterData(
       [$this->variationIds[0]],
       DynamicSegmentFilterData::OPERATOR_ALL

--- a/mailpoet/views/segments/dynamic.html
+++ b/mailpoet/views/segments/dynamic.html
@@ -16,6 +16,7 @@
     var mailpoet_product_categories = <%= json_encode(product_categories)  %>;
     var mailpoet_product_tags = <%= json_encode(product_tags) %>;
     var mailpoet_products = <%= json_encode(products) %>;
+    var mailpoet_variable_products = <%= json_encode(variable_products) %>;
     var mailpoet_membership_plans = <%= json_encode(membership_plans) %>;
     var mailpoet_subscription_products = <%= json_encode(subscription_products) %>;
     var mailpoet_can_use_woocommerce_memberships = <%= json_encode(can_use_woocommerce_memberships)  %>;

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -152,6 +152,8 @@
   'wooSpentAmount': __('amount'),
   'selectWooPurchasedCategory': __('Search categories'),
   'selectWooPurchasedProduct': __('Search products'),
+  'selectWooVariableProduct': __('Search variable products'),
+  'selectWooPurchasedProductVariation': __('Select variations'),
   'selectWooCountry': __('Search countries'),
   'selectWooCouponCodes': __('Search coupon codes'),
   'selectWooPaymentMethods': __('Search payment methods'),


### PR DESCRIPTION
## Description

Allow segmenting by product variation

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8017

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1104" height="766" alt="Screenshot 2026-05-04 at 14 15 24" src="https://github.com/user-attachments/assets/2452935b-04fa-49d2-844a-8a240ef4a6e7" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8017-segment-by-product-variation)

_The latest successful build from `stomail-8017-segment-by-product-variation` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

The implementation demonstrates solid engineering practices:
- SQL queries use parameterized statements with proper type binding
- API endpoint includes appropriate permission validation (PERMISSION_MANAGE_SEGMENTS)
- Input validation ensures non-empty variation_ids arrays and required operators
- React component uses proper async state management with loading guards
- Comprehensive integration test coverage for all operator types (ANY, ALL, NONE)
- Proper error handling and WooCommerce availability checks throughout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->