### PR TITLE
Add WooCommerce order action cards

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
@@ -11,6 +11,8 @@ import { step as BuysFromACategory } from './steps/buys-from-a-category';
 import { step as BuysFromATag } from './steps/buys-from-a-tag';
 import { step as MadeAReview } from './steps/made-a-review';
 import { step as CustomerWinBack } from './steps/customer-win-back';
+import { step as ChangeOrderStatus } from './steps/change-order-status';
+import { step as AddOrderNote } from './steps/add-order-note';
 // Insert new imports here
 
 export const initialize = (): void => {
@@ -28,5 +30,7 @@ export const initialize = (): void => {
   registerStepType(BuysFromATag);
   registerStepType(MadeAReview);
   registerStepType(CustomerWinBack);
+  registerStepType(ChangeOrderStatus);
+  registerStepType(AddOrderNote);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/add-order-note/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/add-order-note/index.tsx
@@ -1,0 +1,34 @@
+import { __, _x } from '@wordpress/i18n';
+import { commentContent } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('order', 'mailpoet'),
+  __('note', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:add-order-note',
+  group: 'actions',
+  title: () => __('Add order note', 'mailpoet'),
+  description: () =>
+    __('Add a private or customer note to an order.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => commentContent,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_add_order_note',
+      }}
+    >
+      {__('Adding an order note is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/change-order-status/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/change-order-status/index.tsx
@@ -1,0 +1,33 @@
+import { __, _x } from '@wordpress/i18n';
+import { update } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('order', 'mailpoet'),
+  __('status', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:change-order-status',
+  group: 'actions',
+  title: () => __('Change order status', 'mailpoet'),
+  description: () => __('Change the status of an order.', 'mailpoet'),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#00a32a',
+  background: '#edfaef',
+  icon: () => update,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_change_order_status',
+      }}
+    >
+      {__('Changing an order status is a premium feature.', 'mailpoet')}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/changelog/2026-05-11-15-00-00-added-order-action-automation-cards.md
+++ b/mailpoet/changelog/2026-05-11-15-00-00-added-order-action-automation-cards.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Automation cards for new WooCommerce triggers and actions


### PR DESCRIPTION
## Description

Adds free-plugin automation action cards for the premium WooCommerce order actions:

- Change order status
- Add order note

These cards appear in the automation editor as locked premium steps and open the premium upsell modal when selected.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

- mailpoet/mailpoet-premium#1063

## Linked tickets

STOMAIL-8031

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8031-order-action-cards)

_The latest successful build from `add/STOMAIL-8031-order-action-cards` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6736)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->