### PR TITLE
Add per-newsletter archive visibility setting

### DIFF
--- a/mailpoet/assets/js/src/common/newsletter-archive-visibility.ts
+++ b/mailpoet/assets/js/src/common/newsletter-archive-visibility.ts
@@ -1,0 +1,32 @@
+export type ExcludeFromArchiveValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+export const ARCHIVE_VISIBLE_OPTION_VALUE = '0';
+export const ARCHIVE_HIDDEN_OPTION_VALUE = '1';
+
+export function isNewsletterShownInArchive(
+  excludeFromArchive: ExcludeFromArchiveValue,
+): boolean {
+  return (
+    excludeFromArchive !== ARCHIVE_HIDDEN_OPTION_VALUE &&
+    excludeFromArchive !== true
+  );
+}
+
+export function getExcludeFromArchiveOptionValue(
+  showInArchive: boolean,
+): typeof ARCHIVE_VISIBLE_OPTION_VALUE | typeof ARCHIVE_HIDDEN_OPTION_VALUE {
+  return showInArchive
+    ? ARCHIVE_VISIBLE_OPTION_VALUE
+    : ARCHIVE_HIDDEN_OPTION_VALUE;
+}
+
+export function isNewsletterShownInArchiveFromEditorValue(
+  showInArchive?: boolean,
+): boolean {
+  return showInArchive !== false;
+}

--- a/mailpoet/assets/js/src/common/newsletter.ts
+++ b/mailpoet/assets/js/src/common/newsletter.ts
@@ -56,6 +56,7 @@ export type NewsLetter = {
     afterTimeNumber: number | string;
     afterTimeType: string;
     filterSegmentId?: string;
+    excludeFromArchive?: string | number | boolean | null;
   };
   parent_id: null | string;
   preheader: string;

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/archive-visibility-row.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/components/archive-visibility-row.tsx
@@ -1,0 +1,64 @@
+import {
+  PanelRow,
+  ToggleControl,
+  __experimentalVStack as VStack,
+} from '@wordpress/components';
+import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { isNewsletterShownInArchiveFromEditorValue } from 'common/newsletter-archive-visibility';
+
+export function ArchiveVisibilityRow() {
+  const [mailpoetEmailData] = useEntityProp(
+    'postType',
+    'mailpoet_email',
+    'mailpoet_data',
+  );
+  const currentShowInArchive = mailpoetEmailData?.show_in_archive as
+    | boolean
+    | undefined;
+
+  const updateShowInArchive = (showInArchive: boolean) => {
+    const postId = select(editorStore).getCurrentPostId();
+    const currentPostType = 'mailpoet_email';
+
+    const editedPost = select(coreDataStore).getEditedEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+    );
+
+    // @ts-expect-error Property 'mailpoet_data' does not exist on type 'Updatable<Attachment<any>>'.
+    const mailpoetData = editedPost?.mailpoet_data || {};
+    void dispatch(coreDataStore).editEntityRecord(
+      'postType',
+      currentPostType,
+      postId,
+      {
+        mailpoet_data: {
+          ...mailpoetData,
+          show_in_archive: showInArchive,
+        },
+      },
+    );
+  };
+
+  return (
+    <PanelRow>
+      <VStack spacing={2}>
+        <ToggleControl
+          checked={isNewsletterShownInArchiveFromEditorValue(
+            currentShowInArchive,
+          )}
+          label={__('Show this newsletter in the archive', 'mailpoet')}
+          help={__(
+            'Shown on pages using the MailPoet archive shortcode.',
+            'mailpoet',
+          )}
+          onChange={updateShowInArchive}
+        />
+      </VStack>
+    </PanelRow>
+  );
+}

--- a/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/email-settings-panel.tsx
+++ b/mailpoet/assets/js/src/mailpoet-email-editor-integration/sidebar/email-settings-panel.tsx
@@ -1,12 +1,14 @@
 import { EmailActionsFill, TemplateSelection } from '@woocommerce/email-editor';
 import { ScheduledRow } from './components/scheduled-row';
 import { RecipientsRow } from './components/recipients-row';
+import { ArchiveVisibilityRow } from './components/archive-visibility-row';
 
 export function EmailSettingsPanel() {
   return (
     <EmailActionsFill>
       <ScheduledRow />
       <RecipientsRow />
+      <ArchiveVisibilityRow />
       <TemplateSelection />
     </EmailActionsFill>
   );

--- a/mailpoet/assets/js/src/newsletters/send/standard.tsx
+++ b/mailpoet/assets/js/src/newsletters/send/standard.tsx
@@ -10,6 +10,10 @@ import { Toggle } from 'common/form/toggle/toggle';
 import { Radio } from 'common/form/radio/radio';
 import { withBoundary } from 'common';
 import { NewsLetter, NewsletterStatus } from 'common/newsletter';
+import {
+  getExcludeFromArchiveOptionValue,
+  isNewsletterShownInArchive,
+} from 'common/newsletter-archive-visibility';
 import { Field } from 'form/types';
 import { SendToFieldWithCount } from './send-to-field';
 
@@ -204,6 +208,44 @@ function StandardOptions(props: StandardSchedulingProps) {
   );
 }
 
