### PR TITLE
Add behavioral signal check to subscription forms

### DIFF
--- a/mailpoet/assets/js/src/global.d.ts
+++ b/mailpoet/assets/js/src/global.d.ts
@@ -32,6 +32,14 @@ interface JQuery {
       recaptchaResponseToken: string;
       turnstileResponseToken?: string;
       mailpoet_subscriber_timezone?: string;
+      behavioral_signals?: {
+        time_ms: number;
+        mm_count: number;
+        kd_count: number;
+        scroll_count: number;
+        focus_count: number;
+        touch: boolean;
+      };
     };
   };
   velocity: (selector: string, options?: Record<string, unknown>) => void;

--- a/mailpoet/assets/js/src/public.tsx
+++ b/mailpoet/assets/js/src/public.tsx
@@ -15,6 +15,25 @@ interface InlineCaptchaMeta {
   captcha_audio_url: string;
 }
 
+interface BehavioralSignalCounters {
+  time_ms: number;
+  mm_count: number;
+  kd_count: number;
+  scroll_count: number;
+  focus_count: number;
+  touch: boolean;
+}
+
+// Per-form counters collected from mount to submit. Counters only — no
+// coordinates or traces — so this is not a fingerprinting surface.
+const behavioralCounters = new WeakMap<
+  HTMLFormElement,
+  BehavioralSignalCounters
+>();
+const behavioralStartTimes = new WeakMap<HTMLFormElement, number>();
+const behavioralAccumulatedMs = new WeakMap<HTMLFormElement, number>();
+const behavioralFocusedFields = new WeakMap<HTMLFormElement, Set<string>>();
+
 jQuery(($) => {
   // Initialize Ajax Error message
   MailPoet.I18n.add(
@@ -66,6 +85,98 @@ jQuery(($) => {
     if (formDiv.data('is-preview')) return;
     const formCookieName = getFormCookieName(form);
     Cookies.set(formCookieName, '1', { expires: 182, path: '/' });
+  }
+
+  const trackedForms: HTMLFormElement[] = [];
+  let behavioralListenersInstalled = false;
+
+  function installBehavioralListeners() {
+    if (behavioralListenersInstalled) return;
+    behavioralListenersInstalled = true;
+
+    const onMousemove = () => {
+      trackedForms.forEach((el) => {
+        const c = behavioralCounters.get(el);
+        if (c) c.mm_count += 1;
+      });
+    };
+    const onScroll = () => {
+      trackedForms.forEach((el) => {
+        const c = behavioralCounters.get(el);
+        if (c) c.scroll_count += 1;
+      });
+    };
+    document.addEventListener('mousemove', onMousemove, { passive: true });
+    document.addEventListener('scroll', onScroll, { passive: true });
+
+    document.addEventListener('visibilitychange', () => {
+      const now = Date.now();
+      if (document.hidden) {
+        trackedForms.forEach((el) => {
+          const start = behavioralStartTimes.get(el);
+          if (start !== undefined) {
+            const acc = behavioralAccumulatedMs.get(el) || 0;
+            behavioralAccumulatedMs.set(el, acc + (now - start));
+            behavioralStartTimes.delete(el);
+          }
+        });
+      } else {
+        trackedForms.forEach((el) => behavioralStartTimes.set(el, now));
+      }
+    });
+  }
+
+  function initBehavioralSignals(form: JQuery<HTMLFormElement>) {
+    const el = form[0];
+    if (!el || behavioralCounters.has(el)) return;
+
+    behavioralCounters.set(el, {
+      time_ms: 0,
+      mm_count: 0,
+      kd_count: 0,
+      scroll_count: 0,
+      focus_count: 0,
+      touch:
+        'maxTouchPoints' in navigator ? navigator.maxTouchPoints > 0 : false,
+    });
+    behavioralStartTimes.set(el, Date.now());
+    behavioralAccumulatedMs.set(el, 0);
+    behavioralFocusedFields.set(el, new Set());
+    trackedForms.push(el);
+
+    form.on('keydown', 'input, textarea, select', () => {
+      const c = behavioralCounters.get(el);
+      if (c) c.kd_count += 1;
+    });
+    form.on('focusin', 'input, textarea, select', (event) => {
+      const focused = behavioralFocusedFields.get(el);
+      const target = event.target as HTMLInputElement;
+      if (focused && target.name) {
+        focused.add(target.name);
+      }
+    });
+
+    installBehavioralListeners();
+  }
+
+  function readBehavioralSignals(
+    form: JQuery<HTMLFormElement>,
+  ): BehavioralSignalCounters | undefined {
+    const el = form[0];
+    if (!el) return undefined;
+    const counters = behavioralCounters.get(el);
+    if (!counters) return undefined;
+    const focused = behavioralFocusedFields.get(el);
+    let elapsedMs = behavioralAccumulatedMs.get(el) || 0;
+    const start = behavioralStartTimes.get(el);
+    if (start !== undefined && !document.hidden) {
+      elapsedMs += Date.now() - start;
+    }
+    return {
+      ...counters,
+      time_ms: elapsedMs,
+      focus_count: focused ? focused.size : 0,
+    };
   }
 
   function playCaptcha(e?: Event) {
@@ -827,6 +938,7 @@ jQuery(($) => {
       if (form.data('font-family')) {
         renderFontFamily(form.data('font-family') as string, form.parent());
       }
+      initBehavioralSignals(form);
     });
     $('.mailpoet_form_close_icon').on('click', (event) => {
       const closeIcon = $(event.target);
@@ -919,6 +1031,10 @@ jQuery(($) => {
           if (browserTimeZone && formData.data) {
             formData.data.mailpoet_subscriber_timezone = browserTimeZone;
           }
+        }
+        const signals = readBehavioralSignals(form);
+        if (signals && formData.data) {
+          formData.data.behavioral_signals = signals;
         }
         const size = form
           .find('.mailpoet_recaptcha')

--- a/mailpoet/changelog/2026-05-11-15-17-52-improved-subscription-forms-now-require-human-like-interact.md
+++ b/mailpoet/changelog/2026-05-11-15-17-52-improved-subscription-forms-now-require-human-like-interact.md
@@ -2,4 +2,4 @@
 
 # Description
 
-Subscription forms now require human-like interaction (mouse, scroll, keystroke timing) when CAPTCHA is disabled, and challenge suspicious submissions with the built-in CAPTCHA
+Subscription forms now require human-like interaction (mouse, scroll, keystroke timing) and challenge suspicious submissions with the built-in CAPTCHA, including on top of a correctly solved built-in CAPTCHA

--- a/mailpoet/changelog/2026-05-11-15-17-52-improved-subscription-forms-now-require-human-like-interact.md
+++ b/mailpoet/changelog/2026-05-11-15-17-52-improved-subscription-forms-now-require-human-like-interact.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Subscription forms now require human-like interaction (mouse, scroll, keystroke timing) when CAPTCHA is disabled, and challenge suspicious submissions with the built-in CAPTCHA

--- a/mailpoet/lib/Captcha/BehavioralSignals.php
+++ b/mailpoet/lib/Captcha/BehavioralSignals.php
@@ -25,20 +25,25 @@ class BehavioralSignals {
   }
 
   public function looksHuman(array $data): bool {
+    $result = true;
     $signals = $data[self::FIELD_NAME] ?? null;
     if (!is_array($signals)) {
-      return false;
+      $result = false;
     }
 
-    $thresholds = $this->getThresholds();
+    $thresholds = [
+      'min_time_ms' => self::DEFAULT_MIN_TIME_MS,
+      'min_interactions' => self::DEFAULT_MIN_INTERACTIONS,
+      'min_field_focus' => self::DEFAULT_MIN_FIELD_FOCUS,
+    ];
     $timeMs = $this->intSignal($signals, 'time_ms');
     $fieldFocusCount = $this->intSignal($signals, 'focus_count');
 
     if ($timeMs < $thresholds['min_time_ms']) {
-      return false;
+      $result = false;
     }
     if ($fieldFocusCount < $thresholds['min_field_focus']) {
-      return false;
+      $result = false;
     }
 
     $mousemoveCount = $this->intSignal($signals, 'mm_count');
@@ -46,31 +51,23 @@ class BehavioralSignals {
     $scrollCount = $this->intSignal($signals, 'scroll_count');
     $isTouch = !empty($signals['touch']);
 
-    // OR-logic across device-appropriate interaction channels handles
-    // password-manager autofill (no keydown), mobile (no mousemove),
-    // and pure-mouse users (no keydown).
-    if ($isTouch) {
-      return $scrollCount >= 1 || $keydownCount >= $thresholds['min_interactions'];
+    if ($result) {
+      // OR-logic across device-appropriate interaction channels handles
+      // password-manager autofill (no keydown), mobile (no mousemove),
+      // and pure-mouse users (no keydown).
+      if ($isTouch) {
+        $result = $scrollCount >= 1 || $keydownCount >= $thresholds['min_interactions'];
+      } else {
+        $result = $mousemoveCount >= $thresholds['min_interactions']
+                  || $keydownCount >= $thresholds['min_interactions'];
+      }
     }
-    return $mousemoveCount >= $thresholds['min_interactions']
-      || $keydownCount >= $thresholds['min_interactions'];
+
+    return (bool)$this->wp->applyFilters('mailpoet_behavioral_signals_looks_human', $result, $signals, $data);
   }
 
   private function intSignal(array $signals, string $key): int {
     $value = $signals[$key] ?? null;
     return is_numeric($value) ? (int)$value : 0;
-  }
-
-  private function getThresholds(): array {
-    $defaults = [
-      'min_time_ms' => self::DEFAULT_MIN_TIME_MS,
-      'min_interactions' => self::DEFAULT_MIN_INTERACTIONS,
-      'min_field_focus' => self::DEFAULT_MIN_FIELD_FOCUS,
-    ];
-    $filtered = $this->wp->applyFilters('mailpoet_behavioral_signals_thresholds', $defaults);
-    if (!is_array($filtered)) {
-      return $defaults;
-    }
-    return array_merge($defaults, $filtered);
   }
 }

--- a/mailpoet/lib/Captcha/BehavioralSignals.php
+++ b/mailpoet/lib/Captcha/BehavioralSignals.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Captcha;
+
+use MailPoet\WP\Functions as WPFunctions;
+
+/**
+ * Evaluates client-side behavioral counters to decide whether a submission
+ * looks human. Used when no CAPTCHA is configured: silent pass when signals
+ * look human, escalate to the built-in CAPTCHA otherwise.
+ */
+class BehavioralSignals {
+  const FIELD_NAME = 'behavioral_signals';
+
+  const DEFAULT_MIN_TIME_MS = 2000;
+  const DEFAULT_MIN_INTERACTIONS = 3;
+  const DEFAULT_MIN_FIELD_FOCUS = 1;
+
+  private WPFunctions $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function looksHuman(array $data): bool {
+    $signals = $data[self::FIELD_NAME] ?? null;
+    if (!is_array($signals)) {
+      return false;
+    }
+
+    $thresholds = $this->getThresholds();
+    $timeMs = $this->intSignal($signals, 'time_ms');
+    $fieldFocusCount = $this->intSignal($signals, 'focus_count');
+
+    if ($timeMs < $thresholds['min_time_ms']) {
+      return false;
+    }
+    if ($fieldFocusCount < $thresholds['min_field_focus']) {
+      return false;
+    }
+
+    $mousemoveCount = $this->intSignal($signals, 'mm_count');
+    $keydownCount = $this->intSignal($signals, 'kd_count');
+    $scrollCount = $this->intSignal($signals, 'scroll_count');
+    $isTouch = !empty($signals['touch']);
+
+    // OR-logic across device-appropriate interaction channels handles
+    // password-manager autofill (no keydown), mobile (no mousemove),
+    // and pure-mouse users (no keydown).
+    if ($isTouch) {
+      return $scrollCount >= 1 || $keydownCount >= $thresholds['min_interactions'];
+    }
+    return $mousemoveCount >= $thresholds['min_interactions']
+      || $keydownCount >= $thresholds['min_interactions'];
+  }
+
+  private function intSignal(array $signals, string $key): int {
+    $value = $signals[$key] ?? null;
+    return is_numeric($value) ? (int)$value : 0;
+  }
+
+  private function getThresholds(): array {
+    $defaults = [
+      'min_time_ms' => self::DEFAULT_MIN_TIME_MS,
+      'min_interactions' => self::DEFAULT_MIN_INTERACTIONS,
+      'min_field_focus' => self::DEFAULT_MIN_FIELD_FOCUS,
+    ];
+    $filtered = $this->wp->applyFilters('mailpoet_behavioral_signals_thresholds', $defaults);
+    if (!is_array($filtered)) {
+      return $defaults;
+    }
+    return array_merge($defaults, $filtered);
+  }
+}

--- a/mailpoet/lib/Captcha/BehavioralSignals.php
+++ b/mailpoet/lib/Captcha/BehavioralSignals.php
@@ -25,11 +25,9 @@ class BehavioralSignals {
   }
 
   public function looksHuman(array $data): bool {
-    $result = true;
-    $signals = $data[self::FIELD_NAME] ?? null;
-    if (!is_array($signals)) {
-      $result = false;
-    }
+    $rawSignals = $data[self::FIELD_NAME] ?? null;
+    $result = is_array($rawSignals);
+    $signals = is_array($rawSignals) ? $rawSignals : [];
 
     $thresholds = [
       'min_time_ms' => self::DEFAULT_MIN_TIME_MS,
@@ -63,7 +61,7 @@ class BehavioralSignals {
       }
     }
 
-    return (bool)$this->wp->applyFilters('mailpoet_behavioral_signals_looks_human', $result, $signals, $data);
+    return (bool)$this->wp->applyFilters('mailpoet_behavioral_signals_looks_human', $result, $rawSignals, $data);
   }
 
   private function intSignal(array $signals, string $key): int {

--- a/mailpoet/lib/Captcha/Validator/CaptchaValidator.php
+++ b/mailpoet/lib/Captcha/Validator/CaptchaValidator.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Captcha\Validator;
 
 use MailPoet\Captcha\CaptchaPhrase;
+use MailPoet\Captcha\CaptchaSession;
 use MailPoet\Captcha\CaptchaUrlFactory;
 use MailPoet\Subscribers\SubscriberIPsRepository;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -25,18 +26,23 @@ class CaptchaValidator {
   /** @var SubscribersRepository */
   private $subscribersRepository;
 
+  /** @var CaptchaSession */
+  private $captchaSession;
+
   public function __construct(
     CaptchaUrlFactory $urlFactory,
     CaptchaPhrase $captchaPhrase,
     WPFunctions $wp,
     SubscriberIPsRepository $subscriberIPsRepository,
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    CaptchaSession $captchaSession
   ) {
     $this->captchaUrlFactory = $urlFactory;
     $this->captchaPhrase = $captchaPhrase;
     $this->wp = $wp;
     $this->subscriberIPsRepository = $subscriberIPsRepository;
     $this->subscribersRepository = $subscribersRepository;
+    $this->captchaSession = $captchaSession;
   }
 
   public function validate(array $data): bool {
@@ -44,7 +50,15 @@ class CaptchaValidator {
     if (!$isBuiltinCaptchaRequired) {
       return true;
     }
+    return $this->validateChallenge($data);
+  }
 
+  /**
+   * Validates the user's CAPTCHA answer without consulting isRequired().
+   * Use this when the caller has already decided a challenge is needed
+   * (e.g. the behavioral-signal escalation path).
+   */
+  public function validateChallenge(array $data): bool {
     // session ID must be set at this point
     $sessionId = $data['captcha_session_id'] ?? null;
     if (!$sessionId) {
@@ -81,6 +95,23 @@ class CaptchaValidator {
     }
 
     return true;
+  }
+
+  /**
+   * Creates a fresh inline CAPTCHA challenge: generates a session, primes a
+   * phrase, and returns the meta the client uses to render it inline.
+   * Optionally stashes form data so the non-JS captcha-page fallback can
+   * restore the original submission on resubmit.
+   *
+   * @param array<string, mixed>|null $formData Form data to stash, or null to skip stashing.
+   */
+  public function getInlineCaptchaChallenge(?array $formData = null): array {
+    $sessionId = $this->captchaSession->generateSessionId();
+    $this->captchaPhrase->createPhrase($sessionId);
+    if ($formData !== null) {
+      $this->captchaSession->setFormData($sessionId, $formData);
+    }
+    return $this->getInlineCaptchaData($sessionId);
   }
 
   public function isRequired($subscriberEmail = null) {
@@ -124,7 +155,7 @@ class CaptchaValidator {
     return false;
   }
 
-  private function isUserExemptFromCaptcha() {
+  public function isUserExemptFromCaptcha(): bool {
     if (!$this->wp->isUserLoggedIn()) {
       return false;
     }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -697,6 +697,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Captcha\CaptchaRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Captcha\CaptchaHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\Captcha\CaptchaPhrase::class);
+    $container->autowire(\MailPoet\Captcha\BehavioralSignals::class);
     $container->autowire(\MailPoet\Captcha\Validator\CaptchaValidator::class)->setPublic(true);
     $container->autowire(\MailPoet\Captcha\Validator\RecaptchaValidator::class)->setPublic(true);
 

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Subscribers;
 
+use MailPoet\Captcha\BehavioralSignals;
 use MailPoet\Captcha\CaptchaConstants;
 use MailPoet\Captcha\CaptchaSession;
 use MailPoet\Captcha\Validator\CaptchaValidator;
@@ -67,6 +68,9 @@ class SubscriberSubscribeController {
   /** @var TurnstileValidator  */
   private $turnstileValidator;
 
+  /** @var BehavioralSignals */
+  private $behavioralSignals;
+
   public function __construct(
     CaptchaSession $captchaSession,
     SubscriberActions $subscriberActions,
@@ -82,7 +86,8 @@ class SubscriberSubscribeController {
     WPFunctions $wp,
     CaptchaValidator $builtInCaptchaValidator,
     RecaptchaValidator $recaptchaValidator,
-    TurnstileValidator $turnstileValidator
+    TurnstileValidator $turnstileValidator,
+    BehavioralSignals $behavioralSignals
   ) {
     $this->formsRepository = $formsRepository;
     $this->captchaSession = $captchaSession;
@@ -99,6 +104,7 @@ class SubscriberSubscribeController {
     $this->builtInCaptchaValidator = $builtInCaptchaValidator;
     $this->recaptchaValidator = $recaptchaValidator;
     $this->turnstileValidator = $turnstileValidator;
+    $this->behavioralSignals = $behavioralSignals;
   }
 
   public function subscribe(array $data): array {
@@ -119,12 +125,15 @@ class SubscriberSubscribeController {
     }
 
     $segmentIds = $this->getSegmentIds($form, $data['segments'] ?? []);
-    unset($data['segments']);
 
-    $meta = $this->validateCaptcha($captchaSettings, $data);
+    // Keep `segments` in $data until after CAPTCHA validation so that, if the
+    // behavioral-baseline path stashes the submission for a deferred challenge,
+    // the stash still carries the selected segments for the resubmit.
+    $meta = $this->validateCaptcha($captchaSettings, $data, $form);
     if (isset($meta['error'])) {
       return $meta;
     }
+    unset($data['segments']);
 
     $submittedTimeZone = SubscriberEntity::sanitizeTimeZone($data[SubscriberEntity::TIME_ZONE_FIELD_NAME] ?? null);
 
@@ -164,7 +173,12 @@ class SubscriberSubscribeController {
 
     [$subscriber, $subscriptionMeta] = $this->subscriberActions->subscribe($data, $segmentIds);
 
-    if (!empty($captchaSettings['type']) && $captchaSettings['type'] === CaptchaConstants::TYPE_BUILTIN && isset($data['captcha_session_id'])) {
+    if (
+      isset($data['captcha_session_id']) && (
+      ($captchaSettings['type'] ?? null) === CaptchaConstants::TYPE_BUILTIN
+      || CaptchaConstants::isDisabled($captchaSettings['type'] ?? null)
+      )
+    ) {
       // Captcha has been verified, invalidate the session vars
       $this->captchaSession->reset($data['captcha_session_id']);
     }
@@ -219,48 +233,90 @@ class SubscriberSubscribeController {
   }
 
   private function initCaptcha(?array $captchaSettings, FormEntity $form, array $data): array {
-    if (
-      !$captchaSettings
-      || !isset($captchaSettings['type'])
-      || $captchaSettings['type'] !== CaptchaConstants::TYPE_BUILTIN
-    ) {
+    $type = $captchaSettings['type'] ?? null;
+
+    if ($type === CaptchaConstants::TYPE_BUILTIN) {
+      // When serving the built-in CAPTCHA for the first time, generate a new session ID.
+      if (!isset($data['captcha_session_id'])) {
+        $data['captcha_session_id'] = $this->captchaSession->generateSessionId();
+      }
+      $sessionId = $data['captcha_session_id'];
+
+      if (!isset($data['captcha'])) {
+        // Save form data to session
+        $this->captchaSession->setFormData($sessionId, array_merge($data, ['form_id' => $form->getId()]));
+      } elseif ($this->captchaSession->getFormData($sessionId)) {
+        // Restore form data from session
+        $data = array_merge($this->captchaSession->getFormData($sessionId), ['captcha' => $data['captcha']]);
+      }
       return $data;
     }
 
-    // When serving the built-in CAPTCHA for the first time, generate a new session ID.
-    if (!isset($data['captcha_session_id'])) {
-      $data['captcha_session_id'] = $this->captchaSession->generateSessionId();
+    // Disabled with behavioral baseline: restore stashed form data on resubmit
+    // (after a previous behavioral escalation). The first submit stashes inside
+    // the escalation path; here we only handle the restore side.
+    if (
+      CaptchaConstants::isDisabled($type)
+      && isset($data['captcha_session_id'], $data['captcha'])
+    ) {
+      $stashed = $this->captchaSession->getFormData($data['captcha_session_id']);
+      if (is_array($stashed)) {
+        $data = array_merge(
+          $stashed,
+          ['captcha' => $data['captcha'], 'captcha_session_id' => $data['captcha_session_id']]
+        );
+      }
     }
-    $sessionId = $data['captcha_session_id'];
 
-    if (!isset($data['captcha'])) {
-      // Save form data to session
-      $this->captchaSession->setFormData($sessionId, array_merge($data, ['form_id' => $form->getId()]));
-    } elseif ($this->captchaSession->getFormData($sessionId)) {
-      // Restore form data from session
-      $data = array_merge($this->captchaSession->getFormData($sessionId), ['captcha' => $data['captcha']]);
-    }
     return $data;
   }
 
-  private function validateCaptcha($captchaSettings, $data): array {
-    if (empty($captchaSettings['type'])) {
-      return [];
-    }
+  private function validateCaptcha($captchaSettings, $data, FormEntity $form): array {
+    $type = $captchaSettings['type'] ?? null;
     try {
-      if ($captchaSettings['type'] === CaptchaConstants::TYPE_BUILTIN) {
+      if (CaptchaConstants::isDisabled($type)) {
+        $this->enforceBehavioralBaseline($data, $form);
+        return [];
+      }
+      if ($type === CaptchaConstants::TYPE_BUILTIN) {
         $this->builtInCaptchaValidator->validate($data);
       }
-      if (CaptchaConstants::isReCaptcha($captchaSettings['type'])) {
+      if (CaptchaConstants::isReCaptcha($type)) {
         $this->recaptchaValidator->validate($data);
       }
-      if (CaptchaConstants::isTurnstile($captchaSettings['type'])) {
+      if (CaptchaConstants::isTurnstile($type)) {
         $this->turnstileValidator->validate($data);
       }
     } catch (ValidationError $error) {
       return $error->getMeta();
     }
     return [];
+  }
+
+  /**
+   * Baseline protection when no CAPTCHA is configured: behavioral signals must
+   * look human, otherwise escalate to the built-in CAPTCHA inline challenge.
+   * isRequired()'s IP-history heuristic is intentionally bypassed here — the
+   * decision is made on per-submission signals, not on the IP's CAPTCHA history.
+   */
+  private function enforceBehavioralBaseline(array $data, FormEntity $form): void {
+    // Resubmit: user already received a challenge, verify their answer
+    // regardless of isRequired() (the caller already decided one was needed).
+    if (!empty($data['captcha_session_id'])) {
+      $this->builtInCaptchaValidator->validateChallenge($data);
+      return;
+    }
+    // Admin/editor exemption mirrors the configured built-in CAPTCHA path.
+    if ($this->builtInCaptchaValidator->isUserExemptFromCaptcha()) {
+      return;
+    }
+    if ($this->behavioralSignals->looksHuman($data)) {
+      return;
+    }
+    // Stash form data so the non-JS captcha-page fallback can restore it.
+    $stash = array_merge($data, ['form_id' => $form->getId()]);
+    $challenge = $this->builtInCaptchaValidator->getInlineCaptchaChallenge($stash);
+    throw new ValidationError(__('Please fill in the CAPTCHA.', 'mailpoet'), $challenge);
   }
 
   private function getSegmentIds(FormEntity $form, array $segmentIds): array {

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -267,10 +267,17 @@ class SubscriberSubscribeController {
     ) {
       $stashed = $this->captchaSession->getFormData($data['captcha_session_id']);
       if (is_array($stashed)) {
-        $data = array_merge(
-          $stashed,
-          ['captcha' => $data['captcha'], 'captcha_session_id' => $data['captcha_session_id']]
-        );
+        // Keep the current request's behavioral signals over the stash so the
+        // resubmit's signal check reflects accumulated interaction, not the
+        // (possibly bot-like) snapshot that triggered the original challenge.
+        $preserve = [
+          'captcha' => $data['captcha'],
+          'captcha_session_id' => $data['captcha_session_id'],
+        ];
+        if (isset($data[BehavioralSignals::FIELD_NAME])) {
+          $preserve[BehavioralSignals::FIELD_NAME] = $data[BehavioralSignals::FIELD_NAME];
+        }
+        $data = array_merge($stashed, $preserve);
       }
     }
 
@@ -286,7 +293,7 @@ class SubscriberSubscribeController {
       }
       if ($type === CaptchaConstants::TYPE_BUILTIN) {
         $this->builtInCaptchaValidator->validate($data);
-        $this->enforceBehavioralSignalsAfterBuiltinCaptcha($data, $form);
+        $this->requireHumanSignals($data, $form);
       }
       if (CaptchaConstants::isReCaptcha($type)) {
         $this->recaptchaValidator->validate($data);
@@ -305,42 +312,29 @@ class SubscriberSubscribeController {
    * look human, otherwise escalate to the built-in CAPTCHA inline challenge.
    * isRequired()'s IP-history heuristic is intentionally bypassed here — the
    * decision is made on per-submission signals, not on the IP's CAPTCHA history.
+   * On resubmit (after a previous escalation), signals are re-checked so that
+   * solving the CAPTCHA alone isn't enough to bypass the baseline.
    */
   private function enforceBehavioralBaseline(array $data, FormEntity $form): void {
-    // Resubmit: user already received a challenge, verify their answer
-    // regardless of isRequired() (the caller already decided one was needed).
     if (!empty($data['captcha_session_id'])) {
       $this->builtInCaptchaValidator->validateChallenge($data);
-      return;
     }
-    // Admin/editor exemption mirrors the configured built-in CAPTCHA path.
-    if ($this->builtInCaptchaValidator->isUserExemptFromCaptcha()) {
-      return;
-    }
-    if ($this->behavioralSignals->looksHuman($data)) {
-      return;
-    }
-    // Stash form data so the non-JS captcha-page fallback can restore it.
-    $stash = array_merge($data, ['form_id' => $form->getId()]);
-    $challenge = $this->builtInCaptchaValidator->getInlineCaptchaChallenge($stash);
-    throw new ValidationError(__('Please fill in the CAPTCHA.', 'mailpoet'), $challenge);
+    $this->requireHumanSignals($data, $form);
   }
 
   /**
-   * Layered defense for the built-in CAPTCHA: even when the CAPTCHA answer is
-   * correct, suspicious behavioral signals trigger a fresh challenge. Catches
-   * solver services and JS-running bots that can solve a CAPTCHA but don't
-   * produce human-like interaction counters.
+   * Throws a fresh CAPTCHA challenge unless behavioral signals look human.
+   * Admin/editor exempt. The suspect signals are dropped from the stash so the
+   * resubmit is evaluated on the current request's freshest counters (via
+   * initCaptcha's preserve step).
    */
-  private function enforceBehavioralSignalsAfterBuiltinCaptcha(array $data, FormEntity $form): void {
+  private function requireHumanSignals(array $data, FormEntity $form): void {
     if ($this->builtInCaptchaValidator->isUserExemptFromCaptcha()) {
       return;
     }
     if ($this->behavioralSignals->looksHuman($data)) {
       return;
     }
-    // Drop the suspect signals from the stash so the resubmit is evaluated on
-    // the current request's freshest counters (via initCaptcha's preserve step).
     $stash = array_merge($data, ['form_id' => $form->getId()]);
     unset($stash[BehavioralSignals::FIELD_NAME]);
     $challenge = $this->builtInCaptchaValidator->getInlineCaptchaChallenge($stash);

--- a/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
+++ b/mailpoet/lib/Subscribers/SubscriberSubscribeController.php
@@ -246,8 +246,14 @@ class SubscriberSubscribeController {
         // Save form data to session
         $this->captchaSession->setFormData($sessionId, array_merge($data, ['form_id' => $form->getId()]));
       } elseif ($this->captchaSession->getFormData($sessionId)) {
-        // Restore form data from session
-        $data = array_merge($this->captchaSession->getFormData($sessionId), ['captcha' => $data['captcha']]);
+        // Restore form data from session, but keep the current request's captcha
+        // and behavioral signals so the resubmit reflects accumulated interaction
+        // rather than the (possibly bot-like) snapshot from the first submit.
+        $preserve = ['captcha' => $data['captcha']];
+        if (isset($data[BehavioralSignals::FIELD_NAME])) {
+          $preserve[BehavioralSignals::FIELD_NAME] = $data[BehavioralSignals::FIELD_NAME];
+        }
+        $data = array_merge($this->captchaSession->getFormData($sessionId), $preserve);
       }
       return $data;
     }
@@ -280,6 +286,7 @@ class SubscriberSubscribeController {
       }
       if ($type === CaptchaConstants::TYPE_BUILTIN) {
         $this->builtInCaptchaValidator->validate($data);
+        $this->enforceBehavioralSignalsAfterBuiltinCaptcha($data, $form);
       }
       if (CaptchaConstants::isReCaptcha($type)) {
         $this->recaptchaValidator->validate($data);
@@ -315,6 +322,27 @@ class SubscriberSubscribeController {
     }
     // Stash form data so the non-JS captcha-page fallback can restore it.
     $stash = array_merge($data, ['form_id' => $form->getId()]);
+    $challenge = $this->builtInCaptchaValidator->getInlineCaptchaChallenge($stash);
+    throw new ValidationError(__('Please fill in the CAPTCHA.', 'mailpoet'), $challenge);
+  }
+
+  /**
+   * Layered defense for the built-in CAPTCHA: even when the CAPTCHA answer is
+   * correct, suspicious behavioral signals trigger a fresh challenge. Catches
+   * solver services and JS-running bots that can solve a CAPTCHA but don't
+   * produce human-like interaction counters.
+   */
+  private function enforceBehavioralSignalsAfterBuiltinCaptcha(array $data, FormEntity $form): void {
+    if ($this->builtInCaptchaValidator->isUserExemptFromCaptcha()) {
+      return;
+    }
+    if ($this->behavioralSignals->looksHuman($data)) {
+      return;
+    }
+    // Drop the suspect signals from the stash so the resubmit is evaluated on
+    // the current request's freshest counters (via initCaptcha's preserve step).
+    $stash = array_merge($data, ['form_id' => $form->getId()]);
+    unset($stash[BehavioralSignals::FIELD_NAME]);
     $challenge = $this->builtInCaptchaValidator->getInlineCaptchaChallenge($stash);
     throw new ValidationError(__('Please fill in the CAPTCHA.', 'mailpoet'), $challenge);
   }

--- a/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/SubscribersTest.php
@@ -1203,6 +1203,14 @@ class SubscribersTest extends \MailPoetTest {
       'captcha_session_id' => $captchaSessionId,
       $this->obfuscatedSegments => [$this->segment1->getId(), $this->segment2->getId()],
       'captcha' => $captchaValue['phrase'],
+      'behavioral_signals' => [
+        'time_ms' => 5000,
+        'mm_count' => 5,
+        'kd_count' => 5,
+        'scroll_count' => 0,
+        'focus_count' => 1,
+        'touch' => false,
+      ],
     ]);
     verify($response->status)->equals(APIResponse::STATUS_OK);
     $this->settings->set('captcha', []);

--- a/mailpoet/tests/integration/Subscription/FormTest.php
+++ b/mailpoet/tests/integration/Subscription/FormTest.php
@@ -57,6 +57,16 @@ class FormTest extends \MailPoetTest {
       'data' => [
         'form_id' => $this->form->getId(),
         $obfuscatedEmail => $this->testEmail,
+        // Human-like signals so the disabled-CAPTCHA baseline doesn't
+        // escalate this submission to an inline CAPTCHA challenge.
+        'behavioral_signals' => [
+          'time_ms' => 5000,
+          'mm_count' => 10,
+          'kd_count' => 10,
+          'scroll_count' => 0,
+          'focus_count' => 1,
+          'touch' => false,
+        ],
       ],
       'token' => WPFunctions::get()->wpCreateNonce('mailpoet_token'),
       'api_version' => 'v1',

--- a/mailpoet/tests/unit/Captcha/BehavioralSignalsTest.php
+++ b/mailpoet/tests/unit/Captcha/BehavioralSignalsTest.php
@@ -1,0 +1,165 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Captcha;
+
+use Codeception\Stub;
+use MailPoet\WP\Functions as WPFunctions;
+
+class BehavioralSignalsTest extends \MailPoetUnitTest {
+  private function makeTestee(?array $customThresholds = null): BehavioralSignals {
+    $wp = Stub::make(
+      WPFunctions::class,
+      [
+        'applyFilters' => function ($filter, $value) use ($customThresholds) {
+          if ($filter === 'mailpoet_behavioral_signals_thresholds' && $customThresholds !== null) {
+            return $customThresholds;
+          }
+          return $value;
+        },
+      ],
+      $this
+    );
+    return new BehavioralSignals($wp);
+  }
+
+  public function testReturnsFalseWhenSignalsMissing() {
+    $testee = $this->makeTestee();
+    verify($testee->looksHuman([]))->false();
+  }
+
+  public function testReturnsFalseWhenSignalsAreNotAnArray() {
+    $testee = $this->makeTestee();
+    verify($testee->looksHuman(['behavioral_signals' => 'malformed']))->false();
+  }
+
+  public function testReturnsFalseWhenTimeBelowThreshold() {
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 500,
+      'mm_count' => 50,
+      'kd_count' => 10,
+      'focus_count' => 2,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->false();
+  }
+
+  public function testReturnsFalseWhenNoFieldFocus() {
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 5000,
+      'mm_count' => 50,
+      'kd_count' => 10,
+      'focus_count' => 0,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->false();
+  }
+
+  public function testDesktopPassesWithMouseMovement() {
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 3000,
+      'mm_count' => 25,
+      'kd_count' => 0,
+      'focus_count' => 1,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->true();
+  }
+
+  public function testDesktopPassesWithKeydownEvenIfNoMouseMovement() {
+    // Password-manager autofill scenario: focus fires but no keystrokes from the user;
+    // a typing user would still pass via kd_count.
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 3000,
+      'mm_count' => 0,
+      'kd_count' => 15,
+      'focus_count' => 2,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->true();
+  }
+
+  public function testDesktopFailsWithoutMouseOrKeydown() {
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 5000,
+      'mm_count' => 0,
+      'kd_count' => 0,
+      'focus_count' => 1,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->false();
+  }
+
+  public function testTouchPassesWithScrollOnly() {
+    // Mobile user who scrolled but didn't type or move a mouse — still human.
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 4000,
+      'mm_count' => 0,
+      'kd_count' => 0,
+      'scroll_count' => 3,
+      'focus_count' => 1,
+      'touch' => true,
+    ]];
+    verify($testee->looksHuman($data))->true();
+  }
+
+  public function testTouchPassesWithKeydown() {
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 4000,
+      'mm_count' => 0,
+      'kd_count' => 5,
+      'scroll_count' => 0,
+      'focus_count' => 1,
+      'touch' => true,
+    ]];
+    verify($testee->looksHuman($data))->true();
+  }
+
+  public function testTouchFailsWithoutInteraction() {
+    $testee = $this->makeTestee();
+    $data = ['behavioral_signals' => [
+      'time_ms' => 5000,
+      'mm_count' => 100,
+      'kd_count' => 0,
+      'scroll_count' => 0,
+      'focus_count' => 1,
+      'touch' => true,
+    ]];
+    // Touch path ignores mm_count; needs scroll or kd.
+    verify($testee->looksHuman($data))->false();
+  }
+
+  public function testThresholdsAreFilterable() {
+    $testee = $this->makeTestee([
+      'min_time_ms' => 100,
+      'min_interactions' => 1,
+      'min_field_focus' => 1,
+    ]);
+    $data = ['behavioral_signals' => [
+      'time_ms' => 150,
+      'mm_count' => 1,
+      'kd_count' => 0,
+      'focus_count' => 1,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->true();
+  }
+
+  public function testInvalidFilterValueFallsBackToDefaults() {
+    $testee = $this->makeTestee(['nonsense' => 'data']);
+    $data = ['behavioral_signals' => [
+      'time_ms' => 3000,
+      'mm_count' => 25,
+      'kd_count' => 0,
+      'focus_count' => 1,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->true();
+  }
+}

--- a/mailpoet/tests/unit/Captcha/BehavioralSignalsTest.php
+++ b/mailpoet/tests/unit/Captcha/BehavioralSignalsTest.php
@@ -6,13 +6,13 @@ use Codeception\Stub;
 use MailPoet\WP\Functions as WPFunctions;
 
 class BehavioralSignalsTest extends \MailPoetUnitTest {
-  private function makeTestee(?array $customThresholds = null): BehavioralSignals {
+  private function makeTestee(?callable $looksHumanFilter = null): BehavioralSignals {
     $wp = Stub::make(
       WPFunctions::class,
       [
-        'applyFilters' => function ($filter, $value) use ($customThresholds) {
-          if ($filter === 'mailpoet_behavioral_signals_thresholds' && $customThresholds !== null) {
-            return $customThresholds;
+        'applyFilters' => function ($filter, $value, ...$args) use ($looksHumanFilter) {
+          if ($filter === 'mailpoet_behavioral_signals_looks_human' && $looksHumanFilter !== null) {
+            return $looksHumanFilter($value, ...$args);
           }
           return $value;
         },
@@ -135,31 +135,45 @@ class BehavioralSignalsTest extends \MailPoetUnitTest {
     verify($testee->looksHuman($data))->false();
   }
 
-  public function testThresholdsAreFilterable() {
-    $testee = $this->makeTestee([
-      'min_time_ms' => 100,
-      'min_interactions' => 1,
-      'min_field_focus' => 1,
-    ]);
-    $data = ['behavioral_signals' => [
-      'time_ms' => 150,
-      'mm_count' => 1,
-      'kd_count' => 0,
-      'focus_count' => 1,
-      'touch' => false,
-    ]];
-    verify($testee->looksHuman($data))->true();
+  public function testLooksHumanFilterCanOverrideToTrue() {
+    // Allows test environments and integration code to short-circuit the
+    // baseline check (e.g. WPLoader scenarios that subscribe without signals).
+    $testee = $this->makeTestee(function () {
+      return true;
+    });
+    verify($testee->looksHuman([]))->true();
   }
 
-  public function testInvalidFilterValueFallsBackToDefaults() {
-    $testee = $this->makeTestee(['nonsense' => 'data']);
+  public function testLooksHumanFilterReceivesSignalsAndData() {
     $data = ['behavioral_signals' => [
       'time_ms' => 3000,
       'mm_count' => 25,
-      'kd_count' => 0,
       'focus_count' => 1,
       'touch' => false,
     ]];
-    verify($testee->looksHuman($data))->true();
+    $invocations = 0;
+    $testee = $this->makeTestee(function ($value, $signals, $contextData) use ($data, &$invocations) {
+      $invocations++;
+      verify($value)->true();
+      verify($signals)->equals($data['behavioral_signals']);
+      verify($contextData)->equals($data);
+      return $value;
+    });
+    $testee->looksHuman($data);
+    verify($invocations)->equals(1);
+  }
+
+  public function testLooksHumanFilterCanOverrideToFalse() {
+    $testee = $this->makeTestee(function () {
+      return false;
+    });
+    $data = ['behavioral_signals' => [
+      'time_ms' => 5000,
+      'mm_count' => 50,
+      'kd_count' => 10,
+      'focus_count' => 2,
+      'touch' => false,
+    ]];
+    verify($testee->looksHuman($data))->false();
   }
 }

--- a/mailpoet/tests/unit/Captcha/Validator/CaptchaValidatorTest.php
+++ b/mailpoet/tests/unit/Captcha/Validator/CaptchaValidatorTest.php
@@ -51,7 +51,8 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       $captchaPhrase,
       $this->wp,
       $subscriberIpRepository,
-      $subscriberRepository
+      $subscriberRepository,
+      Stub::makeEmpty(CaptchaSession::class)
     );
 
     $data = [
@@ -83,7 +84,8 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       $captchaPhrase,
       $wp,
       $subscriberIpRepository,
-      $subscriberRepository
+      $subscriberRepository,
+      Stub::makeEmpty(CaptchaSession::class)
     );
 
     $data = [
@@ -190,7 +192,8 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       $captchaPhrase,
       $wp,
       $subscriberIpRepository,
-      $subscriberRepository
+      $subscriberRepository,
+      Stub::makeEmpty(CaptchaSession::class)
     );
 
     $data = [
@@ -231,7 +234,8 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       $captchaPhrase,
       $this->wp,
       $subscriberIpRepository,
-      $subscriberRepository
+      $subscriberRepository,
+      Stub::makeEmpty(CaptchaSession::class)
     );
 
     $data = [
@@ -276,7 +280,8 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       $captchaPhrase,
       $this->wp,
       $subscriberIpRepository,
-      $subscriberRepository
+      $subscriberRepository,
+      Stub::makeEmpty(CaptchaSession::class)
     );
 
     $data = [
@@ -325,7 +330,8 @@ class CaptchaValidatorTest extends \MailPoetUnitTest {
       $captchaPhrase,
       $this->wp,
       $subscriberIpRepository,
-      $subscriberRepository
+      $subscriberRepository,
+      Stub::makeEmpty(CaptchaSession::class)
     );
 
     $data = [

--- a/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
@@ -755,6 +755,7 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
           verify($data['captcha'])->equals($captcha);
           return true;
         },
+        'isUserExemptFromCaptcha' => false,
       ],
       $this
     );
@@ -777,7 +778,7 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $builtInCaptchaValidator,
       $recaptchaValidator,
       $turnstileValidator,
-      Stub::makeEmpty(BehavioralSignals::class)
+      Stub::make(BehavioralSignals::class, ['looksHuman' => true], $this)
     );
 
     $result = $testee->subscribe(array_merge(['form_id' => 1], $submitData));
@@ -951,6 +952,412 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
 
     $result = $testee->subscribe(['form_id' => 1]);
     verify($result)->equals([]);
+  }
+
+  public function testBuiltInCaptchaEscalatesWhenSignalsLookBotLike() {
+    // Built-in CAPTCHA + correct answer, but behavioral signals look bot-like:
+    // we must re-issue a fresh challenge rather than subscribe.
+    $captchaSessionId = 'sess';
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => CaptchaConstants::TYPE_BUILTIN];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() { return ['form_id' => 1];
+        },
+      ]
+    );
+    $challengeMeta = [
+      'show_captcha' => true,
+      'captcha_session_id' => 'new_session',
+      'captcha_image_url' => 'https://example.com/image',
+      'captcha_audio_url' => 'https://example.com/audio',
+      'redirect_url' => 'https://example.com/page',
+    ];
+    $capturedStash = null;
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'validate' => Expected::once(true),
+        'isUserExemptFromCaptcha' => false,
+        'getInlineCaptchaChallenge' => Expected::once(function($formData) use ($challengeMeta, &$capturedStash) {
+          $capturedStash = $formData;
+          return $challengeMeta;
+        }),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => Expected::once(false)],
+      $this
+    );
+    $subscriberActions = Stub::makeEmpty(
+      SubscriberActions::class,
+      ['subscribe' => Expected::never()],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => $captchaSessionId,
+      'captcha' => 'ABCDEF',
+      BehavioralSignals::FIELD_NAME => ['time_ms' => 100],
+    ]);
+    verify($result['show_captcha'])->true();
+    verify($result['error'])->equals('Please fill in the CAPTCHA.');
+    verify($result['captcha_session_id'])->equals('new_session');
+    // Stash must keep form_id but drop the suspect signals so the resubmit
+    // is evaluated on freshly collected counters, not the cached bot-like ones.
+    verify($capturedStash['form_id'])->equals(1);
+    verify(isset($capturedStash[BehavioralSignals::FIELD_NAME]))->false();
+  }
+
+  public function testBuiltInCaptchaPassesWhenSignalsLookHuman() {
+    $captchaSessionId = 'sess';
+    $subscriber = Stub::makeEmpty(SubscriberEntity::class);
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+        'getSettings' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => CaptchaConstants::TYPE_BUILTIN];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() { return ['form_id' => 1];
+        },
+      ]
+    );
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'validate' => Expected::once(true),
+        'isUserExemptFromCaptcha' => Expected::once(false),
+        'getInlineCaptchaChallenge' => Expected::never(),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => Expected::once(true)],
+      $this
+    );
+    $subscriberActions = Stub::make(
+      SubscriberActions::class,
+      [
+        'subscribe' => Expected::once(function() use ($subscriber) {
+          return [$subscriber, ['confirmationEmailResult' => true]];
+        }),
+      ],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => $captchaSessionId,
+      'captcha' => 'ABCDEF',
+      BehavioralSignals::FIELD_NAME => ['time_ms' => 5000, 'kd_count' => 5, 'focus_count' => 1],
+    ]);
+    verify($result)->equals([]);
+  }
+
+  public function testBuiltInCaptchaSkipsSignalCheckForExemptUsers() {
+    // Admin / editor: exempt from CAPTCHA, must also be exempt from the
+    // behavioral check so they aren't bounced when JS hasn't accumulated signals.
+    $captchaSessionId = 'sess';
+    $subscriber = Stub::makeEmpty(SubscriberEntity::class);
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+        'getSettings' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => CaptchaConstants::TYPE_BUILTIN];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() { return ['form_id' => 1];
+        },
+      ]
+    );
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'validate' => Expected::once(true),
+        'isUserExemptFromCaptcha' => Expected::once(true),
+        'getInlineCaptchaChallenge' => Expected::never(),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => Expected::never()],
+      $this
+    );
+    $subscriberActions = Stub::make(
+      SubscriberActions::class,
+      [
+        'subscribe' => Expected::once(function() use ($subscriber) {
+          return [$subscriber, ['confirmationEmailResult' => true]];
+        }),
+      ],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => $captchaSessionId,
+      'captcha' => 'ABCDEF',
+    ]);
+    verify($result)->equals([]);
+  }
+
+  public function testBuiltInCaptchaResubmitPrefersFreshSignalsOverStash() {
+    // initCaptcha restores the stashed payload on resubmit, but the freshest
+    // behavioral_signals from the current request must win so the user isn't
+    // re-evaluated on the snapshot that triggered the original challenge.
+    $captchaSessionId = 'sess';
+    $stashedSignals = ['time_ms' => 50, 'mm_count' => 0, 'kd_count' => 0, 'focus_count' => 0];
+    $freshSignals = ['time_ms' => 10000, 'mm_count' => 20, 'kd_count' => 10, 'focus_count' => 2];
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+        'getSettings' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => CaptchaConstants::TYPE_BUILTIN];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() use ($stashedSignals) {
+          return ['form_id' => 1, BehavioralSignals::FIELD_NAME => $stashedSignals];
+        },
+      ]
+    );
+    $capturedSignals = null;
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      [
+        'looksHuman' => Expected::once(function($data) use (&$capturedSignals) {
+          $capturedSignals = $data[BehavioralSignals::FIELD_NAME] ?? null;
+          return true;
+        }),
+      ],
+      $this
+    );
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'validate' => Expected::once(true),
+        'isUserExemptFromCaptcha' => false,
+        'getInlineCaptchaChallenge' => Expected::never(),
+      ],
+      $this
+    );
+    $subscriber = Stub::makeEmpty(SubscriberEntity::class);
+    $subscriberActions = Stub::make(
+      SubscriberActions::class,
+      [
+        'subscribe' => Expected::once(function() use ($subscriber) {
+          return [$subscriber, ['confirmationEmailResult' => true]];
+        }),
+      ],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => $captchaSessionId,
+      'captcha' => 'ABCDEF',
+      BehavioralSignals::FIELD_NAME => $freshSignals,
+    ]);
+    verify($result)->equals([]);
+    verify($capturedSignals)->equals($freshSignals);
   }
 
   public function testBehavioralBaselineResubmitVerifiesChallengeAndRestoresStashedSegments() {

--- a/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
@@ -4,6 +4,7 @@ namespace MailPoet\Subscribers;
 
 use Codeception\Stub;
 use Codeception\Stub\Expected;
+use MailPoet\Captcha\BehavioralSignals;
 use MailPoet\Captcha\CaptchaConstants;
 use MailPoet\Captcha\CaptchaSession;
 use MailPoet\Captcha\Validator\CaptchaValidator;
@@ -83,7 +84,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $wp,
       $builtInCaptchaValidator,
       $recaptchaValidator,
-      $turnstileValidator
+      $turnstileValidator,
+      Stub::makeEmpty(BehavioralSignals::class)
     );
 
     $this->expectException(UnexpectedValueException::class);
@@ -174,7 +176,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $wp,
       $builtInCaptchaValidator,
       $recaptchaValidator,
-      $turnstileValidator
+      $turnstileValidator,
+      Stub::make(BehavioralSignals::class, ['looksHuman' => true], $this)
     );
 
     $result = $testee->subscribe(array_merge(['form_id' => 1], $submitData));
@@ -261,7 +264,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $wp,
       $builtInCaptchaValidator,
       $recaptchaValidator,
-      $turnstileValidator
+      $turnstileValidator,
+      Stub::make(BehavioralSignals::class, ['looksHuman' => true], $this)
     );
 
     $this->expectException(UnexpectedValueException::class);
@@ -385,7 +389,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $wp,
       $builtInCaptchaValidator,
       $recaptchaValidator,
-      $turnstileValidator
+      $turnstileValidator,
+      Stub::makeEmpty(BehavioralSignals::class)
     );
 
     $result = $testee->subscribe(array_merge(['form_id' => 1], $submitData));
@@ -522,7 +527,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $wp,
       $builtInCaptchaValidator,
       $recaptchaValidator,
-      $turnstileValidator
+      $turnstileValidator,
+      Stub::makeEmpty(BehavioralSignals::class)
     );
 
     $result = $testee->subscribe(array_merge(['form_id' => 1], $submitData));
@@ -579,7 +585,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       Stub::makeEmpty(WPFunctions::class),
       Stub::makeEmpty(CaptchaValidator::class),
       Stub::makeEmpty(RecaptchaValidator::class),
-      Stub::makeEmpty(TurnstileValidator::class)
+      Stub::makeEmpty(TurnstileValidator::class),
+      Stub::makeEmpty(BehavioralSignals::class)
     );
 
     $result = $testee->isSubscribedToAnyFormSegments($form, $subscriber);
@@ -633,7 +640,8 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       Stub::makeEmpty(WPFunctions::class),
       Stub::makeEmpty(CaptchaValidator::class),
       Stub::makeEmpty(RecaptchaValidator::class),
-      Stub::makeEmpty(TurnstileValidator::class)
+      Stub::makeEmpty(TurnstileValidator::class),
+      Stub::makeEmpty(BehavioralSignals::class)
     );
 
     $result = $testee->isSubscribedToAnyFormSegments($form, $subscriber);
@@ -768,10 +776,281 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
       $wp,
       $builtInCaptchaValidator,
       $recaptchaValidator,
-      $turnstileValidator
+      $turnstileValidator,
+      Stub::makeEmpty(BehavioralSignals::class)
     );
 
     $result = $testee->subscribe(array_merge(['form_id' => 1], $submitData));
     verify($result)->equals([]);
+  }
+
+  public function testBehavioralBaselineEscalatesWhenSignalsAreMissing() {
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => null];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $challengeMeta = [
+      'show_captcha' => true,
+      'captcha_session_id' => 'new_session',
+      'captcha_image_url' => 'https://example.com/image',
+      'captcha_audio_url' => 'https://example.com/audio',
+      'redirect_url' => 'https://example.com/page',
+    ];
+    $capturedStash = null;
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'isUserExemptFromCaptcha' => false,
+        'getInlineCaptchaChallenge' => Expected::once(function($formData) use ($challengeMeta, &$capturedStash) {
+          $capturedStash = $formData;
+          return $challengeMeta;
+        }),
+        'validate' => Expected::never(),
+        'validateChallenge' => Expected::never(),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => false],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      Stub::makeEmpty(CaptchaSession::class),
+      Stub::makeEmpty(SubscriberActions::class, ['subscribe' => Expected::never()], $this),
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe(['form_id' => 1, 'segments' => [1]]);
+    verify($result['show_captcha'])->true();
+    verify($result['error'])->equals('Please fill in the CAPTCHA.');
+    verify($result['captcha_session_id'])->equals('new_session');
+    // The stash must keep the selected segments so the resubmit (inline or via
+    // the non-JS captcha page) can subscribe to the same lists.
+    verify($capturedStash['form_id'])->equals(1);
+    verify($capturedStash['segments'])->equals([1]);
+  }
+
+  public function testBehavioralBaselinePassesSilentlyWhenSignalsLookHuman() {
+    $subscriber = Stub::makeEmpty(SubscriberEntity::class);
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+        'getSettings' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => null];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'isUserExemptFromCaptcha' => false,
+        'getInlineCaptchaChallenge' => Expected::never(),
+        'validate' => Expected::never(),
+        'validateChallenge' => Expected::never(),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => Expected::once(true)],
+      $this
+    );
+    $subscriberActions = Stub::make(
+      SubscriberActions::class,
+      [
+        'subscribe' => Expected::once(function() use ($subscriber) {
+          return [$subscriber, ['confirmationEmailResult' => true]];
+        }),
+      ],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      Stub::makeEmpty(CaptchaSession::class),
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe(['form_id' => 1]);
+    verify($result)->equals([]);
+  }
+
+  public function testBehavioralBaselineResubmitVerifiesChallengeAndRestoresStashedSegments() {
+    $subscriber = Stub::makeEmpty(SubscriberEntity::class);
+    // A form whose segments come from a list-selection block: if the stashed
+    // payload lost `segments`, getSegmentIds() would throw "Please select a list."
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSegmentBlocksSegmentIds' => function(): array { return [1, 2];
+        },
+        'getSettingsSegmentIds' => function(): array { return [99];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+        'getSettings' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => null];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() { return ['form_id' => 1, 'segments' => [1]];
+        },
+      ]
+    );
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'isUserExemptFromCaptcha' => Expected::never(),
+        'getInlineCaptchaChallenge' => Expected::never(),
+        'validate' => Expected::never(),
+        'validateChallenge' => Expected::once(true),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => Expected::never()],
+      $this
+    );
+    $capturedSegmentIds = null;
+    $subscriberActions = Stub::make(
+      SubscriberActions::class,
+      [
+        'subscribe' => Expected::once(function($data, $segmentIds) use ($subscriber, &$capturedSegmentIds) {
+          $capturedSegmentIds = $segmentIds;
+          return [$subscriber, ['confirmationEmailResult' => true]];
+        }),
+      ],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => 'sess',
+      'captcha' => 'ABCDEF',
+    ]);
+    verify($result)->equals([]);
+    verify($capturedSegmentIds)->equals([1]);
   }
 }

