### PR TITLE
Use POST for form token refresh

### DIFF
--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -391,14 +391,13 @@ jQuery(($) => {
       controller.abort();
     }, 5000);
     try {
-      const response = await fetch(
-        `${window.MailPoetForm.ajax_url}?action=mailpoet_token`,
-        {
-          cache: 'no-store',
-          credentials: 'same-origin',
-          signal: controller.signal,
-        },
-      );
+      const response = await fetch(window.MailPoetForm.ajax_url, {
+        body: new URLSearchParams({ action: 'mailpoet_token' }),
+        cache: 'no-store',
+        credentials: 'same-origin',
+        method: 'POST',
+        signal: controller.signal,
+      });
       if (!response.ok) return fallback;
       const body = (await response.json()) as { token?: string };
       if (typeof body.token === 'string' && body.token) {


### PR DESCRIPTION
## Description

Follow-up for https://github.com/mailpoet/mailpoet/pull/6718 based on discussion in the PR.

Updates the subscription form token refresh request to use POST instead of GET, avoiding stale nonce responses from intermediate caches while preserving the existing timeout and fallback behavior.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8056

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8056-newsletter-signup-fails-after-form-nonce-expires)

_The latest successful build from `stomail-8056-newsletter-signup-fails-after-form-nonce-expires` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6721)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->