### PR TITLE
Confirm destructive newsletter deletes

### DIFF
--- a/mailpoet/assets/js/src/common/confirm-alert.jsx
+++ b/mailpoet/assets/js/src/common/confirm-alert.jsx
@@ -7,6 +7,7 @@ import { MailPoet } from 'mailpoet';
 function ConfirmAlert({
   message,
   onConfirm,
+  onCancel = () => {},
   title = __('Confirm to proceed', 'mailpoet'),
   cancelLabel = __('Cancel', 'mailpoet'),
   confirmLabel = __('Confirm', 'mailpoet'),
@@ -42,8 +43,9 @@ function ConfirmAlert({
 
       document
         .getElementById('mailpoet_alert_cancel')
-        .addEventListener('click', () => MailPoet.Modal.close());
+        .addEventListener('click', () => MailPoet.Modal.cancel());
     },
+    onCancel,
   });
   return null;
 }
@@ -53,6 +55,7 @@ ConfirmAlert.propTypes = {
   message: PropTypes.string.isRequired,
   cancelLabel: PropTypes.string,
   confirmLabel: PropTypes.string,
+  onCancel: PropTypes.func,
   onConfirm: PropTypes.func.isRequired,
 };
 
@@ -64,6 +67,7 @@ export function confirmAlert(props) {
       message={props.message}
       cancelLabel={props.cancelLabel}
       confirmLabel={props.confirmLabel}
+      onCancel={props.onCancel}
       onConfirm={props.onConfirm}
     />,
   );

--- a/mailpoet/assets/js/src/listing/bulk-actions.jsx
+++ b/mailpoet/assets/js/src/listing/bulk-actions.jsx
@@ -37,39 +37,58 @@ class ListingBulkActions extends Component {
       return;
     }
 
