### PR TITLE
Avoid repeat confirmation emails

### DIFF
--- a/mailpoet/changelog/2026-05-06-10-33-52-fixed-avoid-repeat-confirmation-emails-for-already-subsc.md
+++ b/mailpoet/changelog/2026-05-06-10-33-52-fixed-avoid-repeat-confirmation-emails-for-already-subsc.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent duplicate confirmation emails when already subscribed users submit signup forms

--- a/mailpoet/lib/API/MP/v1/Subscribers.php
+++ b/mailpoet/lib/API/MP/v1/Subscribers.php
@@ -329,6 +329,7 @@ class Subscribers {
 
     $this->checkSubscriberAndListParams($subscriberId, $listIds);
     $subscriber = $this->findSubscriber($subscriberId);
+    $wasAlreadySubscribed = $subscriber->getStatus() === SubscriberEntity::STATUS_SUBSCRIBED;
     $foundSegments = $this->getAndValidateSegments($listIds, self::CONTEXT_SUBSCRIBE);
 
     // restore trashed subscriber
@@ -379,7 +380,7 @@ class Subscribers {
     }
 
     // send confirmation email
-    if ($sendConfirmationEmail) {
+    if ($sendConfirmationEmail && !$wasAlreadySubscribed) {
       [$confirmationEmailId, $confirmationPageId] = $this->confirmationEmailResolver->resolveFromSegments($foundSegments);
       $this->_sendConfirmationEmail($subscriber, $confirmationEmailId, $confirmationPageId);
     }

--- a/mailpoet/lib/Subscribers/SubscriberActions.php
+++ b/mailpoet/lib/Subscribers/SubscriberActions.php
@@ -79,6 +79,7 @@ class SubscriberActions {
 
     $subscriber = $this->subscribersRepository->findOneBy(['email' => $subscriberData['email']]);
     $previousStatus = $subscriber instanceof SubscriberEntity ? $subscriber->getStatus() : null;
+    $wasAlreadySubscribed = $previousStatus === SubscriberEntity::STATUS_SUBSCRIBED;
     $isUnconfirmedResubscription = (
       $subscriber instanceof SubscriberEntity
       && $subscriber->getStatus() === SubscriberEntity::STATUS_UNCONFIRMED
@@ -92,6 +93,8 @@ class SubscriberActions {
       $subscriber = $this->subscriberSaveController->createOrUpdate($subscriberData, $subscriber);
       // custom fields should use the same approach as the subscriber main data that means to wait on confirmation
       $this->subscriberSaveController->updateCustomFields($subscriberData, $subscriber);
+    } else if ($wasAlreadySubscribed) {
+      $subscriber->setUnconfirmedData(null);
     } else {
       // store subscriber data to be updated after confirmation
       $unconfirmedData = $this->subscriberSaveController->filterOutReservedColumns($subscriberData);
@@ -135,7 +138,7 @@ class SubscriberActions {
         && $subscriber->getConfirmationsCount() >= ConfirmationEmailMailer::MAX_CONFIRMATION_EMAILS
       ) {
         $metaData['error'] = $this->getMaxConfirmationEmailsReachedError();
-      } else {
+      } else if (!$wasAlreadySubscribed) {
         $metaData['confirmationEmailResult'] = $this->confirmationEmailMailer->sendConfirmationEmailOnce($subscriber, $confirmationEmailId, $confirmationPageId, true);
       }
     } catch (\Exception $e) {

--- a/mailpoet/tests/integration/API/MP/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/MP/SubscribersTest.php
@@ -204,6 +204,48 @@ class SubscribersTest extends \MailPoetTest {
     verify($sent)->equals(true);
   }
 
+  public function testItDoesNotSendConfirmationEmailToAlreadySubscribedSubscriberWhenBeingAddedToList() {
+    $subscriber = $this->subscriberFactory
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $subscriberWithExplicitConfirmation = (new SubscriberFactory())
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+    $segment = $this->getSegment('Already Subscribed Default');
+    $segmentWithExplicitConfirmation = $this->getSegment('Already Subscribed Explicit');
+
+    $subscribers = Stub::makeEmptyExcept(
+      Subscribers::class,
+      'subscribeToLists',
+      [
+        '_sendConfirmationEmail' => Expected::never(),
+        'segmentsRepository' => $this->diContainer->get(SegmentsRepository::class),
+        'subscribersRepository' => $this->diContainer->get(SubscribersRepository::class),
+        'subscribersSegmentRepository' => $this->diContainer->get(SubscriberSegmentRepository::class),
+        'subscribersResponseBuilder' => $this->diContainer->get(SubscribersResponseBuilder::class),
+        'settings' => SettingsController::getInstance(),
+        'confirmationEmailResolver' => $this->diContainer->get(ConfirmationEmailResolver::class),
+      ],
+      $this
+    );
+    $API = $this->getApi($subscribers);
+
+    $result = $API->subscribeToLists($subscriber->getId(), [$segment->getId()], [
+      'schedule_welcome_email' => false,
+      'skip_subscriber_notification' => true,
+    ]);
+    verify($result['id'])->equals($subscriber->getId());
+    verify($result['subscriptions'][0]['segment_id'])->equals($segment->getId());
+
+    $result = $API->subscribeToLists($subscriberWithExplicitConfirmation->getId(), [$segmentWithExplicitConfirmation->getId()], [
+      'send_confirmation_email' => true,
+      'schedule_welcome_email' => false,
+      'skip_subscriber_notification' => true,
+    ]);
+    verify($result['id'])->equals($subscriberWithExplicitConfirmation->getId());
+    verify($result['subscriptions'][0]['segment_id'])->equals($segmentWithExplicitConfirmation->getId());
+  }
+
   public function testItSendsNotificationEmailWhenBeingAddedToList() {
     $subscriber = $this->subscriberFactory
       ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)

--- a/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberActionsTest.php
@@ -267,6 +267,56 @@ class SubscriberActionsTest extends \MailPoetTest {
     $this->settings->set('signup_confirmation.enabled', $originalSettingValue);
   }
 
+  public function testItDoesNotSendConfirmationOrStoreDataForAlreadySubscribedSubscriber(): void {
+    $originalConfirmationSettingValue = $this->settings->get('signup_confirmation.enabled');
+    $originalTimeZoneSettingValue = $this->settings->get('collect_subscriber_timezones.enabled');
+    $this->settings->set('signup_confirmation.enabled', true);
+    $this->settings->set('collect_subscriber_timezones.enabled', true);
+    $subscriber = (new SubscriberFactory())
+      ->withEmail('already-subscribed@example.com')
+      ->withFirstName('Original')
+      ->withLastName('Subscriber')
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->withTimeZone('America/New_York')
+      ->withUnconfirmedData('{"first_name":"Stale"}')
+      ->create();
+    $customField = (new CustomField())
+      ->withName('favorite color')
+      ->withSubscriber($subscriber->getId(), 'blue')
+      ->create();
+    $segment = $this->segmentsRepository->createOrUpdate('Already Subscribed List');
+
+    $confirmationEmailMailer = $this->createMock(ConfirmationEmailMailer::class);
+    $confirmationEmailMailer->expects($this->never())
+      ->method('sendConfirmationEmailOnce');
+    $subscriberActions = $this->getServiceWithOverrides(SubscriberActions::class, [
+      'confirmationEmailMailer' => $confirmationEmailMailer,
+    ]);
+
+    [$subscriber, $meta] = $subscriberActions->subscribe([
+      'email' => 'already-subscribed@example.com',
+      'first_name' => 'Updated',
+      'last_name' => 'Person',
+      'cf_' . $customField->getId() => 'red',
+      SubscriberEntity::TIME_ZONE_FIELD_NAME => 'Europe/Prague',
+    ], [$segment->getId()]);
+
+    $this->entityManager->refresh($subscriber);
+    verify($meta['confirmationEmailResult'])->false();
+    verify($subscriber->getStatus())->equals(SubscriberEntity::STATUS_SUBSCRIBED);
+    verify($subscriber->getSegments())->arrayCount(1);
+    verify($subscriber->getFirstName())->equals('Original');
+    verify($subscriber->getLastName())->equals('Subscriber');
+    verify($subscriber->getTimeZone())->equals('America/New_York');
+    verify($subscriber->getUnconfirmedData())->empty();
+    $subscriberCustomField = $subscriber->getSubscriberCustomField($customField);
+    $this->assertInstanceOf(SubscriberCustomFieldEntity::class, $subscriberCustomField);
+    verify($subscriberCustomField->getValue())->equals('blue');
+
+    $this->settings->set('signup_confirmation.enabled', $originalConfirmationSettingValue);
+    $this->settings->set('collect_subscriber_timezones.enabled', $originalTimeZoneSettingValue);
+  }
+
   public function testItUsesPublicConfirmationModeForPublicSubscribes(): void {
     $this->settings->set('signup_confirmation.enabled', true);
     $confirmationEmailMailer = $this->createMock(ConfirmationEmailMailer::class);

--- a/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSubscribeControllerTest.php
@@ -263,6 +263,35 @@ class SubscriberSubscribeControllerTest extends \MailPoetTest {
     $this->assertNotNull($subscriber->getSubscriberTag($tag));
   }
 
+  public function testItAddsFormTagsToAlreadySubscribedSubscriberWithConfirmationEnabled(): void {
+    $this->settings->set('signup_confirmation.enabled', true);
+    $confirmationEmailMailerMock = $this->createMock(ConfirmationEmailMailer::class);
+    $confirmationEmailMailerMock->expects($this->never())
+      ->method('sendConfirmationEmailOnce');
+    $subscriberActions = $this->getServiceWithOverrides(SubscriberActions::class, ['confirmationEmailMailer' => $confirmationEmailMailerMock]);
+    $subscriberController = $this->getServiceWithOverrides(SubscriberSubscribeController::class, ['subscriberActions' => $subscriberActions]);
+
+    $segment = $this->segmentsRepository->createOrUpdate('Segment 1');
+    $tag = (new Tag())->withName('Already Subscribed Tag')->create();
+    $form = $this->createForm($segment, [], [$tag]);
+    $email = 'already-subscribed-tags-' . rand(0, 10000) . '@example.com';
+    $subscriber = (new SubscriberFactory())
+      ->withEmail($email)
+      ->withStatus(SubscriberEntity::STATUS_SUBSCRIBED)
+      ->create();
+
+    $subscriberController->subscribe([
+      $this->obfuscatedEmail => $email,
+      $this->obfuscatedSegments => [$segment->getId()],
+      'form_id' => $form->getId(),
+    ]);
+
+    $this->subscribersRepository->refresh($subscriber);
+    $this->assertEquals(SubscriberEntity::STATUS_SUBSCRIBED, $subscriber->getStatus());
+    $this->assertCount(1, $subscriber->getSubscriberTags());
+    $this->assertNotNull($subscriber->getSubscriberTag($tag));
+  }
+
   /**
    * @param CustomFieldEntity[] $customFields
    * @param TagEntity[] $tags


### PR DESCRIPTION
## Description

Prevents already subscribed subscribers from receiving another confirmation email when they submit a signup form again or are subscribed to a list through the MailPoet API.

Existing subscribers remain linked to the requested lists and tags, and their profile data is not overwritten when signup confirmation is enabled.

## Code review notes

_N/A_

## QA notes

1. Enable signup confirmation.
2. Create a signup form that assigns subscribers to a list and tag.
3. Submit a new email address.
4. Confirm that a confirmation email is sent.
5. Clear the mailbox.
6. Submit an email address that already belongs to a subscribed subscriber, using a different first name.
7. Confirm that the form succeeds, no confirmation email is sent, the subscriber is added to the form list/tag, and the existing first name is not overwritten.

Pavel manually verified this flow locally with Mailpit.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8029

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_ - behavior-only change; Pavel confirmed screenshots are not needed.

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/STOMAIL-8029-avoid-repeat-confirmation-emails)

_The latest successful build from `update/STOMAIL-8029-avoid-repeat-confirmation-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->