### PR TITLE
Protect generated export downloads

### DIFF
--- a/mailpoet/changelog/2026-05-06-19-59-21-improved-export-downloads-require-mailpoet-permissions.md
+++ b/mailpoet/changelog/2026-05-06-19-59-21-improved-export-downloads-require-mailpoet-permissions.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Export downloads require MailPoet permissions

--- a/mailpoet/lib/Config/RequirementsChecker.php
+++ b/mailpoet/lib/Config/RequirementsChecker.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Config;
 
+use MailPoet\Router\Endpoints\ExportDownload;
 use MailPoet\Util\Helpers;
 use MailPoet\WP\Notice as WPNotice;
 
@@ -54,6 +55,16 @@ class RequirementsChecker {
           str_replace('\n', PHP_EOL, '<?php\n\n// Silence is golden')
         );
       }
+    }
+    try {
+      ExportDownload::ensureExportDirectory();
+    } catch (\RuntimeException $e) {
+      $error = Helpers::replaceLinkTags(
+        __('MailPoet requires write permissions inside the /wp-content/uploads folder. Please read our [link]instructions[/link] on how to resolve this issue.', 'mailpoet'),
+        'https://kb.mailpoet.com/article/152-minimum-requirements-for-mailpoet-3#folder_permissions',
+        ['target' => '_blank']
+      );
+      return $this->processError($error);
     }
     return true;
   }

--- a/mailpoet/lib/Cron/Workers/ExportFilesCleanup.php
+++ b/mailpoet/lib/Cron/Workers/ExportFilesCleanup.php
@@ -5,6 +5,7 @@ namespace MailPoet\Cron\Workers;
 use MailPoet\Config\Env;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Router\Endpoints\ExportDownload;
 use MailPoet\Subscribers\ImportExport\Export\Export;
 use MailPoetVendor\Carbon\Carbon;
 
