### PR TITLE
Add automation engine discovery support

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/index.tsx
@@ -7,6 +7,10 @@ import { step as SubscriptionRenewed } from './steps/subscription-renewed';
 import { step as SubscriptionPaymentFailed } from './steps/subscription-payment-failed';
 import { step as SubscriptionExpired } from './steps/subscription-expired';
 import { registerStepType } from '../../editor/store';
+import { step as ChangeSubscriptionStatus } from './steps/change-subscription-status';
+import { step as AddProductToSubscription } from './steps/add-product-to-subscription';
+import { step as RemoveProductFromSubscription } from './steps/remove-product-from-subscription';
+import { step as UpdateProductOnSubscription } from './steps/update-product-on-subscription';
 
 export const initialize = (): void => {
   if (!MailPoet.isWoocommerceSubscriptionsActive) {
@@ -19,5 +23,9 @@ export const initialize = (): void => {
   registerStepType(SubscriptionRenewed);
   registerStepType(SubscriptionPaymentFailed);
   registerStepType(SubscriptionExpired);
+  registerStepType(ChangeSubscriptionStatus);
+  registerStepType(AddProductToSubscription);
+  registerStepType(RemoveProductFromSubscription);
+  registerStepType(UpdateProductOnSubscription);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/add-product-to-subscription/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/add-product-to-subscription/index.tsx
@@ -1,0 +1,33 @@
+import { __, _x } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('subscription', 'mailpoet'),
+  __('product', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce-subscriptions:add-product-to-subscription',
+  group: 'actions',
+  title: () => __('Add product to subscription', 'mailpoet'),
+  description: () => __('Add a product to a subscription.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => plus,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_add_product_to_subscription',
+      }}
+    >
+      {__('Adding products to subscriptions is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/change-subscription-status/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/change-subscription-status/index.tsx
@@ -1,0 +1,33 @@
+import { __, _x } from '@wordpress/i18n';
+import { update } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('subscription', 'mailpoet'),
+  __('status', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce-subscriptions:change-subscription-status',
+  group: 'actions',
+  title: () => __('Change subscription status', 'mailpoet'),
+  description: () => __('Change the status of a subscription.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => update,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_change_subscription_status',
+      }}
+    >
+      {__('Changing a subscription status is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/remove-product-from-subscription/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/remove-product-from-subscription/index.tsx
@@ -1,0 +1,37 @@
+import { __, _x } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('subscription', 'mailpoet'),
+  __('product', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce-subscriptions:remove-product-from-subscription',
+  group: 'actions',
+  title: () => __('Remove product from subscription', 'mailpoet'),
+  description: () => __('Remove a product from a subscription.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => close,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign:
+          'create_automation_editor_remove_product_from_subscription',
+      }}
+    >
+      {__(
+        'Removing products from subscriptions is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/update-product-on-subscription/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce-subscriptions/steps/update-product-on-subscription/index.tsx
@@ -1,0 +1,36 @@
+import { __, _x } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('subscription', 'mailpoet'),
+  __('product', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce-subscriptions:update-product-on-subscription',
+  group: 'actions',
+  title: () => __('Update product on subscription', 'mailpoet'),
+  description: () => __('Update a product line on a subscription.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => pencil,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_update_product_on_subscription',
+      }}
+    >
+      {__(
+        'Updating products on subscriptions is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
@@ -10,6 +10,10 @@ import { step as BuysAProductTrigger } from './steps/buys-a-product';
 import { step as BuysFromACategory } from './steps/buys-from-a-category';
 import { step as BuysFromATag } from './steps/buys-from-a-tag';
 import { step as MadeAReview } from './steps/made-a-review';
+import { step as OrderPaid } from './steps/order-paid';
+import { step as CustomerWinBack } from './steps/customer-win-back';
+import { step as ChangeOrderStatus } from './steps/change-order-status';
+import { step as AddOrderNote } from './steps/add-order-note';
 // Insert new imports here
 
 export const initialize = (): void => {
@@ -26,5 +30,9 @@ export const initialize = (): void => {
   registerStepType(BuysFromACategory);
   registerStepType(BuysFromATag);
   registerStepType(MadeAReview);
+  registerStepType(OrderPaid);
+  registerStepType(CustomerWinBack);
+  registerStepType(ChangeOrderStatus);
+  registerStepType(AddOrderNote);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/add-order-note/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/add-order-note/index.tsx
@@ -1,0 +1,34 @@
+import { __, _x } from '@wordpress/i18n';
+import { commentContent } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('order', 'mailpoet'),
+  __('note', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:add-order-note',
+  group: 'actions',
+  title: () => __('Add order note', 'mailpoet'),
+  description: () =>
+    __('Add a private or customer note to an order.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => commentContent,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_add_order_note',
+      }}
+    >
+      {__('Adding an order note is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/change-order-status/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/change-order-status/index.tsx
@@ -1,0 +1,33 @@
+import { __, _x } from '@wordpress/i18n';
+import { update } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('order', 'mailpoet'),
+  __('status', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:change-order-status',
+  group: 'actions',
+  title: () => __('Change order status', 'mailpoet'),
+  description: () => __('Change the status of an order.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => update,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_change_order_status',
+      }}
+    >
+      {__('Changing an order status is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/customer-win-back/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/customer-win-back/index.tsx
@@ -1,0 +1,41 @@
+import { __, _x } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('customer', 'mailpoet'),
+  __('win back', 'mailpoet'),
+  __('inactive', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:customer-win-back',
+  group: 'triggers',
+  title: () => __('Customer win back', 'mailpoet'),
+  description: () =>
+    __(
+      'Start the automation when a customer has not purchased recently.',
+      'mailpoet',
+    ),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => people,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_customer_win_back',
+      }}
+    >
+      {__(
+        'Starting a customer win-back automation is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-paid/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-paid/index.tsx
@@ -1,0 +1,41 @@
+import { __, _x } from '@wordpress/i18n';
+import { payment } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('order', 'mailpoet'),
+  __('paid', 'mailpoet'),
+  __('payment', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:order-paid',
+  group: 'triggers',
+  title: () => __('Order paid', 'mailpoet'),
+  description: () =>
+    __(
+      'Start the automation when payment for an order is completed.',
+      'mailpoet',
+    ),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => payment,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_order_paid',
+      }}
+    >
+      {__(
+        'Starting an automation when an order is paid is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-paid/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/order-paid/index.tsx
@@ -1,5 +1,5 @@
 import { __, _x } from '@wordpress/i18n';
-import { payment } from '@wordpress/icons';
+import { cart } from '@wordpress/icons';
 import { StepType } from '../../../../editor/store';
 import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
 import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
@@ -24,7 +24,7 @@ export const step: StepType = {
   keywords,
   foreground: '#2271b1',
   background: '#f0f6fc',
-  icon: () => payment,
+  icon: () => cart,
   edit: () => (
     <PremiumModalForStepEdit
       tracking={{

--- a/mailpoet/assets/js/src/automation/integrations/wordpress/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/index.tsx
@@ -1,8 +1,10 @@
 import { registerStepType } from '../../editor/store';
 import { step as MadeACommentTrigger } from './steps/made-a-comment';
+import { step as ChangeUserRole } from './steps/change-user-role';
 // Insert new imports here
 
 export const initialize = (): void => {
   registerStepType(MadeACommentTrigger);
+  registerStepType(ChangeUserRole);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/wordpress/steps/change-user-role/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/steps/change-user-role/index.tsx
@@ -1,0 +1,35 @@
+import { __, _x } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('wordpress', 'mailpoet'),
+  __('user', 'mailpoet'),
+  __('role', 'mailpoet'),
+  __('customer', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'wordpress:change-user-role',
+  group: 'actions',
+  title: () => __('Change customer role', 'mailpoet'),
+  description: () =>
+    __('Change the WordPress role for a customer.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => people,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_change_user_role',
+      }}
+    >
+      {__('Changing a customer role is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/webpack-admin-expose.js
+++ b/mailpoet/assets/js/src/webpack-admin-expose.js
@@ -39,9 +39,10 @@ export * as WordPressI18n from '@wordpress/i18n';
 export * as WordPressIcons from '@wordpress/icons';
 export * as WordPressDataControls from '@wordpress/data-controls';
 export * as WooCommerceDate from '@woocommerce/date';
-import { DateRangeFilterPicker } from '@woocommerce/components';
+import { DateRangeFilterPicker, Search } from '@woocommerce/components';
 export const WooCommerceComponents = {
   DateRangeFilterPicker,
+  Search,
 };
 
 // assets

--- a/mailpoet/changelog/2026-05-07-10-53-30-added-locked-automation-discovery-cards-for-premium-wooc.md
+++ b/mailpoet/changelog/2026-05-07-10-53-30-added-locked-automation-discovery-cards-for-premium-wooc.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Locked automation discovery cards for premium WooCommerce triggers and actions

--- a/mailpoet/changelog/2026-05-07-10-53-30-added-locked-automation-discovery-cards-for-premium-wooc.md
+++ b/mailpoet/changelog/2026-05-07-10-53-30-added-locked-automation-discovery-cards-for-premium-wooc.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Locked automation discovery cards for premium WooCommerce triggers and actions
+Automation cards for new WooCommerce triggers and actions

--- a/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Engine\Builder;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\Validation\AutomationValidator;
@@ -19,14 +20,19 @@ class CreateAutomationFromTemplateController {
   /** @var Registry */
   private $registry;
 
+  /** @var Hooks */
+  private $hooks;
+
   public function __construct(
     AutomationStorage $storage,
     AutomationValidator $automationValidator,
-    Registry $registry
+    Registry $registry,
+    Hooks $hooks
   ) {
     $this->storage = $storage;
     $this->automationValidator = $automationValidator;
     $this->registry = $registry;
+    $this->hooks = $hooks;
   }
 
   public function createAutomation(string $slug): Automation {
@@ -42,6 +48,7 @@ class CreateAutomationFromTemplateController {
     if (!$savedAutomation) {
       throw new InvalidStateException('Automation not found.');
     }
+    $this->hooks->doAutomationAfterCreateFromTemplate($savedAutomation, $slug);
     return $savedAutomation;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Builder/DeleteAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DeleteAutomationController.php
@@ -4,16 +4,22 @@ namespace MailPoet\Automation\Engine\Builder;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 
 class DeleteAutomationController {
   /** @var AutomationStorage */
   private $automationStorage;
 
+  /** @var Hooks */
+  private $hooks;
+
   public function __construct(
-    AutomationStorage $automationStorage
+    AutomationStorage $automationStorage,
+    Hooks $hooks
   ) {
     $this->automationStorage = $automationStorage;
+    $this->hooks = $hooks;
   }
 
   public function deleteAutomation(int $id): Automation {
@@ -27,6 +33,7 @@ class DeleteAutomationController {
     }
 
     $this->automationStorage->deleteAutomation($automation);
+    $this->hooks->doAutomationAfterDelete($automation);
     return $automation;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
@@ -22,14 +23,19 @@ class DuplicateAutomationController {
   /** @var Registry */
   private $registry;
 
+  /** @var Hooks */
+  private $hooks;
+
   public function __construct(
     WordPress $wordPress,
     AutomationStorage $automationStorage,
-    Registry $registry
+    Registry $registry,
+    Hooks $hooks
   ) {
     $this->wordPress = $wordPress;
     $this->automationStorage = $automationStorage;
     $this->registry = $registry;
+    $this->hooks = $hooks;
   }
 
   public function duplicateAutomation(int $id): Automation {
@@ -64,6 +70,7 @@ class DuplicateAutomationController {
     if (!$savedAutomation) {
       throw new InvalidStateException('Automation not found.');
     }
+    $this->hooks->doAutomationAfterDuplicate($savedAutomation, $automation);
     return $savedAutomation;
   }
 

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -54,14 +54,11 @@ class UpdateAutomationController {
   }
 
   public function updateAutomation(int $id, array $data): Automation {
-    $previousAutomation = $this->storage->getAutomation($id);
     $automation = $this->storage->getAutomation($id);
     if (!$automation) {
       throw Exceptions::automationNotFound($id);
     }
-    if (!$previousAutomation) {
-      throw Exceptions::automationNotFound($id);
-    }
+    $previousAutomation = clone $automation;
     $this->validateIfAutomationCanBeUpdated($automation, $data);
 
     if (array_key_exists('name', $data)) {

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -54,8 +54,12 @@ class UpdateAutomationController {
   }
 
   public function updateAutomation(int $id, array $data): Automation {
+    $previousAutomation = $this->storage->getAutomation($id);
     $automation = $this->storage->getAutomation($id);
     if (!$automation) {
+      throw Exceptions::automationNotFound($id);
+    }
+    if (!$previousAutomation) {
       throw Exceptions::automationNotFound($id);
     }
     $this->validateIfAutomationCanBeUpdated($automation, $data);
@@ -99,6 +103,7 @@ class UpdateAutomationController {
     if (!$automation) {
       throw Exceptions::automationNotFound($id);
     }
+    $this->hooks->doAutomationAfterUpdate($automation, $previousAutomation);
     return $automation;
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -48,6 +48,13 @@ class Automation {
   /** @var array<string, mixed> */
   private $meta = [];
 
+  public function __clone() {
+    $this->author = clone $this->author;
+    $this->steps = array_map(function(Step $step): Step {
+      return clone $step;
+    }, $this->steps);
+  }
+
   /** @param array<string, Step> $steps */
   public function __construct(
     string $name,

--- a/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
+++ b/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
@@ -25,6 +25,12 @@ class FilterGroup {
     $this->filters = $filters;
   }
 
+  public function __clone() {
+    $this->filters = array_map(function(Filter $filter): Filter {
+      return clone $filter;
+    }, $this->filters);
+  }
+
   public function getId(): string {
     return $this->id;
   }

--- a/mailpoet/lib/Automation/Engine/Data/Filters.php
+++ b/mailpoet/lib/Automation/Engine/Data/Filters.php
@@ -20,6 +20,12 @@ class Filters {
     $this->groups = $groups;
   }
 
+  public function __clone() {
+    $this->groups = array_map(function(FilterGroup $group): FilterGroup {
+      return clone $group;
+    }, $this->groups);
+  }
+
   public function getOperator(): string {
     return $this->operator;
   }

--- a/mailpoet/lib/Automation/Engine/Data/Step.php
+++ b/mailpoet/lib/Automation/Engine/Data/Step.php
@@ -45,6 +45,15 @@ class Step {
     $this->filters = $filters;
   }
 
+  public function __clone() {
+    $this->nextSteps = array_map(function(NextStep $nextStep): NextStep {
+      return clone $nextStep;
+    }, $this->nextSteps);
+    if ($this->filters !== null) {
+      $this->filters = clone $this->filters;
+    }
+  }
+
   public function getId(): string {
     return $this->id;
   }

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -25,6 +25,12 @@ class Hooks {
 
   public const AUTOMATION_BEFORE_SAVE = 'mailpoet/automation/before_save';
   public const AUTOMATION_STEP_BEFORE_SAVE = 'mailpoet/automation/step/before_save';
+  public const AUTOMATION_AFTER_SAVE = 'mailpoet/automation/after_save';
+  public const AUTOMATION_AFTER_CREATE = 'mailpoet/automation/after_create';
+  public const AUTOMATION_AFTER_CREATE_FROM_TEMPLATE = 'mailpoet/automation/after_create_from_template';
+  public const AUTOMATION_AFTER_UPDATE = 'mailpoet/automation/after_update';
+  public const AUTOMATION_AFTER_DELETE = 'mailpoet/automation/after_delete';
+  public const AUTOMATION_AFTER_DUPLICATE = 'mailpoet/automation/after_duplicate';
 
   public const AUTOMATION_STEP_LOG_AFTER_RUN = 'mailpoet/automation/step/log_after_run';
 
@@ -32,6 +38,34 @@ class Hooks {
 
   public function doAutomationBeforeSave(Automation $automation): void {
     $this->wordPress->doAction(self::AUTOMATION_BEFORE_SAVE, $automation);
+  }
+
+  public function doAutomationAfterSave(Automation $automation, ?Automation $previousAutomation = null): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_SAVE, $automation, $previousAutomation);
+  }
+
+  public function doAutomationAfterCreate(Automation $automation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_CREATE, $automation);
+    $this->doAutomationAfterSave($automation);
+  }
+
+  public function doAutomationAfterCreateFromTemplate(Automation $automation, string $templateSlug): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE, $automation, $templateSlug);
+    $this->doAutomationAfterCreate($automation);
+  }
+
+  public function doAutomationAfterUpdate(Automation $automation, Automation $previousAutomation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_UPDATE, $automation, $previousAutomation);
+    $this->doAutomationAfterSave($automation, $previousAutomation);
+  }
+
+  public function doAutomationAfterDelete(Automation $automation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_DELETE, $automation);
+  }
+
+  public function doAutomationAfterDuplicate(Automation $automation, Automation $sourceAutomation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_DUPLICATE, $automation, $sourceAutomation);
+    $this->doAutomationAfterCreate($automation);
   }
 
   public function doAutomationStepBeforeSave(Step $step, Automation $automation): void {

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -149,6 +149,29 @@ class AutomationRunStorage {
     return $result ? (int)current($result) : 0;
   }
 
+  public function getCountByAutomationTriggerAndSubject(Automation $automation, string $triggerKey, Subject $subject): int {
+    global $wpdb;
+
+    $result = $wpdb->get_col(
+      $wpdb->prepare(
+        '
+          SELECT count(DISTINCT runs.id) AS count FROM %i AS runs
+          JOIN %i AS subjects ON runs.id = subjects.automation_run_id
+          WHERE runs.automation_id = %d
+          AND runs.trigger_key = %s
+          AND subjects.hash = %s
+        ',
+        $this->table,
+        $this->subjectTable,
+        $automation->getId(),
+        $triggerKey,
+        $subject->getHash()
+      )
+    );
+
+    return $result ? (int)current($result) : 0;
+  }
+
   public function getCountForAutomation(Automation $automation, string ...$status): int {
     global $wpdb;
 

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -133,6 +133,24 @@ class WordPress {
   }
 
   /**
+   * @param mixed $value
+   */
+  public function setTransient(string $transient, $value, int $expiration = 0): bool {
+    return set_transient($transient, $value, $expiration);
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getTransient(string $transient) {
+    return get_transient($transient);
+  }
+
+  public function deleteTransient(string $transient): bool {
+    return delete_transient($transient);
+  }
+
+  /**
    * @param int|\WP_Post $post
    * @param bool $leavename
    * @return string|false

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -148,6 +148,10 @@ class WordPress {
     return get_comment_statuses();
   }
 
+  public function getEditableRoles(): array {
+    return get_editable_roles();
+  }
+
   public function getPostStatuses(): array {
     return get_post_statuses();
   }

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -155,6 +155,18 @@ class WordPress {
   }
 
   /**
+   * @param mixed $data
+   */
+  public function wpCacheAdd(string $key, $data, string $group = '', int $expire = 0): bool {
+    // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- Thin wrapper passes the caller-provided TTL.
+    return wp_cache_add($key, $data, $group, $expire);
+  }
+
+  public function wpCacheDelete(string $key, string $group = ''): bool {
+    return wp_cache_delete($key, $group);
+  }
+
+  /**
    * @param int|\WP_Post $post
    * @param bool $leavename
    * @return string|false
@@ -172,6 +184,10 @@ class WordPress {
 
   public function getEditableRoles(): array {
     return get_editable_roles();
+  }
+
+  public function isRole(string $role): bool {
+    return wp_roles()->is_role($role);
   }
 
   public function getPostStatuses(): array {

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -62,6 +62,10 @@ class WordPress {
     return register_rest_route($namespace, $route, $args, $override);
   }
 
+  public function adminUrl(string $path = '', string $scheme = 'admin'): string {
+    return admin_url($path, $scheme);
+  }
+
   public function getWpLocale(): WP_Locale {
     global $wp_locale;
     return $wp_locale;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Actions/SendEmailAction.php
@@ -71,6 +71,7 @@ class SendEmailAction implements Action {
     'mailpoet:custom-trigger',
     'woocommerce:order-status-changed',
     'woocommerce:order-created',
+    'woocommerce:order-paid',
     'woocommerce:order-completed',
     'woocommerce:order-cancelled',
     'woocommerce:abandoned-cart',

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/CustomerSubjectToSubscriberSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/CustomerSubjectToSubscriberSubjectTransformer.php
@@ -20,14 +20,14 @@ class CustomerSubjectToSubscriberSubjectTransformer implements SubjectTransforme
     $this->subscribersRepository = $subscribersRepository;
   }
 
-  public function transform(Subject $data): Subject {
+  public function transform(Subject $data): ?Subject {
     if ($this->accepts() !== $data->getKey()) {
       throw new \InvalidArgumentException('Invalid subject type');
     }
 
       $subscriber = $this->findOrCreateSubscriber($data);
     if (!$subscriber instanceof SubscriberEntity) {
-      throw new \InvalidArgumentException('Subscriber not found');
+      return null;
     }
 
     return new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformer.php
@@ -32,14 +32,14 @@ class OrderSubjectToSubscriberSubjectTransformer implements SubjectTransformer {
     $this->woocommerceHelper = $woocommerceHelper;
   }
 
-  public function transform(Subject $data): Subject {
+  public function transform(Subject $data): ?Subject {
     if ($this->accepts() !== $data->getKey()) {
       throw new \InvalidArgumentException('Invalid subject type');
     }
 
       $subscriber = $this->findOrCreateSubscriber($data);
     if (!$subscriber instanceof SubscriberEntity) {
-      throw new \InvalidArgumentException('Subscriber not found');
+      return null;
     }
 
     return new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformer.php
@@ -37,7 +37,7 @@ class OrderSubjectToSubscriberSubjectTransformer implements SubjectTransformer {
       throw new \InvalidArgumentException('Invalid subject type');
     }
 
-      $subscriber = $this->findOrCreateSubscriber($data);
+    $subscriber = $this->findOrCreateSubscriber($data);
     if (!$subscriber instanceof SubscriberEntity) {
       return null;
     }
@@ -78,8 +78,15 @@ class OrderSubjectToSubscriberSubjectTransformer implements SubjectTransformer {
       return null;
     }
     $billingEmail = $wcOrder->get_billing_email();
-    return $billingEmail ?
-      $this->subscribersRepository->findOneBy(['email' => $billingEmail]) :
-      $this->subscribersRepository->findOneBy(['wpUserId' => $wcOrder->get_user_id()]);
+    if ($billingEmail) {
+      return $this->subscribersRepository->findOneBy(['email' => $billingEmail]);
+    }
+
+    $userId = $wcOrder->get_user_id();
+    if (!$userId) {
+      return null;
+    }
+
+    return $this->subscribersRepository->findOneBy(['wpUserId' => $userId]);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectToWordPressUserSubjectTransformer.php
@@ -33,7 +33,7 @@ class SubscriberSubjectToWordPressUserSubjectTransformer implements SubjectTrans
 
     $subscriber = $this->subscribersRepository->findOneById((int)$data->getArgs()['subscriber_id']);
     if (!$subscriber) {
-      throw new \InvalidArgumentException('Subscriber not found');
+      return null;
     }
     if (!$subscriber->getWpUserId()) {
       return null;

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectToWordPressUserSubjectTransformer.php
@@ -26,7 +26,7 @@ class SubscriberSubjectToWordPressUserSubjectTransformer implements SubjectTrans
     return UserSubject::KEY;
   }
 
-  public function transform(Subject $data): Subject {
+  public function transform(Subject $data): ?Subject {
     if ($this->accepts() !== $data->getKey()) {
       throw new \InvalidArgumentException('Invalid subject type');
     }
@@ -34,6 +34,9 @@ class SubscriberSubjectToWordPressUserSubjectTransformer implements SubjectTrans
     $subscriber = $this->subscribersRepository->findOneById((int)$data->getArgs()['subscriber_id']);
     if (!$subscriber) {
       throw new \InvalidArgumentException('Subscriber not found');
+    }
+    if (!$subscriber->getWpUserId()) {
+      return null;
     }
     return new Subject(UserSubject::KEY, ['user_id' => $subscriber->getWpUserId()]);
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/ContextFactory.php
@@ -22,6 +22,7 @@ class ContextFactory {
 
     $context = [
       'order_statuses' => $this->woocommerce->wcGetOrderStatuses(),
+      'paid_statuses' => $this->woocommerce->wcGetIsPaidStatuses(),
       'review_ratings_enabled' => $this->woocommerce->wcReviewRatingsEnabled(),
     ];
     return $context;

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/CustomerSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/CustomerSubjectToWordPressUserSubjectTransformer.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Integration\SubjectTransformer;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+
+class CustomerSubjectToWordPressUserSubjectTransformer implements SubjectTransformer {
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WordPress $wordPress
+  ) {
+    $this->wordPress = $wordPress;
+  }
+
+  public function accepts(): string {
+    return CustomerSubject::KEY;
+  }
+
+  public function returns(): string {
+    return UserSubject::KEY;
+  }
+
+  public function transform(Subject $data): ?Subject {
+    if ($this->accepts() !== $data->getKey()) {
+      throw new \InvalidArgumentException('Invalid subject type');
+    }
+
+    $customerId = (int)($data->getArgs()['customer_id'] ?? 0);
+    if ($customerId <= 0) {
+      return null;
+    }
+
+    $user = $this->wordPress->getUserBy('id', $customerId);
+    if (!$user instanceof \WP_User || !$user->exists()) {
+      return null;
+    }
+
+    return new Subject(UserSubject::KEY, ['user_id' => $customerId]);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/OrderSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/OrderSubjectToWordPressUserSubjectTransformer.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Integration\SubjectTransformer;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+
+class OrderSubjectToWordPressUserSubjectTransformer implements SubjectTransformer {
+  /** @var WooCommerce */
+  private $wooCommerce;
+
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WooCommerce $wooCommerce,
+    WordPress $wordPress
+  ) {
+    $this->wooCommerce = $wooCommerce;
+    $this->wordPress = $wordPress;
+  }
+
+  public function accepts(): string {
+    return OrderSubject::KEY;
+  }
+
+  public function returns(): string {
+    return UserSubject::KEY;
+  }
+
+  public function transform(Subject $data): ?Subject {
+    if ($this->accepts() !== $data->getKey()) {
+      throw new \InvalidArgumentException('Invalid subject type');
+    }
+
+    $orderId = (int)($data->getArgs()['order_id'] ?? 0);
+    if ($orderId <= 0) {
+      return null;
+    }
+
+    $order = $this->wooCommerce->wcGetOrder($orderId);
+    if (!$order instanceof \WC_Order) {
+      return null;
+    }
+
+    $userId = $order->get_user_id();
+    if ($userId <= 0) {
+      return null;
+    }
+
+    $user = $this->wordPress->getUserBy('id', $userId);
+    if (!$user instanceof \WP_User || !$user->exists()) {
+      return null;
+    }
+
+    return new Subject(UserSubject::KEY, ['user_id' => $userId]);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerceIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerceIntegration.php
@@ -7,6 +7,8 @@ use MailPoet\Automation\Integrations\WooCommerce\Subjects\AbandonedCartSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderStatusChangeSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\CustomerSubjectToWordPressUserSubjectTransformer;
+use MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\OrderSubjectToWordPressUserSubjectTransformer;
 use MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\WordPressUserSubjectToWooCommerceCustomerSubjectTransformer;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysAProductTrigger;
@@ -64,6 +66,12 @@ class WooCommerceIntegration {
   /** @var WordPressUserSubjectToWooCommerceCustomerSubjectTransformer */
   private $wordPressUserToWooCommerceCustomerTransformer;
 
+  /** @var CustomerSubjectToWordPressUserSubjectTransformer */
+  private $woocommerceCustomerToWordPressUserTransformer;
+
+  /** @var OrderSubjectToWordPressUserSubjectTransformer */
+  private $woocommerceOrderToWordPressUserTransformer;
+
   /** @var WooCommerce */
   private $wooCommerce;
 
@@ -83,6 +91,8 @@ class WooCommerceIntegration {
     CustomerSubject $customerSubject,
     ContextFactory $contextFactory,
     WordPressUserSubjectToWooCommerceCustomerSubjectTransformer $wordPressUserToWooCommerceCustomerTransformer,
+    CustomerSubjectToWordPressUserSubjectTransformer $woocommerceCustomerToWordPressUserTransformer,
+    OrderSubjectToWordPressUserSubjectTransformer $woocommerceOrderToWordPressUserTransformer,
     WooCommerce $wooCommerce
   ) {
     $this->orderStatusChangedTrigger = $orderStatusChangedTrigger;
@@ -100,6 +110,8 @@ class WooCommerceIntegration {
     $this->customerSubject = $customerSubject;
     $this->contextFactory = $contextFactory;
     $this->wordPressUserToWooCommerceCustomerTransformer = $wordPressUserToWooCommerceCustomerTransformer;
+    $this->woocommerceCustomerToWordPressUserTransformer = $woocommerceCustomerToWordPressUserTransformer;
+    $this->woocommerceOrderToWordPressUserTransformer = $woocommerceOrderToWordPressUserTransformer;
     $this->wooCommerce = $wooCommerce;
   }
 
@@ -126,5 +138,7 @@ class WooCommerceIntegration {
     $registry->addTrigger($this->buysFromACategoryTrigger);
     $registry->addTrigger($this->buysFromATagTrigger);
     $registry->addSubjectTransformer($this->wordPressUserToWooCommerceCustomerTransformer);
+    $registry->addSubjectTransformer($this->woocommerceCustomerToWordPressUserTransformer);
+    $registry->addSubjectTransformer($this->woocommerceOrderToWordPressUserTransformer);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
@@ -5,6 +5,18 @@ namespace MailPoet\Automation\Integrations\WordPress;
 use MailPoet\Automation\Engine\WordPress;
 
 class ContextFactory {
+  private const ELEVATED_CAPABILITIES = [
+    'create_users',
+    'delete_users',
+    'edit_files',
+    'edit_users',
+    'install_plugins',
+    'manage_options',
+    'manage_woocommerce',
+    'mailpoet_manage_settings',
+    'promote_users',
+    'unfiltered_html',
+  ];
 
   /** @var WordPress  */
   private $wp;
@@ -46,12 +58,31 @@ class ContextFactory {
   private function getEditableRoles(): array {
     $roles = [];
     foreach ($this->wp->getEditableRoles() as $id => $role) {
+      if ($this->isElevatedRole($role)) {
+        continue;
+      }
       $roles[] = [
         'id' => $id,
         'name' => (string)($role['name'] ?? $id),
       ];
     }
     return $roles;
+  }
+
+  /**
+   * @param array{name?: string, capabilities?: array<string, bool>} $role
+   */
+  private function isElevatedRole(array $role): bool {
+    if (!empty($role['capabilities']['administrator'])) {
+      return true;
+    }
+    $capabilities = $role['capabilities'] ?? [];
+    foreach (self::ELEVATED_CAPABILITIES as $capability) {
+      if (!empty($capabilities[$capability])) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
@@ -19,6 +19,7 @@ class ContextFactory {
   public function getContextData(): array {
     return [
       'comment_statuses' => $this->getCommentStatuses(),
+      'editable_roles' => $this->getEditableRoles(),
       'post_types' => $this->getPostTypes(),
       'taxonomies' => $this->getTaxonomies(),
     ];
@@ -37,6 +38,20 @@ class ContextFactory {
       ];
     }
     return $stati;
+  }
+
+  /**
+   * @return string[][]
+   */
+  private function getEditableRoles(): array {
+    $roles = [];
+    foreach ($this->wp->getEditableRoles() as $id => $role) {
+      $roles[] = [
+        'id' => $id,
+        'name' => (string)($role['name'] ?? $id),
+      ];
+    }
+    return $roles;
   }
 
   /**

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -218,6 +218,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\WooCommerce::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\ContextFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\WooCommerceIntegration::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\CustomerSubjectToWordPressUserSubjectTransformer::class)->setPublic(true)->setShared(false);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\OrderSubjectToWordPressUserSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerOrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerReviewFieldsFactory::class)->setPublic(true);

--- a/mailpoet/tests/integration/Automation/Engine/Builder/AutomationLifecycleHooksTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/AutomationLifecycleHooksTest.php
@@ -22,7 +22,7 @@ class AutomationLifecycleHooksTest extends \MailPoetTest {
   /** @var array{automation_id: int, status: string, previous_status: string|null}|null */
   private $saveEvent = null;
 
-  /** @var array{automation_id: int, status: string, previous_status: string}|null */
+  /** @var array{automation_id: int, status: string, previous_status: string, action_args?: array|null, previous_action_args?: array|null}|null */
   private $updateEvent = null;
 
   /** @var array{automation_id: int, status: string}|null */
@@ -79,6 +79,38 @@ class AutomationLifecycleHooksTest extends \MailPoetTest {
     $this->assertSame(Automation::STATUS_ACTIVE, $updateEvent['previous_status']);
     $this->assertSame($updated->getId(), $saveEvent['automation_id']);
     $this->assertSame(Automation::STATUS_ACTIVE, $saveEvent['previous_status']);
+  }
+
+  public function testItFiresUpdateHooksWithPreviousStepConfig(): void {
+    $steps = [
+      'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      'trigger' => new Step('trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('action')]),
+      'action' => new Step('action', Step::TYPE_ACTION, 'core:delay', [
+        'delay' => 1,
+        'delay_type' => 'MINUTES',
+      ], []),
+    ];
+    $automation = (new AutomationFactory())
+      ->withSteps($steps)
+      ->withStatusActive()
+      ->create();
+
+    $updatedSteps = array_map(function(Step $step): array {
+      return $step->toArray();
+    }, $automation->getSteps());
+    $updatedSteps['action']['args']['delay'] = 2;
+
+    $this->diContainer->get(UpdateAutomationController::class)->updateAutomation($automation->getId(), [
+      'steps' => $updatedSteps,
+    ]);
+
+    $updateEvent = $this->getUpdateEvent();
+    $previousActionArgs = $updateEvent['previous_action_args'] ?? null;
+    $actionArgs = $updateEvent['action_args'] ?? null;
+    $this->assertIsArray($previousActionArgs);
+    $this->assertIsArray($actionArgs);
+    $this->assertSame(1, $previousActionArgs['delay']);
+    $this->assertSame(2, $actionArgs['delay']);
   }
 
   public function testItFiresDuplicateHooksWithSourceAutomation(): void {
@@ -144,10 +176,14 @@ class AutomationLifecycleHooksTest extends \MailPoetTest {
     };
     $wp->addAction(Hooks::AUTOMATION_AFTER_SAVE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_SAVE], 10, 2);
     $this->hookCallbacks[Hooks::AUTOMATION_AFTER_UPDATE] = function(Automation $automation, Automation $previousAutomation): void {
+      $step = $automation->getStep('action');
+      $previousStep = $previousAutomation->getStep('action');
       $this->updateEvent = [
         'automation_id' => $automation->getId(),
         'status' => $automation->getStatus(),
         'previous_status' => $previousAutomation->getStatus(),
+        'action_args' => $step ? $step->getArgs() : null,
+        'previous_action_args' => $previousStep ? $previousStep->getArgs() : null,
       ];
     };
     $wp->addAction(Hooks::AUTOMATION_AFTER_UPDATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_UPDATE], 10, 2);
@@ -191,7 +227,7 @@ class AutomationLifecycleHooksTest extends \MailPoetTest {
     return $this->saveEvent;
   }
 
-  /** @return array{automation_id: int, status: string, previous_status: string} */
+  /** @return array{automation_id: int, status: string, previous_status: string, action_args?: array|null, previous_action_args?: array|null} */
   private function getUpdateEvent(): array {
     if ($this->updateEvent === null) {
       $this->fail('Update event was not fired.');

--- a/mailpoet/tests/integration/Automation/Engine/Builder/AutomationLifecycleHooksTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/AutomationLifecycleHooksTest.php
@@ -1,0 +1,247 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Builder;
+
+use MailPoet\Automation\Engine\Builder\CreateAutomationFromTemplateController;
+use MailPoet\Automation\Engine\Builder\DeleteAutomationController;
+use MailPoet\Automation\Engine\Builder\DuplicateAutomationController;
+use MailPoet\Automation\Engine\Builder\UpdateAutomationController;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationTemplate;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+
+class AutomationLifecycleHooksTest extends \MailPoetTest {
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var array{automation_id: int, status: string, previous_status: string|null}|null */
+  private $saveEvent = null;
+
+  /** @var array{automation_id: int, status: string, previous_status: string}|null */
+  private $updateEvent = null;
+
+  /** @var array{automation_id: int, status: string}|null */
+  private $deleteEvent = null;
+
+  /** @var array{automation_id: int, source_automation_id: int, status: string}|null */
+  private $duplicateEvent = null;
+
+  /** @var array{automation_id: int, template_slug: string, status: string}|null */
+  private $templateEvent = null;
+
+  /** @var array{automation_id: int, status: string}|null */
+  private $createEvent = null;
+
+  /** @var array<string, callable> */
+  private $hookCallbacks = [];
+
+  public function _before(): void {
+    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $this->automationStorage->truncate();
+    $this->saveEvent = null;
+    $this->updateEvent = null;
+    $this->deleteEvent = null;
+    $this->duplicateEvent = null;
+    $this->templateEvent = null;
+    $this->createEvent = null;
+    $this->hookCallbacks = [];
+    $this->registerHooks();
+  }
+
+  public function _after(): void {
+    $wp = $this->diContainer->get(\MailPoet\Automation\Engine\WordPress::class);
+    foreach ($this->hookCallbacks as $hook => $callback) {
+      $wp->removeAction($hook, $callback);
+    }
+    $this->automationStorage->truncate();
+  }
+
+  public function testItFiresUpdateHooksWithPreviousAutomationState(): void {
+    $automation = (new AutomationFactory())
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+
+    $updated = $this->diContainer->get(UpdateAutomationController::class)->updateAutomation($automation->getId(), [
+      'status' => Automation::STATUS_DRAFT,
+    ]);
+
+    $updateEvent = $this->getUpdateEvent();
+    $saveEvent = $this->getSaveEvent();
+    $this->assertSame($updated->getId(), $updateEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_DRAFT, $updateEvent['status']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updateEvent['previous_status']);
+    $this->assertSame($updated->getId(), $saveEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $saveEvent['previous_status']);
+  }
+
+  public function testItFiresDuplicateHooksWithSourceAutomation(): void {
+    $source = (new AutomationFactory())
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->create();
+
+    $duplicate = $this->diContainer->get(DuplicateAutomationController::class)->duplicateAutomation($source->getId());
+
+    $duplicateEvent = $this->getDuplicateEvent();
+    $createEvent = $this->getCreateEvent();
+    $this->assertSame($duplicate->getId(), $duplicateEvent['automation_id']);
+    $this->assertSame($source->getId(), $duplicateEvent['source_automation_id']);
+    $this->assertSame(Automation::STATUS_DRAFT, $createEvent['status']);
+  }
+
+  public function testItFiresDeleteHooksWithDeletedAutomationState(): void {
+    $automation = (new AutomationFactory())
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withStatus(Automation::STATUS_TRASH)
+      ->create();
+
+    $deleted = $this->diContainer->get(DeleteAutomationController::class)->deleteAutomation($automation->getId());
+
+    $deleteEvent = $this->getDeleteEvent();
+    $this->assertSame($deleted->getId(), $deleteEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_TRASH, $deleteEvent['status']);
+  }
+
+  public function testItFiresCreateFromTemplateHooksWithActiveAutomationState(): void {
+    $templateSlug = 'lifecycle-hook-template';
+    $this->diContainer->get(Registry::class)->addTemplate(new AutomationTemplate(
+      $templateSlug,
+      'welcome',
+      'Lifecycle hook template',
+      'Lifecycle hook template',
+      function(): Automation {
+        return $this->createAutomationFromTemplateData();
+      }
+    ));
+
+    $automation = $this->diContainer->get(CreateAutomationFromTemplateController::class)->createAutomation($templateSlug);
+
+    $templateEvent = $this->getTemplateEvent();
+    $createEvent = $this->getCreateEvent();
+    $this->assertSame($automation->getId(), $templateEvent['automation_id']);
+    $this->assertSame($templateSlug, $templateEvent['template_slug']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $templateEvent['status']);
+    $this->assertSame($automation->getId(), $createEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $createEvent['status']);
+  }
+
+  private function registerHooks(): void {
+    $wp = $this->diContainer->get(\MailPoet\Automation\Engine\WordPress::class);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_SAVE] = function(Automation $automation, ?Automation $previousAutomation = null): void {
+      $this->saveEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+        'previous_status' => $previousAutomation ? $previousAutomation->getStatus() : null,
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_SAVE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_SAVE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_UPDATE] = function(Automation $automation, Automation $previousAutomation): void {
+      $this->updateEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+        'previous_status' => $previousAutomation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_UPDATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_UPDATE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DELETE] = function(Automation $automation): void {
+      $this->deleteEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_DELETE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DELETE]);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DUPLICATE] = function(Automation $automation, Automation $sourceAutomation): void {
+      $this->duplicateEvent = [
+        'automation_id' => $automation->getId(),
+        'source_automation_id' => $sourceAutomation->getId(),
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_DUPLICATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DUPLICATE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE] = function(Automation $automation, string $templateSlug): void {
+      $this->templateEvent = [
+        'automation_id' => $automation->getId(),
+        'template_slug' => $templateSlug,
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE] = function(Automation $automation): void {
+      $this->createEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_CREATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE]);
+  }
+
+  /** @return array{automation_id: int, status: string, previous_status: string|null} */
+  private function getSaveEvent(): array {
+    if ($this->saveEvent === null) {
+      $this->fail('Save event was not fired.');
+    }
+    return $this->saveEvent;
+  }
+
+  /** @return array{automation_id: int, status: string, previous_status: string} */
+  private function getUpdateEvent(): array {
+    if ($this->updateEvent === null) {
+      $this->fail('Update event was not fired.');
+    }
+    return $this->updateEvent;
+  }
+
+  /** @return array{automation_id: int, status: string} */
+  private function getDeleteEvent(): array {
+    if ($this->deleteEvent === null) {
+      $this->fail('Delete event was not fired.');
+    }
+    return $this->deleteEvent;
+  }
+
+  /** @return array{automation_id: int, source_automation_id: int, status: string} */
+  private function getDuplicateEvent(): array {
+    if ($this->duplicateEvent === null) {
+      $this->fail('Duplicate event was not fired.');
+    }
+    return $this->duplicateEvent;
+  }
+
+  /** @return array{automation_id: int, template_slug: string, status: string} */
+  private function getTemplateEvent(): array {
+    if ($this->templateEvent === null) {
+      $this->fail('Create from template event was not fired.');
+    }
+    return $this->templateEvent;
+  }
+
+  /** @return array{automation_id: int, status: string} */
+  private function getCreateEvent(): array {
+    if ($this->createEvent === null) {
+      $this->fail('Create event was not fired.');
+    }
+    return $this->createEvent;
+  }
+
+  private function createAutomationFromTemplateData(): Automation {
+    $steps = [
+      'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      'trigger' => new Step('trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('action')]),
+      'action' => new Step('action', Step::TYPE_ACTION, 'core:delay', [
+        'delay' => 1,
+        'delay_type' => 'MINUTES',
+      ], []),
+    ];
+    $automation = new Automation('Active template automation', $steps, new \WP_User(1));
+    $automation->setStatus(Automation::STATUS_ACTIVE);
+    return $automation;
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -8,13 +8,17 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\OrderSubjectToSubscriberSubjectTransformer;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderStatusChangedTrigger;
 use MailPoet\Test\Automation\Stubs\TestAction;
+use MailPoet\Test\DataFactories\Subscriber;
 
 require_once __DIR__ . '/../../../Stubs/TestAction.php';
 
@@ -101,6 +105,18 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberSubject::class, $subject);
     $this->assertInstanceOf(SubscriberPayload::class, $payload);
     $this->assertSame($billingAddress, $payload->getEmail());
+  }
+
+  public function testItDoesNotTransformGuestOrderWithoutBillingEmailToZeroWpUserSubscriber() {
+    (new Subscriber())->withWpUserId(0)->create();
+
+    $order = new \WC_Order();
+    $order->save();
+
+    /** @var OrderSubjectToSubscriberSubjectTransformer $transformer */
+    $transformer = $this->diContainer->get(OrderSubjectToSubscriberSubjectTransformer::class);
+
+    $this->assertNull($transformer->transform(new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()])));
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/ContextFactoryTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\WooCommerce;
+
+use MailPoet\Automation\Integrations\WooCommerce\ContextFactory;
+
+/**
+ * @group woo
+ */
+class ContextFactoryTest extends \MailPoetTest {
+  public function testItExposesPaidStatuses(): void {
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+
+    $this->assertArrayHasKey('paid_statuses', $context);
+    $this->assertSame(wc_get_is_paid_statuses(), $context['paid_statuses']);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/SubjectTransformers/WooCommerceSubjectToWordPressUserSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/SubjectTransformers/WooCommerceSubjectToWordPressUserSubjectTransformerTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\WooCommerce\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\User;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+/**
+ * @group woo
+ */
+class WooCommerceSubjectToWordPressUserSubjectTransformerTest extends \MailPoetTest {
+  /** @var SubjectTransformerHandler */
+  private $subjectTransformerHandler;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var EntityManager */
+  private $doctrineEntityManager;
+
+  public function _before(): void {
+    $this->subjectTransformerHandler = $this->diContainer->get(SubjectTransformerHandler::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->doctrineEntityManager = $this->diContainer->get(EntityManager::class);
+  }
+
+  public function testItResolvesRegisteredCustomerToWordPressUserWithoutSubscriber(): void {
+    $user = $this->createUser();
+    $this->deleteSubscriberForUser($user);
+    $this->assertNull($this->subscribersRepository->findOneBy(['wpUserId' => $user->ID]));
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(CustomerSubject::KEY, ['customer_id' => $user->ID]),
+    ]);
+
+    $this->assertSame(['user_id' => $user->ID], $this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  public function testItDoesNotResolveGuestCustomerToWordPressUser(): void {
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(CustomerSubject::KEY, ['customer_id' => 0]),
+    ]);
+
+    $this->assertNull($this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  public function testItResolvesRegisteredOrderToWordPressUserWithoutSubscriber(): void {
+    $user = $this->createUser();
+    $this->deleteSubscriberForUser($user);
+    $this->assertNull($this->subscribersRepository->findOneBy(['wpUserId' => $user->ID]));
+
+    $order = new \WC_Order();
+    $order->set_customer_id($user->ID);
+    $order->save();
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+    ]);
+
+    $this->assertSame(['user_id' => $user->ID], $this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  public function testItDoesNotResolveGuestOrderToWordPressUser(): void {
+    $order = new \WC_Order();
+    $order->save();
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+    ]);
+
+    $this->assertNull($this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  /**
+   * @param Subject[] $subjects
+   * @return array<string, mixed>|null
+   */
+  private function getSubjectArgs(array $subjects, string $key): ?array {
+    foreach ($subjects as $subject) {
+      if ($subject->getKey() === $key) {
+        return $subject->getArgs();
+      }
+    }
+    return null;
+  }
+
+  private function createUser(): \WP_User {
+    $id = uniqid('wc-user-', false);
+    return (new User())->createUser($id, 'customer', $id . '@example.com');
+  }
+
+  private function deleteSubscriberForUser(\WP_User $user): void {
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $user->ID]);
+    if (!$subscriber) {
+      return;
+    }
+    $this->subscribersRepository->remove($subscriber);
+    $this->doctrineEntityManager->flush();
+    $this->doctrineEntityManager->clear();
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\WordPress;
+
+use MailPoet\Automation\Integrations\WordPress\ContextFactory;
+
+class ContextFactoryTest extends \MailPoetTest {
+  public function testItExposesEditableRoles(): void {
+    wp_set_current_user(1);
+
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+
+    $this->assertArrayHasKey('editable_roles', $context);
+    $roleIds = array_column($context['editable_roles'], 'id');
+    $this->assertContains('subscriber', $roleIds);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
@@ -6,6 +6,8 @@ use MailPoet\Automation\Integrations\WordPress\ContextFactory;
 
 class ContextFactoryTest extends \MailPoetTest {
   public function _after(): void {
+    remove_role('automation_safe_role');
+    remove_role('automation_elevated_role');
     wp_set_current_user(0);
   }
 
@@ -17,5 +19,20 @@ class ContextFactoryTest extends \MailPoetTest {
     $this->assertArrayHasKey('editable_roles', $context);
     $roleIds = array_column($context['editable_roles'], 'id');
     $this->assertContains('subscriber', $roleIds);
+  }
+
+  public function testItDoesNotExposeElevatedRoles(): void {
+    wp_set_current_user(1);
+    add_role('automation_safe_role', 'Automation Safe Role', ['read' => true]);
+    add_role('automation_elevated_role', 'Automation Elevated Role', ['unfiltered_html' => true]);
+
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+    $editableRoles = $context['editable_roles'];
+    $this->assertIsArray($editableRoles);
+    $roleIds = array_column($editableRoles, 'id');
+
+    $this->assertContains('automation_safe_role', $roleIds);
+    $this->assertNotContains('automation_elevated_role', $roleIds);
+    $this->assertNotContains('administrator', $roleIds);
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
@@ -5,6 +5,10 @@ namespace MailPoet\Test\Automation\Integrations\WordPress;
 use MailPoet\Automation\Integrations\WordPress\ContextFactory;
 
 class ContextFactoryTest extends \MailPoetTest {
+  public function _after(): void {
+    wp_set_current_user(0);
+  }
+
   public function testItExposesEditableRoles(): void {
     wp_set_current_user(1);
 


### PR DESCRIPTION
## Description

Adds the free-plugin support required for the STOMAIL-8031 premium automation engine improvements:

- Locked discovery cards for the new premium WooCommerce, WooCommerce Subscriptions, and WordPress automation triggers/actions
- Shared automation lifecycle hooks and subject transformers used by premium runtime behavior
- Shared context/helper exposure needed by premium automation panels and review alert templates

## Code review notes

_N/A_

## QA notes


### Setup
  MailPoet active, **Premium inactive** to start. WooCommerce + WooCommerce Subscriptions active.

  ### Locked discovery cards
  1. With Premium inactive, open Automations → Create from scratch.
  2. Confirm new locked/Premium cards appear in the trigger and action pickers:
     - Triggers: *Order paid*, *Customer win-back*, and *Review Posted*
     - Actions: *Change order status*, *Add order note*, *Change user role*, *Change Subscription Status*, *Add Product to Subscription*, *Remove Product from Subscription*, and *Update Product on Subscription*

  ### Subject transformers (with Premium active)
  Run an automation that resolves a Customer/Order subject to a WP user. Verify clean handling of:
  - Guest order (no customer ID)
  - Deleted WP user
  - Registered customer (happy path)

## Linked PRs

- MailPoet Premium PR: https://github.com/mailpoet/mailpoet-premium/pull/1059

## Linked tickets

- https://linear.app/a8c/issue/STOMAIL-8031/mailpoets-automation-engine-improvements

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8031-automation-engine-improvements)

_The latest successful build from `add/STOMAIL-8031-automation-engine-improvements` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->