### PR TITLE
Fix post notification weekday scheduling

### DIFF
--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -20,6 +20,8 @@ import {
 import {
   DEFAULT_DAY,
   formatSelectedValues,
+  getDefaultWeekDay,
+  getOrderedWeekDayKeys,
 } from 'newsletters/scheduling/multi-day';
 import { FilterSegmentTag, SegmentTags } from 'common/tag/tags';
 import { Toggle } from 'common/form/toggle/toggle';
@@ -248,6 +250,8 @@ class NewsletterListNotificationComponent extends Component {
         </Fragment>
       ),
     );
+    const defaultWeekDay = getDefaultWeekDay(MailPoet.wpWeekStartsOn);
+    const orderedWeekDayKeys = getOrderedWeekDayKeys(MailPoet.wpWeekStartsOn);
 
     // set sending frequency
     switch (newsletter.options.intervalType) {
@@ -265,7 +269,8 @@ class NewsletterListNotificationComponent extends Component {
             formatSelectedValues(
               newsletter.options.weekDay,
               weekDayValues,
-              DEFAULT_DAY,
+              defaultWeekDay,
+              orderedWeekDayKeys,
             ),
           )
           .replace('%2$s', timeOfDayValues[newsletter.options.timeOfDay]);

--- a/mailpoet/assets/js/src/newsletters/scheduling/multi-day.ts
+++ b/mailpoet/assets/js/src/newsletters/scheduling/multi-day.ts
@@ -2,9 +2,10 @@ type DayLabels = Record<string, string>;
 type DayValue = string | number | null | undefined;
 
 // Monday for weekDayValues (0..6), 1st for monthDayValues (1..28).
-// Used as the fallback when no day is selected or the stored value
-// is invalid.
+// Used as the fallback when no site-specific day is available, no day is
+// selected, or the stored value is invalid.
 export const DEFAULT_DAY = '1';
+const WEEK_DAY_KEYS = ['0', '1', '2', '3', '4', '5', '6'];
 
 // Numeric-string sort: every entry must parse to a finite number
 // (weekDayValues 0..6 and monthDayValues 1..28). Non-numeric inputs
@@ -15,14 +16,46 @@ const sortNumericKeys = (values: string[]): string[] =>
     (firstValue, secondValue) => Number(firstValue) - Number(secondValue),
   );
 