--- a/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
+++ b/mailpoet/tests/unit/Subscribers/SubscriberSubscribeControllerUnitTest.php
@@ -1409,7 +1409,7 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
     $builtInCaptchaValidator = Stub::make(
       CaptchaValidator::class,
       [
-        'isUserExemptFromCaptcha' => Expected::never(),
+        'isUserExemptFromCaptcha' => Expected::once(false),
         'getInlineCaptchaChallenge' => Expected::never(),
         'validate' => Expected::never(),
         'validateChallenge' => Expected::once(true),
@@ -1418,7 +1418,7 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
     );
     $behavioralSignals = Stub::make(
       BehavioralSignals::class,
-      ['looksHuman' => Expected::never()],
+      ['looksHuman' => Expected::once(true)],
       $this
     );
     $capturedSegmentIds = null;
@@ -1459,5 +1459,212 @@ class SubscriberSubscribeControllerUnitTest extends \MailPoetUnitTest {
     ]);
     verify($result)->equals([]);
     verify($capturedSegmentIds)->equals([1]);
+  }
+
+  public function testBehavioralBaselineResubmitReChallengesWhenSignalsStillLookBotLike() {
+    // No CAPTCHA configured + correct CAPTCHA answer on the escalated challenge,
+    // but the resubmit still has non-human signals (e.g. JS-disabled client):
+    // solving the CAPTCHA alone must not bypass the baseline.
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => null];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() { return ['form_id' => 1];
+        },
+      ]
+    );
+    $challengeMeta = [
+      'show_captcha' => true,
+      'captcha_session_id' => 'new_session',
+      'captcha_image_url' => 'https://example.com/image',
+      'captcha_audio_url' => 'https://example.com/audio',
+      'redirect_url' => 'https://example.com/page',
+    ];
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'isUserExemptFromCaptcha' => Expected::once(false),
+        'validateChallenge' => Expected::once(true),
+        'getInlineCaptchaChallenge' => Expected::once(function() use ($challengeMeta) {
+          return $challengeMeta;
+        }),
+        'validate' => Expected::never(),
+      ],
+      $this
+    );
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      ['looksHuman' => Expected::once(false)],
+      $this
+    );
+    $subscriberActions = Stub::makeEmpty(
+      SubscriberActions::class,
+      ['subscribe' => Expected::never()],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => 'sess',
+      'captcha' => 'ABCDEF',
+    ]);
+    verify($result['show_captcha'])->true();
+    verify($result['captcha_session_id'])->equals('new_session');
+    verify($result['error'])->equals('Please fill in the CAPTCHA.');
+  }
+
+  public function testBehavioralBaselineResubmitPrefersFreshSignalsOverStash() {
+    // The stash carries bot-like signals from the original submit. On resubmit,
+    // the current request's freshest signals must override the stash so the
+    // resubmit's signal check reflects accumulated interaction.
+    $stashedSignals = ['time_ms' => 50, 'kd_count' => 0];
+    $freshSignals = ['time_ms' => 10000, 'mm_count' => 20, 'kd_count' => 10, 'focus_count' => 2];
+    $subscriber = Stub::makeEmpty(SubscriberEntity::class);
+    $form = Stub::makeEmpty(
+      FormEntity::class,
+      [
+        'getId' => 1,
+        'getSettingsSegmentIds' => function(): array { return [1];
+        },
+        'getBlocksByTypes' => function(): array { return [];
+        },
+        'getSettings' => function(): array { return [];
+        },
+      ]
+    );
+    $formsRepository = Stub::makeEmpty(
+      FormsRepository::class,
+      [
+        'findOneById' => function() use ($form): FormEntity { return $form;
+        },
+      ]
+    );
+    $settings = Stub::makeEmpty(
+      SettingsController::class,
+      [
+        'get' => function() { return ['type' => null];
+        },
+      ]
+    );
+    $fieldNameObfuscator = Stub::makeEmpty(
+      FieldNameObfuscator::class,
+      [
+        'deobfuscateFormPayload' => function($data) { return $data;
+        },
+      ]
+    );
+    $captchaSession = Stub::makeEmpty(
+      CaptchaSession::class,
+      [
+        'getFormData' => function() use ($stashedSignals) {
+          return ['form_id' => 1, BehavioralSignals::FIELD_NAME => $stashedSignals];
+        },
+      ]
+    );
+    $capturedSignals = null;
+    $behavioralSignals = Stub::make(
+      BehavioralSignals::class,
+      [
+        'looksHuman' => Expected::once(function($data) use (&$capturedSignals) {
+          $capturedSignals = $data[BehavioralSignals::FIELD_NAME] ?? null;
+          return true;
+        }),
+      ],
+      $this
+    );
+    $builtInCaptchaValidator = Stub::make(
+      CaptchaValidator::class,
+      [
+        'isUserExemptFromCaptcha' => false,
+        'validateChallenge' => Expected::once(true),
+        'getInlineCaptchaChallenge' => Expected::never(),
+        'validate' => Expected::never(),
+      ],
+      $this
+    );
+    $subscriberActions = Stub::make(
+      SubscriberActions::class,
+      [
+        'subscribe' => Expected::once(function() use ($subscriber) {
+          return [$subscriber, ['confirmationEmailResult' => true]];
+        }),
+      ],
+      $this
+    );
+
+    $testee = new SubscriberSubscribeController(
+      $captchaSession,
+      $subscriberActions,
+      Stub::makeEmpty(SubscribersFinder::class),
+      Stub::makeEmpty(SubscriptionThrottling::class),
+      $fieldNameObfuscator,
+      Stub::makeEmpty(RequiredCustomFieldValidator::class),
+      $settings,
+      $formsRepository,
+      Stub::makeEmpty(StatisticsFormsRepository::class),
+      Stub::makeEmpty(TagRepository::class),
+      Stub::makeEmpty(SubscriberTagRepository::class),
+      Stub::makeEmpty(WPFunctions::class),
+      $builtInCaptchaValidator,
+      Stub::makeEmpty(RecaptchaValidator::class),
+      Stub::makeEmpty(TurnstileValidator::class),
+      $behavioralSignals
+    );
+
+    $result = $testee->subscribe([
+      'form_id' => 1,
+      'captcha_session_id' => 'sess',
+      'captcha' => 'ABCDEF',
+      BehavioralSignals::FIELD_NAME => $freshSignals,
+    ]);
+    verify($result)->equals([]);
+    verify($capturedSignals)->equals($freshSignals);
   }
 }

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -133,6 +133,17 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     echo "<?php add_filter('site_transient_woocommerce_blocks_patterns', '__return_false');" > "/wp-core/wp-content/mu-plugins/woo-cache-disable.php"
   fi
 
