### PR TITLE
Add latest content post hook

### DIFF
--- a/mailpoet/changelog/2026-05-06-12-42-50-added-automated-latest-content-post-customization-hook.md
+++ b/mailpoet/changelog/2026-05-06-12-42-50-added-automated-latest-content-post-customization-hook.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Automated Latest Content post customization hook

--- a/mailpoet/lib/Newsletter/AutomatedLatestContent.php
+++ b/mailpoet/lib/Newsletter/AutomatedLatestContent.php
@@ -89,16 +89,19 @@ class AutomatedLatestContent {
   }
 
   public function transformPosts($args, $posts) {
-    $posts = array_map(function($post) use ($args) {
-      return $this->filterPost($post, $args);
-    }, $posts);
+    if ($this->wp->hasFilter(self::FILTER_POST) !== false) {
+      $posts = array_map(function($post) use ($args) {
+        return $this->filterPost($post, $args);
+      }, $posts);
+    }
     $transformer = new Transformer($args);
     return $transformer->transform($posts);
   }
 
   private function filterPost($post, array $args) {
     $filteredPost = is_object($post) ? clone $post : $post;
-    return $this->wp->applyFilters(self::FILTER_POST, $filteredPost, $post, $args);
+    $filteredPost = $this->wp->applyFilters(self::FILTER_POST, $filteredPost, $post, $args);
+    return is_object($filteredPost) ? $filteredPost : $post;
   }
 
   private function _attachSentPostsFilter($newsletterId) {

--- a/mailpoet/lib/Newsletter/AutomatedLatestContent.php
+++ b/mailpoet/lib/Newsletter/AutomatedLatestContent.php
@@ -7,6 +7,7 @@ use MailPoet\Newsletter\Editor\Transformer;
 use MailPoet\WP\Functions as WPFunctions;
 
 class AutomatedLatestContent {
+  const FILTER_POST = 'mailpoet_automated_latest_content_post';
 
   /** @var LoggerFactory */
   private $loggerFactory;
@@ -88,8 +89,16 @@ class AutomatedLatestContent {
   }
 
   public function transformPosts($args, $posts) {
+    $posts = array_map(function($post) use ($args) {
+      return $this->filterPost($post, $args);
+    }, $posts);
     $transformer = new Transformer($args);
     return $transformer->transform($posts);
+  }
+
+  private function filterPost($post, array $args) {
+    $filteredPost = is_object($post) ? clone $post : $post;
+    return $this->wp->applyFilters(self::FILTER_POST, $filteredPost, $post, $args);
   }
 
   private function _attachSentPostsFilter($newsletterId) {

--- a/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentReproductionTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentReproductionTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\API\JSON\v1;
+
+use MailPoet\API\JSON\v1\AutomatedLatestContent as AutomatedLatestContentEndpoint;
+use MailPoet\Newsletter\AutomatedLatestContent;
+use MailPoet\WP\Functions as WPFunctions;
+
+class AutomatedLatestContentReproductionTest extends \MailPoetTest {
+  /** @var AutomatedLatestContentEndpoint */
+  private $endpoint;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->endpoint = $this->diContainer->get(AutomatedLatestContentEndpoint::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
+  }
+
+  public function testItFallsBackToOriginalPostWhenFilterReturnsNull() {
+    $postId = wp_insert_post([
+      'post_title' => 'Original title',
+      'post_status' => 'publish',
+      'post_author' => 1,
+      'post_content' => 'Original content',
+    ]);
+    $this->assertIsNumeric($postId);
+
+    $filter = function() {
+      return null;
+    };
+
+    $this->wp->addFilter(AutomatedLatestContent::FILTER_POST, $filter);
+    try {
+      $response = $this->endpoint->getBulkTransformedPosts([
+        'blocks' => [$this->getAutomatedLatestContentBlock((int)$postId)],
+      ]);
+    } finally {
+      $this->wp->removeFilter(AutomatedLatestContent::FILTER_POST, $filter);
+      wp_delete_post($postId, true);
+    }
+
+    $encodedResponse = json_encode($response->data);
+    $this->assertIsString($encodedResponse);
+    $this->assertStringContainsString('Original title', $encodedResponse);
+    $this->assertStringContainsString('Original content', $encodedResponse);
+  }
+
+  private function getAutomatedLatestContentBlock(int $postId): array {
+    return [
+      'type' => 'automatedLatestContentLayout',
+      'withLayout' => true,
+      'amount' => '1',
+      'posts' => [$postId],
+      'contentType' => 'post',
+      'terms' => [],
+      'inclusionType' => 'include',
+      'displayType' => 'full',
+      'titleFormat' => 'h2',
+      'titleAlignment' => 'left',
+      'titleIsLink' => false,
+      'imageFullWidth' => false,
+      'titlePosition' => 'abovePost',
+      'featuredImagePosition' => 'none',
+      'fullPostFeaturedImagePosition' => 'none',
+      'showAuthor' => 'no',
+      'authorPrecededBy' => 'Author:',
+      'showCategories' => 'no',
+      'categoriesPrecededBy' => 'Categories:',
+      'readMoreType' => 'none',
+      'sortBy' => 'newest',
+      'showDivider' => false,
+      'backgroundColor' => '#ffffff',
+      'backgroundColorAlternate' => '#eeeeee',
+    ];
+  }
+}

--- a/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
@@ -3,16 +3,22 @@
 namespace MailPoet\Test\API\JSON\v1;
 
 use MailPoet\API\JSON\SuccessResponse;
-use MailPoet\API\JSON\v1\AutomatedLatestContent;
+use MailPoet\API\JSON\v1\AutomatedLatestContent as AutomatedLatestContentEndpoint;
+use MailPoet\Newsletter\AutomatedLatestContent;
+use MailPoet\WP\Functions as WPFunctions;
 
 class AutomatedLatestContentTest extends \MailPoetTest {
-  /** @var AutomatedLatestContent */
+  /** @var AutomatedLatestContentEndpoint */
   private $endpoint;
+
+  /** @var WPFunctions */
+  private $wp;
 
   public function _before() {
     parent::_before();
 
-    $this->endpoint = $this->diContainer->get(AutomatedLatestContent::class);
+    $this->endpoint = $this->diContainer->get(AutomatedLatestContentEndpoint::class);
+    $this->wp = $this->diContainer->get(WPFunctions::class);
   }
 
   public function testItGetsPostTypes() {
@@ -95,5 +101,75 @@ class AutomatedLatestContentTest extends \MailPoetTest {
       }
     }
     return $data;
+  }
+
+  public function testItAppliesPostFilterWhenGettingBulkTransformedPosts() {
+    $postId = wp_insert_post([
+      'post_title' => 'Original ALC title',
+      'post_status' => 'publish',
+      'post_author' => 1,
+      'post_content' => 'Original ALC content',
+    ]);
+    $this->assertIsNumeric($postId);
+
+    $receivedOriginalPost = null;
+    $receivedArgs = null;
+    $filter = function($post, $originalPost, $args) use (&$receivedOriginalPost, &$receivedArgs) {
+      $receivedOriginalPost = $originalPost;
+      $receivedArgs = $args;
+      $post->post_title = 'Filtered ALC title'; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $post->post_content = 'Filtered ALC content'; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return $post;
+    };
+
+    $this->wp->addFilter(AutomatedLatestContent::FILTER_POST, $filter, 10, 3);
+    try {
+      $response = $this->endpoint->getBulkTransformedPosts([
+        'blocks' => [$this->getAutomatedLatestContentBlock((int)$postId)],
+      ]);
+    } finally {
+      $this->wp->removeFilter(AutomatedLatestContent::FILTER_POST, $filter);
+      wp_delete_post($postId, true);
+    }
+
+    $encodedResponse = json_encode($response->data);
+    $this->assertIsString($encodedResponse);
+    $this->assertStringContainsString('Filtered ALC title', $encodedResponse);
+    $this->assertStringContainsString('Filtered ALC content', $encodedResponse);
+    $this->assertStringNotContainsString('Original ALC title', $encodedResponse);
+    $this->assertStringNotContainsString('Original ALC content', $encodedResponse);
+    $this->assertInstanceOf(\WP_Post::class, $receivedOriginalPost);
+    $this->assertIsArray($receivedArgs);
+    $this->assertSame((int)$postId, $receivedOriginalPost->ID);
+    $this->assertSame('automatedLatestContentLayout', $receivedArgs['type']);
+  }
+
+  private function getAutomatedLatestContentBlock(int $postId): array {
+    return [
+      'type' => 'automatedLatestContentLayout',
+      'withLayout' => true,
+      'amount' => '1',
+      'posts' => [$postId],
+      'contentType' => 'post',
+      'terms' => [],
+      'inclusionType' => 'include',
+      'displayType' => 'full',
+      'titleFormat' => 'h2',
+      'titleAlignment' => 'left',
+      'titleIsLink' => false,
+      'imageFullWidth' => false,
+      'titlePosition' => 'abovePost',
+      'featuredImagePosition' => 'none',
+      'fullPostFeaturedImagePosition' => 'none',
+      'showAuthor' => 'no',
+      'authorPrecededBy' => 'Author:',
+      'showCategories' => 'no',
+      'categoriesPrecededBy' => 'Categories:',
+      'readMoreType' => 'none',
+      'sortBy' => 'newest',
+      'showDivider' => false,
+      'backgroundColor' => '#ffffff',
+      'backgroundColorAlternate' => '#eeeeee',
+    ];
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Blocks/AutomatedLatestContentBlockTest.php
+++ b/mailpoet/tests/integration/Newsletter/Blocks/AutomatedLatestContentBlockTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Newsletter\Renderer\Blocks;
 
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterPostEntity;
+use MailPoet\Newsletter\AutomatedLatestContent;
 use MailPoet\Newsletter\NewsletterPostsRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\WP\Functions as WPFunctions;
@@ -197,6 +198,42 @@ class AutomatedLatestContentBlockTest extends \MailPoetTest {
     verify($encodedResult)->stringNotContainsString('POST 5');
     verify($encodedResult)->stringContainsString('POST 6');
     verify($encodedResult)->stringContainsString('POST 7');
+  }
+
+  public function testItAppliesPostFilterWhenRendering() {
+    $notification = $this->createNewsletter('Newsletter', NewsletterEntity::TYPE_NOTIFICATION);
+    $notificationHistory = $this->createNewsletter('Newsletter', NewsletterEntity::TYPE_NOTIFICATION_HISTORY, $notification);
+
+    $receivedOriginalPost = null;
+    $receivedArgs = null;
+    $filter = function($post, $originalPost, $args) use (&$receivedOriginalPost, &$receivedArgs) {
+      $receivedOriginalPost = $originalPost;
+      $receivedArgs = $args;
+      $post->post_title = 'Filtered notification title'; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      $post->post_content = 'Filtered notification content'; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      return $post;
+    };
+
+    $this->wp->addFilter(AutomatedLatestContent::FILTER_POST, $filter, 10, 3);
+    try {
+      $result = $this->block->render($notificationHistory, array_merge($this->alcBlock, [
+        'amount' => '1',
+        'posts' => [$this->postIds[3]],
+        'displayType' => 'full',
+        'readMoreType' => 'none',
+      ]));
+    } finally {
+      $this->wp->removeFilter(AutomatedLatestContent::FILTER_POST, $filter);
+    }
+
+    $encodedResult = json_encode($result);
+    verify($encodedResult)->stringContainsString('Filtered notification title');
+    verify($encodedResult)->stringContainsString('Filtered notification content');
+    verify($encodedResult)->stringNotContainsString('POST 4');
+    $this->assertInstanceOf(\WP_Post::class, $receivedOriginalPost);
+    $this->assertIsArray($receivedArgs);
+    $this->assertSame($this->postIds[3], $receivedOriginalPost->ID);
+    $this->assertSame('automatedLatestContentLayout', $receivedArgs['type']);
   }
 
   private function createPost(string $title, string $publishDate, string $type = 'post') {


### PR DESCRIPTION
## Description

Adds a developer hook for Automated Latest Content posts before they are transformed into newsletter blocks. This lets extensions customise post title/content data for post notification emails without parsing the final newsletter HTML.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8030](https://linear.app/a8c/issue/STOMAIL-8030/add-hooks-for-automated-latest-content-posts)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8030-automated-latest-content-hooks)

_The latest successful build from `add/STOMAIL-8030-automated-latest-content-hooks` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->