### PR TITLE
Fix 'Illegal mix of collations' on plugin activation (5.26.0 regression)

### DIFF
--- a/mailpoet/changelog/2026-05-12-13-59-28-fixed-activation-error-illegal-mix-of-collations-during-.md
+++ b/mailpoet/changelog/2026-05-12-13-59-28-fixed-activation-error-illegal-mix-of-collations-during-.md
@@ -1,0 +1,5 @@
+# Type: Fixed
+
+# Description
+
+Activation error 'Illegal mix of collations' during WordPress user sync when wp_users and MailPoet subscribers tables use different collations

--- a/mailpoet/lib/Segments/WP.php
+++ b/mailpoet/lib/Segments/WP.php
@@ -16,6 +16,7 @@ use MailPoet\Subscribers\ConfirmationEmailMailer;
 use MailPoet\Subscribers\Source;
 use MailPoet\Subscribers\SubscriberSegmentRepository;
 use MailPoet\Subscribers\SubscribersRepository;
+use MailPoet\Util\DBCollationChecker;
 use MailPoet\WooCommerce\Helper as WooCommerceHelper;
 use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
@@ -50,6 +51,9 @@ class WP {
   /** @var EntityManager */
   private $entityManager;
 
+  /** @var DBCollationChecker */
+  private $collationChecker;
+
   /** @var string */
   private $subscribersTable;
 
@@ -65,7 +69,8 @@ class WP {
     SubscriberChangesNotifier $subscriberChangesNotifier,
     Validator $validator,
     SegmentsRepository $segmentsRepository,
-    EntityManager $entityManager
+    EntityManager $entityManager,
+    DBCollationChecker $collationChecker
   ) {
     $this->wp = $wp;
     $this->welcomeScheduler = $welcomeScheduler;
@@ -76,6 +81,7 @@ class WP {
     $this->validator = $validator;
     $this->segmentsRepository = $segmentsRepository;
     $this->entityManager = $entityManager;
+    $this->collationChecker = $collationChecker;
     $this->databaseConnection = $this->entityManager->getConnection();
     $this->subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
   }
@@ -475,13 +481,22 @@ class WP {
         WHERE s.wp_user_id IS NULL AND u.user_email != ''";
     $insertedUserIds = $this->databaseConnection->fetchAllAssociative($selectSql);
 
-    // Insert new users into the subscribers table
+    // Insert new users into the subscribers table.
+    // The email-based join can cross a collation boundary when wp_users.user_email and
+    // mailpoet_subscribers.email use different (but compatible) collations — force a
+    // matching collation to avoid "Illegal mix of collations" errors.
+    $emailCollation = $this->collationChecker->getCollateIfNeeded(
+      $wpdb->users,
+      'user_email',
+      $this->subscribersTable,
+      'email'
+    );
     $insertSql =
       "INSERT IGNORE INTO {$this->subscribersTable} (wp_user_id, email, status, created_at, `source`, deleted_at)
         SELECT wu.id, wu.user_email, :subscriberStatus, CURRENT_TIMESTAMP(), :source, {$deletedAt}
         FROM {$wpdb->users} wu
         LEFT JOIN {$this->subscribersTable} s ON wu.id = s.wp_user_id
-        LEFT JOIN {$this->subscribersTable} existingSubscriber ON wu.user_email = existingSubscriber.email
+        LEFT JOIN {$this->subscribersTable} existingSubscriber ON wu.user_email = existingSubscriber.email {$emailCollation}
         WHERE s.wp_user_id IS NULL AND wu.user_email != ''
         ON DUPLICATE KEY UPDATE
           wp_user_id = wu.id,

--- a/mailpoet/tests/integration/Segments/WPTest.php
+++ b/mailpoet/tests/integration/Segments/WPTest.php
@@ -141,6 +141,58 @@ class WPTest extends \MailPoetTest {
     verify($subscribers[1]->getStatus())->equals(SubscriberEntity::STATUS_UNCONFIRMED);
   }
 
+  public function testSynchronizeUsersWorksWithMismatchedEmailColumnCollation(): void {
+    // Regression test for STOMAIL-8067: when wp_users.user_email and
+    // mailpoet_subscribers.email use different (but compatible) collations,
+    // the LEFT JOIN added in 5.26.0's insertSubscribers() raised
+    // "Illegal mix of collations" and broke plugin activation.
+    global $wpdb;
+    $originalCollation = $this->connection->executeQuery(
+      "SELECT COLLATION_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{$wpdb->users}'
+          AND COLUMN_NAME = 'user_email'"
+    )->fetchOne();
+    $this->assertIsString($originalCollation);
+
+    $mismatchCollation = $originalCollation === 'utf8mb4_unicode_ci' ? 'utf8mb4_general_ci' : 'utf8mb4_unicode_ci';
+    $this->connection->executeStatement(
+      "ALTER TABLE {$wpdb->users} MODIFY user_email VARCHAR(100) CHARACTER SET utf8mb4 COLLATE {$mismatchCollation} NOT NULL DEFAULT ''"
+    );
+    $postAlterCollation = $this->connection->executeQuery(
+      "SELECT COLLATION_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{$wpdb->users}'
+          AND COLUMN_NAME = 'user_email'"
+    )->fetchOne();
+    $this->assertSame($mismatchCollation, $postAlterCollation, 'ALTER did not change column collation');
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $subscribersEmailCollation = $this->connection->executeQuery(
+      "SELECT COLLATION_NAME FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = '{$subscribersTable}'
+          AND COLUMN_NAME = 'email'"
+    )->fetchOne();
+    $this->assertNotSame($postAlterCollation, $subscribersEmailCollation, 'Test setup: subscribers.email should not match wp_users.user_email collation');
+
+    try {
+      // A pre-existing subscriber row guarantees the LEFT JOIN on email actually
+      // evaluates the cross-collation comparison instead of short-circuiting on
+      // an empty right side.
+      $this->subscriberFactory
+        ->withEmail('pre-existing-subscriber@example.com')
+        ->create();
+      $this->insertUser();
+      $this->insertUser();
+      $this->wpSegment->synchronizeUsers();
+      verify($this->getSubscribersCount())->equals(2);
+    } finally {
+      $this->connection->executeStatement(
+        "ALTER TABLE {$wpdb->users} MODIFY user_email VARCHAR(100) NOT NULL DEFAULT '' COLLATE {$originalCollation}"
+      );
+    }
+  }
+
   public function testSynchronizeUserRemovesDuplicateSubscriberOnEmailChange(): void {
     $randomNumber = rand();
     // Create a WP user with email A


### PR DESCRIPTION
## Description

5.26.0 shipped a regression that breaks plugin activation on sites where `wp_users.user_email` and `mailpoet_subscribers.email` use compatible-but-different `utf8mb4` collations (a common combination: `utf8mb4_unicode_ci` on core's WP tables, `utf8mb4_unicode_520_ci` on MailPoet's tables). Users see:

```
MailPoet\Doctrine\WPDB\Exceptions\QueryException:
Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
and (utf8mb4_unicode_520_ci,IMPLICIT) for operation '='
```

Stack trace bottoms out at `Initializer::maybeRunActivator` → `Activator::activate` → `Populator::createDefaultSegment` → `Segments\WP::synchronizeUsers` → `insertSubscribers` → `executeStatement` (the new query introduced in 44cb8e8950 / MAILPOET-8018).

The bad query is the `LEFT JOIN existingSubscriber ON wu.user_email = existingSubscriber.email` added so the `ON DUPLICATE KEY UPDATE` block can look at the row that collides on the unique email index. Previously the only cross-table compare was integer (`wu.id = s.wp_user_id`), so no collation issue surfaced.

This PR routes that join through the existing `DBCollationChecker::getCollateIfNeeded()` helper — the same pattern `WooFilterHelper::applyCustomerLookupJoin()` already uses — to append a `COLLATE` clause only when the two columns share a charset but disagree on collation.

## Code review notes

- The cross-table compare on line 484 was the **only** newly-introduced string join in 5.26.0 — the other queries in `synchronizeUsers` (`updateSubscribersEmails`, `updateFirstNames`, `updateLastNames`, `insertUsersToSegment`) all join on integer columns or compare a column against a string literal, so no further `COLLATE` plumbing is needed.
- `DBCollationChecker::getCollateIfNeeded()` returns an empty string when both columns already share a collation, so on a healthy install the SQL is byte-identical to before this fix.
- `Segments\WP` is autowired (`ContainerConfigurator.php:512`), and `DBCollationChecker` is autowired (`:659`), so DI picks up the new constructor parameter automatically. No callers outside DI construct `Segments\WP` manually (checked free + premium).

## QA notes

To reproduce the bug on a clean wp-env install:

1. `pnpm wp db query "ALTER TABLE wp_users MODIFY user_email VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''"` (subscribers.email is `utf8mb4_unicode_520_ci`)
2. Insert at least one row into `mailpoet_subscribers` so the LEFT JOIN actually evaluates its predicate.
3. Deactivate + reactivate MailPoet. Without the fix you see the fatal `Illegal mix of collations` error; with the fix activation completes normally.

Or run the new regression test directly:

```
pnpm test:integration --file=tests/integration/Segments/WPTest.php
```

47 tests / 179 assertions pass locally. The new test (`testSynchronizeUsersWorksWithMismatchedEmailColumnCollation`) errors out with the exact user-reported message when the fix is reverted.

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8067](https://linear.app/a8c/issue/STOMAIL-8067/issue-5260)
- https://wordpress.org/support/topic/update-broke-my-site-37/
- https://wordpress.org/support/topic/warnings-in-5-26-0/

## After-merge notes

Worth considering a 5.26.1 hotfix release — the bug breaks the plugin on activation for a non-trivial slice of sites (anywhere the WP and MailPoet tables disagree on `utf8mb4` collation, which is common on older MariaDB/MySQL installs).

## Screenshots or screencast

_N/A_ — backend change.

## Tasks

- [x] I have added a changelog entry (\`pnpm changelog:add --type=<type> --description=<description>\`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8067-issue-5260)

_The latest successful build from `stomail-8067-issue-5260` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The PR correctly implements the collation mismatch fix for plugin activation. The code:
- Properly injects `DBCollationChecker` as a dependency with correct DI autowiring
- Correctly implements the `getCollateIfNeeded()` method with proper variable assignments and type handling
- Uses hardcoded, non-user-input table and column names in actual usage, avoiding SQL injection concerns
- Includes a comprehensive regression test that validates the fix by intentionally creating a collation mismatch, verifying the collation change took effect, and confirming `synchronizeUsers()` completes without error
- Follows the established pattern already used in other files like `WooFilterHelper.php`
- The early return on line 34-36 ensures mismatched but compatible collations are handled correctly

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6745)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->