### PR TITLE
Batch bulk action IDs

### DIFF
--- a/mailpoet/changelog/2026-05-06-21-04-12-fixed-bulk-actions-now-process-large-selections-in-small.md
+++ b/mailpoet/changelog/2026-05-06-21-04-12-fixed-bulk-actions-now-process-large-selections-in-small.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Bulk actions now process large selections in smaller batches

--- a/mailpoet/lib/API/JSON/v1/DynamicSegments.php
+++ b/mailpoet/lib/API/JSON/v1/DynamicSegments.php
@@ -287,22 +287,30 @@ class DynamicSegments extends APIEndpoint {
 
   public function bulkAction($data = []) {
     $definition = $this->listingHandler->getListingDefinition($data['listing']);
-    $ids = $this->dynamicSegmentsListingRepository->getActionableIds($definition);
     $meta = [];
+    $count = 0;
     if ($data['action'] === 'trash') {
-      $errors = $this->getErrorMessagesForSegmentsUsedInActiveNewsletters($ids);
-      if (count($errors) > 0) {
-        $meta['errors'] = $errors;
-      }
-      $meta['count'] = $this->segmentsRepository->bulkTrash($ids, SegmentEntity::TYPE_DYNAMIC);
+      $action = function(array $ids) use (&$count, &$meta): void {
+        $errors = $this->getErrorMessagesForSegmentsUsedInActiveNewsletters($ids);
+        if (count($errors) > 0) {
+          $meta['errors'] = array_merge($meta['errors'] ?? [], $errors);
+        }
+        $count += $this->segmentsRepository->bulkTrash($ids, SegmentEntity::TYPE_DYNAMIC);
+      };
     } elseif ($data['action'] === 'restore') {
-      $meta['count'] = $this->segmentsRepository->bulkRestore($ids, SegmentEntity::TYPE_DYNAMIC);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->segmentsRepository->bulkRestore($ids, SegmentEntity::TYPE_DYNAMIC);
+      };
     } elseif ($data['action'] === 'delete') {
-      $meta['count'] = $this->segmentsRepository->bulkDelete($ids, SegmentEntity::TYPE_DYNAMIC);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->segmentsRepository->bulkDelete($ids, SegmentEntity::TYPE_DYNAMIC);
+      };
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([Error::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
     }
+    $this->dynamicSegmentsListingRepository->iterateActionableIds($definition, $action);
+    $meta['count'] = $count;
     return $this->successResponse(null, $meta);
   }
 

--- a/mailpoet/lib/API/JSON/v1/Forms.php
+++ b/mailpoet/lib/API/JSON/v1/Forms.php
@@ -324,18 +324,28 @@ class Forms extends APIEndpoint {
 
   public function bulkAction($data = []): SuccessResponse {
     $definition = $this->listingHandler->getListingDefinition($data['listing']);
-    $ids = $this->formListingRepository->getActionableIds($definition);
+    $count = 0;
     if ($data['action'] === 'trash') {
-      $this->formsRepository->bulkTrash($ids);
+      $action = function(array $ids) use (&$count): void {
+        $this->formsRepository->bulkTrash($ids);
+        $count += count($ids);
+      };
     } elseif ($data['action'] === 'restore') {
-      $this->formsRepository->bulkRestore($ids);
+      $action = function(array $ids) use (&$count): void {
+        $this->formsRepository->bulkRestore($ids);
+        $count += count($ids);
+      };
     } elseif ($data['action'] === 'delete') {
-      $this->formsRepository->bulkDelete($ids);
+      $action = function(array $ids) use (&$count): void {
+        $this->formsRepository->bulkDelete($ids);
+        $count += count($ids);
+      };
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
     }
-    return $this->successResponse(null, ['count' => count($ids)]);
+    $this->formListingRepository->iterateActionableIds($definition, $action);
+    return $this->successResponse(null, ['count' => $count]);
   }
 
   private function getForm(array $data): ?FormEntity {

--- a/mailpoet/lib/API/JSON/v1/Newsletters.php
+++ b/mailpoet/lib/API/JSON/v1/Newsletters.php
@@ -445,22 +445,34 @@ class Newsletters extends APIEndpoint {
 
   public function bulkAction($data = []) {
     $definition = $this->listingHandler->getListingDefinition($data['listing']);
-    $ids = $this->newsletterListingRepository->getActionableIds($definition);
     if ($data['action'] === 'trash') {
-      $this->newslettersRepository->bulkTrash($ids);
+      $count = 0;
+      $this->newsletterListingRepository->iterateActionableIds($definition, function(array $ids) use (&$count): void {
+        $this->newslettersRepository->bulkTrash($ids);
+        $count += count($ids);
+      });
     } elseif ($data['action'] === 'restore') {
-      $this->newslettersRepository->bulkRestore($ids);
+      $count = 0;
+      $this->newsletterListingRepository->iterateActionableIds($definition, function(array $ids) use (&$count): void {
+        $this->newslettersRepository->bulkRestore($ids);
+        $count += count($ids);
+      });
     } elseif ($data['action'] === 'delete') {
-      $this->wp->doAction('mailpoet_api_newsletters_delete_before', $ids);
-      $this->newsletterDeleteController->bulkDelete($ids);
-      $this->wp->doAction('mailpoet_api_newsletters_delete_after', $ids);
+      $count = 0;
+      $this->newsletterListingRepository->iterateActionableIds($definition, function(array $ids) use (&$count): void {
+        $this->wp->doAction('mailpoet_api_newsletters_delete_before', $ids);
+        $this->newsletterDeleteController->bulkDelete($ids);
+        $this->wp->doAction('mailpoet_api_newsletters_delete_after', $ids);
+        $count += count($ids);
+      });
     } elseif ($data['action'] === 'export_stats') {
+      $ids = $this->newsletterListingRepository->getActionableIds($definition);
       return $this->scheduleStatsExport($ids, $data);
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
     }
-    return $this->successResponse(null, ['count' => count($ids)]);
+    return $this->successResponse(null, ['count' => $count]);
   }
 
   /**

--- a/mailpoet/lib/API/JSON/v1/Segments.php
+++ b/mailpoet/lib/API/JSON/v1/Segments.php
@@ -282,18 +282,24 @@ class Segments extends APIEndpoint {
 
   public function bulkAction($data = []) {
     $definition = $this->listingHandler->getListingDefinition($data['listing']);
-    $ids = $this->segmentListingRepository->getActionableIds($definition);
     $count = 0;
     if ($data['action'] === 'trash') {
-      $count = $this->segmentsRepository->bulkTrash($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->segmentsRepository->bulkTrash($ids);
+      };
     } elseif ($data['action'] === 'restore') {
-      $count = $this->segmentsRepository->bulkRestore($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->segmentsRepository->bulkRestore($ids);
+      };
     } elseif ($data['action'] === 'delete') {
-      $count = $this->segmentsRepository->bulkDelete($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->segmentsRepository->bulkDelete($ids);
+      };
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
     }
+    $this->segmentListingRepository->iterateActionableIds($definition, $action);
     return $this->successResponse(null, ['count' => $count]);
   }
 

--- a/mailpoet/lib/API/JSON/v1/Subscribers.php
+++ b/mailpoet/lib/API/JSON/v1/Subscribers.php
@@ -298,9 +298,6 @@ class Subscribers extends APIEndpoint {
       return $this->successResponse($this->bulkConfirmationEmailResender->queue($definition, $data));
     }
 
-    $ids = $this->subscriberListingRepository->getActionableIds($definition);
-
-    $count = 0;
     $segment = null;
     if (isset($data['segment_id'])) {
       $segment = $this->getSegment($data);
@@ -321,31 +318,53 @@ class Subscribers extends APIEndpoint {
       }
     }
 
+    $count = 0;
     if ($data['action'] === 'trash') {
-      $count = $this->subscribersRepository->bulkTrash($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->subscribersRepository->bulkTrash($ids);
+      };
     } elseif ($data['action'] === 'restore') {
-      $count = $this->subscribersRepository->bulkRestore($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->subscribersRepository->bulkRestore($ids);
+      };
     } elseif ($data['action'] === 'delete') {
-      $count = $this->subscribersRepository->bulkDelete($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->subscribersRepository->bulkDelete($ids);
+      };
     } elseif ($data['action'] === 'removeFromAllLists') {
-      $count = $this->subscribersRepository->bulkRemoveFromAllSegments($ids);
+      $action = function(array $ids) use (&$count): void {
+        $count += $this->subscribersRepository->bulkRemoveFromAllSegments($ids);
+      };
     } elseif ($data['action'] === 'removeFromList' && $segment instanceof SegmentEntity) {
-      $count = $this->subscribersRepository->bulkRemoveFromSegment($segment, $ids);
+      $action = function(array $ids) use (&$count, $segment): void {
+        $count += $this->subscribersRepository->bulkRemoveFromSegment($segment, $ids);
+      };
     } elseif ($data['action'] === 'addToList' && $segment instanceof SegmentEntity) {
-      $count = $this->subscribersRepository->bulkAddToSegment($segment, $ids);
+      $action = function(array $ids) use (&$count, $segment): void {
+        $count += $this->subscribersRepository->bulkAddToSegment($segment, $ids);
+      };
     } elseif ($data['action'] === 'moveToList' && $segment instanceof SegmentEntity) {
-      $count = $this->subscribersRepository->bulkMoveToSegment($segment, $ids);
+      $action = function(array $ids) use (&$count, $segment): void {
+        $count += $this->subscribersRepository->bulkMoveToSegment($segment, $ids);
+      };
     } elseif ($data['action'] === 'unsubscribe') {
-      $this->trackBulkUnsubscribe($ids);
-      $count = $this->subscribersRepository->bulkUnsubscribe($ids);
+      $action = function(array $ids) use (&$count): void {
+        $this->trackBulkUnsubscribe($ids);
+        $count += $this->subscribersRepository->bulkUnsubscribe($ids);
+      };
     } elseif ($data['action'] === 'addTag' && $tag instanceof TagEntity) {
-      $count = $this->subscribersRepository->bulkAddTag($tag, $ids);
+      $action = function(array $ids) use (&$count, $tag): void {
+        $count += $this->subscribersRepository->bulkAddTag($tag, $ids);
+      };
     } elseif ($data['action'] === 'removeTag' && $tag instanceof TagEntity) {
-      $count = $this->subscribersRepository->bulkRemoveTag($tag, $ids);
+      $action = function(array $ids) use (&$count, $tag): void {
+        $count += $this->subscribersRepository->bulkRemoveTag($tag, $ids);
+      };
     } else {
       throw UnexpectedValueException::create()
         ->withErrors([APIError::BAD_REQUEST => "Invalid bulk action '{$data['action']}' provided."]);
     }
+    $this->subscriberListingRepository->iterateActionableIds($definition, $action);
     $meta = [
       'count' => $count,
     ];

--- a/mailpoet/lib/Listing/ListingRepository.php
+++ b/mailpoet/lib/Listing/ListingRepository.php
@@ -7,6 +7,8 @@ use MailPoetVendor\Doctrine\ORM\EntityManager;
 use MailPoetVendor\Doctrine\ORM\QueryBuilder;
 
 abstract class ListingRepository {
+  public const ACTIONABLE_IDS_BATCH_SIZE = 500;
+
   /** @var QueryBuilder */
   protected $queryBuilder;
 
@@ -37,17 +39,55 @@ abstract class ListingRepository {
   }
 
   public function getActionableIds(ListingDefinition $definition): array {
-    $ids = $definition->getSelection();
-    if (!empty($ids)) {
-      return $ids;
+    $ids = [];
+    $this->iterateActionableIds($definition, function(array $batchIds) use (&$ids): void {
+      $ids = array_merge($ids, $batchIds);
+    });
+    return $ids;
+  }
+
+  public function iterateActionableIds(ListingDefinition $definition, callable $callback, int $batchSize = self::ACTIONABLE_IDS_BATCH_SIZE): void {
+    $batchSize = max(1, $batchSize);
+    $selectedIds = $definition->getSelection();
+    if (!empty($selectedIds)) {
+      foreach (array_chunk($selectedIds, $batchSize) as $batchIds) {
+        $callback(array_map('intval', $batchIds));
+      }
+      return;
     }
+
     $queryBuilder = clone $this->queryBuilder;
     $this->applyFromClause($queryBuilder);
     $this->applyConstraints($queryBuilder, $definition);
     $alias = $queryBuilder->getRootAliases()[0];
-    $queryBuilder->select("$alias.id");
-    $ids = $queryBuilder->getQuery()->getScalarResult();
-    return array_column($ids, 'id');
+
+    $maxIdQueryBuilder = clone $queryBuilder;
+    $maxIdQueryBuilder->select("MAX($alias.id)");
+    $maxId = (int)$maxIdQueryBuilder->getQuery()->getSingleScalarResult();
+    if ($maxId <= 0) {
+      return;
+    }
+
+    $lastId = 0;
+    while ($lastId < $maxId) {
+      $batchQueryBuilder = clone $queryBuilder;
+      $batchQueryBuilder
+        ->select("DISTINCT $alias.id")
+        ->andWhere("$alias.id > :lastActionableId")
+        ->andWhere("$alias.id <= :maxActionableId")
+        ->setParameter('lastActionableId', $lastId)
+        ->setParameter('maxActionableId', $maxId)
+        ->orderBy("$alias.id", 'ASC')
+        ->setMaxResults($batchSize);
+
+      $ids = array_map('intval', array_column($batchQueryBuilder->getQuery()->getScalarResult(), 'id'));
+      if (empty($ids)) {
+        return;
+      }
+
+      $callback($ids);
+      $lastId = max($ids);
+    }
   }
 
   public function getGroups(ListingDefinition $definition): array {

--- a/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsBulkActionEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/DynamicSegmentsBulkActionEndpoint.php
@@ -7,6 +7,7 @@ use MailPoet\API\REST\Request;
 use MailPoet\API\REST\Response;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Listing\ListingDefinition;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Segments\DynamicSegments\DynamicSegmentsListingRepository;
 use MailPoet\Segments\SegmentsRepository;
@@ -71,11 +72,6 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
         'mailpoet_segments_invalid_orderby'
       );
     }
-    $ids = $this->getSelectedIds($request, $orderby, is_string($orderParam) ? strtolower($orderParam) : 'desc');
-    $this->validateDynamicSelection($ids);
-    if ($action === self::ACTION_DELETE) {
-      $this->validateDeletionSelection($ids);
-    }
 
     $result = [
       'updated' => 0,
@@ -84,12 +80,33 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
       'errors' => [],
     ];
 
-    if ($action === self::ACTION_TRASH) {
-      $this->trashSegments($ids, $result);
-    } elseif ($action === self::ACTION_RESTORE) {
-      $result['updated'] = $this->segmentsRepository->bulkRestore($ids, SegmentEntity::TYPE_DYNAMIC);
+    $definition = $this->getAllMatchingIdsDefinition($request, $orderby, is_string($orderParam) ? strtolower($orderParam) : 'desc');
+    if ($definition instanceof ListingDefinition) {
+      $hasIds = false;
+      $this->dynamicSegmentsListingRepository->iterateActionableIds($definition, function(array $ids) use ($action, &$hasIds): void {
+        $hasIds = true;
+        $this->validateDynamicSelection($ids);
+        if ($action === self::ACTION_DELETE) {
+          $this->validateDeletionSelection($ids);
+        }
+      });
+      if (!$hasIds) {
+        throw new ApiException(
+          __('At least one segment id is required.', 'mailpoet'),
+          400,
+          'mailpoet_segments_ids_required'
+        );
+      }
+      $this->dynamicSegmentsListingRepository->iterateActionableIds($definition, function(array $ids) use ($action, &$result): void {
+        $this->processIds($ids, $action, $result);
+      });
     } else {
-      $result['deleted'] = $this->segmentsRepository->bulkDelete($ids, SegmentEntity::TYPE_DYNAMIC);
+      $ids = $this->validateIds($request->getParam('ids'));
+      $this->validateDynamicSelection($ids);
+      if ($action === self::ACTION_DELETE) {
+        $this->validateDeletionSelection($ids);
+      }
+      $this->processIds($ids, $action, $result);
     }
 
     return new Response($result);
@@ -130,30 +147,34 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
   }
 
   /**
-   * @return int[]
+   * @return ListingDefinition|null
    */
-  private function getSelectedIds(Request $request, string $sortBy, string $sortOrder): array {
+  private function getAllMatchingIdsDefinition(Request $request, string $sortBy, string $sortOrder): ?ListingDefinition {
     if ($request->getParam('select_all') !== true) {
-      return $this->validateIds($request->getParam('ids'));
+      return null;
     }
 
-    $definition = $this->listingHandler->getListingDefinition([
+    return $this->listingHandler->getListingDefinition([
       'group' => $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null),
       'search' => is_string($request->getParam('search')) ? (string)$request->getParam('search') : null,
       'sort_by' => $sortBy,
       'sort_order' => $sortOrder,
       'params' => ['segments'],
     ]);
-    $ids = $this->dynamicSegmentsListingRepository->getActionableIds($definition);
-    $ids = array_map('intval', $ids);
-    if ($ids === []) {
-      throw new ApiException(
-        __('At least one segment id is required.', 'mailpoet'),
-        400,
-        'mailpoet_segments_ids_required'
-      );
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function processIds(array $ids, string $action, array &$result): void {
+    if ($action === self::ACTION_TRASH) {
+      $this->trashSegments($ids, $result);
+    } elseif ($action === self::ACTION_RESTORE) {
+      $result['updated'] += $this->segmentsRepository->bulkRestore($ids, SegmentEntity::TYPE_DYNAMIC);
+    } else {
+      $result['deleted'] += $this->segmentsRepository->bulkDelete($ids, SegmentEntity::TYPE_DYNAMIC);
     }
-    return $ids;
   }
 
   /**
@@ -176,7 +197,7 @@ class DynamicSegmentsBulkActionEndpoint extends SegmentsEndpoint {
       }
       $trashIds[] = $id;
     }
-    $result['updated'] = $this->segmentsRepository->bulkTrash($trashIds, SegmentEntity::TYPE_DYNAMIC);
+    $result['updated'] += $this->segmentsRepository->bulkTrash($trashIds, SegmentEntity::TYPE_DYNAMIC);
   }
 
   /**

--- a/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsBulkActionEndpoint.php
+++ b/mailpoet/lib/Segments/RestApi/Endpoints/SegmentsBulkActionEndpoint.php
@@ -8,6 +8,7 @@ use MailPoet\API\REST\Response;
 use MailPoet\Entities\SegmentEntity;
 use MailPoet\Form\FormsRepository;
 use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Listing\ListingDefinition;
 use MailPoet\Newsletter\Segment\NewsletterSegmentRepository;
 use MailPoet\Segments\SegmentListingRepository;
 use MailPoet\Segments\SegmentsRepository;
@@ -64,12 +65,6 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
   public function handle(Request $request): Response {
     $action = $this->validateAction($request);
     $this->validateListingParams($request);
-    $ids = $this->getSelectedIds($request, $action);
-    $this->validateTypeBoundaries($ids);
-    if ($action === self::ACTION_DELETE) {
-      $this->validateDeletionSelection($ids);
-    }
-
     $result = [
       'updated' => 0,
       'deleted' => 0,
@@ -77,12 +72,24 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
       'errors' => [],
     ];
 
-    if ($action === self::ACTION_TRASH) {
-      $this->trashSegments($ids, $result);
-    } elseif ($action === self::ACTION_RESTORE) {
-      $this->restoreSegments($ids, $result);
+    $definition = $this->getAllMatchingIdsDefinition($request, $action);
+    if ($definition instanceof ListingDefinition) {
+      $this->segmentListingRepository->iterateActionableIds($definition, function(array $ids) use ($action): void {
+        $this->validateTypeBoundaries($ids);
+        if ($action === self::ACTION_DELETE) {
+          $this->validateDeletionSelection($ids);
+        }
+      });
+      $this->segmentListingRepository->iterateActionableIds($definition, function(array $ids) use ($action, &$result): void {
+        $this->processIds($ids, $action, $result);
+      });
     } else {
-      $this->deleteSegments($ids, $result);
+      $ids = $this->validateIds($request->getParam('ids'));
+      $this->validateTypeBoundaries($ids);
+      if ($action === self::ACTION_DELETE) {
+        $this->validateDeletionSelection($ids);
+      }
+      $this->processIds($ids, $action, $result);
     }
 
     return new Response($result);
@@ -145,33 +152,42 @@ class SegmentsBulkActionEndpoint extends SegmentsEndpoint {
   }
 
   /**
-   * @return int[]
+   * @return ListingDefinition|null
    */
-  private function getSelectedIds(Request $request, string $action): array {
+  private function getAllMatchingIdsDefinition(Request $request, string $action): ?ListingDefinition {
     if ($action === self::ACTION_EMPTY_TRASH) {
-      return $this->getAllMatchingIds('trash');
+      return $this->createAllMatchingIdsDefinition('trash');
     }
 
     if ($request->getParam('select_all') === true) {
       $group = $this->validateGroup(is_string($request->getParam('group')) ? (string)$request->getParam('group') : null);
-      return $this->getAllMatchingIds($group);
+      return $this->createAllMatchingIdsDefinition($group);
     }
 
-    return $this->validateIds($request->getParam('ids'));
+    return null;
   }
 
-  /**
-   * @return int[]
-   */
-  private function getAllMatchingIds(string $group): array {
-    $definition = $this->listingHandler->getListingDefinition([
+  private function createAllMatchingIdsDefinition(string $group): ListingDefinition {
+    return $this->listingHandler->getListingDefinition([
       'group' => $group,
       'sort_by' => 'name',
       'sort_order' => 'asc',
       'params' => ['lists'],
     ]);
-    $ids = $this->segmentListingRepository->getActionableIds($definition);
-    return array_map('intval', $ids);
+  }
+
+  /**
+   * @param int[] $ids
+   * @param array{updated:int,deleted:int,skipped:int,errors:array<int, array{id:int|null,message:string}>} $result
+   */
+  private function processIds(array $ids, string $action, array &$result): void {
+    if ($action === self::ACTION_TRASH) {
+      $this->trashSegments($ids, $result);
+    } elseif ($action === self::ACTION_RESTORE) {
+      $this->restoreSegments($ids, $result);
+    } else {
+      $this->deleteSegments($ids, $result);
+    }
   }
 
   /**

--- a/mailpoet/lib/Subscribers/SubscriberListingRepository.php
+++ b/mailpoet/lib/Subscribers/SubscriberListingRepository.php
@@ -105,25 +105,58 @@ class SubscriberListingRepository extends ListingRepository {
   }
 
   public function getActionableIds(ListingDefinition $definition): array {
+    $ids = [];
+    $this->iterateActionableIds($definition, function(array $batchIds) use (&$ids): void {
+      $ids = array_merge($ids, $batchIds);
+    });
+    return $ids;
+  }
+
+  public function iterateActionableIds(ListingDefinition $definition, callable $callback, int $batchSize = self::ACTIONABLE_IDS_BATCH_SIZE): void {
+    $batchSize = max(1, $batchSize);
     $this->definition = $definition;
-    $ids = $definition->getSelection();
-    if (!empty($ids)) {
-      return $ids;
+    $selectedIds = $definition->getSelection();
+    if (!empty($selectedIds)) {
+      foreach (array_chunk($selectedIds, $batchSize) as $batchIds) {
+        $callback(array_map('intval', $batchIds));
+      }
+      return;
     }
     $dynamicSegment = $this->getDynamicSegmentFromFilters($definition);
     if ($dynamicSegment === null) {
-      return parent::getActionableIds($definition);
+      parent::iterateActionableIds($definition, $callback, $batchSize);
+      return;
     }
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $lastId = 0;
+    while (true) {
+      $subscribersIdsQuery = $this->createDynamicSegmentActionableIdsQuery($definition, $dynamicSegment, "DISTINCT $subscribersTable.id");
+      $subscribersIdsQuery
+        ->andWhere("$subscribersTable.id > :last_actionable_id")
+        ->setParameter('last_actionable_id', $lastId, ParameterType::INTEGER)
+        ->orderBy("$subscribersTable.id", 'ASC')
+        ->setMaxResults($batchSize);
+
+      $ids = array_map(function($id): int {
+        return $this->toInt($id);
+      }, $subscribersIdsQuery->executeQuery()->fetchFirstColumn());
+      if (empty($ids)) {
+        return;
+      }
+
+      $callback($ids);
+      $lastId = max($ids);
+    }
+  }
+
+  private function createDynamicSegmentActionableIdsQuery(ListingDefinition $definition, SegmentEntity $segment, string $select): DBALQueryBuilder {
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $subscribersIdsQuery = $this->entityManager
       ->getConnection()
       ->createQueryBuilder()
-      ->select("DISTINCT $subscribersTable.id")
+      ->select($select)
       ->from($subscribersTable);
-    $subscribersIdsQuery = $this->applyConstraintsForDynamicSegment($subscribersIdsQuery, $definition, $dynamicSegment);
-    $idsStatement = $subscribersIdsQuery->execute();
-    $result = $idsStatement->fetchAll();
-    return array_column($result, 'id');
+    return $this->applyConstraintsForDynamicSegment($subscribersIdsQuery, $definition, $segment);
   }
 
   /**

--- a/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Form/Listing/FormListingRepositoryTest.php
@@ -94,4 +94,41 @@ class FormListingRepositoryTest extends \MailPoetTest {
     ]));
     verify($forms)->arrayCount(0);
   }
+
+  public function testItIteratesActionableIdsInBatches() {
+    $batches = [];
+    $this->formListingRepository->iterateActionableIds(
+      $this->listingHandler->getListingDefinition(['group' => 'all']),
+      function(array $ids) use (&$batches): void {
+        $batches[] = $ids;
+      },
+      1
+    );
+
+    verify($batches)->equals([
+      [(int)$this->form1->getId()],
+      [(int)$this->form2->getId()],
+    ]);
+  }
+
+  public function testItIteratesSelectedActionableIdsInBatches() {
+    $batches = [];
+    $this->formListingRepository->iterateActionableIds(
+      $this->listingHandler->getListingDefinition([
+        'selection' => [
+          $this->form2->getId(),
+          $this->form1->getId(),
+        ],
+      ]),
+      function(array $ids) use (&$batches): void {
+        $batches[] = $ids;
+      },
+      1
+    );
+
+    verify($batches)->equals([
+      [(int)$this->form2->getId()],
+      [(int)$this->form1->getId()],
+    ]);
+  }
 }

--- a/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/SubscriberListingRepositoryTest.php
@@ -242,6 +242,41 @@ class SubscriberListingRepositoryTest extends \MailPoetTest {
     $this->listingData['offset'] = 0;
   }
 
+  public function testItIteratesActionableIdsForDynamicSegmentInBatches() {
+    $wpUserEmail1 = 'user-role-test1@example.com';
+    $wpUserEmail2 = 'user-role-test2@example.com';
+    $wpUserEmail3 = 'user-role-test3@example.com';
+    $this->tester->deleteWordPressUser($wpUserEmail1);
+    $this->tester->deleteWordPressUser($wpUserEmail2);
+    $this->tester->deleteWordPressUser($wpUserEmail3);
+    $this->tester->createWordPressUser($wpUserEmail1, 'editor');
+    $this->tester->createWordPressUser($wpUserEmail2, 'editor');
+    $this->tester->createWordPressUser($wpUserEmail3, 'editor');
+    $list = $this->createDynamicSegmentEntity();
+    $this->entityManager->flush();
+
+    $this->listingData['filter'] = ['segment' => $list->getId()];
+    $batches = [];
+    $this->repository->iterateActionableIds(
+      $this->getListingDefinition(),
+      function(array $ids) use (&$batches): void {
+        $batches[] = $ids;
+      },
+      2
+    );
+
+    verify($batches)->arrayCount(2);
+    verify(array_merge(...$batches))->arrayCount(3);
+    foreach ($batches as $ids) {
+      verify(count($ids) <= 2)->true();
+    }
+
+    $this->tester->deleteWordPressUser($wpUserEmail1);
+    $this->tester->deleteWordPressUser($wpUserEmail2);
+    $this->tester->deleteWordPressUser($wpUserEmail3);
+    $this->listingData['filter'] = [];
+  }
+
   public function testSearchForSubscribersInDynamicSegment() {
     $wpUserEmail1 = 'user-role-test1@example.com';
     $wpUserEmail2 = 'user-role-test2@example.com';


### PR DESCRIPTION
## Description

Updates bulk action processing to iterate actionable newsletter/form/subscriber IDs in batches instead of loading all matching IDs into memory at once. Keeps select-all behavior applying to all matching records.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8045

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-8045-batch-bulk-actions-without-loading-all-matching-ids)

_The latest successful build from `fix/stomail-8045-batch-bulk-actions-without-loading-all-matching-ids` will be used. If none is available, the link won't work._