### PR TITLE
Add automation lifecycle hooks

### DIFF
--- a/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/CreateAutomationFromTemplateController.php
@@ -5,6 +5,7 @@ namespace MailPoet\Automation\Engine\Builder;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\Validation\AutomationValidator;
@@ -19,14 +20,19 @@ class CreateAutomationFromTemplateController {
   /** @var Registry */
   private $registry;
 
+  /** @var Hooks */
+  private $hooks;
+
   public function __construct(
     AutomationStorage $storage,
     AutomationValidator $automationValidator,
-    Registry $registry
+    Registry $registry,
+    Hooks $hooks
   ) {
     $this->storage = $storage;
     $this->automationValidator = $automationValidator;
     $this->registry = $registry;
+    $this->hooks = $hooks;
   }
 
   public function createAutomation(string $slug): Automation {
@@ -42,6 +48,7 @@ class CreateAutomationFromTemplateController {
     if (!$savedAutomation) {
       throw new InvalidStateException('Automation not found.');
     }
+    $this->hooks->doAutomationAfterCreateFromTemplate($savedAutomation, $slug);
     return $savedAutomation;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Builder/DeleteAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DeleteAutomationController.php
@@ -4,16 +4,22 @@ namespace MailPoet\Automation\Engine\Builder;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 
 class DeleteAutomationController {
   /** @var AutomationStorage */
   private $automationStorage;
 
+  /** @var Hooks */
+  private $hooks;
+
   public function __construct(
-    AutomationStorage $automationStorage
+    AutomationStorage $automationStorage,
+    Hooks $hooks
   ) {
     $this->automationStorage = $automationStorage;
+    $this->hooks = $hooks;
   }
 
   public function deleteAutomation(int $id): Automation {
@@ -27,6 +33,7 @@ class DeleteAutomationController {
     }
 
     $this->automationStorage->deleteAutomation($automation);
+    $this->hooks->doAutomationAfterDelete($automation);
     return $automation;
   }
 }

--- a/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/DuplicateAutomationController.php
@@ -7,6 +7,7 @@ use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\InvalidStateException;
+use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\WordPress;
@@ -22,14 +23,19 @@ class DuplicateAutomationController {
   /** @var Registry */
   private $registry;
 
+  /** @var Hooks */
+  private $hooks;
+
   public function __construct(
     WordPress $wordPress,
     AutomationStorage $automationStorage,
-    Registry $registry
+    Registry $registry,
+    Hooks $hooks
   ) {
     $this->wordPress = $wordPress;
     $this->automationStorage = $automationStorage;
     $this->registry = $registry;
+    $this->hooks = $hooks;
   }
 
   public function duplicateAutomation(int $id): Automation {
@@ -64,6 +70,7 @@ class DuplicateAutomationController {
     if (!$savedAutomation) {
       throw new InvalidStateException('Automation not found.');
     }
+    $this->hooks->doAutomationAfterDuplicate($savedAutomation, $automation);
     return $savedAutomation;
   }
 

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -58,6 +58,7 @@ class UpdateAutomationController {
     if (!$automation) {
       throw Exceptions::automationNotFound($id);
     }
+    $previousAutomation = clone $automation;
     $this->validateIfAutomationCanBeUpdated($automation, $data);
 
     if (array_key_exists('name', $data)) {
@@ -99,6 +100,7 @@ class UpdateAutomationController {
     if (!$automation) {
       throw Exceptions::automationNotFound($id);
     }
+    $this->hooks->doAutomationAfterUpdate($automation, $previousAutomation);
     return $automation;
   }
 

--- a/mailpoet/lib/Automation/Engine/Data/Automation.php
+++ b/mailpoet/lib/Automation/Engine/Data/Automation.php
@@ -48,6 +48,13 @@ class Automation {
   /** @var array<string, mixed> */
   private $meta = [];
 
+  public function __clone() {
+    $this->author = clone $this->author;
+    $this->steps = array_map(function(Step $step): Step {
+      return clone $step;
+    }, $this->steps);
+  }
+
   /** @param array<string, Step> $steps */
   public function __construct(
     string $name,

--- a/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
+++ b/mailpoet/lib/Automation/Engine/Data/FilterGroup.php
@@ -25,6 +25,12 @@ class FilterGroup {
     $this->filters = $filters;
   }
 
+  public function __clone() {
+    $this->filters = array_map(function(Filter $filter): Filter {
+      return clone $filter;
+    }, $this->filters);
+  }
+
   public function getId(): string {
     return $this->id;
   }

--- a/mailpoet/lib/Automation/Engine/Data/Filters.php
+++ b/mailpoet/lib/Automation/Engine/Data/Filters.php
@@ -20,6 +20,12 @@ class Filters {
     $this->groups = $groups;
   }
 
+  public function __clone() {
+    $this->groups = array_map(function(FilterGroup $group): FilterGroup {
+      return clone $group;
+    }, $this->groups);
+  }
+
   public function getOperator(): string {
     return $this->operator;
   }

--- a/mailpoet/lib/Automation/Engine/Data/Step.php
+++ b/mailpoet/lib/Automation/Engine/Data/Step.php
@@ -45,6 +45,15 @@ class Step {
     $this->filters = $filters;
   }
 
+  public function __clone() {
+    $this->nextSteps = array_map(function(NextStep $nextStep): NextStep {
+      return clone $nextStep;
+    }, $this->nextSteps);
+    if ($this->filters !== null) {
+      $this->filters = clone $this->filters;
+    }
+  }
+
   public function getId(): string {
     return $this->id;
   }

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -25,6 +25,12 @@ class Hooks {
 
   public const AUTOMATION_BEFORE_SAVE = 'mailpoet/automation/before_save';
   public const AUTOMATION_STEP_BEFORE_SAVE = 'mailpoet/automation/step/before_save';
+  public const AUTOMATION_AFTER_SAVE = 'mailpoet/automation/after_save';
+  public const AUTOMATION_AFTER_CREATE = 'mailpoet/automation/after_create';
+  public const AUTOMATION_AFTER_CREATE_FROM_TEMPLATE = 'mailpoet/automation/after_create_from_template';
+  public const AUTOMATION_AFTER_UPDATE = 'mailpoet/automation/after_update';
+  public const AUTOMATION_AFTER_DELETE = 'mailpoet/automation/after_delete';
+  public const AUTOMATION_AFTER_DUPLICATE = 'mailpoet/automation/after_duplicate';
 
   public const AUTOMATION_STEP_LOG_AFTER_RUN = 'mailpoet/automation/step/log_after_run';
 
@@ -32,6 +38,34 @@ class Hooks {
 
   public function doAutomationBeforeSave(Automation $automation): void {
     $this->wordPress->doAction(self::AUTOMATION_BEFORE_SAVE, $automation);
+  }
+
+  public function doAutomationAfterSave(Automation $automation, ?Automation $previousAutomation = null): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_SAVE, $automation, $previousAutomation);
+  }
+
+  public function doAutomationAfterCreate(Automation $automation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_CREATE, $automation);
+    $this->doAutomationAfterSave($automation);
+  }
+
+  public function doAutomationAfterCreateFromTemplate(Automation $automation, string $templateSlug): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE, $automation, $templateSlug);
+    $this->doAutomationAfterCreate($automation);
+  }
+
+  public function doAutomationAfterUpdate(Automation $automation, Automation $previousAutomation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_UPDATE, $automation, $previousAutomation);
+    $this->doAutomationAfterSave($automation, $previousAutomation);
+  }
+
+  public function doAutomationAfterDelete(Automation $automation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_DELETE, $automation);
+  }
+
+  public function doAutomationAfterDuplicate(Automation $automation, Automation $sourceAutomation): void {
+    $this->wordPress->doAction(self::AUTOMATION_AFTER_DUPLICATE, $automation, $sourceAutomation);
+    $this->doAutomationAfterCreate($automation);
   }
 
   public function doAutomationStepBeforeSave(Step $step, Automation $automation): void {

--- a/mailpoet/lib/Automation/Engine/Hooks.php
+++ b/mailpoet/lib/Automation/Engine/Hooks.php
@@ -44,16 +44,25 @@ class Hooks {
     $this->wordPress->doAction(self::AUTOMATION_AFTER_SAVE, $automation, $previousAutomation);
   }
 
+  /**
+   * Fires after a plain automation create and then cascades to after-save.
+   */
   public function doAutomationAfterCreate(Automation $automation): void {
     $this->wordPress->doAction(self::AUTOMATION_AFTER_CREATE, $automation);
     $this->doAutomationAfterSave($automation);
   }
 
+  /**
+   * Fires after creating from a template, then cascades to after-create and after-save.
+   */
   public function doAutomationAfterCreateFromTemplate(Automation $automation, string $templateSlug): void {
     $this->wordPress->doAction(self::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE, $automation, $templateSlug);
     $this->doAutomationAfterCreate($automation);
   }
 
+  /**
+   * Fires after updating an automation and then cascades to after-save with the previous persisted state.
+   */
   public function doAutomationAfterUpdate(Automation $automation, Automation $previousAutomation): void {
     $this->wordPress->doAction(self::AUTOMATION_AFTER_UPDATE, $automation, $previousAutomation);
     $this->doAutomationAfterSave($automation, $previousAutomation);
@@ -63,6 +72,9 @@ class Hooks {
     $this->wordPress->doAction(self::AUTOMATION_AFTER_DELETE, $automation);
   }
 
+  /**
+   * Fires after duplicating an automation, then cascades to after-create and after-save.
+   */
   public function doAutomationAfterDuplicate(Automation $automation, Automation $sourceAutomation): void {
     $this->wordPress->doAction(self::AUTOMATION_AFTER_DUPLICATE, $automation, $sourceAutomation);
     $this->doAutomationAfterCreate($automation);

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -149,6 +149,29 @@ class AutomationRunStorage {
     return $result ? (int)current($result) : 0;
   }
 
+  public function getCountByAutomationTriggerAndSubject(Automation $automation, string $triggerKey, Subject $subject): int {
+    global $wpdb;
+
+    $result = $wpdb->get_col(
+      $wpdb->prepare(
+        '
+          SELECT count(DISTINCT runs.id) AS count FROM %i AS runs
+          JOIN %i AS subjects ON runs.id = subjects.automation_run_id
+          WHERE runs.automation_id = %d
+          AND runs.trigger_key = %s
+          AND subjects.hash = %s
+        ',
+        $this->table,
+        $this->subjectTable,
+        $automation->getId(),
+        $triggerKey,
+        $subject->getHash()
+      )
+    );
+
+    return $result ? (int)current($result) : 0;
+  }
+
   public function getCountForAutomation(Automation $automation, string ...$status): int {
     global $wpdb;
 

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationRunStorage.php
@@ -138,11 +138,13 @@ class AutomationRunStorage {
           JOIN %i AS subjects ON runs.id = subjects.automation_run_id
           WHERE runs.automation_id = %d
           AND subjects.hash = %s
+          AND subjects.key = %s
         ',
         $this->table,
         $this->subjectTable,
         $automation->getId(),
-        $subject->getHash()
+        $subject->getHash(),
+        $subject->getKey()
       )
     );
 
@@ -160,12 +162,14 @@ class AutomationRunStorage {
           WHERE runs.automation_id = %d
           AND runs.trigger_key = %s
           AND subjects.hash = %s
+          AND subjects.key = %s
         ',
         $this->table,
         $this->subjectTable,
         $automation->getId(),
         $triggerKey,
-        $subject->getHash()
+        $subject->getHash(),
+        $subject->getKey()
       )
     );
 

--- a/mailpoet/lib/Automation/Engine/WordPress.php
+++ b/mailpoet/lib/Automation/Engine/WordPress.php
@@ -62,6 +62,10 @@ class WordPress {
     return register_rest_route($namespace, $route, $args, $override);
   }
 
+  public function adminUrl(string $path = '', string $scheme = 'admin'): string {
+    return admin_url($path, $scheme);
+  }
+
   public function getWpLocale(): WP_Locale {
     global $wp_locale;
     return $wp_locale;
@@ -133,6 +137,36 @@ class WordPress {
   }
 
   /**
+   * @param mixed $value
+   */
+  public function setTransient(string $transient, $value, int $expiration = 0): bool {
+    return set_transient($transient, $value, $expiration);
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getTransient(string $transient) {
+    return get_transient($transient);
+  }
+
+  public function deleteTransient(string $transient): bool {
+    return delete_transient($transient);
+  }
+
+  /**
+   * @param mixed $data
+   */
+  public function wpCacheAdd(string $key, $data, string $group = '', int $expire = 0): bool {
+    // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined -- Thin wrapper passes the caller-provided TTL.
+    return wp_cache_add($key, $data, $group, $expire);
+  }
+
+  public function wpCacheDelete(string $key, string $group = ''): bool {
+    return wp_cache_delete($key, $group);
+  }
+
+  /**
    * @param int|\WP_Post $post
    * @param bool $leavename
    * @return string|false
@@ -146,6 +180,14 @@ class WordPress {
    */
   public function getCommentStatuses(): array {
     return get_comment_statuses();
+  }
+
+  public function getEditableRoles(): array {
+    return get_editable_roles();
+  }
+
+  public function isRole(string $role): bool {
+    return wp_roles()->is_role($role);
   }
 
   public function getPostStatuses(): array {

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/CustomerSubjectToSubscriberSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/CustomerSubjectToSubscriberSubjectTransformer.php
@@ -20,14 +20,14 @@ class CustomerSubjectToSubscriberSubjectTransformer implements SubjectTransforme
     $this->subscribersRepository = $subscribersRepository;
   }
 
-  public function transform(Subject $data): Subject {
+  public function transform(Subject $data): ?Subject {
     if ($this->accepts() !== $data->getKey()) {
       throw new \InvalidArgumentException('Invalid subject type');
     }
 
-      $subscriber = $this->findOrCreateSubscriber($data);
+    $subscriber = $this->findOrCreateSubscriber($data);
     if (!$subscriber instanceof SubscriberEntity) {
-      throw new \InvalidArgumentException('Subscriber not found');
+      return null;
     }
 
     return new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]);

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformer.php
@@ -32,14 +32,14 @@ class OrderSubjectToSubscriberSubjectTransformer implements SubjectTransformer {
     $this->woocommerceHelper = $woocommerceHelper;
   }
 
-  public function transform(Subject $data): Subject {
+  public function transform(Subject $data): ?Subject {
     if ($this->accepts() !== $data->getKey()) {
       throw new \InvalidArgumentException('Invalid subject type');
     }
 
-      $subscriber = $this->findOrCreateSubscriber($data);
+    $subscriber = $this->findOrCreateSubscriber($data);
     if (!$subscriber instanceof SubscriberEntity) {
-      throw new \InvalidArgumentException('Subscriber not found');
+      return null;
     }
 
     return new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]);
@@ -78,8 +78,15 @@ class OrderSubjectToSubscriberSubjectTransformer implements SubjectTransformer {
       return null;
     }
     $billingEmail = $wcOrder->get_billing_email();
-    return $billingEmail ?
-      $this->subscribersRepository->findOneBy(['email' => $billingEmail]) :
-      $this->subscribersRepository->findOneBy(['wpUserId' => $wcOrder->get_user_id()]);
+    if ($billingEmail) {
+      return $this->subscribersRepository->findOneBy(['email' => $billingEmail]);
+    }
+
+    $userId = $wcOrder->get_user_id();
+    if (!$userId) {
+      return null;
+    }
+
+    return $this->subscribersRepository->findOneBy(['wpUserId' => $userId]);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectToWordPressUserSubjectTransformer.php
@@ -26,14 +26,17 @@ class SubscriberSubjectToWordPressUserSubjectTransformer implements SubjectTrans
     return UserSubject::KEY;
   }
 
-  public function transform(Subject $data): Subject {
+  public function transform(Subject $data): ?Subject {
     if ($this->accepts() !== $data->getKey()) {
       throw new \InvalidArgumentException('Invalid subject type');
     }
 
     $subscriber = $this->subscribersRepository->findOneById((int)$data->getArgs()['subscriber_id']);
     if (!$subscriber) {
-      throw new \InvalidArgumentException('Subscriber not found');
+      return null;
+    }
+    if (!$subscriber->getWpUserId()) {
+      return null;
     }
     return new Subject(UserSubject::KEY, ['user_id' => $subscriber->getWpUserId()]);
   }

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/ContextFactory.php
@@ -22,6 +22,7 @@ class ContextFactory {
 
     $context = [
       'order_statuses' => $this->woocommerce->wcGetOrderStatuses(),
+      'paid_statuses' => $this->woocommerce->wcGetIsPaidStatuses(),
       'review_ratings_enabled' => $this->woocommerce->wcReviewRatingsEnabled(),
     ];
     return $context;

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/CustomerSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/CustomerSubjectToWordPressUserSubjectTransformer.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Integration\SubjectTransformer;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+
+class CustomerSubjectToWordPressUserSubjectTransformer implements SubjectTransformer {
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WordPress $wordPress
+  ) {
+    $this->wordPress = $wordPress;
+  }
+
+  public function accepts(): string {
+    return CustomerSubject::KEY;
+  }
+
+  public function returns(): string {
+    return UserSubject::KEY;
+  }
+
+  public function transform(Subject $data): ?Subject {
+    if ($this->accepts() !== $data->getKey()) {
+      throw new \InvalidArgumentException('Invalid subject type');
+    }
+
+    $customerId = (int)($data->getArgs()['customer_id'] ?? 0);
+    if ($customerId <= 0) {
+      return null;
+    }
+
+    $user = $this->wordPress->getUserBy('id', $customerId);
+    if (!$user instanceof \WP_User || !$user->exists()) {
+      return null;
+    }
+
+    return new Subject(UserSubject::KEY, ['user_id' => $customerId]);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/OrderSubjectToWordPressUserSubjectTransformer.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/SubjectTransformers/OrderSubjectToWordPressUserSubjectTransformer.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Engine\Integration\SubjectTransformer;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WooCommerce\WooCommerce;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+
+class OrderSubjectToWordPressUserSubjectTransformer implements SubjectTransformer {
+  /** @var WooCommerce */
+  private $wooCommerce;
+
+  /** @var WordPress */
+  private $wordPress;
+
+  public function __construct(
+    WooCommerce $wooCommerce,
+    WordPress $wordPress
+  ) {
+    $this->wooCommerce = $wooCommerce;
+    $this->wordPress = $wordPress;
+  }
+
+  public function accepts(): string {
+    return OrderSubject::KEY;
+  }
+
+  public function returns(): string {
+    return UserSubject::KEY;
+  }
+
+  public function transform(Subject $data): ?Subject {
+    if ($this->accepts() !== $data->getKey()) {
+      throw new \InvalidArgumentException('Invalid subject type');
+    }
+
+    $orderId = (int)($data->getArgs()['order_id'] ?? 0);
+    if ($orderId <= 0) {
+      return null;
+    }
+
+    $order = $this->wooCommerce->wcGetOrder($orderId);
+    if (!$order instanceof \WC_Order) {
+      return null;
+    }
+
+    $userId = $order->get_user_id();
+    if ($userId <= 0) {
+      return null;
+    }
+
+    $user = $this->wordPress->getUserBy('id', $userId);
+    if (!$user instanceof \WP_User || !$user->exists()) {
+      return null;
+    }
+
+    return new Subject(UserSubject::KEY, ['user_id' => $userId]);
+  }
+}

--- a/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerceIntegration.php
+++ b/mailpoet/lib/Automation/Integrations/WooCommerce/WooCommerceIntegration.php
@@ -7,6 +7,8 @@ use MailPoet\Automation\Integrations\WooCommerce\Subjects\AbandonedCartSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderStatusChangeSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\CustomerSubjectToWordPressUserSubjectTransformer;
+use MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\OrderSubjectToWordPressUserSubjectTransformer;
 use MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\WordPressUserSubjectToWooCommerceCustomerSubjectTransformer;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\AbandonedCart\AbandonedCartTrigger;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\BuysAProductTrigger;
@@ -64,6 +66,12 @@ class WooCommerceIntegration {
   /** @var WordPressUserSubjectToWooCommerceCustomerSubjectTransformer */
   private $wordPressUserToWooCommerceCustomerTransformer;
 
+  /** @var CustomerSubjectToWordPressUserSubjectTransformer */
+  private $woocommerceCustomerToWordPressUserTransformer;
+
+  /** @var OrderSubjectToWordPressUserSubjectTransformer */
+  private $woocommerceOrderToWordPressUserTransformer;
+
   /** @var WooCommerce */
   private $wooCommerce;
 
@@ -83,6 +91,8 @@ class WooCommerceIntegration {
     CustomerSubject $customerSubject,
     ContextFactory $contextFactory,
     WordPressUserSubjectToWooCommerceCustomerSubjectTransformer $wordPressUserToWooCommerceCustomerTransformer,
+    CustomerSubjectToWordPressUserSubjectTransformer $woocommerceCustomerToWordPressUserTransformer,
+    OrderSubjectToWordPressUserSubjectTransformer $woocommerceOrderToWordPressUserTransformer,
     WooCommerce $wooCommerce
   ) {
     $this->orderStatusChangedTrigger = $orderStatusChangedTrigger;
@@ -100,6 +110,8 @@ class WooCommerceIntegration {
     $this->customerSubject = $customerSubject;
     $this->contextFactory = $contextFactory;
     $this->wordPressUserToWooCommerceCustomerTransformer = $wordPressUserToWooCommerceCustomerTransformer;
+    $this->woocommerceCustomerToWordPressUserTransformer = $woocommerceCustomerToWordPressUserTransformer;
+    $this->woocommerceOrderToWordPressUserTransformer = $woocommerceOrderToWordPressUserTransformer;
     $this->wooCommerce = $wooCommerce;
   }
 
@@ -126,5 +138,7 @@ class WooCommerceIntegration {
     $registry->addTrigger($this->buysFromACategoryTrigger);
     $registry->addTrigger($this->buysFromATagTrigger);
     $registry->addSubjectTransformer($this->wordPressUserToWooCommerceCustomerTransformer);
+    $registry->addSubjectTransformer($this->woocommerceCustomerToWordPressUserTransformer);
+    $registry->addSubjectTransformer($this->woocommerceOrderToWordPressUserTransformer);
   }
 }

--- a/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
@@ -6,16 +6,34 @@ use MailPoet\Automation\Engine\WordPress;
 
 class ContextFactory {
   private const ELEVATED_CAPABILITIES = [
+    'activate_plugins',
     'create_users',
+    'delete_plugins',
+    'delete_themes',
     'delete_users',
     'edit_files',
+    'edit_plugins',
+    'edit_themes',
     'edit_users',
     'install_plugins',
+    'install_themes',
+    'manage_network',
+    'manage_network_options',
+    'manage_network_plugins',
+    'manage_network_themes',
+    'manage_network_users',
     'manage_options',
+    'manage_sites',
     'manage_woocommerce',
     'mailpoet_manage_settings',
     'promote_users',
+    'remove_users',
+    'switch_themes',
     'unfiltered_html',
+    'update_core',
+    'update_plugins',
+    'update_themes',
+    'upgrade_network',
   ];
 
   /** @var WordPress  */
@@ -58,22 +76,24 @@ class ContextFactory {
   private function getEditableRoles(): array {
     $roles = [];
     foreach ($this->wp->getEditableRoles() as $id => $role) {
-      if ($this->isElevatedRole($role)) {
+      $roleId = (string)$id;
+      if ($this->isElevatedRole($roleId, $role)) {
         continue;
       }
       $roles[] = [
-        'id' => $id,
-        'name' => (string)($role['name'] ?? $id),
+        'id' => $roleId,
+        'name' => (string)($role['name'] ?? $roleId),
       ];
     }
     return $roles;
   }
 
   /**
+   * @param string $id
    * @param array{name?: string, capabilities?: array<string, bool>} $role
    */
-  private function isElevatedRole(array $role): bool {
-    if (!empty($role['capabilities']['administrator'])) {
+  private function isElevatedRole(string $id, array $role): bool {
+    if ($id === 'administrator') {
       return true;
     }
     $capabilities = $role['capabilities'] ?? [];

--- a/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
+++ b/mailpoet/lib/Automation/Integrations/WordPress/ContextFactory.php
@@ -5,6 +5,18 @@ namespace MailPoet\Automation\Integrations\WordPress;
 use MailPoet\Automation\Engine\WordPress;
 
 class ContextFactory {
+  private const ELEVATED_CAPABILITIES = [
+    'create_users',
+    'delete_users',
+    'edit_files',
+    'edit_users',
+    'install_plugins',
+    'manage_options',
+    'manage_woocommerce',
+    'mailpoet_manage_settings',
+    'promote_users',
+    'unfiltered_html',
+  ];
 
   /** @var WordPress  */
   private $wp;
@@ -19,6 +31,7 @@ class ContextFactory {
   public function getContextData(): array {
     return [
       'comment_statuses' => $this->getCommentStatuses(),
+      'editable_roles' => $this->getEditableRoles(),
       'post_types' => $this->getPostTypes(),
       'taxonomies' => $this->getTaxonomies(),
     ];
@@ -37,6 +50,39 @@ class ContextFactory {
       ];
     }
     return $stati;
+  }
+
+  /**
+   * @return string[][]
+   */
+  private function getEditableRoles(): array {
+    $roles = [];
+    foreach ($this->wp->getEditableRoles() as $id => $role) {
+      if ($this->isElevatedRole($role)) {
+        continue;
+      }
+      $roles[] = [
+        'id' => $id,
+        'name' => (string)($role['name'] ?? $id),
+      ];
+    }
+    return $roles;
+  }
+
+  /**
+   * @param array{name?: string, capabilities?: array<string, bool>} $role
+   */
+  private function isElevatedRole(array $role): bool {
+    if (!empty($role['capabilities']['administrator'])) {
+      return true;
+    }
+    $capabilities = $role['capabilities'] ?? [];
+    foreach (self::ELEVATED_CAPABILITIES as $capability) {
+      if (!empty($capabilities[$capability])) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -218,6 +218,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\WooCommerce::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\ContextFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\WooCommerceIntegration::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\CustomerSubjectToWordPressUserSubjectTransformer::class)->setPublic(true)->setShared(false);
+    $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\SubjectTransformers\OrderSubjectToWordPressUserSubjectTransformer::class)->setPublic(true)->setShared(false);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerOrderFieldsFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Integrations\WooCommerce\Fields\CustomerReviewFieldsFactory::class)->setPublic(true);

--- a/mailpoet/tests/integration/Automation/Engine/Builder/AutomationLifecycleHooksTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/AutomationLifecycleHooksTest.php
@@ -1,0 +1,283 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Builder;
+
+use MailPoet\Automation\Engine\Builder\CreateAutomationFromTemplateController;
+use MailPoet\Automation\Engine\Builder\DeleteAutomationController;
+use MailPoet\Automation\Engine\Builder\DuplicateAutomationController;
+use MailPoet\Automation\Engine\Builder\UpdateAutomationController;
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\AutomationTemplate;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Hooks;
+use MailPoet\Automation\Engine\Registry;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
+
+class AutomationLifecycleHooksTest extends \MailPoetTest {
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var array{automation_id: int, status: string, previous_status: string|null}|null */
+  private $saveEvent = null;
+
+  /** @var array{automation_id: int, status: string, previous_status: string, action_args?: array|null, previous_action_args?: array|null}|null */
+  private $updateEvent = null;
+
+  /** @var array{automation_id: int, status: string}|null */
+  private $deleteEvent = null;
+
+  /** @var array{automation_id: int, source_automation_id: int, status: string}|null */
+  private $duplicateEvent = null;
+
+  /** @var array{automation_id: int, template_slug: string, status: string}|null */
+  private $templateEvent = null;
+
+  /** @var array{automation_id: int, status: string}|null */
+  private $createEvent = null;
+
+  /** @var array<string, callable> */
+  private $hookCallbacks = [];
+
+  public function _before(): void {
+    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $this->automationStorage->truncate();
+    $this->saveEvent = null;
+    $this->updateEvent = null;
+    $this->deleteEvent = null;
+    $this->duplicateEvent = null;
+    $this->templateEvent = null;
+    $this->createEvent = null;
+    $this->hookCallbacks = [];
+    $this->registerHooks();
+  }
+
+  public function _after(): void {
+    $wp = $this->diContainer->get(\MailPoet\Automation\Engine\WordPress::class);
+    foreach ($this->hookCallbacks as $hook => $callback) {
+      $wp->removeAction($hook, $callback);
+    }
+    $this->automationStorage->truncate();
+  }
+
+  public function testItFiresUpdateHooksWithPreviousAutomationState(): void {
+    $automation = (new AutomationFactory())
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withStatusActive()
+      ->create();
+
+    $updated = $this->diContainer->get(UpdateAutomationController::class)->updateAutomation($automation->getId(), [
+      'status' => Automation::STATUS_DRAFT,
+    ]);
+
+    $updateEvent = $this->getUpdateEvent();
+    $saveEvent = $this->getSaveEvent();
+    $this->assertSame($updated->getId(), $updateEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_DRAFT, $updateEvent['status']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updateEvent['previous_status']);
+    $this->assertSame($updated->getId(), $saveEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $saveEvent['previous_status']);
+  }
+
+  public function testItFiresUpdateHooksWithPreviousStepConfig(): void {
+    $steps = [
+      'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      'trigger' => new Step('trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('action')]),
+      'action' => new Step('action', Step::TYPE_ACTION, 'core:delay', [
+        'delay' => 1,
+        'delay_type' => 'MINUTES',
+      ], []),
+    ];
+    $automation = (new AutomationFactory())
+      ->withSteps($steps)
+      ->withStatusActive()
+      ->create();
+
+    $updatedSteps = array_map(function(Step $step): array {
+      return $step->toArray();
+    }, $automation->getSteps());
+    $updatedSteps['action']['args']['delay'] = 2;
+
+    $this->diContainer->get(UpdateAutomationController::class)->updateAutomation($automation->getId(), [
+      'steps' => $updatedSteps,
+    ]);
+
+    $updateEvent = $this->getUpdateEvent();
+    $previousActionArgs = $updateEvent['previous_action_args'] ?? null;
+    $actionArgs = $updateEvent['action_args'] ?? null;
+    $this->assertIsArray($previousActionArgs);
+    $this->assertIsArray($actionArgs);
+    $this->assertSame(1, $previousActionArgs['delay']);
+    $this->assertSame(2, $actionArgs['delay']);
+  }
+
+  public function testItFiresDuplicateHooksWithSourceAutomation(): void {
+    $source = (new AutomationFactory())
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->create();
+
+    $duplicate = $this->diContainer->get(DuplicateAutomationController::class)->duplicateAutomation($source->getId());
+
+    $duplicateEvent = $this->getDuplicateEvent();
+    $createEvent = $this->getCreateEvent();
+    $this->assertSame($duplicate->getId(), $duplicateEvent['automation_id']);
+    $this->assertSame($source->getId(), $duplicateEvent['source_automation_id']);
+    $this->assertSame(Automation::STATUS_DRAFT, $createEvent['status']);
+  }
+
+  public function testItFiresDeleteHooksWithDeletedAutomationState(): void {
+    $automation = (new AutomationFactory())
+      ->withSomeoneSubscribesTrigger()
+      ->withDelayAction()
+      ->withStatus(Automation::STATUS_TRASH)
+      ->create();
+
+    $deleted = $this->diContainer->get(DeleteAutomationController::class)->deleteAutomation($automation->getId());
+
+    $deleteEvent = $this->getDeleteEvent();
+    $this->assertSame($deleted->getId(), $deleteEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_TRASH, $deleteEvent['status']);
+  }
+
+  public function testItFiresCreateFromTemplateHooksWithActiveAutomationState(): void {
+    $templateSlug = 'lifecycle-hook-template';
+    $this->diContainer->get(Registry::class)->addTemplate(new AutomationTemplate(
+      $templateSlug,
+      'welcome',
+      'Lifecycle hook template',
+      'Lifecycle hook template',
+      function(): Automation {
+        return $this->createAutomationFromTemplateData();
+      }
+    ));
+
+    $automation = $this->diContainer->get(CreateAutomationFromTemplateController::class)->createAutomation($templateSlug);
+
+    $templateEvent = $this->getTemplateEvent();
+    $createEvent = $this->getCreateEvent();
+    $this->assertSame($automation->getId(), $templateEvent['automation_id']);
+    $this->assertSame($templateSlug, $templateEvent['template_slug']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $templateEvent['status']);
+    $this->assertSame($automation->getId(), $createEvent['automation_id']);
+    $this->assertSame(Automation::STATUS_ACTIVE, $createEvent['status']);
+  }
+
+  private function registerHooks(): void {
+    $wp = $this->diContainer->get(\MailPoet\Automation\Engine\WordPress::class);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_SAVE] = function(Automation $automation, ?Automation $previousAutomation = null): void {
+      $this->saveEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+        'previous_status' => $previousAutomation ? $previousAutomation->getStatus() : null,
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_SAVE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_SAVE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_UPDATE] = function(Automation $automation, Automation $previousAutomation): void {
+      $step = $automation->getStep('action');
+      $previousStep = $previousAutomation->getStep('action');
+      $this->updateEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+        'previous_status' => $previousAutomation->getStatus(),
+        'action_args' => $step ? $step->getArgs() : null,
+        'previous_action_args' => $previousStep ? $previousStep->getArgs() : null,
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_UPDATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_UPDATE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DELETE] = function(Automation $automation): void {
+      $this->deleteEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_DELETE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DELETE]);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DUPLICATE] = function(Automation $automation, Automation $sourceAutomation): void {
+      $this->duplicateEvent = [
+        'automation_id' => $automation->getId(),
+        'source_automation_id' => $sourceAutomation->getId(),
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_DUPLICATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_DUPLICATE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE] = function(Automation $automation, string $templateSlug): void {
+      $this->templateEvent = [
+        'automation_id' => $automation->getId(),
+        'template_slug' => $templateSlug,
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE_FROM_TEMPLATE], 10, 2);
+    $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE] = function(Automation $automation): void {
+      $this->createEvent = [
+        'automation_id' => $automation->getId(),
+        'status' => $automation->getStatus(),
+      ];
+    };
+    $wp->addAction(Hooks::AUTOMATION_AFTER_CREATE, $this->hookCallbacks[Hooks::AUTOMATION_AFTER_CREATE]);
+  }
+
+  /** @return array{automation_id: int, status: string, previous_status: string|null} */
+  private function getSaveEvent(): array {
+    if ($this->saveEvent === null) {
+      $this->fail('Save event was not fired.');
+    }
+    return $this->saveEvent;
+  }
+
+  /** @return array{automation_id: int, status: string, previous_status: string, action_args?: array|null, previous_action_args?: array|null} */
+  private function getUpdateEvent(): array {
+    if ($this->updateEvent === null) {
+      $this->fail('Update event was not fired.');
+    }
+    return $this->updateEvent;
+  }
+
+  /** @return array{automation_id: int, status: string} */
+  private function getDeleteEvent(): array {
+    if ($this->deleteEvent === null) {
+      $this->fail('Delete event was not fired.');
+    }
+    return $this->deleteEvent;
+  }
+
+  /** @return array{automation_id: int, source_automation_id: int, status: string} */
+  private function getDuplicateEvent(): array {
+    if ($this->duplicateEvent === null) {
+      $this->fail('Duplicate event was not fired.');
+    }
+    return $this->duplicateEvent;
+  }
+
+  /** @return array{automation_id: int, template_slug: string, status: string} */
+  private function getTemplateEvent(): array {
+    if ($this->templateEvent === null) {
+      $this->fail('Create from template event was not fired.');
+    }
+    return $this->templateEvent;
+  }
+
+  /** @return array{automation_id: int, status: string} */
+  private function getCreateEvent(): array {
+    if ($this->createEvent === null) {
+      $this->fail('Create event was not fired.');
+    }
+    return $this->createEvent;
+  }
+
+  private function createAutomationFromTemplateData(): Automation {
+    $steps = [
+      'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      'trigger' => new Step('trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('action')]),
+      'action' => new Step('action', Step::TYPE_ACTION, 'core:delay', [
+        'delay' => 1,
+        'delay_type' => 'MINUTES',
+      ], []),
+    ];
+    $automation = new Automation('Active template automation', $steps, new \WP_User(1));
+    $automation->setStatus(Automation::STATUS_ACTIVE);
+    return $automation;
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Data/AutomationCloneTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Data/AutomationCloneTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Engine\Data;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Data\Filter;
+use MailPoet\Automation\Engine\Data\FilterGroup;
+use MailPoet\Automation\Engine\Data\Filters;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
+
+class AutomationCloneTest extends \MailPoetTest {
+  public function testItDeepClonesStepsAndFilters(): void {
+    $filter = new Filter(
+      'filter',
+      'string',
+      'mailpoet:subscriber:email',
+      'contains',
+      ['value' => '@example.com']
+    );
+    $filters = new Filters(
+      Filters::OPERATOR_AND,
+      [new FilterGroup('group', FilterGroup::OPERATOR_AND, [$filter])]
+    );
+    $automation = new Automation('Clone test', [
+      'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('trigger')]),
+      'trigger' => new Step('trigger', Step::TYPE_TRIGGER, 'mailpoet:someone-subscribes', [], [new NextStep('action')]),
+      'action' => new Step('action', Step::TYPE_ACTION, 'core:if-else', [], [new NextStep(null), new NextStep(null)], $filters),
+    ], new \WP_User(1));
+
+    $clone = clone $automation;
+
+    $originalTrigger = $automation->getStep('trigger');
+    $originalAction = $automation->getStep('action');
+    $clonedAction = $clone->getStep('action');
+    $this->assertInstanceOf(Step::class, $originalTrigger);
+    $this->assertInstanceOf(Step::class, $originalAction);
+    $this->assertInstanceOf(Step::class, $clonedAction);
+    $this->assertNotSame($originalAction, $clonedAction);
+    $this->assertNotSame($originalAction->getNextSteps()[0], $clonedAction->getNextSteps()[0]);
+    $this->assertNotSame($originalAction->getFilters(), $clonedAction->getFilters());
+
+    $originalFilters = $originalAction->getFilters();
+    $clonedFilters = $clonedAction->getFilters();
+    $this->assertInstanceOf(Filters::class, $originalFilters);
+    $this->assertInstanceOf(Filters::class, $clonedFilters);
+    $this->assertNotSame($originalFilters->getGroups()[0], $clonedFilters->getGroups()[0]);
+    $this->assertNotSame($originalFilters->getGroups()[0]->getFilters()[0], $clonedFilters->getGroups()[0]->getFilters()[0]);
+
+    $clonedAction->setNextSteps([new NextStep('changed')]);
+    $this->assertSame('action', $originalTrigger->getNextStepIds()[0]);
+    $this->assertNull($originalAction->getNextSteps()[0]->getId());
+    $this->assertSame('changed', $clonedAction->getNextSteps()[0]->getId());
+  }
+}

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunStorageTest.php
@@ -3,7 +3,10 @@
 namespace MailPoet\Test\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
+use MailPoet\Test\DataFactories\Automation;
+use MailPoet\Test\DataFactories\AutomationRun as AutomationRunFactory;
 
 class AutomationRunStorageTest extends \MailPoetTest {
 
@@ -122,5 +125,43 @@ class AutomationRunStorageTest extends \MailPoetTest {
 
     // Check automation3 has no runs
     $this->assertNull($result[$automation3->getId()]);
+  }
+
+  public function testGetCountByAutomationTriggerAndSubject() {
+    $automation = (new Automation())->create();
+    $otherAutomation = (new Automation())->create();
+    $subject = new Subject('mailpoet:test-subject', ['id' => 1]);
+    $otherSubject = new Subject('mailpoet:test-subject', ['id' => 2]);
+
+    (new AutomationRunFactory())
+      ->withAutomation($automation)
+      ->withTriggerKey('mailpoet:test-trigger')
+      ->withSubject($subject)
+      ->create();
+    (new AutomationRunFactory())
+      ->withAutomation($automation)
+      ->withTriggerKey('mailpoet:test-trigger')
+      ->withSubject($subject)
+      ->create();
+    (new AutomationRunFactory())
+      ->withAutomation($automation)
+      ->withTriggerKey('mailpoet:other-trigger')
+      ->withSubject($subject)
+      ->create();
+    (new AutomationRunFactory())
+      ->withAutomation($automation)
+      ->withTriggerKey('mailpoet:test-trigger')
+      ->withSubject($otherSubject)
+      ->create();
+    (new AutomationRunFactory())
+      ->withAutomation($otherAutomation)
+      ->withTriggerKey('mailpoet:test-trigger')
+      ->withSubject($subject)
+      ->create();
+
+    $this->assertSame(
+      2,
+      $this->testee->getCountByAutomationTriggerAndSubject($automation, 'mailpoet:test-trigger', $subject)
+    );
   }
 }

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationRunStorageTest.php
@@ -128,6 +128,8 @@ class AutomationRunStorageTest extends \MailPoetTest {
   }
 
   public function testGetCountByAutomationTriggerAndSubject() {
+    global $wpdb;
+
     $automation = (new Automation())->create();
     $otherAutomation = (new Automation())->create();
     $subject = new Subject('mailpoet:test-subject', ['id' => 1]);
@@ -158,6 +160,17 @@ class AutomationRunStorageTest extends \MailPoetTest {
       ->withTriggerKey('mailpoet:test-trigger')
       ->withSubject($subject)
       ->create();
+    $differentKeySubject = new Subject('mailpoet:different-subject', ['id' => 1]);
+    $differentKeyRun = (new AutomationRunFactory())
+      ->withAutomation($automation)
+      ->withTriggerKey('mailpoet:test-trigger')
+      ->withSubject($differentKeySubject)
+      ->create();
+    $wpdb->update(
+      $wpdb->prefix . 'mailpoet_automation_run_subjects',
+      ['hash' => $subject->getHash()],
+      ['automation_run_id' => $differentKeyRun->getId()]
+    );
 
     $this->assertSame(
       2,

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/OrderSubjectToSubscriberSubjectTransformerTest.php
@@ -8,13 +8,17 @@ use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Data\StepRunArgs;
+use MailPoet\Automation\Engine\Data\Subject;
 use MailPoet\Automation\Engine\Data\SubjectEntry;
 use MailPoet\Automation\Engine\Registry;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Integrations\MailPoet\Payloads\SubscriberPayload;
 use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\OrderSubjectToSubscriberSubjectTransformer;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
 use MailPoet\Automation\Integrations\WooCommerce\Triggers\Orders\OrderStatusChangedTrigger;
 use MailPoet\Test\Automation\Stubs\TestAction;
+use MailPoet\Test\DataFactories\Subscriber;
 
 require_once __DIR__ . '/../../../Stubs/TestAction.php';
 
@@ -101,6 +105,18 @@ class OrderSubjectToSubscriberSubjectTransformerTest extends \MailPoetTest {
     $this->assertInstanceOf(SubscriberSubject::class, $subject);
     $this->assertInstanceOf(SubscriberPayload::class, $payload);
     $this->assertSame($billingAddress, $payload->getEmail());
+  }
+
+  public function testItDoesNotTransformGuestOrderWithoutBillingEmailToZeroWpUserSubscriber() {
+    (new Subscriber())->withWpUserId(0)->create();
+
+    $order = new \WC_Order();
+    $order->save();
+
+    /** @var OrderSubjectToSubscriberSubjectTransformer $transformer */
+    $transformer = $this->diContainer->get(OrderSubjectToSubscriberSubjectTransformer::class);
+
+    $this->assertNull($transformer->transform(new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()])));
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectTransformersTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/SubjectTransformers/SubscriberSubjectTransformersTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\MailPoet\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\MailPoet\Subjects\SubscriberSubject;
+use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\CustomerSubjectToSubscriberSubjectTransformer;
+use MailPoet\Automation\Integrations\MailPoet\SubjectTransformers\SubscriberSubjectToWordPressUserSubjectTransformer;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+use MailPoet\Test\DataFactories\Subscriber;
+
+/**
+ * @group woo
+ */
+class SubscriberSubjectTransformersTest extends \MailPoetTest {
+  public function testCustomerSubjectTransformerReturnsNullWhenSubscriberDoesNotExist(): void {
+    $transformer = $this->diContainer->get(CustomerSubjectToSubscriberSubjectTransformer::class);
+
+    $this->assertNull($transformer->transform(new Subject(CustomerSubject::KEY, ['customer_id' => 999999])));
+  }
+
+  public function testSubscriberSubjectTransformerReturnsNullWhenSubscriberDoesNotExist(): void {
+    $transformer = $this->diContainer->get(SubscriberSubjectToWordPressUserSubjectTransformer::class);
+
+    $this->assertNull($transformer->transform(new Subject(SubscriberSubject::KEY, ['subscriber_id' => 999999])));
+  }
+
+  public function testSubscriberSubjectTransformerReturnsNullWhenSubscriberHasNoWordPressUser(): void {
+    $subscriber = (new Subscriber())->create();
+    $transformer = $this->diContainer->get(SubscriberSubjectToWordPressUserSubjectTransformer::class);
+
+    $this->assertNull($transformer->transform(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()])));
+  }
+
+  public function testSubscriberSubjectTransformerReturnsWordPressUserSubject(): void {
+    $subscriber = (new Subscriber())->withWpUserId(123)->create();
+    $transformer = $this->diContainer->get(SubscriberSubjectToWordPressUserSubjectTransformer::class);
+
+    $subject = $transformer->transform(new Subject(SubscriberSubject::KEY, ['subscriber_id' => $subscriber->getId()]));
+
+    $this->assertInstanceOf(Subject::class, $subject);
+    $this->assertSame(UserSubject::KEY, $subject->getKey());
+    $this->assertSame(['user_id' => 123], $subject->getArgs());
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/ContextFactoryTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\WooCommerce;
+
+use MailPoet\Automation\Integrations\WooCommerce\ContextFactory;
+
+/**
+ * @group woo
+ */
+class ContextFactoryTest extends \MailPoetTest {
+  public function testItExposesPaidStatuses(): void {
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+
+    $this->assertArrayHasKey('paid_statuses', $context);
+    $this->assertSame(wc_get_is_paid_statuses(), $context['paid_statuses']);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WooCommerce/SubjectTransformers/WooCommerceSubjectToWordPressUserSubjectTransformerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WooCommerce/SubjectTransformers/WooCommerceSubjectToWordPressUserSubjectTransformerTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\WooCommerce\SubjectTransformers;
+
+use MailPoet\Automation\Engine\Control\SubjectTransformerHandler;
+use MailPoet\Automation\Engine\Data\Subject;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\CustomerSubject;
+use MailPoet\Automation\Integrations\WooCommerce\Subjects\OrderSubject;
+use MailPoet\Automation\Integrations\WordPress\Subjects\UserSubject;
+use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Test\DataFactories\User;
+use MailPoetVendor\Doctrine\ORM\EntityManager;
+
+/**
+ * @group woo
+ */
+class WooCommerceSubjectToWordPressUserSubjectTransformerTest extends \MailPoetTest {
+  /** @var SubjectTransformerHandler */
+  private $subjectTransformerHandler;
+
+  /** @var SubscribersRepository */
+  private $subscribersRepository;
+
+  /** @var EntityManager */
+  private $doctrineEntityManager;
+
+  public function _before(): void {
+    $this->subjectTransformerHandler = $this->diContainer->get(SubjectTransformerHandler::class);
+    $this->subscribersRepository = $this->diContainer->get(SubscribersRepository::class);
+    $this->doctrineEntityManager = $this->diContainer->get(EntityManager::class);
+  }
+
+  public function testItResolvesRegisteredCustomerToWordPressUserWithoutSubscriber(): void {
+    $user = $this->createUser();
+    $this->deleteSubscriberForUser($user);
+    $this->assertNull($this->subscribersRepository->findOneBy(['wpUserId' => $user->ID]));
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(CustomerSubject::KEY, ['customer_id' => $user->ID]),
+    ]);
+
+    $this->assertSame(['user_id' => $user->ID], $this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  public function testItDoesNotResolveGuestCustomerToWordPressUser(): void {
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(CustomerSubject::KEY, ['customer_id' => 0]),
+    ]);
+
+    $this->assertNull($this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  public function testItResolvesRegisteredOrderToWordPressUserWithoutSubscriber(): void {
+    $user = $this->createUser();
+    $this->deleteSubscriberForUser($user);
+    $this->assertNull($this->subscribersRepository->findOneBy(['wpUserId' => $user->ID]));
+
+    $order = new \WC_Order();
+    $order->set_customer_id($user->ID);
+    $order->save();
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+    ]);
+
+    $this->assertSame(['user_id' => $user->ID], $this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  public function testItDoesNotResolveGuestOrderToWordPressUser(): void {
+    $order = new \WC_Order();
+    $order->save();
+
+    $subjects = $this->subjectTransformerHandler->getAllSubjects([
+      new Subject(OrderSubject::KEY, ['order_id' => $order->get_id()]),
+    ]);
+
+    $this->assertNull($this->getSubjectArgs($subjects, UserSubject::KEY));
+  }
+
+  /**
+   * @param Subject[] $subjects
+   * @return array<string, mixed>|null
+   */
+  private function getSubjectArgs(array $subjects, string $key): ?array {
+    foreach ($subjects as $subject) {
+      if ($subject->getKey() === $key) {
+        return $subject->getArgs();
+      }
+    }
+    return null;
+  }
+
+  private function createUser(): \WP_User {
+    $id = uniqid('wc-user-', false);
+    return (new User())->createUser($id, 'customer', $id . '@example.com');
+  }
+
+  private function deleteSubscriberForUser(\WP_User $user): void {
+    $subscriber = $this->subscribersRepository->findOneBy(['wpUserId' => $user->ID]);
+    if (!$subscriber) {
+      return;
+    }
+    $this->subscribersRepository->remove($subscriber);
+    $this->doctrineEntityManager->flush();
+    $this->doctrineEntityManager->clear();
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Automation\Integrations\WordPress;
+
+use MailPoet\Automation\Integrations\WordPress\ContextFactory;
+
+class ContextFactoryTest extends \MailPoetTest {
+  public function _after(): void {
+    remove_role('automation_safe_role');
+    remove_role('automation_elevated_role');
+    wp_set_current_user(0);
+  }
+
+  public function testItExposesEditableRoles(): void {
+    wp_set_current_user(1);
+
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+
+    $this->assertArrayHasKey('editable_roles', $context);
+    $roleIds = array_column($context['editable_roles'], 'id');
+    $this->assertContains('subscriber', $roleIds);
+  }
+
+  public function testItDoesNotExposeElevatedRoles(): void {
+    wp_set_current_user(1);
+    add_role('automation_safe_role', 'Automation Safe Role', ['read' => true]);
+    add_role('automation_elevated_role', 'Automation Elevated Role', ['unfiltered_html' => true]);
+
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+    $editableRoles = $context['editable_roles'];
+    $this->assertIsArray($editableRoles);
+    $roleIds = array_column($editableRoles, 'id');
+
+    $this->assertContains('automation_safe_role', $roleIds);
+    $this->assertNotContains('automation_elevated_role', $roleIds);
+    $this->assertNotContains('administrator', $roleIds);
+  }
+}

--- a/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/WordPress/ContextFactoryTest.php
@@ -5,9 +5,20 @@ namespace MailPoet\Test\Automation\Integrations\WordPress;
 use MailPoet\Automation\Integrations\WordPress\ContextFactory;
 
 class ContextFactoryTest extends \MailPoetTest {
+  /** @var callable|null */
+  private $editableRolesFilter = null;
+
   public function _after(): void {
     remove_role('automation_safe_role');
     remove_role('automation_elevated_role');
+    remove_role('automation_elevated_delete_plugins_role');
+    remove_role('automation_elevated_manage_network_role');
+    remove_role('automation_elevated_update_core_role');
+    remove_role('automation_no_capabilities_role');
+    if ($this->editableRolesFilter !== null) {
+      remove_filter('editable_roles', $this->editableRolesFilter);
+      $this->editableRolesFilter = null;
+    }
     wp_set_current_user(0);
   }
 
@@ -25,6 +36,9 @@ class ContextFactoryTest extends \MailPoetTest {
     wp_set_current_user(1);
     add_role('automation_safe_role', 'Automation Safe Role', ['read' => true]);
     add_role('automation_elevated_role', 'Automation Elevated Role', ['unfiltered_html' => true]);
+    add_role('automation_elevated_delete_plugins_role', 'Automation Elevated Role', ['delete_plugins' => true]);
+    add_role('automation_elevated_manage_network_role', 'Automation Elevated Role', ['manage_network' => true]);
+    add_role('automation_elevated_update_core_role', 'Automation Elevated Role', ['update_core' => true]);
 
     $context = $this->diContainer->get(ContextFactory::class)->getContextData();
     $editableRoles = $context['editable_roles'];
@@ -33,6 +47,44 @@ class ContextFactoryTest extends \MailPoetTest {
 
     $this->assertContains('automation_safe_role', $roleIds);
     $this->assertNotContains('automation_elevated_role', $roleIds);
+    $this->assertNotContains('automation_elevated_delete_plugins_role', $roleIds);
+    $this->assertNotContains('automation_elevated_manage_network_role', $roleIds);
+    $this->assertNotContains('automation_elevated_update_core_role', $roleIds);
     $this->assertNotContains('administrator', $roleIds);
+  }
+
+  public function testItDoesNotExposeAdministratorRoleById(): void {
+    wp_set_current_user(1);
+    $this->editableRolesFilter = function(array $roles): array {
+      $roles['administrator'] = [
+        'name' => 'Administrator',
+        'capabilities' => [
+          'read' => true,
+        ],
+      ];
+      return $roles;
+    };
+    add_filter('editable_roles', $this->editableRolesFilter);
+
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+    $this->assertIsArray($context['editable_roles']);
+
+    $this->assertNotContains('administrator', array_column($context['editable_roles'], 'id'));
+  }
+
+  public function testItExposesRoleWithoutCapabilities(): void {
+    wp_set_current_user(1);
+    $this->editableRolesFilter = function(array $roles): array {
+      $roles['automation_no_capabilities_role'] = [
+        'name' => 'Automation No Capabilities Role',
+      ];
+      return $roles;
+    };
+    add_filter('editable_roles', $this->editableRolesFilter);
+
+    $context = $this->diContainer->get(ContextFactory::class)->getContextData();
+    $this->assertIsArray($context['editable_roles']);
+
+    $this->assertContains('automation_no_capabilities_role', array_column($context['editable_roles'], 'id'));
   }
 }


### PR DESCRIPTION
## Description

Adds free-side automation engine support needed by the remaining split premium automation features: after-save lifecycle hooks, deep snapshots for automation update comparisons, nullable subject-transformer behavior, WordPress context role filtering, and WooCommerce subject-to-user helpers.

## Code review notes

This is a foundation PR for the upcoming premium feature PRs. The deep clone path is intentional: listeners comparing the previous and updated automation must see the pre-mutation step/filter config, not shared mutable step objects.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

https://linear.app/a8c/issue/STOMAIL-8031/mailpoets-automation-engine-improvements

## After-merge notes

This should merge before premium PRs that consume the new lifecycle hooks or subject/context helpers.

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8031-automation-foundation-free)

_The latest successful build from `add/STOMAIL-8031-automation-foundation-free` will be used. If none is available, the link won't work._