### PR TITLE
Fix beta compatibility test failures

### DIFF
--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -93,6 +93,9 @@ class Activator {
     $this->checkForDisabledMailFunction();
   }
 
+  /**
+   * Public because it can be deferred until Action Scheduler is initialized.
+   */
   public function refreshCronActions(): void {
     $currentMethod = $this->settings->get(CronTrigger::SETTING_NAME . '.method');
     if ($currentMethod !== CronTrigger::METHOD_ACTION_SCHEDULER) {

--- a/mailpoet/lib/Config/Activator.php
+++ b/mailpoet/lib/Config/Activator.php
@@ -80,8 +80,7 @@ class Activator {
 
   private function processActivate(): void {
     $this->migrator->run();
-    $this->deactivateCronActions();
-    $this->reactivateCronActions();
+    $this->refreshCronActions();
     $this->populator->up();
     $this->updateDbVersion();
 
@@ -92,6 +91,22 @@ class Activator {
     $localizer->forceInstallLanguagePacks($this->wp);
 
     $this->checkForDisabledMailFunction();
+  }
+
+  public function refreshCronActions(): void {
+    $currentMethod = $this->settings->get(CronTrigger::SETTING_NAME . '.method');
+    if ($currentMethod !== CronTrigger::METHOD_ACTION_SCHEDULER) {
+      $this->daemonActionSchedulerRunner->clearDeactivationFlag();
+      return;
+    }
+
+    if (!$this->cronActionSchedulerRunner->isInitialized()) {
+      $this->cronActionSchedulerRunner->runAfterInitialized([$this, 'refreshCronActions']);
+      return;
+    }
+
+    $this->deactivateCronActions();
+    $this->reactivateCronActions();
   }
 
   public function deactivate() {

--- a/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
+++ b/mailpoet/lib/Cron/ActionScheduler/ActionScheduler.php
@@ -39,4 +39,12 @@ class ActionScheduler {
   public function hasScheduledAction(string $hook, array $args = []): bool {
     return as_has_scheduled_action($hook, $args, self::GROUP_ID);
   }
+
+  public function isInitialized(): bool {
+    return class_exists(\ActionScheduler::class) && \ActionScheduler::is_initialized();
+  }
+
+  public function runAfterInitialized(callable $callback): void {
+    $this->wp->addAction('action_scheduler_init', $callback);
+  }
 }

--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -66,6 +66,13 @@ class CleanupExtension extends Extension {
       ON DUPLICATE KEY UPDATE option_value = 'yes';
     ";
 
+    // Prevent WordPress from running its admin compression test Ajax probe during acceptance tests.
+    $sql .= "
+      INSERT INTO mp_options (option_name, option_value, autoload)
+      VALUES ('can_compress_scripts', '1', 'yes')
+      ON DUPLICATE KEY UPDATE option_value = '1';
+    ";
+
     // wrap SQL with serializable transaction (to avoid other connections like WP-CLI seeing wrong state)
     $sql = "
       SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE;

--- a/mailpoet/tests/_support/CleanupExtension.php
+++ b/mailpoet/tests/_support/CleanupExtension.php
@@ -70,7 +70,7 @@ class CleanupExtension extends Extension {
     $sql .= "
       INSERT INTO mp_options (option_name, option_value, autoload)
       VALUES ('can_compress_scripts', '1', 'yes')
-      ON DUPLICATE KEY UPDATE option_value = '1';
+      ON DUPLICATE KEY UPDATE option_value = '1', autoload = 'yes';
     ";
 
     // wrap SQL with serializable transaction (to avoid other connections like WP-CLI seeing wrong state)

--- a/mailpoet/tests/unit/Config/ActivatorTest.php
+++ b/mailpoet/tests/unit/Config/ActivatorTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\Cron\ActionScheduler\Actions\DaemonTrigger;
+use MailPoet\Cron\ActionScheduler\ActionScheduler as CronActionScheduler;
+use MailPoet\Cron\CronTrigger;
+use MailPoet\Cron\DaemonActionSchedulerRunner;
+use MailPoet\Migrator\Migrator;
+use MailPoet\Settings\SettingsController;
+use MailPoet\WP\Functions as WPFunctions;
+use MailPoetVendor\Doctrine\DBAL\Connection;
+
+class ActivatorTest extends \MailPoetUnitTest {
+  public function testRefreshCronActionsDefersActionSchedulerCallsUntilInitialized(): void {
+    $settings = $this->createMock(SettingsController::class);
+    $settings->expects($this->once())
+      ->method('get')
+      ->with(CronTrigger::SETTING_NAME . '.method')
+      ->willReturn(CronTrigger::METHOD_ACTION_SCHEDULER);
+
+    $cronActionScheduler = $this->createMock(CronActionScheduler::class);
+    $daemonActionSchedulerRunner = $this->createMock(DaemonActionSchedulerRunner::class);
+    $wp = $this->createMock(WPFunctions::class);
+    $activator = $this->createActivator($settings, $cronActionScheduler, $daemonActionSchedulerRunner, $wp);
+
+    $cronActionScheduler->expects($this->once())
+      ->method('isInitialized')
+      ->willReturn(false);
+    $cronActionScheduler->expects($this->once())
+      ->method('runAfterInitialized')
+      ->with([$activator, 'refreshCronActions']);
+    $cronActionScheduler->expects($this->never())
+      ->method('unscheduleAllCronActions');
+    $cronActionScheduler->expects($this->never())
+      ->method('hasScheduledAction');
+    $daemonActionSchedulerRunner->expects($this->never())
+      ->method('clearDeactivationFlag');
+
+    $activator->refreshCronActions();
+  }
+
+  public function testRefreshCronActionsRunsImmediatelyWhenActionSchedulerIsInitialized(): void {
+    $settings = $this->createMock(SettingsController::class);
+    $settings->method('get')
+      ->with(CronTrigger::SETTING_NAME . '.method')
+      ->willReturn(CronTrigger::METHOD_ACTION_SCHEDULER);
+
+    $cronActionScheduler = $this->createMock(CronActionScheduler::class);
+    $daemonActionSchedulerRunner = $this->createMock(DaemonActionSchedulerRunner::class);
+    $wp = $this->createMock(WPFunctions::class);
+    $activator = $this->createActivator($settings, $cronActionScheduler, $daemonActionSchedulerRunner, $wp);
+
+    $cronActionScheduler->expects($this->once())
+      ->method('isInitialized')
+      ->willReturn(true);
+    $cronActionScheduler->expects($this->once())
+      ->method('unscheduleAllCronActions');
+    $daemonActionSchedulerRunner->expects($this->once())
+      ->method('clearDeactivationFlag');
+    $cronActionScheduler->expects($this->once())
+      ->method('hasScheduledAction')
+      ->with(DaemonTrigger::NAME)
+      ->willReturn(false);
+    $wp->expects($this->once())
+      ->method('currentTime')
+      ->with('timestamp', true)
+      ->willReturn(123456);
+    $cronActionScheduler->expects($this->once())
+      ->method('scheduleRecurringAction')
+      ->with(123456, DaemonTrigger::TRIGGER_RUN_INTERVAL, DaemonTrigger::NAME);
+    $cronActionScheduler->expects($this->never())
+      ->method('runAfterInitialized');
+
+    $activator->refreshCronActions();
+  }
+
+  public function testRefreshCronActionsOnlyClearsFlagWhenMethodIsNotActionScheduler(): void {
+    $settings = $this->createMock(SettingsController::class);
+    $settings->expects($this->once())
+      ->method('get')
+      ->with(CronTrigger::SETTING_NAME . '.method')
+      ->willReturn(CronTrigger::METHOD_WORDPRESS);
+
+    $cronActionScheduler = $this->createMock(CronActionScheduler::class);
+    $daemonActionSchedulerRunner = $this->createMock(DaemonActionSchedulerRunner::class);
+    $wp = $this->createMock(WPFunctions::class);
+    $activator = $this->createActivator($settings, $cronActionScheduler, $daemonActionSchedulerRunner, $wp);
+
+    $daemonActionSchedulerRunner->expects($this->once())
+      ->method('clearDeactivationFlag');
+    $cronActionScheduler->expects($this->never())
+      ->method('isInitialized');
+    $cronActionScheduler->expects($this->never())
+      ->method('unscheduleAllCronActions');
+    $cronActionScheduler->expects($this->never())
+      ->method('runAfterInitialized');
+
+    $activator->refreshCronActions();
+  }
+
+  private function createActivator(
+    SettingsController $settings,
+    CronActionScheduler $cronActionScheduler,
+    DaemonActionSchedulerRunner $daemonActionSchedulerRunner,
+    WPFunctions $wp
+  ): Activator {
+    return new Activator(
+      $this->createMock(Connection::class),
+      $settings,
+      $this->createMock(Populator::class),
+      $wp,
+      $this->createMock(Migrator::class),
+      $cronActionScheduler,
+      $daemonActionSchedulerRunner
+    );
+  }
+}

--- a/mailpoet/tests/unit/Config/ActivatorTest.php
+++ b/mailpoet/tests/unit/Config/ActivatorTest.php
@@ -75,6 +75,75 @@ class ActivatorTest extends \MailPoetUnitTest {
     $activator->refreshCronActions();
   }
 
+  public function testRefreshCronActionsRunsAfterActionSchedulerInitialization(): void {
+    $settings = $this->createMock(SettingsController::class);
+    $settings->method('get')
+      ->with(CronTrigger::SETTING_NAME . '.method')
+      ->willReturn(CronTrigger::METHOD_ACTION_SCHEDULER);
+
+    $cronActionScheduler = $this->createMock(CronActionScheduler::class);
+    $daemonActionSchedulerRunner = $this->createMock(DaemonActionSchedulerRunner::class);
+    $wp = $this->createMock(WPFunctions::class);
+    $activator = $this->createActivator($settings, $cronActionScheduler, $daemonActionSchedulerRunner, $wp);
+
+    $cronActionScheduler->expects($this->exactly(2))
+      ->method('isInitialized')
+      ->willReturnOnConsecutiveCalls(false, true);
+    $cronActionScheduler->expects($this->once())
+      ->method('runAfterInitialized')
+      ->with([$activator, 'refreshCronActions']);
+    $cronActionScheduler->expects($this->once())
+      ->method('unscheduleAllCronActions');
+    $daemonActionSchedulerRunner->expects($this->once())
+      ->method('clearDeactivationFlag');
+    $cronActionScheduler->expects($this->once())
+      ->method('hasScheduledAction')
+      ->with(DaemonTrigger::NAME)
+      ->willReturn(false);
+    $wp->expects($this->once())
+      ->method('currentTime')
+      ->with('timestamp', true)
+      ->willReturn(123456);
+    $cronActionScheduler->expects($this->once())
+      ->method('scheduleRecurringAction')
+      ->with(123456, DaemonTrigger::TRIGGER_RUN_INTERVAL, DaemonTrigger::NAME);
+
+    $activator->refreshCronActions();
+    $activator->refreshCronActions();
+  }
+
+  public function testRefreshCronActionsDoesNotScheduleWhenAlreadyScheduled(): void {
+    $settings = $this->createMock(SettingsController::class);
+    $settings->method('get')
+      ->with(CronTrigger::SETTING_NAME . '.method')
+      ->willReturn(CronTrigger::METHOD_ACTION_SCHEDULER);
+
+    $cronActionScheduler = $this->createMock(CronActionScheduler::class);
+    $daemonActionSchedulerRunner = $this->createMock(DaemonActionSchedulerRunner::class);
+    $wp = $this->createMock(WPFunctions::class);
+    $activator = $this->createActivator($settings, $cronActionScheduler, $daemonActionSchedulerRunner, $wp);
+
+    $cronActionScheduler->expects($this->once())
+      ->method('isInitialized')
+      ->willReturn(true);
+    $cronActionScheduler->expects($this->once())
+      ->method('unscheduleAllCronActions');
+    $daemonActionSchedulerRunner->expects($this->once())
+      ->method('clearDeactivationFlag');
+    $cronActionScheduler->expects($this->once())
+      ->method('hasScheduledAction')
+      ->with(DaemonTrigger::NAME)
+      ->willReturn(true);
+    $cronActionScheduler->expects($this->never())
+      ->method('scheduleRecurringAction');
+    $cronActionScheduler->expects($this->never())
+      ->method('runAfterInitialized');
+    $wp->expects($this->never())
+      ->method('currentTime');
+
+    $activator->refreshCronActions();
+  }
+
   public function testRefreshCronActionsOnlyClearsFlagWhenMethodIsNotActionScheduler(): void {
     $settings = $this->createMock(SettingsController::class);
     $settings->expects($this->once())


### PR DESCRIPTION
## Description

Fixes the WordPress beta and WooCommerce beta nightly acceptance failures.

- Seed `can_compress_scripts` in the acceptance DB backup so WordPress does not run the admin compression Ajax probe during tests.
- Defer MailPoet activation-time cron Action Scheduler calls until Action Scheduler has initialized.
- Add regression coverage for deferred cron refresh, existing scheduled actions, and non-Action-Scheduler cron methods.

## Code review notes

A temporary commit was used to run the beta acceptance jobs on this branch, then removed before merge. The verification run passed:

- `acceptance_tests_wordpress_beta` `409961`
- `acceptance_tests_woocommerce_beta` `409949`

No changelog entry is included because this is an internal CI/test-stability fix with no user-facing product change.

## QA notes

Use the WordPress beta acceptance environment to run the reinstall-from-scratch flow and verify no compression-test PHP warnings appear in the debug log.

Use the WooCommerce beta acceptance environment to edit an existing newsletter, save it as draft, and verify no early Action Scheduler initialization notices appear in the debug log.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/nightly-beta-ci-failures)

_The latest successful build from `fix/nightly-beta-ci-failures` will be used. If none is available, the link won't work._