### PR TITLE
Limit default archive shortcode results

### DIFF
--- a/mailpoet/changelog/2026-05-06-22-21-22-fixed-newsletter-archive-shortcode-uses-a-default-result-limi.md
+++ b/mailpoet/changelog/2026-05-06-22-21-22-fixed-newsletter-archive-shortcode-uses-a-default-result-limi.md
@@ -1,0 +1,5 @@
+# Type: Changed
+
+# Description
+
+Newsletter archive shortcode now uses a default result limit of 100 when no limit is specified

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -21,6 +21,8 @@ use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\CarbonImmutable;
 
 class Shortcodes {
+  const DEFAULT_ARCHIVE_LIMIT = 100;
+
   /** @var Pages */
   private $subscriptionPages;
 
@@ -185,7 +187,7 @@ class Shortcodes {
       'endDate' => null,
       'segmentIds' => [],
       'subjectContains' => '',
-      'limit' => null,
+      'limit' => self::DEFAULT_ARCHIVE_LIMIT,
     ];
 
     if (!is_array($params)) {

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -190,6 +190,30 @@ class ShortcodesTest extends \MailPoetTest {
     verify($parsed['endDate'])->null();
   }
 
+  public function testArchiveDefaultsLimitWhenLimitIsMissingOrInvalid(): void {
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
+
+    $limits = [
+      [],
+      ['limit' => ''],
+      ['limit' => '0'],
+      ['limit' => '-5'],
+      ['limit' => ['5']],
+    ];
+
+    foreach ($limits as $params) {
+      $parsed = $shortcodes->getParsedArchiveParams($params);
+      verify($parsed['limit'])->equals(Shortcodes::DEFAULT_ARCHIVE_LIMIT);
+    }
+  }
+
+  public function testArchiveAcceptsExplicitLimit(): void {
+    $shortcodes = ContainerWrapper::getInstance()->get(Shortcodes::class);
+
+    $parsed = $shortcodes->getParsedArchiveParams(['limit' => '7']);
+    verify($parsed['limit'])->equals(7);
+  }
+
   public function testArchiveAcceptsSegments(): void {
     $segment1 = (new Segment())->create();
     $segment2 = (new Segment())->create();
@@ -209,6 +233,21 @@ class ShortcodesTest extends \MailPoetTest {
     $result = do_shortcode(sprintf("[mailpoet_archive segments=\"%s\"]", $segment2->getId()));
     verify($result)->stringNotContainsString('Newsletter 1');
     verify($result)->stringContainsString('Newsletter 2');
+  }
+
+  public function testArchiveUsesDefaultLimitWhenLimitIsMissing(): void {
+    for ($i = 0; $i <= Shortcodes::DEFAULT_ARCHIVE_LIMIT; $i++) {
+      (new NewsletterFactory())
+        ->withSendingQueue(['processed_at' => Carbon::now()->subDays($i)])
+        ->withSentStatus()
+        ->withSubject(sprintf('Archive item %03d', $i))
+        ->create();
+    }
+
+    $result = do_shortcode('[mailpoet_archive]');
+    verify($result)->stringContainsString('Archive item 000');
+    verify($result)->stringContainsString(sprintf('Archive item %03d', Shortcodes::DEFAULT_ARCHIVE_LIMIT - 1));
+    verify($result)->stringNotContainsString(sprintf('Archive item %03d', Shortcodes::DEFAULT_ARCHIVE_LIMIT));
   }
 
   public function testArchiveSupportsLimit() {


### PR DESCRIPTION
## Description

The newsletter archive shortcode now uses a conservative default limit when no valid limit is provided, while preserving explicit positive limit values.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8037

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8037-add-a-default-limit-to-the-newsletter-archive-shortcode)

_The latest successful build from `fix/stomail-8037-add-a-default-limit-to-the-newsletter-archive-shortcode` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6727)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->