### PR TITLE
 Prevent early public API calls from fataling during upgrades

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -16,12 +16,19 @@ Currently supported version is `v1`.
 ### Instantiation
 
 ```php
-if (class_exists(\MailPoet\API\API::class)) {
-  $mailpoet_api = \MailPoet\API\API::MP('v1');
-}
+add_action('init', function () {
+  if (!class_exists(\MailPoet\API\API::class)) {
+    return;
+  }
+  try {
+    $mailpoet_api = \MailPoet\API\API::MP('v1');
+  } catch (\Exception $e) {
+    // MailPoet is still initializing or upgrading on this request.
+  }
+});
 ```
 
-Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by WordPress.
+Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by WordPress. Call the API from `init` (default priority) or later so MailPoet has run any pending database migrations. Calling the API earlier — for example on `plugins_loaded` during an upgrade — will throw a readiness exception you can catch and handle.
 
 ### Available API Methods
 

--- a/doc/UsageExamples.md
+++ b/doc/UsageExamples.md
@@ -4,19 +4,29 @@
 
 Common usage is a rendering of a subscription form and processing it.
 
+Hook your API calls into `init` (default priority) or later, after MailPoet has finished its initialization and any pending database migrations. Calling the API earlier (e.g. on `plugins_loaded`) during a MailPoet upgrade will throw a readiness exception, which you can catch and handle.
+
 ## Fetching data for a subscription form
 
 ```php
 <?php
 
-if (class_exists(\MailPoet\API\API::class)) {
-  // Get MailPoet API instance
-  $mailpoet_api = \MailPoet\API\API::MP('v1');
-  // Get available list so that a subscriber can choose in which to subscribe
-  $lists = $mailpoet_api->getLists();
-  // Get subscriber fields to know what fields can be rendered within a form
-  $subscriber_form_fields = $mailpoet_api->getSubscriberFields();
-}
+add_action('init', function () {
+  if (!class_exists(\MailPoet\API\API::class)) {
+    return;
+  }
+
+  try {
+    // Get MailPoet API instance
+    $mailpoet_api = \MailPoet\API\API::MP('v1');
+    // Get available list so that a subscriber can choose in which to subscribe
+    $lists = $mailpoet_api->getLists();
+    // Get subscriber fields to know what fields can be rendered within a form
+    $subscriber_form_fields = $mailpoet_api->getSubscriberFields();
+  } catch (\Exception $e) {
+    // MailPoet is still upgrading or otherwise unavailable on this request.
+  }
+});
 ```
 
 ## Processing a subscription form
