### PR TITLE
Expose automation email links via NewsletterLinks endpoint

### DIFF
--- a/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
@@ -5,6 +5,9 @@ namespace MailPoet\API\JSON\v1;
 use MailPoet\API\JSON\Endpoint as APIEndpoint;
 use MailPoet\Config\AccessControl;
 use MailPoet\Cron\Workers\StatsNotifications\NewsletterLinkRepository;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\Links\Links as NewsletterLinksService;
+use MailPoet\Newsletter\NewslettersRepository;
 
 class NewsletterLinks extends APIEndpoint {
 
@@ -12,17 +15,42 @@ class NewsletterLinks extends APIEndpoint {
     'global' => AccessControl::PERMISSION_MANAGE_SEGMENTS,
   ];
 
+  private const AUTOMATION_EMAIL_TYPES = [
+    NewsletterEntity::TYPE_AUTOMATION,
+    NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+  ];
+
   /** @var NewsletterLinkRepository */
   private $newsletterLinkRepository;
 
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var NewsletterLinksService */
+  private $newsletterLinks;
+
   public function __construct(
-    NewsletterLinkRepository $newsletterLinkRepository
+    NewsletterLinkRepository $newsletterLinkRepository,
+    NewslettersRepository $newslettersRepository,
+    NewsletterLinksService $newsletterLinks
   ) {
     $this->newsletterLinkRepository = $newsletterLinkRepository;
+    $this->newslettersRepository = $newslettersRepository;
+    $this->newsletterLinks = $newsletterLinks;
   }
 
   public function get($data = []) {
-    $links = $this->newsletterLinkRepository->findBy(['newsletter' => $data['newsletterId']]);
+    $newsletterId = (int)($data['newsletterId'] ?? 0);
+    $newsletter = $this->newslettersRepository->findOneById($newsletterId);
+    if (!$newsletter instanceof NewsletterEntity) {
+      return $this->successResponse([]);
+    }
+
+    if (in_array($newsletter->getType(), self::AUTOMATION_EMAIL_TYPES, true)) {
+      return $this->successResponse($this->getAutomationLinks($newsletter));
+    }
+
+    $links = $this->newsletterLinkRepository->findBy(['newsletter' => $newsletterId]);
     $response = [];
     foreach ($links as $link) {
       $response[] = [
@@ -31,5 +59,84 @@ class NewsletterLinks extends APIEndpoint {
       ];
     }
     return $this->successResponse($response);
+  }
+
+  private function getAutomationLinks(NewsletterEntity $newsletter): array {
+    $newsletterId = $newsletter->getId();
+    if (!$newsletterId) {
+      return [];
+    }
+
+    $urls = [];
+    foreach ($this->newsletterLinkRepository->findUrlsByNewsletterId($newsletterId) as $url) {
+      $this->addUrl($urls, $url);
+    }
+    foreach ($this->extractUrlsFromNewsletterBody($newsletter) as $url) {
+      $this->addUrl($urls, $url);
+    }
+
+    return array_map(function(string $url): array {
+      return [
+        'id' => $url,
+        'url' => $url,
+      ];
+    }, array_values($urls));
+  }
+
+  /**
+   * @return string[]
+   */
+  private function extractUrlsFromNewsletterBody(NewsletterEntity $newsletter): array {
+    $body = $newsletter->getBody();
+    if (!is_array($body)) {
+      return [];
+    }
+
+    $urls = [];
+    $this->collectUrlsFromBody($body['content'] ?? $body, $urls);
+    return array_values($urls);
+  }
+
+  /**
+   * @param mixed $bodyPart
+   * @param array<string, string> $urls
+   */
+  private function collectUrlsFromBody($bodyPart, array &$urls): void {
+    if (!is_array($bodyPart)) {
+      return;
+    }
+
+    foreach ($bodyPart as $key => $value) {
+      if (is_string($value)) {
+        if (in_array($key, ['url', 'link'], true)) {
+          $this->addUrl($urls, $value);
+        }
+        foreach ($this->newsletterLinks->extract($value) as $link) {
+          $this->addUrl($urls, $link['link'] ?? '');
+        }
+      }
+
+      if (is_array($value)) {
+        $this->collectUrlsFromBody($value, $urls);
+      }
+    }
+  }
+
+  /**
+   * @param array<string, string> $urls
+   */
+  private function addUrl(array &$urls, string $url): void {
+    $url = trim($url);
+    if (!$this->isSelectableUrl($url)) {
+      return;
+    }
+    $urls[$url] = $url;
+  }
+
+  private function isSelectableUrl(string $url): bool {
+    if ($url === '') {
+      return false;
+    }
+    return strpos($url, '[') !== 0 || strpos($url, '[link:') === 0;
   }
 }

--- a/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
@@ -141,6 +141,8 @@ class NewsletterLinks extends APIEndpoint {
     if ($url === '') {
       return false;
     }
+    // strpos returns false when '[' is absent and 0 when it's the first char; !== 0 covers both
+    // "no leading bracket" cases. Allow [link:…] shortcodes through; reject other tokens like [postLink].
     return strpos($url, '[') !== 0 || strpos($url, '[link:') === 0;
   }
 }

