### PR TITLE
Allow creating segments with combined AND/OR conditions

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_common.scss
+++ b/mailpoet/assets/css/src/components-plugin/_common.scss
@@ -289,7 +289,7 @@ body .components-modal__screen-overlay {
 .mailpoet-admin-fields {
   column-gap: 24px;
   display: grid;
-  grid-template-columns: 328px auto;
+  grid-template-columns: 250px auto;
 
   @include respond-to(small-screen) {
     grid-template-columns: 1fr;
@@ -299,7 +299,7 @@ body .components-modal__screen-overlay {
     display: flex;
     flex-direction: column;
     gap: 24px;
-    padding: 40px;
+    padding: 24px;
   }
 }
 

--- a/mailpoet/assets/css/src/components-plugin/_segments.scss
+++ b/mailpoet/assets/css/src/components-plugin/_segments.scss
@@ -37,6 +37,25 @@
   }
 }
 
+.mailpoet-segments-filter-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.mailpoet-segments-filter-group-is-separated {
+  background: $color-grey-0;
+  border: 1px solid $color-tertiary-light;
+  border-radius: $grid-border-radius;
+  padding: 24px;
+  position: relative;
+}
+
+.mailpoet-segments-filter-group-actions {
+  display: flex;
+  gap: 16px;
+  padding-top: 16px;
+}
+
 .mailpoet-segments-description-section .mailpoet-form-textarea textarea {
   height: 100px;
 }
@@ -48,7 +67,7 @@
   height: 24px;
   justify-content: center;
   position: absolute;
-  right: 34px;
+  right: 16px;
   width: 24px;
 }
 