@@ -24,27 +34,31 @@ if (class_exists(\MailPoet\API\API::class)) {
 ```php
 <?php
 
-if (class_exists(\MailPoet\API\API::class)) {
-  // Get MailPoet API instance
-  $mailpoet_api = \MailPoet\API\API::MP('v1');
-
-  // Fill subscribed data from $_POST (for simplicity it expects that subscriber field ids are used as input names)
-  $subscriber = [];
-  $subscriber_form_fields = $mailpoet_api->getSubscriberFields();
-  foreach ($subscriber_form_fields as $field) {
-    if (!isset($_POST[$field['id']])) {
-      continue;
-    }
-    $subscriber[$field['id']] = $_POST[$field['id']];
+add_action('init', function () {
+  if (!class_exists(\MailPoet\API\API::class)) {
+    return;
   }
-  $list_ids = $_POST['list_ids'];
-
-  // Check if subscriber exists. If subscriber doesn't exist an exception is thrown
-  try {
-    $get_subscriber = $mailpoet_api->getSubscriber($subscriber['email']);
-  } catch (\Exception $e) {}
 
   try {
+    // Get MailPoet API instance
+    $mailpoet_api = \MailPoet\API\API::MP('v1');
+
+    // Fill subscribed data from $_POST (for simplicity it expects that subscriber field ids are used as input names)
+    $subscriber = [];
+    $subscriber_form_fields = $mailpoet_api->getSubscriberFields();
+    foreach ($subscriber_form_fields as $field) {
+      if (!isset($_POST[$field['id']])) {
+        continue;
+      }
+      $subscriber[$field['id']] = $_POST[$field['id']];
+    }
+    $list_ids = $_POST['list_ids'];
+
+    // Check if subscriber exists. If subscriber doesn't exist an exception is thrown
+    try {
+      $get_subscriber = $mailpoet_api->getSubscriber($subscriber['email']);
+    } catch (\Exception $e) {}
+
     if (!$get_subscriber) {
       // Subscriber doesn't exist let's create one
       $mailpoet_api->addSubscriber($subscriber, $list_ids);
@@ -55,5 +69,5 @@ if (class_exists(\MailPoet\API\API::class)) {
   } catch (\Exception $e) {
     $error_message = $e->getMessage();
   }
-}
+});
 ```

--- a/mailpoet/changelog/2026-05-06-21-41-38-fixed-throw-a-controlled-exception-instead-of-fataling-w.md
+++ b/mailpoet/changelog/2026-05-06-21-41-38-fixed-throw-a-controlled-exception-instead-of-fataling-w.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Throw a controlled exception instead of fataling when the public API is called against an outdated database schema during a MailPoet upgrade

--- a/mailpoet/lib/API/API.php
+++ b/mailpoet/lib/API/API.php
@@ -2,7 +2,9 @@
 
 namespace MailPoet\API;
 
+use MailPoet\Config\Env;
 use MailPoet\DI\ContainerWrapper;
+use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class API {
@@ -14,10 +16,32 @@ class API {
   public static function MP($version) {
     /** @var class-string<\MailPoet\API\MP\v1\API> $apiClass */
     $apiClass = sprintf('%s\MP\%s\API', __NAMESPACE__, $version);
+    $container = ContainerWrapper::getInstance();
+    self::ensureReady($container);
     try {
-      return ContainerWrapper::getInstance()->get($apiClass);
+      return $container->get($apiClass);
     } catch (ServiceNotFoundException $e) {
       throw new \Exception(__('Invalid API version.', 'mailpoet'));
     }
+  }
+
+  /**
+   * Guards against API calls that hit the database before MailPoet has finished
+   * its activator/migration path on `init`. Without this, an early call (e.g. from
+   * `plugins_loaded` during a plugin upgrade) could query Doctrine entities against
+   * an outdated schema and fatal mid-request.
+   */
+  private static function ensureReady(ContainerWrapper $container): void {
+    try {
+      $currentDbVersion = $container->get(SettingsController::class)->get('db_version');
+    } catch (\Throwable $e) {
+      $currentDbVersion = null;
+    }
+
+    if (version_compare((string)$currentDbVersion, Env::$version) === 0) {
+      return;
+    }
+
+    throw new \Exception(__('MailPoet is still initializing or upgrading. Call the public API from the "init" hook (default priority) or later.', 'mailpoet'));
   }
 }

--- a/mailpoet/tests/integration/API/APITest.php
+++ b/mailpoet/tests/integration/API/APITest.php
@@ -3,6 +3,8 @@
 namespace MailPoet\Test\API;
 
 use MailPoet\API\API;
+use MailPoet\Config\Env;
+use MailPoet\Settings\SettingsController;
 
 class APITest extends \MailPoetTest {
   public function testItCallsMPAPI() {
@@ -16,5 +18,27 @@ class APITest extends \MailPoetTest {
     } catch (\Exception $e) {
       verify($e->getMessage())->equals('Invalid API version.');
     }
+  }
+
+  public function testItThrowsWhenCalledBeforeMigrationsHaveRun() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $originalDbVersion = $settings->get('db_version');
+    $settings->set('db_version', '0.0.1');
+
+    try {
+      API::MP('v1');
+      $this->fail('Expected readiness exception was not thrown.');
+    } catch (\Exception $e) {
+      verify($e->getMessage())->stringContainsString('still initializing');
+    } finally {
+      $settings->set('db_version', $originalDbVersion);
+    }
+  }
+
+  public function testItDoesNotThrowOnceDbVersionMatches() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $settings->set('db_version', Env::$version);
+
+    verify(API::MP('v1'))->instanceOf('MailPoet\API\MP\v1\API');
   }
 }

--- a/mailpoet/tests/integration/API/APITest.php
+++ b/mailpoet/tests/integration/API/APITest.php
@@ -37,8 +37,13 @@ class APITest extends \MailPoetTest {
 
   public function testItDoesNotThrowOnceDbVersionMatches() {
     $settings = $this->diContainer->get(SettingsController::class);
+    $originalDbVersion = $settings->get('db_version');
     $settings->set('db_version', Env::$version);
 
-    verify(API::MP('v1'))->instanceOf('MailPoet\API\MP\v1\API');
+    try {
+      verify(API::MP('v1'))->instanceOf('MailPoet\API\MP\v1\API');
+    } finally {
+      $settings->set('db_version', $originalDbVersion);
+    }
   }
 }


### PR DESCRIPTION
## Description

When a third-party integration called `\MailPoet\API\API::MP('v1')` on `plugins_loaded` during a MailPoet upgrade, Doctrine queried entity columns against the not-yet-migrated schema and fataled mid-request.

`API::MP()` now checks `db_version` against `Env::$version` and throws a controlled `\Exception` when stale, instead of letting the mismatch escalate to a Doctrine fatal. Integrators can `try/catch` and degrade gracefully. 

Docs updated to recommend calling from the `init` hook or later.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8046

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8046-prevent-early-public-api-calls-from-fataling-during-upgrades)

_The latest successful build from `stomail-8046-prevent-early-public-api-calls-from-fataling-during-upgrades` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**1 issue found**

1. **Suggestion (Test Consistency)**: In `APITest::testItDoesNotThrowOnceDbVersionMatches()`, the test modifies `db_version` but does not restore it in a finally block, unlike the preceding test `testItThrowsWhenCalledBeforeMigrationsHaveRun()` which properly restores the value. While the test framework's cleanup extension automatically resets `db_version` between tests, this inconsistency reduces code maintainability and violates the test isolation pattern established in the same test class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->