### PR TITLE
Preserve sender settings when skipping wizard

### DIFF
--- a/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
+++ b/mailpoet/assets/js/src/wizard/welcome-wizard-controller.tsx
@@ -94,18 +94,14 @@ function WelcomeWizardStepsController(): JSX.Element {
     async (e) => {
       e.preventDefault();
       setLoading(true);
-      const defaultSenderInfo = { address: window.admin_email, name: '' };
 
       if (window.mailpoet_is_dotcom && !window.wizard_has_tracking_settings) {
         await updateTracking(true, true);
       }
-      await updateSettings(createSenderSettings(defaultSenderInfo)).then(() => {
-        setSender(defaultSenderInfo);
-        redirect(step);
-      });
+      redirect(step);
       setLoading(false);
     },
-    [redirect, step, setSender, updateTracking],
+    [redirect, step, updateTracking],
   );
 
   const stepName = mapStepNumberToStepName(step);

--- a/mailpoet/changelog/2026-05-06-22-13-47-fixed-skipping-the-welcome-wizard-sender-step-preserves-sen.md
+++ b/mailpoet/changelog/2026-05-06-22-13-47-fixed-skipping-the-welcome-wizard-sender-step-preserves-sen.md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Skipping the welcome wizard sender step preserves existing sender details

--- a/mailpoet/changelog/2026-05-06-22-13-47-fixed-skipping-the-welcome-wizard-sender-step-preserves-sen.md
+++ b/mailpoet/changelog/2026-05-06-22-13-47-fixed-skipping-the-welcome-wizard-sender-step-preserves-sen.md
@@ -1,4 +1,5 @@
-Significance: patch
-Type: fixed
+# Type: Fixed
+
+# Description
 
 Skipping the welcome wizard sender step preserves existing sender details


### PR DESCRIPTION
## Description

Skipping the welcome wizard sender step no longer writes blank sender details; existing/default sender settings are preserved while the wizard navigation behavior remains unchanged.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8035

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8035-preserve-sender-settings-when-skipping-welcome-wizard-sender)

_The latest successful build from `fix/stomail-8035-preserve-sender-settings-when-skipping-welcome-wizard-sender` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6725)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->