### PR TITLE
Fix newsletter signup fails after form nonce expires

### DIFF
--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -380,12 +380,36 @@ jQuery(($) => {
     }
   }
 
-  function submitSubscribeForm(
+  // Fetch a fresh nonce just before submit so cached form HTML doesn't break signups.
+  // Falls back to the embedded token if the request fails (offline, blocked, etc.).
+  async function refreshFormToken(
+    form: JQuery<HTMLFormElement>,
+    fallback: string,
+  ): Promise<string> {
+    try {
+      const response = await fetch(
+        `${window.MailPoetForm.ajax_url}?action=mailpoet_token`,
+        { cache: 'no-store', credentials: 'same-origin' },
+      );
+      if (!response.ok) return fallback;
+      const body = (await response.json()) as { token?: string };
+      if (typeof body.token === 'string' && body.token) {
+        form.find('input[name="token"]').val(body.token);
+        return body.token;
+      }
+    } catch {
+      // network/parse error — fall back to embedded token
+    }
+    return fallback;
+  }
+
+  async function submitSubscribeForm(
     form: JQuery<HTMLFormElement>,
     formData: ReturnType<JQuery['mailpoetSerializeObject']>,
     parsley,
   ) {
     form.addClass('mailpoet_form_sending');
+    const token = await refreshFormToken(form, formData.token);
     // ajax request
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     MailPoet.Ajax.post<
@@ -398,7 +422,7 @@ jQuery(($) => {
       } & ErrorResponse
     >({
       url: window.MailPoetForm.ajax_url,
-      token: formData.token,
+      token,
       api_version: formData.api_version,
       endpoint: 'subscribers',
       action: 'subscribe',
@@ -512,7 +536,7 @@ jQuery(($) => {
             ({} as ReturnType<JQuery['mailpoetSerializeObject']>);
           formData.data.recaptchaResponseToken = recaptchaResponseToken;
 
-          submitSubscribeForm(form, formData, form.parsley());
+          void submitSubscribeForm(form, formData, form.parsley());
         };
       }
 
@@ -908,7 +932,7 @@ jQuery(($) => {
         }
 
         if (size !== 'invisible') {
-          submitSubscribeForm(form, formData, parsley);
+          void submitSubscribeForm(form, formData, parsley);
         }
 
         return false;

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -386,10 +386,18 @@ jQuery(($) => {
     form: JQuery<HTMLFormElement>,
     fallback: string,
   ): Promise<string> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, 5000);
     try {
       const response = await fetch(
         `${window.MailPoetForm.ajax_url}?action=mailpoet_token`,
-        { cache: 'no-store', credentials: 'same-origin' },
+        {
+          cache: 'no-store',
+          credentials: 'same-origin',
+          signal: controller.signal,
+        },
       );
       if (!response.ok) return fallback;
       const body = (await response.json()) as { token?: string };
@@ -398,7 +406,9 @@ jQuery(($) => {
         return body.token;
       }
     } catch {
-      // network/parse error — fall back to embedded token
+      // Network/parse errors and AbortError after timeout — use embedded token
+    } finally {
+      clearTimeout(timeoutId);
     }
     return fallback;
   }

--- a/mailpoet/changelog/2026-05-07-07-57-05-fixed-prevent-newsletter-signup-forms-from-failing-when-.md
+++ b/mailpoet/changelog/2026-05-07-07-57-05-fixed-prevent-newsletter-signup-forms-from-failing-when-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent newsletter signup forms from failing when cached form nonces expire

--- a/mailpoet/lib/API/JSON/API.php
+++ b/mailpoet/lib/API/JSON/API.php
@@ -90,6 +90,17 @@ class API {
       [$this, 'setupAjax']
     );
 
+    // fresh-token endpoint for cached pages (e.g. edge-cached signup forms);
+    // intentionally separate from setupAjax() to break the chicken-and-egg of needing a token to fetch a token
+    WPFunctions::get()->addAction(
+      'wp_ajax_mailpoet_token',
+      [$this, 'getToken']
+    );
+    WPFunctions::get()->addAction(
+      'wp_ajax_nopriv_mailpoet_token',
+      [$this, 'getToken']
+    );
+
     // nonce refreshing via heartbeats
     WPFunctions::get()->addAction(
       'wp_refresh_nonces',
@@ -250,6 +261,21 @@ class API {
       esc_js($this->wp->wpCreateNonce('mailpoet_token')),
       esc_js(self::CURRENT_VERSION)
     );
+  }
+
+  public function getToken() {
+    // Bypass intermediate caches so the token is always fresh; the embedded form
+    // token in HTML can be served stale by edge caches and expire by submit time.
+    if (!headers_sent()) {
+      header('Cache-Control: no-store, max-age=0');
+      header('Content-Type: application/json; charset=UTF-8');
+    }
+
+    echo wp_json_encode([
+      'token' => $this->wp->wpCreateNonce('mailpoet_token'),
+      'api_version' => self::CURRENT_VERSION,
+    ]);
+    $this->wp->wpDie();
   }
 
   public function addTokenToHeartbeatResponse($response) {

--- a/mailpoet/tests/integration/API/JSON/APITest.php
+++ b/mailpoet/tests/integration/API/JSON/APITest.php
@@ -98,6 +98,31 @@ class APITest extends \MailPoetTest {
     verify($called)->true();
   }
 
+  public function testGetTokenReturnsFreshNonceWithNoStoreHeader() {
+    $wpStub = Stub::make(new WPFunctions, [
+      'wpCreateNonce' => Expected::once(function($action) {
+        verify($action)->equals('mailpoet_token');
+        return 'fresh-token';
+      }),
+      'wpDie' => Expected::once(),
+    ]);
+    $api = Stub::makeEmptyExcept(
+      $this->api,
+      'getToken',
+      ['wp' => $wpStub]
+    );
+
+    ob_start();
+    $api->getToken();
+    $output = ob_get_clean();
+
+    $decoded = json_decode((string)$output, true);
+    verify($decoded)->equals([
+      'token' => 'fresh-token',
+      'api_version' => JSONAPI::CURRENT_VERSION,
+    ]);
+  }
+
   public function testItCanAddEndpointNamespaces() {
     verify($this->api->getEndpointNamespaces())->arrayCount(1);
 


### PR DESCRIPTION
## Description

Refresh form token when expired, e.g. on cached landing pages.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8056

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8056-newsletter-signup-fails-after-form-nonce-expires)

_The latest successful build from `stomail-8056-newsletter-signup-fails-after-form-nonce-expires` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**1 issue found:**

**Security (Medium)** - Missing rate limiting on token endpoint: The `mailpoet_token` AJAX endpoint is registered for unauthenticated access (`wp_ajax_nopriv_mailpoet_token`) and there is no evidence of rate limiting or throttling in the changes. This public endpoint could be abused to repeatedly request nonces (enumeration/DoS). Consider adding WordPress rate limiting, IP-based throttling, or other protections for the public token endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->