### PR TITLE
Respect WordPress date and time settings in MailPoet UI

### DIFF
--- a/mailpoet/assets/js/src/automation/editor/components/sidebar/automation/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/sidebar/automation/index.tsx
@@ -1,9 +1,9 @@
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { MailPoet } from 'mailpoet';
 import { storeName } from '../../../store';
 import { TrashButton } from '../../actions/trash-button';
-import { locale } from '../../../../config';
 import { Hooks } from '../../../../../hooks';
 import { AutomationSettingElements } from '../../../../types/filters';
 import { sendTelemetryEvent } from '../../../telemetry';
@@ -48,12 +48,6 @@ export function AutomationSidebar(): JSX.Element {
     [],
   );
 
-  const dateOptions: Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  };
-
   return (
     <>
       <PanelBody
@@ -68,23 +62,15 @@ export function AutomationSidebar(): JSX.Element {
       >
         <PanelRow>
           <strong>Date added</strong>{' '}
-          {new Date(Date.parse(automationData.created_at)).toLocaleDateString(
-            locale.toString(),
-            dateOptions,
-          )}
+          {MailPoet.Date.short(automationData.created_at)}
         </PanelRow>
         <PanelRow>
           <strong>Activated</strong>{' '}
           {automationData.status === 'active' &&
-            new Date(Date.parse(automationData.updated_at)).toLocaleDateString(
-              locale.toString(),
-              dateOptions,
-            )}
+            MailPoet.Date.short(automationData.updated_at)}
           {automationData.status !== 'active' &&
             automationData.activated_at &&
-            new Date(
-              Date.parse(automationData.activated_at),
-            ).toLocaleDateString(locale.toString(), dateOptions)}
+            MailPoet.Date.short(automationData.activated_at)}
           {automationData.status !== 'active' &&
             !automationData.activated_at && (
               <span className="mailpoet-deactive">Not activated yet.</span>

--- a/mailpoet/assets/js/src/automation/editor/filters/datetime.ts
+++ b/mailpoet/assets/js/src/automation/editor/filters/datetime.ts
@@ -1,5 +1,6 @@
-import { dateI18n, getSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+import { MailPoet } from '../../../mailpoet';
 import { FilterType } from '../store/types';
 
 export const filter: FilterType = {
@@ -41,11 +42,9 @@ export const filter: FilterType = {
 
     const isDate = condition === 'on' || condition === 'not-on';
 
-    return dateI18n(
-      isDate ? settings.formats.date : settings.formats.datetime,
-      args.value as string,
-      settings.timezone.string,
-    );
+    return isDate
+      ? MailPoet.Date.short(args.value as string)
+      : MailPoet.Date.full(args.value as string);
   },
   validateArgs: (args, condition) => {
     const value = args.value;

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState } from 'react';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 import { dispatch, select as globalSelect, useSelect } from '@wordpress/data';
-import { getSettings, setSettings } from '@wordpress/date';
 import { Platform } from '@wordpress/element';
 import {
   store as interfaceStore,
@@ -181,19 +180,6 @@ function Editor(): JSX.Element {
 
 window.addEventListener('DOMContentLoaded', () => {
   setLocaleData(window.wp.i18n.getLocaleData());
-
-  if (window.wp.date.getSettings !== undefined) {
-    const dateSettings = window.wp as unknown as {
-      date: { getSettings: typeof getSettings };
-    };
-    setSettings(dateSettings.date.getSettings());
-  } else {
-    const dateSettings = window.wp as unknown as {
-      /* eslint-disable no-underscore-dangle */
-      date: { __experimentalGetSettings: typeof getSettings };
-    };
-    setSettings(dateSettings.date.__experimentalGetSettings());
-  }
 
   createStore();
 

--- a/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
+++ b/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
@@ -21,9 +21,7 @@ const WordPressFormattedInput = forwardRef<
   HTMLInputElement,
   WordPressFormattedInputProps
 >(({ selectedDate, value: _value, ...props }, ref) => {
-  const formattedValue = selectedDate
-    ? MailPoet.Date.short(selectedDate)
-    : '';
+  const formattedValue = selectedDate ? MailPoet.Date.short(selectedDate) : '';
 
   return <input {...props} ref={ref} value={formattedValue} readOnly />;
 });

--- a/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
+++ b/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
@@ -1,24 +1,58 @@
 import classnames from 'classnames';
+import { forwardRef, type ComponentProps } from 'react';
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker';
+import { dateI18n, getSettings } from '@wordpress/date';
 import { MailPoet } from 'mailpoet';
 import { withBoundary } from '../error-boundary';
 
 type Props = ReactDatePickerProps & {
   className?: string;
   dimension?: 'small';
+  formatWithWordPressSettings?: boolean;
   isFullWidth?: boolean;
   iconStart?: JSX.Element;
   iconEnd?: JSX.Element;
 };
 
+type WordPressFormattedInputProps = ComponentProps<'input'> & {
+  selectedDate?: Date | null;
+};
+
+const WordPressFormattedInput = forwardRef<
+  HTMLInputElement,
+  WordPressFormattedInputProps
+>(({ selectedDate, value: _value, ...props }, ref) => {
+  const settings = getSettings();
+  const formattedValue = selectedDate
+    ? dateI18n(
+        settings.formats.date,
+        selectedDate,
+        settings.timezone.string || settings.timezone.offset,
+      )
+    : '';
+
+  return <input {...props} ref={ref} value={formattedValue} readOnly />;
+});
+WordPressFormattedInput.displayName = 'WordPressFormattedInput';
+
 function Datepicker({
   className,
   dimension,
+  formatWithWordPressSettings,
   isFullWidth,
   iconStart,
   iconEnd,
   ...props
 }: Props) {
+  const selectedDate =
+    props.selected instanceof Date ? props.selected : undefined;
+  const datePickerProps = formatWithWordPressSettings
+    ? {
+        ...props,
+        customInput: <WordPressFormattedInput selectedDate={selectedDate} />,
+      }
+    : props;
+
   return (
     <div
       className={classnames(
@@ -35,7 +69,7 @@ function Datepicker({
       <ReactDatePicker
         useWeekdaysShort
         calendarStartDay={props.calendarStartDay ?? MailPoet.wpWeekStartsOn}
-        {...props}
+        {...datePickerProps}
       />
       {iconEnd}
     </div>

--- a/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
+++ b/mailpoet/assets/js/src/common/datepicker/datepicker.tsx
@@ -1,7 +1,6 @@
 import classnames from 'classnames';
 import { forwardRef, type ComponentProps } from 'react';
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker';
-import { dateI18n, getSettings } from '@wordpress/date';
 import { MailPoet } from 'mailpoet';
 import { withBoundary } from '../error-boundary';
 
@@ -22,13 +21,8 @@ const WordPressFormattedInput = forwardRef<
   HTMLInputElement,
   WordPressFormattedInputProps
 >(({ selectedDate, value: _value, ...props }, ref) => {
-  const settings = getSettings();
   const formattedValue = selectedDate
-    ? dateI18n(
-        settings.formats.date,
-        selectedDate,
-        settings.timezone.string || settings.timezone.offset,
-      )
+    ? MailPoet.Date.short(selectedDate)
     : '';
 
   return <input {...props} ref={ref} value={formattedValue} readOnly />;

--- a/mailpoet/assets/js/src/date.ts
+++ b/mailpoet/assets/js/src/date.ts
@@ -89,7 +89,7 @@ export const MailPoetDate: {
     syncWordPressDateSettings();
     const settings = getSettings();
     return dateI18n(
-      settings.formats.datetime,
+      `${settings.formats.date} ${settings.formats.time}`,
       date as DateI18nInput,
       settings.timezone.string || settings.timezone.offset,
     );

--- a/mailpoet/assets/js/src/date.ts
+++ b/mailpoet/assets/js/src/date.ts
@@ -1,5 +1,6 @@
 import Moment, { MomentInput } from 'moment';
 import { dateI18n, getSettings } from '@wordpress/date';
+import { syncWordPressDateSettings } from './wordpress-date-settings';
 
 export interface DateOptions {
   format?: string;
@@ -76,6 +77,7 @@ export const MailPoetDate: {
     return Moment.utc(date).toDate();
   },
   short: function short(date: MomentInput): string {
+    syncWordPressDateSettings();
     const settings = getSettings();
     return dateI18n(
       settings.formats.date,
@@ -84,6 +86,7 @@ export const MailPoetDate: {
     );
   },
   full: function full(date: MomentInput): string {
+    syncWordPressDateSettings();
     const settings = getSettings();
     return dateI18n(
       settings.formats.datetime,
@@ -92,6 +95,7 @@ export const MailPoetDate: {
     );
   },
   time: function time(date: MomentInput): string {
+    syncWordPressDateSettings();
     const settings = getSettings();
     return dateI18n(
       settings.formats.time,

--- a/mailpoet/assets/js/src/date.ts
+++ b/mailpoet/assets/js/src/date.ts
@@ -1,9 +1,12 @@
 import Moment, { MomentInput } from 'moment';
+import { dateI18n, getSettings } from '@wordpress/date';
 
 export interface DateOptions {
   format?: string;
   offset?: number;
 }
+
+type DateI18nInput = Parameters<typeof dateI18n>[1];
 
 export const MailPoetDate: {
   version: number;
@@ -73,19 +76,28 @@ export const MailPoetDate: {
     return Moment.utc(date).toDate();
   },
   short: function short(date: MomentInput): string {
-    return this.format(date, {
-      format: window.mailpoet_date_format || 'F j, Y',
-    });
+    const settings = getSettings();
+    return dateI18n(
+      settings.formats.date,
+      date as DateI18nInput,
+      settings.timezone.string || settings.timezone.offset,
+    );
   },
   full: function full(date: MomentInput): string {
-    return this.format(date, {
-      format: window.mailpoet_datetime_format || 'F j, Y H:i:s',
-    });
+    const settings = getSettings();
+    return dateI18n(
+      settings.formats.datetime,
+      date as DateI18nInput,
+      settings.timezone.string || settings.timezone.offset,
+    );
   },
   time: function time(date: MomentInput): string {
-    return this.format(date, {
-      format: window.mailpoet_time_format || 'H:i:s',
-    });
+    const settings = getSettings();
+    return dateI18n(
+      settings.formats.time,
+      date as DateI18nInput,
+      settings.timezone.string || settings.timezone.offset,
+    );
   },
   datetimeString: function gmtToSiteTimestamp(date: MomentInput): string {
     return this.format(date, { format: 'Y-m-d H:i:s' });
@@ -187,7 +199,6 @@ export const MailPoetDate: {
         convertedFormat.push(`[${token}]`);
       }
     }
-
     return convertedFormat.join('');
   },
   isInFuture: (dateString: string, currentTime: MomentInput): boolean =>

--- a/mailpoet/assets/js/src/forms/fields.ts
+++ b/mailpoet/assets/js/src/forms/fields.ts
@@ -97,15 +97,7 @@ export const listFields: Field<FormListingItem>[] = [
       if (!item.updated_at) {
         return createElement('span', null, '—');
       }
-      const date = MailPoet.Date.short(item.updated_at);
-      const time = MailPoet.Date.time(item.updated_at);
-      return createElement(
-        'span',
-        null,
-        createElement('span', null, date),
-        createElement('br', null),
-        createElement('span', null, time),
-      );
+      return createElement('span', null, MailPoet.Date.full(item.updated_at));
     },
   },
 ];

--- a/mailpoet/assets/js/src/help/tasks-list/tasks-list-actions.tsx
+++ b/mailpoet/assets/js/src/help/tasks-list/tasks-list-actions.tsx
@@ -112,9 +112,7 @@ function TaskButton({ task, type }: Props): JSX.Element {
           !isScheduledInPast &&
           sprintf(
             __('The task will be scheduled for sending on %s.', 'mailpoet'),
-            `${MailPoet.Date.short(scheduledDate)} ${MailPoet.Date.time(
-              scheduledDate,
-            )}`,
+            MailPoet.Date.full(scheduledDate),
           )}
       </ConfirmDialog>
 

--- a/mailpoet/assets/js/src/help/tasks-list/tasks-list-data-row.tsx
+++ b/mailpoet/assets/js/src/help/tasks-list/tasks-list-data-row.tsx
@@ -59,22 +59,16 @@ function TasksListDataRow({ type, task }: Props): JSX.Element {
       <td className="column">{task.priority}</td>
       {showScheduledAt ? (
         <td className="column-date">
-          <abbr>{`${MailPoet.Date.short(task.scheduledAt)} ${MailPoet.Date.time(
-            task.scheduledAt,
-          )}`}</abbr>
+          <abbr>{MailPoet.Date.full(task.scheduledAt)}</abbr>
         </td>
       ) : null}
       {showCancelledAt ? (
         <td className="column-date">
-          <abbr>{`${MailPoet.Date.short(task.cancelledAt)} ${MailPoet.Date.time(
-            task.cancelledAt,
-          )}`}</abbr>
+          <abbr>{MailPoet.Date.full(task.cancelledAt)}</abbr>
         </td>
       ) : null}
       <td className="column-date">
-        <abbr>{`${MailPoet.Date.short(task.updatedAt)} ${MailPoet.Date.time(
-          task.updatedAt,
-        )}`}</abbr>
+        <abbr>{MailPoet.Date.full(task.updatedAt)}</abbr>
       </td>
       {canCancelTask ? (
         <td>

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -153,7 +153,7 @@ function List({
           }
           <ErrorBoundary>
             <Datepicker
-              dateFormat="MMMM d, yyyy"
+              formatWithWordPressSettings
               onChange={dateChanged(setFrom)}
               maxDate={new Date()}
               selected={from ? parseISO(from) : undefined}
@@ -164,7 +164,7 @@ function List({
               `${__('To', 'mailpoet')}:`
             }
             <Datepicker
-              dateFormat="MMMM d, yyyy"
+              formatWithWordPressSettings
               onChange={dateChanged(setTo)}
               maxDate={new Date()}
               selected={to ? parseISO(to) : undefined}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/scheduled-row.tsx
@@ -12,11 +12,12 @@ import {
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
-import { dateI18n, getSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 import { closeSmall } from '@wordpress/icons';
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import { MailPoet } from 'mailpoet';
 
 export function ScheduledRow() {
   const [mailpoetEmailData] = useEntityProp(
@@ -58,11 +59,7 @@ export function ScheduledRow() {
     if (!scheduledDate) {
       return __('Immediately', 'mailpoet');
     }
-    return dateI18n(
-      settings.formats.datetime,
-      scheduledDate,
-      settings.timezone.string,
-    );
+    return MailPoet.Date.full(scheduledDate);
   };
 
   const is12HourTime = /a(?!\\)/i.test(

--- a/mailpoet/assets/js/src/newsletters/listings/notification-history.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification-history.jsx
@@ -169,13 +169,7 @@ const renderItem = (newsletter, actions, meta) => {
         className="column-date mailpoet-hide-on-mobile"
         data-colname={__('Sent on', 'mailpoet')}
       >
-        {newsletter.sent_at ? (
-          <>
-            {MailPoet.Date.short(newsletter.sent_at)}
-            <br />
-            {MailPoet.Date.time(newsletter.sent_at)}
-          </>
-        ) : null}
+        {newsletter.sent_at ? MailPoet.Date.full(newsletter.sent_at) : null}
       </td>
     </>
   );

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -383,9 +383,7 @@ class NewsletterListNotificationComponent extends Component {
           className="column-date mailpoet-hide-on-mobile"
           data-colname={__('Last modified on', 'mailpoet')}
         >
-          {MailPoet.Date.short(newsletter.updated_at)}
-          <br />
-          {MailPoet.Date.time(newsletter.updated_at)}
+          {MailPoet.Date.full(newsletter.updated_at)}
         </td>
       </div>
     );

--- a/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
@@ -356,9 +356,7 @@ class NewsletterListReEngagementComponent extends Component {
           className="column-date mailpoet-hide-on-mobile"
           data-colname={__('Last modified on', 'mailpoet')}
         >
-          {MailPoet.Date.short(newsletter.updated_at)}
-          <br />
-          {MailPoet.Date.time(newsletter.updated_at)}
+          {MailPoet.Date.full(newsletter.updated_at)}
         </td>
       </div>
     );

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -306,13 +306,7 @@ class NewsletterListStandardComponent extends Component {
           className="column-date mailpoet-hide-on-mobile"
           data-colname={__('Sent on', 'mailpoet')}
         >
-          {newsletter.sent_at ? (
-            <>
-              {MailPoet.Date.short(newsletter.sent_at)}
-              <br />
-              {MailPoet.Date.time(newsletter.sent_at)}
-            </>
-          ) : null}
+          {newsletter.sent_at ? MailPoet.Date.full(newsletter.sent_at) : null}
         </td>
       </div>
     );

--- a/mailpoet/assets/js/src/newsletters/send/date-text.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-text.tsx
@@ -116,7 +116,6 @@ type DateTextEvent = SyntheticEvent<HTMLInputElement> & {
 };
 
 type DateTextProps = {
-  displayFormat: string;
   onChange: (date: DateTextEvent) => void;
   storageFormat: string;
   value: string;

--- a/mailpoet/assets/js/src/newsletters/send/date-text.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-text.tsx
@@ -143,18 +143,6 @@ class DateText extends Component<DateTextProps> {
 
   getFieldName = () => this.props.name || 'date';
 
-  getDisplayDateFormat = (format: string) => {
-    const convertedFormat = MailPoet.Date.convertFormat(format);
-    // Convert moment format to date-fns, see: https://git.io/fxCyr
-    return convertedFormat
-      .replace(/D/g, 'd')
-      .replace(/Y/g, 'y')
-      .replace(/A/g, 'a')
-      .replace(/o/g, 'Y') // MailPoet.Date.convertFormat converts 'S' to 'o'
-      .replace(/\[/g, '')
-      .replace(/\]/g, '');
-  };
-
   getDate = (date: string) => Moment(date).toDate();
 
   getAsStringInFormat = (date: Date) =>
@@ -165,7 +153,7 @@ class DateText extends Component<DateTextProps> {
       <Datepicker
         name={this.getFieldName()}
         selected={this.getDate(this.props.value)}
-        dateFormat={this.getDisplayDateFormat(this.props.displayFormat)}
+        formatWithWordPressSettings
         disabled={this.props.disabled}
         onChange={this.onChange}
         minDate={this.getDate(window.mailpoet_current_date)}

--- a/mailpoet/assets/js/src/newsletters/send/date-time.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/date-time.tsx
@@ -16,7 +16,6 @@ type DateTimeEvent = SyntheticEvent<HTMLInputElement> & {
 type DateTimeProps = {
   value?: string;
   defaultDateTime: string;
-  dateDisplayFormat: string;
   dateStorageFormat: string;
   onChange: (date: DateTimeEvent) => void;
   name?: string;
@@ -98,7 +97,6 @@ class DateTime extends Component<DateTimeProps, DateTimeState> {
             name="date"
             value={this.state.date}
             onChange={this.handleChange}
-            displayFormat={this.props.dateDisplayFormat}
             storageFormat={this.props.dateStorageFormat}
             disabled={this.props.disabled}
             validation={this.props.dateValidation}

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -19,7 +19,6 @@ const tomorrowDateTime = MailPoet.Date.toGmtDatetimeString(
 const timeOfDayItems = window.mailpoet_schedule_time_of_day as unknown as {
   [key: string]: string;
 };
-const dateDisplayFormat = window.mailpoet_date_format;
 const dateStorageFormat = window.mailpoet_date_storage_format;
 
 type StandardSchedulingProps = {
@@ -99,7 +98,6 @@ class StandardScheduling extends Component<StandardSchedulingProps> {
               dateValidation={this.getDateValidation()}
               defaultDateTime={tomorrowDateTime}
               timeOfDayItems={timeOfDayItems}
-              dateDisplayFormat={dateDisplayFormat}
               dateStorageFormat={dateStorageFormat}
               maxDate={maxDate}
             />

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx
@@ -133,7 +133,7 @@ function DateFields({
         segment.operator === DateOperator.NOT_ON) && (
         <Datepicker
           className="mailpoet-segments-datepicker-small"
-          dateFormat="MMM d, yyyy"
+          formatWithWordPressSettings
           onChange={(value): void => {
             void updateSegmentFilter(
               { value: convertDateToString(value) },

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/subscriber/custom-fields/date.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/subscriber/custom-fields/date.tsx
@@ -227,7 +227,7 @@ function DateFullDate({ onChange, item, filterIndex }: ComponentProps) {
       </Select>
       {!isBlankOption(item.operator) && (
         <Datepicker
-          dateFormat="MMM d, yyyy"
+          formatWithWordPressSettings
           onChange={(value): void =>
             onChange(
               assign(item, { value: convertDateToString(value) }),

--- a/mailpoet/assets/js/src/segments/dynamic/fields.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/fields.ts
@@ -17,9 +17,7 @@ function dateTime(
         ? `mailpoet_dynamic_segment_updated_at_${segmentId}`
         : 'mailpoet_dynamic_segment_updated_at',
     },
-    createElement('span', null, MailPoet.Date.short(value)),
-    createElement('br', null),
-    createElement('span', null, MailPoet.Date.time(value)),
+    MailPoet.Date.full(value),
   );
 }
 

--- a/mailpoet/assets/js/src/segments/dynamic/list/get-row.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/list/get-row.tsx
@@ -165,9 +165,7 @@ export function getRow(
         <div
           data-automation-id={`mailpoet_dynamic_segment_created_at_${dynamicSegment.id}`}
         >
-          {MailPoet.Date.short(dynamicSegment.created_at)}
-          <br />
-          {MailPoet.Date.time(dynamicSegment.created_at)}
+          {MailPoet.Date.full(dynamicSegment.created_at)}
         </div>
       ),
     },

--- a/mailpoet/assets/js/src/segments/static/fields.ts
+++ b/mailpoet/assets/js/src/segments/static/fields.ts
@@ -17,13 +17,7 @@ function count(item: SegmentListingItem, status: string): JSX.Element {
 
 function dateTime(value: string | null): JSX.Element {
   if (!value) return createElement('span', null, '—');
-  return createElement(
-    'span',
-    null,
-    createElement('span', null, MailPoet.Date.short(value)),
-    createElement('br', null),
-    createElement('span', null, MailPoet.Date.time(value)),
-  );
+  return createElement('span', null, MailPoet.Date.full(value));
 }
 
 export const segmentFields: Field<SegmentListingItem>[] = [

--- a/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
+++ b/mailpoet/assets/js/src/settings/pages/basics/shortcode.tsx
@@ -121,7 +121,7 @@ export function Shortcode({ name, title, description }: Props) {
             <br />
             <Datepicker
               dimension="small"
-              dateFormat="MMMM d, yyyy"
+              formatWithWordPressSettings
               onChange={(value): void => {
                 setStartDate(value);
                 if (value !== null) {
@@ -135,7 +135,7 @@ export function Shortcode({ name, title, description }: Props) {
             />
             <Datepicker
               dimension="small"
-              dateFormat="MMMM d, yyyy"
+              formatWithWordPressSettings
               onChange={(value): void => {
                 setEndDate(value);
                 if (value !== null) {

--- a/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
@@ -1,10 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import { dateI18n, getSettings } from '@wordpress/date';
 import { createElement } from 'react';
 import type { Field } from '@wordpress/dataviews';
+import { MailPoet } from 'mailpoet';
 import type { CustomField } from './types';
-
-const dateSettings = getSettings();
 
 const FIELD_TYPE_LABELS: Record<string, string> = {
   text: __('Text', 'mailpoet'),
@@ -77,13 +75,7 @@ export const listFields: Field<CustomField>[] = [
       createElement(
         'span',
         null,
-        item.created_at
-          ? dateI18n(
-              dateSettings.formats.date,
-              item.created_at,
-              dateSettings.timezone.string || dateSettings.timezone.offset,
-            )
-          : '',
+        item.created_at ? MailPoet.Date.full(item.created_at) : '',
       ),
   },
 ];

--- a/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
@@ -1,8 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getSettings } from '@wordpress/date';
 import { createElement } from 'react';
 import type { Field } from '@wordpress/dataviews';
 import type { CustomField } from './types';
+
+const dateSettings = getSettings();
 
 const FIELD_TYPE_LABELS: Record<string, string> = {
   text: __('Text', 'mailpoet'),
@@ -75,7 +77,13 @@ export const listFields: Field<CustomField>[] = [
       createElement(
         'span',
         null,
-        item.created_at ? dateI18n('M j, Y', item.created_at, undefined) : '',
+        item.created_at
+          ? dateI18n(
+              dateSettings.formats.date,
+              item.created_at,
+              dateSettings.timezone.string || dateSettings.timezone.offset,
+            )
+          : '',
       ),
   },
 ];

--- a/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/custom-fields/fields.ts
@@ -75,7 +75,7 @@ export const listFields: Field<CustomField>[] = [
       createElement(
         'span',
         null,
-        item.created_at ? MailPoet.Date.full(item.created_at) : '',
+        item.created_at ? MailPoet.Date.short(item.created_at) : '',
       ),
   },
 ];

--- a/mailpoet/assets/js/src/subscribers/list.tsx
+++ b/mailpoet/assets/js/src/subscribers/list.tsx
@@ -780,25 +780,17 @@ function SubscriberList() {
           className="column-date mailpoet-hide-on-mobile"
           data-colname={__('Confirmed on', 'mailpoet')}
         >
-          {subscriber.last_subscribed_at ? (
-            <>
-              {MailPoet.Date.short(subscriber.last_subscribed_at)}
-              <br />
-              {MailPoet.Date.time(subscriber.last_subscribed_at)}
-            </>
-          ) : null}
+          {subscriber.last_subscribed_at
+            ? MailPoet.Date.full(subscriber.last_subscribed_at)
+            : null}
         </td>
         <td
           className="column-date mailpoet-hide-on-mobile"
           data-colname={__('Subscribed on', 'mailpoet')}
         >
-          {subscriber.created_at ? (
-            <>
-              {MailPoet.Date.short(subscriber.created_at)}
-              <br />
-              {MailPoet.Date.time(subscriber.created_at)}
-            </>
-          ) : null}
+          {subscriber.created_at
+            ? MailPoet.Date.full(subscriber.created_at)
+            : null}
         </td>
       </>
     );

--- a/mailpoet/assets/js/src/subscribers/tags/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/fields.ts
@@ -1,11 +1,9 @@
 import { __ } from '@wordpress/i18n';
-import { dateI18n, getSettings } from '@wordpress/date';
 import { createElement } from 'react';
 import type { Field } from '@wordpress/dataviews';
+import { MailPoet } from 'mailpoet';
 import type { Tag } from './types';
 import { getSubscribersListingUrl } from './api';
-
-const dateSettings = getSettings();
 
 export const listFields: Field<Tag>[] = [
   {
@@ -48,13 +46,7 @@ export const listFields: Field<Tag>[] = [
       createElement(
         'span',
         null,
-        item.created_at
-          ? dateI18n(
-              dateSettings.formats.date,
-              item.created_at,
-              dateSettings.timezone.string || dateSettings.timezone.offset,
-            )
-          : '',
+        item.created_at ? MailPoet.Date.full(item.created_at) : '',
       ),
   },
 ];

--- a/mailpoet/assets/js/src/subscribers/tags/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/fields.ts
@@ -46,7 +46,7 @@ export const listFields: Field<Tag>[] = [
       createElement(
         'span',
         null,
-        item.created_at ? MailPoet.Date.full(item.created_at) : '',
+        item.created_at ? MailPoet.Date.short(item.created_at) : '',
       ),
   },
 ];

--- a/mailpoet/assets/js/src/subscribers/tags/fields.ts
+++ b/mailpoet/assets/js/src/subscribers/tags/fields.ts
@@ -1,9 +1,11 @@
 import { __ } from '@wordpress/i18n';
-import { dateI18n } from '@wordpress/date';
+import { dateI18n, getSettings } from '@wordpress/date';
 import { createElement } from 'react';
 import type { Field } from '@wordpress/dataviews';
 import type { Tag } from './types';
 import { getSubscribersListingUrl } from './api';
+
+const dateSettings = getSettings();
 
 export const listFields: Field<Tag>[] = [
   {
@@ -46,7 +48,13 @@ export const listFields: Field<Tag>[] = [
       createElement(
         'span',
         null,
-        item.created_at ? dateI18n('M j, Y', item.created_at, undefined) : '',
+        item.created_at
+          ? dateI18n(
+              dateSettings.formats.date,
+              item.created_at,
+              dateSettings.timezone.string || dateSettings.timezone.offset,
+            )
+          : '',
       ),
   },
 ];

--- a/mailpoet/assets/js/src/webpack-admin-expose.js
+++ b/mailpoet/assets/js/src/webpack-admin-expose.js
@@ -1,5 +1,8 @@
 // Modules that are exposed for usage in the premium plugin.
 // The exports below are available via "window.MailPoetLib".
+import { syncWordPressDateSettings } from './wordpress-date-settings';
+
+syncWordPressDateSettings();
 
 // libs
 export * as ClassNames from 'classnames';

--- a/mailpoet/assets/js/src/wordpress-date-settings.ts
+++ b/mailpoet/assets/js/src/wordpress-date-settings.ts
@@ -1,0 +1,31 @@
+import { getSettings, setSettings } from '@wordpress/date';
+
+type WordPressDateSettings = ReturnType<typeof getSettings>;
+type WordPressDateGlobal = {
+  date?: {
+    getSettings?: () => WordPressDateSettings;
+    __experimentalGetSettings?: () => WordPressDateSettings;
+  };
+};
+
+let areWordPressDateSettingsSynced = false;
+
+export const syncWordPressDateSettings = (): void => {
+  if (areWordPressDateSettingsSynced) {
+    return;
+  }
+
+  const wpDate = (window.wp as unknown as WordPressDateGlobal | undefined)
+    ?.date;
+  const settings =
+    wpDate?.getSettings?.() ??
+    // eslint-disable-next-line no-underscore-dangle
+    wpDate?.__experimentalGetSettings?.();
+
+  if (!settings) {
+    return;
+  }
+
+  setSettings(settings);
+  areWordPressDateSettingsSynced = true;
+};

--- a/mailpoet/changelog/2026-05-06-23-33-54-fixed-respect-wordpress-date-format-settings-in-date-pic.md
+++ b/mailpoet/changelog/2026-05-06-23-33-54-fixed-respect-wordpress-date-format-settings-in-date-pic.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Respect WordPress date format settings in MailPoet UIs

--- a/mailpoet/lib/AdminPages/AssetsController.php
+++ b/mailpoet/lib/AdminPages/AssetsController.php
@@ -87,7 +87,7 @@ class AssetsController {
   }
 
   public function setupAutomationEditorDependencies(): void {
-    $this->enqueueJsEntrypoint('automation_editor', ['wp-date']);
+    $this->enqueueJsEntrypoint('automation_editor');
     $this->wp->wpEnqueueStyle('mailpoet_automation_editor', $this->getCssUrl('mailpoet-automation-editor.css'));
   }
 
@@ -149,6 +149,7 @@ class AssetsController {
       'mailpoet_admin_vendor',
       $this->getScriptUrl('admin_vendor.js'),
       [
+        'wp-date',
         'wp-i18n',
         'mailpoet_runtime',
         'mailpoet_vendor',

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/completed_order.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/completed_order.hbs
@@ -12,7 +12,7 @@
 		<p style="margin: 0 0 16px;"><%= __('Here’s a reminder of what you’ve ordered:', 'woocommerce') %></p>
 	</div>
 	<h2 class="email-order-detail-heading" style='color: #3c3c3c; display: block; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; font-size: 20px; font-weight: bold; line-height: 160%; margin: 0 0 18px; text-align: left;'>
-		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= date('2025-03-03', wp_date_format()) %>)</span>
+		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= '2025-03-03'|date(wp_date_format()) %>)</span>
 	</h2>
 	<div style="margin-bottom: 24px;">
 		<table class="td font-family email-order-details" cellspacing="0" cellpadding="6" border="0" style='color: #636363; border: 0; vertical-align: middle; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; width: 100%;' width="100%">

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/completed_order.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/completed_order.hbs
@@ -12,7 +12,7 @@
 		<p style="margin: 0 0 16px;"><%= __('Here’s a reminder of what you’ve ordered:', 'woocommerce') %></p>
 	</div>
 	<h2 class="email-order-detail-heading" style='color: #3c3c3c; display: block; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; font-size: 20px; font-weight: bold; line-height: 160%; margin: 0 0 18px; text-align: left;'>
-		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (March 3, 2025)</span>
+		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= date('2025-03-03', wp_date_format()) %>)</span>
 	</h2>
 	<div style="margin-bottom: 24px;">
 		<table class="td font-family email-order-details" cellspacing="0" cellpadding="6" border="0" style='color: #636363; border: 0; vertical-align: middle; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; width: 100%;' width="100%">

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/customer_note.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/customer_note.hbs
@@ -16,7 +16,7 @@
 		<p style="margin: 0 0 16px;"><%= __('As a reminder, here are your order details:', 'woocommerce') %></p>
 	</div>
 	<h2 class="email-order-detail-heading" style='color: #3c3c3c; display: block; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; font-size: 20px; font-weight: bold; line-height: 160%; margin: 0 0 18px; text-align: left;'>
-		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (March 3, 2025)</span>
+		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= date('2025-03-03', wp_date_format()) %>)</span>
 	</h2>
 	<div style="margin-bottom: 24px;">
 		<table class="td font-family email-order-details" cellspacing="0" cellpadding="6" border="0" style='color: #636363; border: 0; vertical-align: middle; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; width: 100%;' width="100%">

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/customer_note.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/customer_note.hbs
@@ -16,7 +16,7 @@
 		<p style="margin: 0 0 16px;"><%= __('As a reminder, here are your order details:', 'woocommerce') %></p>
 	</div>
 	<h2 class="email-order-detail-heading" style='color: #3c3c3c; display: block; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; font-size: 20px; font-weight: bold; line-height: 160%; margin: 0 0 18px; text-align: left;'>
-		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= date('2025-03-03', wp_date_format()) %>)</span>
+		<%= __('Order summary', 'woocommerce') %><br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= '2025-03-03'|date(wp_date_format()) %>)</span>
 	</h2>
 	<div style="margin-bottom: 24px;">
 		<table class="td font-family email-order-details" cellspacing="0" cellpadding="6" border="0" style='color: #636363; border: 0; vertical-align: middle; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; width: 100%;' width="100%">

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/processing_order.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/processing_order.hbs
@@ -12,7 +12,7 @@
 		<p style="margin: 0 0 16px;"><%= __('Here’s a reminder of what you’ve ordered:', 'woocommerce') %></p>
 	</div>
 	<h2 class="email-order-detail-heading" style='color: #3c3c3c; display: block; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; font-size: 20px; font-weight: bold; line-height: 160%; margin: 0 0 18px; text-align: left;'>
-		Order summary<br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (March 3, 2025)</span>
+		Order summary<br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= date('2025-03-03', wp_date_format()) %>)</span>
 	</h2>
 	<div style="margin-bottom: 24px;">
 		<table class="td font-family email-order-details" cellspacing="0" cellpadding="6" border="0" style='color: #636363; border: 0; vertical-align: middle; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; width: 100%;' width="100%">

--- a/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/processing_order.hbs
+++ b/mailpoet/views/newsletter/templates/blocks/woocommerceContentImproved/processing_order.hbs
@@ -12,7 +12,7 @@
 		<p style="margin: 0 0 16px;"><%= __('Here’s a reminder of what you’ve ordered:', 'woocommerce') %></p>
 	</div>
 	<h2 class="email-order-detail-heading" style='color: #3c3c3c; display: block; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; font-size: 20px; font-weight: bold; line-height: 160%; margin: 0 0 18px; text-align: left;'>
-		Order summary<br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= date('2025-03-03', wp_date_format()) %>)</span>
+		Order summary<br><span style="color: #3c3c3c; display: block; font-size: 14px; font-weight: normal;"><%= __('Order #%s', 'woocommerce') | format('12345') %> (<%= '2025-03-03'|date(wp_date_format()) %>)</span>
 	</h2>
 	<div style="margin-bottom: 24px;">
 		<table class="td font-family email-order-details" cellspacing="0" cellpadding="6" border="0" style='color: #636363; border: 0; vertical-align: middle; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; width: 100%;' width="100%">


### PR DESCRIPTION
## Description

Respect **Date Format** and **Time Format** from  **wp-admin > Settings > General** in MailPoet UI.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1058

## Linked tickets

STOMAIL-8055

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="479" height="433" alt="Screenshot 2026-05-07 at 11 31 30" src="https://github.com/user-attachments/assets/7b2fec46-3ea9-4961-892d-01f4c91f1bb4" />

.

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
.
<img width="1464" height="864" alt="Screenshot 2026-05-07 at 11 32 28" src="https://github.com/user-attachments/assets/4f02c11b-ab89-4d16-8ef6-78086df03dcd" /> 
.
<img width="1478" height="1004" alt="Screenshot 2026-05-07 at 11 31 17" src="https://github.com/user-attachments/assets/ef332cac-984f-4288-a566-07d7e7bf0724" /> 

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8055-respect-wordpress-date-and-time-settings-in-mailpoet-ui)

_The latest successful build from `stomail-8055-respect-wordpress-date-and-time-settings-in-mailpoet-ui` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->