### PR TITLE
Remove pause debugging docs

### DIFF
--- a/.ai/skills/writing-tests/SKILL.md
+++ b/.ai/skills/writing-tests/SKILL.md
@@ -65,7 +65,6 @@ Browser-based end-to-end tests using Selenium and Chrome in Docker. **The slowes
 - **Run one file:** `pnpm test:acceptance --file=tests/acceptance/Misc/WordPressSiteEditorCest.php`
 - **Multisite:** `cd mailpoet && ./do test:acceptance-multisite --skip-deps --file ...` (Robo-only)
 - **Reset Docker:** `cd mailpoet && ./do delete:docker` — if you get unexpected errors, delete the Docker runtime and start fresh (Robo-only)
-- **Debug with pause:** Add `$i->pause();` in your test to pause execution and inspect the browser state
 - **Watch tests in browser:** The browser runs in Docker. Connect via VNC at `vnc://localhost:5900` (password: `secret`).
 
 ### JavaScript Tests

--- a/mailpoet/README.md
+++ b/mailpoet/README.md
@@ -295,8 +295,6 @@ The `pnpm` wrapper passes `--skip-deps` by default to speed up the run locally.
 If there are some unexpected errors you can delete all the runtime and start again.
 To delete all the docker runtime for acceptance tests use the Robo-only command `cd mailpoet && ./do delete:docker`.
 
-When debugging you can add `$i->pause();` in to your test which pauses the execution.
-
 We are using Gravity Flow plugin's setup as an example for our acceptance test suite: https://www.stevenhenty.com/learn-acceptance-testing-deeply/
 
 From the article above:


### PR DESCRIPTION
## Description

Removes stale `$i->pause()` debugging guidance after the optional Codeception `hoa/console` dependency was removed.

## Code review notes

This follows up on the comment in #6750. The generated Codeception actor docblock still mentions `pause()`, but this PR only removes documentation that recommends the workflow.

## QA notes

_N/A_

## Linked PRs

#6750

## Linked tickets

STOMAIL-8082

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:chore/STOMAIL-8082-remove-pause-docs)

_The latest successful build from `chore/STOMAIL-8082-remove-pause-docs` will be used. If none is available, the link won't work._