### PR TITLE
Reduce subscriber export batch size

### DIFF
--- a/mailpoet/changelog/2026-05-06-20-11-25-improved-subscriber-exports-use-smaller-batches-to-reduce-m.md
+++ b/mailpoet/changelog/2026-05-06-20-11-25-improved-subscriber-exports-use-smaller-batches-to-reduce-m.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Subscriber exports use smaller batches to reduce memory use

--- a/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
@@ -12,7 +12,7 @@ use MailPoet\Util\Security;
 use MailPoetVendor\XLSXWriter;
 
 class Export {
-  const SUBSCRIBER_BATCH_SIZE = 15000;
+  const SUBSCRIBER_BATCH_SIZE = 1000;
 
   public $exportFormatOption;
   public $subscriberFields;


### PR DESCRIPTION
## Description

Subscriber exports now process subscribers in smaller batches to reduce peak memory use while keeping export output and progress behavior unchanged.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8034

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8034-reduce-subscriber-export-memory-pressure)

_The latest successful build from `fix/stomail-8034-reduce-subscriber-export-memory-pressure` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**No issues found.**

The PR reduces the subscriber export batch size from 15,000 to 1,000 rows per batch to mitigate peak memory usage for large subscriber lists. The change:

- Modifies only the class constant `SUBSCRIBER_BATCH_SIZE` in `Export.php` (1 line change)
- Maintains the same export output and progress flow as stated in the commit message
- Is properly integrated with existing batch retrieval logic that already handles variable batch sizes
- Has existing test coverage (ExportTest.php exists with functional tests)
- Includes a changelog entry as verified by the commit

The modification is straightforward and low-risk, affecting only the iteration frequency without altering the data processing logic, segment handling, or file generation logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6724)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->