+function ArchiveVisibility({
+  item,
+  onValueChange,
+  field,
+}: StandardSchedulingProps) {
+  const currentOptions: Partial<NewsLetter['options']> = item?.options ?? {};
+  const helperTextId = 'mailpoet-archive-visibility-help';
+  const label = __('Show this newsletter in the archive', 'mailpoet');
+
+  return (
+    <>
+      <Toggle
+        checked={isNewsletterShownInArchive(currentOptions.excludeFromArchive)}
+        disabled={field.disabled}
+        name="excludeFromArchive"
+        onCheck={(checked) => {
+          onValueChange({
+            target: {
+              name: 'options',
+              value: {
+                ...currentOptions,
+                excludeFromArchive: getExcludeFromArchiveOptionValue(checked),
+              },
+            },
+          });
+        }}
+        automationId="archive-visibility-toggle"
+        aria-label={label}
+        aria-describedby={helperTextId}
+      />
+      <span className="mailpoet-form-toggle-text">{label}</span>
+      <p id={helperTextId} className="mailpoet-form-field-description">
+        {__('Shown on pages using the MailPoet archive shortcode.', 'mailpoet')}
+      </p>
+    </>
+  );
+}
+
 let fields: Array<Field> = [
   {
     name: 'email-header',
@@ -257,6 +299,12 @@ let fields: Array<Field> = [
     label: __('Schedule it', 'mailpoet'),
     type: 'reactComponent',
     component: withBoundary(StandardOptions),
+  },
+  {
+    name: 'archive-visibility',
+    label: __('Archive', 'mailpoet'),
+    type: 'reactComponent',
+    component: withBoundary(ArchiveVisibility),
   },
   {
     name: 'sender',

--- a/mailpoet/changelog/2026-05-13-11-22-15-added-per-newsletter-archive-visibility-setting.md
+++ b/mailpoet/changelog/2026-05-13-11-22-15-added-per-newsletter-archive-visibility-setting.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Per-newsletter archive visibility setting

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -508,6 +508,10 @@ class Populator {
         'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
       ],
       [
+        'name' => NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+        'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
+      ],
+      [
         'name' => NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID,
         'newsletter_type' => NewsletterEntity::TYPE_RE_ENGAGEMENT,
       ],

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/EmailApiController.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet;
 
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
@@ -64,6 +65,9 @@ class EmailApiController {
   public function getEmailData($postEmailData): array {
     $newsletter = $this->newsletterRepository->findOneBy(['wpPost' => $postEmailData['id']]);
     $isAutomationNewsletter = $newsletter && ($newsletter->isAutomation() || $newsletter->isAutomationTransactional());
+    $showInArchive = $newsletter
+      ? $newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE) !== '1'
+      : true;
     return [
       'id' => $newsletter ? $newsletter->getId() : null,
       'subject' => $newsletter ? $newsletter->getSubject() : '',
@@ -84,6 +88,7 @@ class EmailApiController {
         ? $this->shareVisibility->getEffectiveVisibility($newsletter)
         : $this->shareVisibility->getDefaultVisibility(),
       'can_share' => $newsletter ? $this->shareVisibility->canShare($newsletter) : false,
+      'show_in_archive' => $showInArchive,
     ];
   }
 
@@ -127,12 +132,32 @@ class EmailApiController {
       );
     }
 
+    if (array_key_exists('show_in_archive', $data)) {
+      $this->updateShowInArchiveOption($newsletter, $data['show_in_archive']);
+    }
+
     if (isset($data['segment_ids']) && is_array($data['segment_ids'])) {
       $this->updateSegments($newsletter, $data['segment_ids']);
       $this->entityManager->refresh($newsletter);
     }
 
     $this->newsletterRepository->flush();
+  }
+
+  private function updateShowInArchiveOption(NewsletterEntity $newsletter, $showInArchiveValue): void {
+    if (!is_bool($showInArchiveValue)) {
+      throw new UnexpectedValueException('Invalid show_in_archive value. Expected a boolean.');
+    }
+
+    if ($newsletter->getType() !== NewsletterEntity::TYPE_STANDARD) {
+      return;
+    }
+
+    $this->updateOption(
+      $newsletter,
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      $showInArchiveValue ? '0' : '1'
+    );
   }
 
   private function updateOption($newsletter, string $optionName, $optionValue): void {
@@ -243,6 +268,7 @@ class EmailApiController {
       'share_visibility' => Builder::string(),
       'effective_share_visibility' => Builder::string(),
       'can_share' => Builder::boolean(),
+      'show_in_archive' => Builder::boolean(),
     ])->toArray();
   }
 }

