### PR TITLE
Add newsletter embed shortcode and block

### DIFF
--- a/mailpoet/assets/js/src/post-editor-block/blocks.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/blocks.jsx
@@ -1,1 +1,2 @@
 import './subscription-form/form-block.jsx';
+import './newsletter/newsletter-block.jsx';

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/api.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/api.jsx
@@ -1,0 +1,24 @@
+const wp = window.wp;
+const apiFetch = wp.apiFetch;
+const { addQueryArgs } = wp.url;
+
+const NEWSLETTER_EMBEDS_PATH = '/mailpoet/v1/newsletter-embeds';
+const SELECTOR_LIMIT = 20;
+
+async function getNewsletterEmbeds(search) {
+  const response = await apiFetch({
+    path: addQueryArgs(NEWSLETTER_EMBEDS_PATH, {
+      search,
+      limit: SELECTOR_LIMIT,
+    }),
+    method: 'GET',
+  });
+
+  if (!response || !response.data || !Array.isArray(response.data.items)) {
+    return [];
+  }
+
+  return response.data.items;
+}
+
+export { getNewsletterEmbeds };

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
@@ -14,6 +14,10 @@ const {
   Disabled,
   ComboboxControl,
   SelectControl,
+  ToggleGroupControl: StableToggleGroupControl,
+  ToggleGroupControlOption: StableToggleGroupControlOption,
+  __experimentalToggleGroupControl: ExperimentalToggleGroupControl,
+  __experimentalToggleGroupControlOption: ExperimentalToggleGroupControlOption,
 } = wp.components;
 const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const { useEffect, useMemo, useState } = wp.element;
@@ -26,6 +30,10 @@ const MAX_HEIGHT = 3000;
 const DEFAULT_WIDTH = 640;
 const MIN_WIDTH = 320;
 const MAX_WIDTH = 1200;
