### PR TITLE
Release 5.26.1

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -20,15 +20,11 @@ add_action('init', function () {
   if (!class_exists(\MailPoet\API\API::class)) {
     return;
   }
-  try {
-    $mailpoet_api = \MailPoet\API\API::MP('v1');
-  } catch (\Exception $e) {
-    // MailPoet is still initializing or upgrading on this request.
-  }
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
 });
 ```
 
-Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by WordPress. Call the API from `init` (default priority) or later so MailPoet has run any pending database migrations. Calling the API earlier — for example on `plugins_loaded` during an upgrade — will throw a readiness exception you can catch and handle.
+Class `\MailPoet\API\API` becomes available once MailPoet plugin is loaded by WordPress. Call the API from `init` (default priority) or later so MailPoet has finished bootstrapping and run any pending database migrations.
 
 ### Available API Methods
 

--- a/doc/UsageExamples.md
+++ b/doc/UsageExamples.md
@@ -4,7 +4,7 @@
 
 Common usage is a rendering of a subscription form and processing it.
 
-Hook your API calls into `init` (default priority) or later, after MailPoet has finished its initialization and any pending database migrations. Calling the API earlier (e.g. on `plugins_loaded`) during a MailPoet upgrade will throw a readiness exception, which you can catch and handle.
+Hook your API calls into `init` (default priority) or later, after MailPoet has finished its initialization and any pending database migrations.
 
 ## Fetching data for a subscription form
 
@@ -16,16 +16,12 @@ add_action('init', function () {
     return;
   }
 
-  try {
-    // Get MailPoet API instance
-    $mailpoet_api = \MailPoet\API\API::MP('v1');
-    // Get available list so that a subscriber can choose in which to subscribe
-    $lists = $mailpoet_api->getLists();
-    // Get subscriber fields to know what fields can be rendered within a form
-    $subscriber_form_fields = $mailpoet_api->getSubscriberFields();
-  } catch (\Exception $e) {
-    // MailPoet is still upgrading or otherwise unavailable on this request.
-  }
+  // Get MailPoet API instance
+  $mailpoet_api = \MailPoet\API\API::MP('v1');
+  // Get available list so that a subscriber can choose in which to subscribe
+  $lists = $mailpoet_api->getLists();
+  // Get subscriber fields to know what fields can be rendered within a form
+  $subscriber_form_fields = $mailpoet_api->getSubscriberFields();
 });
 ```
 

--- a/mailpoet/changelog.txt
+++ b/mailpoet/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 5.26.1 - 2026-05-12 =
+* Fixed: Activation error 'Illegal mix of collations' during WordPress user sync when wp_users and MailPoet subscribers tables use different collations;
+* Fixed: Avoid breaking third-party integrations that call MailPoet public API before init hook.
+
 = 5.26.0 - 2026-05-12 =
 * Added: WooCommerce dynamic segment filter for product variations;
 * Added: "Email subscriber unsubscribed" automation trigger;

--- a/mailpoet/changelog/2026-05-12-13-59-28-fixed-activation-error-illegal-mix-of-collations-during-.md
+++ b/mailpoet/changelog/2026-05-12-13-59-28-fixed-activation-error-illegal-mix-of-collations-during-.md
@@ -1,5 +1,0 @@
-# Type: Fixed
-
-# Description
-
-Activation error 'Illegal mix of collations' during WordPress user sync when wp_users and MailPoet subscribers tables use different collations

--- a/mailpoet/lib/API/API.php
+++ b/mailpoet/lib/API/API.php
@@ -2,9 +2,7 @@
 
 namespace MailPoet\API;
 
-use MailPoet\Config\Env;
 use MailPoet\DI\ContainerWrapper;
