### PR TITLE
Stabilize acceptance test filters

### DIFF
--- a/mailpoet/tests/_support/AcceptanceTester.php
+++ b/mailpoet/tests/_support/AcceptanceTester.php
@@ -1037,30 +1037,37 @@ class AcceptanceTester extends \Codeception\Actor {
   public function changeGroupInListingFilter(string $name): void {
     $i = $this;
     $legacySelector = '[data-automation-id="filters_' . $name . '"]';
+    $activeLegacySelector = $legacySelector . '.is-active';
     // DataViews-backed listings render group tabs as @wordpress/components
     // TabPanel buttons; the "mailpoet-dataviews-group-X" class is a stable
     // hook all migrations are expected to apply.
     $dataViewsSelector = '.mailpoet-dataviews-group-' . $name;
+    $lastException = new Exception("Unable to change listing filter group to $name.");
 
     for ($x = 1; $x <= 3; $x++) {
       try {
-        $i->waitForElementClickable($legacySelector, 1);
+        $i->waitForElementClickable($legacySelector, 3);
         $i->click($legacySelector);
         $i->seeInCurrentURL(urlencode('group[' . $name . ']'));
+        $i->waitForElement($activeLegacySelector);
         return;
       } catch (Exception $legacyException) {
+        $lastException = $legacyException;
         // ignore and try DataViews variant
       }
 
       try {
-        $i->waitForElementClickable($dataViewsSelector, 1);
+        $i->waitForElementClickable($dataViewsSelector, 3);
         $i->click($dataViewsSelector);
         return;
       } catch (Exception $dataViewsException) {
+        $lastException = $dataViewsException;
         $this->wait(0.5);
         continue;
       }
     }
+
+    throw $lastException;
   }
 
   public function checkWooTableCheckboxForItemName(string $itemName): void {

--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -332,7 +332,7 @@ class SubscribersListingCest {
     $i->login();
     $i->amOnMailpoetPage('Subscribers');
     $i->changeGroupInListingFilter('unconfirmed');
-    $i->waitForText('bulk-resend-all-pages-01@example.com');
+    $i->waitForText('bulk-resend-all-pages-');
     $i->click("[data-automation-id='select_all']");
     $i->waitForText('Select all items on all pages');
     $i->click('Select all items on all pages');


### PR DESCRIPTION
## Description

Stabilizes acceptance tests that failed on CI by waiting for listing filter tabs to finish becoming active and by avoiding a first-page sort assumption in the subscriber bulk resend test.

## Code review notes

The subscriber test seeds enough rows for two pages; CI showed the lowest suffix can sort onto the second page, so the wait only needs to confirm the seeded listing scope is visible before selecting all pages.

## QA notes

_N/A_

## Linked PRs

- mailpoet/mailpoet-premium#1053

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes
