### PR TITLE
Allow editing active automations

### DIFF
--- a/mailpoet/assets/css/src/components-automation-editor/_deactivate-modal.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_deactivate-modal.scss
@@ -11,6 +11,7 @@
   }
 
   .mailpoet-automation-option {
+    align-items: center;
     border: 2px solid #dcdcde;
     border-radius: 4px;
     color: #646970;

--- a/mailpoet/assets/css/src/components-automation-editor/_deactivate-modal.scss
+++ b/mailpoet/assets/css/src/components-automation-editor/_deactivate-modal.scss
@@ -1,4 +1,5 @@
-.mailpoet-automation-deactivate-modal {
+.mailpoet-automation-deactivate-modal,
+.mailpoet-automation-save-active-modal {
   color: #1d2327;
   font-size: 13px;
   line-height: 21px;

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -1,11 +1,6 @@
 import { useMemo, useState } from 'react';
 import classnames from 'classnames';
-import {
-  Button,
-  NavigableMenu,
-  TextControl,
-  Tooltip,
-} from '@wordpress/components';
+import { Button, NavigableMenu, TextControl } from '@wordpress/components';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { Icon, check, cloud } from '@wordpress/icons';
 import { PinnedItems } from '@wordpress/interface';
@@ -29,19 +24,16 @@ import { sendTelemetryEvent } from '../../telemetry';
 //   https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/header/index.js
 
 export function ActivateButton({ label }): JSX.Element {
-  const { errors, isDeactivating, automationId } = useSelect(
+  const { errors, automationId } = useSelect(
     (select) => ({
       errors: select(storeName).getErrors(),
-      isDeactivating:
-        select(storeName).getAutomationData().status ===
-        AutomationStatus.DEACTIVATING,
       automationId: select(storeName).getAutomationData().id,
     }),
     [],
   );
   const { openActivationPanel } = useDispatch(storeName);
 
-  const button = (
+  return (
     <Button
       variant="primary"
       className="editor-post-publish-button"
@@ -52,35 +44,18 @@ export function ActivateButton({ label }): JSX.Element {
         });
         void openActivationPanel();
       }}
-      disabled={isDeactivating || !!errors}
+      disabled={!!errors}
     >
       {label}
     </Button>
   );
-
-  if (isDeactivating) {
-    return (
-      <Tooltip
-        delay={0}
-        text={__(
-          'Editing an active automation is currently unavailable.',
-          'mailpoet',
-        )}
-      >
-        {button}
-      </Tooltip>
-    );
-  }
-
-  return button;
 }
 
 export function UpdateButton(): JSX.Element {
   const { save } = useDispatch(storeName);
 
-  const { automation, savedState } = useSelect(
+  const { savedState } = useSelect(
     (select) => ({
-      automation: select(storeName).getAutomationData(),
       savedState: select(storeName).getSavedState(),
     }),
     [],
@@ -93,40 +68,20 @@ export function UpdateButton(): JSX.Element {
       ? __('Updating…', 'mailpoet')
       : __('Update', 'mailpoet');
 
-  if (automation.stats.totals.in_progress === 0) {
-    return (
-      <Button
-        variant="primary"
-        className="editor-post-publish-button"
-        label={label}
-        showTooltip
-        shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
-        isBusy={savedState === 'saving'}
-        disabled={isDisabled}
-        aria-disabled={isDisabled}
-        onClick={save}
-      >
-        {label}
-      </Button>
-    );
-  }
   return (
-    <Tooltip
-      delay={0}
-      text={__(
-        'Editing an active automation is currently unavailable.',
-        'mailpoet',
-      )}
+    <Button
+      variant="primary"
+      className="editor-post-publish-button"
+      label={label}
+      showTooltip
+      shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
+      isBusy={savedState === 'saving'}
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
+      onClick={save}
     >
-      <Button
-        variant="primary"
-        className="editor-post-publish-button"
-        onClick={save}
-        disabled
-      >
-        {__('Update', 'mailpoet')}
-      </Button>
-    </Tooltip>
+      {label}
+    </Button>
   );
 }
 

--- a/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/header/index.tsx
@@ -17,6 +17,7 @@ import {
   DeactivateImmediatelyModal,
   DeactivateModal,
 } from '../modals/deactivate-modal';
+import { SaveActiveModal } from '../modals/save-active-modal';
 import { sendTelemetryEvent } from '../../telemetry';
 
 // See:
@@ -53,9 +54,12 @@ export function ActivateButton({ label }): JSX.Element {
 
 export function UpdateButton(): JSX.Element {
   const { save } = useDispatch(storeName);
+  const [showSaveModal, setShowSaveModal] = useState(false);
 
-  const { savedState } = useSelect(
+  const { hasUsersInProgress, savedState } = useSelect(
     (select) => ({
+      hasUsersInProgress:
+        select(storeName).getAutomationData().stats.totals.in_progress > 0,
       savedState: select(storeName).getSavedState(),
     }),
     [],
@@ -68,20 +72,33 @@ export function UpdateButton(): JSX.Element {
       ? __('Updating…', 'mailpoet')
       : __('Update', 'mailpoet');
 
+  const onClick = () => {
+    if (hasUsersInProgress) {
+      setShowSaveModal(true);
+      return;
+    }
+    void save();
+  };
+
   return (
-    <Button
-      variant="primary"
-      className="editor-post-publish-button"
-      label={label}
-      showTooltip
-      shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
-      isBusy={savedState === 'saving'}
-      disabled={isDisabled}
-      aria-disabled={isDisabled}
-      onClick={save}
-    >
-      {label}
-    </Button>
+    <>
+      {showSaveModal && (
+        <SaveActiveModal onClose={() => setShowSaveModal(false)} />
+      )}
+      <Button
+        variant="primary"
+        className="editor-post-publish-button"
+        label={label}
+        showTooltip
+        shortcut={isDisabled ? undefined : displayShortcut.primary('s')}
+        isBusy={savedState === 'saving'}
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        onClick={onClick}
+      >
+        {label}
+      </Button>
+    </>
   );
 }
 

--- a/mailpoet/assets/js/src/automation/editor/components/keyboard-shortcuts/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/keyboard-shortcuts/index.tsx
@@ -1,25 +1,42 @@
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import {
   useShortcut,
   store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
 import { __ } from '@wordpress/i18n';
 import { stepSidebarKey, storeName, automationSidebarKey } from '../../store';
+import { AutomationStatus } from '../../../listing/automation';
+import { SaveActiveModal } from '../modals/save-active-modal';
 
 // See:
 //    https://github.com/WordPress/gutenberg/blob/9601a33e30ba41bac98579c8d822af63dd961488/packages/edit-post/src/components/keyboard-shortcuts/index.js
 //    https://github.com/WordPress/gutenberg/blob/0ee78b1bbe9c6f3e6df99f3b967132fa12bef77d/packages/edit-site/src/components/keyboard-shortcuts/index.js
 
-export function KeyboardShortcuts(): null {
-  const { isSidebarOpened, selectedStep, savedState } = useSelect((select) => ({
+export function KeyboardShortcuts(): JSX.Element | null {
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const {
+    automationStatus,
+    hasUsersInProgress,
+    isSidebarOpened,
+    selectedStep,
+    savedState,
+  } = useSelect((select) => ({
+    automationStatus: select(storeName).getAutomationData().status,
+    hasUsersInProgress:
+      select(storeName).getAutomationData().stats.totals.in_progress > 0,
     isSidebarOpened: select(storeName).isSidebarOpened,
     selectedStep: select(storeName).getSelectedStep,
     savedState: select(storeName).getSavedState(),
   }));
 
-  const { openSidebar, closeSidebar, save, toggleFeature } =
-    useDispatch(storeName);
+  const {
+    openActivationPanel,
+    openSidebar,
+    closeSidebar,
+    save,
+    toggleFeature,
+  } = useDispatch(storeName);
 
   const { registerShortcut } = useDispatch(keyboardShortcutsStore);
 
@@ -75,10 +92,24 @@ export function KeyboardShortcuts(): null {
   useShortcut('mailpoet/automation-editor/save', (event) => {
     event.preventDefault();
 
-    if (savedState === 'unsaved') {
-      void save();
+    if (savedState !== 'unsaved') {
+      return;
     }
+
+    if (automationStatus === AutomationStatus.ACTIVE && hasUsersInProgress) {
+      setShowSaveModal(true);
+      return;
+    }
+
+    if (automationStatus === AutomationStatus.DEACTIVATING) {
+      void openActivationPanel();
+      return;
+    }
+
+    void save();
   });
 
-  return null;
+  return showSaveModal ? (
+    <SaveActiveModal onClose={() => setShowSaveModal(false)} />
+  ) : null;
 }

--- a/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
@@ -38,7 +38,7 @@ export function SaveActiveModal({
 
   // translators: %s is the name of the automation.
   const title = sprintf(
-    __('Save changes to "%s"?', 'mailpoet'),
+    __('Save changes to the "%s" automation?', 'mailpoet'),
     automationName,
   );
 
@@ -49,7 +49,7 @@ export function SaveActiveModal({
       onRequestClose={onRequestClose ?? onClose}
     >
       {__(
-        'Some subscribers are mid-flow. Choose how this update should affect them.',
+        "Some subscribers entered but have not finished the flow. Let's decide what to do in this case.",
         'mailpoet',
       )}
       <ul className="mailpoet-automation-options">
@@ -79,10 +79,10 @@ export function SaveActiveModal({
             </span>
             <span>
               <strong>
-                {__('Let in-flight subscribers finish', 'mailpoet')}
+                {__('Let entered subscribers finish the flow', 'mailpoet')}
               </strong>
               {__(
-                'They continue on the previous version. New subscribers use the updated automation.',
+                'New subscribers will enter the updated automation, but recently entered could proceed through the previous version.',
                 'mailpoet',
               )}
             </span>
@@ -113,9 +113,11 @@ export function SaveActiveModal({
               />
             </span>
             <span>
-              <strong>{__('Drop in-flight subscribers', 'mailpoet')}</strong>
+              <strong>
+                {__('Stop automation for entered subscribers', 'mailpoet')}
+              </strong>
               {__(
-                'In-flight runs are cancelled. Only new subscribers will go through the updated automation.',
+                'Automation will stop for recently entered subscribers immediately. New subscribers will go through the updated automation.',
                 'mailpoet',
               )}
             </span>

--- a/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { Button, Modal } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { dispatch, useSelect } from '@wordpress/data';
+import { storeName } from '../../store';
+import { sendTelemetryEvent } from '../../telemetry';
+
+const LET_FINISH = 'let_existing_finish';
+const STOP_ALL = 'stop_all_subscribers';
+
+type Props = {
+  onClose: () => void;
+  onRequestClose?: () => void;
+};
+
+export function SaveActiveModal({
+  onClose,
+  onRequestClose,
+}: Props): JSX.Element {
+  const { automationName, automationId } = useSelect(
+    (s) => ({
+      automationName: s(storeName).getAutomationData().name,
+      automationId: s(storeName).getAutomationData().id,
+    }),
+    [],
+  );
+  const [selected, setSelected] = useState<typeof LET_FINISH | typeof STOP_ALL>(
+    LET_FINISH,
+  );
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+
+  useEffect(() => {
+    sendTelemetryEvent('modal_view', {
+      modal_title: 'save_active_automation',
+      automation_id: automationId,
+    });
+  }, [automationId]);
+
+  // translators: %s is the name of the automation.
+  const title = sprintf(
+    __('Save changes to "%s"?', 'mailpoet'),
+    automationName,
+  );
+
+  return (
+    <Modal
+      className="mailpoet-automation-deactivate-modal"
+      title={title}
+      onRequestClose={onRequestClose ?? onClose}
+    >
+      {__(
+        'Some subscribers are mid-flow. Choose how this update should affect them.',
+        'mailpoet',
+      )}
+      <ul className="mailpoet-automation-options">
+        <li>
+          <label
+            className={
+              selected === LET_FINISH
+                ? 'mailpoet-automation-option active'
+                : 'mailpoet-automation-option'
+            }
+          >
+            <span>
+              <input
+                type="radio"
+                disabled={isBusy}
+                name="save-method"
+                checked={selected === LET_FINISH}
+                onChange={() => {
+                  sendTelemetryEvent('modal_option_select', {
+                    modal_title: 'save_active_automation',
+                    selected_option: LET_FINISH,
+                    automation_id: automationId,
+                  });
+                  setSelected(LET_FINISH);
+                }}
+              />
+            </span>
+            <span>
+              <strong>
+                {__('Let in-flight subscribers finish', 'mailpoet')}
+              </strong>
+              {__(
+                'They continue on the previous version. New subscribers use the updated automation.',
+                'mailpoet',
+              )}
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            className={
+              selected === STOP_ALL
+                ? 'mailpoet-automation-option active'
+                : 'mailpoet-automation-option'
+            }
+          >
+            <span>
+              <input
+                type="radio"
+                disabled={isBusy}
+                name="save-method"
+                checked={selected === STOP_ALL}
+                onChange={() => {
+                  sendTelemetryEvent('modal_option_select', {
+                    modal_title: 'save_active_automation',
+                    selected_option: STOP_ALL,
+                    automation_id: automationId,
+                  });
+                  setSelected(STOP_ALL);
+                }}
+              />
+            </span>
+            <span>
+              <strong>{__('Drop in-flight subscribers', 'mailpoet')}</strong>
+              {__(
+                'In-flight runs are cancelled. Only new subscribers will go through the updated automation.',
+                'mailpoet',
+              )}
+            </span>
+          </label>
+        </li>
+      </ul>
+
+      <Button
+        isBusy={isBusy}
+        variant="primary"
+        onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'save_active_automation',
+            button_label: 'save',
+            selected_option: selected,
+            automation_id: automationId,
+          });
+          setIsBusy(true);
+          void dispatch(storeName).save({
+            cancelRunningRuns: selected === STOP_ALL,
+          });
+          onClose();
+        }}
+      >
+        {__('Save', 'mailpoet')}
+      </Button>
+
+      <Button
+        disabled={isBusy}
+        variant="tertiary"
+        onClick={() => {
+          sendTelemetryEvent('modal_button_click', {
+            modal_title: 'save_active_automation',
+            button_label: 'cancel',
+            automation_id: automationId,
+          });
+          onClose();
+        }}
+      >
+        {__('Cancel', 'mailpoet')}
+      </Button>
+    </Modal>
+  );
+}

--- a/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
@@ -44,7 +44,7 @@ export function SaveActiveModal({
 
   return (
     <Modal
-      className="mailpoet-automation-deactivate-modal"
+      className="mailpoet-automation-save-active-modal"
       title={title}
       onRequestClose={onRequestClose ?? onClose}
     >
@@ -140,8 +140,9 @@ export function SaveActiveModal({
             await dispatch(storeName).save({
               cancelRunningRuns: selected === STOP_ALL,
             });
-          } finally {
             onClose();
+          } catch {
+            setIsBusy(false);
           }
         }}
       >

--- a/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
+++ b/mailpoet/assets/js/src/automation/editor/components/modals/save-active-modal.tsx
@@ -128,7 +128,7 @@ export function SaveActiveModal({
       <Button
         isBusy={isBusy}
         variant="primary"
-        onClick={() => {
+        onClick={async () => {
           sendTelemetryEvent('modal_button_click', {
             modal_title: 'save_active_automation',
             button_label: 'save',
@@ -136,10 +136,13 @@ export function SaveActiveModal({
             automation_id: automationId,
           });
           setIsBusy(true);
-          void dispatch(storeName).save({
-            cancelRunningRuns: selected === STOP_ALL,
-          });
-          onClose();
+          try {
+            await dispatch(storeName).save({
+              cancelRunningRuns: selected === STOP_ALL,
+            });
+          } finally {
+            onClose();
+          }
         }}
       >
         {__('Save', 'mailpoet')}

--- a/mailpoet/assets/js/src/automation/editor/index.tsx
+++ b/mailpoet/assets/js/src/automation/editor/index.tsx
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import { createRoot } from 'react-dom/client';
 import { useEffect, useRef, useState } from 'react';
 import { SlotFillProvider } from '@wordpress/components';
-import { store as noticesStore } from '@wordpress/notices';
 import { dispatch, select as globalSelect, useSelect } from '@wordpress/data';
 import { Platform } from '@wordpress/element';
 import {
@@ -29,7 +28,6 @@ import { MailPoet } from '../../mailpoet';
 import { LISTING_NOTICES } from '../listing/automation-listing-notices';
 import { registerApiErrorHandler } from './api-error-handler';
 import { ActivatePanel } from './components/panel/activate-panel';
-import { AutomationStatus } from '../listing/automation';
 import { initializeIntegrations } from './integrations';
 import { sendTelemetryEvent } from './telemetry';
 
@@ -39,33 +37,6 @@ import { sendTelemetryEvent } from './telemetry';
 
 // disable inserter sidebar until we implement drag & drop
 const showInserterSidebar = false;
-
-/**
- * Show temporary message that active automations cant be updated
- *
- * see MAILPOET-4744
- */
-function updatingActiveAutomationNotPossible() {
-  const automation = globalSelect(storeName).getAutomationData();
-  if (
-    ![AutomationStatus.ACTIVE, AutomationStatus.DEACTIVATING].includes(
-      automation.status,
-    )
-  ) {
-    return;
-  }
-  if (automation.stats.totals.in_progress === 0) {
-    return;
-  }
-  const { createNotice } = dispatch(noticesStore);
-  void createNotice(
-    'success',
-    __('Editing an active automation is currently unavailable.', 'mailpoet'),
-    {
-      type: 'snackbar',
-    },
-  );
-}
 
 function onUnload(event) {
   if (globalSelect(storeName).getSavedState() !== 'saved') {
@@ -125,7 +96,6 @@ function Editor(): JSX.Element {
         'notice-args': [automation.name],
       });
     }
-    updatingActiveAutomationNotPossible();
     if (!pageViewFiredRef.current) {
       pageViewFiredRef.current = true;
       sendTelemetryEvent('page_view', {

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -95,7 +95,7 @@ export function setAutomationName(name) {
   } as const;
 }
 
-export function* save() {
+export function* save(options: { cancelRunningRuns?: boolean } = {}) {
   const automation = select(storeName).getAutomationData();
 
   yield {
@@ -105,7 +105,10 @@ export function* save() {
   const data = yield apiFetch({
     path: `/automations/${automation.id}`,
     method: 'PUT',
-    data: { ...automation },
+    data: {
+      ...automation,
+      ...(options.cancelRunningRuns ? { cancel_running_runs: true } : {}),
+    },
   });
 
   const { createNotice } = dispatch(noticesStore);

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -102,14 +102,23 @@ export function* save(options: { cancelRunningRuns?: boolean } = {}) {
     type: 'SAVING',
   };
 
-  const data = yield apiFetch({
-    path: `/automations/${automation.id}`,
-    method: 'PUT',
-    data: {
-      ...automation,
-      ...(options.cancelRunningRuns ? { cancel_running_runs: true } : {}),
-    },
-  });
+  let data;
+  try {
+    data = yield apiFetch({
+      path: `/automations/${automation.id}`,
+      method: 'PUT',
+      data: {
+        ...automation,
+        ...(options.cancelRunningRuns ? { cancel_running_runs: true } : {}),
+      },
+    });
+  } catch {
+    sendTelemetryEvent('button_error', {
+      button_label: 'save',
+      automation_id: automation.id,
+    });
+    throw new Error(__('Failed to save automation.', 'mailpoet'));
+  }
 
   const { createNotice } = dispatch(noticesStore);
   if (data?.data) {

--- a/mailpoet/assets/js/src/automation/editor/store/actions.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/actions.ts
@@ -117,6 +117,9 @@ export function* save(options: { cancelRunningRuns?: boolean } = {}) {
       button_label: 'save',
       automation_id: automation.id,
     });
+    yield {
+      type: 'SAVE_ERROR',
+    };
     throw new Error(__('Failed to save automation.', 'mailpoet'));
   }
 

--- a/mailpoet/assets/js/src/automation/editor/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/editor/store/reducer.ts
@@ -67,6 +67,11 @@ export function reducer(state: State, action): State {
         ...state,
         savedState: 'saving',
       };
+    case 'SAVE_ERROR':
+      return {
+        ...state,
+        savedState: 'unsaved',
+      };
     case 'REGISTER_STEP_TYPE':
       return {
         ...state,

--- a/mailpoet/changelog/2026-05-04-16-00-06-improved-allow-editing-active-automations-existing-in-fligh.md
+++ b/mailpoet/changelog/2026-05-04-16-00-06-improved-allow-editing-active-automations-existing-in-fligh.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Allow editing active automations. Existing in-flight subscribers continue on the previous version, and you can optionally cancel them

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -65,6 +65,7 @@ class UpdateAutomationController {
     }
 
     if (array_key_exists('steps', $data)) {
+      $this->validateTriggerInvariants($automation, $data['steps']);
       $this->validateAutomationSteps($automation, $data['steps']);
       $this->updateStepsController->updateSteps($automation, $data['steps']);
       foreach ($automation->getSteps() as $step) {
@@ -101,6 +102,33 @@ class UpdateAutomationController {
     if (!in_array($status, Automation::STATUS_ALL, true)) {
       // translators: %s is the status.
       throw UnexpectedValueException::create()->withMessage(sprintf(__('Invalid status: %s', 'mailpoet'), $status));
+    }
+  }
+
+  private function validateTriggerInvariants(Automation $automation, array $steps): void {
+    $existingTriggers = [];
+    foreach ($automation->getSteps() as $step) {
+      if ($step->getType() === Step::TYPE_TRIGGER) {
+        $existingTriggers[$step->getId()] = $step;
+      }
+    }
+
+    $newTriggers = [];
+    foreach ($steps as $id => $data) {
+      if (($data['type'] ?? null) === Step::TYPE_TRIGGER) {
+        $newTriggers[$id] = $data;
+      }
+    }
+
+    if (count($newTriggers) !== count($existingTriggers)) {
+      throw Exceptions::automationTriggerModificationNotSupported();
+    }
+
+    foreach ($existingTriggers as $id => $existingTrigger) {
+      $newTrigger = $newTriggers[$id] ?? null;
+      if (!$newTrigger || ($newTrigger['key'] ?? '') !== $existingTrigger->getKey()) {
+        throw Exceptions::automationTriggerModificationNotSupported();
+      }
     }
   }
 

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -76,6 +76,8 @@ class UpdateAutomationController {
 
     if (($automation->getStatus() === Automation::STATUS_DRAFT) && ($originalStatus === Automation::STATUS_ACTIVE)) {
       $this->unscheduleAutomationRuns($automation);
+    } elseif (!empty($data['cancel_running_runs'])) {
+      $this->unscheduleAutomationRuns($automation);
     }
 
     if (array_key_exists('meta', $data)) {

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -11,7 +11,6 @@ use MailPoet\Automation\Engine\Exceptions;
 use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
-use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\Validation\AutomationValidator;
 
@@ -21,9 +20,6 @@ class UpdateAutomationController {
 
   /** @var AutomationStorage */
   private $storage;
-
-  /** @var AutomationStatisticsStorage */
-  private $statisticsStorage;
 
   /** @var AutomationValidator */
   private $automationValidator;
@@ -38,7 +34,6 @@ class UpdateAutomationController {
   public function __construct(
     Hooks $hooks,
     AutomationStorage $storage,
-    AutomationStatisticsStorage $statisticsStorage,
     AutomationValidator $automationValidator,
     AutomationRunStorage $automationRunStorage,
     ActionScheduler $actionScheduler,
@@ -46,7 +41,6 @@ class UpdateAutomationController {
   ) {
     $this->hooks = $hooks;
     $this->storage = $storage;
-    $this->statisticsStorage = $statisticsStorage;
     $this->automationValidator = $automationValidator;
     $this->updateStepsController = $updateStepsController;
     $this->automationRunStorage = $automationRunStorage;
@@ -59,7 +53,6 @@ class UpdateAutomationController {
       throw Exceptions::automationNotFound($id);
     }
     $previousAutomation = clone $automation;
-    $this->validateIfAutomationCanBeUpdated($automation, $data);
 
     if (array_key_exists('name', $data)) {
       $automation->setName($data['name']);
@@ -102,34 +95,6 @@ class UpdateAutomationController {
     }
     $this->hooks->doAutomationAfterUpdate($automation, $previousAutomation);
     return $automation;
-  }
-
-  /**
-   * This is a temporary validation, see MAILPOET-4744
-   */
-  private function validateIfAutomationCanBeUpdated(Automation $automation, array $data): void {
-
-    if (
-      !in_array(
-        $automation->getStatus(),
-        [
-        Automation::STATUS_ACTIVE,
-        Automation::STATUS_DEACTIVATING,
-        ],
-        true
-      )
-    ) {
-      return;
-    }
-
-    $statistics = $this->statisticsStorage->getAutomationStats($automation->getId());
-    if ($statistics->getInProgress() === 0) {
-      return;
-    }
-
-    if (!isset($data['status']) || $data['status'] === $automation->getStatus()) {
-      throw Exceptions::automationHasActiveRuns($automation->getId());
-    }
   }
 
   private function checkAutomationStatus(string $status): void {

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -125,15 +125,23 @@ class UpdateAutomationController {
       }
     }
 
+    $triggersChanged = false;
     if (count($newTriggers) !== count($existingTriggers)) {
-      throw Exceptions::automationTriggerModificationNotSupported();
+      $triggersChanged = true;
     }
 
-    foreach ($existingTriggers as $id => $existingTrigger) {
-      $newTrigger = $newTriggers[$id] ?? null;
-      if (!$newTrigger || ($newTrigger['key'] ?? '') !== $existingTrigger->getKey()) {
-        throw Exceptions::automationTriggerModificationNotSupported();
+    if (!$triggersChanged) {
+      foreach ($existingTriggers as $id => $existingTrigger) {
+        $newTrigger = $newTriggers[$id] ?? null;
+        if (!$newTrigger || ($newTrigger['key'] ?? '') !== $existingTrigger->getKey()) {
+          $triggersChanged = true;
+          break;
+        }
       }
+    }
+
+    if ($triggersChanged && $this->automationRunStorage->getCountForAutomation($automation) > 0) {
+      throw Exceptions::automationTriggerModificationNotSupported();
     }
   }
 

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -74,11 +74,10 @@ class UpdateAutomationController {
       }
     }
 
-    if (($automation->getStatus() === Automation::STATUS_DRAFT) && ($originalStatus === Automation::STATUS_ACTIVE)) {
-      $this->unscheduleAutomationRuns($automation);
-    } elseif (!empty($data['cancel_running_runs'])) {
-      $this->unscheduleAutomationRuns($automation);
-    }
+    $shouldUnscheduleAutomationRuns = (
+      ($automation->getStatus() === Automation::STATUS_DRAFT)
+      && ($originalStatus === Automation::STATUS_ACTIVE)
+    ) || !empty($data['cancel_running_runs']);
 
     if (array_key_exists('meta', $data)) {
       $automation->deleteAllMetas();
@@ -91,6 +90,10 @@ class UpdateAutomationController {
 
     $this->automationValidator->validate($automation);
     $this->storage->updateAutomation($automation);
+
+    if ($shouldUnscheduleAutomationRuns) {
+      $this->unscheduleAutomationRuns($automation);
+    }
 
     $automation = $this->storage->getAutomation($id);
     if (!$automation) {

--- a/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
+++ b/mailpoet/lib/Automation/Engine/Builder/UpdateAutomationController.php
@@ -121,8 +121,8 @@ class UpdateAutomationController {
   private function stepChanged(Step $a, Step $b): bool {
     $aData = $a->toArray();
     $bData = $b->toArray();
-    unset($aData['args']);
-    unset($bData['args']);
+    unset($aData['args'], $aData['filters']);
+    unset($bData['args'], $bData['filters']);
     return $aData === $bData;
   }
 

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsPutEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationsPutEndpoint.php
@@ -40,6 +40,7 @@ class AutomationsPutEndpoint extends Endpoint {
       'status' => Builder::string(),
       'steps' => AutomationSchema::getStepsSchema(),
       'meta' => Builder::object(),
+      'cancel_running_runs' => Builder::boolean(),
     ];
   }
 }

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -36,7 +36,6 @@ class Exceptions {
   private const MISSING_REQUIRED_SUBJECTS = 'mailpoet_automation_missing_required_subjects';
   private const AUTOMATION_NOT_TRASHED = 'mailpoet_automation_not_trashed';
   private const AUTOMATION_TEMPLATE_NOT_FOUND = 'mailpoet_automation_template_not_found';
-  private const AUTOMATION_HAS_ACTIVE_RUNS = 'mailpoet_automation_has_active_runs';
   private const AUTOMATION_STEP_NOT_STARTED = 'mailpoet_automation_step_not_started';
   private const AUTOMATION_STEP_NOT_RUNNING = 'mailpoet_automation_step_not_running';
   private const AUTOMATION_STEP_ACTION_PROCESSED = 'mailpoet_automation_step_action_processed';
@@ -273,16 +272,6 @@ class Exceptions {
       ->withErrorCode(self::AUTOMATION_TEMPLATE_NOT_FOUND)
       // translators: %d is the ID of the automation template.
       ->withMessage(sprintf(__("Automation template with ID '%d' not found.", 'mailpoet'), $id));
-  }
-
-  /**
-   * This is a temporary block, see MAILPOET-4744
-   */
-  public static function automationHasActiveRuns(int $id): InvalidStateException {
-    return InvalidStateException::create()
-      ->withErrorCode(self::AUTOMATION_HAS_ACTIVE_RUNS)
-      // translators: %d is the ID of the automation.
-      ->withMessage(sprintf(__("Can not update automation with ID '%d' because users are currently active.", 'mailpoet'), $id));
   }
 
   public static function stepNotStarted(string $id, int $runId): InvalidStateException {

--- a/mailpoet/lib/Automation/Engine/Exceptions.php
+++ b/mailpoet/lib/Automation/Engine/Exceptions.php
@@ -30,6 +30,7 @@ class Exceptions {
   private const NEXT_STEP_NOT_FOUND = 'mailpoet_next_step_not_found';
   private const NEXT_STEP_NOT_SCHEDULED = 'mailpoet_next_step_not_scheduled';
   private const AUTOMATION_STRUCTURE_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_structure_modification_not_supported';
+  private const AUTOMATION_TRIGGER_MODIFICATION_NOT_SUPPORTED = 'mailpoet_automation_trigger_modification_not_supported';
   private const AUTOMATION_STRUCTURE_NOT_VALID = 'mailpoet_automation_structure_not_valid';
   private const AUTOMATION_STEP_MODIFIED_WHEN_UNKNOWN = 'mailpoet_automation_step_modified_when_unknown';
   private const AUTOMATION_NOT_VALID = 'mailpoet_automation_not_valid';
@@ -212,6 +213,12 @@ class Exceptions {
     return UnexpectedValueException::create()
       ->withErrorCode(self::AUTOMATION_STRUCTURE_MODIFICATION_NOT_SUPPORTED)
       ->withMessage(__('Automation structure modification not supported.', 'mailpoet'));
+  }
+
+  public static function automationTriggerModificationNotSupported(): UnexpectedValueException {
+    return UnexpectedValueException::create()
+      ->withErrorCode(self::AUTOMATION_TRIGGER_MODIFICATION_NOT_SUPPORTED)
+      ->withMessage(__('Changing the trigger of an existing automation is not supported. You can edit its settings or filters instead.', 'mailpoet'));
   }
 
   public static function automationStructureNotValid(string $detail, string $ruleId): UnexpectedValueException {

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -51,6 +51,39 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     $this->assertNotSame($updated->getVersionId(), $run->getVersionId());
   }
 
+  public function testItCancelsRunningRunsWhenCancelFlagIsSet(): void {
+    $automation = $this->tester->createAutomation(
+      'Active automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
+    );
+
+    $run = $this->tester->createAutomationRun($automation);
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $runStorage->updateStatus($run->getId(), AutomationRun::STATUS_RUNNING);
+
+    $this->scheduleAction(time() + 100, ['automation_run_id' => $run->getId(), 'step_id' => 'a1', 'run_number' => 1]);
+
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+    $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'cancel_running_runs' => true,
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
+        ],
+      ]
+    );
+
+    $updated = $this->diContainer->get(AutomationStorage::class)->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $updated);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updated->getStatus());
+    $this->assertSame(AutomationRun::STATUS_CANCELLED, $this->getAutomationRun($run->getId())->getStatus());
+    $this->assertCount(0, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
+  }
+
   public function testItRejectsTriggerKeyChange(): void {
     $automation = $this->tester->createAutomation(
       'Trigger lock automation',

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -15,15 +15,15 @@ use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Engine\Validation\AutomationValidator;
+use MailPoet\Automation\Engine\WordPress;
+use MailPoet\Automation\Integrations\Core\Actions\DelayAction;
+use MailPoet\Automation\Integrations\MailPoet\Triggers\SomeoneSubscribesTrigger;
+use MailPoet\Test\DataFactories\Automation as AutomationFactory;
 use MailPoetTest;
 
 class UpdateAutomationControllerTest extends MailPoetTest {
   public function testItUpdatesActiveAutomationWithRunningRuns(): void {
-    $automation = $this->tester->createAutomation(
-      'Active automation',
-      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
-      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
-    );
+    $automation = $this->createActiveAutomationWithDelay();
     $this->assertSame(Automation::STATUS_ACTIVE, $automation->getStatus());
 
     $run = $this->tester->createAutomationRun($automation);
@@ -34,11 +34,7 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     $controller->updateAutomation(
       $automation->getId(),
       [
-        'steps' => [
-          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
-          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
-          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
-        ],
+        'steps' => $this->getDelayAutomationSteps(2),
       ]
     );
 
@@ -47,7 +43,7 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     $this->assertSame(Automation::STATUS_ACTIVE, $updated->getStatus());
     $updatedStep = $updated->getStep('a1');
     $this->assertInstanceOf(Step::class, $updatedStep);
-    $this->assertSame('after', $updatedStep->getArgs()['note']);
+    $this->assertSame(2, $updatedStep->getArgs()['delay']);
 
     // existing run is preserved on its original version
     $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
@@ -55,11 +51,7 @@ class UpdateAutomationControllerTest extends MailPoetTest {
   }
 
   public function testItCancelsRunningRunsWhenCancelFlagIsSet(): void {
-    $automation = $this->tester->createAutomation(
-      'Active automation',
-      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
-      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
-    );
+    $automation = $this->createActiveAutomationWithDelay();
 
     $run = $this->tester->createAutomationRun($automation);
     $runStorage = $this->diContainer->get(AutomationRunStorage::class);
@@ -72,11 +64,7 @@ class UpdateAutomationControllerTest extends MailPoetTest {
       $automation->getId(),
       [
         'cancel_running_runs' => true,
-        'steps' => [
-          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
-          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
-          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
-        ],
+        'steps' => $this->getDelayAutomationSteps(2),
       ]
     );
 
@@ -88,11 +76,7 @@ class UpdateAutomationControllerTest extends MailPoetTest {
   }
 
   public function testItDoesNotCancelRunningRunsWhenSaveFails(): void {
-    $automation = $this->tester->createAutomation(
-      'Active automation',
-      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
-      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
-    );
+    $automation = $this->createActiveAutomationWithDelay();
 
     $run = $this->tester->createAutomationRun($automation);
     $runStorage = $this->diContainer->get(AutomationRunStorage::class);
@@ -100,10 +84,11 @@ class UpdateAutomationControllerTest extends MailPoetTest {
 
     $this->scheduleAction(time() + 100, ['automation_run_id' => $run->getId(), 'step_id' => 'a1', 'run_number' => 1]);
 
+    $wp = $this->diContainer->get(WordPress::class);
     $throwOnSave = function(): void {
       throw new \RuntimeException('Save failed');
     };
-    add_action(Hooks::AUTOMATION_BEFORE_SAVE, $throwOnSave);
+    $wp->addAction(Hooks::AUTOMATION_BEFORE_SAVE, $throwOnSave);
 
     try {
       $controller = $this->diContainer->get(UpdateAutomationController::class);
@@ -111,25 +96,21 @@ class UpdateAutomationControllerTest extends MailPoetTest {
         $automation->getId(),
         [
           'cancel_running_runs' => true,
-          'steps' => [
-            'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
-            't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
-            'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
-          ],
+          'steps' => $this->getDelayAutomationSteps(2),
         ]
       );
       $this->fail('Expected save to fail.');
     } catch (\RuntimeException $e) {
       $this->assertSame('Save failed', $e->getMessage());
     } finally {
-      remove_action(Hooks::AUTOMATION_BEFORE_SAVE, $throwOnSave);
+      $wp->removeAction(Hooks::AUTOMATION_BEFORE_SAVE, $throwOnSave);
     }
 
     $updated = $this->diContainer->get(AutomationStorage::class)->getAutomation($automation->getId());
     $this->assertInstanceOf(Automation::class, $updated);
     $updatedStep = $updated->getStep('a1');
     $this->assertInstanceOf(Step::class, $updatedStep);
-    $this->assertSame('before', $updatedStep->getArgs()['note']);
+    $this->assertSame(1, $updatedStep->getArgs()['delay']);
     $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
     $this->assertCount(1, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
   }
@@ -270,6 +251,50 @@ class UpdateAutomationControllerTest extends MailPoetTest {
         array_merge(['hook' => Hooks::AUTOMATION_STEP, 'group' => 'mailpoet-automation'], $args)
       )
     );
+  }
+
+  private function createActiveAutomationWithDelay(int $delay = 1): Automation {
+    return (new AutomationFactory())
+      ->withName('Active automation')
+      ->withSteps([
+        'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], [new NextStep('t')]),
+        't' => new Step('t', Step::TYPE_TRIGGER, SomeoneSubscribesTrigger::KEY, [], [new NextStep('a1')]),
+        'a1' => new Step('a1', Step::TYPE_ACTION, DelayAction::KEY, [
+          'delay_type' => 'MINUTES',
+          'delay' => $delay,
+        ], []),
+      ])
+      ->withStatusActive()
+      ->create();
+  }
+
+  private function getDelayAutomationSteps(int $delay): array {
+    return [
+      'root' => [
+        'id' => 'root',
+        'type' => Step::TYPE_ROOT,
+        'key' => 'core:root',
+        'args' => [],
+        'next_steps' => [['id' => 't']],
+      ],
+      't' => [
+        'id' => 't',
+        'type' => Step::TYPE_TRIGGER,
+        'key' => SomeoneSubscribesTrigger::KEY,
+        'args' => [],
+        'next_steps' => [['id' => 'a1']],
+      ],
+      'a1' => [
+        'id' => 'a1',
+        'type' => Step::TYPE_ACTION,
+        'key' => DelayAction::KEY,
+        'args' => [
+          'delay_type' => 'MINUTES',
+          'delay' => $delay,
+        ],
+        'next_steps' => [],
+      ],
+    ];
   }
 
   private function createRootOnlyAutomation(): Automation {

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -4,6 +4,8 @@ namespace MailPoet\Test\Automation\Engine\Control;
 
 use ActionScheduler_Store;
 use MailPoet\Automation\Engine\Builder\UpdateAutomationController;
+use MailPoet\Automation\Engine\Builder\UpdateStepsController;
+use MailPoet\Automation\Engine\Control\ActionScheduler;
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
@@ -12,6 +14,7 @@ use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Engine\Validation\AutomationValidator;
 use MailPoetTest;
 
 class UpdateAutomationControllerTest extends MailPoetTest {
@@ -131,26 +134,57 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     $this->assertCount(1, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
   }
 
-  public function testItRejectsTriggerKeyChange(): void {
+  /**
+   * @group automation-trigger-invariants
+   */
+  public function testItAllowsTriggerChangeWhenNoRunIsRecorded(): void {
+    $automation = $this->createRootOnlyAutomation();
+    $controller = $this->getEditableStructureUpdateAutomationController();
+
+    $updated = $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'status' => Automation::STATUS_ACTIVE,
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'core:root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'mailpoet:someone-subscribes', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'core:delay', 'args' => ['delay' => 1, 'delay_type' => 'MINUTES'], 'next_steps' => []],
+        ],
+      ]
+    );
+
+    $this->assertSame(Automation::STATUS_ACTIVE, $updated->getStatus());
+    $this->assertInstanceOf(Step::class, $updated->getTrigger('mailpoet:someone-subscribes'));
+  }
+
+  /**
+   * @group automation-trigger-invariants
+   */
+  public function testItRejectsTriggerKeyChangeWhenRunIsRecorded(): void {
     $automation = $this->tester->createAutomation(
       'Trigger lock automation',
       new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
       new Step('a1', Step::TYPE_ACTION, 'test:action', [], [])
     );
+    $this->tester->createAutomationRun($automation);
 
     $controller = $this->diContainer->get(UpdateAutomationController::class);
 
-    $this->expectException(UnexpectedValueException::class);
-    $controller->updateAutomation(
-      $automation->getId(),
-      [
-        'steps' => [
-          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
-          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:other-trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
-          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => [], 'next_steps' => []],
-        ],
-      ]
-    );
+    try {
+      $controller->updateAutomation(
+        $automation->getId(),
+        [
+          'steps' => [
+            'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+            't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:other-trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+            'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => [], 'next_steps' => []],
+          ],
+        ]
+      );
+      $this->fail('Expected trigger modification to fail.');
+    } catch (UnexpectedValueException $e) {
+      $this->assertSame('mailpoet_automation_trigger_modification_not_supported', $e->getErrorCode());
+    }
   }
 
   public function testItUnschedulesTasksWhenSwitchedToDraft(): void {
@@ -236,6 +270,34 @@ class UpdateAutomationControllerTest extends MailPoetTest {
         array_merge(['hook' => Hooks::AUTOMATION_STEP, 'group' => 'mailpoet-automation'], $args)
       )
     );
+  }
+
+  private function createRootOnlyAutomation(): Automation {
+    $automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $automation = new Automation(
+      'New automation',
+      [
+        'root' => new Step('root', Step::TYPE_ROOT, 'core:root', [], []),
+      ],
+      wp_get_current_user()
+    );
+    $automation = $automationStorage->getAutomation($automationStorage->createAutomation($automation));
+    $this->assertInstanceOf(Automation::class, $automation);
+    return $automation;
+  }
+
+  private function getEditableStructureUpdateAutomationController(): UpdateAutomationController {
+    return new class(
+      $this->diContainer->get(Hooks::class),
+      $this->diContainer->get(AutomationStorage::class),
+      $this->diContainer->get(AutomationValidator::class),
+      $this->diContainer->get(AutomationRunStorage::class),
+      $this->diContainer->get(ActionScheduler::class),
+      $this->diContainer->get(UpdateStepsController::class)
+    ) extends UpdateAutomationController {
+      protected function validateAutomationSteps(Automation $automation, array $steps): void {
+      }
+    };
   }
 
   public function _before(): void {

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -14,6 +14,42 @@ use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoetTest;
 
 class UpdateAutomationControllerTest extends MailPoetTest {
+  public function testItUpdatesActiveAutomationWithRunningRuns(): void {
+    $automation = $this->tester->createAutomation(
+      'Active automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
+    );
+    $this->assertSame(Automation::STATUS_ACTIVE, $automation->getStatus());
+
+    $run = $this->tester->createAutomationRun($automation);
+    $this->diContainer->get(AutomationRunStorage::class)
+      ->updateStatus($run->getId(), AutomationRun::STATUS_RUNNING);
+
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+    $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
+        ],
+      ]
+    );
+
+    $updated = $this->diContainer->get(AutomationStorage::class)->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $updated);
+    $this->assertSame(Automation::STATUS_ACTIVE, $updated->getStatus());
+    $updatedStep = $updated->getStep('a1');
+    $this->assertInstanceOf(Step::class, $updatedStep);
+    $this->assertSame('after', $updatedStep->getArgs()['note']);
+
+    // existing run is preserved on its original version
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
+    $this->assertNotSame($updated->getVersionId(), $run->getVersionId());
+  }
+
   public function testItUnschedulesTasksWhenSwitchedToDraft(): void {
     $automation = $this->tester->createAutomation(
       'Test automation',

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -8,6 +8,7 @@ use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
 use MailPoet\Automation\Engine\Data\NextStep;
 use MailPoet\Automation\Engine\Data\Step;
+use MailPoet\Automation\Engine\Exceptions\UnexpectedValueException;
 use MailPoet\Automation\Engine\Hooks;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
@@ -48,6 +49,28 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     // existing run is preserved on its original version
     $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
     $this->assertNotSame($updated->getVersionId(), $run->getVersionId());
+  }
+
+  public function testItRejectsTriggerKeyChange(): void {
+    $automation = $this->tester->createAutomation(
+      'Trigger lock automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', [], [])
+    );
+
+    $controller = $this->diContainer->get(UpdateAutomationController::class);
+
+    $this->expectException(UnexpectedValueException::class);
+    $controller->updateAutomation(
+      $automation->getId(),
+      [
+        'steps' => [
+          'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+          't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:other-trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+          'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => [], 'next_steps' => []],
+        ],
+      ]
+    );
   }
 
   public function testItUnschedulesTasksWhenSwitchedToDraft(): void {

--- a/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Builder/UpdateAutomationControllerTest.php
@@ -84,6 +84,53 @@ class UpdateAutomationControllerTest extends MailPoetTest {
     $this->assertCount(0, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
   }
 
+  public function testItDoesNotCancelRunningRunsWhenSaveFails(): void {
+    $automation = $this->tester->createAutomation(
+      'Active automation',
+      new Step('t', Step::TYPE_TRIGGER, 'test:trigger', [], [new NextStep('a1')]),
+      new Step('a1', Step::TYPE_ACTION, 'test:action', ['note' => 'before'], [])
+    );
+
+    $run = $this->tester->createAutomationRun($automation);
+    $runStorage = $this->diContainer->get(AutomationRunStorage::class);
+    $runStorage->updateStatus($run->getId(), AutomationRun::STATUS_RUNNING);
+
+    $this->scheduleAction(time() + 100, ['automation_run_id' => $run->getId(), 'step_id' => 'a1', 'run_number' => 1]);
+
+    $throwOnSave = function(): void {
+      throw new \RuntimeException('Save failed');
+    };
+    add_action(Hooks::AUTOMATION_BEFORE_SAVE, $throwOnSave);
+
+    try {
+      $controller = $this->diContainer->get(UpdateAutomationController::class);
+      $controller->updateAutomation(
+        $automation->getId(),
+        [
+          'cancel_running_runs' => true,
+          'steps' => [
+            'root' => ['id' => 'root', 'type' => Step::TYPE_ROOT, 'key' => 'root', 'args' => [], 'next_steps' => [['id' => 't']]],
+            't' => ['id' => 't', 'type' => Step::TYPE_TRIGGER, 'key' => 'test:trigger', 'args' => [], 'next_steps' => [['id' => 'a1']]],
+            'a1' => ['id' => 'a1', 'type' => Step::TYPE_ACTION, 'key' => 'test:action', 'args' => ['note' => 'after'], 'next_steps' => []],
+          ],
+        ]
+      );
+      $this->fail('Expected save to fail.');
+    } catch (\RuntimeException $e) {
+      $this->assertSame('Save failed', $e->getMessage());
+    } finally {
+      remove_action(Hooks::AUTOMATION_BEFORE_SAVE, $throwOnSave);
+    }
+
+    $updated = $this->diContainer->get(AutomationStorage::class)->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $updated);
+    $updatedStep = $updated->getStep('a1');
+    $this->assertInstanceOf(Step::class, $updatedStep);
+    $this->assertSame('before', $updatedStep->getArgs()['note']);
+    $this->assertSame(AutomationRun::STATUS_RUNNING, $this->getAutomationRun($run->getId())->getStatus());
+    $this->assertCount(1, $this->getActions(['status' => ActionScheduler_Store::STATUS_PENDING]));
+  }
+
   public function testItRejectsTriggerKeyChange(): void {
     $automation = $this->tester->createAutomation(
       'Trigger lock automation',


### PR DESCRIPTION
## Description

Allow editing automation with subscribers in the middle.

- Trigger can only be changed when no previous run exist
- Trigger filters or settings can be changed freely
- Any step can be added/changed/replace
- On update, user needs to decide if subscribers in the middle will finish their version of automation or are dropped completely.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8019

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="509" height="388" alt="Screenshot 2026-05-13 at 17 51 47" src="https://github.com/user-attachments/assets/5269ba19-2606-47a4-a320-aa05069770d0" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8019-allow-editing-active-automations)

_The latest successful build from `stomail-8019-allow-editing-active-automations` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Review Issues Found: 1

### Suggestion (1)
1. **No user-facing error feedback in SaveActiveModal** - The modal catches save failures and resets its busy state but does not surface an error message to the user or emit an explicit error telemetry event for failures; consider adding visible error feedback and/or a telemetry `button_error` event for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6751)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->