-    const selectedIds =
-      this.props.selection === 'all' ? 'all' : this.props.selected_ids;
+    const submitAction = () => {
+      const selectedIds =
+        this.props.selection === 'all' ? 'all' : this.props.selected_ids;
 
-    const data = action.getData !== undefined ? action.getData() : {};
+      const data = action.getData !== undefined ? action.getData() : {};
 
-    data.action = action.name;
+      data.action = action.name;
 
-    let onSuccess = () => {};
-    if (action.onSuccess !== undefined) {
-      onSuccess = action.onSuccess;
-    }
-
-    if (data.action) {
-      this.isSubmittingAction = true;
-      const promise = this.props.onBulkAction(selectedIds, data);
-      if (promise !== false) {
-        promise.then(onSuccess);
-        promise.always(() => {
-          this.isSubmittingAction = false;
-        });
-      } else {
-        this.isSubmittingAction = false;
+      let onSuccess = () => {};
+      if (action.onSuccess !== undefined) {
+        onSuccess = action.onSuccess;
       }
+
+      if (data.action) {
+        this.isSubmittingAction = true;
+        const promise = this.props.onBulkAction(selectedIds, data);
+        if (promise !== false) {
+          promise.then(onSuccess);
+          promise.always(() => {
+            this.isSubmittingAction = false;
+          });
+        } else {
+          this.isSubmittingAction = false;
+        }
+      }
+
+      this.setState(
+        {
+          extra: false,
+        },
+        () => {
+          this.restoreTriggerElementFocus();
+        },
+      );
+    };
+
+    if (typeof action.confirm === 'function') {
+      this.isSubmittingAction = true;
+      action.confirm({
+        count: this.props.count,
+        selection: this.props.selection,
+        selectedIds:
+          this.props.selection === 'all' ? 'all' : this.props.selected_ids,
+        onCancel: () => {
+          this.isSubmittingAction = false;
+        },
+        onConfirm: submitAction,
+      });
+      return;
     }
 
-    this.setState(
-      {
-        extra: false,
-      },
-      () => {
-        this.restoreTriggerElementFocus();
-      },
-    );
+    submitAction();
   }
 
   getSelectedAction(actionName) {
@@ -132,6 +151,7 @@ class ListingBulkActions extends Component {
 
 ListingBulkActions.propTypes = {
   bulk_actions: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line react/forbid-prop-types
+  count: PropTypes.number.isRequired,
   selection: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   selected_ids: PropTypes.arrayOf(PropTypes.number).isRequired,
   onBulkAction: PropTypes.func.isRequired,

--- a/mailpoet/assets/js/src/listing/listing.jsx
+++ b/mailpoet/assets/js/src/listing/listing.jsx
@@ -300,6 +300,10 @@ class ListingComponent extends Component {
   };
 
   handleTrashItem = (id) => {
+    this.confirmAction('trashItem', () => this.trashItem(id), { id });
+  };
+
+  trashItem = (id) => {
     const { endpoint, messages = undefined } = this.props;
     this.setState({
       loading: true,
@@ -327,6 +331,10 @@ class ListingComponent extends Component {
   };
 
   handleDeleteItem = (id) => {
+    this.confirmAction('deleteItem', () => this.deleteItem(id), { id });
+  };
+
+  deleteItem = (id) => {
     const { endpoint, messages = undefined } = this.props;
     this.setState({
       loading: true,
@@ -352,7 +360,9 @@ class ListingComponent extends Component {
       });
   };
 
-  handleEmptyTrash = () =>
+  handleEmptyTrash = () => this.confirmAction('emptyTrash', this.emptyTrash);
+
+  emptyTrash = () =>
     this.handleBulkAction('all', {
       action: 'delete',
       group: 'trash',
@@ -368,6 +378,53 @@ class ListingComponent extends Component {
       .fail((response) => {
         this.context.notices.apiError(response, { scroll: true });
       });
+
+  confirmAction = (confirmationName, onConfirm, context = {}) => {
+    const { confirmations = undefined } = this.props;
+    const confirmation =
+      confirmations !== undefined ? confirmations[confirmationName] : null;
+
+    if (typeof confirmation !== 'function') {
+      onConfirm();
+      return;
+    }
+
+    confirmation({
+      ...context,
+      onConfirm,
+    });
+  };
+
+  getBulkActionConfirmation = (actionName) => {
+    const { confirmations = undefined } = this.props;
+
+    if (confirmations === undefined) {
+      return null;
+    }
+
+    if (actionName === 'trash') {
+      return confirmations.bulkTrash || null;
+    }
+
+    if (actionName === 'delete') {
+      return confirmations.bulkDelete || null;
+    }
+
+    return null;
+  };
+
+  addBulkActionConfirmation = (action) => {
+    const confirmation = this.getBulkActionConfirmation(action.name);
+
+    if (typeof confirmation !== 'function') {
+      return action;
+    }
+
+    return {
+      ...action,
+      confirm: confirmation,
+    };
+  };
 
   handleBulkAction = (selectedIds, params) => {
     if (
@@ -618,18 +675,20 @@ class ListingComponent extends Component {
 
     // bulk actions
     let bulkActions = this.props.bulk_actions || [];
-    bulkActions = bulkActions.filter(
-      (action) =>
-        action.display === undefined ||
-        action.display({
-          group: this.state.group,
-          filter: this.state.filter,
-          search: this.state.search,
-          count: this.state.count,
-          selection: this.state.selection,
-          selected_ids: this.state.selected_ids,
-        }),
-    );
+    bulkActions = bulkActions
+      .filter(
+        (action) =>
+          action.display === undefined ||
+          action.display({
+            group: this.state.group,
+            filter: this.state.filter,
+            search: this.state.search,
+            count: this.state.count,
+            selection: this.state.selection,
+            selected_ids: this.state.selected_ids,
+          }),
+      )
+      .map(this.addBulkActionConfirmation);
 
     if (this.state.group === 'trash' && bulkActions.length > 0) {
       bulkActions = [
@@ -643,7 +702,7 @@ class ListingComponent extends Component {
           label: __('Delete permanently', 'mailpoet'),
           onSuccess: this.props.messages.onDelete,
         },
-      ];
+      ].map(this.addBulkActionConfirmation);
     }
 
     // item actions
@@ -809,6 +868,13 @@ ListingComponent.propTypes = {
     onRestore: PropTypes.func,
     onTrash: PropTypes.func,
     onDelete: PropTypes.func,
+  }),
+  confirmations: PropTypes.shape({
+    trashItem: PropTypes.func,
+    deleteItem: PropTypes.func,
+    emptyTrash: PropTypes.func,
+    bulkTrash: PropTypes.func,
+    bulkDelete: PropTypes.func,
   }),
   onRenderItem: PropTypes.func.isRequired,
   isItemInactive: PropTypes.func,

--- a/mailpoet/assets/js/src/newsletters/listings/notification-history.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification-history.jsx
@@ -11,6 +11,7 @@ import {
   addStatsCTAAction,
   checkCronStatus,
   checkMailerStatus,
+  newsletterActionConfirmations,
 } from 'newsletters/listings/utils.jsx';
 import { FilterSegmentTag, SegmentTags } from 'common/tag/tags';
 import { withBoundary } from '../../common';
@@ -211,6 +212,7 @@ function NewsletterListNotificationHistoryComponent(props) {
         messages={messages}
         item_actions={newsletterActions}
         bulk_actions={bulkActions}
+        confirmations={newsletterActionConfirmations}
         auto_refresh
         sort_by="sent_at"
         sort_order="desc"

--- a/mailpoet/assets/js/src/newsletters/listings/notification.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/notification.jsx
@@ -30,6 +30,7 @@ import {
   checkCronStatus,
   checkMailerStatus,
   confirmEdit,
+  newsletterActionConfirmations,
 } from 'newsletters/listings/utils.jsx';
 import { withBoundary } from '../../common';
 
@@ -420,6 +421,7 @@ class NewsletterListNotificationComponent extends Component {
             columns={columns}
             bulk_actions={bulkActions}
             item_actions={newsletterActions}
+            confirmations={newsletterActionConfirmations}
             messages={messages}
             auto_refresh
             sort_by="updated_at"

--- a/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/re-engagement.jsx
@@ -17,6 +17,7 @@ import {
   checkCronStatus,
   checkMailerStatus,
   confirmEdit,
+  newsletterActionConfirmations,
 } from 'newsletters/listings/utils.jsx';
 import { NewsletterTypes } from 'newsletters/types';
 import { withBoundary } from 'common';
@@ -388,6 +389,7 @@ class NewsletterListReEngagementComponent extends Component {
             columns={columns}
             bulk_actions={bulkActions}
             item_actions={newsletterActions}
+            confirmations={newsletterActionConfirmations}
             messages={messages}
             auto_refresh
             sort_by="updated_at"

--- a/mailpoet/assets/js/src/newsletters/listings/standard.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/standard.jsx
@@ -15,6 +15,7 @@ import {
   addStatsCTAAction,
   checkCronStatus,
   checkMailerStatus,
+  newsletterActionConfirmations,
 } from 'newsletters/listings/utils.jsx';
 import { pollExportStatus } from 'newsletters/statistics-export/poll-export-status';
 import { NewsletterTypes } from 'newsletters/types';
@@ -419,6 +420,7 @@ class NewsletterListStandardComponent extends Component {
             columns={columns}
             bulk_actions={bulkActions}
             item_actions={this.getNewsletterActions()}
+            confirmations={newsletterActionConfirmations}
             messages={messages}
             auto_refresh
             sort_by="sent_at"

--- a/mailpoet/assets/js/src/newsletters/listings/utils.jsx
+++ b/mailpoet/assets/js/src/newsletters/listings/utils.jsx
@@ -121,3 +121,57 @@ export const confirmEdit = (newsletter) => {
     window.location.href = editorHref;
   }
 };
+
+const isSelectingAllMatchingEmails = ({ selection, selectedIds }) =>
+  selection === 'all' || selectedIds === 'all';
+
+export const newsletterActionConfirmations = {
+  trashItem: ({ onConfirm }) =>
+    confirmAlert({
+      message: __('Move this email to trash?', 'mailpoet'),
+      confirmLabel: __('Move to trash', 'mailpoet'),
+      onConfirm,
+    }),
+  deleteItem: ({ onConfirm }) =>
+    confirmAlert({
+      message: __(
+        'Delete this email permanently? This action cannot be undone.',
+        'mailpoet',
+      ),
+      confirmLabel: __('Delete permanently', 'mailpoet'),
+      onConfirm,
+    }),
+  emptyTrash: ({ onConfirm }) =>
+    confirmAlert({
+      message: __(
+        'Delete all emails in trash permanently? This action cannot be undone.',
+        'mailpoet',
+      ),
+      confirmLabel: __('Empty Trash', 'mailpoet'),
+      onConfirm,
+    }),
+  bulkTrash: ({ selection, selectedIds, onCancel, onConfirm }) =>
+    confirmAlert({
+      message: isSelectingAllMatchingEmails({ selection, selectedIds })
+        ? __('Move all matching emails to trash?', 'mailpoet')
+        : __('Move selected emails to trash?', 'mailpoet'),
+      confirmLabel: __('Move to trash', 'mailpoet'),
+      onCancel,
+      onConfirm,
+    }),
+  bulkDelete: ({ selection, selectedIds, onCancel, onConfirm }) =>
+    confirmAlert({
+      message: isSelectingAllMatchingEmails({ selection, selectedIds })
+        ? __(
+            'Delete all matching emails permanently? This action cannot be undone.',
+            'mailpoet',
+          )
+        : __(
+            'Delete selected emails permanently? This action cannot be undone.',
+            'mailpoet',
+          ),
+      confirmLabel: __('Delete permanently', 'mailpoet'),
+      onCancel,
+      onConfirm,
+    }),
+};

--- a/mailpoet/changelog/2026-05-06-20-41-36-fixed-confirmation-prompts-for-destructive-email-delete-.md
+++ b/mailpoet/changelog/2026-05-06-20-41-36-fixed-confirmation-prompts-for-destructive-email-delete-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Confirmation prompts for destructive email delete actions

--- a/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
+++ b/mailpoet/tests/acceptance/Newsletters/DeleteNewsletterCest.php
@@ -16,12 +16,14 @@ class DeleteNewsletterCest {
     $i->amOnMailpoetPage('Emails');
     $i->waitForText($newsletterName);
     $i->clickItemRowActionByItemName($newsletterName, 'Move to trash');
+    $this->confirmNewsletterAction($i, 'Move this email to trash?');
     $i->waitForNoticeAndClose('1 email was moved to the trash.');
     $i->waitForListingItemsToLoad();
     $i->selectAllListingItems();
     $i->waitForText('Move to trash', 10, '.mailpoet-listing-bulk-actions');
     $i->waitForElementClickable('[data-automation-id="action-trash"]');
     $i->click('[data-automation-id="action-trash"]');
+    $this->confirmNewsletterAction($i, 'Move selected emails to trash?');
     $i->waitForNoticeAndClose('2 emails were moved to the trash.', 20);
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
@@ -46,7 +48,8 @@ class DeleteNewsletterCest {
     $i->waitForElementClickable('[data-automation-id="action-restore"]');
     $i->click('[data-automation-id="action-restore"]');
     $i->waitForText('2 emails have been restored from the Trash.', 20);
-    $i->changeGroupInListingFilter('all');
+    $i->waitForListingItemsToLoad();
+    $i->waitForElement('[data-automation-id="filters_all"]');
     $i->waitForText($newsletterName);
   }
 
@@ -64,12 +67,14 @@ class DeleteNewsletterCest {
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
     $i->clickItemRowActionByItemName($newsletterName, 'Delete permanently');
+    $this->confirmNewsletterAction($i, 'Delete this email permanently? This action cannot be undone.');
     $i->waitForText('1 email was permanently deleted.');
     $i->waitForElementNotVisible($newsletterName);
     $i->waitForText($newsletterName . '2');
     $i->waitForText($newsletterName . '3');
     $i->selectAllListingItems();
     $i->click('Delete permanently');
+    $this->confirmNewsletterAction($i, 'Delete selected emails permanently? This action cannot be undone.');
     $i->waitForText('2 emails were permanently deleted.');
     $i->waitForElement('[data-automation-id="filters_all"]');
     $i->waitForText($newsletterName . '4');
@@ -88,9 +93,11 @@ class DeleteNewsletterCest {
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
     $i->click('[data-automation-id="empty_trash"]');
+    $this->confirmNewsletterAction($i, 'Delete all emails in trash permanently? This action cannot be undone.');
     $i->waitForText('2 emails were permanently deleted.');
     $i->waitForElementNotVisible($newsletterName);
-    $i->changeGroupInListingFilter('all');
+    $i->waitForListingItemsToLoad();
+    $i->waitForElement('[data-automation-id="filters_all"]');
     $i->waitForText($newsletterName . '3');
   }
 
@@ -110,7 +117,9 @@ class DeleteNewsletterCest {
     $i->waitForText('All 22 items are selected.');
     $i->waitForElementVisible('[data-automation-id="action-trash"]');
     $i->click('[data-automation-id="action-trash"]');
-    $i->waitForText('22 emails were moved to the trash.');
+    $this->confirmNewsletterAction($i, 'Move all matching emails to trash?');
+    $i->waitForNoticeAndClose('22 emails were moved to the trash.');
+    $i->waitForListingItemsToLoad();
     $i->changeGroupInListingFilter('trash');
     $i->waitForText($newsletterName);
     $i->selectAllListingItems();
@@ -118,6 +127,13 @@ class DeleteNewsletterCest {
     $i->click('Select all items on all pages');
     $i->waitForText('All 22 items are selected.');
     $i->click('Delete permanently');
+    $this->confirmNewsletterAction($i, 'Delete all matching emails permanently? This action cannot be undone.');
     $i->waitForText('22 emails were permanently deleted.');
+  }
+
+  private function confirmNewsletterAction(\AcceptanceTester $i, string $message): void {
+    $i->waitForText($message, 10);
+    $i->waitForElement('#mailpoet_alert_confirm');
+    $i->executeJS("document.querySelector('#mailpoet_alert_confirm').click();");
   }
 }


### PR DESCRIPTION
## Description

Newsletter trash/delete actions now ask for confirmation for single-item actions, selected bulk actions, all-matching bulk actions, and Empty Trash.

## Code review notes

Confirmation support is wired through the shared Listing component, but only newsletter listing screens pass confirmation callbacks in this branch.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8042

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8042-confirm-destructive-newsletter-delete-actions)

_The latest successful build from `fix/stomail-8042-confirm-destructive-newsletter-delete-actions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6732)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->