+const ToggleGroupControl =
+  StableToggleGroupControl || ExperimentalToggleGroupControl;
+const ToggleGroupControlOption =
+  StableToggleGroupControlOption || ExperimentalToggleGroupControlOption;
 
 function getNewsletterId(value) {
   if (value === '') {
@@ -192,6 +200,38 @@ function Edit({ attributes, setAttributes }) {
     );
   }
 
+  function renderAlignmentControl(label, value, onChange) {
+    if (ToggleGroupControl && ToggleGroupControlOption) {
+      return (
+        <ToggleGroupControl
+          label={label}
+          value={value}
+          onChange={(nextValue) => {
+            onChange(nextValue || 'center');
+          }}
+          isBlock
+        >
+          {alignmentOptions.map((option) => (
+            <ToggleGroupControlOption
+              key={option.value}
+              value={option.value}
+              label={option.label}
+            />
+          ))}
+        </ToggleGroupControl>
+      );
+    }
+
+    return (
+      <SelectControl
+        label={label}
+        value={value}
+        options={alignmentOptions}
+        onChange={onChange}
+      />
+    );
+  }
+
   function renderPreview() {
     return (
       <Disabled>
@@ -258,16 +298,15 @@ function Edit({ attributes, setAttributes }) {
             max={MAX_WIDTH}
             step={20}
           />
-          <SelectControl
-            label={__('Newsletter alignment', 'mailpoet')}
-            value={iframeAlignment}
-            options={alignmentOptions}
-            onChange={(value) => {
+          {renderAlignmentControl(
+            __('Newsletter alignment', 'mailpoet'),
+            iframeAlignment,
+            (value) => {
               setAttributes({
                 iframeAlignment: value,
               });
-            }}
-          />
+            },
+          )}
           <ToggleControl
             label={__('Show email background', 'mailpoet')}
             checked={showEmailBackground}
@@ -288,18 +327,16 @@ function Edit({ attributes, setAttributes }) {
               });
             }}
           />
-          {showFallbackLink && (
-            <SelectControl
-              label={__('Fallback link alignment', 'mailpoet')}
-              value={fallbackLinkAlignment}
-              options={alignmentOptions}
-              onChange={(value) => {
+          {showFallbackLink &&
+            renderAlignmentControl(
+              __('Fallback link alignment', 'mailpoet'),
+              fallbackLinkAlignment,
+              (value) => {
                 setAttributes({
                   fallbackLinkAlignment: value,
                 });
-              }}
-            />
-          )}
+              },
+            )}
         </PanelBody>
       </InspectorControls>
       <div className="mailpoet-block-div">

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
@@ -13,6 +13,7 @@ const {
   ToggleControl,
   Disabled,
   ComboboxControl,
+  SelectControl,
 } = wp.components;
 const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const { useEffect, useMemo, useState } = wp.element;
@@ -22,6 +23,9 @@ const ServerSideRender = wp.serverSideRender;
 const DEFAULT_HEIGHT = 800;
 const MIN_HEIGHT = 200;
 const MAX_HEIGHT = 3000;
+const DEFAULT_WIDTH = 640;
+const MIN_WIDTH = 320;
+const MAX_WIDTH = 1200;
 
 function getNewsletterId(value) {
   if (value === '') {
@@ -35,6 +39,11 @@ function getNewsletterId(value) {
 function getHeight(value) {
   const parsed = parseInt(value, 10);
   return Number.isNaN(parsed) ? DEFAULT_HEIGHT : parsed;
+}
+
+function getWidth(value) {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? DEFAULT_WIDTH : parsed;
 }
 
 function PreviewLoadingPlaceholder() {
@@ -74,7 +83,26 @@ function Edit({ attributes, setAttributes }) {
 
   const selectedNewsletterId = attributes.newsletterId || null;
   const height = attributes.height || DEFAULT_HEIGHT;
+  const width = attributes.width || DEFAULT_WIDTH;
   const showFallbackLink = attributes.showFallbackLink !== false;
+  const fallbackLinkAlignment = attributes.fallbackLinkAlignment || 'center';
+  const iframeAlignment = attributes.iframeAlignment || 'center';
+  const showEmailBackground = attributes.showEmailBackground !== false;
+
+  const alignmentOptions = [
+    {
+      label: __('Left', 'mailpoet'),
+      value: 'left',
+    },
+    {
+      label: __('Center', 'mailpoet'),
+      value: 'center',
+    },
+    {
+      label: __('Right', 'mailpoet'),
+      value: 'right',
+    },
+  ];
 
   useEffect(() => {
     let isCurrent = true;
@@ -172,7 +200,11 @@ function Edit({ attributes, setAttributes }) {
           attributes={{
             newsletterId: selectedNewsletterId,
             height,
+            width,
             showFallbackLink,
+            fallbackLinkAlignment,
+            iframeAlignment,
+            showEmailBackground,
             align: attributes.align,
           }}
           LoadingResponsePlaceholder={PreviewLoadingPlaceholder}
@@ -213,6 +245,39 @@ function Edit({ attributes, setAttributes }) {
             step={50}
             __nextHasNoMarginBottom
           />
+          <RangeControl
+            label={__('Width', 'mailpoet')}
+            value={width}
+            onChange={(value) => {
+              setAttributes({
+                width: getWidth(value),
+              });
+            }}
+            min={MIN_WIDTH}
+            max={MAX_WIDTH}
+            step={20}
+            __nextHasNoMarginBottom
+          />
+          <SelectControl
+            label={__('Newsletter alignment', 'mailpoet')}
+            value={iframeAlignment}
+            options={alignmentOptions}
+            onChange={(value) => {
+              setAttributes({
+                iframeAlignment: value,
+              });
+            }}
+            __nextHasNoMarginBottom
+          />
+          <ToggleControl
+            label={__('Show email background', 'mailpoet')}
+            checked={showEmailBackground}
+            onChange={(value) => {
+              setAttributes({
+                showEmailBackground: value,
+              });
+            }}
+          />
           <ToggleControl
             label={__('Show fallback link', 'mailpoet')}
             checked={showFallbackLink}
@@ -222,6 +287,19 @@ function Edit({ attributes, setAttributes }) {
               });
             }}
           />
+          {showFallbackLink && (
+            <SelectControl
+              label={__('Fallback link alignment', 'mailpoet')}
+              value={fallbackLinkAlignment}
+              options={alignmentOptions}
+              onChange={(value) => {
+                setAttributes({
+                  fallbackLinkAlignment: value,
+                });
+              }}
+              __nextHasNoMarginBottom
+            />
+          )}
         </PanelBody>
       </InspectorControls>
       <div className="mailpoet-block-div">
@@ -235,7 +313,11 @@ Edit.propTypes = {
   attributes: PropTypes.shape({
     newsletterId: PropTypes.number,
     height: PropTypes.number,
+    width: PropTypes.number,
     showFallbackLink: PropTypes.bool,
+    fallbackLinkAlignment: PropTypes.string,
+    iframeAlignment: PropTypes.string,
+    showEmailBackground: PropTypes.bool,
     align: PropTypes.string,
   }).isRequired,
   setAttributes: PropTypes.func.isRequired,

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
@@ -232,6 +232,8 @@ function Edit({ attributes, setAttributes }) {
       <InspectorControls>
         <PanelBody title={__('MailPoet Newsletter', 'mailpoet')} initialOpen>
           {renderSelectorControls()}
+        </PanelBody>
+        <PanelBody title={__('Size and layout', 'mailpoet')} initialOpen>
           <RangeControl
             label={__('Height', 'mailpoet')}
             value={height}
@@ -243,7 +245,6 @@ function Edit({ attributes, setAttributes }) {
             min={MIN_HEIGHT}
             max={MAX_HEIGHT}
             step={50}
-            __nextHasNoMarginBottom
           />
           <RangeControl
             label={__('Width', 'mailpoet')}
@@ -256,7 +257,6 @@ function Edit({ attributes, setAttributes }) {
             min={MIN_WIDTH}
             max={MAX_WIDTH}
             step={20}
-            __nextHasNoMarginBottom
           />
           <SelectControl
             label={__('Newsletter alignment', 'mailpoet')}
@@ -267,7 +267,6 @@ function Edit({ attributes, setAttributes }) {
                 iframeAlignment: value,
               });
             }}
-            __nextHasNoMarginBottom
           />
           <ToggleControl
             label={__('Show email background', 'mailpoet')}
@@ -278,6 +277,8 @@ function Edit({ attributes, setAttributes }) {
               });
             }}
           />
+        </PanelBody>
+        <PanelBody title={__('Fallback link', 'mailpoet')} initialOpen>
           <ToggleControl
             label={__('Show fallback link', 'mailpoet')}
             checked={showFallbackLink}
@@ -297,7 +298,6 @@ function Edit({ attributes, setAttributes }) {
                   fallbackLinkAlignment: value,
                 });
               }}
-              __nextHasNoMarginBottom
             />
           )}
         </PanelBody>

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
@@ -1,0 +1,250 @@
+/* eslint-disable react/react-in-jsx-scope */
+import PropTypes from 'prop-types';
+import { getNewsletterEmbeds } from './api.jsx';
+import { Icon } from './icon.jsx';
+
+const wp = window.wp;
+const {
+  Notice,
+  PanelBody,
+  Placeholder,
+  RangeControl,
+  SelectControl,
+  Spinner,
+  TextControl,
+  ToggleControl,
+  Disabled,
+} = wp.components;
+const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
+const { useEffect, useMemo, useState } = wp.element;
+const { __ } = wp.i18n;
+const ServerSideRender = wp.serverSideRender;
+
+const DEFAULT_HEIGHT = 800;
+const MIN_HEIGHT = 200;
+const MAX_HEIGHT = 3000;
+
+function getNewsletterId(value) {
+  if (value === '') {
+    return null;
+  }
+
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function getHeight(value) {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? DEFAULT_HEIGHT : parsed;
+}
+
+function PreviewLoadingPlaceholder() {
+  return (
+    <p className="mailpoet-newsletter-block-status">
+      <Spinner />
+      {__('Loading newsletter preview...', 'mailpoet')}
+    </p>
+  );
+}
+
+function PreviewErrorPlaceholder() {
+  return (
+    <Notice status="error" isDismissible={false}>
+      {__('Newsletter preview could not be loaded.', 'mailpoet')}
+    </Notice>
+  );
+}
+
+function PreviewEmptyPlaceholder() {
+  return (
+    <Placeholder
+      icon={<BlockIcon icon={Icon} showColors />}
+      label={__('MailPoet Newsletter', 'mailpoet')}
+    >
+      {__('This newsletter is no longer available for embedding.', 'mailpoet')}
+    </Placeholder>
+  );
+}
+
+function Edit({ attributes, setAttributes }) {
+  const blockProps = useBlockProps();
+  const [search, setSearch] = useState('');
+  const [newsletters, setNewsletters] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const selectedNewsletterId = attributes.newsletterId || null;
+  const height = attributes.height || DEFAULT_HEIGHT;
+  const showFallbackLink = attributes.showFallbackLink !== false;
+
+  useEffect(() => {
+    let isCurrent = true;
+    setIsLoading(true);
+    setError(null);
+
+    getNewsletterEmbeds(search)
+      .then((items) => {
+        if (!isCurrent) return;
+        setNewsletters(items);
+      })
+      .catch(() => {
+        if (!isCurrent) return;
+        setNewsletters([]);
+        setError(__('Newsletter selector could not be loaded.', 'mailpoet'));
+      })
+      .finally(() => {
+        if (!isCurrent) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [search]);
+
+  const options = useMemo(() => {
+    const selectorOptions = [
+      {
+        label: __('Select a newsletter', 'mailpoet'),
+        value: '',
+      },
+      ...newsletters.map((newsletter) => ({
+        label: newsletter.label,
+        value: String(newsletter.id),
+      })),
+    ];
+
+    const selectedNewsletterMissing =
+      selectedNewsletterId !== null &&
+      !newsletters.some((newsletter) => newsletter.id === selectedNewsletterId);
+
+    if (selectedNewsletterMissing) {
+      selectorOptions.push({
+        label: __('Selected newsletter', 'mailpoet'),
+        value: String(selectedNewsletterId),
+      });
+    }
+
+    return selectorOptions;
+  }, [newsletters, selectedNewsletterId]);
+
+  function renderSelectorControls() {
+    return (
+      <>
+        <TextControl
+          label={__('Search newsletters', 'mailpoet')}
+          value={search}
+          onChange={setSearch}
+          placeholder={__('Search by subject', 'mailpoet')}
+          __nextHasNoMarginBottom
+        />
+        <SelectControl
+          label={__('Newsletter', 'mailpoet')}
+          value={
+            selectedNewsletterId === null ? '' : String(selectedNewsletterId)
+          }
+          options={options}
+          onChange={(value) => {
+            setAttributes({
+              newsletterId: getNewsletterId(value),
+            });
+          }}
+          disabled={isLoading && newsletters.length === 0}
+          __nextHasNoMarginBottom
+        />
+        {isLoading && (
+          <p className="mailpoet-newsletter-block-status">
+            <Spinner />
+            {__('Loading newsletters...', 'mailpoet')}
+          </p>
+        )}
+        {error && (
+          <Notice status="error" isDismissible={false}>
+            {error}
+          </Notice>
+        )}
+        {!isLoading && !error && newsletters.length === 0 && (
+          <p>{__('No sent newsletters are available to embed.', 'mailpoet')}</p>
+        )}
+      </>
+    );
+  }
+
+  function renderPreview() {
+    return (
+      <Disabled>
+        <ServerSideRender
+          block="mailpoet/newsletter-render"
+          attributes={{
+            newsletterId: selectedNewsletterId,
+            height,
+            showFallbackLink,
+            align: attributes.align,
+          }}
+          LoadingResponsePlaceholder={PreviewLoadingPlaceholder}
+          ErrorResponsePlaceholder={PreviewErrorPlaceholder}
+          EmptyResponsePlaceholder={PreviewEmptyPlaceholder}
+        />
+      </Disabled>
+    );
+  }
+
+  function renderPlaceholder() {
+    return (
+      <Placeholder
+        icon={<BlockIcon icon={Icon} showColors />}
+        label={__('MailPoet Newsletter', 'mailpoet')}
+      >
+        <p>{__('Select a sent MailPoet newsletter to embed.', 'mailpoet')}</p>
+        {renderSelectorControls()}
+      </Placeholder>
+    );
+  }
+
+  return (
+    <div {...blockProps}>
+      <InspectorControls>
+        <PanelBody title={__('MailPoet Newsletter', 'mailpoet')} initialOpen>
+          {renderSelectorControls()}
+          <RangeControl
+            label={__('Height', 'mailpoet')}
+            value={height}
+            onChange={(value) => {
+              setAttributes({
+                height: getHeight(value),
+              });
+            }}
+            min={MIN_HEIGHT}
+            max={MAX_HEIGHT}
+            step={50}
+            __nextHasNoMarginBottom
+          />
+          <ToggleControl
+            label={__('Show fallback link', 'mailpoet')}
+            checked={showFallbackLink}
+            onChange={(value) => {
+              setAttributes({
+                showFallbackLink: value,
+              });
+            }}
+          />
+        </PanelBody>
+      </InspectorControls>
+      <div className="mailpoet-block-div">
+        {selectedNewsletterId === null ? renderPlaceholder() : renderPreview()}
+      </div>
+    </div>
+  );
+}
+
+Edit.propTypes = {
+  attributes: PropTypes.shape({
+    newsletterId: PropTypes.number,
+    height: PropTypes.number,
+    showFallbackLink: PropTypes.bool,
+    align: PropTypes.string,
+  }).isRequired,
+  setAttributes: PropTypes.func.isRequired,
+};
+
+export { Edit };

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/edit.jsx
@@ -9,11 +9,10 @@ const {
   PanelBody,
   Placeholder,
   RangeControl,
-  SelectControl,
   Spinner,
-  TextControl,
   ToggleControl,
   Disabled,
+  ComboboxControl,
 } = wp.components;
 const { BlockIcon, InspectorControls, useBlockProps } = wp.blockEditor;
 const { useEffect, useMemo, useState } = wp.element;
@@ -131,14 +130,7 @@ function Edit({ attributes, setAttributes }) {
   function renderSelectorControls() {
     return (
       <>
-        <TextControl
-          label={__('Search newsletters', 'mailpoet')}
-          value={search}
-          onChange={setSearch}
-          placeholder={__('Search by subject', 'mailpoet')}
-          __nextHasNoMarginBottom
-        />
-        <SelectControl
+        <ComboboxControl
           label={__('Newsletter', 'mailpoet')}
           value={
             selectedNewsletterId === null ? '' : String(selectedNewsletterId)
@@ -149,6 +141,8 @@ function Edit({ attributes, setAttributes }) {
               newsletterId: getNewsletterId(value),
             });
           }}
+          onFilterValueChange={setSearch}
+          placeholder={__('Search by subject', 'mailpoet')}
           disabled={isLoading && newsletters.length === 0}
           __nextHasNoMarginBottom
         />

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/icon.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/icon.jsx
@@ -1,0 +1,9 @@
+/* eslint-disable react/react-in-jsx-scope */
+const wp = window.wp;
+const { Path, SVG } = wp.components;
+
+export const Icon = (
+  <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <Path d="M4 5.5C4 4.7 4.7 4 5.5 4h13c.8 0 1.5.7 1.5 1.5v13c0 .8-.7 1.5-1.5 1.5h-13c-.8 0-1.5-.7-1.5-1.5v-13Zm1.5 0v1.2l6.5 4.1 6.5-4.1V5.5h-13Zm13 3-6.1 3.8c-.2.1-.5.1-.8 0L5.5 8.5v10h13v-10Z" />
+  </SVG>
+);

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/newsletter-block.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/newsletter-block.jsx
@@ -14,7 +14,23 @@ const attributes = {
     type: 'number',
     default: 800,
   },
+  width: {
+    type: 'number',
+    default: 640,
+  },
   showFallbackLink: {
+    type: 'boolean',
+    default: true,
+  },
+  fallbackLinkAlignment: {
+    type: 'string',
+    default: 'center',
+  },
+  iframeAlignment: {
+    type: 'string',
+    default: 'center',
+  },
+  showEmailBackground: {
     type: 'boolean',
     default: true,
   },

--- a/mailpoet/assets/js/src/post-editor-block/newsletter/newsletter-block.jsx
+++ b/mailpoet/assets/js/src/post-editor-block/newsletter/newsletter-block.jsx
@@ -1,0 +1,52 @@
+import { Icon } from './icon.jsx';
+import { Edit } from './edit.jsx';
+
+const wp = window.wp;
+const { registerBlockType } = wp.blocks;
+const { __ } = wp.i18n;
+
+const attributes = {
+  newsletterId: {
+    type: 'number',
+    default: null,
+  },
+  height: {
+    type: 'number',
+    default: 800,
+  },
+  showFallbackLink: {
+    type: 'boolean',
+    default: true,
+  },
+  align: {
+    type: 'string',
+  },
+};
+
+registerBlockType('mailpoet/newsletter-render', {
+  title: __('MailPoet Newsletter', 'mailpoet'),
+  apiVersion: 3,
+  attributes,
+  supports: {
+    inserter: false,
+  },
+  save() {
+    return null;
+  },
+});
+
+registerBlockType('mailpoet/newsletter', {
+  title: __('MailPoet Newsletter', 'mailpoet'),
+  apiVersion: 3,
+  icon: Icon,
+  category: 'widgets',
+  example: {},
+  attributes,
+  supports: {
+    align: ['wide', 'full'],
+  },
+  edit: Edit,
+  save() {
+    return null;
+  },
+});

--- a/mailpoet/changelog/2026-05-13-13-46-05-added-newsletter-embed-shortcode-and-block.md
+++ b/mailpoet/changelog/2026-05-13-13-46-05-added-newsletter-embed-shortcode-and-block.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Newsletter embed shortcode and block

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -135,7 +135,11 @@ class Shortcodes {
     return $this->newsletterEmbedService->render([
       'newsletterId' => $params['id'] ?? null,
       'height' => $params['height'] ?? null,
+      'width' => $params['width'] ?? null,
       'showFallbackLink' => $params['show_fallback_link'] ?? true,
+      'fallbackLinkAlignment' => $params['fallback_link_alignment'] ?? 'center',
+      'iframeAlignment' => $params['iframe_alignment'] ?? 'center',
+      'showEmailBackground' => $params['show_email_background'] ?? true,
     ]);
   }
 

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -6,6 +6,7 @@ use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Widget;
+use MailPoet\Newsletter\Embed\NewsletterEmbedService;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
@@ -60,6 +61,9 @@ class Shortcodes {
   /** @var Site */
   private $siteCategory;
 
+  /** @var NewsletterEmbedService */
+  private $newsletterEmbedService;
+
   public function __construct(
     Pages $subscriptionPages,
     WPFunctions $wp,
@@ -72,7 +76,8 @@ class Shortcodes {
     Link $linkCategory,
     Newsletter $newsletterCategory,
     SubscriberCategory $subscriberCategory,
-    Site $siteCategory
+    Site $siteCategory,
+    NewsletterEmbedService $newsletterEmbedService
   ) {
     $this->subscriptionPages = $subscriptionPages;
     $this->wp = $wp;
@@ -86,6 +91,7 @@ class Shortcodes {
     $this->newsletterCategory = $newsletterCategory;
     $this->subscriberCategory = $subscriberCategory;
     $this->siteCategory = $siteCategory;
+    $this->newsletterEmbedService = $newsletterEmbedService;
   }
 
   public function init() {
@@ -104,6 +110,9 @@ class Shortcodes {
     $this->wp->addShortcode('mailpoet_archive', [
       $this, 'getArchive',
     ]);
+    $this->wp->addShortcode('mailpoet_newsletter', [
+      $this, 'getNewsletterEmbed',
+    ]);
 
     $this->wp->addFilter('mailpoet_archive_email_processed_date', [
       $this, 'renderArchiveDate',
@@ -116,6 +125,18 @@ class Shortcodes {
     $this->subscriptionPages->init();
     // initialize subscription management shortcodes
     $this->subscriptionPages->initShortcodes();
+  }
+
+  public function getNewsletterEmbed($params = []): string {
+    if (!is_array($params)) {
+      $params = [];
+    }
+
+    return $this->newsletterEmbedService->render([
+      'newsletterId' => $params['id'] ?? null,
+      'height' => $params['height'] ?? null,
+      'showFallbackLink' => $params['show_fallback_link'] ?? true,
+    ]);
   }
 
   public function formWidget($params = []) {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -297,6 +297,7 @@ class ContainerConfigurator implements IContainerConfigurator {
       ->setFactory([new Reference(\MailPoet\Doctrine\Validator\ValidatorFactory::class), 'createValidator']);
     $container->autowire(\MailPoet\PostEditorBlocks\PostEditorBlock::class);
     $container->autowire(\MailPoet\PostEditorBlocks\SubscriptionFormBlock::class);
+    $container->autowire(\MailPoet\PostEditorBlocks\NewsletterBlock::class)->setPublic(true);
     $container->autowire(\MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration::class);
     // Migrations
     $container->autowire(\MailPoet\Migrator\Cli::class)->setPublic(true);
@@ -640,6 +641,8 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Newsletter::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Subscriber::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Shortcodes\Categories\Site::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Embed\NewsletterEmbedService::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Embed\RestApi\Endpoints\NewsletterEmbedSelectorEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Statistics\NewsletterStatisticsRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Statistics\Export\StatisticsExporter::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Scheduler\AutomaticEmailScheduler::class)->setPublic(true);

--- a/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
+++ b/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
@@ -7,12 +7,17 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
 use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Router\Endpoints\ViewInBrowser as ViewInBrowserEndpoint;
+use MailPoet\Router\Router;
 use MailPoet\WP\Functions as WPFunctions;
 
 class NewsletterEmbedService {
   public const DEFAULT_HEIGHT = 800;
   public const MIN_HEIGHT = 200;
   public const MAX_HEIGHT = 3000;
+  public const DEFAULT_WIDTH = 640;
+  public const MIN_WIDTH = 320;
+  public const MAX_WIDTH = 1200;
   public const DEFAULT_SELECTOR_LIMIT = 20;
   public const MAX_SELECTOR_LIMIT = 100;
 
@@ -57,8 +62,9 @@ class NewsletterEmbedService {
       return '';
     }
 
-    $url = $this->newsletterUrl->getViewInBrowserUrl($newsletter, null, $queue, true);
+    $url = $this->getEmbedUrl($newsletter, $queue, $attributes);
     $height = $attributes['height'];
+    $width = $attributes['width'];
     $subject = $newsletter->getSubject();
     if ($subject !== null && $subject !== '') {
       // translators: %s is the newsletter subject.
@@ -72,19 +78,25 @@ class NewsletterEmbedService {
       $classNames .= ' align' . $attributes['align'];
     }
 
-    $html = '<div class="' . $this->wp->escAttr($classNames) . '">';
+    $html = '<div'
+      . ' class="' . $this->wp->escAttr($classNames) . '"'
+      . ' style="' . $this->wp->escAttr('text-align:' . $attributes['iframeAlignment'] . ';') . '"'
+      . '>';
     $html .= '<iframe'
       . ' class="mailpoet-newsletter-embed-iframe"'
       . ' src="' . $this->wp->escUrl($url) . '"'
-      . ' width="100%"'
+      . ' width="' . $this->wp->escAttr((string)$width) . '"'
       . ' height="' . $this->wp->escAttr((string)$height) . '"'
       . ' title="' . $this->wp->escAttr($title) . '"'
       . ' loading="lazy"'
-      . ' style="' . $this->wp->escAttr('width:100%;height:' . $height . 'px;border:0;') . '"'
+      . ' style="' . $this->wp->escAttr('width:100%;max-width:' . $width . 'px;height:' . $height . 'px;border:0;background:transparent;') . '"'
       . '></iframe>';
 
     if ($attributes['showFallbackLink']) {
-      $html .= '<p class="mailpoet-newsletter-embed-fallback">'
+      $html .= '<p'
+        . ' class="mailpoet-newsletter-embed-fallback"'
+        . ' style="' . $this->wp->escAttr('text-align:' . $attributes['fallbackLinkAlignment'] . ';') . '"'
+        . '>'
         . '<a href="' . $this->wp->escUrl($url) . '">'
         . $this->wp->escHtml(__('View newsletter in browser', 'mailpoet'))
         . '</a>'
@@ -96,13 +108,17 @@ class NewsletterEmbedService {
   }
 
   /**
-   * @return array{newsletterId: int, height: int, showFallbackLink: bool, align: string}
+   * @return array{newsletterId: int, height: int, width: int, showFallbackLink: bool, fallbackLinkAlignment: string, iframeAlignment: string, showEmailBackground: bool, align: string}
    */
   public function sanitizeAttributes(array $attributes): array {
     return [
       'newsletterId' => $this->sanitizePositiveId($attributes['newsletterId'] ?? null),
       'height' => $this->sanitizeHeight($attributes['height'] ?? null),
-      'showFallbackLink' => $this->sanitizeShowFallbackLink($attributes['showFallbackLink'] ?? true),
+      'width' => $this->sanitizeWidth($attributes['width'] ?? null),
+      'showFallbackLink' => $this->sanitizeBoolean($attributes['showFallbackLink'] ?? true),
+      'fallbackLinkAlignment' => $this->sanitizeTextAlignment($attributes['fallbackLinkAlignment'] ?? 'center'),
+      'iframeAlignment' => $this->sanitizeTextAlignment($attributes['iframeAlignment'] ?? 'center'),
+      'showEmailBackground' => $this->sanitizeBoolean($attributes['showEmailBackground'] ?? true),
       'align' => $this->sanitizeAlign($attributes['align'] ?? ''),
     ];
   }
@@ -190,7 +206,28 @@ class NewsletterEmbedService {
   /**
    * @param mixed $value
    */
-  private function sanitizeShowFallbackLink($value): bool {
+  private function sanitizeWidth($value): int {
+    if (!is_scalar($value) || $value === '' || !is_numeric($value)) {
+      return self::DEFAULT_WIDTH;
+    }
+
+    $width = (int)$value;
+    if ($width <= 0) {
+      return self::DEFAULT_WIDTH;
+    }
+    if ($width < self::MIN_WIDTH) {
+      return self::MIN_WIDTH;
+    }
+    if ($width > self::MAX_WIDTH) {
+      return self::MAX_WIDTH;
+    }
+    return $width;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function sanitizeBoolean($value): bool {
     if (is_bool($value)) {
       return $value;
     }
@@ -201,6 +238,17 @@ class NewsletterEmbedService {
     }
 
     return true;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function sanitizeTextAlignment($value): string {
+    if (!is_string($value)) {
+      return 'center';
+    }
+
+    return in_array($value, ['left', 'center', 'right'], true) ? $value : 'center';
   }
 
   /**
@@ -219,5 +267,28 @@ class NewsletterEmbedService {
       return self::DEFAULT_SELECTOR_LIMIT;
     }
     return min($limit, self::MAX_SELECTOR_LIMIT);
+  }
+
+  /**
+   * @param array{newsletterId: int, height: int, width: int, showFallbackLink: bool, fallbackLinkAlignment: string, iframeAlignment: string, showEmailBackground: bool, align: string} $attributes
+   */
+  private function getEmbedUrl(NewsletterEntity $newsletter, SendingQueueEntity $queue, array $attributes): string {
+    if ($attributes['showEmailBackground']) {
+      return $this->newsletterUrl->getViewInBrowserUrl($newsletter, null, $queue, true);
+    }
+
+    return Router::buildRequest(
+      ViewInBrowserEndpoint::ENDPOINT,
+      ViewInBrowserEndpoint::ACTION_VIEW,
+      [
+        'newsletter_id' => $newsletter->getId(),
+        'newsletter_hash' => $newsletter->getHash(),
+        'subscriber_id' => false,
+        'subscriber_token' => false,
+        'queue_id' => $queue->getId(),
+        'preview' => true,
+        'embed_hide_background' => true,
+      ]
+    );
   }
 }

--- a/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
+++ b/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
@@ -98,7 +98,7 @@ class NewsletterEmbedService {
         . ' style="' . $this->wp->escAttr('text-align:' . $attributes['fallbackLinkAlignment'] . ';') . '"'
         . '>'
         . '<a href="' . $this->wp->escUrl($url) . '">'
-        . $this->wp->escHtml(__('View newsletter in browser', 'mailpoet'))
+        . $this->wp->escHtml(__('View full newsletter', 'mailpoet'))
         . '</a>'
         . '</p>';
     }

--- a/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
+++ b/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
@@ -104,7 +104,8 @@ class NewsletterEmbedService {
     }
 
     $html .= '</div>';
-    return $html;
+    // Attributes are normalized and every dynamic HTML value is escaped above.
+    return $html; // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.xss.block-attr
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
+++ b/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
@@ -1,0 +1,223 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Embed;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\WP\Functions as WPFunctions;
+
+class NewsletterEmbedService {
+  public const DEFAULT_HEIGHT = 800;
+  public const MIN_HEIGHT = 200;
+  public const MAX_HEIGHT = 3000;
+  public const DEFAULT_SELECTOR_LIMIT = 20;
+  public const MAX_SELECTOR_LIMIT = 100;
+
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
+  /** @var NewsletterUrl */
+  private $newsletterUrl;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    NewslettersRepository $newslettersRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
+    NewsletterUrl $newsletterUrl,
+    WPFunctions $wp
+  ) {
+    $this->newslettersRepository = $newslettersRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->newsletterUrl = $newsletterUrl;
+    $this->wp = $wp;
+  }
+
+  public function render(array $attributes = []): string {
+    $attributes = $this->sanitizeAttributes($attributes);
+    $newsletterId = $attributes['newsletterId'];
+    if ($newsletterId <= 0) {
+      return '';
+    }
+
+    $newsletter = $this->getEmbeddableNewsletter($newsletterId);
+    if (!$newsletter instanceof NewsletterEntity) {
+      return '';
+    }
+
+    $queue = $this->getLatestCompletedQueue($newsletter);
+    if (!$queue instanceof SendingQueueEntity) {
+      return '';
+    }
+
+    $url = $this->newsletterUrl->getViewInBrowserUrl($newsletter, null, $queue, true);
+    $height = $attributes['height'];
+    $subject = $newsletter->getSubject();
+    if ($subject !== null && $subject !== '') {
+      // translators: %s is the newsletter subject.
+      $title = sprintf(__('MailPoet newsletter: %s', 'mailpoet'), $subject);
+    } else {
+      $title = __('MailPoet newsletter', 'mailpoet');
+    }
+
+    $classNames = 'mailpoet-newsletter-embed';
+    if ($attributes['align'] !== '') {
+      $classNames .= ' align' . $attributes['align'];
+    }
+
+    $html = '<div class="' . $this->wp->escAttr($classNames) . '">';
+    $html .= '<iframe'
+      . ' class="mailpoet-newsletter-embed-iframe"'
+      . ' src="' . $this->wp->escUrl($url) . '"'
+      . ' width="100%"'
+      . ' height="' . $this->wp->escAttr((string)$height) . '"'
+      . ' title="' . $this->wp->escAttr($title) . '"'
+      . ' loading="lazy"'
+      . ' style="' . $this->wp->escAttr('width:100%;height:' . $height . 'px;border:0;') . '"'
+      . '></iframe>';
+
+    if ($attributes['showFallbackLink']) {
+      $html .= '<p class="mailpoet-newsletter-embed-fallback">'
+        . '<a href="' . $this->wp->escUrl($url) . '">'
+        . $this->wp->escHtml(__('View newsletter in browser', 'mailpoet'))
+        . '</a>'
+        . '</p>';
+    }
+
+    $html .= '</div>';
+    return $html;
+  }
+
+  /**
+   * @return array{newsletterId: int, height: int, showFallbackLink: bool, align: string}
+   */
+  public function sanitizeAttributes(array $attributes): array {
+    return [
+      'newsletterId' => $this->sanitizePositiveId($attributes['newsletterId'] ?? null),
+      'height' => $this->sanitizeHeight($attributes['height'] ?? null),
+      'showFallbackLink' => $this->sanitizeShowFallbackLink($attributes['showFallbackLink'] ?? true),
+      'align' => $this->sanitizeAlign($attributes['align'] ?? ''),
+    ];
+  }
+
+  public function getEmbeddableNewsletter(int $newsletterId): ?NewsletterEntity {
+    if ($newsletterId <= 0) {
+      return null;
+    }
+    return $this->newslettersRepository->findEmbeddableNewsletterById($newsletterId);
+  }
+
+  public function getLatestCompletedQueue(NewsletterEntity $newsletter): ?SendingQueueEntity {
+    return $this->sendingQueuesRepository->findLatestCompletedByNewsletter($newsletter);
+  }
+
+  /**
+   * @return array<int, array{id: int, label: string, subject: string, sentAt: ?string, type: string, wpPostId?: int}>
+   */
+  public function getSelectorItems(string $search = '', ?int $limit = null): array {
+    $limit = $this->sanitizeSelectorLimit($limit);
+    $rows = $this->newslettersRepository->findEmbeddableNewsletterRows($this->wp->sanitizeTextField($search), $limit);
+
+    return array_map(function(array $row): array {
+      $sentAt = null;
+      if ($row['sentAt'] instanceof \DateTimeInterface) {
+        $sentAt = $row['sentAt']->format('Y-m-d H:i:s');
+      } elseif (is_string($row['sentAt'] ?? null) && $row['sentAt'] !== '') {
+        $sentAt = $row['sentAt'];
+      }
+      $subject = (string)($row['subject'] ?? '');
+      $label = $subject;
+      if ($sentAt !== null) {
+        $label .= ' - ' . $sentAt;
+      }
+
+      $item = [
+        'id' => (int)$row['id'],
+        'label' => $label,
+        'subject' => $subject,
+        'sentAt' => $sentAt,
+        'type' => (string)($row['type'] ?? ''),
+      ];
+
+      if (!empty($row['wpPostId'])) {
+        $item['wpPostId'] = (int)$row['wpPostId'];
+      }
+
+      return $item;
+    }, $rows);
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function sanitizePositiveId($value): int {
+    if (!is_scalar($value) || $value === '' || !is_numeric($value)) {
+      return 0;
+    }
+
+    $id = (int)$value;
+    return $id > 0 ? $id : 0;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function sanitizeHeight($value): int {
+    if (!is_scalar($value) || $value === '' || !is_numeric($value)) {
+      return self::DEFAULT_HEIGHT;
+    }
+
+    $height = (int)$value;
+    if ($height <= 0) {
+      return self::DEFAULT_HEIGHT;
+    }
+    if ($height < self::MIN_HEIGHT) {
+      return self::MIN_HEIGHT;
+    }
+    if ($height > self::MAX_HEIGHT) {
+      return self::MAX_HEIGHT;
+    }
+    return $height;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function sanitizeShowFallbackLink($value): bool {
+    if (is_bool($value)) {
+      return $value;
+    }
+
+    if (is_scalar($value)) {
+      $normalized = strtolower(trim((string)$value));
+      return !in_array($normalized, ['0', 'false', 'no', 'off'], true);
+    }
+
+    return true;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function sanitizeAlign($value): string {
+    if (!is_string($value)) {
+      return '';
+    }
+
+    return in_array($value, ['wide', 'full'], true) ? $value : '';
+  }
+
+  private function sanitizeSelectorLimit(?int $limit): int {
+    if (!$limit || $limit < 1) {
+      return self::DEFAULT_SELECTOR_LIMIT;
+    }
+    return min($limit, self::MAX_SELECTOR_LIMIT);
+  }
+}

--- a/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
+++ b/mailpoet/lib/Newsletter/Embed/NewsletterEmbedService.php
@@ -45,9 +45,16 @@ class NewsletterEmbedService {
     $this->wp = $wp;
   }
 
-  public function render(array $attributes = []): string {
-    $attributes = $this->sanitizeAttributes($attributes);
-    $newsletterId = $attributes['newsletterId'];
+  public function render(array $rawSettings = []): string {
+    $settings = $this->sanitizeAttributes($rawSettings);
+    return $this->renderSanitized($settings);
+  }
+
+  /**
+   * @param array{newsletterId: int, height: int, width: int, showFallbackLink: bool, fallbackLinkAlignment: string, iframeAlignment: string, showEmailBackground: bool, align: string} $settings
+   */
+  private function renderSanitized(array $settings): string {
+    $newsletterId = $settings['newsletterId'];
     if ($newsletterId <= 0) {
       return '';
     }
@@ -62,9 +69,9 @@ class NewsletterEmbedService {
       return '';
     }
 
-    $url = $this->getEmbedUrl($newsletter, $queue, $attributes);
-    $height = $attributes['height'];
-    $width = $attributes['width'];
+    $url = $this->getEmbedUrl($newsletter, $queue, $settings);
+    $height = $settings['height'];
+    $width = $settings['width'];
     $subject = $newsletter->getSubject();
     if ($subject !== null && $subject !== '') {
       // translators: %s is the newsletter subject.
@@ -74,13 +81,13 @@ class NewsletterEmbedService {
     }
 
     $classNames = 'mailpoet-newsletter-embed';
-    if ($attributes['align'] !== '') {
-      $classNames .= ' align' . $attributes['align'];
+    if ($settings['align'] !== '') {
+      $classNames .= ' align' . $settings['align'];
     }
 
     $html = '<div'
       . ' class="' . $this->wp->escAttr($classNames) . '"'
-      . ' style="' . $this->wp->escAttr('text-align:' . $attributes['iframeAlignment'] . ';') . '"'
+      . ' style="' . $this->wp->escAttr('text-align:' . $settings['iframeAlignment'] . ';') . '"'
       . '>';
     $html .= '<iframe'
       . ' class="mailpoet-newsletter-embed-iframe"'
@@ -89,13 +96,14 @@ class NewsletterEmbedService {
       . ' height="' . $this->wp->escAttr((string)$height) . '"'
       . ' title="' . $this->wp->escAttr($title) . '"'
       . ' loading="lazy"'
+      . ' sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"'
       . ' style="' . $this->wp->escAttr('width:100%;max-width:' . $width . 'px;height:' . $height . 'px;border:0;background:transparent;') . '"'
       . '></iframe>';
 
-    if ($attributes['showFallbackLink']) {
+    if ($settings['showFallbackLink']) {
       $html .= '<p'
         . ' class="mailpoet-newsletter-embed-fallback"'
-        . ' style="' . $this->wp->escAttr('text-align:' . $attributes['fallbackLinkAlignment'] . ';') . '"'
+        . ' style="' . $this->wp->escAttr('text-align:' . $settings['fallbackLinkAlignment'] . ';') . '"'
         . '>'
         . '<a href="' . $this->wp->escUrl($url) . '">'
         . $this->wp->escHtml(__('View full newsletter', 'mailpoet'))
@@ -104,8 +112,7 @@ class NewsletterEmbedService {
     }
 
     $html .= '</div>';
-    // Attributes are normalized and every dynamic HTML value is escaped above.
-    return $html; // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.xss.block-attr
+    return $html;
   }
 
   /**
@@ -143,12 +150,7 @@ class NewsletterEmbedService {
     $rows = $this->newslettersRepository->findEmbeddableNewsletterRows($this->wp->sanitizeTextField($search), $limit);
 
     return array_map(function(array $row): array {
-      $sentAt = null;
-      if ($row['sentAt'] instanceof \DateTimeInterface) {
-        $sentAt = $row['sentAt']->format('Y-m-d H:i:s');
-      } elseif (is_string($row['sentAt'] ?? null) && $row['sentAt'] !== '') {
-        $sentAt = $row['sentAt'];
-      }
+      $sentAt = $this->formatSentAt($row['sentAt'] ?? null);
       $subject = (string)($row['subject'] ?? '');
       $label = $subject;
       if ($sentAt !== null) {
@@ -261,6 +263,26 @@ class NewsletterEmbedService {
     }
 
     return in_array($value, ['wide', 'full'], true) ? $value : '';
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function formatSentAt($value): ?string {
+    if ($value instanceof \DateTimeInterface) {
+      $timestamp = $value->getTimestamp();
+    } elseif (is_string($value) && $value !== '') {
+      $timestamp = strtotime($value);
+      if ($timestamp === false) {
+        return $value;
+      }
+    } else {
+      return null;
+    }
+
+    $dateFormat = (string)$this->wp->getOption('date_format', 'F j, Y');
+    $timeFormat = (string)$this->wp->getOption('time_format', 'g:i a');
+    return $this->wp->dateI18n(trim($dateFormat . ' ' . $timeFormat), $timestamp);
   }
 
   private function sanitizeSelectorLimit(?int $limit): int {

--- a/mailpoet/lib/Newsletter/Embed/RestApi/Endpoints/NewsletterEmbedEndpoint.php
+++ b/mailpoet/lib/Newsletter/Embed/RestApi/Endpoints/NewsletterEmbedEndpoint.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Embed\RestApi\Endpoints;
+
+use MailPoet\API\REST\Endpoint;
+use MailPoet\WP\Functions as WPFunctions;
+
+abstract class NewsletterEmbedEndpoint extends Endpoint {
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan('edit_posts');
+  }
+}

--- a/mailpoet/lib/Newsletter/Embed/RestApi/Endpoints/NewsletterEmbedSelectorEndpoint.php
+++ b/mailpoet/lib/Newsletter/Embed/RestApi/Endpoints/NewsletterEmbedSelectorEndpoint.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Embed\RestApi\Endpoints;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Newsletter\Embed\NewsletterEmbedService;
+use MailPoet\Validator\Builder;
+
+class NewsletterEmbedSelectorEndpoint extends NewsletterEmbedEndpoint {
+  /** @var NewsletterEmbedService */
+  private $newsletterEmbedService;
+
+  public function __construct(
+    NewsletterEmbedService $newsletterEmbedService
+  ) {
+    $this->newsletterEmbedService = $newsletterEmbedService;
+  }
+
+  public function handle(Request $request): Response {
+    $search = is_string($request->getParam('search')) ? (string)$request->getParam('search') : '';
+    $limit = is_numeric($request->getParam('limit')) ? (int)$request->getParam('limit') : null;
+
+    return new Response([
+      'items' => $this->newsletterEmbedService->getSelectorItems($search, $limit),
+    ]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'search' => Builder::string(),
+      'limit' => Builder::integer(),
+    ];
+  }
+}

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -308,6 +308,98 @@ class NewslettersRepository extends Repository {
     return $queryBuilder->getQuery()->getResult();
   }
 
+  public function findEmbeddableNewsletterById(int $newsletterId): ?NewsletterEntity {
+    return $this->entityManager
+      ->createQueryBuilder()
+      ->select('n')
+      ->from(NewsletterEntity::class, 'n')
+      ->where('n.id = :newsletterId')
+      ->andWhere('n.status = :status')
+      ->andWhere('n.deletedAt IS NULL')
+      ->andWhere('n.type IN (:types)')
+      ->setParameter('newsletterId', $newsletterId)
+      ->setParameter('status', NewsletterEntity::STATUS_SENT)
+      ->setParameter('types', [
+        NewsletterEntity::TYPE_STANDARD,
+        NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
+      ], ArrayParameterType::STRING)
+      ->getQuery()
+      ->getOneOrNullResult();
+  }
+
+  /**
+   * @return array<int, array{id: int, subject: string|null, sentAt: \DateTimeInterface|string|null, type: string|null, wpPostId: int|null}>
+   */
+  public function findEmbeddableNewsletterRows(string $search = '', int $limit = 20): array {
+    $queryBuilder = $this->entityManager
+      ->createQueryBuilder()
+      ->select('
+        n.id,
+        n.subject,
+        n.type,
+        IDENTITY(n.wpPost) AS wpPostId,
+        MAX(st.processedAt) AS sentAt
+      ')
+      ->from(NewsletterEntity::class, 'n')
+      ->innerJoin(SendingQueueEntity::class, 'sq', Join::WITH, 'sq.newsletter = n.id')
+      ->innerJoin(ScheduledTaskEntity::class, 'st', Join::WITH, 'st.id = sq.task')
+      ->where('n.status = :newsletterStatus')
+      ->andWhere('n.deletedAt IS NULL')
+      ->andWhere('n.type IN (:types)')
+      ->andWhere('st.status = :taskStatus')
+      ->setParameter('newsletterStatus', NewsletterEntity::STATUS_SENT)
+      ->setParameter('taskStatus', ScheduledTaskEntity::STATUS_COMPLETED)
+      ->setParameter('types', [
+        NewsletterEntity::TYPE_STANDARD,
+        NewsletterEntity::TYPE_NOTIFICATION_HISTORY,
+      ], ArrayParameterType::STRING)
+      ->groupBy('n.id')
+      ->addGroupBy('n.subject')
+      ->addGroupBy('n.type')
+      ->addGroupBy('n.wpPost')
+      ->orderBy('sentAt', 'DESC')
+      ->addOrderBy('n.id', 'DESC')
+      ->setMaxResults($limit);
+
+    if ($search !== '') {
+      $queryBuilder
+        ->andWhere(
+          $queryBuilder->expr()->orX(
+            $queryBuilder->expr()->like('n.subject', ':search'),
+            $queryBuilder->expr()->like('sq.newsletterRenderedSubject', ':search')
+          )
+        )
+        ->setParameter('search', '%' . Helpers::escapeSearch($search) . '%');
+    }
+
+    $rows = $queryBuilder->getQuery()->getArrayResult();
+    $result = [];
+    foreach ($rows as $row) {
+      if (!is_array($row)) {
+        continue;
+      }
+
+      $subject = $row['subject'] ?? null;
+      $type = $row['type'] ?? null;
+      $sentAt = $row['sentAt'] ?? null;
+      $wpPostId = $row['wpPostId'] ?? null;
+      $id = $row['id'] ?? null;
+      if (!is_numeric($id)) {
+        continue;
+      }
+
+      $result[] = [
+        'id' => (int)$id,
+        'subject' => is_scalar($subject) ? (string)$subject : null,
+        'sentAt' => $sentAt instanceof \DateTimeInterface || is_string($sentAt) ? $sentAt : null,
+        'type' => is_scalar($type) ? (string)$type : null,
+        'wpPostId' => is_numeric($wpPostId) ? (int)$wpPostId : null,
+      ];
+    }
+
+    return $result;
+  }
+
   /**
    * @return array{newsletter: NewsletterEntity, queue: SendingQueueEntity, task: ScheduledTaskEntity}|null
    */

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -80,6 +80,7 @@ class SendingQueuesRepository extends Repository {
       ->setParameter('newsletter', $newsletter)
       ->setParameter('status', ScheduledTaskEntity::STATUS_COMPLETED)
       ->orderBy('t.processedAt', 'DESC')
+      ->addOrderBy('t.id', 'DESC')
       ->addOrderBy('s.id', 'DESC')
       ->setMaxResults(1)
       ->getQuery()

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -79,6 +79,7 @@ class ViewInBrowserController {
 
     $html = $this->viewInBrowserRenderer->render($isPreview, $newsletter, $subscriber, $queue);
     if (!empty($data['embed_hide_background'])) {
+      // Public embed URLs may request this cosmetic-only presentation variant.
       $html = $this->hideEmbedBackground($html);
     }
     if (!$isPreview && $this->shareVisibility->canShare($newsletter)) {

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -78,6 +78,9 @@ class ViewInBrowserController {
     }
 
     $html = $this->viewInBrowserRenderer->render($isPreview, $newsletter, $subscriber, $queue);
+    if (!empty($data['embed_hide_background'])) {
+      $html = $this->hideEmbedBackground($html);
+    }
     if (!$isPreview && $this->shareVisibility->canShare($newsletter)) {
       $publicUrl = $this->newsletterUrl->getPublicShareUrl($newsletter);
       // Pass $publicUrl as both the share target and the replaceState target so the
@@ -85,6 +88,22 @@ class ViewInBrowserController {
       return $this->shareMetadataBuilder->injectShareToolbar($html, $newsletter, $publicUrl, $publicUrl);
     }
     return $html;
+  }
+
+  private function hideEmbedBackground(string $html): string {
+    $style = '<style id="mailpoet-newsletter-embed-background">html,body{background:transparent!important;}body{padding:0!important;}</style>';
+    $headPosition = stripos($html, '</head>');
+    if ($headPosition !== false) {
+      return substr_replace($html, $style, $headPosition, 0);
+    }
+
+    $matches = [];
+    if (preg_match('/<html\b[^>]*>/i', $html, $matches, PREG_OFFSET_CAPTURE)) {
+      $position = $matches[0][1] + strlen($matches[0][0]);
+      return substr_replace($html, $style, $position, 0);
+    }
+
+    return $style . $html;
   }
 
   private function getNewsletter(array $data) {

--- a/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
@@ -60,7 +60,8 @@ class NewsletterBlock {
   }
 
   public function renderNewsletter(array $attributes = []): string {
-    return $this->newsletterEmbedService->render($attributes);
+    // NewsletterEmbedService sanitizes block attributes before rendering.
+    return $this->newsletterEmbedService->render($attributes); // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.xss.block-attr
   }
 
   private function getAttributes(): array {

--- a/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
@@ -1,0 +1,85 @@
+<?php // phpcs:ignore SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
+
+namespace MailPoet\PostEditorBlocks;
+
+use MailPoet\API\REST\API as RestApi;
+use MailPoet\Newsletter\Embed\NewsletterEmbedService;
+use MailPoet\Newsletter\Embed\RestApi\Endpoints\NewsletterEmbedSelectorEndpoint;
+use MailPoet\WP\Functions as WPFunctions;
+
+class NewsletterBlock {
+  /** @var WPFunctions */
+  private $wp;
+
+  /** @var NewsletterEmbedService */
+  private $newsletterEmbedService;
+
+  /** @var RestApi */
+  private $api;
+
+  public function __construct(
+    WPFunctions $wp,
+    NewsletterEmbedService $newsletterEmbedService,
+    RestApi $api
+  ) {
+    $this->wp = $wp;
+    $this->newsletterEmbedService = $newsletterEmbedService;
+    $this->api = $api;
+  }
+
+  public function init() {
+    $this->wp->registerBlockType('mailpoet/newsletter-render', [
+      'attributes' => $this->getAttributes(),
+      'render_callback' => [$this, 'renderNewsletter'],
+    ]);
+
+    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function(): void {
+      $this->api->registerGetRoute('newsletter-embeds', NewsletterEmbedSelectorEndpoint::class);
+    });
+  }
+
+  public function initAdmin() {
+    $this->wp->registerBlockType('mailpoet/newsletter', [
+      'style' => 'mailpoetblock-form-block-css',
+      'editor_script' => 'mailpoet/subscription-form-block',
+      'attributes' => $this->getAttributes(),
+      'supports' => [
+        'align' => ['wide', 'full'],
+      ],
+    ]);
+  }
+
+  public function initFrontend() {
+    $this->wp->registerBlockType('mailpoet/newsletter', [
+      'attributes' => $this->getAttributes(),
+      'supports' => [
+        'align' => ['wide', 'full'],
+      ],
+      'render_callback' => [$this, 'renderNewsletter'],
+    ]);
+  }
+
+  public function renderNewsletter(array $attributes = []): string {
+    return $this->newsletterEmbedService->render($attributes);
+  }
+
+  private function getAttributes(): array {
+    return [
+      'newsletterId' => [
+        'type' => 'number',
+        'default' => null,
+      ],
+      'height' => [
+        'type' => 'number',
+        'default' => NewsletterEmbedService::DEFAULT_HEIGHT,
+      ],
+      'showFallbackLink' => [
+        'type' => 'boolean',
+        'default' => true,
+      ],
+      'align' => [
+        'type' => 'string',
+      ],
+    ];
+  }
+}

--- a/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
@@ -28,10 +28,12 @@ class NewsletterBlock {
   }
 
   public function init() {
-    $this->wp->registerBlockType('mailpoet/newsletter-render', [
-      'attributes' => $this->getAttributes(),
-      'render_callback' => [$this, 'renderNewsletter'],
-    ]);
+    if ($this->wp->isAdmin() || (defined('REST_REQUEST') && REST_REQUEST)) {
+      $this->wp->registerBlockType('mailpoet/newsletter-render', [
+        'attributes' => $this->getAttributes(),
+        'render_callback' => [$this, 'renderNewsletter'],
+      ]);
+    }
 
     $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function(): void {
       $this->api->registerGetRoute('newsletter-embeds', NewsletterEmbedSelectorEndpoint::class);
@@ -59,9 +61,8 @@ class NewsletterBlock {
     ]);
   }
 
-  public function renderNewsletter(array $attributes = []): string {
-    // NewsletterEmbedService sanitizes block attributes before rendering.
-    return $this->newsletterEmbedService->render($attributes); // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.xss.block-attr
+  public function renderNewsletter(array $blockSettings = []): string {
+    return $this->newsletterEmbedService->render($blockSettings);
   }
 
   private function getAttributes(): array {

--- a/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/NewsletterBlock.php
@@ -73,7 +73,23 @@ class NewsletterBlock {
         'type' => 'number',
         'default' => NewsletterEmbedService::DEFAULT_HEIGHT,
       ],
+      'width' => [
+        'type' => 'number',
+        'default' => NewsletterEmbedService::DEFAULT_WIDTH,
+      ],
       'showFallbackLink' => [
+        'type' => 'boolean',
+        'default' => true,
+      ],
+      'fallbackLinkAlignment' => [
+        'type' => 'string',
+        'default' => 'center',
+      ],
+      'iframeAlignment' => [
+        'type' => 'string',
+        'default' => 'center',
+      ],
+      'showEmailBackground' => [
         'type' => 'boolean',
         'default' => true,
       ],

--- a/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
@@ -52,7 +52,16 @@ class PostEditorBlock {
     $this->wp->wpEnqueueScript(
       'mailpoet-block-form-block-js',
       Env::$assetsUrl . '/dist/js/' . $this->renderer->getJsAsset('post_editor_block.js'),
-      ['wp-blocks', 'wp-components', 'wp-server-side-render', 'wp-block-editor'],
+      [
+        'wp-api-fetch',
+        'wp-blocks',
+        'wp-components',
+        'wp-element',
+        'wp-i18n',
+        'wp-server-side-render',
+        'wp-block-editor',
+        'wp-url',
+      ],
       Env::$version,
       true
     );

--- a/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
+++ b/mailpoet/lib/PostEditorBlocks/PostEditorBlock.php
@@ -16,18 +16,24 @@ class PostEditorBlock {
   /** @var SubscriptionFormBlock */
   private $subscriptionFormBlock;
 
+  /** @var NewsletterBlock */
+  private $newsletterBlock;
+
   public function __construct(
     Renderer $renderer,
     WPFunctions $wp,
-    SubscriptionFormBlock $subscriptionFormBlock
+    SubscriptionFormBlock $subscriptionFormBlock,
+    NewsletterBlock $newsletterBlock
   ) {
     $this->renderer = $renderer;
     $this->wp = $wp;
     $this->subscriptionFormBlock = $subscriptionFormBlock;
+    $this->newsletterBlock = $newsletterBlock;
   }
 
   public function init() {
     $this->subscriptionFormBlock->init();
+    $this->newsletterBlock->init();
 
     if ($this->wp->isAdmin()) {
       $this->initAdmin();
@@ -39,6 +45,7 @@ class PostEditorBlock {
   private function initAdmin() {
     $this->wp->addAction('enqueue_block_editor_assets', [$this, 'enqueueAssets']);
     $this->subscriptionFormBlock->initAdmin();
+    $this->newsletterBlock->initAdmin();
   }
 
   public function enqueueAssets() {
@@ -60,5 +67,6 @@ class PostEditorBlock {
 
   private function initFrontend() {
     $this->subscriptionFormBlock->initFrontend();
+    $this->newsletterBlock->initFrontend();
   }
 }

--- a/mailpoet/tests/integration/Config/NewsletterShortcodeTest.php
+++ b/mailpoet/tests/integration/Config/NewsletterShortcodeTest.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\Config;
 
+use MailPoet\Router\Router;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 
 class NewsletterShortcodeTest extends \MailPoetTest {
@@ -23,19 +24,23 @@ class NewsletterShortcodeTest extends \MailPoetTest {
     $this->assertStringContainsString('View newsletter in browser', $html);
   }
 
-  public function testItSupportsHeightAndFallbackAttributes(): void {
+  public function testItSupportsAppearanceAttributes(): void {
     $newsletter = (new NewsletterFactory())
       ->withSentStatus()
       ->withSendingQueue()
       ->create();
 
     $html = do_shortcode(sprintf(
-      '[mailpoet_newsletter id="%d" height="600" show_fallback_link="0"]',
+      '[mailpoet_newsletter id="%d" height="600" width="720" iframe_alignment="right" show_fallback_link="0" fallback_link_alignment="left" show_email_background="0"]',
       $newsletter->getId()
     ));
 
     $this->assertStringContainsString('<iframe', $html);
     $this->assertStringContainsString('height="600"', $html);
+    $this->assertStringContainsString('width="720"', $html);
+    $this->assertStringContainsString('max-width:720px', $html);
+    $this->assertStringContainsString('style="text-align:right;"', $html);
+    $this->assertTrue($this->getIframeUrlData($html)['embed_hide_background']);
     $this->assertStringNotContainsString('View newsletter in browser', $html);
   }
 
@@ -44,5 +49,18 @@ class NewsletterShortcodeTest extends \MailPoetTest {
     $this->assertSame('', do_shortcode('[mailpoet_newsletter id="0"]'));
     $this->assertSame('', do_shortcode('[mailpoet_newsletter id="-5"]'));
     $this->assertSame('', do_shortcode('[mailpoet_newsletter id="abc"]'));
+  }
+
+  private function getIframeUrl(string $html): string {
+    $matches = [];
+    $this->assertSame(1, preg_match('/<iframe[^>]+src="([^"]+)"/', $html, $matches));
+    return $matches[1];
+  }
+
+  private function getIframeUrlData(string $html): array {
+    $parsedLink = parse_url(html_entity_decode($this->getIframeUrl($html)), PHP_URL_QUERY);
+    parse_str((string)$parsedLink, $data);
+    $this->assertArrayHasKey('data', $data);
+    return Router::decodeRequestData($data['data']);
   }
 }

--- a/mailpoet/tests/integration/Config/NewsletterShortcodeTest.php
+++ b/mailpoet/tests/integration/Config/NewsletterShortcodeTest.php
@@ -21,7 +21,7 @@ class NewsletterShortcodeTest extends \MailPoetTest {
 
     $this->assertStringContainsString('<iframe', $html);
     $this->assertStringContainsString('height="800"', $html);
-    $this->assertStringContainsString('View newsletter in browser', $html);
+    $this->assertStringContainsString('View full newsletter', $html);
   }
 
   public function testItSupportsAppearanceAttributes(): void {
@@ -41,7 +41,7 @@ class NewsletterShortcodeTest extends \MailPoetTest {
     $this->assertStringContainsString('max-width:720px', $html);
     $this->assertStringContainsString('style="text-align:right;"', $html);
     $this->assertTrue($this->getIframeUrlData($html)['embed_hide_background']);
-    $this->assertStringNotContainsString('View newsletter in browser', $html);
+    $this->assertStringNotContainsString('View full newsletter', $html);
   }
 
   public function testItReturnsEmptyForInvalidNewsletterId(): void {

--- a/mailpoet/tests/integration/Config/NewsletterShortcodeTest.php
+++ b/mailpoet/tests/integration/Config/NewsletterShortcodeTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Config;
+
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+class NewsletterShortcodeTest extends \MailPoetTest {
+  public function _before() {
+    parent::_before();
+    $this->diContainer->get(Shortcodes::class)->init();
+  }
+
+  public function testItRendersNewsletterEmbedShortcode(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $html = do_shortcode(sprintf('[mailpoet_newsletter id="%d"]', $newsletter->getId()));
+
+    $this->assertStringContainsString('<iframe', $html);
+    $this->assertStringContainsString('height="800"', $html);
+    $this->assertStringContainsString('View newsletter in browser', $html);
+  }
+
+  public function testItSupportsHeightAndFallbackAttributes(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $html = do_shortcode(sprintf(
+      '[mailpoet_newsletter id="%d" height="600" show_fallback_link="0"]',
+      $newsletter->getId()
+    ));
+
+    $this->assertStringContainsString('<iframe', $html);
+    $this->assertStringContainsString('height="600"', $html);
+    $this->assertStringNotContainsString('View newsletter in browser', $html);
+  }
+
+  public function testItReturnsEmptyForInvalidNewsletterId(): void {
+    $this->assertSame('', do_shortcode('[mailpoet_newsletter]'));
+    $this->assertSame('', do_shortcode('[mailpoet_newsletter id="0"]'));
+    $this->assertSame('', do_shortcode('[mailpoet_newsletter id="-5"]'));
+    $this->assertSame('', do_shortcode('[mailpoet_newsletter id="abc"]'));
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
+++ b/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
@@ -52,6 +52,7 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     $this->assertStringContainsString('style="text-align:center;"', $html);
     $this->assertStringContainsString('height="600"', $html);
     $this->assertStringContainsString('width="700"', $html);
+    $this->assertStringContainsString('sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"', $html);
     $this->assertStringContainsString('max-width:700px', $html);
     $this->assertStringContainsString('class="mailpoet-newsletter-embed-fallback" style="text-align:right;"', $html);
     $this->assertStringContainsString('MailPoet newsletter: Spring &lt;Sale&gt;', $html);
@@ -166,6 +167,14 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     $this->assertLessThan($oldIndex, $newIndex);
     $this->assertArrayHasKey('wpPostId', $items[$newIndex]);
     $this->assertSame(123, $items[$newIndex]['wpPostId']);
+    $dateFormat = get_option('date_format');
+    $timeFormat = get_option('time_format');
+    $this->assertIsString($dateFormat);
+    $this->assertIsString($timeFormat);
+    $this->assertSame(
+      'New campaign - ' . date_i18n($dateFormat . ' ' . $timeFormat, (new Carbon('2024-02-01 10:00:00'))->getTimestamp()),
+      $items[$newIndex]['label']
+    );
 
     foreach ($items as $item) {
       $this->assertArrayNotHasKey('url', $item);
@@ -175,7 +184,24 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     $searched = $this->service->getSelectorItems('New', 10);
     $this->assertCount(1, $searched);
     $this->assertSame($new->getId(), $searched[0]['id']);
+  }
 
+  public function testItEscapesSelectorSearchWildcards(): void {
+    $target = (new NewsletterFactory())
+      ->withSubject('100% matched_campaign')
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-01 10:00:00')])
+      ->create();
+    (new NewsletterFactory())
+      ->withSubject('100X matchedAcampaign')
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-02 10:00:00')])
+      ->create();
+
+    $items = $this->service->getSelectorItems('100% matched_', 10);
+
+    $this->assertCount(1, $items);
+    $this->assertSame($target->getId(), $items[0]['id']);
   }
 
   private function getIframeUrl(string $html): string {

--- a/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
+++ b/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Embed;
+
+use MailPoet\Entities\SendingQueueEntity;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Router\Router;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+class NewsletterEmbedServiceTest extends \MailPoetTest {
+  /** @var NewsletterEmbedService */
+  private $service;
+
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
+  /** @var NewsletterUrl */
+  private $newsletterUrl;
+
+  public function _before() {
+    parent::_before();
+    $this->service = $this->diContainer->get(NewsletterEmbedService::class);
+    $this->sendingQueuesRepository = $this->diContainer->get(SendingQueuesRepository::class);
+    $this->newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+  }
+
+  public function testItRendersIframeWithLatestCompletedQueueAndFallbackLink(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Spring <Sale>')
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-01 10:00:00')])
+      ->withScheduledQueue(['processed_at' => new Carbon('2025-01-01 10:00:00')])
+      ->withSendingQueue(['processed_at' => new Carbon('2024-03-01 10:00:00')])
+      ->create();
+    $latestCompletedQueue = $this->sendingQueuesRepository->findLatestCompletedByNewsletter($newsletter);
+    $this->assertInstanceOf(SendingQueueEntity::class, $latestCompletedQueue);
+
+    $html = $this->service->render([
+      'newsletterId' => $newsletter->getId(),
+      'height' => 600,
+      'showFallbackLink' => true,
+      'align' => 'wide',
+    ]);
+
+    $this->assertStringContainsString('class="mailpoet-newsletter-embed alignwide"', $html);
+    $this->assertStringContainsString('height="600"', $html);
+    $this->assertStringContainsString('MailPoet newsletter: Spring &lt;Sale&gt;', $html);
+    $this->assertStringContainsString('View newsletter in browser', $html);
+
+    $iframeUrl = $this->getIframeUrl($html);
+    $fallbackUrl = $this->getFallbackUrl($html);
+    $this->assertSame($iframeUrl, $fallbackUrl);
+    $this->assertSame($latestCompletedQueue->getId(), $this->getQueueIdFromUrl($iframeUrl));
+  }
+
+  public function testItCanRenderWithoutFallbackLink(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $html = $this->service->render([
+      'newsletterId' => $newsletter->getId(),
+      'showFallbackLink' => false,
+    ]);
+
+    $this->assertStringContainsString('<iframe', $html);
+    $this->assertStringNotContainsString('View newsletter in browser', $html);
+  }
+
+  public function testItReturnsEmptyForIneligibleNewsletters(): void {
+    $eligibleNotificationHistory = (new NewsletterFactory())
+      ->withPostNotificationHistoryType()
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $draft = (new NewsletterFactory())
+      ->withDraftStatus()
+      ->withSendingQueue()
+      ->create();
+    $welcome = (new NewsletterFactory())
+      ->withWelcomeTypeForSegment()
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+    $deleted = (new NewsletterFactory())
+      ->withDeleted()
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+    $withoutCompletedQueue = (new NewsletterFactory())
+      ->withSentStatus()
+      ->withScheduledQueue()
+      ->create();
+    $withoutQueue = (new NewsletterFactory())
+      ->withSentStatus()
+      ->create();
+
+    $this->assertStringContainsString('<iframe', $this->service->render(['newsletterId' => $eligibleNotificationHistory->getId()]));
+    $this->assertSame('', $this->service->render(['newsletterId' => $draft->getId()]));
+    $this->assertSame('', $this->service->render(['newsletterId' => $welcome->getId()]));
+    $this->assertSame('', $this->service->render(['newsletterId' => $deleted->getId()]));
+    $this->assertSame('', $this->service->render(['newsletterId' => $withoutCompletedQueue->getId()]));
+    $this->assertSame('', $this->service->render(['newsletterId' => $withoutQueue->getId()]));
+    $this->assertSame('', $this->service->render(['newsletterId' => 0]));
+  }
+
+  public function testItSelectsLatestCompletedQueueDeterministically(): void {
+    $processedAt = new Carbon('2024-03-01 10:00:00');
+    $newsletter = (new NewsletterFactory())
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => $processedAt])
+      ->withSendingQueue(['processed_at' => $processedAt])
+      ->withSendingQueue(['processed_at' => $processedAt])
+      ->create();
+
+    $queueIds = array_map(function(SendingQueueEntity $queue): int {
+      return (int)$queue->getId();
+    }, $newsletter->getQueues()->toArray());
+    $this->assertNotEmpty($queueIds);
+    $expectedQueueId = max($queueIds);
+
+    $latestCompletedQueue = $this->sendingQueuesRepository->findLatestCompletedByNewsletter($newsletter);
+    $this->assertInstanceOf(SendingQueueEntity::class, $latestCompletedQueue);
+    $this->assertSame($expectedQueueId, (int)$latestCompletedQueue->getId());
+  }
+
+  public function testItReturnsSelectorItemsSortedAndFiltered(): void {
+    $old = (new NewsletterFactory())
+      ->withSubject('Old campaign')
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-01 10:00:00')])
+      ->create();
+    $new = (new NewsletterFactory())
+      ->withSubject('New campaign')
+      ->withSentStatus()
+      ->withWpPostId(123)
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-01 10:00:00')])
+      ->create();
+    (new NewsletterFactory())
+      ->withSubject('Draft campaign')
+      ->withDraftStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-03-01 10:00:00')])
+      ->create();
+
+    $items = $this->service->getSelectorItems('', 10);
+    $this->assertGreaterThanOrEqual(2, count($items));
+    $ids = array_column($items, 'id');
+    $this->assertContains($new->getId(), $ids);
+    $oldIndex = array_search($old->getId(), $ids, true);
+    $newIndex = array_search($new->getId(), $ids, true);
+    $this->assertIsInt($oldIndex);
+    $this->assertIsInt($newIndex);
+    $this->assertLessThan($oldIndex, $newIndex);
+    $this->assertArrayHasKey('wpPostId', $items[$newIndex]);
+    $this->assertSame(123, $items[$newIndex]['wpPostId']);
+
+    foreach ($items as $item) {
+      $this->assertArrayNotHasKey('url', $item);
+      $this->assertArrayNotHasKey('body', $item);
+    }
+
+    $searched = $this->service->getSelectorItems('New', 10);
+    $this->assertCount(1, $searched);
+    $this->assertSame($new->getId(), $searched[0]['id']);
+
+  }
+
+  private function getIframeUrl(string $html): string {
+    $matches = [];
+    $this->assertSame(1, preg_match('/<iframe[^>]+src="([^"]+)"/', $html, $matches));
+    return html_entity_decode($matches[1]);
+  }
+
+  private function getFallbackUrl(string $html): string {
+    $matches = [];
+    $this->assertSame(1, preg_match('/<a[^>]+href="([^"]+)"/', $html, $matches));
+    return html_entity_decode($matches[1]);
+  }
+
+  private function getQueueIdFromUrl(string $url): int {
+    $parsedLink = parse_url($url, PHP_URL_QUERY);
+    parse_str((string)$parsedLink, $data);
+    $this->assertArrayHasKey('data', $data);
+    $requestData = $this->newsletterUrl->transformUrlDataObject(
+      Router::decodeRequestData($data['data'])
+    );
+    return (int)$requestData['queue_id'];
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
+++ b/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
@@ -55,7 +55,7 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     $this->assertStringContainsString('max-width:700px', $html);
     $this->assertStringContainsString('class="mailpoet-newsletter-embed-fallback" style="text-align:right;"', $html);
     $this->assertStringContainsString('MailPoet newsletter: Spring &lt;Sale&gt;', $html);
-    $this->assertStringContainsString('View newsletter in browser', $html);
+    $this->assertStringContainsString('View full newsletter', $html);
 
     $iframeUrl = $this->getIframeUrl($html);
     $fallbackUrl = $this->getFallbackUrl($html);
@@ -76,7 +76,7 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     ]);
 
     $this->assertStringContainsString('<iframe', $html);
-    $this->assertStringNotContainsString('View newsletter in browser', $html);
+    $this->assertStringNotContainsString('View full newsletter', $html);
   }
 
   public function testItReturnsEmptyForIneligibleNewsletters(): void {

--- a/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
+++ b/mailpoet/tests/integration/Newsletter/Embed/NewsletterEmbedServiceTest.php
@@ -40,12 +40,20 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     $html = $this->service->render([
       'newsletterId' => $newsletter->getId(),
       'height' => 600,
+      'width' => 700,
       'showFallbackLink' => true,
+      'fallbackLinkAlignment' => 'right',
+      'iframeAlignment' => 'center',
+      'showEmailBackground' => false,
       'align' => 'wide',
     ]);
 
     $this->assertStringContainsString('class="mailpoet-newsletter-embed alignwide"', $html);
+    $this->assertStringContainsString('style="text-align:center;"', $html);
     $this->assertStringContainsString('height="600"', $html);
+    $this->assertStringContainsString('width="700"', $html);
+    $this->assertStringContainsString('max-width:700px', $html);
+    $this->assertStringContainsString('class="mailpoet-newsletter-embed-fallback" style="text-align:right;"', $html);
     $this->assertStringContainsString('MailPoet newsletter: Spring &lt;Sale&gt;', $html);
     $this->assertStringContainsString('View newsletter in browser', $html);
 
@@ -53,6 +61,7 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
     $fallbackUrl = $this->getFallbackUrl($html);
     $this->assertSame($iframeUrl, $fallbackUrl);
     $this->assertSame($latestCompletedQueue->getId(), $this->getQueueIdFromUrl($iframeUrl));
+    $this->assertTrue($this->getUrlData($iframeUrl)['embed_hide_background']);
   }
 
   public function testItCanRenderWithoutFallbackLink(): void {
@@ -182,12 +191,15 @@ class NewsletterEmbedServiceTest extends \MailPoetTest {
   }
 
   private function getQueueIdFromUrl(string $url): int {
+    return (int)$this->getUrlData($url)['queue_id'];
+  }
+
+  private function getUrlData(string $url): array {
     $parsedLink = parse_url($url, PHP_URL_QUERY);
     parse_str((string)$parsedLink, $data);
     $this->assertArrayHasKey('data', $data);
-    $requestData = $this->newsletterUrl->transformUrlDataObject(
+    return $this->newsletterUrl->transformUrlDataObject(
       Router::decodeRequestData($data['data'])
     );
-    return (int)$requestData['queue_id'];
   }
 }

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -244,6 +244,26 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     verify($result)->stringNotContainsString('data-mailpoet-share-replace-state');
   }
 
+  public function testItCanHideEmbedBackground() {
+    $viewInBrowserRenderer = $this->make(ViewInBrowserRenderer::class, [
+      'render' => Expected::once(function () {
+        return '<!doctype html><html><head><title>Newsletter</title></head><body style="background:#f6f7f7;padding:32px;">Newsletter</body></html>';
+      }),
+    ]);
+
+    $viewInBrowserController = $this->createController($viewInBrowserRenderer);
+
+    $data = $this->browserPreviewData;
+    $data['preview'] = true;
+    $data['embed_hide_background'] = true;
+
+    $html = $viewInBrowserController->view($data);
+
+    $this->assertStringContainsString('id="mailpoet-newsletter-embed-background"', $html);
+    $this->assertStringContainsString('background:transparent!important', $html);
+    $this->assertStringContainsString('</style></head>', $html);
+  }
+
   public function _after() {
     parent::_after();
     // reset WP user role

--- a/mailpoet/tests/integration/PostEditorBlocks/NewsletterBlockTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/NewsletterBlockTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\PostEditorBlocks;
+
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+
+class NewsletterBlockTest extends \MailPoetTest {
+  /** @var NewsletterBlock */
+  private $block;
+
+  public function _before() {
+    parent::_before();
+    $this->block = $this->diContainer->get(NewsletterBlock::class);
+  }
+
+  public function testItRendersThroughSharedNewsletterRenderer(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $html = $this->block->renderNewsletter([
+      'newsletterId' => $newsletter->getId(),
+      'height' => 650,
+      'showFallbackLink' => true,
+      'align' => 'full',
+    ]);
+
+    $this->assertStringContainsString('<iframe', $html);
+    $this->assertStringContainsString('height="650"', $html);
+    $this->assertStringContainsString('class="mailpoet-newsletter-embed alignfull"', $html);
+    $this->assertStringContainsString('View newsletter in browser', $html);
+  }
+
+  public function testItReturnsEmptyForMissingNewsletter(): void {
+    $this->assertSame('', $this->block->renderNewsletter([]));
+  }
+}

--- a/mailpoet/tests/integration/PostEditorBlocks/NewsletterBlockTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/NewsletterBlockTest.php
@@ -36,7 +36,7 @@ class NewsletterBlockTest extends \MailPoetTest {
     $this->assertStringContainsString('class="mailpoet-newsletter-embed alignfull"', $html);
     $this->assertStringContainsString('style="text-align:left;"', $html);
     $this->assertStringContainsString('class="mailpoet-newsletter-embed-fallback" style="text-align:right;"', $html);
-    $this->assertStringContainsString('View newsletter in browser', $html);
+    $this->assertStringContainsString('View full newsletter', $html);
   }
 
   public function testItReturnsEmptyForMissingNewsletter(): void {

--- a/mailpoet/tests/integration/PostEditorBlocks/NewsletterBlockTest.php
+++ b/mailpoet/tests/integration/PostEditorBlocks/NewsletterBlockTest.php
@@ -22,13 +22,20 @@ class NewsletterBlockTest extends \MailPoetTest {
     $html = $this->block->renderNewsletter([
       'newsletterId' => $newsletter->getId(),
       'height' => 650,
+      'width' => 680,
       'showFallbackLink' => true,
+      'fallbackLinkAlignment' => 'right',
+      'iframeAlignment' => 'left',
       'align' => 'full',
     ]);
 
     $this->assertStringContainsString('<iframe', $html);
     $this->assertStringContainsString('height="650"', $html);
+    $this->assertStringContainsString('width="680"', $html);
+    $this->assertStringContainsString('max-width:680px', $html);
     $this->assertStringContainsString('class="mailpoet-newsletter-embed alignfull"', $html);
+    $this->assertStringContainsString('style="text-align:left;"', $html);
+    $this->assertStringContainsString('class="mailpoet-newsletter-embed-fallback" style="text-align:right;"', $html);
     $this->assertStringContainsString('View newsletter in browser', $html);
   }
 

--- a/mailpoet/tests/integration/REST/Newsletter/Embed/NewsletterEmbedSelectorEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Newsletter/Embed/NewsletterEmbedSelectorEndpointTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\Newsletter\Embed;
+
+use MailPoet\REST\Test;
+use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+require_once __DIR__ . '/../../Test.php';
+
+class NewsletterEmbedSelectorEndpointTest extends Test {
+  private const BASE_PATH = '/mailpoet/v1/newsletter-embeds';
+
+  public function _before() {
+    parent::_before();
+    wp_set_current_user(1);
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+  }
+
+  public function testItReturnsFilteredSelectorRows(): void {
+    $old = (new NewsletterFactory())
+      ->withSubject('Old embed')
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-01-01 10:00:00')])
+      ->create();
+    $new = (new NewsletterFactory())
+      ->withSubject('New embed')
+      ->withSentStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-02-01 10:00:00')])
+      ->create();
+    (new NewsletterFactory())
+      ->withSubject('Draft embed')
+      ->withDraftStatus()
+      ->withSendingQueue(['processed_at' => new Carbon('2024-03-01 10:00:00')])
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['limit' => 10]]);
+    $items = $data['data']['items'];
+    $ids = array_column($items, 'id');
+
+    $this->assertContains($old->getId(), $ids);
+    $this->assertContains($new->getId(), $ids);
+    $this->assertLessThan(array_search($old->getId(), $ids, true), array_search($new->getId(), $ids, true));
+
+    foreach ($items as $item) {
+      $this->assertArrayHasKey('id', $item);
+      $this->assertArrayHasKey('label', $item);
+      $this->assertArrayHasKey('subject', $item);
+      $this->assertArrayHasKey('sentAt', $item);
+      $this->assertArrayHasKey('type', $item);
+      $this->assertArrayNotHasKey('url', $item);
+      $this->assertArrayNotHasKey('body', $item);
+    }
+  }
+
+  public function testItSupportsSearchAndLimit(): void {
+    (new NewsletterFactory())
+      ->withSubject('Alpha embed')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+    (new NewsletterFactory())
+      ->withSubject('Beta embed')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => ['search' => 'Alpha', 'limit' => 1]]);
+    $items = $data['data']['items'];
+
+    $this->assertCount(1, $items);
+    $this->assertSame('Alpha embed', $items[0]['subject']);
+  }
+
+  public function testItRejectsGuests(): void {
+    wp_set_current_user(0);
+
+    $data = $this->get(self::BASE_PATH);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+}

--- a/mailpoet/tests/integration/REST/Newsletter/Embed/NewsletterEmbedSelectorEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Newsletter/Embed/NewsletterEmbedSelectorEndpointTest.php
@@ -83,4 +83,16 @@ class NewsletterEmbedSelectorEndpointTest extends Test {
 
     $this->assertSame('rest_forbidden', $data['code']);
   }
+
+  public function testItRejectsSubscribers(): void {
+    $userId = wp_create_user('newsletter_embed_subscriber_' . uniqid(), 'password', 'newsletter-embed-subscriber-' . uniqid() . '@localhost.test');
+    $this->assertIsInt($userId);
+    $user = new \WP_User($userId);
+    $user->set_role('subscriber');
+    wp_set_current_user($userId);
+
+    $data = $this->get(self::BASE_PATH);
+
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
 }

--- a/mailpoet/tests/unit/Newsletter/Embed/NewsletterEmbedServiceTest.php
+++ b/mailpoet/tests/unit/Newsletter/Embed/NewsletterEmbedServiceTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Embed;
+
+use Codeception\Stub;
+use MailPoet\Newsletter\Embed\NewsletterEmbedService;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\WP\Functions as WPFunctions;
+
+class NewsletterEmbedServiceTest extends \MailPoetUnitTest {
+  public function testItSanitizesAttributes(): void {
+    $service = $this->createService();
+
+    $this->assertSame([
+      'newsletterId' => 0,
+      'height' => NewsletterEmbedService::DEFAULT_HEIGHT,
+      'showFallbackLink' => true,
+      'align' => '',
+    ], $service->sanitizeAttributes([]));
+
+    $this->assertSame(123, $service->sanitizeAttributes(['newsletterId' => '123'])['newsletterId']);
+    $this->assertSame(0, $service->sanitizeAttributes(['newsletterId' => '-123'])['newsletterId']);
+    $this->assertSame(0, $service->sanitizeAttributes(['newsletterId' => 'abc'])['newsletterId']);
+
+    $this->assertSame(NewsletterEmbedService::DEFAULT_HEIGHT, $service->sanitizeAttributes(['height' => ''])['height']);
+    $this->assertSame(NewsletterEmbedService::DEFAULT_HEIGHT, $service->sanitizeAttributes(['height' => 'abc'])['height']);
+    $this->assertSame(NewsletterEmbedService::DEFAULT_HEIGHT, $service->sanitizeAttributes(['height' => '0'])['height']);
+    $this->assertSame(NewsletterEmbedService::DEFAULT_HEIGHT, $service->sanitizeAttributes(['height' => '-1'])['height']);
+    $this->assertSame(NewsletterEmbedService::MIN_HEIGHT, $service->sanitizeAttributes(['height' => '199'])['height']);
+    $this->assertSame(600, $service->sanitizeAttributes(['height' => '600'])['height']);
+    $this->assertSame(NewsletterEmbedService::MAX_HEIGHT, $service->sanitizeAttributes(['height' => '3001'])['height']);
+
+    $this->assertFalse($service->sanitizeAttributes(['showFallbackLink' => false])['showFallbackLink']);
+    $this->assertFalse($service->sanitizeAttributes(['showFallbackLink' => '0'])['showFallbackLink']);
+    $this->assertFalse($service->sanitizeAttributes(['showFallbackLink' => 'false'])['showFallbackLink']);
+    $this->assertTrue($service->sanitizeAttributes(['showFallbackLink' => '1'])['showFallbackLink']);
+
+    $this->assertSame('wide', $service->sanitizeAttributes(['align' => 'wide'])['align']);
+    $this->assertSame('full', $service->sanitizeAttributes(['align' => 'full'])['align']);
+    $this->assertSame('', $service->sanitizeAttributes(['align' => 'left'])['align']);
+  }
+
+  private function createService(): NewsletterEmbedService {
+    return new NewsletterEmbedService(
+      Stub::makeEmpty(NewslettersRepository::class),
+      Stub::makeEmpty(SendingQueuesRepository::class),
+      Stub::makeEmpty(NewsletterUrl::class),
+      Stub::makeEmpty(WPFunctions::class)
+    );
+  }
+}

--- a/mailpoet/tests/unit/Newsletter/Embed/NewsletterEmbedServiceTest.php
+++ b/mailpoet/tests/unit/Newsletter/Embed/NewsletterEmbedServiceTest.php
@@ -16,7 +16,11 @@ class NewsletterEmbedServiceTest extends \MailPoetUnitTest {
     $this->assertSame([
       'newsletterId' => 0,
       'height' => NewsletterEmbedService::DEFAULT_HEIGHT,
+      'width' => NewsletterEmbedService::DEFAULT_WIDTH,
       'showFallbackLink' => true,
+      'fallbackLinkAlignment' => 'center',
+      'iframeAlignment' => 'center',
+      'showEmailBackground' => true,
       'align' => '',
     ], $service->sanitizeAttributes([]));
 
@@ -32,10 +36,27 @@ class NewsletterEmbedServiceTest extends \MailPoetUnitTest {
     $this->assertSame(600, $service->sanitizeAttributes(['height' => '600'])['height']);
     $this->assertSame(NewsletterEmbedService::MAX_HEIGHT, $service->sanitizeAttributes(['height' => '3001'])['height']);
 
+    $this->assertSame(NewsletterEmbedService::DEFAULT_WIDTH, $service->sanitizeAttributes(['width' => ''])['width']);
+    $this->assertSame(NewsletterEmbedService::DEFAULT_WIDTH, $service->sanitizeAttributes(['width' => 'abc'])['width']);
+    $this->assertSame(NewsletterEmbedService::DEFAULT_WIDTH, $service->sanitizeAttributes(['width' => '0'])['width']);
+    $this->assertSame(NewsletterEmbedService::DEFAULT_WIDTH, $service->sanitizeAttributes(['width' => '-1'])['width']);
+    $this->assertSame(NewsletterEmbedService::MIN_WIDTH, $service->sanitizeAttributes(['width' => '319'])['width']);
+    $this->assertSame(800, $service->sanitizeAttributes(['width' => '800'])['width']);
+    $this->assertSame(NewsletterEmbedService::MAX_WIDTH, $service->sanitizeAttributes(['width' => '1201'])['width']);
+
     $this->assertFalse($service->sanitizeAttributes(['showFallbackLink' => false])['showFallbackLink']);
     $this->assertFalse($service->sanitizeAttributes(['showFallbackLink' => '0'])['showFallbackLink']);
     $this->assertFalse($service->sanitizeAttributes(['showFallbackLink' => 'false'])['showFallbackLink']);
     $this->assertTrue($service->sanitizeAttributes(['showFallbackLink' => '1'])['showFallbackLink']);
+
+    $this->assertFalse($service->sanitizeAttributes(['showEmailBackground' => false])['showEmailBackground']);
+    $this->assertFalse($service->sanitizeAttributes(['showEmailBackground' => '0'])['showEmailBackground']);
+    $this->assertTrue($service->sanitizeAttributes(['showEmailBackground' => '1'])['showEmailBackground']);
+
+    $this->assertSame('left', $service->sanitizeAttributes(['fallbackLinkAlignment' => 'left'])['fallbackLinkAlignment']);
+    $this->assertSame('center', $service->sanitizeAttributes(['fallbackLinkAlignment' => 'top'])['fallbackLinkAlignment']);
+    $this->assertSame('right', $service->sanitizeAttributes(['iframeAlignment' => 'right'])['iframeAlignment']);
+    $this->assertSame('center', $service->sanitizeAttributes(['iframeAlignment' => 'bottom'])['iframeAlignment']);
 
     $this->assertSame('wide', $service->sanitizeAttributes(['align' => 'wide'])['align']);
     $this->assertSame('full', $service->sanitizeAttributes(['align' => 'full'])['align']);


### PR DESCRIPTION
## Description

Adds a MailPoet newsletter embed flow for WordPress posts:

- `[mailpoet_newsletter id="..."]` shortcode for embedding sent newsletters.
- `mailpoet/newsletter` editor block with newsletter search and appearance controls.
- Shared backend rendering and eligibility checks for shortcode and block output.

## Code review notes

The shortcode and block share `NewsletterEmbedService`, so eligibility, iframe markup, and fallback-link behaviour stay consistent across both entry points.

Iframe is used here to ensure the design of the email doesn't conflict with the design of the parent post.

## QA notes

1. Create or use a sent standard newsletter, then add a MailPoet Newsletter block to a post.
2. Search for and select the newsletter from the block sidebar, then verify the frontend renders the embedded newsletter.
3. Verify the appearance controls update the embed: height, width, iframe alignment, email background visibility, fallback link visibility, and fallback link alignment.
4. Verify the fallback link text reads “View full newsletter”.
5. Verify `[mailpoet_newsletter id="<sent-newsletter-id>"]` renders the same embed behavior.
6. Verify invalid, missing, deleted, draft, or unsent newsletters do not render public embed content.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8078

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->


### Post Editor

<img width="1681" height="1040" alt="editor" src="https://github.com/user-attachments/assets/7fe64c54-414f-4a2c-b88b-f6f1b9e33e49" />

---

### Final Post

<img width="1650" height="1098" alt="page" src="https://github.com/user-attachments/assets/42fe4ea4-46d1-4147-a061-4286c9739147" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/STOMAIL-8078-newsletter-embed-shortcode-block)

_The latest successful build from `add/STOMAIL-8078-newsletter-embed-shortcode-block` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->