--- a/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
@@ -37,6 +37,7 @@ class NewsletterOptionFieldEntity {
   public const NAME_AUTOMATION_STEP_ID = 'automationStepId';
   public const NAME_FILTER_SEGMENT_ID = 'filterSegmentId';
   public const NAME_SHARE_VISIBILITY = 'shareVisibility';
+  public const NAME_EXCLUDE_FROM_ARCHIVE = 'excludeFromArchive';
 
   use AutoincrementedIdTrait;
   use CreatedAtTrait;

--- a/mailpoet/lib/Newsletter/NewsletterSaveController.php
+++ b/mailpoet/lib/Newsletter/NewsletterSaveController.php
@@ -282,6 +282,7 @@ class NewsletterSaveController {
     $ignoredOptions = [
       NewsletterOptionFieldEntity::NAME_IS_SCHEDULED,
       NewsletterOptionFieldEntity::NAME_SCHEDULED_AT,
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
     ];
     foreach ($newsletter->getOptions() as $newsletterOption) {
       $optionField = $newsletterOption->getOptionField();

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -9,6 +9,7 @@ use MailPoet\AutomaticEmails\WooCommerce\Events\PurchasedInCategory;
 use MailPoet\AutomaticEmails\WooCommerce\Events\PurchasedProduct;
 use MailPoet\Doctrine\Repository;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
@@ -271,6 +272,25 @@ class NewslettersRepository extends Repository {
       ->addOrderBy('st.id', 'ASC')
       ->setParameter('types', $types)
       ->setParameter('statusCompleted', SendingQueueEntity::STATUS_COMPLETED);
+
+    $excludeFromArchiveSubQuery = $this->entityManager
+      ->createQueryBuilder()
+      ->select('1')
+      ->from(NewsletterOptionEntity::class, 'archiveOption')
+      ->innerJoin('archiveOption.optionField', 'archiveOptionField')
+      ->where('archiveOption.newsletter = n')
+      ->andWhere('archiveOption.value = :excludeFromArchive')
+      ->andWhere('archiveOptionField.name = :excludeFromArchiveOptionName')
+      ->getDQL();
+
+    $queryBuilder
+      ->andWhere($queryBuilder->expr()->orX(
+        'n.type != :standardNewsletterType',
+        $queryBuilder->expr()->not($queryBuilder->expr()->exists($excludeFromArchiveSubQuery))
+      ))
+      ->setParameter('standardNewsletterType', NewsletterEntity::TYPE_STANDARD)
+      ->setParameter('excludeFromArchive', '1')
+      ->setParameter('excludeFromArchiveOptionName', NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE);
 
     $segmentIds = $params['segmentIds'] ?? [];
     if (!empty($segmentIds)) {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -10,6 +10,7 @@ use MailPoet\API\JSON\ResponseBuilders\NewslettersResponseBuilder;
 use MailPoet\API\JSON\v1\Newsletters;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Logging\LogRepository;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Preview\SendPreviewController;
@@ -22,6 +23,7 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\Statistics\StatisticsUnsubscribesRepository;
 use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\WooCommerce\Helper as WCHelper;
 use MailPoet\WP\Emoji;
 use MailPoet\WP\Functions as WPFunctions;
@@ -164,167 +166,6 @@ class NewslettersTest extends \MailPoetTest {
     $response = $this->endpoint->get(['id' => $this->newsletter->getId()]);
     verify($response->status)->equals(APIResponse::STATUS_OK);
     verify($response->data['options'][NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE])->equals('0');
-  }
-
-  public function testItReturnsErrorIfSubscribersLimitReached() {
-    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
-      'cronHelper' => $this->cronHelper,
-      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true]),
-    ]);
-    $res = $endpoint->setStatus([
-      'id' => $this->newsletter->getId(),
-      'status' => NewsletterEntity::STATUS_ACTIVE,
-    ]);
-    verify($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
-  }
-
-  public function testItReturnsErrorIfSenderAddressNotValidForActivation() {
-    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
-      'cronHelper' => $this->cronHelper,
-      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true]),
-      'authorizedEmailsController' => Stub::make(AuthorizedEmailsController::class, [
-        'isSenderAddressValid' => Expected::once(false),
-      ]),
-    ]);
-    $res = $endpoint->setStatus([
-      'id' => $this->postNotification->getId(),
-      'status' => NewsletterEntity::STATUS_ACTIVE,
-    ]);
-    verify($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
-  }
-
-  public function testItCanSetANewsletterStatus() {
-    // set status to sending
-    $response = $this->endpoint->setStatus([
-       'id' => $this->newsletter->getId(),
-       'status' => NewsletterEntity::STATUS_SENDING,
-      ]);
-    verify($response->status)->equals(APIResponse::STATUS_OK);
-    verify($response->data['status'])->equals(NewsletterEntity::STATUS_SENDING);
-
-    // set status to draft
-    $response = $this->endpoint->setStatus(
-      [
-        'id' => $this->newsletter->getId(),
-        'status' => NewsletterEntity::STATUS_DRAFT,
-      ]
-    );
-    verify($response->status)->equals(APIResponse::STATUS_OK);
-    verify($response->data['status'])->equals(NewsletterEntity::STATUS_DRAFT);
-
-    // no status specified throws an error
-    $response = $this->endpoint->setStatus(
-      [
-        'id' => $this->newsletter->getId(),
-      ]
-    );
-    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
-    verify($response->errors[0]['message'])
-      ->equals('You need to specify a status.');
-
-    // invalid newsletter id throws an error
-    $response = $this->endpoint->setStatus(
-      [
-        'status' => NewsletterEntity::STATUS_DRAFT,
-      ]
-    );
-    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
-    verify($response->errors[0]['message'])
-      ->equals('This email does not exist.');
-  }
-
-  public function testItActivatesTasksWhenStatusIsSetBackToActive() {
-    $scheduledTask1 = (new ScheduledTaskFactory())
-      ->create(
-        SendingQueueWorker::TASK_TYPE,
-        ScheduledTaskEntity::STATUS_PAUSED,
-      );
-    $queue = (new SendingQueueFactory())->create($scheduledTask1, $this->postNotification);
-    $queue->setCountToProcess(1);
-    $segment = $this->segmentRepository->createOrUpdate('Segment 1');
-    $this->createNewsletterSegment($this->postNotification, $segment);
-
-    $this->entityManager->clear();
-
-    $this->endpoint->setStatus(
-      [
-        'id' => $this->postNotification->getId(),
-        'status' => NewsletterEntity::STATUS_ACTIVE,
-      ]
-    );
-    $tasks = $this->scheduledTasksRepository->findAll();
-
-    verify($tasks)->arrayCount(1);
-    verify($tasks[0]->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
-  }
-
-  public function testItReschedulesPastDuePostNotificationsWhenStatusIsSetBackToActive() {
-    $schedule = sprintf('0 %d * * *', Carbon::now()->millisecond(0)->hour); // every day at current hour
-    $randomFutureDate = Carbon::now()->millisecond(0)->addDays(10); // 10 days from now
-    (new NewsletterOption())->create($this->postNotification, NewsletterOptionFieldEntity::NAME_SCHEDULE, $schedule);
-
-    $scheduledTask1 = (new ScheduledTaskFactory())
-      ->create(
-        SendingQueueWorker::TASK_TYPE,
-        ScheduledTaskEntity::STATUS_SCHEDULED,
-        new Carbon($this->scheduler->getPreviousRunDate($schedule))
-      );
-    (new SendingQueueFactory())->create($scheduledTask1, $this->postNotification);
-
-    $scheduledTask2 = (new ScheduledTaskFactory())
-      ->create(
-        SendingQueueWorker::TASK_TYPE,
-        ScheduledTaskEntity::STATUS_SCHEDULED,
-        $randomFutureDate
-      );
-    (new SendingQueueFactory())->create($scheduledTask2, $this->postNotification);
-
-    $scheduledTask3 = (new ScheduledTaskFactory())
-      ->create(
-        SendingQueueWorker::TASK_TYPE,
-        null,
-        new Carbon($this->scheduler->getPreviousRunDate($schedule))
-      );
-    (new SendingQueueFactory())->create($scheduledTask3, $this->postNotification);
-
-    $segment1 = $this->segmentRepository->createOrUpdate('Segment 1');
-    $this->createNewsletterSegment($this->postNotification, $segment1);
-
-    $this->entityManager->clear();
-    $this->endpoint->setStatus(
-      [
-        'id' => $this->postNotification->getId(),
-        'status' => NewsletterEntity::STATUS_ACTIVE,
-      ]
-    );
-    $tasks = $this->scheduledTasksRepository->findAll();
-    // previously scheduled notification is rescheduled for future date
-    $this->assertInstanceOf(\DateTimeInterface::class, $tasks[0]->getScheduledAt());
-    verify($tasks[0]->getScheduledAt()->format('Y-m-d H:i:s'))->equals($this->scheduler->getNextRunDate($schedule));
-    // future scheduled notifications are left intact
-    $this->assertInstanceOf(\DateTimeInterface::class, $tasks[1]->getScheduledAt());
-    verify($tasks[1]->getScheduledAt())->equals($randomFutureDate);
-    // previously unscheduled (e.g., sent/sending) notifications are left intact
-    $this->assertInstanceOf(\DateTimeInterface::class, $tasks[2]->getScheduledAt());
-    verify($tasks[2]->getScheduledAt()->format('Y-m-d H:i:s'))->equals($this->scheduler->getPreviousRunDate($schedule));
-  }
-
-  public function testItSchedulesPostNotificationsWhenStatusIsSetBackToActive() {
-    $schedule = '* * * * *';
-    (new NewsletterOption())->create($this->postNotification, NewsletterOptionFieldEntity::NAME_SCHEDULE, $schedule);
-
-    $segment1 = $this->segmentRepository->createOrUpdate('Segment 1');
-    $this->createNewsletterSegment($this->postNotification, $segment1);
-
-    $this->entityManager->clear();
-    $this->endpoint->setStatus(
-      [
-        'id' => $this->postNotification->getId(),
-        'status' => NewsletterEntity::STATUS_ACTIVE,
-      ]
-    );
-    $tasks = $this->scheduledTasksRepository->findAll();
-    verify($tasks)->notEmpty();
   }
 
   public function testItCanRestoreANewsletter() {

--- a/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/NewslettersTest.php
@@ -133,6 +133,200 @@ class NewslettersTest extends \MailPoetTest {
     verify($updatedNewsletter->getGaCampaign())->equals('Updated GA campaign');
   }
 
+  public function testItCanSaveAndLoadArchiveVisibilityOption(): void {
+    (new NewsletterOption())
+      ->create($this->newsletter, NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE, '0');
+
+    $response = $this->endpoint->save([
+      'id' => $this->newsletter->getId(),
+      'type' => NewsletterEntity::TYPE_STANDARD,
+      'subject' => $this->newsletter->getSubject(),
+      'options' => [
+        NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1',
+      ],
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+
+    $response = $this->endpoint->get(['id' => $this->newsletter->getId()]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['options'][NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE])->equals('1');
+
+    $response = $this->endpoint->save([
+      'id' => $this->newsletter->getId(),
+      'type' => NewsletterEntity::TYPE_STANDARD,
+      'subject' => $this->newsletter->getSubject(),
+      'options' => [
+        NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '0',
+      ],
+    ]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+
+    $response = $this->endpoint->get(['id' => $this->newsletter->getId()]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['options'][NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE])->equals('0');
+  }
+
+  public function testItReturnsErrorIfSubscribersLimitReached() {
+    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
+      'cronHelper' => $this->cronHelper,
+      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true]),
+    ]);
+    $res = $endpoint->setStatus([
+      'id' => $this->newsletter->getId(),
+      'status' => NewsletterEntity::STATUS_ACTIVE,
+    ]);
+    verify($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
+  }
+
+  public function testItReturnsErrorIfSenderAddressNotValidForActivation() {
+    $endpoint = $this->getServiceWithOverrides(Newsletters::class, [
+      'cronHelper' => $this->cronHelper,
+      'subscribersFeature' => Stub::make(Subscribers::class, ['check' => true]),
+      'authorizedEmailsController' => Stub::make(AuthorizedEmailsController::class, [
+        'isSenderAddressValid' => Expected::once(false),
+      ]),
+    ]);
+    $res = $endpoint->setStatus([
+      'id' => $this->postNotification->getId(),
+      'status' => NewsletterEntity::STATUS_ACTIVE,
+    ]);
+    verify($res->status)->equals(APIResponse::STATUS_FORBIDDEN);
+  }
+
+  public function testItCanSetANewsletterStatus() {
+    // set status to sending
+    $response = $this->endpoint->setStatus([
+       'id' => $this->newsletter->getId(),
+       'status' => NewsletterEntity::STATUS_SENDING,
+      ]);
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['status'])->equals(NewsletterEntity::STATUS_SENDING);
+
+    // set status to draft
+    $response = $this->endpoint->setStatus(
+      [
+        'id' => $this->newsletter->getId(),
+        'status' => NewsletterEntity::STATUS_DRAFT,
+      ]
+    );
+    verify($response->status)->equals(APIResponse::STATUS_OK);
+    verify($response->data['status'])->equals(NewsletterEntity::STATUS_DRAFT);
+
+    // no status specified throws an error
+    $response = $this->endpoint->setStatus(
+      [
+        'id' => $this->newsletter->getId(),
+      ]
+    );
+    verify($response->status)->equals(APIResponse::STATUS_BAD_REQUEST);
+    verify($response->errors[0]['message'])
+      ->equals('You need to specify a status.');
+
+    // invalid newsletter id throws an error
+    $response = $this->endpoint->setStatus(
+      [
+        'status' => NewsletterEntity::STATUS_DRAFT,
+      ]
+    );
+    verify($response->status)->equals(APIResponse::STATUS_NOT_FOUND);
+    verify($response->errors[0]['message'])
+      ->equals('This email does not exist.');
+  }
+
+  public function testItActivatesTasksWhenStatusIsSetBackToActive() {
+    $scheduledTask1 = (new ScheduledTaskFactory())
+      ->create(
+        SendingQueueWorker::TASK_TYPE,
+        ScheduledTaskEntity::STATUS_PAUSED,
+      );
+    $queue = (new SendingQueueFactory())->create($scheduledTask1, $this->postNotification);
+    $queue->setCountToProcess(1);
+    $segment = $this->segmentRepository->createOrUpdate('Segment 1');
+    $this->createNewsletterSegment($this->postNotification, $segment);
+
+    $this->entityManager->clear();
+
+    $this->endpoint->setStatus(
+      [
+        'id' => $this->postNotification->getId(),
+        'status' => NewsletterEntity::STATUS_ACTIVE,
+      ]
+    );
+    $tasks = $this->scheduledTasksRepository->findAll();
+
+    verify($tasks)->arrayCount(1);
+    verify($tasks[0]->getStatus())->equals(ScheduledTaskEntity::STATUS_SCHEDULED);
+  }
+
+  public function testItReschedulesPastDuePostNotificationsWhenStatusIsSetBackToActive() {
+    $schedule = sprintf('0 %d * * *', Carbon::now()->millisecond(0)->hour); // every day at current hour
+    $randomFutureDate = Carbon::now()->millisecond(0)->addDays(10); // 10 days from now
+    (new NewsletterOption())->create($this->postNotification, NewsletterOptionFieldEntity::NAME_SCHEDULE, $schedule);
+
+    $scheduledTask1 = (new ScheduledTaskFactory())
+      ->create(
+        SendingQueueWorker::TASK_TYPE,
+        ScheduledTaskEntity::STATUS_SCHEDULED,
+        new Carbon($this->scheduler->getPreviousRunDate($schedule))
+      );
+    (new SendingQueueFactory())->create($scheduledTask1, $this->postNotification);
+
+    $scheduledTask2 = (new ScheduledTaskFactory())
+      ->create(
+        SendingQueueWorker::TASK_TYPE,
+        ScheduledTaskEntity::STATUS_SCHEDULED,
+        $randomFutureDate
+      );
+    (new SendingQueueFactory())->create($scheduledTask2, $this->postNotification);
+
+    $scheduledTask3 = (new ScheduledTaskFactory())
+      ->create(
+        SendingQueueWorker::TASK_TYPE,
+        null,
+        new Carbon($this->scheduler->getPreviousRunDate($schedule))
+      );
+    (new SendingQueueFactory())->create($scheduledTask3, $this->postNotification);
+
+    $segment1 = $this->segmentRepository->createOrUpdate('Segment 1');
+    $this->createNewsletterSegment($this->postNotification, $segment1);
+
+    $this->entityManager->clear();
+    $this->endpoint->setStatus(
+      [
+        'id' => $this->postNotification->getId(),
+        'status' => NewsletterEntity::STATUS_ACTIVE,
+      ]
+    );
+    $tasks = $this->scheduledTasksRepository->findAll();
+    // previously scheduled notification is rescheduled for future date
+    $this->assertInstanceOf(\DateTimeInterface::class, $tasks[0]->getScheduledAt());
+    verify($tasks[0]->getScheduledAt()->format('Y-m-d H:i:s'))->equals($this->scheduler->getNextRunDate($schedule));
+    // future scheduled notifications are left intact
+    $this->assertInstanceOf(\DateTimeInterface::class, $tasks[1]->getScheduledAt());
+    verify($tasks[1]->getScheduledAt())->equals($randomFutureDate);
+    // previously unscheduled (e.g., sent/sending) notifications are left intact
+    $this->assertInstanceOf(\DateTimeInterface::class, $tasks[2]->getScheduledAt());
+    verify($tasks[2]->getScheduledAt()->format('Y-m-d H:i:s'))->equals($this->scheduler->getPreviousRunDate($schedule));
+  }
+
+  public function testItSchedulesPostNotificationsWhenStatusIsSetBackToActive() {
+    $schedule = '* * * * *';
+    (new NewsletterOption())->create($this->postNotification, NewsletterOptionFieldEntity::NAME_SCHEDULE, $schedule);
+
+    $segment1 = $this->segmentRepository->createOrUpdate('Segment 1');
+    $this->createNewsletterSegment($this->postNotification, $segment1);
+
+    $this->entityManager->clear();
+    $this->endpoint->setStatus(
+      [
+        'id' => $this->postNotification->getId(),
+        'status' => NewsletterEntity::STATUS_ACTIVE,
+      ]
+    );
+    $tasks = $this->scheduledTasksRepository->findAll();
+    verify($tasks)->notEmpty();
+  }
+
   public function testItCanRestoreANewsletter() {
     $this->newsletterRepository->bulkTrash([$this->newsletter->getId()]);
     $this->entityManager->clear();

--- a/mailpoet/tests/integration/Config/PopulatorTest.php
+++ b/mailpoet/tests/integration/Config/PopulatorTest.php
@@ -3,6 +3,7 @@
 namespace MailPoet\Test\Config;
 
 use MailPoet\Config\Populator;
+use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterTemplateEntity;
 use MailPoetTest;
@@ -27,6 +28,7 @@ class PopulatorTest extends MailPoetTest {
     $populator->up();
     $optionFields = $this->getAllOptionFields();
     $this->assertSame(self::OPTION_FIELD_COUNT, count($optionFields));
+    $this->assertStandardExcludeFromArchiveOptionFieldExists();
 
     // delete only some fields
     $this->entityManager->createQueryBuilder()
@@ -43,6 +45,7 @@ class PopulatorTest extends MailPoetTest {
     $populator->up();
     $optionFields = $this->getAllOptionFields();
     $this->assertSame(self::OPTION_FIELD_COUNT, count($optionFields));
+    $this->assertStandardExcludeFromArchiveOptionFieldExists();
   }
 
   public function testItInsertsTemplates(): void {
@@ -128,6 +131,15 @@ class PopulatorTest extends MailPoetTest {
       ->getQuery()
       ->setHint(Query::HINT_REFRESH, true)
       ->getResult();
+  }
+
+  private function assertStandardExcludeFromArchiveOptionFieldExists(): void {
+    $optionField = $this->entityManager->getRepository(NewsletterOptionFieldEntity::class)->findOneBy([
+      'name' => NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      'newsletterType' => NewsletterEntity::TYPE_STANDARD,
+    ]);
+
+    $this->assertInstanceOf(NewsletterOptionFieldEntity::class, $optionField);
   }
 
   private function getAllTemplates(): array {

--- a/mailpoet/tests/integration/Config/PopulatorTest.php
+++ b/mailpoet/tests/integration/Config/PopulatorTest.php
@@ -10,7 +10,7 @@ use MailPoetTest;
 use MailPoetVendor\Doctrine\ORM\Query;
 
 class PopulatorTest extends MailPoetTest {
-  private const OPTION_FIELD_COUNT = 35;
+  private const OPTION_FIELD_COUNT = 36;
   private const TEMPLATE_COUNT = 77;
 
   public function testItInsertsOptionFields(): void {

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -342,6 +342,25 @@ class ShortcodesTest extends \MailPoetTest {
     verify($result)->stringNotContainsString('Newsletter 3');
   }
 
+  public function testArchiveDoesNotRenderExcludedNewsletter(): void {
+    (new NewsletterFactory())
+      ->withOptions([NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1'])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-03-02')])
+      ->withSentStatus()
+      ->withSubject('Hidden newsletter')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => new Carbon('2024-03-01')])
+      ->withSentStatus()
+      ->withSubject('Visible newsletter')
+      ->create();
+
+    $result = do_shortcode('[mailpoet_archive]');
+
+    verify($result)->stringNotContainsString('Hidden newsletter');
+    verify($result)->stringContainsString('Visible newsletter');
+  }
+
   public function testItRendersShortcodeDefaultsInSubject() {
     $newsletterFactory = new NewsletterFactory();
     $this->newsletter = $newsletterFactory

--- a/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailApiControllerTest.php
+++ b/mailpoet/tests/integration/EmailEditor/Integrations/MailPoet/EmailApiControllerTest.php
@@ -10,6 +10,7 @@ use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\NotFoundException;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\NewsletterOptionField;
 use MailPoet\Test\DataFactories\Segment as SegmentFactory;
 use MailPoet\UnexpectedValueException;
@@ -58,6 +59,25 @@ class EmailApiControllerTest extends \MailPoetTest {
     verify($emailData['share_visibility'])->equals(ShareVisibility::VISIBILITY_PUBLIC);
     verify($emailData['effective_share_visibility'])->equals(ShareVisibility::VISIBILITY_PUBLIC);
     verify($emailData['can_share'])->true();
+  }
+
+  public function testItGetsShowInArchiveFromNewsletterOption(): void {
+    $wpPostId = 15;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $emailData = $this->emailApiController->getEmailData(['id' => $wpPostId]);
+    verify($emailData['show_in_archive'])->true();
+
+    (new NewsletterOption())->create(
+      $newsletter,
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      '1'
+    );
+
+    $emailData = $this->emailApiController->getEmailData(['id' => $wpPostId]);
+    verify($emailData['show_in_archive'])->false();
   }
 
   public function testItSaveEmailDataToNewsletterEntity(): void {
@@ -233,6 +253,115 @@ class EmailApiControllerTest extends \MailPoetTest {
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
     verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SCHEDULED_AT))->null();
     verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_IS_SCHEDULED))->equals('0');
+  }
+
+  public function testItSavesShowInArchiveOption(): void {
+    $wpPostId = 16;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    $this->entityManager->flush();
+
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'show_in_archive' => false,
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->equals('1');
+
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'show_in_archive' => true,
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->equals('0');
+  }
+
+  public function testItDoesNotChangeShowInArchiveWhenFieldIsMissing(): void {
+    $wpPostId = 17;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+    (new NewsletterOption())->create(
+      $newsletter,
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      '1'
+    );
+
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->equals('1');
+  }
+
+  public function testItRejectsNonBooleanShowInArchiveValue(): void {
+    $wpPostId = 18;
+    $newsletter = (new NewsletterFactory())
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    $this->expectException(UnexpectedValueException::class);
+    $this->expectExceptionMessage('Invalid show_in_archive value. Expected a boolean.');
+
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'show_in_archive' => 'false',
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+  }
+
+  public function testItDoesNotSaveShowInArchiveForNonStandardNewsletters(): void {
+    $wpPostId = 19;
+    $newsletter = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_NOTIFICATION)
+      ->withWpPostId($wpPostId)
+      ->create();
+
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    $this->entityManager->flush();
+
+    $this->emailApiController->saveEmailData([
+      'id' => $newsletter->getId(),
+      'subject' => 'Test Subject',
+      'preheader' => 'Test Preheader',
+      'show_in_archive' => false,
+    ], new \WP_Post((object)['ID' => $wpPostId]));
+
+    $this->entityManager->clear();
+    $newsletter = $this->newslettersRepository->findOneById($newsletter->getId());
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->null();
+  }
+
+  public function testEmailDataSchemaIncludesShowInArchiveBoolean(): void {
+    $schema = $this->emailApiController->getEmailDataSchema();
+
+    verify($schema['properties']['show_in_archive']['type'])->equals('boolean');
   }
 
   public function testItUpdatesSegmentIds(): void {

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -5,6 +5,7 @@ namespace MailPoet\Newsletter;
 use Codeception\Util\Fixtures;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\NewsletterSegmentEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\ScheduledTaskSubscriberEntity;
@@ -216,6 +217,83 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     verify($results[0]->getType())->equals(NewsletterEntity::TYPE_STANDARD);
     verify($results[1]->getId())->equals($newsletters[6]->getId());
     verify($results[1]->getType())->equals(NewsletterEntity::TYPE_NOTIFICATION_HISTORY);
+  }
+
+  public function testItExcludesStandardArchiveNewslettersWithArchiveOptOut(): void {
+    $missingOption = (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-04')])
+      ->withSentStatus()
+      ->withSubject('Visible without option')
+      ->create();
+    $visibleOption = (new NewsletterFactory())
+      ->withOptions([NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '0'])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-03')])
+      ->withSentStatus()
+      ->withSubject('Visible with option')
+      ->create();
+    $excludedOption = (new NewsletterFactory())
+      ->withOptions([NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1'])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-02')])
+      ->withSentStatus()
+      ->withSubject('Excluded with option')
+      ->create();
+    $notificationHistory = (new NewsletterFactory())
+      ->withType(NewsletterEntity::TYPE_NOTIFICATION_HISTORY)
+      ->withOptions([NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1'])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-01')])
+      ->withSentStatus()
+      ->withSubject('Notification history')
+      ->create();
+
+    $resultIds = array_map(function(NewsletterEntity $newsletter): int {
+      return (int)$newsletter->getId();
+    }, $this->repository->getArchives());
+
+    $this->assertContains($missingOption->getId(), $resultIds);
+    $this->assertContains($visibleOption->getId(), $resultIds);
+    $this->assertNotContains($excludedOption->getId(), $resultIds);
+    $this->assertContains($notificationHistory->getId(), $resultIds);
+  }
+
+  public function testItFiltersArchiveOptOutBeforeSegmentFilterAndLimit(): void {
+    $segment = new SegmentEntity('Segment', SegmentEntity::TYPE_DEFAULT, 'description');
+    $this->entityManager->persist($segment);
+    $this->entityManager->flush();
+
+    (new NewsletterFactory())
+      ->withOptions([NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1'])
+      ->withSegments([$segment])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-04')])
+      ->withSentStatus()
+      ->withSubject('Newest hidden')
+      ->create();
+    $firstVisible = (new NewsletterFactory())
+      ->withSegments([$segment])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-03')])
+      ->withSentStatus()
+      ->withSubject('First visible')
+      ->create();
+    $secondVisible = (new NewsletterFactory())
+      ->withOptions([NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '0'])
+      ->withSegments([$segment])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-02')])
+      ->withSentStatus()
+      ->withSubject('Second visible')
+      ->create();
+    (new NewsletterFactory())
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-01')])
+      ->withSentStatus()
+      ->withSubject('Different segment')
+      ->create();
+
+    $results = $this->repository->getArchives([
+      'segmentIds' => [$segment->getId()],
+      'limit' => 2,
+    ]);
+
+    verify($results)->arrayCount(2);
+    verify($results[0]->getId())->equals($firstVisible->getId());
+    verify($results[1]->getId())->equals($secondVisible->getId());
   }
 
   public function testFindStuckPostNotificationParentsReturnsOneRowPerParent() {

--- a/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterSaveControllerTest.php
@@ -152,6 +152,31 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($scheduleOption->getValue())->equals('* * * * *');
   }
 
+  public function testItCanUpdateArchiveVisibilityOptionUponSave(): void {
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    $this->entityManager->flush();
+
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD);
+    $newsletterData = [
+      'id' => $newsletter->getId(),
+      'type' => NewsletterEntity::TYPE_STANDARD,
+      'subject' => 'Newsletter',
+      'options' => [
+        NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1',
+      ],
+    ];
+
+    $savedNewsletter = $this->saveController->save($newsletterData);
+    verify($savedNewsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->equals('1');
+
+    $newsletterData['options'][NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE] = '0';
+    $savedNewsletter = $this->saveController->save($newsletterData);
+    verify($savedNewsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->equals('0');
+  }
+
   public function testItCanReschedulePreviouslyScheduledSendingQueueJobs() {
     $this->createPostNotificationOptions();
 
@@ -376,6 +401,29 @@ class NewsletterSaveControllerTest extends \MailPoetTest {
     verify($duplicate->getHash())->notEquals($newsletter->getHash());
     verify($duplicate->getBody())->equals($newsletter->getBody());
     verify($duplicate->getStatus())->equals(NewsletterEntity::STATUS_DRAFT);
+  }
+
+  public function testItDoesNotDuplicateArchiveExclusionOption(): void {
+    (new NewsletterOptionField())->findOrCreate(
+      NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE,
+      NewsletterEntity::TYPE_STANDARD
+    );
+    $this->entityManager->flush();
+
+    $newsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
+    $this->saveController->save([
+      'id' => $newsletter->getId(),
+      'type' => NewsletterEntity::TYPE_STANDARD,
+      'subject' => $newsletter->getSubject(),
+      'options' => [
+        NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE => '1',
+      ],
+    ]);
+
+    $duplicate = $this->saveController->duplicate($newsletter);
+
+    verify($newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->equals('1');
+    verify($duplicate->getOptionValue(NewsletterOptionFieldEntity::NAME_EXCLUDE_FROM_ARCHIVE))->null();
   }
 
   public function testItDuplicatesNewsletterWithAssociatedPost() {

--- a/mailpoet/tests/javascript/newsletters/send/archive-visibility.spec.ts
+++ b/mailpoet/tests/javascript/newsletters/send/archive-visibility.spec.ts
@@ -1,0 +1,52 @@
+import {
+  ARCHIVE_HIDDEN_OPTION_VALUE,
+  ARCHIVE_VISIBLE_OPTION_VALUE,
+  getExcludeFromArchiveOptionValue,
+  isNewsletterShownInArchive,
+  isNewsletterShownInArchiveFromEditorValue,
+} from '../../../../assets/js/src/common/newsletter-archive-visibility';
+
+describe('newsletter archive visibility helpers', () => {
+  describe('isNewsletterShownInArchive', () => {
+    it('defaults missing and false-like excludeFromArchive values to visible', () => {
+      expect(isNewsletterShownInArchive(undefined)).to.equal(true);
+      expect(isNewsletterShownInArchive(null)).to.equal(true);
+      expect(isNewsletterShownInArchive('')).to.equal(true);
+      expect(isNewsletterShownInArchive('0')).to.equal(true);
+      expect(isNewsletterShownInArchive(0)).to.equal(true);
+      expect(isNewsletterShownInArchive(false)).to.equal(true);
+    });
+
+    it('treats canonical hidden values as not visible', () => {
+      expect(isNewsletterShownInArchive('1')).to.equal(false);
+      expect(isNewsletterShownInArchive(true)).to.equal(false);
+    });
+  });
+
+  describe('getExcludeFromArchiveOptionValue', () => {
+    it('maps visible UI state to the visible option value', () => {
+      expect(getExcludeFromArchiveOptionValue(true)).to.equal(
+        ARCHIVE_VISIBLE_OPTION_VALUE,
+      );
+    });
+
+    it('maps hidden UI state to the hidden option value', () => {
+      expect(getExcludeFromArchiveOptionValue(false)).to.equal(
+        ARCHIVE_HIDDEN_OPTION_VALUE,
+      );
+    });
+  });
+
+  describe('isNewsletterShownInArchiveFromEditorValue', () => {
+    it('defaults missing editor values to visible', () => {
+      expect(isNewsletterShownInArchiveFromEditorValue(undefined)).to.equal(
+        true,
+      );
+    });
+
+    it('uses the editor positive boolean value directly', () => {
+      expect(isNewsletterShownInArchiveFromEditorValue(true)).to.equal(true);
+      expect(isNewsletterShownInArchiveFromEditorValue(false)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a per-newsletter archive visibility setting for standard newsletters.

Newsletters remain visible in archive shortcodes by default. 

## Code review notes

_N/A_

## QA notes

1. Create or edit a standard newsletter in the classic editor and open the send/settings step.
2. Confirm the `Show this newsletter in the archive` toggle is visible, enabled by default, and can be turned off and back on.
3. Save/send state as appropriate, then confirm a newsletter hidden with this setting is not returned by a page using the MailPoet archive shortcode.
4. Create or edit a Gutenberg email-editor newsletter, click `Review & send`, and confirm the same archive visibility toggle is shown under `Archive`.
5. Duplicate a newsletter that was hidden from the archive and confirm the duplicate starts visible in the archive.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8079

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1440" height="1202" alt="classic-archive-checkbox-full-css" src="https://github.com/user-attachments/assets/a1f10ad0-1b20-48d3-bdc0-af748803fcde" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8079-per-newsletter-archive-exclusion)

_The latest successful build from `add/STOMAIL-8079-per-newsletter-archive-exclusion` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->