+  # Always treat submissions as human-like in the test environment. Selenium
+  # completes form interactions faster than the production thresholds and
+  # integration tests subscribe directly without ever populating signals, so the
+  # baseline check would otherwise escalate every form-driven test to the inline
+  # CAPTCHA. Production thresholds stay untouched.
+  mkdir -p /wp-core/wp-content/mu-plugins
+  cat > /wp-core/wp-content/mu-plugins/mailpoet-test-behavioral-signals.php <<'PHP'
+<?php
+add_filter('mailpoet_behavioral_signals_looks_human', '__return_true');
+PHP
+
   ACTIVATION_CONTEXT=$HTTP_HOST
   # For integration tests in multisite environment we need to activate the plugin for correct site that is loaded in tests
   # The acceptance tests activate/deactivate plugins using a helper.

--- a/tests_env/docker/codeception/docker-entrypoint.sh
+++ b/tests_env/docker/codeception/docker-entrypoint.sh
@@ -133,17 +133,6 @@ if [[ $SKIP_PLUGINS != "1" ]]; then
     echo "<?php add_filter('site_transient_woocommerce_blocks_patterns', '__return_false');" > "/wp-core/wp-content/mu-plugins/woo-cache-disable.php"
   fi
 
-  # Always treat submissions as human-like in the test environment. Selenium
-  # completes form interactions faster than the production thresholds and
-  # integration tests subscribe directly without ever populating signals, so the
-  # baseline check would otherwise escalate every form-driven test to the inline
-  # CAPTCHA. Production thresholds stay untouched.
-  mkdir -p /wp-core/wp-content/mu-plugins
-  cat > /wp-core/wp-content/mu-plugins/mailpoet-test-behavioral-signals.php <<'PHP'
-<?php
-add_filter('mailpoet_behavioral_signals_looks_human', '__return_true');
-PHP
-
   ACTIVATION_CONTEXT=$HTTP_HOST
   # For integration tests in multisite environment we need to activate the plugin for correct site that is loaded in tests
   # The acceptance tests activate/deactivate plugins using a helper.
