### PR TITLE
Allow viewing automation stats per version [STOMAIL-8020]

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -9,6 +9,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
 import { chevronDown, Icon } from '@wordpress/icons';
 import { Filter } from './filter';
+import { VersionSelector } from './version-selector';
 import { MailPoet } from '../../../../../../mailpoet';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
 import { AutomationStatus } from '../../../../../listing/automation';
@@ -26,6 +27,7 @@ export function Header(): JSX.Element {
   return (
     <header className="mailpoet-analytics-header">
       <Filter />
+      <VersionSelector />
       <EditorNotices />
       <Dropdown
         focusOnMount={false}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/version-selector.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/version-selector.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+import { SelectControl } from '@wordpress/components';
+import { dispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { storeName } from '../../store';
+import { AutomationVersion } from '../../store/types';
+
+const ALL_VERSIONS = 'all';
+
+function formatLabel(version: AutomationVersion): string {
+  const date = dateI18n('M j, Y, g:i a', version.created_at, true);
+  return version.is_current
+    ? sprintf(
+        // translators: %s is a localised date/time, e.g. "Mar 5, 2026, 2:15 pm"
+        __('Current version (saved %s)', 'mailpoet'),
+        date,
+      )
+    : sprintf(
+        // translators: %s is a localised date/time
+        __('Version saved %s', 'mailpoet'),
+        date,
+      );
+}
+
+export function VersionSelector(): JSX.Element | null {
+  const { versions, selectedVersionId } = useSelect(
+    (s) => ({
+      versions: s(storeName).getVersions(),
+      selectedVersionId: s(storeName).getSelectedVersionId(),
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    void dispatch(storeName).loadVersions();
+  }, []);
+
+  if (versions.length <= 1) {
+    return null;
+  }
+
+  const value =
+    selectedVersionId === undefined ? ALL_VERSIONS : String(selectedVersionId);
+
+  const options = [
+    { label: __('All versions', 'mailpoet'), value: ALL_VERSIONS },
+    ...versions.map((version) => ({
+      label: formatLabel(version),
+      value: String(version.id),
+    })),
+  ];
+
+  return (
+    <div className="mailpoet-analytics-version-selector">
+      <SelectControl
+        label={__('Version', 'mailpoet')}
+        value={value}
+        options={options}
+        onChange={(next) => {
+          void dispatch(storeName).setSelectedVersionId(
+            next === ALL_VERSIONS ? undefined : Number(next),
+          );
+        }}
+        __nextHasNoMarginBottom
+      />
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/actions/index.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/actions/index.ts
@@ -6,7 +6,13 @@ import { apiFetch } from '@wordpress/data-controls';
 import { store as noticesStore } from '@wordpress/notices';
 import { Hooks } from 'wp-js-hooks';
 import { Data } from 'common/premium-modal/upgrade-info';
-import { CurrentView, Query, Section, SectionData } from '../types';
+import {
+  AutomationVersion,
+  CurrentView,
+  Query,
+  Section,
+  SectionData,
+} from '../types';
 import { storeName } from '../constants';
 import { getSampleData } from '../samples';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
@@ -20,6 +26,47 @@ export function setQuery(query: Query) {
     type: 'SET_QUERY',
     payload: query,
   };
+}
+
+export function setVersions(versions: AutomationVersion[]) {
+  return {
+    type: 'SET_VERSIONS',
+    payload: versions,
+  } as const;
+}
+
+export function* setSelectedVersionId(versionId: number | undefined) {
+  yield {
+    type: 'SET_SELECTED_VERSION_ID',
+    payload: versionId,
+  };
+  const sections = select(storeName).getSections();
+  sections.forEach((section: Section) => {
+    void dispatch(storeName).updateSection(section);
+  });
+}
+
+export function* loadVersions() {
+  const id = select(editorStoreName).getAutomationData().id;
+  if (!id) {
+    return { type: 'NOOP' } as const;
+  }
+  try {
+    const response: { data: { items: AutomationVersion[] } } = yield apiFetch({
+      path: `/automations/${id}/versions`,
+      method: 'GET',
+    });
+    const items = response?.data?.items ?? [];
+    void dispatch(storeName).setVersions(items);
+
+    const current = items.find((v) => v.is_current);
+    if (current && select(storeName).getSelectedVersionId() === undefined) {
+      void dispatch(storeName).setSelectedVersionId(current.id);
+    }
+  } catch (_error) {
+    // ignore — analytics still loads, just without version filtering
+  }
+  return { type: 'NOOP' } as const;
 }
 
 export function setSectionData(payload: Section) {
@@ -105,7 +152,15 @@ export function* updateSection(
 
   const id = select(editorStoreName).getAutomationData().id;
   const customQuery = section.customQuery ?? {};
-  const args = { id, query: { ...dates, ...customQuery } };
+  const versionId = select(storeName).getSelectedVersionId();
+  const args = {
+    id,
+    query: {
+      ...dates,
+      ...customQuery,
+      ...(versionId ? { version_id: versionId } : {}),
+    },
+  };
 
   const response: { data: SectionData } = yield apiFetch({
     path: addQueryArgs(section.endpoint, args),

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
@@ -82,4 +82,6 @@ export const getInitialState = (): State => ({
     before: undefined,
   },
   runStatusUpdates: {},
+  versions: [],
+  selectedVersionId: undefined,
 });

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
@@ -25,6 +25,16 @@ export function reducer(state: State, action): State {
         ...state,
         query: action.payload,
       };
+    case 'SET_VERSIONS':
+      return {
+        ...state,
+        versions: action.payload,
+      };
+    case 'SET_SELECTED_VERSION_ID':
+      return {
+        ...state,
+        selectedVersionId: action.payload,
+      };
     case 'SET_SECTION_DATA':
       return {
         ...state,

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/selectors/index.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/selectors/index.ts
@@ -1,4 +1,4 @@
-import { Query, Section, State } from '../types';
+import { AutomationVersion, Query, Section, State } from '../types';
 
 export function getCurrentQuery(state: State): Query {
   return state.query;
@@ -18,4 +18,12 @@ export function getPremiumModal(state: State): State['premiumModal'] {
 
 export function getRunStatusUpdate(state: State, runId: number) {
   return state.runStatusUpdates[runId];
+}
+
+export function getVersions(state: State): AutomationVersion[] {
+  return state.versions;
+}
+
+export function getSelectedVersionId(state: State): number | undefined {
+  return state.selectedVersionId;
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -184,10 +184,19 @@ export type RunStatusUpdate = {
   status: string;
   error?: string;
 };
+
+export type AutomationVersion = {
+  id: number;
+  created_at: string;
+  is_current: boolean;
+};
+
 export type State = {
   sections: Record<string, Section>;
   query: Query;
   runStatusUpdates: Record<number, RunStatusUpdate>;
+  versions: AutomationVersion[];
+  selectedVersionId: number | undefined;
   premiumModal?: {
     content: string | JSX.Element;
     utmCampaign?: string;

--- a/mailpoet/changelog/2026-05-04-16-46-35-added-view-automation-analytics-for-a-specific-saved-ver.md
+++ b/mailpoet/changelog/2026-05-04-16-46-35-added-view-automation-analytics-for-a-specific-saved-ver.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+View automation analytics for a specific saved version. New runs use the latest version, and the analytics header now lets you switch between versions or aggregate across all of them

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationVersionsGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationVersionsGetEndpoint.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Automations;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Validator\Builder;
+
+class AutomationVersionsGetEndpoint extends Endpoint {
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  public function __construct(
+    AutomationStorage $automationStorage
+  ) {
+    $this->automationStorage = $automationStorage;
+  }
+
+  public function handle(Request $request): Response {
+    $rawId = $request->getParam('id');
+    $automationId = is_numeric($rawId) ? (int)$rawId : 0;
+    $automation = $this->automationStorage->getAutomation($automationId);
+    if (!$automation) {
+      throw Exceptions::automationNotFound($automationId);
+    }
+
+    $versions = $this->automationStorage->getAutomationVersionDates($automationId);
+    $currentVersionId = $automation->getVersionId();
+
+    $items = array_map(
+      function (array $version) use ($currentVersionId): array {
+        return [
+          'id' => $version['id'],
+          'created_at' => $version['created_at']->format(\DateTimeInterface::ATOM),
+          'is_current' => $version['id'] === $currentVersionId,
+        ];
+      },
+      $versions
+    );
+
+    return new Response(['items' => $items]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -12,6 +12,7 @@ use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Automations\AutomationVersionsGetEndpoint;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\CoreIntegration;
 use MailPoet\Automation\Integrations\WordPress\WordPressIntegration;
@@ -80,6 +81,7 @@ class Engine {
     $this->wordPress->addAction(Hooks::API_INITIALIZE, function (API $api) {
       $api->registerGetRoute('automations', AutomationsGetEndpoint::class);
       $api->registerPutRoute('automations/(?P<id>\d+)', AutomationsPutEndpoint::class);
+      $api->registerGetRoute('automations/(?P<id>\d+)/versions', AutomationVersionsGetEndpoint::class);
       $api->registerDeleteRoute('automations/(?P<id>\d+)', AutomationsDeleteEndpoint::class);
       $api->registerPostRoute('automations/(?P<id>\d+)/duplicate', AutomationsDuplicateEndpoint::class);
       $api->registerPostRoute('automations/create-from-template', AutomationsCreateFromTemplateEndpoint::class);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanController.php
@@ -24,7 +24,11 @@ class AutomationTimeSpanController {
     $this->newslettersRepository = $newslettersRepository;
   }
 
-  public function getAutomationsInTimespan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before): array {
+  public function getAutomationsInTimespan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
+    if ($versionId !== null) {
+      return $this->automationStorage->getAutomationWithDifferentVersions([$versionId]);
+    }
+
     $automationVersions = $this->automationStorage->getAutomationVersionDates($automation->getId());
     usort(
       $automationVersions,
@@ -57,8 +61,8 @@ class AutomationTimeSpanController {
    * @param \DateTimeImmutable $before
    * @return NewsletterEntity[]
    */
-  public function getAutomationEmailsInTimeSpan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before): array {
-    $automations = $this->getAutomationsInTimespan($automation, $after, $before);
+  public function getAutomationEmailsInTimeSpan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
+    $automations = $this->getAutomationsInTimespan($automation, $after, $before, $versionId);
     return count($automations) > 0 ? $this->getEmailsFromAutomations($automations) : [];
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
@@ -37,8 +37,8 @@ class OverviewStatisticsController {
   }
 
   public function getStatisticsForAutomation(Automation $automation, QueryWithCompare $query): array {
-    $currentEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getAfter(), $query->getBefore());
-    $previousEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getCompareWithAfter(), $query->getCompareWithBefore());
+    $currentEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getAfter(), $query->getBefore(), $query->getVersionId());
+    $previousEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getCompareWithAfter(), $query->getCompareWithBefore(), $query->getVersionId());
     $data = [
       'sent' => ['current' => 0, 'previous' => 0],
       'opened' => ['current' => 0, 'previous' => 0],

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/StepStatisticController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/StepStatisticController.php
@@ -31,7 +31,8 @@ class StepStatisticController {
       $automation->getId(),
       AutomationRun::STATUS_RUNNING,
       $query->getAfter(),
-      $query->getBefore()
+      $query->getBefore(),
+      $query->getVersionId()
     );
 
     $data = [];
@@ -50,7 +51,8 @@ class StepStatisticController {
       $automation->getId(),
       AutomationRun::STATUS_FAILED,
       $query->getAfter(),
-      $query->getBefore()
+      $query->getBefore(),
+      $query->getVersionId()
     );
 
     $data = [];
@@ -69,7 +71,8 @@ class StepStatisticController {
       $automation->getId(),
       AutomationRunLog::STATUS_COMPLETE,
       $query->getAfter(),
-      $query->getBefore()
+      $query->getBefore(),
+      $query->getVersionId()
     );
 
     $data = [];

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/AutomationFlowEndpoint.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/AutomationFlowEndpoint.php
@@ -53,14 +53,14 @@ class AutomationFlowEndpoint extends Endpoint {
       throw Exceptions::automationNotFound($id);
     }
     $query = Query::fromRequest($request);
-    $automations = $this->automationTimeSpanController->getAutomationsInTimespan($automation, $query->getAfter(), $query->getBefore());
+    $automations = $this->automationTimeSpanController->getAutomationsInTimespan($automation, $query->getAfter(), $query->getBefore(), $query->getVersionId());
     if (!count($automations)) {
       throw Exceptions::automationNotFoundInTimeSpan($id);
     }
     $automation = current($automations);
     $shortStatistics = $this->automationStatisticsStorage->getAutomationStats(
       $automation->getId(),
-      null,
+      $query->getVersionId(),
       $query->getAfter(),
       $query->getBefore()
     );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/Query.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/Query.php
@@ -33,6 +33,9 @@ class Query {
   /** @var string | null */
   private $search;
 
+  /** @var int | null */
+  private $versionId;
+
   public function __construct(
     \DateTimeImmutable $primaryAfter,
     \DateTimeImmutable $primaryBefore,
@@ -41,7 +44,8 @@ class Query {
     string $orderDirection = 'asc',
     int $page = 1,
     array $filter = [],
-    ?string $search = null
+    ?string $search = null,
+    ?int $versionId = null
   ) {
     $this->primaryAfter = $primaryAfter;
     $this->primaryBefore = $primaryBefore;
@@ -51,6 +55,7 @@ class Query {
     $this->page = $page;
     $this->filter = $filter;
     $this->search = $search;
+    $this->versionId = $versionId;
   }
 
   public function getAfter(): \DateTimeImmutable {
@@ -85,6 +90,10 @@ class Query {
     return $this->search;
   }
 
+  public function getVersionId(): ?int {
+    return $this->versionId;
+  }
+
   /**
    * @param Request $request
    * @return Query
@@ -115,6 +124,7 @@ class Query {
     $page = is_int($query['page'] ?? null) ? $query['page'] : 1;
     $filter = is_array($query['filter'] ?? null) ? $query['filter'] : [];
     $search = isset($query['search']) && is_string($query['search']) ? $query['search'] : null;
+    $versionId = is_int($query['version_id'] ?? null) ? $query['version_id'] : null;
 
     return new self(
       new \DateTimeImmutable($primaryAfter),
@@ -124,7 +134,8 @@ class Query {
       $orderDirection,
       $page,
       $filter,
-      $search
+      $search,
+      $versionId
     );
   }
 
@@ -143,6 +154,7 @@ class Query {
         'page' => Builder::integer()->minimum(1),
         'filter' => Builder::object([]),
         'search' => Builder::string()->nullable(),
+        'version_id' => Builder::integer()->minimum(1)->nullable(),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/QueryWithCompare.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/QueryWithCompare.php
@@ -25,9 +25,10 @@ class QueryWithCompare extends Query {
     string $orderDirection = 'asc',
     int $page = 0,
     array $filter = [],
-    ?string $search = null
+    ?string $search = null,
+    ?int $versionId = null
   ) {
-    parent::__construct($primaryAfter, $primaryBefore, $limit, $orderBy, $orderDirection, $page, $filter, $search);
+    parent::__construct($primaryAfter, $primaryBefore, $limit, $orderBy, $orderDirection, $page, $filter, $search, $versionId);
     $this->secondaryAfter = $secondaryAfter;
     $this->secondaryBefore = $secondaryBefore;
   }
@@ -75,6 +76,7 @@ class QueryWithCompare extends Query {
     $page = is_int($query['page'] ?? null) ? $query['page'] : 0;
     $filter = is_array($query['filter'] ?? null) ? $query['filter'] : [];
     $search = isset($query['search']) && is_string($query['search']) ? $query['search'] : null;
+    $versionId = is_int($query['version_id'] ?? null) ? $query['version_id'] : null;
 
     return new self(
       new \DateTimeImmutable($primaryAfter),
@@ -86,7 +88,8 @@ class QueryWithCompare extends Query {
       $orderDirection,
       $page,
       $filter,
-      $search
+      $search,
+      $versionId
     );
   }
 
@@ -111,6 +114,7 @@ class QueryWithCompare extends Query {
         'page' => Builder::integer()->minimum(1),
         'filter' => Builder::object(),
         'search' => Builder::string()->nullable(),
+        'version_id' => Builder::integer()->minimum(1)->nullable(),
       ]
     );
   }


### PR DESCRIPTION
## Description

Adds a version selector to the automation analytics page. Each save of an automation already creates a new row in `mailpoet_automation_versions`, and runs are pinned to the version that started them — this PR exposes that history to the UI.

- New endpoint `GET /automations/{id}/versions` returns `[{id, created_at, is_current}, ...]`.
- `Query` and `QueryWithCompare` accept an optional `version_id`.
- `AutomationFlowEndpoint`, `OverviewStatisticsController`, and `StepStatisticController` honor it: flow data, overview, and per-step counters are scoped to the chosen version when one is set.
- Frontend dropdown in the analytics header lists every version and lets the user pick one or "All versions". Default is the current version, so changes to step structure or emails after the current view do not pollute the displayed numbers.

## Code review notes

- The selector hides itself when there is only one version, so existing single-version automations are unaffected.
- "All versions" mirrors the previous behavior (no `version_id` on the query), so any third-party code relying on the old endpoint shape keeps working.
- `AutomationTimeSpanController::getAutomationsInTimespan` now short-circuits to a single version when `version_id` is given, instead of iterating over all versions in the time span.
- `setSelectedVersionId` is a generator: it yields the state update first, then triggers `updateSection` for each section so each fetch sees the new selectorId via `getSelectedVersionId`.

## QA notes

- Open analytics for an automation with multiple versions → version selector appears, current version is selected, stats reflect that version.
- Switch to "All versions" → flow, overview, and per-step counts go back to aggregating across all overlapping versions in the time range.
- Switch to an older version → counts (entered, in-progress, completed, failed, opens/clicks/orders) reflect only that version.
- Open analytics for an automation with one version → no selector shown.
- Old saved-bookmark URLs without `version_id` keep working (defaults to current).

## Linked PRs

Stacked on #6700 (STOMAIL-8019).

## Linked tickets

[STOMAIL-8020](https://linear.app/automattic/issue/STOMAIL-8020)
- Canny: https://mailpoet.canny.io/feature-requests/p/edit-active-automations

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8020-allow-viewing-automation-stats-per-version)

_The latest successful build from `stomail-8020-allow-viewing-automation-stats-per-version` will be used. If none is available, the link won't work._