### PR TITLE
Add public share URLs for sent emails

### DIFF
--- a/mailpoet/changelog/2026-04-28-13-52-01-added-add-public-sharing-urls-for-sent-newsletters.md
+++ b/mailpoet/changelog/2026-04-28-13-52-01-added-add-public-sharing-urls-for-sent-newsletters.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Public share URLs for sent newsletters

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -21,6 +21,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\Logger;
 use MailPoet\Form\RestApi\Api as FormsRestApi;
 use MailPoet\InvalidStateException;
 use MailPoet\Migrator\Cli as MigratorCli;
+use MailPoet\Newsletter\Sharing\PublicEmailRoute;
 use MailPoet\PostEditorBlocks\PostEditorBlock;
 use MailPoet\PostEditorBlocks\WooCommerceBlocksIntegration;
 use MailPoet\Router;
@@ -70,6 +71,9 @@ class Initializer {
 
   /** @var Changelog */
   private $changelog;
+
+  /** @var PublicEmailRoute */
+  private $publicEmailRoute;
 
   /** @var Menu */
   private $menu;
@@ -189,7 +193,8 @@ class Initializer {
     TagsRestApi $tagsRestApi,
     CustomFieldsRestApi $customFieldsRestApi,
     FormsRestApi $formsRestApi,
-    SegmentsRestApi $segmentsRestApi
+    SegmentsRestApi $segmentsRestApi,
+    PublicEmailRoute $publicEmailRoute
   ) {
     $this->rendererFactory = $rendererFactory;
     $this->accessControl = $accessControl;
@@ -226,6 +231,7 @@ class Initializer {
     $this->customFieldsRestApi = $customFieldsRestApi;
     $this->formsRestApi = $formsRestApi;
     $this->segmentsRestApi = $segmentsRestApi;
+    $this->publicEmailRoute = $publicEmailRoute;
 
     $emailEditorContainer = Email_Editor_Container::container();
     $this->emailEditorBootstrap = $emailEditorContainer->get(EmailEditorBootstrap::class);
@@ -348,6 +354,7 @@ class Initializer {
 
   public function pluginsLoaded() {
     $this->hooks->init();
+    $this->publicEmailRoute->init();
   }
 
   public function preInitialize() {

--- a/mailpoet/lib/Config/Populator.php
+++ b/mailpoet/lib/Config/Populator.php
@@ -515,6 +515,10 @@ class Populator {
         'name' => NewsletterOptionFieldEntity::NAME_FILTER_SEGMENT_ID,
         'newsletter_type' => NewsletterEntity::TYPE_NOTIFICATION,
       ],
+      [
+        'name' => NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY,
+        'newsletter_type' => NewsletterEntity::TYPE_STANDARD,
+      ],
     ];
 
     // 1. Load all existing option fields from the database.

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -642,6 +642,10 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Newsletter\Sending\ScheduledTaskSubscribersListingRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\SendingQueuesRepository::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\Sending\TimeZoneCampaignScheduler::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sharing\PublicEmailController::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sharing\PublicEmailRoute::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sharing\ShareMetadataBuilder::class)->setPublic(true);
+    $container->autowire(\MailPoet\Newsletter\Sharing\ShareVisibility::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserController::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\ViewInBrowser\ViewInBrowserRenderer::class)->setPublic(true);
     $container->autowire(\MailPoet\Newsletter\NewsletterCoupon::class)->setPublic(true);

--- a/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
+++ b/mailpoet/lib/Entities/NewsletterOptionFieldEntity.php
@@ -36,6 +36,7 @@ class NewsletterOptionFieldEntity {
   public const NAME_AUTOMATION_ID = 'automationId';
   public const NAME_AUTOMATION_STEP_ID = 'automationStepId';
   public const NAME_FILTER_SEGMENT_ID = 'filterSegmentId';
+  public const NAME_SHARE_VISIBILITY = 'shareVisibility';
 
   use AutoincrementedIdTrait;
   use CreatedAtTrait;

--- a/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
+++ b/mailpoet/lib/Newsletter/Sending/SendingQueuesRepository.php
@@ -69,6 +69,23 @@ class SendingQueuesRepository extends Repository {
     return $queryBuilder->getQuery()->getOneOrNullResult();
   }
 
+  public function findLatestCompletedByNewsletter(NewsletterEntity $newsletter): ?SendingQueueEntity {
+    return $this->entityManager->createQueryBuilder()
+      ->select('s')
+      ->from(SendingQueueEntity::class, 's')
+      ->join('s.task', 't')
+      ->andWhere('s.newsletter = :newsletter')
+      ->andWhere('s.deletedAt IS NULL')
+      ->andWhere('t.status = :status')
+      ->setParameter('newsletter', $newsletter)
+      ->setParameter('status', ScheduledTaskEntity::STATUS_COMPLETED)
+      ->orderBy('t.processedAt', 'DESC')
+      ->addOrderBy('s.id', 'DESC')
+      ->setMaxResults(1)
+      ->getQuery()
+      ->getOneOrNullResult();
+  }
+
   public function countAllToProcessByNewsletter(NewsletterEntity $newsletter): int {
     return intval($this->entityManager->createQueryBuilder()
       ->select('sum(s.countToProcess)')

--- a/mailpoet/lib/Newsletter/Sharing/PublicEmailController.php
+++ b/mailpoet/lib/Newsletter/Sharing/PublicEmailController.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sharing;
+
+use InvalidArgumentException;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Newsletter\ViewInBrowser\ViewInBrowserRenderer;
+
+class PublicEmailController {
+  /** @var NewslettersRepository */
+  private $newslettersRepository;
+
+  /** @var SendingQueuesRepository */
+  private $sendingQueuesRepository;
+
+  /** @var NewsletterUrl */
+  private $newsletterUrl;
+
+  /** @var ShareVisibility */
+  private $shareVisibility;
+
+  /** @var ViewInBrowserRenderer */
+  private $viewInBrowserRenderer;
+
+  /** @var ShareMetadataBuilder */
+  private $shareMetadataBuilder;
+
+  public function __construct(
+    NewslettersRepository $newslettersRepository,
+    SendingQueuesRepository $sendingQueuesRepository,
+    NewsletterUrl $newsletterUrl,
+    ShareVisibility $shareVisibility,
+    ViewInBrowserRenderer $viewInBrowserRenderer,
+    ShareMetadataBuilder $shareMetadataBuilder
+  ) {
+    $this->newslettersRepository = $newslettersRepository;
+    $this->sendingQueuesRepository = $sendingQueuesRepository;
+    $this->newsletterUrl = $newsletterUrl;
+    $this->shareVisibility = $shareVisibility;
+    $this->viewInBrowserRenderer = $viewInBrowserRenderer;
+    $this->shareMetadataBuilder = $shareMetadataBuilder;
+  }
+
+  public function getNewsletter(string $identifier): NewsletterEntity {
+    $data = $this->newsletterUrl->parsePublicShareIdentifier($identifier);
+    if (!$data) {
+      throw new InvalidArgumentException('Invalid public email identifier.');
+    }
+
+    $newsletter = $this->newslettersRepository->findOneBy(['hash' => $data['hash']]);
+    if (!$newsletter instanceof NewsletterEntity || !$this->shareVisibility->canShare($newsletter)) {
+      throw new InvalidArgumentException('Email is not publicly shareable.');
+    }
+
+    return $newsletter;
+  }
+
+  public function isCanonicalIdentifier(string $identifier, NewsletterEntity $newsletter): bool {
+    return $identifier === $this->newsletterUrl->getPublicShareIdentifier($newsletter);
+  }
+
+  public function getCanonicalUrl(NewsletterEntity $newsletter): string {
+    return $this->newsletterUrl->getPublicShareUrl($newsletter);
+  }
+
+  public function render(NewsletterEntity $newsletter): string {
+    $queue = $this->sendingQueuesRepository->findLatestCompletedByNewsletter($newsletter);
+    $canonicalUrl = $this->getCanonicalUrl($newsletter);
+    $html = $this->viewInBrowserRenderer->renderPublicShare($newsletter, $queue);
+    return $this->shareMetadataBuilder->injectMetadata($html, $newsletter, $canonicalUrl);
+  }
+}

--- a/mailpoet/lib/Newsletter/Sharing/PublicEmailRoute.php
+++ b/mailpoet/lib/Newsletter/Sharing/PublicEmailRoute.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sharing;
+
+use InvalidArgumentException;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\WP\Functions as WPFunctions;
+
+class PublicEmailRoute {
+  public const QUERY_VAR = 'mailpoet_public_email';
+  private const IDENTIFIER_CAPTURE = '([0-9a-f]{12}(?:-[^/]+)?)';
+
+  /** @var PublicEmailController */
+  private $controller;
+
+  /** @var NewsletterUrl */
+  private $newsletterUrl;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    PublicEmailController $controller,
+    NewsletterUrl $newsletterUrl,
+    WPFunctions $wp
+  ) {
+    $this->controller = $controller;
+    $this->newsletterUrl = $newsletterUrl;
+    $this->wp = $wp;
+  }
+
+  public function init(): void {
+    $this->wp->addAction('init', [$this, 'registerRewriteRule']);
+    $this->wp->addFilter('query_vars', [$this, 'addQueryVars']);
+    $this->wp->addAction('template_redirect', [$this, 'render']);
+  }
+
+  public function registerRewriteRule(): void {
+    $prefix = ltrim($this->newsletterUrl->getPublicSharePathPrefix(), '/');
+    $this->wp->addRewriteRule(
+      '^' . $prefix . self::IDENTIFIER_CAPTURE . '/?$',
+      'index.php?' . self::QUERY_VAR . '=$matches[1]',
+      'top'
+    );
+  }
+
+  public function addQueryVars(array $queryVars): array {
+    $queryVars[] = self::QUERY_VAR;
+    return $queryVars;
+  }
+
+  public function render(): void {
+    $identifier = $this->getIdentifier();
+    if ($identifier === '') {
+      return;
+    }
+
+    try {
+      $newsletter = $this->controller->getNewsletter($identifier);
+    } catch (InvalidArgumentException $e) {
+      // The path matched our prefix but the identifier didn't resolve to a
+      // shareable newsletter. Let WP continue: it will serve a real page at
+      // that URL if one exists, or fall through to its own 404.
+      return;
+    }
+    if (!$this->controller->isCanonicalIdentifier($identifier, $newsletter)) {
+      $this->wp->wpSafeRedirect($this->controller->getCanonicalUrl($newsletter), 301);
+      exit;
+    }
+    $this->display($this->controller->render($newsletter));
+  }
+
+  private function getIdentifier(): string {
+    $identifier = $this->wp->getQueryVar(self::QUERY_VAR, '');
+    if (is_string($identifier) && trim($identifier) !== '') {
+      return trim($identifier);
+    }
+
+    return $this->getIdentifierFromRequestPath();
+  }
+
+  private function getIdentifierFromRequestPath(): string {
+    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized through WPFunctions below.
+    $rawUri = $_SERVER['REQUEST_URI'] ?? '';
+    if (!is_string($rawUri) || $rawUri === '') {
+      return '';
+    }
+    $unslashed = $this->wp->wpUnslash($rawUri);
+    if (!is_string($unslashed)) {
+      return '';
+    }
+    $requestUri = $this->wp->sanitizeTextField($unslashed);
+    if (!is_string($requestUri) || $requestUri === '') {
+      return '';
+    }
+
+    $requestPath = $this->wp->wpParseUrl($requestUri, PHP_URL_PATH);
+    if (!is_string($requestPath)) {
+      return '';
+    }
+
+    $homePath = $this->wp->wpParseUrl($this->wp->homeUrl('/'), PHP_URL_PATH);
+    if (is_string($homePath) && $homePath !== '/') {
+      $homePath = rtrim($homePath, '/');
+      if (strpos($requestPath, $homePath . '/') === 0) {
+        $requestPath = substr($requestPath, strlen($homePath));
+      }
+    }
+
+    $pathPrefix = $this->newsletterUrl->getPublicSharePathPrefix();
+    if (strpos($requestPath, $pathPrefix) !== 0) {
+      return '';
+    }
+
+    $identifier = trim(substr($requestPath, strlen($pathPrefix)), '/');
+    if ($identifier === '' || strpos($identifier, '/') !== false) {
+      return '';
+    }
+
+    return $this->newsletterUrl->parsePublicShareIdentifier($identifier) ? $identifier : '';
+  }
+
+  private function display(string $html): void {
+    header('Content-Type: text/html; charset=utf-8');
+    header('Cache-Control: private, no-store, max-age=0');
+    header('X-Robots-Tag: noindex, nofollow');
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    echo $html;
+    exit;
+  }
+}

--- a/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
+++ b/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
@@ -18,11 +18,15 @@ class ShareMetadataBuilder {
 
   public function injectMetadata(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
     $metadata = $this->buildMetadata($html, $newsletter, $canonicalUrl);
-    if (stripos($html, '</head>') === false) {
+    $position = stripos($html, '</head>');
+    if ($position === false) {
       return $metadata . "\n" . $html;
     }
 
-    return preg_replace('/<\/head>/i', $metadata . "\n</head>", $html, 1) ?: $html;
+    // Inject before </head> using substr_replace rather than preg_replace so
+    // that dollar-digit sequences in the newsletter subject (e.g. "Save $50")
+    // are not interpreted as backreferences in the replacement string.
+    return substr_replace($html, $metadata . "\n", $position, 0);
   }
 
   public function buildMetadata(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {

--- a/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
+++ b/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sharing;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Util\pQuery\pQuery;
+use MailPoet\WP\Functions as WPFunctions;
+
+class ShareMetadataBuilder {
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    WPFunctions $wp
+  ) {
+    $this->wp = $wp;
+  }
+
+  public function injectMetadata(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
+    $metadata = $this->buildMetadata($html, $newsletter, $canonicalUrl);
+    if (stripos($html, '</head>') === false) {
+      return $metadata . "\n" . $html;
+    }
+
+    return preg_replace('/<\/head>/i', $metadata . "\n</head>", $html, 1) ?: $html;
+  }
+
+  public function buildMetadata(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
+    $tags = [
+      $this->metaTag('name', 'robots', 'noindex, nofollow'),
+    ];
+
+    $title = $newsletter->getCampaignNameOrSubject();
+    if ($title === '') {
+      return implode("\n", $tags);
+    }
+
+    $description = trim($newsletter->getPreheader());
+    $image = $this->findFirstContentImage($html);
+
+    $tags[] = $this->metaTag('property', 'og:title', $title);
+    $tags[] = $this->metaTag('property', 'og:type', 'website');
+    $tags[] = $this->metaTag('property', 'og:url', $canonicalUrl);
+    $tags[] = $this->metaTag('name', 'twitter:card', $image ? 'summary_large_image' : 'summary');
+    $tags[] = $this->metaTag('name', 'twitter:title', $title);
+
+    if ($description !== '') {
+      $tags[] = $this->metaTag('property', 'og:description', $description);
+      $tags[] = $this->metaTag('name', 'twitter:description', $description);
+    }
+
+    if ($image) {
+      $tags[] = $this->metaTag('property', 'og:image', $image['src']);
+      $tags[] = $this->metaTag('name', 'twitter:image', $image['src']);
+      if ($image['alt'] !== '') {
+        $tags[] = $this->metaTag('property', 'og:image:alt', $image['alt']);
+      }
+    }
+
+    return implode("\n", $tags);
+  }
+
+  /**
+   * @return array{src: string, alt: string}|null
+   */
+  private function findFirstContentImage(string $html): ?array {
+    $dom = pQuery::parseStr($html);
+    foreach ($dom->query('img') as $image) {
+      $src = trim((string)$image->src);
+      if (!$this->isUsableImage($src, $image)) {
+        continue;
+      }
+      return [
+        'src' => $src,
+        'alt' => trim((string)$image->alt),
+      ];
+    }
+    return null;
+  }
+
+  private function isUsableImage(string $src, $image): bool {
+    if ($src === '' || !preg_match('/^https?:\/\//i', $src)) {
+      return false;
+    }
+
+    $haystack = strtolower($src . ' ' . (string)$image->alt);
+    foreach (['fake-logo', 'your-logo-placeholder', 'social-icons', 'mailpoet-logo', 'powered-by-mailpoet'] as $needle) {
+      if (strpos($haystack, $needle) !== false) {
+        return false;
+      }
+    }
+
+    $width = isset($image->width) ? (int)$image->width : 0;
+    $height = isset($image->height) ? (int)$image->height : 0;
+    if (($width > 0 && $width < 64) || ($height > 0 && $height < 64)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private function metaTag(string $attribute, string $name, string $content): string {
+    return sprintf(
+      '<meta %s="%s" content="%s" />',
+      $attribute,
+      $this->wp->escAttr($name),
+      $this->wp->escAttr($content)
+    );
+  }
+}

--- a/mailpoet/lib/Newsletter/Sharing/ShareVisibility.php
+++ b/mailpoet/lib/Newsletter/Sharing/ShareVisibility.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Newsletter\Sharing;
+
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Settings\SettingsController;
+
+class ShareVisibility {
+  public const SETTING_DEFAULT_VISIBILITY = 'sharing.default_visibility';
+  public const VISIBILITY_DEFAULT = 'default';
+  public const VISIBILITY_PUBLIC = 'public';
+  public const VISIBILITY_PRIVATE = 'private';
+
+  private const ALLOWED_VISIBILITIES = [
+    self::VISIBILITY_DEFAULT,
+    self::VISIBILITY_PUBLIC,
+    self::VISIBILITY_PRIVATE,
+  ];
+
+  /** @var SettingsController */
+  private $settings;
+
+  public function __construct(
+    SettingsController $settings
+  ) {
+    $this->settings = $settings;
+  }
+
+  public function canShare(NewsletterEntity $newsletter): bool {
+    if (!$this->isSupported($newsletter)) {
+      return false;
+    }
+    return $this->getEffectiveVisibility($newsletter) === self::VISIBILITY_PUBLIC;
+  }
+
+  public function isSupported(NewsletterEntity $newsletter): bool {
+    return $newsletter->getType() === NewsletterEntity::TYPE_STANDARD
+      && $newsletter->getStatus() === NewsletterEntity::STATUS_SENT
+      && $newsletter->getDeletedAt() === null
+      && (bool)$newsletter->getHash();
+  }
+
+  public function getEffectiveVisibility(NewsletterEntity $newsletter): string {
+    $visibility = $this->getConfiguredVisibility($newsletter);
+    if ($visibility === self::VISIBILITY_DEFAULT) {
+      return $this->getDefaultVisibility();
+    }
+    return $visibility;
+  }
+
+  public function getConfiguredVisibility(NewsletterEntity $newsletter): string {
+    $visibility = (string)$newsletter->getOptionValue(NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY);
+    return in_array($visibility, self::ALLOWED_VISIBILITIES, true)
+      ? $visibility
+      : self::VISIBILITY_DEFAULT;
+  }
+
+  public function getDefaultVisibility(): string {
+    $visibility = (string)$this->settings->get(self::SETTING_DEFAULT_VISIBILITY, self::VISIBILITY_PRIVATE);
+    return in_array($visibility, [self::VISIBILITY_PUBLIC, self::VISIBILITY_PRIVATE], true)
+      ? $visibility
+      : self::VISIBILITY_PRIVATE;
+  }
+}

--- a/mailpoet/lib/Newsletter/Url.php
+++ b/mailpoet/lib/Newsletter/Url.php
@@ -8,15 +8,23 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Router\Endpoints\ViewInBrowser as ViewInBrowserEndpoint;
 use MailPoet\Router\Router;
 use MailPoet\Subscribers\LinkTokens;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Url {
+  public const PUBLIC_SHARE_PATH = '/mailpoet-email/';
+
   /** @var LinkTokens */
   private $linkTokens;
 
+  /** @var WPFunctions */
+  private $wp;
+
   public function __construct(
-    LinkTokens $linkTokens
+    LinkTokens $linkTokens,
+    WPFunctions $wp
   ) {
     $this->linkTokens = $linkTokens;
+    $this->wp = $wp;
   }
 
   public function getViewInBrowserUrl(
@@ -31,6 +39,68 @@ class Url {
       ViewInBrowserEndpoint::ACTION_VIEW,
       $data
     );
+  }
+
+  public function getPublicShareUrl(?NewsletterEntity $newsletter): string {
+    if (!$newsletter || !$newsletter->getHash()) {
+      return '';
+    }
+    $identifier = $this->getPublicShareIdentifier($newsletter);
+    if ($this->usesPrettyPermalinks()) {
+      return $this->wp->homeUrl($this->getPublicSharePathPrefix() . $identifier . '/');
+    }
+    return $this->wp->addQueryArg(
+      ['mailpoet_public_email' => $identifier],
+      $this->wp->homeUrl('/')
+    );
+  }
+
+  public function getPublicSharePathPrefix(): string {
+    /**
+     * Filters the URL path prefix used for the public share route.
+     *
+     * Useful when the default `/mailpoet-email/` slug collides with an
+     * existing page or you want to namespace it under another segment.
+     *
+     * @param string $prefix Default `/mailpoet-email/`.
+     */
+    $filtered = $this->wp->applyFilters('mailpoet_public_share_url_prefix', self::PUBLIC_SHARE_PATH);
+    $prefix = is_string($filtered) ? trim($filtered, '/') : '';
+    if ($prefix === '' || !preg_match('#^[a-zA-Z0-9_/-]+$#', $prefix)) {
+      $prefix = trim(self::PUBLIC_SHARE_PATH, '/');
+    }
+    return '/' . $prefix . '/';
+  }
+
+  public function getPublicShareIdentifier(NewsletterEntity $newsletter): string {
+    $hash = $newsletter->getHash();
+    return sprintf(
+      '%s-%s',
+      is_string($hash) ? $hash : '',
+      $this->getPublicShareSlug($newsletter)
+    );
+  }
+
+  public function getPublicShareSlug(NewsletterEntity $newsletter): string {
+    $slug = $this->wp->sanitizeTitle($newsletter->getCampaignNameOrSubject());
+    return $slug ?: 'email';
+  }
+
+  /**
+   * @return array{hash: string, slug: string|null}|null
+   */
+  public function parsePublicShareIdentifier(string $identifier): ?array {
+    if (!preg_match('/^(?P<hash>[0-9a-f]{12})(?:-(?P<slug>[^\/]+))?$/', $identifier, $matches)) {
+      return null;
+    }
+    return [
+      'hash' => $matches['hash'],
+      'slug' => $matches['slug'] ?? null,
+    ];
+  }
+
+  public function usesPrettyPermalinks(): bool {
+    return (string)$this->wp->getOption('permalink_structure', '') !== '';
   }
 
   public function createUrlDataObject(

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -15,6 +15,13 @@ use MailPoet\Settings\TrackingConfig;
 use MailPoet\WP\Emoji;
 
 class ViewInBrowserRenderer {
+  private const OPTION_RENDER_AS_PREVIEW = 'renderAsPreview';
+  private const OPTION_SANITIZE_RENDERED_QUEUE_LINKS = 'sanitizeRenderedQueueLinks';
+  private const OPTION_SHORTCODES_PREVIEW = 'shortcodesPreview';
+  private const OPTION_REPLACE_SUBSCRIBER_TRACKING = 'replaceSubscriberTracking';
+  private const OPTION_PERSONALIZER_PREVIEW = 'personalizerPreview';
+  private const OPTION_REPLACE_VIEW_IN_BROWSER_URL = 'replaceViewInBrowserUrlWithPublicShareUrl';
+
   /** @var Emoji */
   private $emoji;
 
@@ -62,12 +69,7 @@ class ViewInBrowserRenderer {
       $newsletter,
       $subscriber,
       $queue,
-      $isPreview,
-      $isPreview,
-      $isPreview,
-      !$isPreview,
-      $isPreview,
-      false
+      $this->buildRenderOptionsForPreview($isPreview)
     );
   }
 
@@ -82,26 +84,33 @@ class ViewInBrowserRenderer {
       $newsletter,
       new SubscriberEntity(),
       $queue,
-      false,
-      true,
-      true,
-      false,
-      false,
-      true
+      $this->buildRenderOptionsForPublicShare()
     );
   }
 
+  /**
+   * @param array{
+   *   renderAsPreview: bool,
+   *   sanitizeRenderedQueueLinks: bool,
+   *   shortcodesPreview: bool,
+   *   replaceSubscriberTracking: bool,
+   *   personalizerPreview: bool,
+   *   replaceViewInBrowserUrlWithPublicShareUrl: bool
+   * } $options
+   */
   private function renderWithContext(
     NewsletterEntity $newsletter,
     ?SubscriberEntity $subscriber,
     ?SendingQueueEntity $queue,
-    bool $renderAsPreview,
-    bool $sanitizeRenderedQueueLinks,
-    bool $shortcodesPreview,
-    bool $replaceSubscriberTracking,
-    bool $personalizerPreview,
-    bool $replaceViewInBrowserUrlWithPublicShareUrl
+    array $options
   ): string {
+    $renderAsPreview = $options[self::OPTION_RENDER_AS_PREVIEW];
+    $sanitizeRenderedQueueLinks = $options[self::OPTION_SANITIZE_RENDERED_QUEUE_LINKS];
+    $shortcodesPreview = $options[self::OPTION_SHORTCODES_PREVIEW];
+    $replaceSubscriberTracking = $options[self::OPTION_REPLACE_SUBSCRIBER_TRACKING];
+    $personalizerPreview = $options[self::OPTION_PERSONALIZER_PREVIEW];
+    $replaceViewInBrowserUrlWithPublicShareUrl = $options[self::OPTION_REPLACE_VIEW_IN_BROWSER_URL];
+
     $isTrackingEnabled = $this->trackingConfig->isEmailTrackingEnabled();
 
     if ($queue && $queue->getNewsletterRenderedBody()) {
@@ -163,6 +172,48 @@ class ViewInBrowserRenderer {
       $renderedNewsletter = $this->personalizer->personalize_content($renderedNewsletter);
     }
     return $renderedNewsletter;
+  }
+
+  /**
+   * @return array{
+   *   renderAsPreview: bool,
+   *   sanitizeRenderedQueueLinks: bool,
+   *   shortcodesPreview: bool,
+   *   replaceSubscriberTracking: bool,
+   *   personalizerPreview: bool,
+   *   replaceViewInBrowserUrlWithPublicShareUrl: bool
+   * }
+   */
+  private function buildRenderOptionsForPreview(bool $isPreview): array {
+    return [
+      self::OPTION_RENDER_AS_PREVIEW => $isPreview,
+      self::OPTION_SANITIZE_RENDERED_QUEUE_LINKS => $isPreview,
+      self::OPTION_SHORTCODES_PREVIEW => $isPreview,
+      self::OPTION_REPLACE_SUBSCRIBER_TRACKING => !$isPreview,
+      self::OPTION_PERSONALIZER_PREVIEW => $isPreview,
+      self::OPTION_REPLACE_VIEW_IN_BROWSER_URL => false,
+    ];
+  }
+
+  /**
+   * @return array{
+   *   renderAsPreview: bool,
+   *   sanitizeRenderedQueueLinks: bool,
+   *   shortcodesPreview: bool,
+   *   replaceSubscriberTracking: bool,
+   *   personalizerPreview: bool,
+   *   replaceViewInBrowserUrlWithPublicShareUrl: bool
+   * }
+   */
+  private function buildRenderOptionsForPublicShare(): array {
+    return [
+      self::OPTION_RENDER_AS_PREVIEW => false,
+      self::OPTION_SANITIZE_RENDERED_QUEUE_LINKS => true,
+      self::OPTION_SHORTCODES_PREVIEW => true,
+      self::OPTION_REPLACE_SUBSCRIBER_TRACKING => false,
+      self::OPTION_PERSONALIZER_PREVIEW => false,
+      self::OPTION_REPLACE_VIEW_IN_BROWSER_URL => true,
+    ];
   }
 
   private function prepareShortcodes(

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -10,6 +10,7 @@ use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Links\Links;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
+use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Settings\TrackingConfig;
 use MailPoet\WP\Emoji;
 
@@ -29,6 +30,9 @@ class ViewInBrowserRenderer {
   /** @var Links */
   private $links;
 
+  /** @var NewsletterUrl */
+  private $newsletterUrl;
+
   private Personalizer $personalizer;
 
   public function __construct(
@@ -36,13 +40,15 @@ class ViewInBrowserRenderer {
     TrackingConfig $trackingConfig,
     Shortcodes $shortcodes,
     Renderer $renderer,
-    Links $links
+    Links $links,
+    NewsletterUrl $newsletterUrl
   ) {
     $this->emoji = $emoji;
     $this->trackingConfig = $trackingConfig;
     $this->renderer = $renderer;
     $this->shortcodes = $shortcodes;
     $this->links = $links;
+    $this->newsletterUrl = $newsletterUrl;
     $this->personalizer = Email_Editor_Container::container()->get(Personalizer::class);
   }
 
@@ -52,7 +58,50 @@ class ViewInBrowserRenderer {
     ?SubscriberEntity $subscriber = null,
     ?SendingQueueEntity $queue = null
   ) {
-    $wpUserPreview = $isPreview;
+    return $this->renderWithContext(
+      $newsletter,
+      $subscriber,
+      $queue,
+      $isPreview,
+      $isPreview,
+      $isPreview,
+      !$isPreview,
+      $isPreview,
+      false
+    );
+  }
+
+  public function renderPublicShare(
+    NewsletterEntity $newsletter,
+    ?SendingQueueEntity $queue = null
+  ): string {
+    // An empty SubscriberEntity (not null) is intentional: the subscriber
+    // shortcode handler treats null as "leave the shortcode in place" but
+    // resolves `default:` arguments against any SubscriberEntity instance.
+    return $this->renderWithContext(
+      $newsletter,
+      new SubscriberEntity(),
+      $queue,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    );
+  }
+
+  private function renderWithContext(
+    NewsletterEntity $newsletter,
+    ?SubscriberEntity $subscriber,
+    ?SendingQueueEntity $queue,
+    bool $renderAsPreview,
+    bool $sanitizeRenderedQueueLinks,
+    bool $shortcodesPreview,
+    bool $replaceSubscriberTracking,
+    bool $personalizerPreview,
+    bool $replaceViewInBrowserUrlWithPublicShareUrl
+  ): string {
     $isTrackingEnabled = $this->trackingConfig->isEmailTrackingEnabled();
 
     if ($queue && $queue->getNewsletterRenderedBody()) {
@@ -67,7 +116,7 @@ class ViewInBrowserRenderer {
       // isolate "view in browser", "unsubscribe" and "manage subscription" links
       // and convert them to shortcodes, which later will be replaced with "#" when
       // newsletter is previewed
-      if ($wpUserPreview && preg_match($this->links->getLinkRegex(), $newsletterBody)) {
+      if ($sanitizeRenderedQueueLinks && preg_match($this->links->getLinkRegex(), $newsletterBody)) {
         $newsletterBody = $this->links->convertHashedLinksToShortcodesAndUrls(
           $newsletterBody,
           $queue->getId(),
@@ -77,7 +126,7 @@ class ViewInBrowserRenderer {
         $newsletterBody = str_replace(Links::DATA_TAG_OPEN, '', $newsletterBody);
       }
     } else {
-      if ($wpUserPreview) {
+      if ($renderAsPreview) {
         $newsletterBody = $this->renderer->renderAsPreview($newsletter, 'html');
       } else {
         $newsletterBody = $this->renderer->render($newsletter, $sendingTask = null, 'html');
@@ -87,10 +136,17 @@ class ViewInBrowserRenderer {
       $newsletter,
       $subscriber,
       $queue,
-      $wpUserPreview
+      $shortcodesPreview
     );
     $renderedNewsletter = $this->shortcodes->replace($newsletterBody);
-    if (!$wpUserPreview && $queue && $subscriber && $isTrackingEnabled) {
+    if ($replaceViewInBrowserUrlWithPublicShareUrl) {
+      $renderedNewsletter = str_replace(
+        $this->newsletterUrl->getViewInBrowserUrl($newsletter, null, $queue, true),
+        $this->newsletterUrl->getPublicShareUrl($newsletter),
+        $renderedNewsletter
+      );
+    }
+    if ($replaceSubscriberTracking && $queue && $subscriber && $isTrackingEnabled) {
       $renderedNewsletter = $this->links->replaceSubscriberData(
         $subscriber->getId(),
         $queue->getId(),
@@ -100,7 +156,7 @@ class ViewInBrowserRenderer {
     if ($newsletter->getWpPostId() !== null) {
       $this->personalizer->set_context([
         'recipient_email' => $subscriber ? $subscriber->getEmail() : null,
-        'is_user_preview' => $wpUserPreview,
+        'is_user_preview' => $personalizerPreview,
         'newsletter_id' => $newsletter->getId(),
         'queue_id' => $queue ? $queue->getId() : null,
       ]);

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserRenderer.php
@@ -207,11 +207,14 @@ class ViewInBrowserRenderer {
    */
   private function buildRenderOptionsForPublicShare(): array {
     return [
-      self::OPTION_RENDER_AS_PREVIEW => false,
+      // Keep no-queue public share fallback in preview mode to avoid
+      // send-time preprocessing side effects and keep shortcode behavior
+      // consistent with the rendering mode.
+      self::OPTION_RENDER_AS_PREVIEW => true,
       self::OPTION_SANITIZE_RENDERED_QUEUE_LINKS => true,
       self::OPTION_SHORTCODES_PREVIEW => true,
       self::OPTION_REPLACE_SUBSCRIBER_TRACKING => false,
-      self::OPTION_PERSONALIZER_PREVIEW => false,
+      self::OPTION_PERSONALIZER_PREVIEW => true,
       self::OPTION_REPLACE_VIEW_IN_BROWSER_URL => true,
     ];
   }

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -98,6 +98,9 @@ class SettingsController {
         'delete_unconfirmed_subscribers_after_days' => self::DEFAULT_DELETE_UNCONFIRMED_SUBSCRIBERS_AFTER_DAYS,
         'sending_status_retention_days' => self::DEFAULT_SENDING_STATUS_RETENTION_DAYS,
         'sending_queue_body_retention_days' => self::DEFAULT_SENDING_QUEUE_BODY_RETENTION_DAYS,
+        'sharing' => [
+          'default_visibility' => 'private',
+        ],
       ];
     }
 

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -106,6 +106,10 @@ class Functions {
     return add_query_arg($key, $value, $url); // nosemgrep: tools.wpscan-semgrep-rules.audit.php.wp.security.xss.query-arg
   }
 
+  public function addRewriteRule($regex, $query, $after = 'bottom') {
+    return add_rewrite_rule($regex, $query, $after);
+  }
+
   public function addScreenOption($option, $args = []) {
     add_screen_option($option, $args);
   }
@@ -258,6 +262,10 @@ class Functions {
 
   public function getOption($option, $default = false) {
     return get_option($option, $default);
+  }
+
+  public function getQueryVar($queryVar, $default = '') {
+    return get_query_var($queryVar, $default);
   }
 
   public function getPages($args = []) {
@@ -515,6 +523,10 @@ class Functions {
 
   public function shortcodeParseAtts($text) {
     return shortcode_parse_atts($text);
+  }
+
+  public function sanitizeTitle($title, $fallbackTitle = '', $context = 'save') {
+    return sanitize_title($title, $fallbackTitle, $context);
   }
 
   public function singlePostTitle($prefix = '', $display = true) {

--- a/mailpoet/tests/integration/Config/PopulatorTest.php
+++ b/mailpoet/tests/integration/Config/PopulatorTest.php
@@ -9,7 +9,7 @@ use MailPoetTest;
 use MailPoetVendor\Doctrine\ORM\Query;
 
 class PopulatorTest extends MailPoetTest {
-  private const OPTION_FIELD_COUNT = 34;
+  private const OPTION_FIELD_COUNT = 35;
   private const TEMPLATE_COUNT = 77;
 
   public function testItInsertsOptionFields(): void {

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Sharing;
+
+use InvalidArgumentException;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Newsletter\Links\Links;
+use MailPoet\Newsletter\Sharing\PublicEmailController;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Router\Router;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterLink;
+
+class PublicEmailControllerTest extends \MailPoetTest {
+  public function testItRendersPublicEmailByNewsletterId() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
+      ])
+      ->create();
+    $queue = $newsletter->getLatestQueue();
+    $this->assertNotNull($queue);
+    $queue->setNewsletterRenderedBody([
+      'html' => '<html><head></head><body>Hello, [subscriber:firstname | default:reader]. '
+        . '<a href="' . Links::DATA_TAG_CLICK . '-abcde">Google</a>'
+        . '<img src="' . Links::DATA_TAG_OPEN . '" /></body></html>',
+      'text' => 'test',
+    ]);
+    (new NewsletterLink($newsletter))
+      ->withUrl('https://example.com')
+      ->withHash('abcde')
+      ->create();
+    $this->entityManager->flush();
+
+    $controller = $this->diContainer->get(PublicEmailController::class);
+    $identifier = $this->diContainer->get(NewsletterUrl::class)->getPublicShareIdentifier($newsletter);
+    $result = $controller->render($controller->getNewsletter($identifier));
+
+    verify($result)->stringContainsString('Hello, reader');
+    verify($result)->stringContainsString('<meta property="og:title"');
+    verify($result)->stringContainsString('<a href="https://example.com">');
+    verify($result)->stringNotContainsString(Router::NAME . '&endpoint=track');
+    verify($result)->stringNotContainsString('[mailpoet_open_data]');
+  }
+
+  public function testItRendersFromCurrentEntityWhenNoCompletedQueueIsStored() {
+    $newsletter = (new Newsletter())
+      ->withSubject('Resilient Share')
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
+      ])
+      ->create();
+
+    $controller = $this->diContainer->get(PublicEmailController::class);
+    $result = $controller->render($newsletter);
+
+    verify($result)->stringContainsString('<meta property="og:title" content="Resilient Share" />');
+  }
+
+  public function testItRejectsPrivatePublicEmails() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PRIVATE,
+      ])
+      ->create();
+
+    $this->expectException(InvalidArgumentException::class);
+
+    $this->diContainer->get(PublicEmailController::class)
+      ->getNewsletter($this->diContainer->get(NewsletterUrl::class)->getPublicShareIdentifier($newsletter));
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
@@ -47,8 +47,50 @@ class PublicEmailControllerTest extends \MailPoetTest {
   }
 
   public function testItRendersFromCurrentEntityWhenNoCompletedQueueIsStored() {
+    $newsletterBody = [
+      'content' => [
+        'type' => 'container',
+        'orientation' => 'vertical',
+        'styles' => [
+          'block' => [
+            'backgroundColor' => 'transparent',
+          ],
+        ],
+        'blocks' => [
+          [
+            'type' => 'container',
+            'orientation' => 'horizontal',
+            'styles' => [
+              'block' => [
+                'backgroundColor' => 'transparent',
+              ],
+            ],
+            'blocks' => [
+              [
+                'type' => 'container',
+                'orientation' => 'vertical',
+                'styles' => [
+                  'block' => [
+                    'backgroundColor' => 'transparent',
+                  ],
+                ],
+                'blocks' => [
+                  [
+                    'type' => 'text',
+                    'text' => '<p>Hello, [subscriber:firstname | default:reader]. '
+                      . '<a href="[link:newsletter_view_in_browser_url]">View in browser</a></p>',
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+
     $newsletter = (new Newsletter())
       ->withSubject('Resilient Share')
+      ->withBody($newsletterBody)
       ->withSentStatus()
       ->withOptions([
         NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
@@ -59,6 +101,9 @@ class PublicEmailControllerTest extends \MailPoetTest {
     $result = $controller->render($newsletter);
 
     verify($result)->stringContainsString('<meta property="og:title" content="Resilient Share" />');
+    verify($result)->stringContainsString($this->diContainer->get(NewsletterUrl::class)->getPublicShareUrl($newsletter));
+    verify($result)->stringNotContainsString(Router::NAME . '&endpoint=view_in_browser');
+    verify($result)->stringNotContainsString(Router::NAME . '&endpoint=track');
   }
 
   public function testItRejectsPrivatePublicEmails() {

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailRouteTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailRouteTest.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Sharing;
+
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Newsletter\Sharing\PublicEmailController;
+use MailPoet\Newsletter\Sharing\PublicEmailRoute;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
+use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\WP\Functions as WPFunctions;
+use ReflectionMethod;
+
+class PublicEmailRouteTest extends \MailPoetTest {
+  /** @var string|null */
+  private $previousRequestUri;
+
+  public function _before() {
+    parent::_before();
+    $uri = $_SERVER['REQUEST_URI'] ?? null;
+    $this->previousRequestUri = is_string($uri) ? $uri : null;
+  }
+
+  public function _after() {
+    if ($this->previousRequestUri === null) {
+      unset($_SERVER['REQUEST_URI']);
+    } else {
+      $_SERVER['REQUEST_URI'] = $this->previousRequestUri;
+    }
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('home', '');
+    $wp->updateOption('permalink_structure', '');
+    parent::_after();
+  }
+
+  public function testItReadsIdentifierFromPrettyRequestPath() {
+    $_SERVER['REQUEST_URI'] = '/mailpoet-email/abc123def456-spring-sale/';
+
+    verify($this->invokeGetIdentifier())->equals('abc123def456-spring-sale');
+  }
+
+  public function testItReadsIdentifierWhenHomeUrlLivesInSubdirectory() {
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('home', 'http://example.com/blog');
+    $_SERVER['REQUEST_URI'] = '/blog/mailpoet-email/abc123def456-spring-sale/';
+
+    verify($this->invokeGetIdentifier())->equals('abc123def456-spring-sale');
+  }
+
+  public function testItIgnoresRequestPathsOutsideThePublicSharePrefix() {
+    $_SERVER['REQUEST_URI'] = '/some-other-page/abc123def456/';
+
+    verify($this->invokeGetIdentifier())->equals('');
+  }
+
+  public function testItIgnoresMalformedIdentifiers() {
+    $_SERVER['REQUEST_URI'] = '/mailpoet-email/not a valid identifier!/';
+
+    verify($this->invokeGetIdentifier())->equals('');
+  }
+
+  public function testItIgnoresOrdinarySlugsThatLookLikePageNames() {
+    // A site that already has a page at this URL must not get hijacked.
+    $_SERVER['REQUEST_URI'] = '/mailpoet-email/about/';
+
+    verify($this->invokeGetIdentifier())->equals('');
+  }
+
+  public function testItRedirectsNonCanonicalIdentifierToCanonicalUrl() {
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->updateOption('permalink_structure', '/%postname%/');
+    $newsletter = (new Newsletter())
+      ->withSubject('Spring Sale')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
+      ])
+      ->create();
+    $hash = (string)$newsletter->getHash();
+    $_SERVER['REQUEST_URI'] = '/mailpoet-email/' . $hash . '-stale-slug/';
+
+    $route = $this->buildRouteWithRedirectInterceptor($capturedUrl);
+
+    try {
+      $route->render();
+      $this->fail('Expected redirect to interrupt execution');
+    } catch (\RuntimeException $e) {
+      verify($e->getMessage())->equals('exit_redirect');
+    }
+    verify($capturedUrl)->stringContainsString(sprintf('/mailpoet-email/%s-spring-sale/', $hash));
+  }
+
+  public function testItReturnsSilentlyWhenIdentifierDoesNotResolveToNewsletter() {
+    // The path matches our share prefix but no newsletter has this hash.
+    // We must not 404 — a real page could live at this URL on the site.
+    $_SERVER['REQUEST_URI'] = '/mailpoet-email/000000000000-missing/';
+
+    $route = $this->buildRouteWithSilentExpectations();
+
+    $route->render();
+    // No exception, no redirect, no status header — the test would have
+    // failed on the `expects($this->never())` calls inside the mock if we
+    // had taken either branch.
+  }
+
+  private function invokeGetIdentifier(): string {
+    $route = $this->diContainer->get(PublicEmailRoute::class);
+    $method = new ReflectionMethod($route, 'getIdentifier');
+    $method->setAccessible(true);
+    $result = $method->invoke($route);
+    return is_string($result) ? $result : '';
+  }
+
+  private function buildRouteWithRedirectInterceptor(&$capturedUrl): PublicEmailRoute {
+    $wp = $this->createMock(WPFunctions::class);
+    $wp->method('getQueryVar')->willReturn('');
+    $wp->method('wpUnslash')->willReturnArgument(0);
+    $wp->method('sanitizeTextField')->willReturnArgument(0);
+    $wp->method('wpParseUrl')->willReturnCallback(function ($url, $component) {
+      return parse_url((string)$url, $component);
+    });
+    $wp->method('homeUrl')->willReturn('http://example.com/');
+    $wp->method('applyFilters')->willReturnArgument(1);
+    $wp->method('wpSafeRedirect')->willReturnCallback(function ($url) use (&$capturedUrl) {
+      $capturedUrl = $url;
+      throw new \RuntimeException('exit_redirect');
+    });
+    return new PublicEmailRoute(
+      $this->diContainer->get(PublicEmailController::class),
+      new NewsletterUrl($this->diContainer->get(\MailPoet\Subscribers\LinkTokens::class), $wp),
+      $wp
+    );
+  }
+
+  private function buildRouteWithSilentExpectations(): PublicEmailRoute {
+    $wp = $this->createMock(WPFunctions::class);
+    $wp->method('getQueryVar')->willReturn('');
+    $wp->method('wpUnslash')->willReturnArgument(0);
+    $wp->method('sanitizeTextField')->willReturnArgument(0);
+    $wp->method('wpParseUrl')->willReturnCallback(function ($url, $component) {
+      return parse_url((string)$url, $component);
+    });
+    $wp->method('homeUrl')->willReturn('http://example.com/');
+    $wp->method('applyFilters')->willReturnArgument(1);
+    $wp->expects($this->never())->method('wpSafeRedirect');
+    $wp->expects($this->never())->method('statusHeader');
+    return new PublicEmailRoute(
+      $this->diContainer->get(PublicEmailController::class),
+      new NewsletterUrl($this->diContainer->get(\MailPoet\Subscribers\LinkTokens::class), $wp),
+      $wp
+    );
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailRouteTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailRouteTest.php
@@ -15,10 +15,19 @@ class PublicEmailRouteTest extends \MailPoetTest {
   /** @var string|null */
   private $previousRequestUri;
 
+  /** @var string|false */
+  private $previousHomeOption;
+
+  /** @var string|false */
+  private $previousPermalinkStructureOption;
+
   public function _before() {
     parent::_before();
+    $wp = $this->diContainer->get(WPFunctions::class);
     $uri = $_SERVER['REQUEST_URI'] ?? null;
     $this->previousRequestUri = is_string($uri) ? $uri : null;
+    $this->previousHomeOption = $wp->getOption('home');
+    $this->previousPermalinkStructureOption = $wp->getOption('permalink_structure');
   }
 
   public function _after() {
@@ -28,8 +37,16 @@ class PublicEmailRouteTest extends \MailPoetTest {
       $_SERVER['REQUEST_URI'] = $this->previousRequestUri;
     }
     $wp = $this->diContainer->get(WPFunctions::class);
-    $wp->updateOption('home', '');
-    $wp->updateOption('permalink_structure', '');
+    if (is_string($this->previousHomeOption)) {
+      $wp->updateOption('home', $this->previousHomeOption);
+    } else {
+      $wp->deleteOption('home');
+    }
+    if (is_string($this->previousPermalinkStructureOption)) {
+      $wp->updateOption('permalink_structure', $this->previousPermalinkStructureOption);
+    } else {
+      $wp->deleteOption('permalink_structure');
+    }
     parent::_after();
   }
 

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Sharing;
+
+use MailPoet\Newsletter\Sharing\ShareMetadataBuilder;
+use MailPoet\Test\DataFactories\Newsletter;
+
+class ShareMetadataBuilderTest extends \MailPoetTest {
+  public function testItInjectsEscapedOpenGraphAndTwitterMetadata() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSubject('Spring <Sale>')
+      ->withPreheader('Preview & share')
+      ->create();
+    $html = '<html><head><title>Email</title></head><body>'
+      . '<img src="https://example.com/hero.jpg" alt="Hero & image" width="600" height="300" />'
+      . '</body></html>';
+
+    $result = $this->diContainer->get(ShareMetadataBuilder::class)
+      ->injectMetadata($html, $newsletter, 'https://example.com/mailpoet-email/1-spring-sale/');
+
+    verify($result)->stringContainsString('<meta name="robots" content="noindex, nofollow" />');
+    verify($result)->stringContainsString('<meta property="og:title" content="Spring &lt;Sale&gt;" />');
+    verify($result)->stringContainsString('<meta property="og:description" content="Preview &amp; share" />');
+    verify($result)->stringContainsString('<meta property="og:image" content="https://example.com/hero.jpg" />');
+    verify($result)->stringContainsString('<meta property="og:image:alt" content="Hero &amp; image" />');
+    verify($result)->stringContainsString('<meta name="twitter:card" content="summary_large_image" />');
+    verify($result)->stringContainsString('</head>');
+  }
+
+  public function testItStillInjectsRobotsMetaEvenWhenTitleIsEmpty() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSubject('')
+      ->create();
+    $html = '<html><head></head><body></body></html>';
+
+    $result = $this->diContainer->get(ShareMetadataBuilder::class)
+      ->injectMetadata($html, $newsletter, 'https://example.com/mailpoet-email/abc123/');
+
+    verify($result)->stringContainsString('<meta name="robots" content="noindex, nofollow" />');
+    verify($result)->stringNotContainsString('og:title');
+  }
+
+  public function testItOmitsUnsuitableImages() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSubject('Text update')
+      ->create();
+    $html = '<html><head></head><body>'
+      . '<img src="https://example.com/social-icons/facebook.png" width="32" height="32" />'
+      . '</body></html>';
+
+    $result = $this->diContainer->get(ShareMetadataBuilder::class)
+      ->injectMetadata($html, $newsletter, 'https://example.com/mailpoet-email/1-text-update/');
+
+    verify($result)->stringContainsString('<meta name="twitter:card" content="summary" />');
+    verify($result)->stringNotContainsString('og:image');
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
@@ -42,6 +42,20 @@ class ShareMetadataBuilderTest extends \MailPoetTest {
     verify($result)->stringNotContainsString('og:title');
   }
 
+  public function testItPreservesDollarDigitSequencesInSubject() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSubject('Save $50 today, $5 off, $0 trial')
+      ->create();
+    $html = '<html><head></head><body></body></html>';
+
+    $result = $this->diContainer->get(ShareMetadataBuilder::class)
+      ->injectMetadata($html, $newsletter, 'https://example.com/mailpoet-email/1-save/');
+
+    verify($result)->stringContainsString('<meta property="og:title" content="Save $50 today, $5 off, $0 trial" />');
+    verify($result)->stringContainsString('<meta name="twitter:title" content="Save $50 today, $5 off, $0 trial" />');
+  }
+
   public function testItOmitsUnsuitableImages() {
     $newsletter = (new Newsletter())
       ->withSentStatus()

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareVisibilityTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareVisibilityTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\Newsletter\Sharing;
+
+use MailPoet\Entities\NewsletterOptionFieldEntity;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
+use MailPoet\Settings\SettingsController;
+use MailPoet\Test\DataFactories\Newsletter;
+
+class ShareVisibilityTest extends \MailPoetTest {
+  public function testItBlocksSentStandardNewslettersByDefault() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->create();
+
+    $shareVisibility = $this->diContainer->get(ShareVisibility::class);
+
+    verify($shareVisibility->getConfiguredVisibility($newsletter))->equals(ShareVisibility::VISIBILITY_DEFAULT);
+    verify($shareVisibility->getDefaultVisibility())->equals(ShareVisibility::VISIBILITY_PRIVATE);
+    verify($shareVisibility->canShare($newsletter))->false();
+  }
+
+  public function testItAllowsNewslettersExplicitlyMarkedPublic() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PUBLIC,
+      ])
+      ->create();
+
+    $shareVisibility = $this->diContainer->get(ShareVisibility::class);
+
+    verify($shareVisibility->canShare($newsletter))->true();
+  }
+
+  public function testItBlocksPrivateNewsletters() {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PRIVATE,
+      ])
+      ->create();
+
+    $shareVisibility = $this->diContainer->get(ShareVisibility::class);
+
+    verify($shareVisibility->canShare($newsletter))->false();
+  }
+
+  public function testItUsesGlobalDefaultForDefaultVisibility() {
+    $this->diContainer->get(SettingsController::class)->set(
+      ShareVisibility::SETTING_DEFAULT_VISIBILITY,
+      ShareVisibility::VISIBILITY_PUBLIC
+    );
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_DEFAULT,
+      ])
+      ->create();
+
+    $shareVisibility = $this->diContainer->get(ShareVisibility::class);
+
+    verify($shareVisibility->canShare($newsletter))->true();
+  }
+
+  public function testItBlocksUnsupportedNewsletterTypesAndStatuses() {
+    $draft = (new Newsletter())
+      ->withDraftStatus()
+      ->create();
+    $notificationHistory = (new Newsletter())
+      ->withPostNotificationHistoryType()
+      ->withSentStatus()
+      ->create();
+
+    $shareVisibility = $this->diContainer->get(ShareVisibility::class);
+
+    verify($shareVisibility->canShare($draft))->false();
+    verify($shareVisibility->canShare($notificationHistory))->false();
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/UrlTest.php
+++ b/mailpoet/tests/integration/Newsletter/UrlTest.php
@@ -5,7 +5,9 @@ namespace MailPoet\Test\Newsletter;
 use MailPoet\Entities\NewsletterEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\Url as NewsletterUrl;
+use MailPoet\Test\DataFactories\Newsletter;
 use MailPoet\Util\Security;
+use MailPoet\WP\Functions as WPFunctions;
 
 class UrlTest extends \MailPoetTest {
   public function testPreviewUrlIsTheSameForNullOrEmptySubscriber() {
@@ -22,5 +24,82 @@ class UrlTest extends \MailPoetTest {
     $urlEmptySubscriber = $newsletterUrl->getViewInBrowserUrl($newsletter, $emptySubscriber);
 
     verify($urlNullSubscriber)->equals($urlEmptySubscriber);
+  }
+
+  public function testItBuildsPublicShareUrlWithNewsletterHashAndSlug() {
+    $this->diContainer->get(WPFunctions::class)->updateOption('permalink_structure', '/%postname%/');
+    $newsletter = (new Newsletter())
+      ->withSubject('Spring Sale & Updates')
+      ->withSentStatus()
+      ->create();
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+
+    $url = $newsletterUrl->getPublicShareUrl($newsletter);
+    $identifier = sprintf('%s-spring-sale-updates', $newsletter->getHash());
+
+    verify(parse_url($url, PHP_URL_PATH))->equals(sprintf('/mailpoet-email/%s/', $identifier));
+  }
+
+  public function testItBuildsPublicShareUrlFallbackForPlainPermalinks() {
+    $this->diContainer->get(WPFunctions::class)->updateOption('permalink_structure', '');
+    $newsletter = (new Newsletter())
+      ->withSubject('Plain Permalinks')
+      ->withSentStatus()
+      ->create();
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+
+    $url = $newsletterUrl->getPublicShareUrl($newsletter);
+    $identifier = sprintf('%s-plain-permalinks', $newsletter->getHash());
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $queryParams);
+
+    verify($queryParams)->equals(['mailpoet_public_email' => $identifier]);
+  }
+
+  public function testItRespectsThePublicSharePrefixFilter() {
+    $this->diContainer->get(WPFunctions::class)->updateOption('permalink_structure', '/%postname%/');
+    $newsletter = (new Newsletter())
+      ->withSubject('Filtered')
+      ->withSentStatus()
+      ->create();
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+
+    $filter = function () {
+      return '/share/email/';
+    };
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->addFilter('mailpoet_public_share_url_prefix', $filter);
+
+    try {
+      verify($newsletterUrl->getPublicSharePathPrefix())->equals('/share/email/');
+      verify($newsletterUrl->getPublicShareUrl($newsletter))
+        ->stringContainsString(sprintf('/share/email/%s-filtered/', $newsletter->getHash()));
+    } finally {
+      $wp->removeFilter('mailpoet_public_share_url_prefix', $filter);
+    }
+  }
+
+  public function testItIgnoresInvalidPublicSharePrefixFilter() {
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+
+    $filter = function () {
+      return '/bad prefix?/';
+    };
+    $wp = $this->diContainer->get(WPFunctions::class);
+    $wp->addFilter('mailpoet_public_share_url_prefix', $filter);
+
+    try {
+      verify($newsletterUrl->getPublicSharePathPrefix())->equals('/mailpoet-email/');
+    } finally {
+      $wp->removeFilter('mailpoet_public_share_url_prefix', $filter);
+    }
+  }
+
+  public function testItReturnsEmptyPublicShareUrlWhenNewsletterHasNoHash() {
+    $newsletter = (new Newsletter())->create();
+    $newsletter->setHash(null);
+    $newsletterUrl = $this->diContainer->get(NewsletterUrl::class);
+
+    verify($newsletterUrl->getPublicShareUrl($newsletter))->equals('');
+    verify($newsletterUrl->getPublicShareUrl(null))->equals('');
   }
 }

--- a/mailpoet/tests/integration/Newsletter/UrlTest.php
+++ b/mailpoet/tests/integration/Newsletter/UrlTest.php
@@ -37,7 +37,7 @@ class UrlTest extends \MailPoetTest {
     $url = $newsletterUrl->getPublicShareUrl($newsletter);
     $identifier = sprintf('%s-spring-sale-updates', $newsletter->getHash());
 
-    verify(parse_url($url, PHP_URL_PATH))->equals(sprintf('/mailpoet-email/%s/', $identifier));
+    verify($url)->equals(home_url(sprintf('/mailpoet-email/%s/', $identifier)));
   }
 
   public function testItBuildsPublicShareUrlFallbackForPlainPermalinks() {

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -255,4 +255,15 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     verify($renderedBody)->stringNotContainsString('[mailpoet_click_data]');
     verify($renderedBody)->stringNotContainsString('[mailpoet_open_data]');
   }
+
+  public function testItRendersPublicShareWithoutQueueInPreviewFallbackMode() {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
+
+    $renderedBody = $this->viewInBrowserRenderer->renderPublicShare($this->newsletter, null);
+
+    verify($renderedBody)->stringContainsString('Rendered newsletter. Hello, reader');
+    verify($renderedBody)->stringContainsString($this->diContainer->get(NewsletterUrl::class)->getPublicShareUrl($this->newsletter));
+    verify($renderedBody)->stringNotContainsString(Router::NAME . '&endpoint=track');
+    verify($renderedBody)->stringNotContainsString(Router::NAME . '&endpoint=view_in_browser');
+  }
 }

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserRendererTest.php
@@ -13,6 +13,7 @@ use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Renderer\Renderer;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Shortcodes\Shortcodes;
+use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Router\Router;
 use MailPoet\Settings\SettingsController;
 use MailPoet\Settings\TrackingConfig;
@@ -171,6 +172,7 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
       $this->diContainer->get(Shortcodes::class),
       $this->diContainer->get(Renderer::class),
       $this->diContainer->get(Links::class),
+      $this->diContainer->get(NewsletterUrl::class),
     );
     $renderedBody = $viewInBrowser->render(
       $preview = false,
@@ -235,5 +237,22 @@ class ViewInBrowserRendererTest extends \MailPoetTest {
     // open tracking data tag should be removed
     verify($renderedBody)->stringNotContainsString('[mailpoet_open_data]');
     verify($renderedBody)->stringContainsString('<img alt="" class="" src="">');
+  }
+
+  public function testItRendersPublicShareWithoutRecipientTracking() {
+    $this->settings->set('tracking.level', TrackingConfig::LEVEL_PARTIAL);
+    $queue = $this->sendingQueue;
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+    $queue->setNewsletterRenderedBody($this->queueRenderedNewsletterWithTracking);
+
+    $renderedBody = $this->viewInBrowserRenderer->renderPublicShare($this->newsletter, $queue);
+
+    verify($renderedBody)->stringContainsString('Hello, reader');
+    verify($renderedBody)->stringContainsString($this->diContainer->get(NewsletterUrl::class)->getPublicShareUrl($this->newsletter));
+    verify($renderedBody)->stringContainsString('<a href="http://google.com">');
+    verify($renderedBody)->stringNotContainsString(Router::NAME . '&endpoint=track');
+    verify($renderedBody)->stringNotContainsString(Router::NAME . '&endpoint=view_in_browser');
+    verify($renderedBody)->stringNotContainsString('[mailpoet_click_data]');
+    verify($renderedBody)->stringNotContainsString('[mailpoet_open_data]');
   }
 }


### PR DESCRIPTION
## Description

Adds the backend foundation for public sharing of sent standard newsletters using hash-based URLs, default-private visibility, canonical routing, noindex/no-cache safeguards, metadata injection, and public rendering that avoids subscriber tracking. This prepares the feature for follow-up UI and archive integration without exposing share links to customers by default.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7989

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="865" height="339" alt="Screenshot 2026-05-15 at 15 18 38" src="https://github.com/user-attachments/assets/ddfcafd6-1a57-4fba-9b8c-98e4b0903388" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7989-add-safe-public-share-urls-for-sent-emails)

_The latest successful build from `stomail-7989-add-safe-public-share-urls-for-sent-emails` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6757)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->