### PR TITLE
Use WordPress timezone in system reports

### DIFF
--- a/mailpoet/changelog/2026-05-06-20-37-19-fixed-system-report-timestamps-now-use-the-wordpress-tim.md
+++ b/mailpoet/changelog/2026-05-06-20-37-19-fixed-system-report-timestamps-now-use-the-wordpress-tim.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+System report timestamps now use the WordPress timezone

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -166,8 +166,8 @@ class SystemReportCollector {
         'Is reachable' => $this->cronHelper->validatePingResponse($cronPingResponse) ? 'Yes' : 'No',
         'Ping URL' => $cronPingUrl,
         'Ping response' => $cronPingResponse,
-        'Last run start' => isset($cronDaemonStatus['run_started_at']) ? date('Y-m-d H:i:s', $cronDaemonStatus['run_started_at']) : 'Unknown',
-        'Last run end' => isset($cronDaemonStatus['run_completed_at']) ? date('Y-m-d H:i:s', $cronDaemonStatus['run_completed_at']) : 'Unknown',
+        'Last run start' => isset($cronDaemonStatus['run_started_at']) ? $this->formatTimestamp((int)$cronDaemonStatus['run_started_at']) : 'Unknown',
+        'Last run end' => isset($cronDaemonStatus['run_completed_at']) ? $this->formatTimestamp((int)$cronDaemonStatus['run_completed_at']) : 'Unknown',
         'Last seen error' => $cronDaemonStatus['last_error'] ?? 'None',
       ]),
       'Total number of subscribers' => $this->subscribersFeature->getSubscribersCount(),
@@ -175,7 +175,7 @@ class SystemReportCollector {
       'Installed via WooCommerce onboarding wizard' => $this->wooCommerceHelper->wasMailPoetInstalledViaWooCommerceOnboardingWizard(),
       'Sending queue status' => $this->formatCompositeField([
         'Status' => $mailerLog['status'] ?? 'Unknown',
-        'Started at' => isset($mailerLog['started']) ? date('Y-m-d H:i:s', $mailerLog['started']) : 'Unknown',
+        'Started at' => isset($mailerLog['started']) ? $this->formatTimestamp((int)$mailerLog['started']) : 'Unknown',
         'Emails sent' => $mailerLog['sent'],
         'Retry attempts' => $mailerLog['retry_attempt'] ?? 0,
         'Last seen error' => isset($mailerLog['error'])
@@ -286,6 +286,12 @@ class SystemReportCollector {
     }
 
     return $result;
+  }
+
+  private function formatTimestamp(int $timestamp): string {
+    return (new \DateTimeImmutable('@' . $timestamp))
+      ->setTimezone($this->wp->wpTimezone())
+      ->format('Y-m-d H:i:s');
   }
 
   protected function maskApiKey($key) {

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -210,10 +210,13 @@ class SystemReportCollectorTest extends \MailPoetTest {
   }
 
   public function testItReturnsCronStatusDetailsWhenDaemonIsActive() {
+    update_option('timezone_string', 'Asia/Tokyo');
+    update_option('gmt_offset', 9);
+
     $cronSettings = [
       'status' => CronHelper::DAEMON_STATUS_ACTIVE,
-      'run_started_at' => time(),
-      'run_completed_at' => time() + 10,
+      'run_started_at' => 0,
+      'run_completed_at' => 60,
       'last_error' => 'Some error',
     ];
 
@@ -224,8 +227,8 @@ class SystemReportCollectorTest extends \MailPoetTest {
     verify($subjectField)->stringContainsString('Status: ' . $cronSettings['status']);
     verify($subjectField)->stringContainsString('Is reachable: Yes');
     verify($subjectField)->stringContainsString('Ping response: pong');
-    verify($subjectField)->stringContainsString('Last run start: ' . date('Y-m-d H:i:s', $cronSettings['run_started_at']));
-    verify($subjectField)->stringContainsString('Last run end: ' . date('Y-m-d H:i:s', $cronSettings['run_completed_at']));
+    verify($subjectField)->stringContainsString('Last run start: 1970-01-01 09:00:00');
+    verify($subjectField)->stringContainsString('Last run end: 1970-01-01 09:01:00');
     verify($subjectField)->stringContainsString('Last seen error: ' . $cronSettings['last_error']);
   }
 
@@ -245,18 +248,24 @@ class SystemReportCollectorTest extends \MailPoetTest {
   }
 
   public function testItReturnsSendingQueueStatus() {
-    $mailerLog = MailerLog::createMailerLog();
-    MailerLog::resumeSending();
+    update_option('timezone_string', 'Asia/Tokyo');
+    update_option('gmt_offset', 9);
 
-    try {
-      MailerLog::processError($operation = 'send', $error = 'email rejected');
-    } catch (\Exception $e) {
-      // ignore
-    }
+    $mailerLog = MailerLog::createMailerLog();
+    $operation = 'send';
+    $error = 'email rejected';
+    $mailerLog['started'] = 0;
+    $mailerLog['retry_attempt'] = 1;
+    $mailerLog['error'] = [
+      'error_message' => $error,
+      'operation' => $operation,
+    ];
+
+    MailerLog::updateMailerLog($mailerLog);
 
     $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
     $subjectField = $systemInfoData['Sending queue status'];
-    verify($subjectField)->stringContainsString('Started at: ' . date('Y-m-d')); // ignoring time segment
+    verify($subjectField)->stringContainsString('Started at: 1970-01-01 09:00:00');
     verify($subjectField)->stringContainsString('Retry attempts: 1');
     verify($subjectField)->stringContainsString("Last seen error: $error ($operation)");
 


### PR DESCRIPTION
## Description

System report cron and sending queue timestamps now format with the configured WordPress timezone instead of the server/PHP timezone.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8041

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8041-use-wordpress-timezone-in-system-report-timestamps)

_The latest successful build from `fix/stomail-8041-use-wordpress-timezone-in-system-report-timestamps` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6731)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->