@@ -17,6 +18,14 @@ class ExportFilesCleanup extends SimpleWorker {
     $this->cleanup(
       Export::getExportPath() . '/' . Export::getFilePrefix() . '*.*',
       self::DELETE_FILES_AFTER_X_DAYS
+    );
+    $this->cleanup(
+      Env::$tempPath . '/' . Export::getFilePrefix() . '*.*',
+      self::DELETE_FILES_AFTER_X_DAYS
+    );
+    $this->cleanup(
+      ExportDownload::getExportDirectory() . '/' . StatisticsExporter::FILE_PREFIX . '*.*',
+      self::DELETE_STATS_FILES_AFTER_X_DAYS
     );
     $this->cleanup(
       Env::$tempPath . '/' . StatisticsExporter::FILE_PREFIX . '*.*',

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -447,6 +447,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Router\Endpoints\FormPreview::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Subscription::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\ViewInBrowser::class)->setPublic(true);
+    $container->autowire(\MailPoet\Router\Endpoints\ExportDownload::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\TemplateImage::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Track::class)->setPublic(true);
     $container->autowire(\MailPoet\Router\Endpoints\Captcha::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
+++ b/mailpoet/lib/Newsletter/Statistics/Export/StatisticsExporter.php
@@ -2,12 +2,11 @@
 
 namespace MailPoet\Newsletter\Statistics\Export;
 
-use MailPoet\Config\Env;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
-use MailPoet\Util\Security;
+use MailPoet\Router\Endpoints\ExportDownload;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\XLSXWriter;
 
@@ -16,8 +15,6 @@ class StatisticsExporter {
   public const FORMAT_XLSX = 'xlsx';
 
   public const FILE_PREFIX = 'MailPoet_stats_export_';
-  private const RANDOM_NAME_LENGTH = 15;
-
   /**
    * Filter applied to populate per-recipient rows when exporting recipients.
    * The free plugin ships an empty implementation; the premium plugin
@@ -53,11 +50,11 @@ class StatisticsExporter {
     $row = $this->buildAggregateRow($newsletter, $stats);
 
     $this->ensureExportDirectory();
-    $filePath = $this->getExportFilePath($format);
-    $this->writeFile($filePath, $headers, [$row], $format);
+    $file = ExportDownload::createExportFile(self::FILE_PREFIX, $format);
+    $this->writeFile($file['path'], $headers, [$row], $format);
 
     return [
-      'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
+      'exportFileURL' => $this->getExportFileUrl($file['token'], $format),
       'totalExported' => 1,
     ];
   }
@@ -83,11 +80,11 @@ class StatisticsExporter {
     }
 
     $this->ensureExportDirectory();
-    $filePath = $this->getExportFilePath($format);
-    $this->writeFile($filePath, $headers, $rows, $format);
+    $file = ExportDownload::createExportFile(self::FILE_PREFIX, $format);
+    $this->writeFile($file['path'], $headers, $rows, $format);
 
     return [
-      'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
+      'exportFileURL' => $this->getExportFileUrl($file['token'], $format),
       'totalExported' => count($rows),
     ];
   }
@@ -107,11 +104,11 @@ class StatisticsExporter {
     $rows = (array)$this->wp->applyFilters(self::FILTER_RECIPIENT_ROWS, [], $newsletter);
 
     $this->ensureExportDirectory();
-    $filePath = $this->getExportFilePath($format);
-    $this->writeFile($filePath, $headers, $rows, $format);
+    $file = ExportDownload::createExportFile(self::FILE_PREFIX, $format);
+    $this->writeFile($file['path'], $headers, $rows, $format);
 
     return [
-      'exportFileURL' => $this->getExportFileUrl(basename($filePath)),
+      'exportFileURL' => $this->getExportFileUrl($file['token'], $format),
       'totalExported' => count($rows),
     ];
   }
@@ -240,18 +237,11 @@ class StatisticsExporter {
   }
 
   private function ensureExportDirectory(): void {
-    $path = Env::$tempPath;
-    if (!is_dir($path)) {
-      $this->wp->wpMkdirP($path);
-    }
+    ExportDownload::ensureExportDirectory($this->wp);
   }
 
-  private function getExportFilePath(string $format): string {
-    return Env::$tempPath . '/' . self::FILE_PREFIX . Security::generateRandomString(self::RANDOM_NAME_LENGTH) . '.' . $format;
-  }
-
-  private function getExportFileUrl(string $filename): string {
-    return Env::$tempUrl . '/' . $filename;
+  private function getExportFileUrl(string $token, string $format): string {
+    return ExportDownload::buildStatisticsExportUrl($token, $format, $this->wp->homeUrl());
   }
 
   private function normalizeFormat(string $format): string {

--- a/mailpoet/lib/Router/Endpoints/ExportDownload.php
+++ b/mailpoet/lib/Router/Endpoints/ExportDownload.php
@@ -1,0 +1,232 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Router\Endpoints;
+
+use MailPoet\Config\AccessControl;
+use MailPoet\Config\Env;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Router\Router;
+use MailPoet\Subscribers\ImportExport\Export\Export;
+use MailPoet\Util\Helpers;
+use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ExportDownload {
+  public const ENDPOINT = 'export_download';
+  public const ACTION_SUBSCRIBER_EXPORT = 'subscriberExport';
+  public const ACTION_STATISTICS_EXPORT = 'statisticsExport';
+
+  private const DOWNLOAD_TOKEN_LENGTH = 32;
+  private const DOWNLOAD_TOKEN_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  private const EXPORT_DIRECTORY = 'exports';
+  private const CONTENT_TYPES = [
+    'csv' => 'text/csv; charset=utf-8',
+    'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ];
+
+  /** @var string[] */
+  public $allowedActions = [
+    self::ACTION_SUBSCRIBER_EXPORT,
+    self::ACTION_STATISTICS_EXPORT,
+  ];
+
+  public $permissions = [
+    'actions' => [
+      self::ACTION_SUBSCRIBER_EXPORT => AccessControl::PERMISSION_MANAGE_SUBSCRIBERS,
+      self::ACTION_STATISTICS_EXPORT => AccessControl::PERMISSION_MANAGE_EMAILS,
+    ],
+  ];
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public static function buildSubscriberExportUrl(string $token, string $format, ?string $baseUrl = null): string {
+    return self::buildExportUrl(self::ACTION_SUBSCRIBER_EXPORT, $token, $format, $baseUrl);
+  }
+
+  public static function buildStatisticsExportUrl(string $token, string $format, ?string $baseUrl = null): string {
+    return self::buildExportUrl(self::ACTION_STATISTICS_EXPORT, $token, $format, $baseUrl);
+  }
+
+  public static function getExportDirectory(): string {
+    return Env::$tempPath . '/' . self::EXPORT_DIRECTORY;
+  }
+
+  /**
+   * @return array{path: string, token: string}
+   */
+  public static function createExportFile(string $filePrefix, string $format): array {
+    $token = self::generateDownloadToken();
+    return [
+      'path' => self::getFilePathForToken($filePrefix, $token, $format),
+      'token' => $token,
+    ];
+  }
+
+  public static function generateDownloadToken(): string {
+    return Security::generateRandomString(self::DOWNLOAD_TOKEN_LENGTH);
+  }
+
+  public static function getFilePathForToken(string $filePrefix, string $token, string $format): string {
+    return self::getExportDirectory() . '/' . self::getFileNameForToken($filePrefix, $token, $format);
+  }
+
+  public static function ensureExportDirectory(?WPFunctions $wp = null): void {
+    $wp = $wp ?? WPFunctions::get();
+    $exportDirectory = self::getExportDirectory();
+    if (!is_dir($exportDirectory) && !$wp->wpMkdirP($exportDirectory)) {
+      throw new \RuntimeException('Could not create the export directory.');
+    }
+    if (!is_dir($exportDirectory)) {
+      throw new \RuntimeException('Could not create the export directory.');
+    }
+    if (!self::writeFile($exportDirectory . '/index.php', str_replace('\n', PHP_EOL, '<?php\n\n// Silence is golden'))) {
+      throw new \RuntimeException('Could not protect the export directory.');
+    }
+    $htaccessWritten = self::writeFile(
+      $exportDirectory . '/.htaccess',
+      implode(PHP_EOL, [
+        '<IfModule mod_authz_core.c>',
+        'Require all denied',
+        '</IfModule>',
+        '<IfModule !mod_authz_core.c>',
+        'Deny from all',
+        '</IfModule>',
+        '',
+      ])
+    );
+    if (!$htaccessWritten) {
+      throw new \RuntimeException('Could not protect the export directory.');
+    }
+  }
+
+  public function subscriberExport(array $data): void {
+    $this->downloadFile($data, Export::getFilePrefix());
+  }
+
+  public function statisticsExport(array $data): void {
+    $this->downloadFile($data, StatisticsExporter::FILE_PREFIX);
+  }
+
+  public function getDownloadFilePath(array $data, string $filePrefix): ?string {
+    if (empty($data['token']) || !is_string($data['token'])) {
+      return null;
+    }
+
+    $token = $data['token'];
+    if (
+      strlen($token) !== self::DOWNLOAD_TOKEN_LENGTH
+      || strspn($token, self::DOWNLOAD_TOKEN_CHARACTERS) !== self::DOWNLOAD_TOKEN_LENGTH
+    ) {
+      return null;
+    }
+
+    if (empty($data['format']) || !is_string($data['format'])) {
+      return null;
+    }
+
+    $extension = strtolower($data['format']);
+    if (!isset(self::CONTENT_TYPES[$extension])) {
+      return null;
+    }
+
+    $realExportPath = realpath(self::getExportDirectory());
+    $filePath = self::getFilePathForToken($filePrefix, $token, $extension);
+    $realFilePath = is_file($filePath) ? realpath($filePath) : false;
+    if (!is_string($realExportPath) || !is_string($realFilePath)) {
+      return null;
+    }
+
+    $exportPath = rtrim($realExportPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    if (strpos($realFilePath, $exportPath) !== 0) {
+      return null;
+    }
+
+    return $realFilePath;
+  }
+
+  private static function buildExportUrl(string $action, string $token, string $format, ?string $baseUrl): string {
+    $baseUrl = $baseUrl ?? WPFunctions::get()->homeUrl();
+    $params = [
+      Router::NAME => '',
+      'endpoint' => self::ENDPOINT,
+      'action' => Helpers::camelCaseToUnderscore($action),
+      'data' => Router::encodeRequestData([
+        'token' => $token,
+        'format' => strtolower($format),
+      ]),
+    ];
+    $separator = strpos($baseUrl, '?') === false ? '?' : '&';
+    return $baseUrl . $separator . http_build_query($params, '', '&');
+  }
+
+  private static function getFileNameForToken(string $filePrefix, string $token, string $format): string {
+    return sprintf(
+      '%s%s.%s',
+      $filePrefix,
+      hash_hmac('sha256', $token, self::getDownloadSecret()),
+      strtolower($format)
+    );
+  }
+
+  private static function getDownloadSecret(): string {
+    $secret = '';
+    $secretConstants = [
+      'AUTH_KEY',
+      'SECURE_AUTH_KEY',
+      'LOGGED_IN_KEY',
+      'NONCE_KEY',
+      'AUTH_SALT',
+      'SECURE_AUTH_SALT',
+      'LOGGED_IN_SALT',
+      'NONCE_SALT',
+    ];
+    foreach ($secretConstants as $constant) {
+      if (defined($constant)) {
+        $secret .= (string)constant($constant);
+      }
+    }
+    return $secret !== '' ? $secret : (string)Env::$path;
+  }
+
+  private static function writeFile(string $filePath, string $contents): bool {
+    // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads protection files in MailPoet's export directory.
+    if (is_file($filePath) && file_get_contents($filePath) === $contents) {
+      return true;
+    }
+    // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Writes protection files to MailPoet's export directory.
+    return file_put_contents($filePath, $contents) !== false;
+  }
+
+  private function downloadFile(array $data, string $filePrefix): void {
+    $filePath = $this->getDownloadFilePath($data, $filePrefix);
+    if (!$filePath) {
+      $this->wp->statusHeader(404);
+      exit;
+    }
+
+    $extension = strtolower((string)pathinfo($filePath, PATHINFO_EXTENSION));
+    if (!$this->wp->headersSent()) {
+      header('Content-Type: ' . self::CONTENT_TYPES[$extension]);
+      header('Content-Disposition: attachment; filename="' . rtrim($filePrefix, '_') . '.' . $extension . '"');
+      header('X-Content-Type-Options: nosniff');
+      header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+      header('Pragma: no-cache');
+      header('Expires: 0');
+      $fileSize = filesize($filePath);
+      if ($fileSize !== false) {
+        header('Content-Length: ' . $fileSize);
+      }
+    }
+
+    // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads a validated local export file from Env::$tempPath.
+    readfile($filePath);
+    exit;
+  }
+}

--- a/mailpoet/lib/Router/Endpoints/ExportDownload.php
+++ b/mailpoet/lib/Router/Endpoints/ExportDownload.php
@@ -80,7 +80,8 @@ class ExportDownload {
   public static function ensureExportDirectory(?WPFunctions $wp = null): void {
     $wp = $wp ?? WPFunctions::get();
     $exportDirectory = self::getExportDirectory();
-    if (!is_dir($exportDirectory) && !$wp->wpMkdirP($exportDirectory)) {
+    $wasJustCreated = !is_dir($exportDirectory);
+    if ($wasJustCreated && !$wp->wpMkdirP($exportDirectory)) {
       throw new \RuntimeException('Could not create the export directory.');
     }
     if (!is_dir($exportDirectory)) {
@@ -103,6 +104,23 @@ class ExportDownload {
     );
     if (!$htaccessWritten) {
       throw new \RuntimeException('Could not protect the export directory.');
+    }
+    if ($wasJustCreated) {
+      self::purgeLegacyExportFiles();
+    }
+  }
+
+  private static function purgeLegacyExportFiles(): void {
+    $patterns = [
+      Env::$tempPath . '/' . Export::getFilePrefix() . '*.*',
+      Env::$tempPath . '/' . StatisticsExporter::FILE_PREFIX . '*.*',
+    ];
+    foreach ($patterns as $pattern) {
+      foreach (glob($pattern) ?: [] as $file) {
+        if (is_file($file)) {
+          unlink($file);
+        }
+      }
     }
   }
 

--- a/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
+++ b/mailpoet/lib/Subscribers/ImportExport/Export/Export.php
@@ -2,13 +2,12 @@
 
 namespace MailPoet\Subscribers\ImportExport\Export;
 
-use MailPoet\Config\Env;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\SegmentEntity;
+use MailPoet\Router\Endpoints\ExportDownload;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\ImportExport\ImportExportFactory;
 use MailPoet\Subscribers\ImportExport\ImportExportRepository;
-use MailPoet\Util\Security;
 use MailPoetVendor\XLSXWriter;
 
 class Export {
@@ -22,6 +21,7 @@ class Export {
   public $exportPath;
   public $exportFile;
   public $exportFileURL;
+  public $exportFileToken;
 
   /** @var int */
   private $subscribersOffset;
@@ -76,13 +76,14 @@ class Export {
   }
 
   public static function getExportPath() {
-    return Env::$tempPath;
+    return ExportDownload::getExportDirectory();
   }
 
   public function process(): array {
     $processedSubscribers = 0;
     $this->resetCounters();
     try {
+      ExportDownload::ensureExportDirectory();
       if (is_writable($this->exportPath) === false) {
         throw new \Exception(__('The export file could not be saved on the server.', 'mailpoet'));
       }
@@ -101,7 +102,7 @@ class Export {
     }
     return [
       'totalExported' => $processedSubscribers,
-      'exportFileURL' => $this->exportFileURL,
+      'exportFileURL' => $this->getExportFileURL($this->exportFile),
     ];
   }
 
@@ -222,19 +223,15 @@ class Export {
   }
 
   public function getExportFileURL($file): string {
-    return sprintf(
-      '%s/%s',
-      Env::$tempUrl,
-      basename($file)
+    return ExportDownload::buildSubscriberExportUrl(
+      $this->exportFileToken,
+      (string)pathinfo($file, PATHINFO_EXTENSION)
     );
   }
 
   public function getExportFile($format): string {
-    return sprintf(
-      $this->exportPath . '/' . self::getFilePrefix() . '%s.%s',
-      Security::generateRandomString(15),
-      $format
-    );
+    $this->exportFileToken = ExportDownload::generateDownloadToken();
+    return ExportDownload::getFilePathForToken(self::getFilePrefix(), $this->exportFileToken, $format);
   }
 
   /**

--- a/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/StatisticsExportTest.php
@@ -11,6 +11,8 @@ use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Router\Endpoints\ExportDownload;
+use MailPoet\Router\Router;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Util\License\Features\CapabilitiesManager;
 use MailPoet\Util\License\Features\Data\Capability;
@@ -41,8 +43,11 @@ class StatisticsExportTest extends \MailPoetTest {
   }
 
   public function _after() {
-    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+    foreach ($this->getExportFiles() as $file) {
       unlink($file);
+    }
+    if (is_dir(ExportDownload::getExportDirectory())) {
+      rmdir(ExportDownload::getExportDirectory());
     }
     if (is_dir($this->tempDir)) {
       rmdir($this->tempDir);
@@ -87,10 +92,9 @@ class StatisticsExportTest extends \MailPoetTest {
 
     verify($response->status)->equals(APIResponse::STATUS_OK);
     verify($response->data['totalExported'])->equals(1);
-    verify($response->data['exportFileURL'])->stringStartsWith('https://example.test/uploads/mailpoet/MailPoet_stats_export_');
-    verify($response->data['exportFileURL'])->stringEndsWith('.csv');
+    $this->verifyStatisticsDownloadUrl($response->data['exportFileURL'], StatisticsExporter::FORMAT_CSV);
 
-    $files = glob($this->tempDir . '/*.csv') ?: [];
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
     verify($files)->arrayCount(1);
 
     $content = (string)file_get_contents($files[0]);
@@ -109,9 +113,9 @@ class StatisticsExportTest extends \MailPoetTest {
     ]);
 
     verify($response->status)->equals(APIResponse::STATUS_OK);
-    verify($response->data['exportFileURL'])->stringEndsWith('.xlsx');
+    $this->verifyStatisticsDownloadUrl($response->data['exportFileURL'], StatisticsExporter::FORMAT_XLSX);
 
-    $files = glob($this->tempDir . '/*.xlsx') ?: [];
+    $files = glob(ExportDownload::getExportDirectory() . '/*.xlsx') ?: [];
     verify($files)->arrayCount(1);
     verify(filesize($files[0]))->greaterThan(0);
   }
@@ -124,7 +128,7 @@ class StatisticsExportTest extends \MailPoetTest {
     ]);
 
     verify($response->status)->equals(APIResponse::STATUS_OK);
-    verify($response->data['exportFileURL'])->stringEndsWith('.csv');
+    $this->verifyStatisticsDownloadUrl($response->data['exportFileURL'], StatisticsExporter::FORMAT_CSV);
   }
 
   public function testItRejectsRecipientsExportWhenDetailedAnalyticsRestricted() {
@@ -215,5 +219,23 @@ class StatisticsExportTest extends \MailPoetTest {
         'getCapability' => $capability,
       ]),
     ]);
+  }
+
+  private function verifyStatisticsDownloadUrl(string $url, string $extension): void {
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $query);
+    verify($query[Router::NAME] ?? null)->equals('');
+    verify($query['endpoint'] ?? null)->equals(ExportDownload::ENDPOINT);
+    verify($query['action'] ?? null)->equals('statistics_export');
+    $data = Router::decodeRequestData($query['data'] ?? '');
+    verify($data['token'] ?? null)->stringMatchesRegExp('/^[a-z0-9]{32}$/');
+    verify($data['format'] ?? null)->equals($extension);
+    verify(isset($data['filename']))->false();
+  }
+
+  private function getExportFiles(): array {
+    return array_merge(
+      glob(ExportDownload::getExportDirectory() . '/*') ?: [],
+      glob(ExportDownload::getExportDirectory() . '/.htaccess') ?: []
+    );
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/ExportFilesCleanupTest.php
@@ -6,6 +6,7 @@ use MailPoet\Config\Env;
 use MailPoet\Cron\Workers\ExportFilesCleanup;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Router\Endpoints\ExportDownload;
 use MailPoet\Subscribers\ImportExport\Export\Export;
 
 class ExportFilesCleanupTest extends \MailPoetTest {
@@ -25,9 +26,7 @@ class ExportFilesCleanupTest extends \MailPoetTest {
   }
 
   public function _after() {
-    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
-      unlink($file);
-    }
+    $this->cleanupDirectory($this->tempDir);
     if (is_dir($this->tempDir)) {
       rmdir($this->tempDir);
     }
@@ -49,6 +48,22 @@ class ExportFilesCleanupTest extends \MailPoetTest {
     $this->assertFileNotExists($oldFilePath);
   }
 
+  public function testItCleansUpOldSubscriberExportFilesFromProtectedDirectory() {
+    if (!is_dir(ExportDownload::getExportDirectory())) {
+      mkdir(ExportDownload::getExportDirectory(), 0777, true);
+    }
+    $oldFilePath = ExportDownload::getExportDirectory() . '/' . Export::getFilePrefix() . 'old_file.csv';
+    $newFilePath = ExportDownload::getExportDirectory() . '/' . Export::getFilePrefix() . 'new_file.csv';
+    touch($oldFilePath, time() - (60 * 60 * 24 * 2));
+    touch($newFilePath);
+
+    $cleanup = new ExportFilesCleanup();
+    $cleanup->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
+
+    $this->assertFileExists($newFilePath);
+    $this->assertFileNotExists($oldFilePath);
+  }
+
   public function testItCleansUpOldStatisticsExportFiles() {
     $oldFilePath = $this->tempDir . '/' . StatisticsExporter::FILE_PREFIX . 'old_file.csv';
     $newFilePath = $this->tempDir . '/' . StatisticsExporter::FILE_PREFIX . 'new_file.csv';
@@ -60,5 +75,32 @@ class ExportFilesCleanupTest extends \MailPoetTest {
 
     $this->assertFileExists($newFilePath);
     $this->assertFileNotExists($oldFilePath);
+  }
+
+  public function testItCleansUpOldStatisticsExportFilesFromProtectedDirectory() {
+    if (!is_dir(ExportDownload::getExportDirectory())) {
+      mkdir(ExportDownload::getExportDirectory(), 0777, true);
+    }
+    $oldFilePath = ExportDownload::getExportDirectory() . '/' . StatisticsExporter::FILE_PREFIX . 'old_file.csv';
+    $newFilePath = ExportDownload::getExportDirectory() . '/' . StatisticsExporter::FILE_PREFIX . 'new_file.csv';
+    touch($oldFilePath, time() - (60 * 60 * 24 * 8));
+    touch($newFilePath, time() - (60 * 60 * 24 * 6));
+
+    $cleanup = new ExportFilesCleanup();
+    $cleanup->processTaskStrategy(new ScheduledTaskEntity(), microtime(true));
+
+    $this->assertFileExists($newFilePath);
+    $this->assertFileNotExists($oldFilePath);
+  }
+
+  private function cleanupDirectory(string $directory): void {
+    foreach (glob($directory . '/*') ?: [] as $file) {
+      if (is_dir($file)) {
+        $this->cleanupDirectory($file);
+        rmdir($file);
+        continue;
+      }
+      unlink($file);
+    }
   }
 }

--- a/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
+++ b/mailpoet/tests/integration/Cron/Workers/StatisticsExportTest.php
@@ -7,6 +7,8 @@ use MailPoet\Cron\Workers\StatisticsExport as StatisticsExportWorker;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Newsletter\Sending\ScheduledTasksRepository;
 use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Router\Endpoints\ExportDownload;
+use MailPoet\Router\Router;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 
 class StatisticsExportTest extends \MailPoetTest {
@@ -39,8 +41,11 @@ class StatisticsExportTest extends \MailPoetTest {
   }
 
   public function _after() {
-    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+    foreach ($this->getExportFiles() as $file) {
       unlink($file);
+    }
+    if (is_dir(ExportDownload::getExportDirectory())) {
+      rmdir(ExportDownload::getExportDirectory());
     }
     if (is_dir($this->tempDir)) {
       rmdir($this->tempDir);
@@ -63,7 +68,7 @@ class StatisticsExportTest extends \MailPoetTest {
     verify($result)->true();
 
     $meta = $task->getMeta() ?? [];
-    verify($meta['export_file_url'])->stringContainsString('MailPoet_stats_export_');
+    $this->verifyStatisticsDownloadUrl($meta['export_file_url'], StatisticsExporter::FORMAT_CSV);
     verify($meta['total_exported'])->equals(0);
     verify(isset($meta['error']))->false();
   }
@@ -81,7 +86,7 @@ class StatisticsExportTest extends \MailPoetTest {
     verify($result)->true();
 
     $meta = $task->getMeta() ?? [];
-    verify($meta['export_file_url'])->stringContainsString('MailPoet_stats_export_');
+    $this->verifyStatisticsDownloadUrl($meta['export_file_url'], StatisticsExporter::FORMAT_CSV);
     verify($meta['total_exported'])->equals(2);
   }
 
@@ -106,5 +111,23 @@ class StatisticsExportTest extends \MailPoetTest {
     $this->scheduledTasksRepository->persist($task);
     $this->scheduledTasksRepository->flush();
     return $task;
+  }
+
+  private function verifyStatisticsDownloadUrl(string $url, string $extension): void {
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $query);
+    verify($query[Router::NAME] ?? null)->equals('');
+    verify($query['endpoint'] ?? null)->equals(ExportDownload::ENDPOINT);
+    verify($query['action'] ?? null)->equals('statistics_export');
+    $data = Router::decodeRequestData($query['data'] ?? '');
+    verify($data['token'] ?? null)->stringMatchesRegExp('/^[a-z0-9]{32}$/');
+    verify($data['format'] ?? null)->equals($extension);
+    verify(isset($data['filename']))->false();
+  }
+
+  private function getExportFiles(): array {
+    return array_merge(
+      glob(ExportDownload::getExportDirectory() . '/*') ?: [],
+      glob(ExportDownload::getExportDirectory() . '/.htaccess') ?: []
+    );
   }
 }

--- a/mailpoet/tests/integration/Router/Endpoints/ExportDownloadTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/ExportDownloadTest.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Router\Endpoints;
+
+use MailPoet\Config\Env;
+use MailPoet\Newsletter\Statistics\Export\StatisticsExporter;
+use MailPoet\Router\Endpoints\ExportDownload;
+use MailPoet\Router\Router;
+use MailPoet\Subscribers\ImportExport\Export\Export;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ExportDownloadTest extends \MailPoetTest {
+  /** @var string */
+  private $previousTempPath;
+
+  /** @var string */
+  private $tempDir;
+
+  public function _before() {
+    parent::_before();
+    $this->previousTempPath = (string)Env::$tempPath;
+    $this->tempDir = sys_get_temp_dir() . '/mailpoet-export-download-' . uniqid('', true);
+    mkdir($this->tempDir, 0777, true);
+    Env::$tempPath = $this->tempDir;
+    ExportDownload::ensureExportDirectory(new WPFunctions());
+  }
+
+  public function _after() {
+    foreach ($this->getExportFiles() as $file) {
+      unlink($file);
+    }
+    if (is_dir(ExportDownload::getExportDirectory())) {
+      rmdir(ExportDownload::getExportDirectory());
+    }
+    if (is_dir($this->tempDir)) {
+      rmdir($this->tempDir);
+    }
+    Env::$tempPath = $this->previousTempPath;
+    parent::_after();
+  }
+
+  public function testItBuildsSubscriberExportDownloadUrl() {
+    $url = ExportDownload::buildSubscriberExportUrl('abc123abc123abc123abc123abc123ab', 'csv');
+    $data = $this->getRouterData($url);
+
+    verify($data['endpoint'])->equals(ExportDownload::ENDPOINT);
+    verify($data['action'])->equals('subscriber_export');
+    verify($data['data']['token'])->equals('abc123abc123abc123abc123abc123ab');
+    verify($data['data']['format'])->equals('csv');
+    verify(isset($data['data']['filename']))->false();
+  }
+
+  public function testItBuildsStatisticsExportDownloadUrl() {
+    $url = ExportDownload::buildStatisticsExportUrl('abc123abc123abc123abc123abc123ab', 'xlsx');
+    $data = $this->getRouterData($url);
+
+    verify($data['endpoint'])->equals(ExportDownload::ENDPOINT);
+    verify($data['action'])->equals('statistics_export');
+    verify($data['data']['token'])->equals('abc123abc123abc123abc123abc123ab');
+    verify($data['data']['format'])->equals('xlsx');
+    verify(isset($data['data']['filename']))->false();
+  }
+
+  public function testItAllowsValidExportFilesFromTempDirectory() {
+    $file = ExportDownload::createExportFile(Export::getFilePrefix(), 'csv');
+    file_put_contents($file['path'], 'email');
+    $endpoint = new ExportDownload(new WPFunctions());
+
+    verify($endpoint->getDownloadFilePath(
+      [
+        'token' => $file['token'],
+        'format' => 'csv',
+      ],
+      Export::getFilePrefix()
+    ))->equals(realpath($file['path']));
+  }
+
+  public function testItRejectsUnexpectedExportFileNames() {
+    $file = ExportDownload::createExportFile(StatisticsExporter::FILE_PREFIX, 'csv');
+    file_put_contents($file['path'], 'stats');
+    $endpoint = new ExportDownload(new WPFunctions());
+
+    verify($endpoint->getDownloadFilePath(
+      [
+        'token' => '../MailPoet_stats_export_abc123abc123abc.csv',
+        'format' => 'csv',
+      ],
+      StatisticsExporter::FILE_PREFIX
+    ))->null();
+    verify($endpoint->getDownloadFilePath(
+      [
+        'token' => $file['token'],
+        'format' => 'csv',
+      ],
+      Export::getFilePrefix()
+    ))->null();
+    verify($endpoint->getDownloadFilePath(
+      [
+        'token' => $file['token'],
+        'format' => 'php',
+      ],
+      StatisticsExporter::FILE_PREFIX
+    ))->null();
+  }
+
+  public function testItFailsWhenExportDirectoryCannotBeCreated() {
+    $previousTempPath = Env::$tempPath;
+    Env::$tempPath = $this->tempDir . '/missing';
+    $wp = new class extends WPFunctions {
+      public function wpMkdirP(string $dir) {
+        return false;
+      }
+    };
+
+    try {
+      ExportDownload::ensureExportDirectory($wp);
+      $this->fail('Export directory creation did not fail');
+    } catch (\RuntimeException $e) {
+      verify($e->getMessage())->equals('Could not create the export directory.');
+    } finally {
+      Env::$tempPath = $previousTempPath;
+    }
+  }
+
+  private function getRouterData(string $url): array {
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $query);
+    return [
+      'endpoint' => $query['endpoint'] ?? null,
+      'action' => $query['action'] ?? null,
+      'data' => Router::decodeRequestData($query['data'] ?? ''),
+    ];
+  }
+
+  private function getExportFiles(): array {
+    return array_merge(
+      glob(ExportDownload::getExportDirectory() . '/*') ?: [],
+      glob(ExportDownload::getExportDirectory() . '/.htaccess') ?: []
+    );
+  }
+}

--- a/mailpoet/tests/integration/Router/Endpoints/ExportDownloadTest.php
+++ b/mailpoet/tests/integration/Router/Endpoints/ExportDownloadTest.php
@@ -103,6 +103,38 @@ class ExportDownloadTest extends \MailPoetTest {
     ))->null();
   }
 
+  public function testItPurgesLegacyExportFilesWhenCreatingDirectory() {
+    foreach ($this->getExportFiles() as $file) {
+      unlink($file);
+    }
+    rmdir(ExportDownload::getExportDirectory());
+
+    $legacySubscriberFile = $this->tempDir . '/' . Export::getFilePrefix() . 'legacy.csv';
+    $legacyStatsFile = $this->tempDir . '/' . StatisticsExporter::FILE_PREFIX . 'legacy.csv';
+    $unrelatedFile = $this->tempDir . '/unrelated.txt';
+    file_put_contents($legacySubscriberFile, 'legacy');
+    file_put_contents($legacyStatsFile, 'legacy');
+    file_put_contents($unrelatedFile, 'keep');
+
+    ExportDownload::ensureExportDirectory(new WPFunctions());
+
+    $this->assertFileNotExists($legacySubscriberFile);
+    $this->assertFileNotExists($legacyStatsFile);
+    $this->assertFileExists($unrelatedFile);
+
+    unlink($unrelatedFile);
+  }
+
+  public function testItDoesNotPurgeLegacyExportFilesWhenDirectoryAlreadyExists() {
+    $legacySubscriberFile = $this->tempDir . '/' . Export::getFilePrefix() . 'legacy.csv';
+    file_put_contents($legacySubscriberFile, 'legacy');
+
+    ExportDownload::ensureExportDirectory(new WPFunctions());
+
+    $this->assertFileExists($legacySubscriberFile);
+    unlink($legacySubscriberFile);
+  }
+
   public function testItFailsWhenExportDirectoryCannotBeCreated() {
     $previousTempPath = Env::$tempPath;
     Env::$tempPath = $this->tempDir . '/missing';

--- a/mailpoet/tests/integration/Subscribers/ImportExport/Export/ExportTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/Export/ExportTest.php
@@ -2,13 +2,14 @@
 
 namespace MailPoet\Subscribers\ImportExport\Export;
 
-use MailPoet\Config\Env;
 use MailPoet\CustomFields\CustomFieldsRepository;
 use MailPoet\Entities\CustomFieldEntity;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Entities\SubscriberCustomFieldEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Entities\SubscriberSegmentEntity;
+use MailPoet\Router\Endpoints\ExportDownload;
+use MailPoet\Router\Router;
 use MailPoet\Segments\SegmentsRepository;
 use MailPoet\Subscribers\ImportExport\ImportExportRepository;
 use MailPoet\Subscribers\SubscriberCustomFieldRepository;
@@ -175,21 +176,14 @@ class ExportTest extends \MailPoetTest {
     verify(
       preg_match(
         '|' .
-        preg_quote(Env::$tempPath, '|') . '/MailPoet_export_[a-z0-9]{15}.' .
+        preg_quote(Export::getExportPath(), '|') . '/MailPoet_export_[a-f0-9]{64}.' .
         $this->export->exportFormatOption .
         '|',
         $this->export->exportFile
       )
     )->equals(1);
-    verify(
-      preg_match(
-        '|' .
-        preg_quote(Env::$tempUrl, '|') . '/' .
-        basename($this->export->exportFile) .
-        '|',
-        $this->export->exportFileURL
-      )
-    )->equals(1);
+    verify($this->getSubscriberDownloadFormat($this->export->exportFileURL))->equals($this->export->exportFormatOption);
+    verify($this->export->exportFileURL)->stringNotContainsString(basename($this->export->exportFile));
   }
 
   public function testItCanGetSubscriberCustomFields() {
@@ -261,6 +255,7 @@ class ExportTest extends \MailPoetTest {
     }
     verify($result['totalExported'])->equals(4);
     verify($result['exportFileURL'])->notEmpty();
+    verify($this->getSubscriberDownloadFormat($result['exportFileURL']))->equals('csv');
 
     try {
       $this->export->exportFile = $this->export->getExportFile('xlsx');
@@ -271,6 +266,18 @@ class ExportTest extends \MailPoetTest {
     }
     verify($result['totalExported'])->equals(4);
     verify($result['exportFileURL'])->notEmpty();
+    verify($this->getSubscriberDownloadFormat($result['exportFileURL']))->equals('xlsx');
+  }
+
+  private function getSubscriberDownloadFormat(string $url): string {
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $query);
+    verify($query[Router::NAME] ?? null)->equals('');
+    verify($query['endpoint'] ?? null)->equals(ExportDownload::ENDPOINT);
+    verify($query['action'] ?? null)->equals('subscriber_export');
+    $data = Router::decodeRequestData($query['data'] ?? '');
+    verify($data['token'] ?? null)->stringMatchesRegExp('/^[a-z0-9]{32}$/');
+    verify(isset($data['filename']))->false();
+    return (string)$data['format'];
   }
 
   private function createCustomField(string $name, string $type): CustomFieldEntity {

--- a/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
+++ b/mailpoet/tests/unit/Newsletter/Statistics/Export/StatisticsExporterTest.php
@@ -7,6 +7,8 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Newsletter\Statistics\NewsletterStatistics;
 use MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository;
 use MailPoet\Newsletter\Statistics\WooCommerceRevenue;
+use MailPoet\Router\Endpoints\ExportDownload;
+use MailPoet\Router\Router;
 use MailPoet\WooCommerce\Helper;
 use MailPoet\WP\Functions as WPFunctions;
 
@@ -30,8 +32,11 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
   }
 
   public function _after() {
-    foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+    foreach ($this->getExportFiles() as $file) {
       unlink($file);
+    }
+    if (is_dir(ExportDownload::getExportDirectory())) {
+      rmdir(ExportDownload::getExportDirectory());
     }
     if (is_dir($this->tempDir)) {
       rmdir($this->tempDir);
@@ -48,11 +53,11 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $result = $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
 
     verify($result['totalExported'])->equals(1);
-    verify($result['exportFileURL'])->stringStartsWith('https://example.test/uploads/mailpoet/MailPoet_stats_export_');
-    verify($result['exportFileURL'])->stringEndsWith('.csv');
+    $this->verifyStatisticsDownloadUrl($result['exportFileURL'], StatisticsExporter::FORMAT_CSV);
 
-    $files = glob($this->tempDir . '/*.csv') ?: [];
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
     verify($files)->arrayCount(1);
+    verify($result['exportFileURL'])->stringNotContainsString(basename($files[0]));
 
     $content = (string)file_get_contents($files[0]);
     // Starts with the UTF-8 BOM (EF BB BF).
@@ -79,7 +84,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $exporter = $this->createExporter($stats);
     $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_CSV);
 
-    $files = glob($this->tempDir . '/*.csv') ?: [];
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
     $rows = $this->parseCsvRows(substr((string)file_get_contents($files[0]), 3));
     verify($rows[1][10])->equals('1234.56');
     verify($rows[1][11])->equals('USD');
@@ -93,8 +98,8 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $exporter = $this->createExporter($stats);
     $result = $exporter->exportSingleAggregate($newsletter, StatisticsExporter::FORMAT_XLSX);
 
-    verify($result['exportFileURL'])->stringEndsWith('.xlsx');
-    $files = glob($this->tempDir . '/*.xlsx') ?: [];
+    $this->verifyStatisticsDownloadUrl($result['exportFileURL'], StatisticsExporter::FORMAT_XLSX);
+    $files = glob(ExportDownload::getExportDirectory() . '/*.xlsx') ?: [];
     verify($files)->arrayCount(1);
     verify(filesize($files[0]))->greaterThan(0);
   }
@@ -128,7 +133,7 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $result = $exporter->exportBulkAggregate([$newsletterA, $newsletterB], StatisticsExporter::FORMAT_CSV);
 
     verify($result['totalExported'])->equals(2);
-    $files = glob($this->tempDir . '/*.csv') ?: [];
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
     verify($files)->arrayCount(1);
 
     $body = substr((string)file_get_contents($files[0]), 3);
@@ -159,20 +164,23 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
 
     $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
     $wp = $this->makeEmpty(WPFunctions::class, [
-      'wpMkdirP' => true,
+      'wpMkdirP' => function (string $dir) {
+        return mkdir($dir, 0777, true);
+      },
       'applyFilters' => function (string $hook, $value) use ($rows) {
         if ($hook === StatisticsExporter::FILTER_RECIPIENT_ROWS) {
           return $rows;
         }
         return $value;
       },
+      'homeUrl' => 'https://example.test',
     ]);
     $exporter = new StatisticsExporter($repository, $wp);
 
     $result = $exporter->exportRecipients($newsletter, StatisticsExporter::FORMAT_CSV);
     verify($result['totalExported'])->equals(1);
 
-    $files = glob($this->tempDir . '/*.csv') ?: [];
+    $files = glob(ExportDownload::getExportDirectory() . '/*.csv') ?: [];
     verify($files)->arrayCount(1);
     $body = substr((string)file_get_contents($files[0]), 3);
     $exportedRows = $this->parseCsvRows($body);
@@ -185,10 +193,13 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
     $newsletter = $this->createNewsletter(99, 'Empty', null, '2026-02-01 00:00:00');
     $repository = $this->makeEmpty(NewsletterStatisticsRepository::class);
     $wp = $this->makeEmpty(WPFunctions::class, [
-      'wpMkdirP' => true,
+      'wpMkdirP' => function (string $dir) {
+        return mkdir($dir, 0777, true);
+      },
       'applyFilters' => function (string $hook, $value) {
         return $value;
       },
+      'homeUrl' => 'https://example.test',
     ]);
     $exporter = new StatisticsExporter($repository, $wp);
 
@@ -201,9 +212,30 @@ class StatisticsExporterTest extends \MailPoetUnitTest {
       'getStatistics' => $stats,
     ]);
     $wp = $this->makeEmpty(WPFunctions::class, [
-      'wpMkdirP' => true,
+      'wpMkdirP' => function (string $dir) {
+        return mkdir($dir, 0777, true);
+      },
+      'homeUrl' => 'https://example.test',
     ]);
     return new StatisticsExporter($repository, $wp);
+  }
+
+  private function verifyStatisticsDownloadUrl(string $url, string $extension): void {
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $query);
+    verify($query[Router::NAME] ?? null)->equals('');
+    verify($query['endpoint'] ?? null)->equals(ExportDownload::ENDPOINT);
+    verify($query['action'] ?? null)->equals('statistics_export');
+    $data = Router::decodeRequestData($query['data'] ?? '');
+    verify($data['token'] ?? null)->stringMatchesRegExp('/^[a-z0-9]{32}$/');
+    verify($data['format'] ?? null)->equals($extension);
+    verify(isset($data['filename']))->false();
+  }
+
+  private function getExportFiles(): array {
+    return array_merge(
+      glob(ExportDownload::getExportDirectory() . '/*') ?: [],
+      glob(ExportDownload::getExportDirectory() . '/.htaccess') ?: []
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

Routes generated subscriber and statistics export downloads through authenticated MailPoet endpoints instead of exposing public uploads URLs. Adds capability checks per export type while preserving export cleanup behavior.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8032

## After-merge notes

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8032-protect-generated-export-files-from-public-download)

_The latest successful build from `fix/stomail-8032-protect-generated-export-files-from-public-download` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
2 issues found:
- Suggestion: Internationalization best-practices not followed (translation checklist partially open).
- Suggestion: Some files not converted to TypeScript per the checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->