### PR TITLE
Allow editing active automations [STOMAIL-8019]

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -1,11 +1,6 @@
 import { useMemo, useState } from 'react';
 import classnames from 'classnames';
-import {
-  Button,
-  NavigableMenu,
-  TextControl,
-  Tooltip,
-} from '@wordpress/components';
+import { Button, NavigableMenu, TextControl } from '@wordpress/components';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { Icon, check, cloud } from '@wordpress/icons';
 import { PinnedItems } from '@wordpress/interface';
@@ -29,19 +24,16 @@ import { sendTelemetryEvent } from '../../telemetry';
 //   https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/header/index.js
 
 export function ActivateButton({ label }): JSX.Element {
-  const { errors, isDeactivating, automationId } = useSelect(
+  const { errors, automationId } = useSelect(
     (select) => ({
       errors: select(storeName).getErrors(),
-      isDeactivating:
-        select(storeName).getAutomationData().status ===
-        AutomationStatus.DEACTIVATING,
       automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
   const { openActivationPanel } = useDispatch(storeName);
 
-  const button = (
+  return (
     <Button
       variant="primary"
       className="editor-post-publish-button"
@@ -52,35 +44,18 @@ export function ActivateButton({ label }): JSX.Element {
         });
         void openActivationPanel();
       }}
-      disabled={isDeactivating || !!errors}
+      disabled={!!errors}
     >
       {label}
     </Button>
   );
-
-  if (isDeactivating) {
-    return (
-      <Tooltip
-        delay={0}
-        text={__(
-          'Editing an active automation is currently unavailable.',
-          'mailpoet',
-        )}
-      >
-        {button}
-      </Tooltip>
-    );
-  }
-
-  return button;
 }
 
 export function UpdateButton(): JSX.Element {
   const { save } = useDispatch(storeName);
 
-  const { automation, savedState } = useSelect(
+  const { savedState } = useSelect(
     (select) => ({
-      automation: select(storeName).getAutomationData(),
       savedState: select(storeName).getSavedState(),
     }),
     [],
@@ -93,40 +68,20 @@ export function UpdateButton(): JSX.Element {
       ? __('Updating…', 'mailpoet')
       : __('Update', 'mailpoet');
 
-  if (automation.stats.totals.in_progress === 0) {
-    return (
-      <Button
-        variant="primary"
-        className="editor-post-publish-button"
-        label={label}
-        showTooltip
-        shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
-        isBusy={savedState === 'saving'}
-        disabled={isDisabled}
-        aria-disabled={isDisabled}
-        onClick={save}
-      >
-        {label}
-      </Button>
-    );
-  }
   return (
-    <Tooltip
-      delay={0}
-      text={__(
-        'Editing an active automation is currently unavailable.',
-        'mailpoet',
-      )}
+    <Button
+      variant="primary"
+      className="editor-post-publish-button"
+      label={label}
+      showTooltip
+      shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
+      isBusy={savedState === 'saving'}
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
+      onClick={save}
     >
-      <Button
-        variant="primary"
-        className="editor-post-publish-button"
-        onClick={save}
-        disabled
-      >
-        {__('Update', 'mailpoet')}
-      </Button>
-    </Tooltip>
+      {label}
+    </Button>
   );
 }
 

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -17,6 +17,7 @@ import {
   DeactivateImmediatelyModal,
   DeactivateModal,
 } from '../modals/deactivate-modal';
+import { SaveActiveModal } from '../modals/save-active-modal';
 import { sendTelemetryEvent } from '../../telemetry';
 
 // See:
@@ -53,9 +54,12 @@ export function ActivateButton({ label }): JSX.Element {
 
 export function UpdateButton(): JSX.Element {
   const { save } = useDispatch(storeName);
+  const [showSaveModal, setShowSaveModal] = useState(false);
 
-  const { savedState } = useSelect(
+  const { hasUsersInProgress, savedState } = useSelect(
     (select) => ({
+      hasUsersInProgress:
+        select(storeName).getAutomationData().stats.totals.in_progress > 0,
       savedState: select(storeName).getSavedState(),
     }),
     [],
@@ -68,20 +72,33 @@ export function UpdateButton(): JSX.Element {
       ? __('Updating…', 'mailpoet')
       : __('Update', 'mailpoet');
 
+  const onClick = () => {
+    if (hasUsersInProgress) {
+      setShowSaveModal(true);
+      return;
+    }
+    void save();
+  };
+
   return (
-    <Button
-      variant="primary"
-      className="editor-post-publish-button"
-      label={label}
-      showTooltip
-      shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
-      isBusy={savedState === 'saving'}
-      disabled={isDisabled}
-      aria-disabled={isDisabled}
-      onClick={save}
-    >
-      {label}
-    </Button>
+    <>
+      {showSaveModal && (
+        <SaveActiveModal onClose={() => setShowSaveModal(false)} />
+      )}
+      <Button
+        variant="primary"
+        className="editor-post-publish-button"
+        label={label}
+        showTooltip
+        shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
+        isBusy={savedState === 'saving'}
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        onClick={onClick}
+      >
+        {label}
+      </Button>
+    </>
   );
 }
 

--- a/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { Button, Modal } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { dispatch, useSelect } from '@wordpress/data';
+import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
+
+const LET_FINISH = 'let_existing_finish';
+const STOP_ALL = 'stop_all_subscribers';
+
+type Props = {
+  onClose: () => void;
+  onRequestClose?: () => void;
+};
+
+export function SaveActiveModal({
+  onClose,
+  onRequestClose,
+}: Props): JSX.Element {
+  const { automationName, automationId } = useSelect(
+    (s) => ({
+      automationName: s(storeName).getAutomationData().name,
+      automationId: s(storeName).getAutomationData().id,
+    }),
+    [],
+  );
+  const [selected, setSelected] = useState<typeof LET_FINISH | typeof STOP_ALL>(
+    LET_FINISH,
+  );
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+
+  useEffect(() => {
+    sendTelemetryEvent('modal_view', {
+      modal_title: 'save_active_automation',
+      automation_id: automationId,
+    });
+  }, [automationId]);
+
+  // translators: %s is the name of the automation.
+  const title = sprintf(
+    __('Save changes to "%s"?', 'mailpoet'),
+    automationName,
+  );
+
+  return (
+    <Modal
+      className="mailpoet-automation-deactivate-modal"
+      title={title}
+      onRequestClose={onRequestClose ?? onClose}
+    >
+      {__(
+        'Some subscribers are mid-flow. Choose how this update should affect them.',
+        'mailpoet',
+      )}
+      <ul className="mailpoet-automation-options">
+        <li>
+          <label
+            className={
+              selected === LET_FINISH
+                ? 'mailpoet-automation-option active'
+                : 'mailpoet-automation-option'
+            }
+          >
+            <span>
+              <input
+                type="radio"
+                disabled={isBusy}
+                name="save-method"
+                checked={selected === LET_FINISH}
+                onChange={() => {
+                  sendTelemetryEvent('modal_option_select', {
+                    modal_title: 'save_active_automation',
+                    selected_option: LET_FINISH,
+                    automation_id: automationId,
+                  });
+                  setSelected(LET_FINISH);
+                }}
+              />
+            </span>
+            <span>
+              <strong>
+                {__('Let in-flight subscribers finish', 'mailpoet')}
+              </strong>
+              {__(
+                'They continue on the previous version. New subscribers use the updated automation.',
+                'mailpoet',
+              )}
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            className={
+              selected === STOP_ALL
+                ? 'mailpoet-automation-option active'
+                : 'mailpoet-automation-option'
+            }
+          >
+            <span>
+              <input
+                type="radio"
+                disabled={isBusy}
+                name="save-method"
+                checked={selected === STOP_ALL}
+                onChange={() => {
+                  sendTelemetryEvent('modal_option_select', {
+                    modal_title: 'save_active_automation',
+                    selected_option: STOP_ALL,
+                    automation_id: automationId,
+                  });
+                  setSelected(STOP_ALL);
+                }}
+              />
+            </span>
+            <span>
+              <strong>{__('Drop in-flight subscribers', 'mailpoet')}</strong>
+              {__(
+                'In-flight runs are cancelled. Only new subscribers will go through the updated automation.',
+                'mailpoet',
+              )}
+            </span>
+          </label>
+        </li>
+      </ul>
+
+      <Button
+        isBusy={isBusy}
+        variant="primary"
+        onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'save_active_automation',
+            button_label: 'save',
+            selected_option: selected,
+            automation_id: automationId,
+          });
+          setIsBusy(true);
+          void dispatch(storeName).save({
+            cancelRunningRuns: selected === STOP_ALL,
+          });
+          onClose();
+        }}
+      >
+        {__('Save', 'mailpoet')}
+      </Button>
+
+      <Button
+        disabled={isBusy}
+        variant="tertiary"
+        onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'save_active_automation',
+            button_label: 'cancel',
+            automation_id: automationId,
+          });
+          onClose();
+        }}
+      >
+        {__('Cancel', 'mailpoet')}
+      </Button>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import { createRoot } from 'react-dom/client';
 import { useEffect, useRef, useState } from 'react';
 import { SlotFillProvider } from '@wordpress/components';
-import { store as noticesStore } from '@wordpress/notices';
 import { dispatch, select as globalSelect, useSelect } from '@wordpress/data';
 import { getSettings, setSettings } from '@wordpress/date';
 import { Platform } from '@wordpress/element';
@@ -30,7 +29,6 @@ import { MailPoet } from '../../mailpoet';
 import { LISTING_NOTICES } from '../listing/automation-listing-notices';
 import { registerApiErrorHandler } from './api-error-handler';
 import { ActivatePanel } from './components/panel/activate-panel';
-import { AutomationStatus } from '../listing/automation';
 import { initializeIntegrations } from './integrations';
 import { sendTelemetryEvent } from './telemetry';
 
@@ -40,33 +38,6 @@ import { sendTelemetryEvent } from './telemetry';
 
 // disable inserter sidebar until we implement drag & drop
 const showInserterSidebar = false;
-
-/**
- * Show temporary message that active automations cant be updated
- *
- * see MAILPOET-4744
- */
-function updatingActiveAutomationNotPossible() {
-  const automation = globalSelect(storeName).getAutomationData();
-  if (
-    ![AutomationStatus.ACTIVE, AutomationStatus.DEACTIVATING].includes(
-      automation.status,
-    )
-  ) {
-    return;
-  }
-  if (automation.stats.totals.in_progress === 0) {
-    return;
-  }
-  const { createNotice } = dispatch(noticesStore);
-  void createNotice(
-    'success',
-    __('Editing an active automation is currently unavailable.', 'mailpoet'),
-    {
-      type: 'snackbar',
-    },
-  );
-}
 
 function onUnload(event) {
   if (globalSelect(storeName).getSavedState() !== 'saved') {
@@ -126,7 +97,6 @@ function Editor(): JSX.Element {
         'notice-args': [automation.name],
       });
     }
-    updatingActiveAutomationNotPossible();
     if (!pageViewFiredRef.current) {
       pageViewFiredRef.current = true;
       sendTelemetryEvent('page_view', {

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -95,7 +95,7 @@ export function setAutomationName(name) {
   } as const;
 }
 
-export function* save() {
+export function* save(options: { cancelRunningRuns?: boolean } = {}) {
   const automation = select(storeName).getAutomationData();
 
   yield {
@@ -105,7 +105,10 @@ export function* save() {
   const data = yield apiFetch({
     path: `/automations/${automation.id}`,
     method: 'PUT',
-    data: { ...automation },
+    data: {
+      ...automation,
+      ...(options.cancelRunningRuns ? { cancel_running_runs: true } : {}),
+    },
   });
 
   const { createNotice } = dispatch(noticesStore);

--- a/mailpoet/changelog/2026-05-04-16-00-06-improved-allow-editing-active-automations-existing-in-fligh.md
+++ b/mailpoet/changelog/2026-05-04-16-00-06-improved-allow-editing-active-automations-existing-in-fligh.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Allow editing active automations. Existing in-flight subscribers continue on the previous version, and you can optionally cancel them

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -64,6 +64,7 @@ class UpdateAutomationController {
     }
 
     if (array_key_exists('steps', $data)) {
+      $this->validateTriggerInvariants($automation, $data['steps']);
       $this->validateAutomationSteps($automation, $data['steps']);
       $this->updateStepsController->updateSteps($automation, $data['steps']);
       foreach ($automation->getSteps() as $step) {
@@ -99,6 +100,33 @@ class UpdateAutomationController {
     if (!in_array($status, Automation::STATUS_ALL, true)) {
       // translators: %s is the status.
       throw UnexpectedValueException::create()->withMessage(sprintf(__('Invalid status: %s', 'mailpoet'), $status));
+    }
+  }
+
+  private function validateTriggerInvariants(Automation $automation, array $steps): void {
+    $existingTriggers = [];
+    foreach ($automation->getSteps() as $step) {
+      if ($step->getType() === Step::TYPE_TRIGGER) {
+        $existingTriggers[$step->getId()] = $step;
+      }
+    }
+
+    $newTriggers = [];
+    foreach ($steps as $id => $data) {
+      if (($data['type'] ?? null) === Step::TYPE_TRIGGER) {
+        $newTriggers[$id] = $data;
+      }
+    }
+
+    if (count($newTriggers) !== count($existingTriggers)) {
+      throw Exceptions::automationTriggerModificationNotSupported();
+    }
+
+    foreach ($existingTriggers as $id => $existingTrigger) {
+      $newTrigger = $newTriggers[$id] ?? null;
+      if (!$newTrigger || ($newTrigger['key'] ?? '') !== $existingTrigger->getKey()) {
+        throw Exceptions::automationTriggerModificationNotSupported();
+      }
     }
   }
 

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -75,6 +75,8 @@ class UpdateAutomationController {
 
     if (($automation->getStatus() === Automation::STATUS_DRAFT) && ($originalStatus === Automation::STATUS_ACTIVE)) {
       $this->unscheduleAutomationRuns($automation);
+    } elseif (!empty($data['cancel_running_runs'])) {
+      $this->unscheduleAutomationRuns($automation);
     }
 
     if (array_key_exists('meta', $data)) {

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -119,8 +119,8 @@ class UpdateAutomationController {
   private function stepChanged(Step $a, Step $b): bool {
     $aData = $a->toArray();
     $bData = $b->toArray();
-    unset($aData['args']);
-    unset($bData['args']);
+    unset($aData['args'], $aData['filters']);
+    unset($bData['args'], $bData['filters']);
     return $aData === $bData;
   }
 

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -11,7 +11,6 @@ use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
-use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\Validation\AutomationValidator;
 
@@ -21,9 +20,6 @@ class UpdateAutomationController {
 
   /** @var AutomationStorage */
   private $storage;
-
-  /** @var AutomationStatisticsStorage */
-  private $statisticsStorage;
 
   /** @var AutomationValidator */
   private $automationValidator;
@@ -38,7 +34,6 @@ class UpdateAutomationController {
   public function __construct(
     Hooks $hooks,
     AutomationStorage $storage,
-    AutomationStatisticsStorage $statisticsStorage,
     AutomationValidator $automationValidator,
     AutomationRunStorage $automationRunStorage,
     ActionScheduler $actionScheduler,
@@ -46,7 +41,6 @@ class UpdateAutomationController {
   ) {
     $this->hooks = $hooks;
     $this->storage = $storage;
-    $this->statisticsStorage = $statisticsStorage;
     $this->automationValidator = $automationValidator;
     $this->updateStepsController = $updateStepsController;
     $this->automationRunStorage = $automationRunStorage;
@@ -58,7 +52,6 @@ class UpdateAutomationController {
     if (!$automation) {
       throw Exceptions::automationNotFound($id);
     }
-    $this->validateIfAutomationCanBeUpdated($automation, $data);
 
     if (array_key_exists('name', $data)) {
       $automation->setName($data['name']);
@@ -100,34 +93,6 @@ class UpdateAutomationController {
       throw Exceptions::automationNotFound($id);
     }
     return $automation;
-  }
-
-  /**
-   * This is a temporary validation, see MAILPOET-4744
-   */
-  private function validateIfAutomationCanBeUpdated(Automation $automation, array $data): void {
-
-    if (
-      !in_array(
-        $automation->getStatus(),
-        [
-        Automation::STATUS_ACTIVE,
-        Automation::STATUS_DEACTIVATING,
-        ],
-        true
-      )
-    ) {
-      return;
-    }
-
-    $statistics = $this->statisticsStorage->getAutomationStats($automation->getId());
-    if ($statistics->getInProgress() === 0) {
-      return;
-    }
-
-    if (!isset($data['status']) || $data['status'] === $automation->getStatus()) {
-      throw Exceptions::automationHasActiveRuns($automation->getId());
-    }
   }
 
   private function checkAutomationStatus(string $status): void {

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsPutEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsPutEndpoint.php
@@ -40,6 +40,7 @@ class AutomationsPutEndpoint extends Endpoint {
       'status' => Builder::string(),
       'steps' => AutomationSchema::getStepsSchema(),
       'meta' => Builder::object(),
+      'cancel_running_runs' => Builder::boolean(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -36,7 +36,6 @@ class Exceptions {
   private const MISSING_REQUIRED_SUBJECTS = 'mailpoet_automation_missing_required_subjects';
   private const AUTOMATION_NOT_TRASHED = 'mailpoet_automation_not_trashed';
   private const AUTOMATION_TEMPLATE_NOT_FOUND = 'mailpoet_automation_template_not_found';
-  private const AUTOMATION_HAS_ACTIVE_RUNS = 'mailpoet_automation_has_active_runs';
   private const AUTOMATION_STEP_NOT_STARTED = 'mailpoet_automation_step_not_started';
   private const AUTOMATION_STEP_NOT_RUNNING = 'mailpoet_automation_step_not_running';
   private const AUTOMATION_STEP_ACTION_PROCESSED = 'mailpoet_automation_step_action_processed';
@@ -273,16 +272,6 @@ class Exceptions {
       ->withErrorCode(self::AUTOMATION_TEMPLATE_NOT_FOUND)
       // translators: %d is the ID of the automation template.
       ->withMessage(sprintf(__("Automation template with ID '%d' not found.", 'mailpoet'), $id));
-  }
-
-  /**
-   * This is a temporary block, see MAILPOET-4744
-   */
-  public static function automationHasActiveRuns(int $id): InvalidStateException {
-    return InvalidStateException::create()
-      ->withErrorCode(self::AUTOMATION_HAS_ACTIVE_RUNS)
-      // translators: %d is the ID of the automation.
-      ->withMessage(sprintf(__("Can not update automation with ID '%d' because users are currently active.", 'mailpoet'), $id));
   }
 
   public static function stepNotStarted(string $id, int $runId): InvalidStateException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -30,6 +30,7 @@ class Exceptions {
   private const NEXT_STEP_NOT_FOUND = 'mailpoet_next_step_not_found';
   private const NEXT_STEP_NOT_SCHEDULED = 'mailpoet_next_step_not_scheduled';
   private const AUTOMATION_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_structure_modification_not_supported';
+  private const AUTOMATION_TRIGGER_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_trigger_modification_not_supported';
   private const AUTOMATION_STRUCTURE_NOT_VALID = 'mailpoet_automation_structure_not_valid';
   private const AUTOMATION_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_step_modified_when_unknown';
   private const AUTOMATION_NOT_VALID = 'mailpoet_automation_not_valid';
@@ -212,6 +213,12 @@ class Exceptions {
     return UnexpectedValueException::create()
       ->withErrorCode(self::AUTOMATION_STRUCTURE_MODIFICATION_NOT_SUPPORTED)
       ->withMessage(__('Automation structure modification not supported.', 'mailpoet'));
+  }
+
+  public static function automationTriggerModificationNotSupported(): UnexpectedValueException {
+    return UnexpectedValueException::create()
+      ->withErrorCode(self::AUTOMATION_TRIGGER_MODIFICATION_NOT_SUPPORTED)
+      ->withMessage(__('Changing the trigger of an existing automation is not supported. You can edit its settings or filters instead.', 'mailpoet'));
   }
 
   public static function automationStructureNotValid(string $detail, string $ruleId): UnexpectedValueException {

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -51,6 +51,39 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     $this->assertNotSame($updated->getVersionId(), $run->getVersionId());
   }
 
+  public function testItCancelsRunningRunsWhenCancelFlagIsSet(): void {
+    $automation = $this->tester->createAutomation(
+      'Active automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
+    );
+
+    $run = $this->tester->createAutomationRun($automation);
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $runStorage->updateStatus($run->getId(), AutomationRun::STATUS_RUNNING);
+
+    $this->scheduleAction(time() + 100, ['automation_run_id' => $run->getId(), 'step_id' => 'a1', 'run_number' => 1]);
+
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+    $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'cancel_running_runs' => true,
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
+        ],
+      ]
+    );
+
+    $updated = $this->diContainer->get(AutomationStorage::class)->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $updated);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updated->getStatus());
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $this->getAutomationRun($run->getId())->getStatus());
+    $this->assertCount(0, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
+  }
+
   public function testItRejectsTriggerKeyChange(): void {
     $automation = $this->tester->createAutomation(
       'Trigger lock automation',

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -14,6 +14,42 @@ use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoetTest;
 
 class UpdateAutomationControllerTest extends MailPoetTest {
+  public function testItUpdatesActiveAutomationWithRunningRuns(): void {
+    $automation = $this->tester->createAutomation(
+      'Active automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
+    );
+    $this->assertSame(Automation::STATUS_ACTIVE, $automation->getStatus());
+
+    $run = $this->tester->createAutomationRun($automation);
+    $this->diContainer->get(AutomationRunStorage::class)
+      ->updateStatus($run->getId(), AutomationRun::STATUS_RUNNING);
+
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+    $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
+        ],
+      ]
+    );
+
+    $updated = $this->diContainer->get(AutomationStorage::class)->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $updated);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updated->getStatus());
+    $updatedStep = $updated->getStep('a1');
+    $this->assertInstanceOf(Step::class, $updatedStep);
+    $this->assertSame('after', $updatedStep->getArgs()['note']);
+
+    // existing run is preserved on its original version
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
+    $this->assertNotSame($updated->getVersionId(), $run->getVersionId());
+  }
+
   public function testItUnschedulesTasksWhenSwitchedToDraft(): void {
     $automation = $this->tester->createAutomation(
       'Test automation',

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
@@ -48,6 +49,28 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     // existing run is preserved on its original version
     $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
     $this->assertNotSame($updated->getVersionId(), $run->getVersionId());
+  }
+
+  public function testItRejectsTriggerKeyChange(): void {
+    $automation = $this->tester->createAutomation(
+      'Trigger lock automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', [], [])
+    );
+
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+
+    $this->expectException(UnexpectedValueException::class);
+    $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:other-trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => [], 'next_steps' => []],
+        ],
+      ]
+    );
   }
 
   public function testItUnschedulesTasksWhenSwitchedToDraft(): void {


### PR DESCRIPTION
## Description

Removes the temporary block (MAILPOET-4744) that prevented editing an automation while subscribers were mid-flow. Saving now writes a new version row, while existing in-flight runs keep their pinned `version_id` and continue running on the previous structure. New subscribers use the latest version.

If subscribers are mid-flow, the editor's Update button opens a modal to choose:

- **Let in-flight subscribers finish** (default) — they continue on the previous version, new subscribers use the new one.
- **Drop in-flight subscribers** — running runs are cancelled and their pending Action Scheduler tasks unscheduled.

The trigger is locked: its `id` and `key` cannot change once an automation has been saved. Args, filters, and outgoing connections may still change. The lock runs as a separate, non-overridable invariant in `UpdateAutomationController::validateTriggerInvariants`, so it also applies to plugins (e.g. Premium) that override the looser step-structure check.

## Code review notes

- The trigger-lock check is intentionally separate from `validateAutomationSteps` because Premium overrides the latter to a no-op for full structural editing. Keeping the trigger invariant in `updateAutomation` itself ensures it cannot be bypassed.
- `cancel_running_runs` reuses the existing `unscheduleAutomationRuns` path that already runs on ACTIVE → DRAFT transitions, so the cancellation semantics match what a manual deactivate does.
- Filter changes are now allowed on every step by excluding `filters` from `stepChanged`'s comparison. Args were already excluded.
- The `validateIfAutomationCanBeUpdated` exception (`automationHasActiveRuns`) is removed entirely. It was only thrown by the now-deleted block, with no other callers.

## QA notes

- Active automation with no in-flight subscribers — Update button saves directly with no modal.
- Active automation with in-flight subscribers — Update button opens the new save modal:
  - "Let in-flight subscribers finish" → in-flight runs keep `STATUS_RUNNING` on their old `version_id`; new subscribers go through the latest version.
  - "Drop in-flight subscribers" → in-flight runs become `STATUS_CANCELLED`, pending Action Scheduler tasks are unscheduled.
- Try to save an automation with the trigger swapped to a different trigger key → 4xx with the new "trigger modification not supported" error.
- Try to save an automation with edited trigger filters → succeeds.
- Reactivate from `DEACTIVATING` via "Update & Activate" → status flips to `ACTIVE`, in-flight runs (which were already finishing) keep going.

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8019](https://linear.app/automattic/issue/STOMAIL-8019)
- Canny: https://mailpoet.canny.io/feature-requests/p/edit-active-automations
- Canny: https://mailpoet.canny.io/feature-requests/p/automations-allow-activate-after-deactivate-let-users-finish-the-flow

A follow-up PR (STOMAIL-8020) will add per-version analytics so users can see stats for the version a given run was started on.

## After-merge notes

Premium has its own `UpdateAutomationController` override (`mailpoet-premium/lib/Automation/Engine/Builder/UpdateAutomationController.php`) that disables `validateAutomationSteps` to allow full structural editing. With this change, the trigger invariant runs from the parent class regardless of that override, so no Premium-side change is required for the trigger lock. Premium's UI for adding/removing/reordering steps continues to work for non-trigger steps.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8019-allow-editing-active-automations)

_The latest successful build from `stomail-8019-allow-editing-active-automations` will be used. If none is available, the link won't work._