### PR TITLE
Fix deferred admin notice warning

### DIFF
--- a/mailpoet/changelog/2026-05-10-19-54-05-fixed-prevent-php-warnings-from-invalid-deferred-admin-n.md
+++ b/mailpoet/changelog/2026-05-10-19-54-05-fixed-prevent-php-warnings-from-invalid-deferred-admin-n.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Prevent PHP warnings from invalid deferred admin notice data

--- a/mailpoet/lib/Config/DeferredAdminNotices.php
+++ b/mailpoet/lib/Config/DeferredAdminNotices.php
@@ -14,6 +14,7 @@ class DeferredAdminNotices {
    */
   public function addNetworkAdminNotice($message) {
     $notices = WPFunctions::get()->getOption(DeferredAdminNotices::OPTIONS_KEY_NAME, []);
+    $notices = is_array($notices) ? $notices : [];
     $notices[] = [
       "message" => $message,
       "networkAdmin" => true,// if we'll need to display the notice to anyone else
@@ -24,7 +25,18 @@ class DeferredAdminNotices {
   public function printAndClean() {
     $notices = WPFunctions::get()->getOption(DeferredAdminNotices::OPTIONS_KEY_NAME, []);
 
+    if (!is_array($notices)) {
+      if (!empty($notices)) {
+        WPFunctions::get()->deleteOption(DeferredAdminNotices::OPTIONS_KEY_NAME);
+      }
+      return;
+    }
+
     foreach ($notices as $notice) {
+      if (!is_array($notice) || empty($notice["message"])) {
+        continue;
+      }
+
       $notice = new Notice(Notice::TYPE_WARNING, $notice["message"]);
       WPFunctions::get()->addAction('network_admin_notices', [$notice, 'displayWPNotice']);
     }

--- a/mailpoet/tests/unit/Config/DeferredAdminNoticesTest.php
+++ b/mailpoet/tests/unit/Config/DeferredAdminNoticesTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class DeferredAdminNoticesTest extends \MailPoetUnitTest {
+  /** @var WPFunctions & MockObject */
+  private $wpFunctions;
+
+  public function _before() {
+    parent::_before();
+    $this->wpFunctions = $this->createMock(WPFunctions::class);
+    WPFunctions::set($this->wpFunctions);
+  }
+
+  public function _after() {
+    WPFunctions::set(new WPFunctions());
+    parent::_after();
+  }
+
+  public function testItCleansInvalidStoredNotices(): void {
+    $this->wpFunctions->expects($this->once())
+      ->method('getOption')
+      ->with(DeferredAdminNotices::OPTIONS_KEY_NAME, [])
+      ->willReturn('invalid');
+    $this->wpFunctions->expects($this->once())
+      ->method('deleteOption')
+      ->with(DeferredAdminNotices::OPTIONS_KEY_NAME);
+    $this->wpFunctions->expects($this->never())
+      ->method('addAction');
+
+    (new DeferredAdminNotices())->printAndClean();
+  }
+
+  public function testItSkipsMalformedNoticeItems(): void {
+    $this->wpFunctions->expects($this->once())
+      ->method('getOption')
+      ->with(DeferredAdminNotices::OPTIONS_KEY_NAME, [])
+      ->willReturn([
+        ['message' => 'Multisite warning'],
+        'invalid',
+        ['unknown' => 'value'],
+      ]);
+    $this->wpFunctions->expects($this->once())
+      ->method('addAction')
+      ->with('network_admin_notices', $this->isType('array'));
+    $this->wpFunctions->expects($this->once())
+      ->method('deleteOption')
+      ->with(DeferredAdminNotices::OPTIONS_KEY_NAME);
+
+    (new DeferredAdminNotices())->printAndClean();
+  }
+
+  public function testItResetsInvalidStoredNoticesWhenAddingANotice(): void {
+    $this->wpFunctions->expects($this->once())
+      ->method('getOption')
+      ->with(DeferredAdminNotices::OPTIONS_KEY_NAME, [])
+      ->willReturn('invalid');
+    $this->wpFunctions->expects($this->once())
+      ->method('updateOption')
+      ->with(DeferredAdminNotices::OPTIONS_KEY_NAME, [[
+        'message' => 'Multisite warning',
+        'networkAdmin' => true,
+      ]]);
+
+    (new DeferredAdminNotices())->addNetworkAdminNotice('Multisite warning');
+  }
+}


### PR DESCRIPTION
## Description

Fixes a PHP warning when stored deferred admin notice data is malformed. Invalid notice option data is now ignored and cleaned up, and malformed notice entries are skipped.

https://wordpress.org/support/topic/php-warning-foreach-argument-must-be-of-type-arrayobject/

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8061

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8061-deferred-admin-notice-warning)

_The latest successful build from `fix/stomail-8061-deferred-admin-notice-warning` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6722)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->