+const normalizeValue = (value: DayValue): string =>
+  value === undefined || value === null ? '' : String(value).trim();
+
+export const getDefaultWeekDay = (weekStartsOn: DayValue): string => {
+  const normalizedWeekStartsOn = normalizeValue(weekStartsOn);
+
+  return WEEK_DAY_KEYS.includes(normalizedWeekStartsOn)
+    ? normalizedWeekStartsOn
+    : DEFAULT_DAY;
+};
+
+export const getOrderedWeekDayKeys = (weekStartsOn: DayValue): string[] => {
+  const defaultWeekDay = getDefaultWeekDay(weekStartsOn);
+  const defaultWeekDayIndex = WEEK_DAY_KEYS.indexOf(defaultWeekDay);
+
+  return [
+    ...WEEK_DAY_KEYS.slice(defaultWeekDayIndex),
+    ...WEEK_DAY_KEYS.slice(0, defaultWeekDayIndex),
+  ];
+};
+
+const sortByValueOrder = (values: string[], valueOrder: string[]): string[] =>
+  [...values].sort((firstValue, secondValue) => {
+    const firstIndex = valueOrder.indexOf(firstValue);
+    const secondIndex = valueOrder.indexOf(secondValue);
+
+    if (firstIndex === -1 || secondIndex === -1) {
+      return Number(firstValue) - Number(secondValue);
+    }
+
+    return firstIndex - secondIndex;
+  });
+
 export const parseSelectedValues = (
   value: DayValue,
   defaultValue: string,
   availableValues: DayLabels,
 ): string[] => {
   const availableValueKeys = Object.keys(availableValues);
-  const normalizedValue = value === undefined || value === null ? '' : value;
-  const selectedValues = String(normalizedValue)
+  const selectedValues = normalizeValue(value)
     .split(',')
     .map((selectedValue) => selectedValue.trim())
     .filter((selectedValue) => availableValueKeys.includes(selectedValue));
@@ -41,8 +74,9 @@ export const formatSelectedValues = (
   value: DayValue,
   labels: DayLabels,
   defaultValue: string,
+  valueOrder: string[] = sortNumericKeys(Object.keys(labels)),
 ): string =>
-  parseSelectedValues(value, defaultValue, labels)
+  sortByValueOrder(parseSelectedValues(value, defaultValue, labels), valueOrder)
     .map((key) => labels[key])
     // English-style ", " joiner. wp.i18n has no locale-aware list
     // formatter, so locales like Japanese (e.g. "、") render with the

--- a/mailpoet/assets/js/src/newsletters/types/notification/notification.tsx
+++ b/mailpoet/assets/js/src/newsletters/types/notification/notification.tsx
@@ -9,6 +9,7 @@ import { Heading } from 'common/typography/heading/heading';
 import { Grid } from 'common/grid';
 import { useNavigate } from 'react-router-dom';
 import { GlobalContext, GlobalContextValue } from 'context';
+import { getDefaultWeekDay } from 'newsletters/scheduling/multi-day';
 
 interface NewsletterNotificationState {
   options: {
@@ -55,7 +56,7 @@ class NewsletterNotificationComponent extends Component<
       options: {
         intervalType: 'daily',
         timeOfDay: 0,
-        weekDay: '1',
+        weekDay: getDefaultWeekDay(MailPoet.wpWeekStartsOn),
         monthDay: '1',
         nthWeekDay: '1',
       },

--- a/mailpoet/assets/js/src/newsletters/types/notification/scheduling.jsx
+++ b/mailpoet/assets/js/src/newsletters/types/notification/scheduling.jsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { FormFieldSelect as Select } from 'form/fields/select.jsx';
 import { Checkbox } from 'common/form/checkbox/checkbox';
+import { MailPoet } from 'mailpoet';
 import {
   intervalValues,
   timeOfDayValues,
@@ -13,6 +14,8 @@ import {
 } from 'newsletters/scheduling/common.jsx';
 import {
   DEFAULT_DAY,
+  getDefaultWeekDay,
+  getOrderedWeekDayKeys,
   parseSelectedValues,
   serializeSelectedValues,
 } from 'newsletters/scheduling/multi-day';
@@ -51,11 +54,13 @@ function MultipleCheckboxSelection({
   onValueChange,
   automationId,
   columns,
+  valueOrder,
 }) {
   const normalizedSelectedValues = selectedValues.map((value) => `${value}`);
+  const orderedValueKeys = valueOrder || Object.keys(values);
   return (
     <div className={checkboxGridClassName(columns)}>
-      {Object.keys(values).map((value) => (
+      {orderedValueKeys.map((value) => (
         <span key={`${name}-${value}`}>
           <Checkbox
             name={name}
@@ -89,10 +94,15 @@ MultipleCheckboxSelection.propTypes = {
   onValueChange: PropTypes.func.isRequired,
   automationId: PropTypes.string.isRequired,
   columns: PropTypes.oneOf([3, 4]).isRequired,
+  valueOrder: PropTypes.arrayOf(PropTypes.string),
 };
 
 class NotificationScheduling extends Component {
   getCurrentValue = () => this.props.item[this.props.field.name] || {};
+
+  getDefaultWeekDay = () => getDefaultWeekDay(MailPoet.wpWeekStartsOn);
+
+  getOrderedWeekDayKeys = () => getOrderedWeekDayKeys(MailPoet.wpWeekStartsOn);
 
   handleValueChanges = (changes) => {
     const oldValue = this.getCurrentValue();
@@ -119,11 +129,18 @@ class NotificationScheduling extends Component {
       // Route through parseSelectedValues so weekDay = 0 (Sunday) is preserved
       // -- a plain `oldValue.weekDay || '1'` would treat 0 as missing.
       changes.weekDay = serializeSelectedValues(
-        parseSelectedValues(oldValue.weekDay, DEFAULT_DAY, weekDayValues),
+        parseSelectedValues(
+          oldValue.weekDay,
+          this.getDefaultWeekDay(),
+          weekDayValues,
+        ),
       );
     }
     if (intervalType === 'nthWeekDay') {
-      changes.weekDay = getFirstSelectedValue(oldValue.weekDay, DEFAULT_DAY);
+      changes.weekDay = getFirstSelectedValue(
+        oldValue.weekDay,
+        this.getDefaultWeekDay(),
+      );
       changes.nthWeekDay = oldValue.nthWeekDay || DEFAULT_DAY;
     }
     this.handleValueChanges(changes);
@@ -144,6 +161,12 @@ class NotificationScheduling extends Component {
 
   render() {
     const value = this.getCurrentValue();
+    const defaultWeekDay = this.getDefaultWeekDay();
+    const orderedWeekDayKeys = this.getOrderedWeekDayKeys();
+    const orderedWeekDayField = {
+      ...weekDayField,
+      sortBy: (dayValue) => orderedWeekDayKeys.indexOf(dayValue),
+    };
     let multipleCheckboxSelection;
     let timeOfDaySelection;
     let weekDaySelection;
@@ -166,12 +189,13 @@ class NotificationScheduling extends Component {
           values={weekDayValues}
           selectedValues={parseSelectedValues(
             value.weekDay,
-            DEFAULT_DAY,
+            defaultWeekDay,
             weekDayValues,
           )}
           onValueChange={this.handleWeekDaysChange}
           automationId="newsletter_week_day"
           columns={3}
+          valueOrder={orderedWeekDayKeys}
         />
       );
     }
@@ -179,7 +203,7 @@ class NotificationScheduling extends Component {
     if (value.intervalType === 'nthWeekDay') {
       weekDaySelection = (
         <Select
-          field={weekDayField}
+          field={orderedWeekDayField}
           item={this.getCurrentValue()}
           onValueChange={this.handleWeekDayChange}
         />

--- a/mailpoet/changelog/2026-05-07-20-49-20-fixed-post-notification-scheduling-follows-the-wordpress.md
+++ b/mailpoet/changelog/2026-05-07-20-49-20-fixed-post-notification-scheduling-follows-the-wordpress.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Post notification scheduling follows the WordPress week start setting

--- a/mailpoet/tests/javascript/newsletters/scheduling/multi-day.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/scheduling/multi-day.spec.ts
@@ -1,6 +1,8 @@
 import {
   DEFAULT_DAY,
   formatSelectedValues,
+  getDefaultWeekDay,
+  getOrderedWeekDayKeys,
   parseSelectedValues,
   serializeSelectedValues,
 } from '../../../../assets/js/src/newsletters/scheduling/multi-day';
@@ -24,6 +26,53 @@ const monthDayValues = {
 };
 
 describe('multi-day helpers', () => {
+  describe('getDefaultWeekDay', () => {
+    it('uses the WordPress week start day when it is valid', () => {
+      expect(getDefaultWeekDay('0')).to.equal('0');
+      expect(getDefaultWeekDay(2)).to.equal('2');
+    });
+
+    it('falls back to Monday when the WordPress week start day is missing or invalid', () => {
+      expect(getDefaultWeekDay(null)).to.equal(DEFAULT_DAY);
+      expect(getDefaultWeekDay('8')).to.equal(DEFAULT_DAY);
+    });
+  });
+
+  describe('getOrderedWeekDayKeys', () => {
+    it('orders weekdays from the WordPress week start day', () => {
+      expect(getOrderedWeekDayKeys('0')).to.deep.equal([
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+      ]);
+      expect(getOrderedWeekDayKeys('2')).to.deep.equal([
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '0',
+        '1',
+      ]);
+    });
+
+    it('uses Monday-first order when the WordPress week start day is invalid', () => {
+      expect(getOrderedWeekDayKeys('8')).to.deep.equal([
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '0',
+      ]);
+    });
+  });
+
   describe('parseSelectedValues', () => {
     it('returns the default when value is null', () => {
       expect(
@@ -117,6 +166,20 @@ describe('multi-day helpers', () => {
       expect(formatSelectedValues('0', weekDayValues, DEFAULT_DAY)).to.equal(
         'Sunday',
       );
+    });
+
+    it('renders labels in the provided value order', () => {
+      expect(
+        formatSelectedValues('0,5', weekDayValues, DEFAULT_DAY, [
+          '1',
+          '2',
+          '3',
+          '4',
+          '5',
+          '6',
+          '0',
+        ]),
+      ).to.equal('Friday, Sunday');
     });
 
     it('drops invalid entries before rendering', () => {


### PR DESCRIPTION
## Description

Fixes post notification scheduling so weekday choices follow the WordPress week start setting.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[STOMAIL-8058](https://linear.app/a8c/issue/STOMAIL-8058/respect-wordpress-week-start-in-post-notification-scheduling)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="396" height="146" alt="Screenshot 2026-05-08 at 17 35 39" src="https://github.com/user-attachments/assets/fc7a81f6-2048-4530-91b4-67e2f6074472" />
.
<img width="430" height="345" alt="Screenshot 2026-05-08 at 17 35 42" src="https://github.com/user-attachments/assets/25cbce4b-616f-474a-ae0f-4f0ee56557c4" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8058-respect-wordpress-week-start-in-post-notification-scheduling)

_The latest successful build from `fix/stomail-8058-respect-wordpress-week-start-in-post-notification-scheduling` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The code implements the WordPress week start setting correctly across all modified files:

**multi-day.ts**: Well-structured helper functions with proper type safety and fallback handling (normalizeValue, getDefaultWeekDay, getOrderedWeekDayKeys).

**notification.tsx**: Correctly uses `getDefaultWeekDay(MailPoet.wpWeekStartsOn)` for weekday initialization instead of the hardcoded '1'.

**scheduling.jsx**: Properly implements wrapper methods and passes the `valueOrder` parameter to MultipleCheckboxSelection with correct PropTypes validation.

**notification.jsx**: Correctly calls formatSelectedValues with the optional `valueOrder` parameter for weekly schedules and omits it for monthly schedules as appropriate.

All edge cases are handled (null/undefined values, invalid inputs, backwards compatibility with optional parameters).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->