--- a/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
+++ b/mailpoet/lib/API/JSON/v1/NewsletterLinks.php
@@ -111,8 +111,12 @@ class NewsletterLinks extends APIEndpoint {
         if (in_array($key, ['url', 'link'], true)) {
           $this->addUrl($urls, $value);
         }
-        foreach ($this->newsletterLinks->extract($value) as $link) {
-          $this->addUrl($urls, $link['link'] ?? '');
+        // Links::extract parses HTML and scans for shortcodes; skip when neither marker is present
+        // to avoid running a DOM parse on every plain-text leaf of the body tree.
+        if (strpos($value, '<') !== false || strpos($value, '[') !== false) {
+          foreach ($this->newsletterLinks->extract($value) as $link) {
+            $this->addUrl($urls, $link['link'] ?? '');
+          }
         }
       }
 

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
@@ -55,9 +55,13 @@ class NewsletterLinkRepository extends Repository {
       ->getQuery()
       ->getSingleColumnResult();
 
-    return array_values(array_filter(array_map('strval', $urls), function(string $url): bool {
-      return $url !== '';
-    }));
+    $result = [];
+    foreach ($urls as $url) {
+      if (is_string($url) && $url !== '') {
+        $result[] = $url;
+      }
+    }
+    return $result;
   }
 
   /** @param int[] $ids */

--- a/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
+++ b/mailpoet/lib/Cron/Workers/StatsNotifications/NewsletterLinkRepository.php
@@ -41,6 +41,25 @@ class NewsletterLinkRepository extends Repository {
     return null;
   }
 
+  /**
+   * @return string[]
+   */
+  public function findUrlsByNewsletterId(int $newsletterId): array {
+    $urls = $this->entityManager->createQueryBuilder()
+      ->select('l.url')
+      ->from(NewsletterLinkEntity::class, 'l')
+      ->where('l.newsletter = :newsletterId')
+      ->setParameter('newsletterId', $newsletterId)
+      ->groupBy('l.url')
+      ->orderBy('l.url', 'ASC')
+      ->getQuery()
+      ->getSingleColumnResult();
+
+    return array_values(array_filter(array_map('strval', $urls), function(string $url): bool {
+      return $url !== '';
+    }));
+  }
+
   /** @param int[] $ids */
   public function deleteByNewsletterIds(array $ids): void {
     $this->entityManager->createQueryBuilder()

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -508,6 +508,36 @@ class NewslettersRepository extends Repository {
   }
 
   /**
+   * Returns standard newsletters and active automation emails ordered by sentAt
+   * @return NewsletterEntity[]
+   */
+  public function getStandardAndAutomationNewsletterList(): array {
+    $queryBuilder = $this->entityManager->createQueryBuilder();
+    return $queryBuilder
+      ->select('PARTIAL n.{id,subject,type,sentAt}, PARTIAL wpPost.{id, postTitle}')
+      ->addSelect('CASE WHEN n.sentAt IS NULL THEN 1 ELSE 0 END as HIDDEN sent_at_is_null')
+      ->from(NewsletterEntity::class, 'n')
+      ->leftJoin('n.wpPost', 'wpPost')
+      ->where(
+        $queryBuilder->expr()->orX(
+          $queryBuilder->expr()->eq('n.type', ':typeStandard'),
+          $queryBuilder->expr()->andX(
+            $queryBuilder->expr()->in('n.type', ':automationTypes'),
+            $queryBuilder->expr()->eq('n.status', ':statusActive')
+          )
+        )
+      )
+      ->andWhere('n.deletedAt IS NULL')
+      ->orderBy('sent_at_is_null', 'DESC')
+      ->addOrderBy('n.sentAt', 'DESC')
+      ->setParameter('typeStandard', NewsletterEntity::TYPE_STANDARD)
+      ->setParameter('automationTypes', [NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL], ArrayParameterType::STRING)
+      ->setParameter('statusActive', NewsletterEntity::STATUS_ACTIVE)
+      ->getQuery()
+      ->getResult();
+  }
+
+  /**
    * Returns standard newsletters ordered by sentAt
    * filter by status STATUS_SCHEDULED, STATUS_SENDING, STATUS_SENT
    * @return NewsletterEntity[]

--- a/mailpoet/tests/integration/API/JSON/v1/NewsletterLinksTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewsletterLinksTest.php
@@ -86,6 +86,38 @@ class NewsletterLinksTest extends \MailPoetTest {
     verify($ids)->equals($urls);
   }
 
+  public function testItDispatchesAutomationPathForTransactionalEmails(): void {
+    $newsletter = $this->createNewsletter(
+      NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+      NewsletterEntity::STATUS_ACTIVE,
+      [
+        'content' => [
+          'blocks' => [
+            [
+              'type' => 'button',
+              'url' => 'https://example.com/transactional-button',
+            ],
+            [
+              'type' => 'button',
+              'url' => '[postLink]',
+            ],
+          ],
+        ],
+      ]
+    );
+    $queue = $this->createQueue($newsletter);
+    $this->createLink($newsletter, $queue, 'https://example.com/transactional-stored');
+
+    $response = $this->endpoint->get(['newsletterId' => $newsletter->getId()]);
+    $urls = array_column($response->data, 'url');
+    $ids = array_column($response->data, 'id');
+
+    $this->assertContains('https://example.com/transactional-stored', $urls);
+    $this->assertContains('https://example.com/transactional-button', $urls);
+    $this->assertNotContains('[postLink]', $urls);
+    verify($ids)->equals($urls);
+  }
+
   private function createNewsletter(string $type, string $status, array $body = []): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType($type);

--- a/mailpoet/tests/integration/API/JSON/v1/NewsletterLinksTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewsletterLinksTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\API\JSON\v1;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterLinkEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Entities\SendingQueueEntity;
+
+class NewsletterLinksTest extends \MailPoetTest {
+  /** @var NewsletterLinks */
+  private $endpoint;
+
+  public function _before() {
+    parent::_before();
+    $this->endpoint = $this->diContainer->get(NewsletterLinks::class);
+  }
+
+  public function testItReturnsStoredLinksForStandardNewsletters(): void {
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
+    $queue = $this->createQueue($newsletter);
+    $link = $this->createLink($newsletter, $queue, 'https://example.com/standard');
+
+    $response = $this->endpoint->get(['newsletterId' => $newsletter->getId()]);
+
+    verify($response->data)->equals([
+      [
+        'id' => $link->getId(),
+        'url' => 'https://example.com/standard',
+      ],
+    ]);
+  }
+
+  public function testItReturnsUniqueAutomationLinksFromStoredRunsAndBody(): void {
+    $newsletter = $this->createNewsletter(
+      NewsletterEntity::TYPE_AUTOMATION,
+      NewsletterEntity::STATUS_ACTIVE,
+      [
+        'content' => [
+          'blocks' => [
+            [
+              'type' => 'text',
+              'text' => '<a href="https://example.com/body">Body link</a> <a href="[link:subscription_manage_url]">Manage</a>',
+            ],
+            [
+              'type' => 'button',
+              'url' => 'https://example.com/button',
+            ],
+            [
+              'type' => 'button',
+              'url' => '[postLink]',
+            ],
+            [
+              'type' => 'image',
+              'link' => 'https://example.com/image',
+            ],
+            [
+              'type' => 'social',
+              'icons' => [
+                [
+                  'link' => 'https://example.com/social',
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]
+    );
+    $queue1 = $this->createQueue($newsletter);
+    $queue2 = $this->createQueue($newsletter);
+    $this->createLink($newsletter, $queue1, 'https://example.com/stored');
+    $this->createLink($newsletter, $queue2, 'https://example.com/stored');
+
+    $response = $this->endpoint->get(['newsletterId' => $newsletter->getId()]);
+    $urls = array_column($response->data, 'url');
+    $ids = array_column($response->data, 'id');
+
+    $this->assertContains('https://example.com/stored', $urls);
+    $this->assertContains('https://example.com/body', $urls);
+    $this->assertContains('[link:subscription_manage_url]', $urls);
+    $this->assertContains('https://example.com/button', $urls);
+    $this->assertContains('https://example.com/image', $urls);
+    $this->assertContains('https://example.com/social', $urls);
+    $this->assertNotContains('[postLink]', $urls);
+    $this->assertCount(count(array_unique($urls)), $urls);
+    verify($ids)->equals($urls);
+  }
+
+  private function createNewsletter(string $type, string $status, array $body = []): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType($type);
+    $newsletter->setStatus($status);
+    $newsletter->setSubject('Newsletter Links Test');
+    $newsletter->setBody($body);
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    return $newsletter;
+  }
+
+  private function createQueue(NewsletterEntity $newsletter): SendingQueueEntity {
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->persist($task);
+
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $newsletter->getQueues()->add($queue);
+
+    $this->entityManager->flush();
+    return $queue;
+  }
+
+  private function createLink(NewsletterEntity $newsletter, SendingQueueEntity $queue, string $url): NewsletterLinkEntity {
+    $link = new NewsletterLinkEntity($newsletter, $queue, $url, uniqid('', true));
+    $this->entityManager->persist($link);
+    $this->entityManager->flush();
+    return $link;
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -24,6 +24,24 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     $this->repository = $this->diContainer->get(NewslettersRepository::class);
   }
 
+  public function testItGetsStandardAndAutomationNewsletterList() {
+    $standardNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
+    $automationEmail = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $automationTransactionalEmail = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_ACTIVE);
+    $automationDraftEmail = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_DRAFT);
+    $notification = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
+
+    $newsletterIds = array_map(function(NewsletterEntity $newsletter) {
+      return $newsletter->getId();
+    }, $this->repository->getStandardAndAutomationNewsletterList());
+
+    $this->assertContains($standardNewsletter->getId(), $newsletterIds);
+    $this->assertContains($automationEmail->getId(), $newsletterIds);
+    $this->assertContains($automationTransactionalEmail->getId(), $newsletterIds);
+    $this->assertNotContains($automationDraftEmail->getId(), $newsletterIds);
+    $this->assertNotContains($notification->getId(), $newsletterIds);
+  }
+
   public function testItBulkTrashNewslettersAndChildren() {
     $standardNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD);
     $this->createQueueWithTaskAndSegmentAndSubscribers($standardNewsletter);


### PR DESCRIPTION
## Description

Lets the `newsletter_links` JSON endpoint return link options for automation emails. For automation emails, URLs are deduplicated across all generated sends and the newsletter body — `id` is the URL string instead of a numeric row id. Standard-newsletter responses are unchanged.

Also adds `NewslettersRepository::getStandardAndAutomationNewsletterList` for the premium dropdown.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1056

## Linked tickets

STOMAIL-7626

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7626-cant-select-link-from-automation-emails-when-using-the)

_The latest successful build from `stomail-7626-cant-select-link-from-automation-emails-when-using-the` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**No issues found.**

The PR introduces well-structured changes with proper validation, security considerations, and test coverage. Key aspects verified:

- **Code Quality**: Proper null checks, type validation, and parameterized database queries prevent injection vulnerabilities
- **Logic**: URL filtering logic is correct, with appropriate handling of shortcodes (including `[link:]` placeholders while excluding others like `[postLink]`)
- **Performance**: The optimization to skip `Links::extract` on plain-text leaves is a thoughtful performance improvement
- **Testing**: Comprehensive test coverage for both standard newsletters and automation emails with edge cases
- **Backward Compatibility**: The old `getStandardNewsletterList()` method is preserved for existing usage in `DynamicSegments.php` and other locations
- **Database Design**: Proper use of `ArrayParameterType::STRING` for type safety in queries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->