### PR TITLE
Show disabled cron scheduler setting

### DIFF
--- a/mailpoet/assets/js/src/settings/pages/advanced/task-scheduler.tsx
+++ b/mailpoet/assets/js/src/settings/pages/advanced/task-scheduler.tsx
@@ -67,6 +67,28 @@ export function TaskScheduler() {
             {__('Server side cron (Linux cron)', 'mailpoet')}
           </label>
         </div>
+        {method === 'Disabled' && (
+          <>
+            <div className="mailpoet-settings-inputs-row">
+              <Radio
+                id="cron_trigger-method-disabled"
+                value="Disabled"
+                checked={method === 'Disabled'}
+                onCheck={setMethod}
+                automationId="disabled_cron_radio"
+              />
+              <label htmlFor="cron_trigger-method-disabled">
+                {__('Disabled', 'mailpoet')}
+              </label>
+            </div>
+            <div className="mailpoet-settings-inputs-row">
+              {__(
+                'MailPoet will not process scheduled emails automatically.',
+                'mailpoet',
+              )}
+            </div>
+          </>
+        )}
         {method === 'Linux Cron' && (
           <div className="mailpoet-settings-inputs-row">
             <div className="mailpoet-settings-inputs-row">

--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -116,7 +116,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
     }),
     cron_trigger: asObject({
       method: asEnum(
-        ['WordPress', 'Action Scheduler', 'Linux Cron'],
+        ['WordPress', 'Action Scheduler', 'Linux Cron', 'Disabled'],
         'Action Scheduler',
       ),
     }),

--- a/mailpoet/assets/js/src/settings/store/types.ts
+++ b/mailpoet/assets/js/src/settings/store/types.ts
@@ -49,7 +49,7 @@ export type Settings = {
     address: string;
   };
   cron_trigger: {
-    method: 'WordPress' | 'Action Scheduler' | 'Linux Cron';
+    method: 'WordPress' | 'Action Scheduler' | 'Linux Cron' | 'Disabled';
   };
   tracking: {
     level: 'full' | 'basic' | 'partial';

--- a/mailpoet/changelog/2026-05-06-22-28-09-fixed-disabled-newsletter-task-scheduler-settings-display-c.md
+++ b/mailpoet/changelog/2026-05-06-22-28-09-fixed-disabled-newsletter-task-scheduler-settings-display-c.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Disabled newsletter task scheduler settings display correctly


### PR DESCRIPTION
## Description

Advanced settings now recognizes and displays the stored Disabled newsletter task scheduler mode instead of normalizing it back to Action Scheduler.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8039

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8039-show-disabled-cron-trigger-accurately-in-advanced-settings)

_The latest successful build from `fix/stomail-8039-show-disabled-cron-trigger-accurately-in-advanced-settings` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**1 issue found**

**Bug**: The "Disabled" radio option in the TaskScheduler component is conditionally rendered only when `method === 'Disabled'` (line 70 of task-scheduler.tsx). This creates a usability problem where users cannot select the "Disabled" option if it is not already the current selection, as the radio button will be hidden. The other scheduler options (Action Scheduler, WordPress, Linux Cron) are always visible regardless of the current selection, creating an inconsistent user experience. The "Disabled" option should be unconditionally rendered like the other options to allow users to switch to it.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6729)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->