### PR TITLE
Improve changelog entry formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,8 @@ pnpm changelog:add --type=Fixed --description="Describe what was fixed"
 ```
 
 Valid types: `Added`, `Improved`, `Fixed`, `Changed`, `Updated`, `Removed`.
+Do not end changelog descriptions with punctuation; release compilation adds semicolons between entries and a period after the final entry.
+Write descriptions so they start with a capital letter and read naturally after the generated type prefix. Avoid repeating the type verb, for example use `Generated WooCommerce coupon block support for regular newsletters and automation emails` instead of `Added generated WooCommerce coupon block support for regular newsletters and automation emails`.
 
 ### Pull Requests
 

--- a/mailpoet/CHANGELOG.md
+++ b/mailpoet/CHANGELOG.md
@@ -30,6 +30,9 @@ Each changelog file should contain:
 Brief description of the change
 ```
 
+Descriptions should not end with punctuation. The release compiler adds semicolons between entries and a period after the final entry.
+Descriptions should also start with a capital letter and read naturally after the generated type prefix. Avoid repeating the type verb, for example use `Generated WooCommerce coupon block support for regular newsletters and automation emails` instead of `Added generated WooCommerce coupon block support for regular newsletters and automation emails`.
+
 ## Types
 
 - `Added`: New features

--- a/mailpoet/tasks/release/Changelogger.php
+++ b/mailpoet/tasks/release/Changelogger.php
@@ -34,7 +34,7 @@ class Changelogger {
     foreach (self::VALID_TYPES as $type) {
       if (isset($groupedEntries[$type])) {
         foreach ($groupedEntries[$type] as $entry) {
-          $compiledEntries[] = "* {$entry['type']}: {$entry['description']}";
+          $compiledEntries[] = "* {$entry['type']}: " . $this->removeTrailingPunctuation($entry['description']);
         }
       }
     }
@@ -169,9 +169,7 @@ class Changelogger {
       throw new \Exception("Invalid changelog type: $type");
     }
 
-    // Trim whitespace and remove trailing punctuation
-    $description = trim($description);
-    $description = rtrim($description, '.!?;,');
+    $description = $this->removeTrailingPunctuation($description);
     // Ensure description starts with a capital letter
     $description = ucfirst($description);
 
@@ -203,5 +201,9 @@ class Changelogger {
     $filename = preg_replace('/\s+/', '-', $filename);
     $filename = trim($filename, '-');
     return substr($filename, 0, 50); // Limit length
+  }
+
+  private function removeTrailingPunctuation(string $description): string {
+    return rtrim(trim($description), '.!?;,');
   }
 }

--- a/mailpoet/tests/unit/Tasks/Release/ChangeloggerTest.php
+++ b/mailpoet/tests/unit/Tasks/Release/ChangeloggerTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Tasks\Release;
+
+use MailPoetTasks\Release\Changelogger;
+
+class ChangeloggerTest extends \MailPoetUnitTest {
+  /** @var string */
+  private $tempDir;
+
+  public function _before() {
+    $this->tempDir = sys_get_temp_dir() . '/mailpoet-changelog-' . uniqid('', true) . '/';
+    mkdir($this->tempDir, 0777, true);
+  }
+
+  public function _after() {
+    foreach (glob($this->tempDir . '*') ?: [] as $file) {
+      unlink($file);
+    }
+    rmdir($this->tempDir);
+  }
+
+  public function testItRemovesTrailingPunctuationWhenCompilingChangelog() {
+    $this->createChangelogEntry(
+      '2026-01-01-10-00-00-added-duplicate-action.md',
+      'Added',
+      'Duplicate action for automations.'
+    );
+    $this->createChangelogEntry(
+      '2026-01-01-10-01-00-fixed-duplicate-punctuation.md',
+      'Fixed',
+      'Avoid duplicate punctuation;'
+    );
+
+    $changelog = (new Changelogger($this->tempDir))->compileChangelog('1.2.3');
+
+    verify($changelog)->equals(
+      "= 1.2.3 - " . date('Y-m-d') . " =\n" .
+      "* Added: Duplicate action for automations;\n" .
+      "* Fixed: Avoid duplicate punctuation."
+    );
+  }
+
+  private function createChangelogEntry(string $filename, string $type, string $description): void {
+    file_put_contents(
+      $this->tempDir . $filename,
+      "# Type: $type\n\n# Description\n\n$description\n"
+    );
+  }
+}


### PR DESCRIPTION
## Description

Improve changelog entry formatting so release compilation strips trailing punctuation from entry descriptions before adding semicolons between entries and a period after the final entry.

Also document changelog wording guidance for agents so entries start with a capital letter and avoid repeated type verbs like `Added: Added ...`.

## Code review notes

_N/A_

## QA notes

Preview a release changelog that includes entries ending with `.`, `;`, or `,`. The compiled changelog should contain one separator only: semicolons between entries and a period after the final entry.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:improve-changelog-entry-formatting)

_The latest successful build from `improve-changelog-entry-formatting` will be used. If none is available, the link won't work._