@@ -187,6 +176,19 @@ PHP
     echo "WooCommerce HPOS is disabled!";
   fi
 fi
+
+# Always treat submissions as human-like in the test environment. Selenium
+# completes form interactions faster than the production thresholds and
+# integration tests subscribe directly without ever populating signals, so the
+# baseline check would otherwise escalate every form-driven test to the inline
+# CAPTCHA. Installed regardless of SKIP_PLUGINS because integration tests run
+# without the WooCommerce plugins but still hit the subscribe endpoint.
+# Production thresholds stay untouched.
+mkdir -p /wp-core/wp-content/mu-plugins
+cat > /wp-core/wp-content/mu-plugins/mailpoet-test-behavioral-signals.php <<'PHP'
+<?php
+add_filter('mailpoet_behavioral_signals_looks_human', '__return_true');
+PHP
 
 # Set constants in wp-config.php
 wp config set WP_DEBUG true --raw


### PR DESCRIPTION
## Description

MailPoet subscription forms previously had no automated-submission protection when CAPTCHA was disabled, and the built-in CAPTCHA mode treated a correct CAPTCHA answer as sufficient even for non-human interaction. This adds a behavioral-signal baseline that applies on **both** the CAPTCHA-disabled path and on top of the built-in CAPTCHA:

- The form JS collects per-form **counters** from mount to submit — fill time, mouse-move count, keydown count, scroll count, distinct focused fields, and a touch-device flag. No coordinates, no traces, no fingerprinting surface.
- On submit, `BehavioralSignals::looksHuman()` evaluates those counters (device-appropriate OR-logic so password-manager autofill, mobile, and pure-mouse users still pass). The result passes through a `mailpoet_behavioral_signals_looks_human` filter so subscribers can override per-site.
- **CAPTCHA disabled:** bot-looking signals escalate to the built-in inline CAPTCHA. Solving the inline CAPTCHA is no longer sufficient — signals are re-checked on the resubmit, so a JS-disabled client (no signals at all) can't bypass the baseline by solving a single CAPTCHA.
- **Built-in CAPTCHA active:** behavioral signals are required in addition to a correct CAPTCHA answer. Solver services or JS-running bots that pass the CAPTCHA but don't produce human-like interaction get re-challenged with a fresh CAPTCHA.
- Admin/editor exemption applies on both paths, mirroring the existing built-in CAPTCHA exemption.