-use MailPoet\Settings\SettingsController;
 use MailPoetVendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class API {
@@ -16,32 +14,10 @@ class API {
   public static function MP($version) {
     /** @var class-string<\MailPoet\API\MP\v1\API> $apiClass */
     $apiClass = sprintf('%s\MP\%s\API', __NAMESPACE__, $version);
-    $container = ContainerWrapper::getInstance();
-    self::ensureReady($container);
     try {
-      return $container->get($apiClass);
+      return ContainerWrapper::getInstance()->get($apiClass);
     } catch (ServiceNotFoundException $e) {
       throw new \Exception(__('Invalid API version.', 'mailpoet'));
     }
-  }
-
-  /**
-   * Guards against API calls that hit the database before MailPoet has finished
-   * its activator/migration path on `init`. Without this, an early call (e.g. from
-   * `plugins_loaded` during a plugin upgrade) could query Doctrine entities against
-   * an outdated schema and fatal mid-request.
-   */
-  private static function ensureReady(ContainerWrapper $container): void {
-    try {
-      $currentDbVersion = $container->get(SettingsController::class)->get('db_version');
-    } catch (\Throwable $e) {
-      $currentDbVersion = null;
-    }
-
-    if (version_compare((string)$currentDbVersion, Env::$version) === 0) {
-      return;
-    }
-
-    throw new \Exception(__('MailPoet is still initializing or upgrading. Call the public API from the "init" hook (default priority) or later.', 'mailpoet'));
   }
 }

--- a/mailpoet/mailpoet.php
+++ b/mailpoet/mailpoet.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: MailPoet
- * Version: 5.26.0
+ * Version: 5.26.1
  * Plugin URI: https://www.mailpoet.com
  * Description: Create and send newsletters, post notifications and welcome emails from your WordPress.
  * Author: MailPoet
@@ -20,7 +20,7 @@
  */
 
 $mailpoetPlugin = [
-  'version' => '5.26.0',
+  'version' => '5.26.1',
   'filename' => __FILE__,
   'path' => dirname(__FILE__),
   'autoloader' => dirname(__FILE__) . '/vendor/autoload_packages.php',

--- a/mailpoet/readme.txt
+++ b/mailpoet/readme.txt
@@ -3,7 +3,7 @@ Contributors: mailpoet, woocommerce, automattic
 Tags: email marketing, post notification, woocommerce emails, email automation, newsletter
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 5.26.0
+Stable tag: 5.26.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -227,30 +227,8 @@ Check our [Knowledge Base](https://kb.mailpoet.com) or contact us through our [s
 
 == Changelog ==
 
-= 5.26.0 - 2026-05-12 =
-* Added: WooCommerce dynamic segment filter for product variations;
-* Added: "Email subscriber unsubscribed" automation trigger;
-* Added: Add email notifications when sites near their subscriber limit;
-* Added: Cloudflare Turnstile as a CAPTCHA option;
-* Added: Automated Latest Content post customization hook;
-* Improved: Clarify the automation email editor return button label;
-* Improved: Post notifications can now be scheduled weekly or monthly on multiple days;
-* Improved: Subscriber exports use smaller batches to reduce memory use;
-* Improved: Subscriber import results now include skipped rows;
-* Improved: Respect WordPress date format settings in MailPoet UIs;
-* Changed: Deleting a WordPress user no longer deletes the linked MailPoet subscriber; the subscriber is unlinked from the WP user and kept on any other lists (use the mailpoet_delete_subscriber_on_wp_user_delete filter to restore the previous hard-delete behavior);
-* Changed: Subscriber exports no longer select IP address fields by default;
-* Changed: Adding a subscriber with an existing email now shows an error instead of updating the existing subscriber;
-* Changed: Newsletter archive shortcode now uses a default result limit of 100 when no limit is specified;
-* Fixed: Match purchased product across orders for the all-of operator in WooCommerce dynamic segments;
-* Fixed: Prevent duplicate confirmation emails when already subscribed users submit signup forms;
-* Fixed: System report timestamps now use the WordPress timezone;
-* Fixed: Throw a controlled exception instead of fataling when the public API is called against an outdated database schema during a MailPoet upgrade;
-* Fixed: Skipping the welcome wizard sender step preserves existing sender details;
-* Fixed: MailPoet cookie deletion now expires browser cookies;
-* Fixed: Disabled newsletter task scheduler settings display correctly;
-* Fixed: Prevent newsletter signup forms from failing when cached form nonces expire;
-* Fixed: Post notification scheduling follows the WordPress week start setting;
-* Fixed: Prevent PHP warnings from invalid deferred admin notice data.
+= 5.26.1 - 2026-05-12 =
+* Fixed: Activation error 'Illegal mix of collations' during WordPress user sync when wp_users and MailPoet subscribers tables use different collations;
+* Fixed: Avoid breaking third-party integrations that call MailPoet public API before init hook.
 
 [See the changelog for all versions.](https://github.com/mailpoet/mailpoet/blob/trunk/mailpoet/changelog.txt)

--- a/mailpoet/tests/integration/API/APITest.php
+++ b/mailpoet/tests/integration/API/APITest.php
@@ -3,8 +3,6 @@
 namespace MailPoet\Test\API;
 
 use MailPoet\API\API;
-use MailPoet\Config\Env;
-use MailPoet\Settings\SettingsController;
 
 class APITest extends \MailPoetTest {
   public function testItCallsMPAPI() {
@@ -17,33 +15,6 @@ class APITest extends \MailPoetTest {
       $this->fail('Incorrect API version exception should have been thrown.');
     } catch (\Exception $e) {
       verify($e->getMessage())->equals('Invalid API version.');
-    }
-  }
-
-  public function testItThrowsWhenCalledBeforeMigrationsHaveRun() {
-    $settings = $this->diContainer->get(SettingsController::class);
-    $originalDbVersion = $settings->get('db_version');
-    $settings->set('db_version', '0.0.1');
-
-    try {
-      API::MP('v1');
-      $this->fail('Expected readiness exception was not thrown.');
-    } catch (\Exception $e) {
-      verify($e->getMessage())->stringContainsString('still initializing');
-    } finally {
-      $settings->set('db_version', $originalDbVersion);
-    }
-  }
-
-  public function testItDoesNotThrowOnceDbVersionMatches() {
-    $settings = $this->diContainer->get(SettingsController::class);
-    $originalDbVersion = $settings->get('db_version');
-    $settings->set('db_version', Env::$version);
-
-    try {
-      verify(API::MP('v1'))->instanceOf('MailPoet\API\MP\v1\API');
-    } finally {
-      $settings->set('db_version', $originalDbVersion);
     }
   }
 }


### PR DESCRIPTION


## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:release)

_The latest successful build from `release` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Issues Found: 2 Bugs

### Bug Category
1. **Registry singleton template leak (STOMAIL-8031)** - Fixed test isolation for lifecycle hook template by unregistering a template in `_after()` to prevent a Registry singleton template leak that caused `AutomationTemplatesGetEndpointTest` to observe an extra template.

2. **Published product leakage between tests** - Made `DynamicProductsAPITest` self-contained by truncating the posts table in `_before()` and `_after()` methods to prevent published product leakage from other tests affecting unauthenticated-visibility assertions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6746)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->