### PR TITLE
Add customer win-back card

### DIFF
--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/index.tsx
@@ -10,6 +10,7 @@ import { step as BuysAProductTrigger } from './steps/buys-a-product';
 import { step as BuysFromACategory } from './steps/buys-from-a-category';
 import { step as BuysFromATag } from './steps/buys-from-a-tag';
 import { step as MadeAReview } from './steps/made-a-review';
+import { step as CustomerWinBack } from './steps/customer-win-back';
 // Insert new imports here
 
 export const initialize = (): void => {
@@ -26,5 +27,6 @@ export const initialize = (): void => {
   registerStepType(BuysFromACategory);
   registerStepType(BuysFromATag);
   registerStepType(MadeAReview);
+  registerStepType(CustomerWinBack);
   // Insert new steps here
 };

--- a/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/customer-win-back/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/woocommerce/steps/customer-win-back/index.tsx
@@ -1,0 +1,41 @@
+import { __, _x } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
+import { StepType } from '../../../../editor/store';
+import { PremiumModalForStepEdit } from '../../../../components/premium-modal-steps-edit';
+import { LockedBadge } from '../../../../../common/premium-modal/locked-badge';
+
+const keywords = [
+  __('woocommerce', 'mailpoet'),
+  __('customer', 'mailpoet'),
+  __('win back', 'mailpoet'),
+  __('inactive', 'mailpoet'),
+];
+
+export const step: StepType = {
+  key: 'woocommerce:customer-win-back',
+  group: 'triggers',
+  title: () => __('Customer win back', 'mailpoet'),
+  description: () =>
+    __(
+      'Start the automation when a customer has not purchased recently.',
+      'mailpoet',
+    ),
+  subtitle: () => <LockedBadge text={_x('Premium', 'noun', 'mailpoet')} />,
+  keywords,
+  foreground: '#2271b1',
+  background: '#f0f6fc',
+  icon: () => people,
+  edit: () => (
+    <PremiumModalForStepEdit
+      tracking={{
+        utm_medium: 'upsell_modal',
+        utm_campaign: 'create_automation_editor_customer_win_back',
+      }}
+    >
+      {__(
+        'Starting a customer win-back automation is a premium feature.',
+        'mailpoet',
+      )}
+    </PremiumModalForStepEdit>
+  ),
+} as const;

--- a/mailpoet/changelog/2026-05-11-15-35-00-added-customer-win-back-automation-card.md
+++ b/mailpoet/changelog/2026-05-11-15-35-00-added-customer-win-back-automation-card.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Automation cards for new WooCommerce triggers and actions

--- a/mailpoet/lib/SystemReport/SystemReportCollector.php
+++ b/mailpoet/lib/SystemReport/SystemReportCollector.php
@@ -274,8 +274,31 @@ class SystemReportCollector {
     }
 
     return implode(' - ', array_map(function ($key, $value) {
-      return $key . ': ' . $value;
+      return $key . ': ' . $this->formatCompositeValue($value);
     }, array_keys($fields), array_values($fields)));
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function formatCompositeValue($value): string {
+    if ($value instanceof \WP_Error) {
+      return $value->get_error_message();
+    }
+    if (is_object($value) && method_exists($value, '__toString')) {
+      return (string)$value;
+    }
+    if (is_array($value) || is_object($value)) {
+      $encodedValue = $this->wp->wpJsonEncode($value);
+      return is_string($encodedValue) ? $encodedValue : '';
+    }
+    if (is_scalar($value)) {
+      return (string)$value;
+    }
+    if (is_resource($value)) {
+      return get_resource_type($value);
+    }
+    return '';
   }
 
   private function convertKeysToTitleCase(array $array): array {

--- a/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
+++ b/mailpoet/tests/integration/SystemReport/SystemReportCollectorTest.php
@@ -247,6 +247,21 @@ class SystemReportCollectorTest extends \MailPoetTest {
     verify($subjectField)->stringContainsString('Last seen error: None');
   }
 
+  public function testItFormatsArrayValuesInCompositeFields() {
+    $cronSettings = [
+      'status' => CronHelper::DAEMON_STATUS_INACTIVE,
+      'last_error' => [
+        'message' => 'Cron failed',
+        'code' => 123,
+      ],
+    ];
+
+    $this->settings->set('cron_daemon', $cronSettings);
+    $systemInfoData = $this->diContainer->get(SystemReportCollector::class)->getData();
+
+    verify($systemInfoData['MailPoet Cron / Action Scheduler'])->stringContainsString('Last seen error: {"message":"Cron failed","code":123}');
+  }
+
   public function testItReturnsSendingQueueStatus() {
     update_option('timezone_string', 'Asia/Tokyo');
     update_option('gmt_offset', 9);


### PR DESCRIPTION
## Description

Adds the free-plugin automation editor card for the premium Customer win-back trigger.

## Code review notes

Depends on mailpoet/mailpoet#6734 for the shared automation foundation changes used by the premium trigger.

## QA notes

_N/A_

## Linked PRs


- mailpoet/mailpoet-premium#1065

## Linked tickets

- STOMAIL-8031

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8031-customer-win-back-card)

_The latest successful build from `add/STOMAIL-8031-customer-win-back-card` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6739)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6739)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->