### PR TITLE
Reject duplicate subscriber when creating a new one

### DIFF
--- a/mailpoet/changelog/2026-05-06-22-18-46-fixed-adding-a-subscriber-with-an-existing-email-now-shows-an.md
+++ b/mailpoet/changelog/2026-05-06-22-18-46-fixed-adding-a-subscriber-with-an-existing-email-now-shows-an.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Adding a subscriber with an existing email now shows an error instead of updating the existing subscriber

--- a/mailpoet/lib/API/JSON/Error.php
+++ b/mailpoet/lib/API/JSON/Error.php
@@ -5,6 +5,7 @@ namespace MailPoet\API\JSON;
 final class Error {
   const UNKNOWN = 'unknown';
   const BAD_REQUEST = 'bad_request';
+  const CONFLICT = 'conflict';
   const UNAUTHORIZED = 'unauthorized';
   const FORBIDDEN = 'forbidden';
   const NOT_FOUND = 'not_found';

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -179,9 +179,9 @@ class Subscribers extends APIEndpoint {
     } catch (ValidationException $validationException) {
       return $this->badRequest([$this->getErrorMessage($validationException)]);
     } catch (ConflictException $conflictException) {
-      return $this->badRequest([
-        APIError::BAD_REQUEST => $conflictException->getMessage(),
-      ]);
+      return $this->errorResponse([
+        APIError::CONFLICT => $conflictException->getMessage(),
+      ], [], Response::STATUS_CONFLICT);
     };
 
     return $this->successResponse(

--- a/mailpoet/lib/Subscribers/SubscriberSaveController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSaveController.php
@@ -294,20 +294,13 @@ class SubscriberSaveController {
   }
 
   private function findSubscriber(array &$data): ?SubscriberEntity {
-    $subscriber = null;
     if (isset($data['id']) && (int)$data['id'] > 0) {
-      $subscriber = $this->subscribersRepository->findOneById(((int)$data['id']));
+      $subscriber = $this->subscribersRepository->findOneById((int)$data['id']);
       unset($data['id']);
+      return $subscriber;
     }
 
-    if (!$subscriber && !empty($data['email'])) {
-      $subscriber = $this->subscribersRepository->findOneBy(['email' => $data['email']]);
-      if ($subscriber) {
-        unset($data['email']);
-      }
-    }
-
-    return $subscriber;
+    return null;
   }
 
   public function updateCustomFields(array $data, SubscriberEntity $subscriber): void {

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -1371,6 +1371,7 @@ class SubscribersTest extends \MailPoetTest {
     $response = $this->endpoint->save($subscriberData);
     verify($this->sendingQueuesRepository->findAll())->empty();
 
+    $this->assertInstanceOf(SuccessResponse::class, $response);
     $subscriberData['id'] = $response->data['id'];
     $subscriberData['segments'] = [$this->segment1->getId()];
     $this->endpoint->save($subscriberData);

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -268,6 +268,7 @@ class SubscribersTest extends \MailPoetTest {
 
   public function testItCanSaveAnExistingSubscriber() {
     $subscriberData = [
+      'id' => $this->subscriber2->getId(),
       'email' => 'jane@mailpoet.com',
       'first_name' => 'Super Jane',
       'last_name' => 'Doe',
@@ -284,6 +285,28 @@ class SubscribersTest extends \MailPoetTest {
     );
     verify($response->data['first_name'])->equals('Super Jane');
     verify($response->data['source'])->equals('api');
+  }
+
+  public function testItCannotCreateSubscriberWithDuplicateEmail() {
+    $subscriberData = [
+      'email' => 'jane@mailpoet.com',
+      'first_name' => 'Super Jane',
+      'last_name' => 'Doe',
+      'status' => SubscriberEntity::STATUS_SUBSCRIBED,
+      'segments' => [$this->segment1->getId()],
+      'source' => Source::API,
+    ];
+
+    $response = $this->endpoint->save($subscriberData);
+    $this->assertInstanceOf(ErrorResponse::class, $response);
+    verify($response->status)->equals(APIResponse::STATUS_CONFLICT);
+    verify($response->errors[0]['error'])->equals(Error::CONFLICT);
+    verify($response->errors[0]['message'])->equals('A subscriber with E-mail "jane@mailpoet.com" already exists.');
+
+    $this->entityManager->clear();
+    $subscriber = $this->subscribersRepository->findOneBy(['email' => 'jane@mailpoet.com']);
+    $this->assertInstanceOf(SubscriberEntity::class, $subscriber);
+    verify($subscriber->getFirstName())->equals('Jane');
   }
 
   public function testItCanUpdateEmailOfAnExistingSubscriber() {
@@ -304,12 +327,14 @@ class SubscribersTest extends \MailPoetTest {
     $subscriberData['email'] = $this->subscriber1->getEmail();
     $response = $this->endpoint->save($subscriberData);
     $this->assertInstanceOf(ErrorResponse::class, $response);
-    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    verify($response->status)->equals(APIResponse::STATUS_CONFLICT);
+    verify($response->errors[0]['error'])->equals(Error::CONFLICT);
     verify($response->errors[0]['message'])->equals('A subscriber with E-mail "' . $this->subscriber1->getEmail() . '" already exists.');
   }
 
   public function testItCanRemoveListsFromAnExistingSubscriber() {
     $subscriberData = [
+      'id' => $this->subscriber2->getId(),
       'email' => 'jane@mailpoet.com',
       'first_name' => 'Super Jane',
       'last_name' => 'Doe',
@@ -1343,9 +1368,10 @@ class SubscribersTest extends \MailPoetTest {
     ];
 
     // welcome notification is created only for segment #1
-    $this->endpoint->save($subscriberData);
+    $response = $this->endpoint->save($subscriberData);
     verify($this->sendingQueuesRepository->findAll())->empty();
 
+    $subscriberData['id'] = $response->data['id'];
     $subscriberData['segments'] = [$this->segment1->getId()];
     $this->endpoint->save($subscriberData);
     verify($this->sendingQueuesRepository->findAll())->arrayCount(1);

--- a/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberSaveControllerTest.php
@@ -149,6 +149,21 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
     verify($data['tags'])->equals($tagNames);
   }
 
+  public function testItThrowsExceptionWhenCreatingSubscriberWithDuplicateEmail(): void {
+    $subscriber = $this->createSubscriber('duplicate@test.com', SubscriberEntity::STATUS_UNCONFIRMED);
+
+    $data = [
+      'email' => $subscriber->getEmail(),
+      'first_name' => 'Changed',
+    ];
+
+    $this->entityManager->clear();
+    $this->expectException(ConflictException::class);
+    $this->expectExceptionMessage('A subscriber with E-mail "' . $subscriber->getEmail() . '" already exists.');
+
+    $this->saveController->save($data);
+  }
+
   public function testItThrowsExceptionWhenUpdatingSubscriberEmailIfNotUnique(): void {
     $subscriber = $this->createSubscriber('second@test.com', SubscriberEntity::STATUS_UNCONFIRMED);
     $subscriber2 = $this->createSubscriber('third@test.com', SubscriberEntity::STATUS_UNCONFIRMED);
@@ -213,17 +228,20 @@ class SubscriberSaveControllerTest extends \MailPoetTest {
 
     // create subscriber with subscribed status
     $count = 0;
-    $this->saveController->save($data);
+    $subscriber = $this->saveController->save($data);
     $this->assertSame(2, $count); // @phpstan-ignore-line -- PHPStan doesn't get the $count side effect
 
     // update subscriber to non-subscribed status
     $count = 0;
-    $this->saveController->save(array_merge($data, ['status' => SubscriberEntity::STATUS_UNCONFIRMED]));
+    $this->saveController->save(array_merge($data, [
+      'id' => $subscriber->getId(),
+      'status' => SubscriberEntity::STATUS_UNCONFIRMED,
+    ]));
     $this->assertSame(0, $count); // @phpstan-ignore-line -- PHPStan doesn't get the $count side effect
 
     // update subscriber to subscribed status
     $count = 0;
-    $this->saveController->save($data);
+    $this->saveController->save(array_merge($data, ['id' => $subscriber->getId()]));
     $this->assertSame(2, $count); // @phpstan-ignore-line -- PHPStan doesn't get the $count side effect
   }
 


### PR DESCRIPTION
## Description

Creating a subscriber with an email that already exists now returns a conflict instead of silently updating the existing subscriber. Editing existing subscribers still works through the ID path.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8036

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1138" height="567" alt="Screenshot 2026-05-11 at 10 49 20" src="https://github.com/user-attachments/assets/52af0d10-0d09-4a02-bc23-c2f42f72af91" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8036-reject-duplicate-email-when-adding-a-new-subscriber)

_The latest successful build from `fix/stomail-8036-reject-duplicate-email-when-adding-a-new-subscriber` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6726)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->