### PR TITLE
Add last subscribed date to subscriber exports

### DIFF
--- a/mailpoet/changelog/2026-05-15-22-01-26-improved-add-last-subscribed-date-to-subscriber-exports.md
+++ b/mailpoet/changelog/2026-05-15-22-01-26-improved-add-last-subscribed-date-to-subscriber-exports.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Add last subscribed date to subscriber exports

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportFactory.php
@@ -69,6 +69,7 @@ class ImportExportFactory {
       $fields = array_merge(
         $fields,
         [
+          'last_subscribed_at' => __('Last subscribed on', 'mailpoet'),
           'list_status' => _x('List status', 'Subscription status', 'mailpoet'),
           'global_status' => _x('Global status', 'Subscription status', 'mailpoet'),
         ]
@@ -83,7 +84,7 @@ class ImportExportFactory {
         'id' => $fieldId,
         'name' => $fieldName,
         'text' => $fieldName, // Required for select2 default functionality
-        'type' => ($fieldId === 'confirmed_at' || $fieldId === 'created_at') ? 'date' : null,
+        'type' => in_array($fieldId, ['confirmed_at', 'created_at', 'last_subscribed_at'], true) ? 'date' : null,
         'custom' => false,
       ];
     }, array_keys($subscriberFields), $subscriberFields);

--- a/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
+++ b/mailpoet/lib/Subscribers/ImportExport/ImportExportRepository.php
@@ -268,6 +268,7 @@ class ImportExportRepository {
         {$subscriberTable}.confirmed_at,
         {$subscriberTable}.confirmed_ip,
         {$subscriberTable}.created_at,
+        {$subscriberTable}.last_subscribed_at,
         {$subscriberTable}.status AS global_status,
         {$subscriberSegmentTable}.status AS list_status
       ")

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportFactoryTest.php
@@ -155,6 +155,7 @@ class ImportExportFactoryTest extends \MailPoetTest {
       'list_status',
       'global_status',
       'subscribed_ip',
+      'last_subscribed_at',
     ];
     foreach ($exportFields as $field) {
       verify(in_array($field, array_keys($subsriberFields)))->true();
@@ -177,6 +178,17 @@ class ImportExportFactoryTest extends \MailPoetTest {
         ->true();
     }
     verify($formattedSubscriberFields[0]['custom'])->false();
+    $this->importFactory->action = 'export';
+    $formattedSubscriberFields = $this->importFactory->formatSubscriberFields(
+      $this->importFactory->getSubscriberFields()
+    );
+    foreach ($formattedSubscriberFields as $field) {
+      if ($field['id'] === 'last_subscribed_at') {
+        verify($field['type'])->equals('date');
+        return;
+      }
+    }
+    $this->fail('Last subscribed field not found.');
   }
 
   public function testItCanGetSubscriberCustomFields() {

--- a/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
+++ b/mailpoet/tests/integration/Subscribers/ImportExport/ImportExportRepositoryTest.php
@@ -244,12 +244,16 @@ class ImportExportRepositoryTest extends \MailPoetTest {
   public function testItGetSubscribersByDefaultSegment(): void {
     $confirmedAt = Carbon::createFromFormat(DateTime::DEFAULT_DATE_TIME_FORMAT, '2021-02-12 12:11:00');
     $this->assertInstanceOf(Carbon::class, $confirmedAt);
+    $lastSubscribedAt = Carbon::createFromFormat(DateTime::DEFAULT_DATE_TIME_FORMAT, '2021-02-13 13:12:00');
+    $this->assertInstanceOf(Carbon::class, $lastSubscribedAt);
     $confirmedIp = '122.122.122.122';
     $subscribedIp = '123.123.123.123';
     $user1 = $this->createSubscriber('user1@export-test.com', 'One', 'User');
     $user1->setConfirmedAt($confirmedAt->toDateTime());
+    $user1->setLastSubscribedAt($lastSubscribedAt->toDateTime());
     $user1->setConfirmedIp($confirmedIp);
     $user1->setSubscribedIp($subscribedIp);
+    $this->subscribersRepository->flush();
     $user2 = $this->createSubscriber('user2@export-test.com', 'Two', 'User');
     $user3 = $this->createSubscriber('user3@export-test.com', 'Three', 'User');
     $segment1 = $this->createSegment('First', SegmentEntity::TYPE_DEFAULT);
@@ -266,6 +270,7 @@ class ImportExportRepositoryTest extends \MailPoetTest {
     verify($exported[0]['segment_name'])->equals('First');
     verify($exported[0]['confirmed_at'])->equals($confirmedAt);
     verify($exported[0]['created_at'])->equals($user1->getCreatedAt());
+    verify($exported[0]['last_subscribed_at'])->equals($lastSubscribedAt);
     verify($exported[0]['confirmed_ip'])->equals($confirmedIp);
     verify($exported[0]['subscribed_ip'])->equals($subscribedIp);
     verify($exported[1]['first_name'])->equals('Two');


### PR DESCRIPTION
## Description

Adds `last_subscribed_at` as a selectable date column on the subscriber export screen (CSV/XLSX), reusing the existing column already present on the subscribers table.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8090

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8090-add-last-subscribed-export)

_The latest successful build from `stomail-8090-add-last-subscribed-export` will be used. If none is available, the link won't work._