### PR TITLE
Add Change User Role automation card

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/wordpress/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/index.tsx
@@ -1,8 +1,10 @@
 import { registerStepType } from '../../editor/store';
 import { step as MadeACommentTrigger } from './steps/made-a-comment';
+import { step as ChangeUserRole } from './steps/change-user-role';
 // Insert new imports here
 
 export const initialize = (): void => {
   registerStepType(MadeACommentTrigger);
+  registerStepType(ChangeUserRole);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/wordpress/steps/change-user-role/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/steps/change-user-role/index.tsx
@@ -8,15 +8,14 @@ const keywords = [
   __('wordpress', 'mailpoet'),
   __('user', 'mailpoet'),
   __('role', 'mailpoet'),
-  __('customer', 'mailpoet'),
+  __('account', 'mailpoet'),
 ];
 
 export const step: StepType = {
   key: 'wordpress:change-user-role',
   group: 'actions',
-  title: () => __('Change customer role', 'mailpoet'),
-  description: () =>
-    __('Change the WordPress role for a customer.', 'mailpoet'),
+  title: () => __('Change user role', 'mailpoet'),
+  description: () => __('Change the WordPress role for a user.', 'mailpoet'),
   subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
   keywords,
   foreground: '#00a32a',
@@ -29,7 +28,7 @@ export const step: StepType = {
         utm_campaign: 'create_automation_editor_change_user_role',
       }}
     >
-      {__('Changing a customer role is a premium feature.', 'mailpoet')}
+      {__('Changing a user role is a premium feature.', 'mailpoet')}
     </PremiumModalForStepEdit>
   ),
 } as const;

--- a/mailpoet/assets/js/src/automation/integrations/wordpress/steps/change-user-role/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/wordpress/steps/change-user-role/index.tsx
@@ -1,0 +1,35 @@
+import { __, _x } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('wordpress', 'mailpoet'),
+  __('user', 'mailpoet'),
+  __('role', 'mailpoet'),
+  __('customer', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'wordpress:change-user-role',
+  group: 'actions',
+  title: () => __('Change customer role', 'mailpoet'),
+  description: () =>
+    __('Change the WordPress role for a customer.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => people,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_change_user_role',
+      }}
+    >
+      {__('Changing a customer role is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/changelog/2026-05-11-14-05-00-added-change-user-role-automation-card.md
+++ b/mailpoet/changelog/2026-05-11-14-05-00-added-change-user-role-automation-card.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Automation card for the WordPress Change customer role action
+Automation card for the WordPress Change user role action

--- a/mailpoet/changelog/2026-05-11-14-05-00-added-change-user-role-automation-card.md
+++ b/mailpoet/changelog/2026-05-11-14-05-00-added-change-user-role-automation-card.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Automation card for the WordPress Change customer role action


### PR DESCRIPTION
## Description

Adds the free editor card for the WordPress Change user role automation action. The card appears as a premium-locked action and links users to the premium flow.

## Code review notes

_N/A_

## QA notes

In the free plugin, open the automation editor and add an action. Search for role, user, or WordPress, then verify Change user role appears as a locked premium action and opens the premium upsell modal when selected.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8031

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8031-change-user-role-card)

_The latest successful build from `add/STOMAIL-8031-change-user-role-card` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6735)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6735)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

