### PR TITLE
Remove IP fields from default subscriber exports

### DIFF
--- a/mailpoet/assets/js/src/subscribers/import-export/export.ts
+++ b/mailpoet/assets/js/src/subscribers/import-export/export.ts
@@ -141,10 +141,8 @@ jQuery(document).ready(() => {
       'last_name',
       'list_status',
       'global_status',
-      'subscribed_ip',
       'created_at',
       'confirmed_at',
-      'confirmed_ip',
     ])
     .trigger('change');
 

--- a/mailpoet/changelog/2026-05-06-20-04-38-changed-subscriber-exports-no-longer-select-ip-address-fie.md
+++ b/mailpoet/changelog/2026-05-06-20-04-38-changed-subscriber-exports-no-longer-select-ip-address-fie.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Subscriber exports no longer select IP address fields by default


### PR DESCRIPTION
## Description

Subscriber exports no longer preselect subscribed/confirmed IP fields. The fields remain available for manual selection when needed.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8033

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8033-remove-ip-fields-from-default-subscriber-exports)

_The latest successful build from `fix/stomail-8033-remove-ip-fields-from-default-subscriber-exports` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Issues Found: 4 (Code Quality)**

1. **Untyped Function Parameters** - Multiple function parameters lack TypeScript type annotations:
   - Line 59: `toggleNextStepButton(condition)` - `condition` parameter is untyped
   - Line 65: `templateRendered(option)` - `option` parameter is untyped
   - Line 74: `renderSegmentsAndFields(container, data)` - both parameters are untyped

2. **Undefined Type Reference** - Line 178 uses `ErrorResponse` type annotation without importing or declaring it, which would cause a TypeScript compilation error.

3. **Type Safety** - The early return validation at lines 33-36 checks `!window.exportData.segments` against a `number | null` value without proper type narrowing, which could be improved for clarity.

4. **Empty ESLint Disable Comments** - Line 128 contains an `eslint-disable-line no-param-reassign` comment without specific rule context, which is a code quality anti-pattern.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6723)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->