@@ -73,6 +92,10 @@
 
 .mailpoet-segments-condition-type-selector {
   padding-bottom: 40px;
+}
+
+.mailpoet-segments-filter-group .mailpoet-segments-condition-type-selector {
+  padding-bottom: 24px;
 }
 
 .mailpoet-segments-condition-type {

--- a/mailpoet/assets/js/src/segments/dynamic/form.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/form.tsx
@@ -18,12 +18,37 @@ import { isFormValid } from './validator';
 import { PrivacyProtectionNotice } from './privacy-protection-notice';
 import { storeName } from './store';
 
-import { FilterValue } from './types';
+import { FilterRow, FilterValue, Segment } from './types';
 
 interface Props {
   isNewSegment: boolean;
   newsletterId?: string;
 }
+
+interface FilterRowsGroup {
+  groupId: number;
+  rows: FilterRow[];
+}
+
+interface FilterGroupProps {
+  groupFilterRows: FilterRow[];
+  groupId: number;
+}
+
+const groupFilterRows = (
+  filterRows: FilterRow[],
+  segment: Segment,
+): FilterRowsGroup[] =>
+  filterRows.reduce((groups: FilterRowsGroup[], filterRow) => {
+    const groupId = segment.filters[filterRow.index]?.group_id ?? 0;
+    const group = groups.find((item) => item.groupId === groupId);
+    if (group) {
+      group.rows.push(filterRow);
+    } else {
+      groups.push({ groupId, rows: [filterRow] });
+    }
+    return groups;
+  }, []);
 
 const FiltersBefore = Hooks.applyFilters(
   'mailpoet_dynamic_segments_form_filters_before',
@@ -36,6 +61,14 @@ const FilterBefore = Hooks.applyFilters(
 const FilterAfter = Hooks.applyFilters(
   'mailpoet_dynamic_filters_filter_after',
   (): JSX.Element => <div className="mailpoet-gap" />,
+);
+const ConditionsBottom = Hooks.applyFilters(
+  'mailpoet_dynamic_segments_form_conditions_bottom',
+  (): FunctionComponent => null,
+);
+const FilterGroupBefore = Hooks.applyFilters(
+  'mailpoet_dynamic_segments_filter_group_before',
+  (): FunctionComponent<FilterGroupProps> => null,
 );
 
 export function Form({ isNewSegment, newsletterId }: Props): JSX.Element {
@@ -72,6 +105,10 @@ export function Form({ isNewSegment, newsletterId }: Props): JSX.Element {
     'mailpoet_dynamic_segments_form_add_condition_action',
     showPremiumModalOnClick,
   );
+  const groupedFilterRows = Array.isArray(filterRows)
+    ? groupFilterRows(filterRows, segment)
+    : [];
+  const hasMultipleFilterGroups = groupedFilterRows.length > 1;
 
   return (
     <div className="mailpoet-form-container">
@@ -128,51 +165,89 @@ export function Form({ isNewSegment, newsletterId }: Props): JSX.Element {
           <FieldWrapper>
             <div className="mailpoet-segments-segments-section">
               <FiltersBefore />
-              {Array.isArray(filterRows) &&
-                filterRows.map((filterRow, index) => (
-                  <Fragment key={filterRow.index}>
-                    <div
-                      className="mailpoet-segments-grid"
-                      data-automation-id={`filter-row-${index}`}
-                    >
-                      <FilterBefore filterRows={filterRows} index={index} />
-                      <div className="mailpoet-segments-filter-selector">
-                        <ReactSelect
-                          dimension="small"
-                          placeholder={__('Select action', 'mailpoet')}
-                          options={segmentFilters}
-                          value={filterRow.filterValue}
-                          onChange={(newValue: FilterValue): void => {
-                            void updateSegmentFilter(
-                              {
-                                segmentType: newValue.group,
-                                action: newValue.value,
-                              },
-                              index,
-                            );
-                          }}
-                          automationId="select-segment-action"
-                          isFullWidth
-                        />
-                      </div>
-                      {filterRow.index !== undefined && (
-                        <FormFilterFields filterIndex={filterRow.index} />
-                      )}
+              {groupedFilterRows.map((filterRowsGroup, groupIndex) => (
+                <Fragment key={filterRowsGroup.groupId}>
+                  <div
+                    className={`mailpoet-segments-filter-group${
+                      hasMultipleFilterGroups
+                        ? ' mailpoet-segments-filter-group-is-separated'
+                        : ''
+                    }`}
+                    data-automation-id={`filter-group-${filterRowsGroup.groupId}`}
+                  >
+                    <FilterGroupBefore
+                      groupFilterRows={filterRowsGroup.rows}
+                      groupId={filterRowsGroup.groupId}
+                    />
+                    {filterRowsGroup.rows.map((filterRow, rowIndex) => (
+                      <Fragment key={filterRow.index}>
+                        <div
+                          className="mailpoet-segments-grid"
+                          data-automation-id={`filter-row-${filterRow.index}`}
+                        >
+                          <FilterBefore
+                            filterRows={filterRows}
+                            groupFilterRows={filterRowsGroup.rows}
+                            groupId={filterRowsGroup.groupId}
+                            index={filterRow.index}
+                          />
+                          <div className="mailpoet-segments-filter-selector">
+                            <ReactSelect
+                              dimension="small"
+                              placeholder={__('Select action', 'mailpoet')}
+                              options={segmentFilters}
+                              value={filterRow.filterValue}
+                              onChange={(newValue: FilterValue): void => {
+                                void updateSegmentFilter(
+                                  {
+                                    segmentType: newValue.group,
+                                    action: newValue.value,
+                                  },
+                                  filterRow.index,
+                                );
+                              }}
+                              automationId="select-segment-action"
+                              isFullWidth
+                            />
+                          </div>
+                          {filterRow.index !== undefined && (
+                            <FormFilterFields filterIndex={filterRow.index} />
+                          )}
+                        </div>
+                        {rowIndex < filterRowsGroup.rows.length - 1 && (
+                          <FilterAfter index={filterRow.index} />
+                        )}
+                      </Fragment>
+                    ))}
+                    <div className="mailpoet-segments-filter-group-actions">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={(e): void => {
+                          e.preventDefault();
+                          addConditionAction(
+                            segment,
+                            updateSegment,
+                            filterRowsGroup.groupId,
+                          );
+                        }}
+                      >
+                        {__('Add a condition', 'mailpoet')}
+                      </Button>
                     </div>
-                    <FilterAfter index={index} />
-                  </Fragment>
-                ))}
+                  </div>
+                  {groupIndex < groupedFilterRows.length - 1 && (
+                    <FilterAfter
+                      index={
+                        filterRowsGroup.rows[filterRowsGroup.rows.length - 1]
+                          .index
+                      }
+                    />
+                  )}
+                </Fragment>
+              ))}
               <div className="mailpoet-segments-conditions-bottom">
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={(e): void => {
-                    e.preventDefault();
-                    addConditionAction(segment, updateSegment);
-                  }}
-                >
-                  {__('Add a condition', 'mailpoet')}
-                </Button>
+                <ConditionsBottom />
 
                 {(!MailPoet.premiumActive ||
                   !MailPoet.hasValidPremiumKey ||

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -83,6 +83,8 @@ export interface FormItem {
   id?: number;
   segmentType?: string;
   action?: string;
+  group_id?: number;
+  group_operator?: SegmentConnectTypes;
 }
 
 export interface DateFormItem extends FormItem {

--- a/mailpoet/changelog/2026-05-15-20-58-39-added-combine-segment-filter-conditions-into-groups-with.md
+++ b/mailpoet/changelog/2026-05-15-20-58-39-added-combine-segment-filter-conditions-into-groups-with.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Combine segment filter conditions into groups with mixed AND/OR logic

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -271,18 +271,17 @@ class SegmentEntity {
     }
 
     $groups = [];
+    $legacyGroupKey = 0;
     foreach ($filters as $filter) {
       $data = $filter->getFilterData();
       if (!$data) {
         continue;
       }
       $groupId = $data->getParam('group_id');
-      if (!is_int($groupId) && !is_numeric($groupId)) {
-        continue;
-      }
-      $groupKey = (int)$groupId;
+      $hasNumericGroupId = is_int($groupId) || is_numeric($groupId);
+      $groupKey = $hasNumericGroupId ? (int)$groupId : $legacyGroupKey;
       if (!isset($groups[$groupKey])) {
-        $operator = $data->getParam('group_operator');
+        $operator = $hasNumericGroupId ? $data->getParam('group_operator') : $this->getFiltersConnectOperator();
         $groups[$groupKey] = [
           'operator' => is_string($operator) && $operator !== '' ? $operator : DynamicSegmentFilterData::CONNECT_TYPE_AND,
           'filters' => [],

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -277,7 +277,10 @@ class SegmentEntity {
         continue;
       }
       $groupId = $data->getParam('group_id');
-      $groupKey = is_int($groupId) ? $groupId : (int)$groupId;
+      if (!is_int($groupId) && !is_numeric($groupId)) {
+        continue;
+      }
+      $groupKey = (int)$groupId;
       if (!isset($groups[$groupKey])) {
         $operator = $data->getParam('group_operator');
         $groups[$groupKey] = [

--- a/mailpoet/lib/Entities/SegmentEntity.php
+++ b/mailpoet/lib/Entities/SegmentEntity.php
@@ -223,6 +223,11 @@ class SegmentEntity {
 
   /**
    * Returns connect operand from the first filter, when doesn't exist, then returns a default value.
+   *
+   * For segments with multiple filter groups this is the outer connector between the groups
+   * (and/or). For legacy single-group segments it carries the within-group operator
+   * (and/or/none).
+   *
    * @return string
    */
   public function getFiltersConnectOperator(): string {
@@ -233,5 +238,57 @@ class SegmentEntity {
     }
     $connect = $filterData->getParam('connect');
     return is_string($connect) && $connect !== '' ? $connect : DynamicSegmentFilterData::CONNECT_TYPE_AND;
+  }
+
+  /**
+   * Returns dynamic filters grouped by their group_id.
+   *
+   * Legacy filters (no group_id) collapse into a single group whose operator is the
+   * legacy filters_connect value. Saved groups carry their own group_operator.
+   *
+   * @return array<int, array{operator: string, filters: DynamicSegmentFilterEntity[]}>
+   */
+  public function getFilterGroups(): array {
+    $filters = $this->getDynamicFilters()->toArray();
+    if (!$filters) {
+      return [];
+    }
+
+    $hasGroupData = false;
+    foreach ($filters as $filter) {
+      $data = $filter->getFilterData();
+      if ($data && $data->getParam('group_id') !== null) {
+        $hasGroupData = true;
+        break;
+      }
+    }
+
+    if (!$hasGroupData) {
+      return [[
+        'operator' => $this->getFiltersConnectOperator(),
+        'filters' => array_values($filters),
+      ]];
+    }
+
+    $groups = [];
+    foreach ($filters as $filter) {
+      $data = $filter->getFilterData();
+      if (!$data) {
+        continue;
+      }
+      $groupId = $data->getParam('group_id');
+      $groupKey = is_int($groupId) ? $groupId : (int)$groupId;
+      if (!isset($groups[$groupKey])) {
+        $operator = $data->getParam('group_operator');
+        $groups[$groupKey] = [
+          'operator' => is_string($operator) && $operator !== '' ? $operator : DynamicSegmentFilterData::CONNECT_TYPE_AND,
+          'filters' => [],
+        ];
+      }
+      $groups[$groupKey]['filters'][] = $filter;
+    }
+
+    ksort($groups);
+    return array_values($groups);
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Exceptions/InvalidFilterException.php
@@ -24,4 +24,7 @@ class InvalidFilterException extends InvalidStateException {
   const MISSING_SINGLE_ORDER_VALUE_FIELDS = 17;
   const MISSING_AVERAGE_SPENT_FIELDS = 18;
   const MISSING_VARIATION_ID = 19;
+  const TOO_MANY_GROUPS = 20;
+  const TOO_MANY_FILTERS_PER_GROUP = 21;
+  const INVALID_OUTER_CONNECTOR = 22;
 };

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -41,6 +41,9 @@ use MailPoet\Segments\DynamicSegments\Filters\WooCommerceUsedShippingMethod;
 use MailPoet\WP\Functions as WPFunctions;
 
 class FilterDataMapper {
+  public const MAX_GROUPS = 5;
+  public const MAX_FILTERS_PER_GROUP = 10;
+
   private WPFunctions $wp;
 
   private DateFilterHelper $dateFilterHelper;
@@ -81,9 +84,10 @@ class FilterDataMapper {
     if (!isset($data['filters']) || count($data['filters'] ?? []) < 1) {
       throw new InvalidFilterException('Filters are missing', InvalidFilterException::MISSING_FILTER);
     }
+    $this->validateGroups($data['filters'], $data['filters_connect'] ?? null);
     $processFilter = function ($filter, $data) {
       $filter['connect'] = $data['filters_connect'] ?? DynamicSegmentFilterData::CONNECT_TYPE_AND;
-      return $this->createFilter($filter);
+      return $this->withGroupingParams($this->createFilter($filter), $filter);
     };
     $wpFilterName = 'mailpoet_dynamic_segments_filters_map';
     if ($this->wp->hasFilter($wpFilterName)) {
@@ -96,6 +100,69 @@ class FilterDataMapper {
     }
     $filter = reset($data['filters']);
     return [$processFilter($filter, $data)];
+  }
+
+  /**
+   * @throws InvalidFilterException
+   */
+  private function validateGroups(array $filters, ?string $filtersConnect): void {
+    $groupCounts = [];
+    foreach ($filters as $filter) {
+      if (!isset($filter['group_id'])) {
+        continue;
+      }
+      $groupId = (int)$filter['group_id'];
+      $groupCounts[$groupId] = ($groupCounts[$groupId] ?? 0) + 1;
+    }
+    if (count($groupCounts) > self::MAX_GROUPS) {
+      throw new InvalidFilterException(
+        'Too many filter groups (max ' . self::MAX_GROUPS . ')',
+        InvalidFilterException::TOO_MANY_GROUPS
+      );
+    }
+    foreach ($groupCounts as $count) {
+      if ($count > self::MAX_FILTERS_PER_GROUP) {
+        throw new InvalidFilterException(
+          'Too many filters in a group (max ' . self::MAX_FILTERS_PER_GROUP . ')',
+          InvalidFilterException::TOO_MANY_FILTERS_PER_GROUP
+        );
+      }
+    }
+    if (count($groupCounts) > 1 && $filtersConnect === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
+      throw new InvalidFilterException(
+        'Outer connector must be and/or for grouped segments',
+        InvalidFilterException::INVALID_OUTER_CONNECTOR
+      );
+    }
+  }
+
+  /**
+   * Stamps group_id/group_operator from the raw filter row onto the constructed
+   * filter data so the entity can group filters at query time.
+   */
+  private function withGroupingParams(DynamicSegmentFilterData $filterData, array $rawFilter): DynamicSegmentFilterData {
+    if (!isset($rawFilter['group_id'])) {
+      return $filterData;
+    }
+    $existingData = $filterData->getData() ?? [];
+    $existingData['group_id'] = (int)$rawFilter['group_id'];
+    $existingData['group_operator'] = $this->normalizeGroupOperator($rawFilter['group_operator'] ?? null);
+    return new DynamicSegmentFilterData(
+      (string)$filterData->getFilterType(),
+      (string)$filterData->getAction(),
+      $existingData
+    );
+  }
+
+  private function normalizeGroupOperator($value): string {
+    if (
+      $value === DynamicSegmentFilterData::CONNECT_TYPE_AND
+      || $value === DynamicSegmentFilterData::CONNECT_TYPE_OR
+      || $value === DynamicSegmentFilterData::CONNECT_TYPE_NONE
+    ) {
+      return $value;
+    }
+    return DynamicSegmentFilterData::CONNECT_TYPE_AND;
   }
 
   private function createFilter(array $filterData): DynamicSegmentFilterData {

--- a/mailpoet/lib/Segments/DynamicSegments/FilterHandler.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterHandler.php
@@ -31,44 +31,116 @@ class FilterHandler {
   }
 
   public function apply(QueryBuilder $queryBuilder, SegmentEntity $segment): QueryBuilder {
-    $filters = $segment->getDynamicFilters();
-    $filterSelects = [];
+    $allFilters = $segment->getDynamicFilters();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-    $pluginsForAllFiltersMissing = $this->segmentDependencyValidator->getMissingPluginsByAllFilters($filters);
+    $pluginsForAllFiltersMissing = $this->segmentDependencyValidator->getMissingPluginsByAllFilters($allFilters);
     if ($pluginsForAllFiltersMissing) {
       return $queryBuilder->andWhere('1 = 0');
     }
-    $filtersConnectOperator = $segment->getFiltersConnectOperator();
-    foreach ($filters as $filter) {
-      $subscribersIdsQuery = $this->entityManager
-        ->getConnection()
-        ->createQueryBuilder()
-        ->select("DISTINCT $subscribersTable.id as inner_subscriber_id")
-        ->from($subscribersTable);
-      // When a required plugin is missing we want to return empty result
-      $missingPlugins = $this->segmentDependencyValidator->getMissingPluginsByFilter($filter);
-      if ($missingPlugins && $filtersConnectOperator === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
-        return $queryBuilder->andWhere('1 = 0');
+
+    $groups = $segment->getFilterGroups();
+    $builtGroups = [];
+    foreach ($groups as $group) {
+      $groupOperator = $group['operator'];
+      $filterSelects = [];
+      foreach ($group['filters'] as $filter) {
+        $subscribersIdsQuery = $this->entityManager
+          ->getConnection()
+          ->createQueryBuilder()
+          ->select("DISTINCT $subscribersTable.id as inner_subscriber_id")
+          ->from($subscribersTable);
+        // When a required plugin is missing inside a NONE group, we cannot evaluate the
+        // negation reliably — fail closed and return empty.
+        $missingPlugins = $this->segmentDependencyValidator->getMissingPluginsByFilter($filter);
+        if ($missingPlugins && $groupOperator === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
+          return $queryBuilder->andWhere('1 = 0');
+        }
+        if ($missingPlugins) {
+          $subscribersIdsQuery->andWhere('1 = 0');
+        } else {
+          $this->filterFactory->getFilterForFilterEntity($filter)->apply($subscribersIdsQuery, $filter);
+        }
+        $filterSelects[] = $subscribersIdsQuery->getSQL();
+        $queryBuilder->setParameters(
+          array_merge(
+            $subscribersIdsQuery->getParameters(),
+            $queryBuilder->getParameters()
+          ),
+          array_merge(
+            $subscribersIdsQuery->getParameterTypes(),
+            $queryBuilder->getParameterTypes()
+          )
+        );
       }
-      if ($missingPlugins) {
-        $subscribersIdsQuery->andWhere('1 = 0');
-      } else {
-        $this->filterFactory->getFilterForFilterEntity($filter)->apply($subscribersIdsQuery, $filter);
+      if ($filterSelects) {
+        $builtGroups[] = ['operator' => $groupOperator, 'selects' => $filterSelects];
       }
-      $filterSelects[] = $subscribersIdsQuery->getSQL();
-      $queryBuilder->setParameters(
-        array_merge(
-          $subscribersIdsQuery->getParameters(),
-          $queryBuilder->getParameters()
-        ),
-        array_merge(
-          $subscribersIdsQuery->getParameterTypes(),
-          $queryBuilder->getParameterTypes()
-        )
+    }
+
+    // Fast path: a single group — emit its filter subqueries directly via joinSubqueries
+    // with the group's own operator. Covers every legacy segment (which always collapses
+    // to one group) and avoids wrapping the filter selects in an extra derived table.
+    // Preserves the SQL shape MySQL was previously optimizing against.
+    if (count($builtGroups) === 1) {
+      $only = $builtGroups[0];
+      $this->joinSubqueries($queryBuilder, $only['operator'], $only['selects']);
+      return $queryBuilder;
+    }
+
+    $groupSelects = [];
+    foreach ($builtGroups as $built) {
+      $groupSelects[] = $this->combineGroupFilters($built['operator'], $built['selects'], $subscribersTable);
+    }
+
+    $outerOperator = $segment->getFiltersConnectOperator();
+    // Multi-group segments must use AND/OR as the outer connector — FilterDataMapper
+    // rejects NONE in that case. Coerce defensively in case unusual data slips through.
+    if ($outerOperator === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
+      $outerOperator = DynamicSegmentFilterData::CONNECT_TYPE_AND;
+    }
+    $this->joinSubqueries($queryBuilder, $outerOperator, $groupSelects);
+    return $queryBuilder;
+  }
+
+  /**
+   * Combines filter subqueries within a single group into one derived-table SQL string
+   * that yields `inner_subscriber_id` rows.
+   *
+   * @param string[] $filterSelects
+   */
+  private function combineGroupFilters(string $groupOperator, array $filterSelects, string $subscribersTable): string {
+    if ($groupOperator === DynamicSegmentFilterData::CONNECT_TYPE_NONE) {
+      $unionSql = join(' UNION ', $filterSelects);
+      return sprintf(
+        "SELECT %s.id AS inner_subscriber_id FROM %s LEFT JOIN (%s) excluded_subscribers ON excluded_subscribers.inner_subscriber_id = %s.id WHERE excluded_subscribers.inner_subscriber_id IS NULL",
+        $subscribersTable,
+        $subscribersTable,
+        $unionSql,
+        $subscribersTable
       );
     }
-    $this->joinSubqueries($queryBuilder, $filtersConnectOperator, $filterSelects);
-    return $queryBuilder;
+
+    if (count($filterSelects) === 1) {
+      return $filterSelects[0];
+    }
+
+    if ($groupOperator === DynamicSegmentFilterData::CONNECT_TYPE_OR) {
+      return join(' UNION ', $filterSelects);
+    }
+
+    // AND: chain INNER JOINs on inner_subscriber_id
+    $sql = sprintf('SELECT a0.inner_subscriber_id FROM (%s) a0', array_shift($filterSelects));
+    $index = 1;
+    foreach ($filterSelects as $filterSelect) {
+      $sql .= sprintf(
+        ' INNER JOIN (%s) a%d ON a%d.inner_subscriber_id = a0.inner_subscriber_id',
+        $filterSelect,
+        $index,
+        $index
+      );
+      $index++;
+    }
+    return $sql;
   }
 
   private function joinSubqueries(QueryBuilder $queryBuilder, string $filtersConnectOperator, array $subQueries): QueryBuilder {

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -1221,4 +1221,98 @@ class FilterDataMapperTest extends \MailPoetTest {
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
     ]);
   }
+
+  public function testItPropagatesGroupingParamsOntoFilterData(): void {
+    $data = [
+      'filters_connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
+      'filters' => [[
+        'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+        'action' => EmailAction::ACTION_OPENED,
+        'newsletters' => [1],
+        'group_id' => 2,
+        'group_operator' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
+      ]],
+    ];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'newsletters' => [1],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
+      'group_id' => 2,
+      'group_operator' => DynamicSegmentFilterData::CONNECT_TYPE_OR,
+    ]);
+  }
+
+  public function testItDefaultsInvalidGroupOperatorToAnd(): void {
+    $data = [
+      'filters' => [[
+        'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+        'action' => EmailAction::ACTION_OPENED,
+        'newsletters' => [1],
+        'group_id' => 0,
+        'group_operator' => 'bogus',
+      ]],
+    ];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    $filterData = $filter->getData();
+    $this->assertIsArray($filterData);
+    verify($filterData['group_operator'])->equals(DynamicSegmentFilterData::CONNECT_TYPE_AND);
+  }
+
+  public function testItRejectsTooManyGroups(): void {
+    $filters = [];
+    for ($i = 0; $i < FilterDataMapper::MAX_GROUPS + 1; $i++) {
+      $filters[] = [
+        'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+        'action' => EmailAction::ACTION_OPENED,
+        'newsletters' => [1],
+        'group_id' => $i,
+      ];
+    }
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::TOO_MANY_GROUPS);
+    $this->mapper->map(['filters' => $filters]);
+  }
+
+  public function testItRejectsTooManyFiltersInOneGroup(): void {
+    $filters = [];
+    for ($i = 0; $i < FilterDataMapper::MAX_FILTERS_PER_GROUP + 1; $i++) {
+      $filters[] = [
+        'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+        'action' => EmailAction::ACTION_OPENED,
+        'newsletters' => [1],
+        'group_id' => 0,
+      ];
+    }
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::TOO_MANY_FILTERS_PER_GROUP);
+    $this->mapper->map(['filters' => $filters]);
+  }
+
+  public function testItRejectsNoneAsOuterConnectorWhenMultipleGroups(): void {
+    $filters = [
+      [
+        'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+        'action' => EmailAction::ACTION_OPENED,
+        'newsletters' => [1],
+        'group_id' => 0,
+      ],
+      [
+        'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+        'action' => EmailAction::ACTION_OPENED,
+        'newsletters' => [2],
+        'group_id' => 1,
+      ],
+    ];
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_OUTER_CONNECTOR);
+    $this->mapper->map([
+      'filters' => $filters,
+      'filters_connect' => DynamicSegmentFilterData::CONNECT_TYPE_NONE,
+    ]);
+  }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterHandlerTest.php
@@ -175,6 +175,87 @@ class FilterHandlerTest extends \MailPoetTest {
     verify($result)->arrayCount(0);
   }
 
+  public function testItOrsTwoSingleFilterGroups(): void {
+    // Group 0: editor (s1, s3) — single filter, group operator irrelevant.
+    // Group 1: administrator (s2).
+    // Outer OR → {s1, s2, s3}.
+    $filterHandler = $this->getFilterHandlerWithoutMissingDependencies();
+    $segment = $this->getGroupedSegment(
+      [
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_AND, 'roles' => ['editor']],
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_AND, 'roles' => ['administrator']],
+      ],
+      DynamicSegmentFilterData::CONNECT_TYPE_OR
+    );
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    $result = $statement->fetchAll();
+
+    verify($this->getEmailsFromResult($result))->equals([
+      'user-role-test1@example.com',
+      'user-role-test2@example.com',
+      'user-role-test3@example.com',
+    ]);
+  }
+
+  public function testItAndsTwoSingleFilterGroupsToEmptyIntersection(): void {
+    // Group 0: editor → {s1, s3}. Group 1: administrator → {s2}. No overlap.
+    $filterHandler = $this->getFilterHandlerWithoutMissingDependencies();
+    $segment = $this->getGroupedSegment(
+      [
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_AND, 'roles' => ['editor']],
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_AND, 'roles' => ['administrator']],
+      ],
+      DynamicSegmentFilterData::CONNECT_TYPE_AND
+    );
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+    verify($statement->fetchAll())->arrayCount(0);
+  }
+
+  public function testItIntersectsNoneGroupWithAndGroup(): void {
+    // Group 0: NONE editor → {s2, s4} (everyone except editors).
+    // Group 1: administrator → {s2}.
+    // Outer AND → {s2}.
+    $filterHandler = $this->getFilterHandlerWithoutMissingDependencies();
+    $segment = $this->getGroupedSegment(
+      [
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_NONE, 'roles' => ['editor']],
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_AND, 'roles' => ['administrator']],
+      ],
+      DynamicSegmentFilterData::CONNECT_TYPE_AND
+    );
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+
+    verify($this->getEmailsFromResult($statement->fetchAll()))->equals([
+      'user-role-test2@example.com',
+    ]);
+  }
+
+  public function testItOrsAcrossNoneAndOrGroupsWithMultipleFiltersEach(): void {
+    // Group 0: OR editor, administrator → {s1, s2, s3}.
+    // Group 1: NONE editor, administrator → {s4}.
+    // Outer OR → {s1, s2, s3, s4}.
+    $filterHandler = $this->getFilterHandlerWithoutMissingDependencies();
+    $segment = $this->getGroupedSegment(
+      [
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_OR, 'roles' => ['editor', 'administrator']],
+        ['operator' => DynamicSegmentFilterData::CONNECT_TYPE_NONE, 'roles' => ['editor', 'administrator']],
+      ],
+      DynamicSegmentFilterData::CONNECT_TYPE_OR
+    );
+    $statement = $filterHandler->apply($this->getQueryBuilder(), $segment)->execute();
+    $this->assertInstanceOf(Result::class, $statement);
+
+    verify($this->getEmailsFromResult($statement->fetchAll()))->equals([
+      'user-role-test1@example.com',
+      'user-role-test2@example.com',
+      'user-role-test3@example.com',
+      'user-role-test4@example.com',
+    ]);
+  }
+
   /**
    * @param string[] $roles
    */
@@ -188,6 +269,29 @@ class FilterHandlerTest extends \MailPoetTest {
       $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $filterData);
       $segment->addDynamicFilter($dynamicSegmentFilter);
       $this->entityManager->persist($dynamicSegmentFilter);
+    }
+    $this->entityManager->persist($segment);
+    $this->entityManager->flush();
+    return $segment;
+  }
+
+  /**
+   * @param array<int, array{operator: string, roles: string[]}> $groupSpecs
+   */
+  private function getGroupedSegment(array $groupSpecs, string $outerConnect): SegmentEntity {
+    $segment = new SegmentEntity('Dynamic Segment', SegmentEntity::TYPE_DYNAMIC, 'description');
+    foreach ($groupSpecs as $groupId => $spec) {
+      foreach ($spec['roles'] as $role) {
+        $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, UserRole::TYPE, [
+          'wordpressRole' => $role,
+          'connect' => $outerConnect,
+          'group_id' => $groupId,
+          'group_operator' => $spec['operator'],
+        ]);
+        $dynamicSegmentFilter = new DynamicSegmentFilterEntity($segment, $filterData);
+        $segment->addDynamicFilter($dynamicSegmentFilter);
+        $this->entityManager->persist($dynamicSegmentFilter);
+      }
     }
     $this->entityManager->persist($segment);
     $this->entityManager->flush();

--- a/mailpoet/tests/performance/tests/segments-create-custom.js
+++ b/mailpoet/tests/performance/tests/segments-create-custom.js
@@ -78,7 +78,7 @@ export async function segmentsCreateCustom() {
 
     // Click to add a new segment action
     await page
-      .locator('div.mailpoet-segments-conditions-bottom > button')
+      .locator('.mailpoet-segments-filter-group-actions > button')
       .click();
 
     // Select "Subscribed date" action
@@ -97,7 +97,7 @@ export async function segmentsCreateCustom() {
 
     // Click to add a new segment action
     await page
-      .locator('div.mailpoet-segments-conditions-bottom > button')
+      .locator('.mailpoet-segments-filter-group-actions > button')
       .click();
 
     // WordPress user role action has been automatically added


### PR DESCRIPTION
## Description

Adds filter groups to segments so users can build `(A OR B) AND (C OR D)`-style segments — mix `AND/OR/NONE` within a group, then combine groups with `AND/OR`. 

## Code review notes

Backwards compatible: legacy filters collapse into a single group, and `FilterHandler` has a single-group fast path that preserves `trunk` SQL shape so existing segments don't regress.

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1070

## Linked tickets

STOMAIL-8021

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1111" height="859" alt="Screenshot 2026-05-15 at 22 12 28" src="https://github.com/user-attachments/assets/3fb7a414-7157-4558-bb5c-c89357810977" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8021-allow-creating-segments-with-combined-and-and-or-conditions)

_The latest successful build from `stomail-8021-allow-creating-segments-with-combined-and-and-or-conditions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->