### PR TITLE
Don't delete MailPoet subscriber when WordPress user is deleted

### DIFF
--- a/mailpoet/changelog/2026-05-04-15-55-24-changed-deleting-a-wordpress-user-no-longer-deletes-the-li.md
+++ b/mailpoet/changelog/2026-05-04-15-55-24-changed-deleting-a-wordpress-user-no-longer-deletes-the-li.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Deleting a WordPress user no longer deletes the linked MailPoet subscriber; the subscriber is unlinked from the WP user and kept on any other lists (use the mailpoet_delete_subscriber_on_wp_user_delete filter to restore the previous hard-delete behavior)

--- a/mailpoet/lib/API/JSON/v1/SubscriberStats.php
+++ b/mailpoet/lib/API/JSON/v1/SubscriberStats.php
@@ -183,6 +183,8 @@ class SubscriberStats extends APIEndpoint {
         return __('API', 'mailpoet');
       case Source::WORDPRESS_USER:
         return __('WordPress user sync', 'mailpoet');
+      case Source::WORDPRESS_USER_DELETED:
+        return __('WordPress user (deleted)', 'mailpoet');
       case Source::WOOCOMMERCE_USER:
         return __('WooCommerce customer sync', 'mailpoet');
       case Source::WOOCOMMERCE_CHECKOUT:

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberFieldsFactory.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Fields/SubscriberFieldsFactory.php
@@ -164,6 +164,10 @@ class SubscriberFieldsFactory {
                 'name' => __('WordPress user', 'mailpoet'),
               ],
               [
+                'id' => 'wordpress_user_deleted',
+                'name' => __('WordPress user (deleted)', 'mailpoet'),
+              ],
+              [
                 'id' => 'woocommerce_user',
                 'name' => __('WooCommerce user', 'mailpoet'),
               ],

--- a/mailpoet/lib/Entities/SubscriberEntity.php
+++ b/mailpoet/lib/Entities/SubscriberEntity.php
@@ -527,6 +527,7 @@ class SubscriberEntity {
         'imported',
         'administrator',
         'wordpress_user',
+        'wordpress_user_deleted',
         'woocommerce_user',
         'woocommerce_checkout',
       ])

