### PR TITLE
Fix showing `Contact support` button in chat

### DIFF
--- a/mailpoet/views/layout.html
+++ b/mailpoet/views/layout.html
@@ -170,10 +170,11 @@
 <% endif %>
 
 <% if display_chatbot_widget and not is_dotcom_ecommerce_plan() %>
+  <% set chatbot_bot_id = 'mailpoet-workflow-support_chat' %>
   <script type="text/javascript" src="<%= getJavascriptScriptUrl('haw.js') %>"></script>
   <chat-widget
     id="chat"
-    bot="mailpoet-workflow-support_chat"
+    bot="<%= chatbot_bot_id %>"
     avatar="<%= cdn_url('chat-avatar.png') %>"
     title="<%= __('MailPoet support', 'mailpoet') %>"
     subtitle="<%= __('Chat with our AI assistant', 'mailpoet') %>"
@@ -190,7 +191,8 @@
     </a>
   </chat-widget>
   <script>
-    const getChatId = () => localStorage.getItem('ai-widget-mailpoet-chat-support-chat-id');
+    const botId = '<%= chatbot_bot_id %>';
+    const getChatId = () => localStorage.getItem(`ai-widget-${botId}-chat-id`);
 
     document.addEventListener('DOMContentLoaded', function() {
       const supportLink = document.getElementById('mailpoet-support-link');


### PR DESCRIPTION
## Description

A follow-up to https://github.com/mailpoet/mailpoet/pull/6632 to fix that `Contact support` button isn't shown.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="424" height="718" alt="Screenshot 2026-05-11 at 22 36 00" src="https://github.com/user-attachments/assets/9b837ed9-0761-4e95-95c7-eb309098222c" /> | <img width="443" height="720" alt="Screenshot 2026-05-11 at 22 35 38" src="https://github.com/user-attachments/assets/a566af0c-da12-4d45-86ab-f101b635c50d" /> |

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:missing-contact-us-button)

_The latest successful build from `missing-contact-us-button` will be used. If none is available, the link won't work._