### PR TITLE
 Show subscriber email on unsubscribe confirmation page

### DIFF
--- a/mailpoet/changelog/2026-05-15-21-55-52-improved-show-the-subscriber-email-address-on-the-unsubscri.md
+++ b/mailpoet/changelog/2026-05-15-21-55-52-improved-show-the-subscriber-email-address-on-the-unsubscri.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Show the subscriber email address on the unsubscribe confirmation page

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -170,6 +170,18 @@ class Pages {
     $this->wp->addFilter('the_content', [$this, 'setPageContent'], 10, 1);
     $this->wp->removeAction('wp_head', 'noindex', 1);
     $this->wp->addAction('wp_head', [$this, 'setMetaRobots'], 1);
+    $this->setSubscriptionPageHeaders();
+  }
+
+  private function setSubscriptionPageHeaders(): void {
+    if ($this->wp->headersSent()) {
+      return;
+    }
+    // Prevent the rendered subscriber email and other personal data on
+    // subscription pages from leaking via outbound link referrers, and stop
+    // archivers that honor HTTP headers but not <meta name="robots">.
+    header('X-Robots-Tag: noindex, nofollow');
+    header('Referrer-Policy: no-referrer');
   }
 
   public function initShortcodes() {

--- a/mailpoet/lib/Subscription/Pages.php
+++ b/mailpoet/lib/Subscription/Pages.php
@@ -567,6 +567,7 @@ class Pages {
     $unsubscribeUrl = $unsubscribeUrl . (parse_url($unsubscribeUrl, PHP_URL_QUERY) ? '&' : '?') . 'request_method=POST';
     $templateData = [
       'unsubscribeUrl' => $unsubscribeUrl,
+      'subscriberEmail' => $this->subscriber instanceof SubscriberEntity ? $this->subscriber->getEmail() : null,
     ];
     return $this->wp->applyFilters(
       'mailpoet_unsubscribe_confirmation_page',

--- a/mailpoet/tests/integration/Subscription/PagesTest.php
+++ b/mailpoet/tests/integration/Subscription/PagesTest.php
@@ -296,6 +296,15 @@ class PagesTest extends \MailPoetTest {
     verify($clickStat)->arrayCount(1);
   }
 
+  public function testItRendersSubscriberEmailOnConfirmUnsubscribePage() {
+    $pages = $this->getPages()->init(Pages::ACTION_CONFIRM_UNSUBSCRIBE, $this->testData);
+
+    $content = $pages->setPageContent('[mailpoet_page]');
+
+    verify($content)->stringContainsString('You are about to unsubscribe this email address:');
+    verify($content)->stringContainsString('jane.doe@example.com');
+  }
+
   public function testItRendersUnsubscribeReasonSurveyWhenEnabled() {
     SettingsController::getInstance()->set('subscription.unsubscribe_survey.enabled', '1');
     $pages = $this->getPages()->init('unsubscribe', $this->testData);

--- a/mailpoet/views/subscription/confirm_unsubscribe.html
+++ b/mailpoet/views/subscription/confirm_unsubscribe.html
@@ -2,6 +2,13 @@
 <form action="<%= unsubscribeUrl %>" method="post">
 <!--  if updating this hidden field form value, remember to update the corresponding logic in mailpoet/lib/Router/Endpoints/Subscription.php::addTypeParamToUnsubscribeUrl -->
   <input type="hidden" name="type" value="confirmation">
+  <% if subscriberEmail %>
+    <p class="mailpoet_confirm_unsubscribe_email">
+      <%= __('You are about to unsubscribe this email address:', 'mailpoet') %>
+      <br>
+      <strong><%= subscriberEmail|escape %></strong>
+    </p>
+  <% endif %>
   <p class="mailpoet_confirm_unsubscribe">
     <%= __('Simply click on this link to stop receiving emails from us.') %>
     <br>


### PR DESCRIPTION
## Description

Adds the subscriber email to the unsubscribe confirmation page and hardens subscription page responses with `Referrer-Policy: no-referrer` and `X-Robots-Tag: noindex, nofollow` so the address can't leak via referrers or archivers.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8089

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
|   <img width="596" height="358" alt="Screenshot 2026-05-16 at 22 58 23" src="https://github.com/user-attachments/assets/d5db528f-6a8c-4d05-95c3-c9aecdd1de09" />   |   <img width="675" height="452" alt="Screenshot 2026-05-16 at 22 58 02" src="https://github.com/user-attachments/assets/9f821c6c-eae7-437e-8cfd-4513f8e2c18e" />  |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8089-show-unsubscribe-email)

_The latest successful build from `stomail-8089-show-unsubscribe-email` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->