--- a/mailpoet/lib/Migrations/Db/Migration_20260504_120000_Db.php
+++ b/mailpoet/lib/Migrations/Db/Migration_20260504_120000_Db.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Migrations\Db;
+
+use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Migrator\DbMigration;
+
+class Migration_20260504_120000_Db extends DbMigration {
+  public function run(): void {
+    $subscribersTable = $this->getTableName(SubscriberEntity::class);
+
+    $columnType = $this->connection->fetchOne(
+      "SELECT COLUMN_TYPE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = ?
+          AND COLUMN_NAME = 'source'",
+      [$subscribersTable]
+    );
+
+    if (is_string($columnType) && strpos($columnType, "'wordpress_user_deleted'") !== false) {
+      return;
+    }
+
+    $this->connection->executeQuery(
+      "ALTER TABLE `{$subscribersTable}`
+        MODIFY `source` enum(
+          'form',
+          'imported',
+          'administrator',
+          'api',
+          'wordpress_user',
+          'wordpress_user_deleted',
+          'woocommerce_user',
+          'woocommerce_checkout',
+          'unknown'
+        ) DEFAULT 'unknown'"
+    );
+  }
+}

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -143,14 +143,9 @@ class WP {
 
       // If the subscriber was only on the WP-Users list and is not a WC customer,
       // they had no list of their own to remain on — trash them instead of leaving a floating row.
-      $otherActiveSegments = array_filter(
-        $subscriber->getSegments()->toArray(),
-        static function (SegmentEntity $segment): bool {
-          return $segment->getType() !== SegmentEntity::TYPE_WP_USERS && $segment->getDeletedAt() === null;
-        }
-      );
+      $hasOtherActiveSegments = $this->hasOtherActiveSegments($subscriber);
       $isWooCustomer = $this->wooHelper->isWooCommerceActive() && in_array('customer', (array)$wpUser->roles, true); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      if (!$otherActiveSegments && !$isWooCustomer) {
+      if (!$hasOtherActiveSegments && !$isWooCustomer) {
         $subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
         $subscriber->setDeletedAt(Carbon::now()->millisecond(0));
       }
@@ -158,6 +153,27 @@ class WP {
       $this->subscribersRepository->persist($subscriber);
       $this->subscribersRepository->flush();
     });
+  }
+
+  private function hasOtherActiveSegments(SubscriberEntity $subscriber): bool {
+    $subscriberId = $subscriber->getId();
+    if ($subscriberId === null) {
+      return false;
+    }
+
+    $count = $this->entityManager->createQueryBuilder()
+      ->select('COUNT(segment.id)')
+      ->from(SubscriberSegmentEntity::class, 'subscriberSegment')
+      ->innerJoin('subscriberSegment.segment', 'segment')
+      ->where('subscriberSegment.subscriber = :subscriber')
+      ->andWhere('segment.type != :wpType')
+      ->andWhere('segment.deletedAt IS NULL')
+      ->setParameter('subscriber', $subscriber)
+      ->setParameter('wpType', SegmentEntity::TYPE_WP_USERS)
+      ->getQuery()
+      ->getSingleScalarResult();
+
+    return is_numeric($count) && (int)$count > 0;
   }
 
   /**

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -94,7 +94,7 @@ class WP {
     // Delete
     if (in_array($currentFilter, ['delete_user', 'deleted_user', 'remove_user_from_blog'])) {
       if ($subscriber instanceof SubscriberEntity) {
-        $this->deleteSubscriber($subscriber);
+        $this->unlinkSubscriberFromWpUser($subscriber, $wpUser);
       }
       return;
     }
@@ -108,6 +108,54 @@ class WP {
     $this->entityManager->wrapInTransaction(function() use ($subscriber): void {
       $this->subscriberSegmentRepository->deleteAllBySubscriber($subscriber);
       $this->subscribersRepository->remove($subscriber);
+      $this->subscribersRepository->flush();
+    });
+  }
+
+  private function unlinkSubscriberFromWpUser(SubscriberEntity $subscriber, \WP_User $wpUser): void {
+    // Backwards-compat escape hatch for sites that need the legacy hard-delete behavior
+    // (e.g. GDPR-driven account deletion flows). Returning true reproduces pre-STOMAIL-8018 behavior.
+    $hardDelete = (bool)$this->wp->applyFilters(
+      'mailpoet_delete_subscriber_on_wp_user_delete',
+      false,
+      $subscriber,
+      (int)$wpUser->ID // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    );
+    if ($hardDelete) {
+      $this->deleteSubscriber($subscriber);
+      return;
+    }
+
+    $this->entityManager->wrapInTransaction(function() use ($subscriber, $wpUser): void {
+      $wpSegment = $this->segmentsRepository->getWPUsersSegment();
+
+      // Remove only the WP-Users segment membership; other list subscriptions stay intact.
+      $this->entityManager->createQueryBuilder()
+        ->delete(SubscriberSegmentEntity::class, 'ss')
+        ->where('ss.subscriber = :subscriber AND ss.segment = :segment')
+        ->setParameter('subscriber', $subscriber)
+        ->setParameter('segment', $wpSegment)
+        ->getQuery()
+        ->execute();
+
+      $subscriber->setWpUserId(null);
+      $subscriber->setSource(Source::WORDPRESS_USER_DELETED);
+
+      // If the subscriber was only on the WP-Users list and is not a WC customer,
+      // they had no list of their own to remain on — trash them instead of leaving a floating row.
+      $otherActiveSegments = array_filter(
+        $subscriber->getSegments()->toArray(),
+        static function (SegmentEntity $segment): bool {
+          return $segment->getType() !== SegmentEntity::TYPE_WP_USERS && $segment->getDeletedAt() === null;
+        }
+      );
+      $isWooCustomer = $this->wooHelper->isWooCommerceActive() && in_array('customer', (array)$wpUser->roles, true); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      if (!$otherActiveSegments && !$isWooCustomer) {
+        $subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
+        $subscriber->setDeletedAt(Carbon::now()->millisecond(0));
+      }
+
+      $this->subscribersRepository->persist($subscriber);
       $this->subscribersRepository->flush();
     });
   }

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -143,9 +143,11 @@ class WP {
 
       // If the subscriber was only on the WP-Users list and is not a WC customer,
       // they had no list of their own to remain on — trash them instead of leaving a floating row.
+      // Skip when the subscriber was already trashed (e.g. manually by an admin) so we keep
+      // the original deleted_at and status as audit information.
       $hasOtherActiveSegments = $this->hasOtherActiveSegments($subscriber);
-      $isWooCustomer = $this->wooHelper->isWooCommerceActive() && in_array('customer', (array)$wpUser->roles, true); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-      if (!$hasOtherActiveSegments && !$isWooCustomer) {
+      $isWooCustomer = $this->wooHelper->isWooCommerceActive() && in_array('customer', $wpUser->roles, true); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      if (!$hasOtherActiveSegments && !$isWooCustomer && $subscriber->getDeletedAt() === null) {
         $subscriber->setStatus(SubscriberEntity::STATUS_UNCONFIRMED);
         $subscriber->setDeletedAt(Carbon::now()->millisecond(0));
       }
@@ -207,8 +209,9 @@ class WP {
     }
 
     // subscriber data
+    $wpUserId = (int)$wpUser->ID; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
     $data = [
-      'wp_user_id' => $wpUser->ID,
+      'wp_user_id' => $wpUserId,
       'email' => $wpUser->user_email, // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       'first_name' => $firstName,
       'last_name' => $lastName,
@@ -216,10 +219,22 @@ class WP {
       'source' => Source::WORDPRESS_USER,
     ];
 
+    $isRelinkingDeletedWpUser = $subscriber !== null
+      && $subscriber->getSource() === Source::WORDPRESS_USER_DELETED
+      && $subscriber->getWpUserId() !== $wpUserId;
     if (!is_null($subscriber)) {
       $data['id'] = $subscriber->getId();
       unset($data['status']); // don't override status for existing users
       unset($data['source']); // don't override source for existing users
+      if ($isRelinkingDeletedWpUser) {
+        // Restore the live WP-user source on any re-link, not only the auto-trashed case.
+        // Only revive deleted_at when the subscriber was actually trashed by the unlink
+        // (subscribers kept on other lists were never trashed and must keep deleted_at IS NULL).
+        $data['source'] = Source::WORDPRESS_USER;
+        if ($subscriber->getDeletedAt() !== null) {
+          $data['deleted_at'] = null;
+        }
+      }
     }
 
     $addingNewUserToDisabledWPSegment = $wpSegment->getDeletedAt() !== null && $currentFilter === 'user_register';
@@ -233,7 +248,7 @@ class WP {
     $isWooCustomer = $this->wooHelper->isWooCommerceActive() && in_array('customer', $wpUser->roles, true);
     // When WP Segment is disabled force trashed state and unconfirmed status for new WPUsers without active segment
     // or who are not WooCommerce customers at the same time since customers are added to the WooCommerce list
-    if ($addingNewUserToDisabledWPSegment && !$otherActiveSegments && !$isWooCustomer) {
+    if ($addingNewUserToDisabledWPSegment && !$isRelinkingDeletedWpUser && !$otherActiveSegments && !$isWooCustomer) {
       $data['deleted_at'] = Carbon::now()->millisecond(0);
       $data['status'] = SubscriberEntity::STATUS_UNCONFIRMED;
     }
@@ -362,7 +377,7 @@ class WP {
       $subscriber->setSource($data['source']);
     }
 
-    if (isset($data['deleted_at'])) {
+    if (array_key_exists('deleted_at', $data)) {
       $subscriber->setDeletedAt($data['deleted_at']);
     }
 
@@ -466,11 +481,24 @@ class WP {
         SELECT wu.id, wu.user_email, :subscriberStatus, CURRENT_TIMESTAMP(), :source, {$deletedAt}
         FROM {$wpdb->users} wu
         LEFT JOIN {$this->subscribersTable} s ON wu.id = s.wp_user_id
+        LEFT JOIN {$this->subscribersTable} existingSubscriber ON wu.user_email = existingSubscriber.email
         WHERE s.wp_user_id IS NULL AND wu.user_email != ''
-        ON DUPLICATE KEY UPDATE wp_user_id = wu.id";
+        ON DUPLICATE KEY UPDATE
+          wp_user_id = wu.id,
+          deleted_at = IF(
+            existingSubscriber.`source` = :deletedSource AND existingSubscriber.deleted_at IS NOT NULL,
+            NULL,
+            existingSubscriber.deleted_at
+          ),
+          `source` = IF(
+            existingSubscriber.`source` = :deletedSource,
+            :source,
+            existingSubscriber.`source`
+          )";
     $stmt = $this->databaseConnection->prepare($insertSql);
     $stmt->bindValue('subscriberStatus', $subscriberStatus);
     $stmt->bindValue('source', Source::WORDPRESS_USER);
+    $stmt->bindValue('deletedSource', Source::WORDPRESS_USER_DELETED);
     $stmt->executeStatement();
 
     return $insertedUserIds;

--- a/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
+++ b/mailpoet/lib/Subscribers/ImportExport/PersonalDataExporters/SubscriberExporter.php
@@ -191,6 +191,8 @@ class SubscriberExporter {
     switch ($source) {
       case Source::WORDPRESS_USER:
         return __('Subscriber information synchronized via WP user sync', 'mailpoet');
+      case Source::WORDPRESS_USER_DELETED:
+        return __('Originally synchronized from a WordPress user that has since been deleted', 'mailpoet');
       case Source::FORM:
         return __('Subscription via a MailPoet subscription form', 'mailpoet');
       case Source::API:

--- a/mailpoet/lib/Subscribers/Source.php
+++ b/mailpoet/lib/Subscribers/Source.php
@@ -8,6 +8,7 @@ class Source {
   const ADMINISTRATOR = 'administrator';
   const API = 'api';
   const WORDPRESS_USER = 'wordpress_user';
+  const WORDPRESS_USER_DELETED = 'wordpress_user_deleted';
   const WOOCOMMERCE_USER = 'woocommerce_user';
   const WOOCOMMERCE_CHECKOUT = 'woocommerce_checkout';
   const UNKNOWN = 'unknown';

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1043,15 +1043,35 @@ class SubscribersRepository extends Repository {
     $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
 
-    // Hard-delete broken subscribers (no email) in the WP-Users segment.
-    // These rows are unusable; unlinking them would leave invalid data behind.
+    // Hard-delete broken subscribers in the WP-Users segment when they have no
+    // email, or when they have no WP user ID and no other list to belong to.
     $this->entityManager->getConnection()->executeStatement(
       "DELETE s
        FROM {$subscribersTable} s
        INNER JOIN {$subscriberSegmentsTable} ss ON s.id = ss.subscriber_id
-       WHERE ss.segment_id = :segmentId AND s.email = ''",
-      ['segmentId' => $segmentId],
-      ['segmentId' => ParameterType::INTEGER]
+       WHERE ss.segment_id = :segmentId
+         AND (
+           s.email = ''
+           OR (
+             s.wp_user_id IS NULL
+             AND s.is_woocommerce_user = 0
+             AND NOT EXISTS (
+               SELECT 1 FROM {$subscriberSegmentsTable} ss_other
+               INNER JOIN {$segmentsTable} seg ON seg.id = ss_other.segment_id
+               WHERE ss_other.subscriber_id = s.id
+                 AND seg.type != :wpType
+                 AND seg.deleted_at IS NULL
+             )
+           )
+         )",
+      [
+        'segmentId' => $segmentId,
+        'wpType' => SegmentEntity::TYPE_WP_USERS,
+      ],
+      [
+        'segmentId' => ParameterType::INTEGER,
+        'wpType' => ParameterType::STRING,
+      ]
     );
 
     // Trash subscribers whose WP user is gone, who are only on the WP-Users list,
@@ -1095,8 +1115,7 @@ class SubscribersRepository extends Repository {
        INNER JOIN {$subscribersTable} s ON s.id = ss.subscriber_id
        LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
        WHERE ss.segment_id = :segmentId
-         AND s.wp_user_id IS NOT NULL
-         AND u.id IS NULL",
+         AND (s.wp_user_id IS NULL OR u.id IS NULL)",
       ['segmentId' => $segmentId],
       ['segmentId' => ParameterType::INTEGER]
     );

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -1042,93 +1042,98 @@ class SubscribersRepository extends Repository {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
     $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
+    $deletedAt = $this->getCurrentDateTime()->format('Y-m-d H:i:s');
 
-    // Hard-delete broken subscribers in the WP-Users segment when they have no
-    // email, or when they have no WP user ID and no other list to belong to.
-    $this->entityManager->getConnection()->executeStatement(
-      "DELETE s
-       FROM {$subscribersTable} s
-       INNER JOIN {$subscriberSegmentsTable} ss ON s.id = ss.subscriber_id
-       WHERE ss.segment_id = :segmentId
-         AND (
-           s.email = ''
-           OR (
-             s.wp_user_id IS NULL
-             AND s.is_woocommerce_user = 0
-             AND NOT EXISTS (
-               SELECT 1 FROM {$subscriberSegmentsTable} ss_other
-               INNER JOIN {$segmentsTable} seg ON seg.id = ss_other.segment_id
-               WHERE ss_other.subscriber_id = s.id
-                 AND seg.type != :wpType
-                 AND seg.deleted_at IS NULL
+    $this->entityManager->wrapInTransaction(function () use ($segmentId, $subscribersTable, $subscriberSegmentsTable, $segmentsTable, $deletedAt, $wpdb): void {
+      // Hard-delete broken subscribers in the WP-Users segment when they have no
+      // email, or when they have no WP user ID and no other list to belong to.
+      $this->entityManager->getConnection()->executeStatement(
+        "DELETE s
+         FROM {$subscribersTable} s
+         INNER JOIN {$subscriberSegmentsTable} ss ON s.id = ss.subscriber_id
+         WHERE ss.segment_id = :segmentId
+           AND (
+             s.email = ''
+             OR (
+               s.wp_user_id IS NULL
+               AND s.is_woocommerce_user = 0
+               AND NOT EXISTS (
+                 SELECT 1 FROM {$subscriberSegmentsTable} ss_other
+                 INNER JOIN {$segmentsTable} seg ON seg.id = ss_other.segment_id
+                 WHERE ss_other.subscriber_id = s.id
+                   AND seg.type != :wpType
+                   AND seg.deleted_at IS NULL
+               )
              )
+           )",
+        [
+          'segmentId' => $segmentId,
+          'wpType' => SegmentEntity::TYPE_WP_USERS,
+        ],
+        [
+          'segmentId' => ParameterType::INTEGER,
+          'wpType' => ParameterType::STRING,
+        ]
+      );
+
+      // Trash subscribers whose WP user is gone, who are only on the WP-Users list,
+      // and who are not WC customers — they have nowhere left to belong, but we keep
+      // them as soft-deleted so admins can recover them if needed.
+      $this->entityManager->getConnection()->executeStatement(
+        "UPDATE {$subscribersTable} s
+         LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+         SET s.deleted_at = :deletedAt, s.status = :unconfirmed
+         WHERE s.deleted_at IS NULL
+           AND s.is_woocommerce_user = 0
+           AND s.wp_user_id IS NOT NULL
+           AND u.id IS NULL
+           AND EXISTS (
+             SELECT 1 FROM {$subscriberSegmentsTable} ss_wp
+             WHERE ss_wp.subscriber_id = s.id AND ss_wp.segment_id = :segmentId
            )
-         )",
-      [
-        'segmentId' => $segmentId,
-        'wpType' => SegmentEntity::TYPE_WP_USERS,
-      ],
-      [
-        'segmentId' => ParameterType::INTEGER,
-        'wpType' => ParameterType::STRING,
-      ]
-    );
+           AND NOT EXISTS (
+             SELECT 1 FROM {$subscriberSegmentsTable} ss_other
+             INNER JOIN {$segmentsTable} seg ON seg.id = ss_other.segment_id
+             WHERE ss_other.subscriber_id = s.id
+               AND seg.type != :wpType
+               AND seg.deleted_at IS NULL
+           )",
+        [
+          'segmentId' => $segmentId,
+          'unconfirmed' => SubscriberEntity::STATUS_UNCONFIRMED,
+          'wpType' => SegmentEntity::TYPE_WP_USERS,
+          'deletedAt' => $deletedAt,
+        ],
+        [
+          'segmentId' => ParameterType::INTEGER,
+          'unconfirmed' => ParameterType::STRING,
+          'wpType' => ParameterType::STRING,
+          'deletedAt' => ParameterType::STRING,
+        ]
+      );
 
-    // Trash subscribers whose WP user is gone, who are only on the WP-Users list,
-    // and who are not WC customers — they have nowhere left to belong, but we keep
-    // them as soft-deleted so admins can recover them if needed.
-    $this->entityManager->getConnection()->executeStatement(
-      "UPDATE {$subscribersTable} s
-       LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
-       SET s.deleted_at = NOW(), s.status = :unconfirmed
-       WHERE s.deleted_at IS NULL
-         AND s.is_woocommerce_user = 0
-         AND s.wp_user_id IS NOT NULL
-         AND u.id IS NULL
-         AND EXISTS (
-           SELECT 1 FROM {$subscriberSegmentsTable} ss_wp
-           WHERE ss_wp.subscriber_id = s.id AND ss_wp.segment_id = :segmentId
-         )
-         AND NOT EXISTS (
-           SELECT 1 FROM {$subscriberSegmentsTable} ss_other
-           INNER JOIN {$segmentsTable} seg ON seg.id = ss_other.segment_id
-           WHERE ss_other.subscriber_id = s.id
-             AND seg.type != :wpType
-             AND seg.deleted_at IS NULL
-         )",
-      [
-        'segmentId' => $segmentId,
-        'unconfirmed' => SubscriberEntity::STATUS_UNCONFIRMED,
-        'wpType' => SegmentEntity::TYPE_WP_USERS,
-      ],
-      [
-        'segmentId' => ParameterType::INTEGER,
-        'unconfirmed' => ParameterType::STRING,
-        'wpType' => ParameterType::STRING,
-      ]
-    );
+      // Remove WP-Users segment memberships for orphans.
+      $this->entityManager->getConnection()->executeStatement(
+        "DELETE ss
+         FROM {$subscriberSegmentsTable} ss
+         INNER JOIN {$subscribersTable} s ON s.id = ss.subscriber_id
+         LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+         WHERE ss.segment_id = :segmentId
+           AND (s.wp_user_id IS NULL OR u.id IS NULL)",
+        ['segmentId' => $segmentId],
+        ['segmentId' => ParameterType::INTEGER]
+      );
 
-    // Remove WP-Users segment memberships for orphans.
-    $this->entityManager->getConnection()->executeStatement(
-      "DELETE ss
-       FROM {$subscriberSegmentsTable} ss
-       INNER JOIN {$subscribersTable} s ON s.id = ss.subscriber_id
-       LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
-       WHERE ss.segment_id = :segmentId
-         AND (s.wp_user_id IS NULL OR u.id IS NULL)",
-      ['segmentId' => $segmentId],
-      ['segmentId' => ParameterType::INTEGER]
-    );
-
-    // Detach subscribers from non-existent WP users and mark the source.
-    $this->entityManager->getConnection()->executeStatement(
-      "UPDATE {$subscribersTable} s
-       LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
-       SET s.wp_user_id = NULL, s.source = :source
-       WHERE s.wp_user_id IS NOT NULL AND u.id IS NULL",
-      ['source' => Source::WORDPRESS_USER_DELETED],
-      ['source' => ParameterType::STRING]
-    );
+      // Detach subscribers from non-existent WP users and mark the source.
+      $this->entityManager->getConnection()->executeStatement(
+        "UPDATE {$subscribersTable} s
+         LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+         SET s.wp_user_id = NULL, s.source = :source
+         WHERE s.wp_user_id IS NOT NULL AND u.id IS NULL",
+        ['source' => Source::WORDPRESS_USER_DELETED],
+        ['source' => ParameterType::STRING]
+      );
+    });
   }
 
   public function removeByWpUserIds(array $wpUserIds) {

--- a/mailpoet/lib/Subscribers/SubscribersRepository.php
+++ b/mailpoet/lib/Subscribers/SubscribersRepository.php
@@ -13,6 +13,7 @@ use MailPoet\Entities\SubscriberSegmentEntity;
 use MailPoet\Entities\SubscriberTagEntity;
 use MailPoet\Entities\TagEntity;
 use MailPoet\Segments\SegmentsRepository;
+use MailPoet\Subscribers\Source;
 use MailPoet\Util\License\Features\Subscribers;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -1040,15 +1041,74 @@ class SubscribersRepository extends Repository {
 
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $subscriberSegmentsTable = $this->entityManager->getClassMetadata(SubscriberSegmentEntity::class)->getTableName();
+    $segmentsTable = $this->entityManager->getClassMetadata(SegmentEntity::class)->getTableName();
 
+    // Hard-delete broken subscribers (no email) in the WP-Users segment.
+    // These rows are unusable; unlinking them would leave invalid data behind.
     $this->entityManager->getConnection()->executeStatement(
       "DELETE s
        FROM {$subscribersTable} s
        INNER JOIN {$subscriberSegmentsTable} ss ON s.id = ss.subscriber_id
-       LEFT JOIN {$wpdb->users} u ON s.wp_user_id = u.id
-       WHERE ss.segment_id = :segmentId AND (u.id IS NULL OR s.email = '')",
+       WHERE ss.segment_id = :segmentId AND s.email = ''",
       ['segmentId' => $segmentId],
       ['segmentId' => ParameterType::INTEGER]
+    );
+
+    // Trash subscribers whose WP user is gone, who are only on the WP-Users list,
+    // and who are not WC customers — they have nowhere left to belong, but we keep
+    // them as soft-deleted so admins can recover them if needed.
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE {$subscribersTable} s
+       LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+       SET s.deleted_at = NOW(), s.status = :unconfirmed
+       WHERE s.deleted_at IS NULL
+         AND s.is_woocommerce_user = 0
+         AND s.wp_user_id IS NOT NULL
+         AND u.id IS NULL
+         AND EXISTS (
+           SELECT 1 FROM {$subscriberSegmentsTable} ss_wp
+           WHERE ss_wp.subscriber_id = s.id AND ss_wp.segment_id = :segmentId
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM {$subscriberSegmentsTable} ss_other
+           INNER JOIN {$segmentsTable} seg ON seg.id = ss_other.segment_id
+           WHERE ss_other.subscriber_id = s.id
+             AND seg.type != :wpType
+             AND seg.deleted_at IS NULL
+         )",
+      [
+        'segmentId' => $segmentId,
+        'unconfirmed' => SubscriberEntity::STATUS_UNCONFIRMED,
+        'wpType' => SegmentEntity::TYPE_WP_USERS,
+      ],
+      [
+        'segmentId' => ParameterType::INTEGER,
+        'unconfirmed' => ParameterType::STRING,
+        'wpType' => ParameterType::STRING,
+      ]
+    );
+
+    // Remove WP-Users segment memberships for orphans.
+    $this->entityManager->getConnection()->executeStatement(
+      "DELETE ss
+       FROM {$subscriberSegmentsTable} ss
+       INNER JOIN {$subscribersTable} s ON s.id = ss.subscriber_id
+       LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+       WHERE ss.segment_id = :segmentId
+         AND s.wp_user_id IS NOT NULL
+         AND u.id IS NULL",
+      ['segmentId' => $segmentId],
+      ['segmentId' => ParameterType::INTEGER]
+    );
+
+    // Detach subscribers from non-existent WP users and mark the source.
+    $this->entityManager->getConnection()->executeStatement(
+      "UPDATE {$subscribersTable} s
+       LEFT JOIN {$wpdb->users} u ON u.id = s.wp_user_id
+       SET s.wp_user_id = NULL, s.source = :source
+       WHERE s.wp_user_id IS NOT NULL AND u.id IS NULL",
+      ['source' => Source::WORDPRESS_USER_DELETED],
+      ['source' => ParameterType::STRING]
     );
   }
 

--- a/mailpoet/tests/integration/Migrations/Db/Migration_20221028_105818_Test.php
+++ b/mailpoet/tests/integration/Migrations/Db/Migration_20221028_105818_Test.php
@@ -21,6 +21,15 @@ class Migration_20221028_105818_Test extends \MailPoetTest {
     $this->settings = $this->diContainer->get(SettingsController::class);
   }
 
+  public function _after() {
+    try {
+      (new Migration_20230421_135915($this->diContainer))->run();
+      (new Migration_20260504_120000_Db($this->diContainer))->run();
+    } finally {
+      parent::_after();
+    }
+  }
+
   public function testItMigratesEmailMachineOpensFiltersCorrectly() {
     $this->settings->set('db_version', '3.76.0');
     $data = ['newsletter_id' => '1'];

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -468,6 +468,7 @@ class WPTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $subscriberId = $subscriber->getId();
     $this->assertNotNull($subscriberId);
+    $subscriberStatus = $subscriber->getStatus();
 
     // Add the subscriber to a separate, non-WP list.
     $segment = $this->segmentFactory->withName('Newsletter list')->create();
@@ -481,7 +482,7 @@ class WPTest extends \MailPoetTest {
     $reloaded = $this->subscribersRepository->findOneById($subscriberId);
     $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
     $this->assertNull($reloaded->getDeletedAt());
-    $this->assertSame(SubscriberEntity::STATUS_SUBSCRIBED, $reloaded->getStatus());
+    $this->assertSame($subscriberStatus, $reloaded->getStatus());
 
     $segments = $reloaded->getSegments()->toArray();
     $this->assertCount(1, $segments);
@@ -612,6 +613,34 @@ class WPTest extends \MailPoetTest {
     $this->wpSegment->synchronizeUsers();
     $subscribersCount = $this->getSubscribersCount();
     verify($subscribersCount)->equals(0);
+  }
+
+  public function testItKeepsSubscribersWithoutWPIdOnOtherSegments(): void {
+    $wpSegment = $this->segmentsRepository->getWPUsersSegment();
+    $this->assertInstanceOf(SegmentEntity::class, $wpSegment);
+    $segment = $this->segmentFactory->withName('Newsletter list')->create();
+
+    $subscriber = $this->subscriberFactory
+      ->withFirstName('Mike')
+      ->withLastName('Mike')
+      ->withEmail('user-sync-test' . rand() . '@example.com')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withSegments([$wpSegment, $segment])
+      ->create();
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    $this->wpSegment->synchronizeUsers();
+    $this->entityManager->clear();
+
+    $reloaded = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    $this->assertNull($reloaded->getDeletedAt());
+    $segments = $reloaded->getSegments()->toArray();
+    $this->assertCount(1, $segments);
+    $remainingSegment = reset($segments);
+    $this->assertInstanceOf(SegmentEntity::class, $remainingSegment);
+    $this->assertSame($segment->getId(), $remainingSegment->getId());
   }
 
   public function testItRemovesSubscribersInWPSegmentWithoutEmail(): void {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -405,23 +405,28 @@ class WPTest extends \MailPoetTest {
     verify($subscriber->getDeletedAt())->notNull();
   }
 
-  public function testItSynchronizesDeletedWPUsersUsingHooks(): void {
+  public function testItUnlinksSubscriberWhenWPUserIsDeletedUsingHooks(): void {
     $id = $this->insertUser();
     $this->insertUser();
     $this->wpSegment->synchronizeUsers();
     $subscribersCount = $this->getSubscribersCount();
     verify($subscribersCount)->equals(2);
+
     wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    // The subscriber row is preserved; only the WP linkage is dropped.
     $subscribersCount = $this->getSubscribersCount();
-    verify($subscribersCount)->equals(1);
+    verify($subscribersCount)->equals(2);
+    $stillLinked = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertNull($stillLinked);
   }
 
-  public function testItDeletesSubscriberSegmentEntriesWhenWPUserIsDeleted(): void {
+  public function testItRemovesOnlyWpUsersSegmentMembershipWhenWPUserIsDeleted(): void {
     // Insert a user directly (no hooks) and sync to MailPoet tables.
     $id = $this->insertUser();
     $this->wpSegment->synchronizeUsers();
 
-    // Confirm the subscriber and its segment entry were created.
     $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
     $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
     $subscriberId = $subscriber->getId();
@@ -437,21 +442,90 @@ class WPTest extends \MailPoetTest {
       )->fetchOne();
     $this->assertEquals(1, is_numeric($segmentCountRaw) ? (int)$segmentCountRaw : 0);
 
-    // Delete the WP user — this fires delete_user → synchronizeUser → deleteSubscriber.
     wp_delete_user((int)$id);
     $this->entityManager->clear();
 
-    // The subscriber row must be gone.
-    $deletedSubscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
-    $this->assertNull($deletedSubscriber);
+    // The subscriber row survives but is unlinked from the WP user.
+    $reloaded = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    $this->assertNull($reloaded->getWpUserId());
+    $this->assertSame(\MailPoet\Subscribers\Source::WORDPRESS_USER_DELETED, $reloaded->getSource());
 
-    // The subscriber_segment row must also be gone (this is what the bug was about).
+    // The WP-Users segment_subscriber row is gone.
     $orphanedCountRaw = $this->entityManager->getConnection()
       ->executeQuery(
         "SELECT COUNT(*) FROM $subscriberSegmentTable WHERE subscriber_id = :id",
         ['id' => $subscriberId]
       )->fetchOne();
-    $this->assertEquals(0, is_numeric($orphanedCountRaw) ? (int)$orphanedCountRaw : 0, $subscriberSegmentTable . ' row was not deleted when WP user was deleted');
+    $this->assertEquals(0, is_numeric($orphanedCountRaw) ? (int)$orphanedCountRaw : 0);
+  }
+
+  public function testItKeepsSubscriberOnOtherSegmentsWhenWPUserIsDeleted(): void {
+    $id = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    // Add the subscriber to a separate, non-WP list.
+    $segment = $this->segmentFactory->withName('Newsletter list')->create();
+    $subscriberSegment = new SubscriberSegmentEntity($segment, $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
+    $this->entityManager->persist($subscriberSegment);
+    $this->entityManager->flush();
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $reloaded = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    $this->assertNull($reloaded->getDeletedAt());
+    $this->assertSame(SubscriberEntity::STATUS_SUBSCRIBED, $reloaded->getStatus());
+
+    $segments = $reloaded->getSegments()->toArray();
+    $this->assertCount(1, $segments);
+    $remainingSegment = reset($segments);
+    $this->assertInstanceOf(SegmentEntity::class, $remainingSegment);
+    $this->assertSame($segment->getId(), $remainingSegment->getId());
+  }
+
+  public function testItTrashesSubscriberOnlyOnWpUsersSegmentWhenWPUserIsDeleted(): void {
+    $id = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $reloaded = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    $this->assertInstanceOf(\DateTimeInterface::class, $reloaded->getDeletedAt());
+    $this->assertSame(SubscriberEntity::STATUS_UNCONFIRMED, $reloaded->getStatus());
+  }
+
+  public function testItRespectsHardDeleteFilterOnWPUserDeletion(): void {
+    $id = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+
+    add_filter('mailpoet_delete_subscriber_on_wp_user_delete', '__return_true');
+    try {
+      wp_delete_user((int)$id);
+    } finally {
+      remove_filter('mailpoet_delete_subscriber_on_wp_user_delete', '__return_true');
+    }
+    $this->entityManager->clear();
+
+    // Filter restores legacy behavior: subscriber row is gone entirely.
+    $this->assertNull($this->subscribersRepository->findOneById($subscriberId));
   }
 
   public function testItSynchronizesNewUsersToDisabledWPSegmentAsUnconfirmedAndTrashed(): void {

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -12,6 +12,7 @@ use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Segments\WP;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Subscribers\ConfirmationEmailMailer;
+use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Subscription\Registration;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
@@ -507,6 +508,148 @@ class WPTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
     $this->assertInstanceOf(\DateTimeInterface::class, $reloaded->getDeletedAt());
     $this->assertSame(SubscriberEntity::STATUS_UNCONFIRMED, $reloaded->getStatus());
+  }
+
+  public function testItPreservesManualTrashStateWhenWPUserIsDeleted(): void {
+    $id = $this->insertUser();
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    // Simulate a subscriber that was already trashed manually (e.g. by an admin)
+    // with a meaningful status before the WP user is deleted.
+    $manualDeletedAt = new Carbon('2026-01-15 10:00:00');
+    $subscriber->setStatus(SubscriberEntity::STATUS_BOUNCED);
+    $subscriber->setDeletedAt($manualDeletedAt);
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $reloaded = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $reloaded);
+    $reloadedDeletedAt = $reloaded->getDeletedAt();
+    $this->assertInstanceOf(\DateTimeInterface::class, $reloadedDeletedAt);
+    $this->assertSame($manualDeletedAt->format('Y-m-d H:i:s'), $reloadedDeletedAt->format('Y-m-d H:i:s'));
+    $this->assertSame(SubscriberEntity::STATUS_BOUNCED, $reloaded->getStatus());
+  }
+
+  public function testSynchronizeUserRestoresDeletedSubscriberWhenWpUserIsRecreatedWithSameEmail(): void {
+    $randomNumber = rand();
+    $id = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $recreatedId = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUser($recreatedId);
+    $this->entityManager->clear();
+
+    $relinked = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $relinked);
+    $this->assertSame($recreatedId, $relinked->getWpUserId());
+    $this->assertNull($relinked->getDeletedAt());
+    $this->assertSame(Source::WORDPRESS_USER, $relinked->getSource());
+    $this->assertSame(SubscriberEntity::STATUS_UNCONFIRMED, $relinked->getStatus());
+  }
+
+  public function testSynchronizeUsersRestoresDeletedSubscriberWhenWpUserIsRecreatedWithSameEmail(): void {
+    $randomNumber = rand();
+    $id = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $recreatedId = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUsers();
+    $this->entityManager->clear();
+
+    $relinked = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $relinked);
+    $this->assertSame($recreatedId, $relinked->getWpUserId());
+    $this->assertNull($relinked->getDeletedAt());
+    $this->assertSame(Source::WORDPRESS_USER, $relinked->getSource());
+    $this->assertSame(SubscriberEntity::STATUS_UNCONFIRMED, $relinked->getStatus());
+  }
+
+  public function testSynchronizeUserPreservesStatusWhenRelinkingUntrashedDeletedWpUser(): void {
+    $randomNumber = rand();
+    $id = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    $segment = $this->segmentFactory->withName('Newsletter list')->create();
+    $subscriberSegment = new SubscriberSegmentEntity($segment, $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
+    $subscriber->setStatus(SubscriberEntity::STATUS_UNSUBSCRIBED);
+    $this->entityManager->persist($subscriberSegment);
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $recreatedId = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUser($recreatedId);
+    $this->entityManager->clear();
+
+    $relinked = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $relinked);
+    $this->assertSame($recreatedId, $relinked->getWpUserId());
+    $this->assertNull($relinked->getDeletedAt());
+    $this->assertSame(Source::WORDPRESS_USER, $relinked->getSource());
+    $this->assertSame(SubscriberEntity::STATUS_UNSUBSCRIBED, $relinked->getStatus());
+  }
+
+  public function testSynchronizeUsersPreservesStatusWhenRelinkingUntrashedDeletedWpUser(): void {
+    $randomNumber = rand();
+    $id = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUsers();
+
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $id]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    $subscriberId = $subscriber->getId();
+    $this->assertNotNull($subscriberId);
+
+    $segment = $this->segmentFactory->withName('Newsletter list')->create();
+    $subscriberSegment = new SubscriberSegmentEntity($segment, $subscriber, SubscriberEntity::STATUS_SUBSCRIBED);
+    $subscriber->setStatus(SubscriberEntity::STATUS_BOUNCED);
+    $this->entityManager->persist($subscriberSegment);
+    $this->subscribersRepository->persist($subscriber);
+    $this->subscribersRepository->flush();
+
+    wp_delete_user((int)$id);
+    $this->entityManager->clear();
+
+    $recreatedId = $this->insertUser($randomNumber);
+    $this->wpSegment->synchronizeUsers();
+    $this->entityManager->clear();
+
+    $relinked = $this->subscribersRepository->findOneById($subscriberId);
+    $this->assertInstanceOf(SubscriberEntity::class, $relinked);
+    $this->assertSame($recreatedId, $relinked->getWpUserId());
+    $this->assertNull($relinked->getDeletedAt());
+    $this->assertSame(Source::WORDPRESS_USER, $relinked->getSource());
+    $this->assertSame(SubscriberEntity::STATUS_BOUNCED, $relinked->getStatus());
   }
 
   public function testItRespectsHardDeleteFilterOnWPUserDeletion(): void {

--- a/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscribersRepositoryTest.php
@@ -406,17 +406,33 @@ class SubscribersRepositoryTest extends \MailPoetTest {
     $wpUserId1 = $this->tester->createWordPressUser('subscriber1@email.com', 'author');
     $wpUserId2 = $this->tester->createWordPressUser('subscriber2@email.com', 'author');
     $wpUserId3 = $this->tester->createWordPressUser('subscriber3@email.com', 'author');
+    $subscriber1 = $this->repository->findOneBy(['wpUserId' => $wpUserId1]);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber1);
+    $subscriber1Id = $subscriber1->getId();
     $subscriber2 = $this->repository->findOneBy(['wpUserId' => $wpUserId2]);
     $subscriber3 = $this->repository->findOneBy(['wpUserId' => $wpUserId3]);
 
     $this->tester->deleteWPUserFromDatabase($wpUserId1);
 
     $this->repository->removeOrphanedSubscribersFromWpSegment();
+    $this->entityManager->clear();
 
+    // Subscriber for the deleted WP user is preserved but unlinked and marked
+    // with the WORDPRESS_USER_DELETED source. Subscribers for live WP users are untouched.
     $subscribers = $this->repository->findAll();
-    $this->assertCount(2, $subscribers);
-    $this->assertSame($subscribers[0], $subscriber2);
-    $this->assertSame($subscribers[1], $subscriber3);
+    $this->assertCount(3, $subscribers);
+
+    $detachedSubscriber = $this->repository->findOneById($subscriber1Id);
+    $this->assertInstanceOf(SubscriberEntity::class, $detachedSubscriber);
+    $this->assertNull($detachedSubscriber->getWpUserId());
+    $this->assertSame(Source::WORDPRESS_USER_DELETED, $detachedSubscriber->getSource());
+
+    $stillLinked2 = $this->repository->findOneBy(['wpUserId' => $wpUserId2]);
+    $this->assertInstanceOf(SubscriberEntity::class, $stillLinked2);
+    $stillLinked3 = $this->repository->findOneBy(['wpUserId' => $wpUserId3]);
+    $this->assertInstanceOf(SubscriberEntity::class, $stillLinked3);
+    $this->assertSame($subscriber2 ? $subscriber2->getId() : null, $stillLinked2->getId());
+    $this->assertSame($subscriber3 ? $subscriber3->getId() : null, $stillLinked3->getId());
   }
 
   public function testRemoveByWpUserIds(): void {


### PR DESCRIPTION
## Description

Previously, when WordPress user is deleted, MailPoet subscriber is hard deleted from database with all associated data (lists, tags...). 

This PR changes that behaviour so when WordPress user is deleted, MailPoet subscriber is unlinked from that user and removed from "WordPress Users" lists. 

If they are part of any other list, no other changes happen. If they were only part of "WordPress Users" list, they'll become trashed and unconfirmed. 

This will also update the source of the subscriber to a new `WordPress user (deleted)` value, so these subscribers are detectable. 

There is also new `mailpoet_delete_subscriber_on_wp_user_delete` filter which can be set to `true` in which case the hard-delete will happen as before.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8018

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

| WP user exists                          | WP user is deleted                          |
| ------------------------------- | ------------------------------ |
|   <img width="814" height="355" alt="Screenshot 2026-05-05 at 09 05 19" src="https://github.com/user-attachments/assets/79339be7-e1d8-4c6f-89b6-24a71178f265" />  |  <img width="913" height="422" alt="Screenshot 2026-05-05 at 09 07 20" src="https://github.com/user-attachments/assets/35e9e99c-56bc-4228-947a-bdee97327b36" />   |
|  <img width="888" height="353" alt="Screenshot 2026-05-05 at 09 08 08" src="https://github.com/user-attachments/assets/ec518b9a-9023-40aa-b463-2f91dcb2d40d" />   |   <img width="880" height="338" alt="Screenshot 2026-05-05 at 09 08 32" src="https://github.com/user-attachments/assets/03e008d9-0629-4300-9e05-7b35b637f693" />  | 

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8018-deleting-wp-user-shouldnt-delete-mailpoet-subscriber)

_The latest successful build from `stomail-8018-deleting-wp-user-shouldnt-delete-mailpoet-subscriber` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 1

### 1. Bug: Timestamp Inconsistency Between Deletion Paths (Medium severity)
unlinkSubscriberFromWpUser() uses Carbon::now()->millisecond(0) (mailpoet/lib/Segments/WP.php) while removeOrphanedSubscribersFromWpSegment()/SubscribersRepository sets deleted_at using $this->getCurrentDateTime()->format('Y-m-d H:i:s') (mailpoet/lib/Subscribers/SubscribersRepository.php). These use different code paths/representations for deleted_at (DateTime/Carbon vs. formatted string) and can cause minor inconsistencies in how trashed timestamps are stored/compared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->