It also fixes a stash-ordering bug found while wiring this up: the escalation stash keeps the selected `segments`, so the resubmit (inline or via the non-JS captcha page) subscribes to the same lists — including forms that use a list-selection block, which would otherwise fail with "Please select a list." after the visitor solved the CAPTCHA. The resubmit's payload also keeps the freshest `behavioral_signals` from the current request over the stash, so retries are evaluated on accumulated interaction rather than the original (possibly bot-like) snapshot.

## Code review notes

- A single `requireHumanSignals()` helper is used by both the disabled-path and built-in-CAPTCHA path, so exemption/escalation/stash-stripping behavior can't drift between them.
- `SubscriberSubscribeController::subscribe()` now `unset($data['segments'])` *after* `validateCaptcha()` instead of before — without that, the behavioral-escalation stash lost the segments. `segments` is dropped a few lines later by the existing form-field `array_intersect_key` filter anyway, so nothing downstream changes.
- `initCaptcha()` preserves the current request's `captcha` and `behavioral_signals` over the stash on both the built-in branch and the disabled-baseline branch, so resubmits are scored on the latest counters.
- This is **on by default** for every install — no feature flag or settings toggle. Non-JS visitors and direct programmatic submissions to `POST /subscribers/subscribe` always get escalated to the built-in image CAPTCHA. Intentional, but worth a second opinion on whether it should be gated.
- On the touch path, `looksHuman()` requires `scroll_count >= 1 || keydown_count >= min_interactions`; a mobile visitor who autofills a short form without scrolling or typing would be challenged. Acceptable tradeoff for "baseline" protection.
- The signals are client-supplied and forgeable by a bot tailored to MailPoet — this raises the bar for naive bots; the CAPTCHA escalation is the real backstop.
- `tests_env/docker/codeception/docker-entrypoint.sh` installs a small mu-plugin that hooks `mailpoet_behavioral_signals_looks_human` and returns `true`, so existing integration and acceptance tests (which subscribe through forms without populating signals) keep working without per-test boilerplate.

