### PR TITLE
Expire deleted MailPoet cookies

### DIFF
--- a/mailpoet/changelog/2026-05-06-22-24-33-fixed-mailpoet-cookie-deletion-now-expires-browser-cookies.md
+++ b/mailpoet/changelog/2026-05-06-22-24-33-fixed-mailpoet-cookie-deletion-now-expires-browser-cookies.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+MailPoet cookie deletion now expires browser cookies

--- a/mailpoet/lib/Util/Cookies.php
+++ b/mailpoet/lib/Util/Cookies.php
@@ -14,7 +14,7 @@ class Cookies {
   ];
 
   public function set($name, $value, array $options = []) {
-    if (headers_sent()) {
+    if ($this->headersSent()) {
       return;
     }
     $options = $options + self::DEFAULT_OPTIONS;
@@ -24,11 +24,7 @@ class Cookies {
       throw new InvalidArgumentException('Failed to JSON-encode cookie value');
     }
 
-    setcookie(
-      $name,
-      $value,
-      $options
-    );
+    $this->setCookie($name, $value, $options);
   }
 
   public function get($name) {
@@ -43,7 +39,26 @@ class Cookies {
     return $value;
   }
 
-  public function delete($name) {
+  public function delete($name, array $options = []) {
+    if (!$this->headersSent()) {
+      $options = $options + self::DEFAULT_OPTIONS;
+      $options['expires'] = time() - 3600;
+      $this->setCookie($name, '', $options);
+
+      if ($options['path'] === '') {
+        $options['path'] = '/';
+        $this->setCookie($name, '', $options);
+      }
+    }
+
     unset($_COOKIE[$name]);
+  }
+
+  protected function headersSent(): bool {
+    return headers_sent();
+  }
+
+  protected function setCookie($name, string $value, array $options): void {
+    setcookie($name, $value, $options);
   }
 }

--- a/mailpoet/tests/unit/Util/CookiesTest.php
+++ b/mailpoet/tests/unit/Util/CookiesTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Util;
+
+use MailPoet\Util\Cookies;
+
+class CookiesTest extends \MailPoetUnitTest {
+  public function testDeleteExpiresBrowserCookieAndUnsetsLocalCookie(): void {
+    $_COOKIE['mailpoet_test'] = '{"value":"set"}';
+    $cookies = $this->createTestableCookies();
+
+    $cookies->delete('mailpoet_test', ['path' => '/']);
+
+    verify($cookies->setCookies)->arrayCount(1);
+    verify($cookies->setCookies[0]['name'])->equals('mailpoet_test');
+    verify($cookies->setCookies[0]['value'])->equals('');
+    verify($cookies->setCookies[0]['options']['expires'])->lessThan(time());
+    verify($cookies->setCookies[0]['options']['path'])->equals('/');
+    $this->assertArrayNotHasKey('mailpoet_test', $_COOKIE);
+  }
+
+  public function testDeleteExpiresDefaultAndRootPathsWhenPathIsNotProvided(): void {
+    $_COOKIE['mailpoet_test'] = '{"value":"set"}';
+    $cookies = $this->createTestableCookies();
+
+    $cookies->delete('mailpoet_test');
+
+    verify($cookies->setCookies)->arrayCount(2);
+    verify($cookies->setCookies[0]['options']['path'])->equals('');
+    verify($cookies->setCookies[1]['options']['path'])->equals('/');
+    $this->assertArrayNotHasKey('mailpoet_test', $_COOKIE);
+  }
+
+  public function testDeleteSkipsBrowserExpirationWhenHeadersWereSent(): void {
+    $_COOKIE['mailpoet_test'] = '{"value":"set"}';
+    $cookies = $this->createTestableCookies();
+    $cookies->headersSent = true;
+
+    $cookies->delete('mailpoet_test', ['path' => '/']);
+
+    verify($cookies->setCookies)->arrayCount(0);
+    $this->assertArrayNotHasKey('mailpoet_test', $_COOKIE);
+  }
+
+  private function createTestableCookies() {
+    return new class extends Cookies {
+      /** @var bool */
+      public $headersSent = false;
+
+      /** @var array<int, array{name: mixed, value: string, options: array}> */
+      public $setCookies = [];
+
+      protected function headersSent(): bool {
+        return $this->headersSent;
+      }
+
+      protected function setCookie($name, string $value, array $options): void {
+        $this->setCookies[] = [
+          'name' => $name,
+          'value' => $value,
+          'options' => $options,
+        ];
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Description

Cookie deletion now sends expired browser cookies when headers are available and still clears the local PHP cookie value.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8038

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8038-expire-browser-cookies-when-deleting-mailpoet-cookies)

_The latest successful build from `fix/stomail-8038-expire-browser-cookies-when-deleting-mailpoet-cookies` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6728)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->