### PR TITLE
Add API and SQL guardrail follow-ups

### DIFF
--- a/.ai/skills/sql-collation-safety/SKILL.md
+++ b/.ai/skills/sql-collation-safety/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: sql-collation-safety
+description: Use when adding or changing SQL joins, WHERE comparisons, temporary tables, segment filters, subscriber synchronization, or WooCommerce queries that compare text columns across WordPress, WooCommerce, and MailPoet tables.
+---
+
+# SQL Collation Safety
+
+## Overview
+
+MailPoet runs on WordPress databases where text columns can use compatible but different collations. A direct comparison such as `wp_users.user_email = mailpoet_subscribers.email` can fail on some sites with `Illegal mix of collations`.
+
+Use this skill whenever a change compares text columns across WordPress, WooCommerce, and MailPoet tables.
+
+## What to Check
+
+- Look for joins or comparisons on text columns, especially email, status, name, slug, country, and meta values.
+- Treat cross-table comparisons as risky when one side is a WordPress/WooCommerce table and the other side is a MailPoet table.
+- Check raw SQL, Doctrine query builders that contain SQL snippets, temporary-table joins, segment filters, activation code, synchronization code, and migrations.
+
+## Required Handling
+
+When adding or changing a risky text comparison:
+
+1. Prefer the existing `MailPoet\Util\DBCollationChecker` helper.
+2. Apply the returned `COLLATE ...` clause to the target column in the comparison.
+3. If the helper is not a good fit, document why and use the smallest explicit collation handling needed.
+4. Add or update an integration test that forces mismatched but compatible collations and executes the affected query.
+
+Good local examples:
+
+- `mailpoet/lib/Util/DBCollationChecker.php`
+- `mailpoet/lib/Segments/WP.php`
+- `mailpoet/tests/integration/Segments/WPTest.php`
+
+## Test Expectations
+
+A regression test should:
+
+- Change one compared column to a compatible but different collation.
+- Assert the setup really produced different collations.
+- Execute the real query path, not just inspect generated SQL.
+- Restore the original column collation in a `finally` block.
+
+If the comparison runs during activation, user synchronization, or WooCommerce segment filtering, prefer an integration test over a unit test because MySQL is the failure surface.

--- a/mailpoet/tests/integration/API/APITest.php
+++ b/mailpoet/tests/integration/API/APITest.php
@@ -3,10 +3,26 @@
 namespace MailPoet\Test\API;
 
 use MailPoet\API\API;
+use MailPoet\Settings\SettingsController;
 
 class APITest extends \MailPoetTest {
   public function testItCallsMPAPI() {
     verify(API::MP('v1'))->instanceOf('MailPoet\API\MP\v1\API');
+  }
+
+  public function testItAllowsSafeMPAPICallsWhenDbVersionIsBehind() {
+    $settings = $this->diContainer->get(SettingsController::class);
+    $originalDbVersion = $settings->get('db_version');
+    $settings->set('db_version', '0.0.1');
+
+    try {
+      $api = API::MP('v1');
+
+      verify($api)->instanceOf('MailPoet\API\MP\v1\API');
+      verify(is_bool($api->isSetupComplete()))->true();
+    } finally {
+      $settings->set('db_version', $originalDbVersion);
+    }
   }
 
   public function testItThrowsErrorWhenWrongMPAPIVersionIsCalled() {


### PR DESCRIPTION
## Description

Adds two 5.26.1 post-mortem follow-ups:

- regression coverage for public API access when `db_version` is behind
- a repo-local agent skill for SQL collation safety

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

- [STOMAIL-8080](https://linear.app/a8c/issue/STOMAIL-8080/add-regression-coverage-for-public-api-access-during-initialization)
- [STOMAIL-8081](https://linear.app/a8c/issue/STOMAIL-8081/add-llm-agent-skill-for-sql-collation-safety)

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8080-add-regression-coverage-for-public-api-access-during)

_The latest successful build from `stomail-8080-add-regression-coverage-for-public-api-access-during` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

The new integration test `testItAllowsSafeMPAPICallsWhenDbVersionIsBehind()` is well-implemented with proper cleanup via try/finally, correct save/restore of the original `db_version` setting, appropriate assertions to verify API compatibility when the database version is outdated, and no security, performance, or logical concerns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6748)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->