## QA notes

**With CAPTCHA set to "Disabled" (Settings → Advanced):**

1. Submit a form normally in a browser (move the mouse / type) → subscribes without showing a CAPTCHA.
2. Submit with no behavioral interaction — e.g. POST to `/?action=mailpoet_subscription_form` (or the `wp-json` subscribe endpoint) without a `behavioral_signals` payload → response asks for the CAPTCHA (`show_captcha`). Solving the inline CAPTCHA without producing signals (e.g. JS disabled, or replaying the POST) should re-issue another CAPTCHA, not subscribe you.
3. Use a form that contains a **List selection** block. Trigger the escalation (step 2 from the browser), solve the CAPTCHA → subscribed to the list you picked.
4. Log in as an administrator, repeat step 2 → no CAPTCHA challenge (exempt).

**With Built-in CAPTCHA active:**

5. Submit a form normally in a browser → solve the CAPTCHA → subscribed.
6. Submit with a correct CAPTCHA answer but no behavioral signals (e.g. programmatic POST) → response asks for a fresh CAPTCHA. Solving the CAPTCHA alone is not enough.
7. Log in as administrator → no CAPTCHA shown (existing exemption).

## Linked PRs

_N/A_

## Linked tickets

[MPI-330](https://linear.app/a8c/issue/MPI-330)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/mpi-330-behavioral-signals-baseline-protection)

_The latest successful build from `add/mpi-330-behavioral-signals-baseline-protection` will be used. If none is available, the link won't work._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 1 Issue Found

**Bug: Missing threshold filter implementation**

The PR objectives state "Thresholds are filterable via `mailpoet_behavioral_signals_thresholds`", but the `BehavioralSignals::looksHuman()` implementation does not apply this filter. The thresholds are hardcoded in an array (`DEFAULT_MIN_TIME_MS`, `DEFAULT_MIN_INTERACTIONS`, `DEFAULT_MIN_FIELD_FOCUS`) and the code builds a hardcoded `$thresholds` array without consulting the promised `mailpoet_behavioral_signals_thresholds` filter. Only the `mailpoet_behavioral_signals_looks_human` filter is implemented, not the threshold customization filter mentioned in the requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->