### PR TITLE
Add public share toolbar and archive integration

### DIFF
--- a/mailpoet/assets/js/src/settings/store/normalize-settings.ts
+++ b/mailpoet/assets/js/src/settings/store/normalize-settings.ts
@@ -139,7 +139,7 @@ export function normalizeSettings(data: Record<string, unknown>): Settings {
     analytics: asObject({ enabled: disabledRadio }),
     collect_subscriber_timezones: asObject({ enabled: enabledRadio }),
     sharing: asObject({
-      default_visibility: asEnum(['public', 'private'], 'private'),
+      default_visibility: asEnum(['public', 'private'], 'public'),
     }),
     '3rd_party_libs': asObject({ enabled: disabledRadio }),
     captcha: asObject({

--- a/mailpoet/changelog/2026-04-28-20-46-43-added-add-public-sharing-bars-and-archive-links-for-emai.md
+++ b/mailpoet/changelog/2026-04-28-20-46-43-added-add-public-sharing-bars-and-archive-links-for-emai.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Public sharing bars and archive links for emails; sent emails are public by default and the default can be changed in Settings → Advanced → Email sharing visibility, with a per-email override on each email's settings

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -278,13 +278,16 @@ class Shortcodes {
     $shortcodeProcessor->setSubscriber($subscriber);
     $shortcodeProcessor->setQueue($queue);
     $subject = (string)$shortcodeProcessor->replace($queue ? $queue->getNewsletterRenderedSubject() : '');
-    if (!$this->shareVisibility->canShare($newsletter)) {
-      return $this->wp->escHtml($subject);
+    if ($newsletter->getType() === NewsletterEntity::TYPE_STANDARD && $this->shareVisibility->canShare($newsletter)) {
+      $previewUrl = $this->newsletterUrl->getPublicShareUrl($newsletter);
+      $linkTitle = __('Read in a new tab', 'mailpoet');
+    } else {
+      $previewUrl = $this->newsletterUrl->getViewInBrowserUrl($newsletter, $subscriber, $queue);
+      $linkTitle = __('Preview in a new tab', 'mailpoet');
     }
 
-    $previewUrl = $this->newsletterUrl->getPublicShareUrl($newsletter);
     return '<a href="' . $this->wp->escUrl($previewUrl) . '" target="_blank" rel="noopener noreferrer" title="'
-      . $this->wp->escAttr(__('Read in a new tab', 'mailpoet')) . '">'
+      . $this->wp->escAttr($linkTitle) . '">'
       . $this->wp->escHtml($subject) .
       '</a>';
   }

--- a/mailpoet/lib/Config/Shortcodes.php
+++ b/mailpoet/lib/Config/Shortcodes.php
@@ -7,6 +7,7 @@ use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Form\Widget;
 use MailPoet\Newsletter\NewslettersRepository;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Shortcodes\Categories\Date;
 use MailPoet\Newsletter\Shortcodes\Categories\Link;
 use MailPoet\Newsletter\Shortcodes\Categories\Newsletter;
@@ -41,6 +42,9 @@ class Shortcodes {
   /** @var NewslettersRepository */
   private $newslettersRepository;
 
+  /** @var ShareVisibility */
+  private $shareVisibility;
+
   /** @var Date */
   private $dateCategory;
 
@@ -63,6 +67,7 @@ class Shortcodes {
     SubscribersRepository $subscribersRepository,
     NewsletterUrl $newsletterUrl,
     NewslettersRepository $newslettersRepository,
+    ShareVisibility $shareVisibility,
     Date $dateCategory,
     Link $linkCategory,
     Newsletter $newsletterCategory,
@@ -75,6 +80,7 @@ class Shortcodes {
     $this->subscribersRepository = $subscribersRepository;
     $this->newsletterUrl = $newsletterUrl;
     $this->newslettersRepository = $newslettersRepository;
+    $this->shareVisibility = $shareVisibility;
     $this->dateCategory = $dateCategory;
     $this->linkCategory = $linkCategory;
     $this->newsletterCategory = $newsletterCategory;
@@ -253,7 +259,6 @@ class Shortcodes {
       $subscriber = new SubscriberEntity();
     }
 
-    $previewUrl = $this->newsletterUrl->getViewInBrowserUrl($newsletter, $subscriber, $queue);
     /**
      * An ugly workaround to make sure state is not shared via NewsletterShortcodes service
      * This should be replaced with injected service when state is removed from this service
@@ -272,9 +277,15 @@ class Shortcodes {
 
     $shortcodeProcessor->setSubscriber($subscriber);
     $shortcodeProcessor->setQueue($queue);
-    return '<a href="' . esc_attr($previewUrl) . '" target="_blank" title="'
-      . esc_attr(__('Preview in a new tab', 'mailpoet')) . '">'
-      . esc_attr((string)$shortcodeProcessor->replace($queue ? $queue->getNewsletterRenderedSubject() : '')) .
+    $subject = (string)$shortcodeProcessor->replace($queue ? $queue->getNewsletterRenderedSubject() : '');
+    if (!$this->shareVisibility->canShare($newsletter)) {
+      return $this->wp->escHtml($subject);
+    }
+
+    $previewUrl = $this->newsletterUrl->getPublicShareUrl($newsletter);
+    return '<a href="' . $this->wp->escUrl($previewUrl) . '" target="_blank" rel="noopener noreferrer" title="'
+      . $this->wp->escAttr(__('Read in a new tab', 'mailpoet')) . '">'
+      . $this->wp->escHtml($subject) .
       '</a>';
   }
 }

--- a/mailpoet/lib/Newsletter/Sharing/PublicEmailController.php
+++ b/mailpoet/lib/Newsletter/Sharing/PublicEmailController.php
@@ -70,6 +70,7 @@ class PublicEmailController {
     $queue = $this->sendingQueuesRepository->findLatestCompletedByNewsletter($newsletter);
     $canonicalUrl = $this->getCanonicalUrl($newsletter);
     $html = $this->viewInBrowserRenderer->renderPublicShare($newsletter, $queue);
+    $html = $this->shareMetadataBuilder->injectShareToolbar($html, $newsletter, $canonicalUrl);
     return $this->shareMetadataBuilder->injectMetadata($html, $newsletter, $canonicalUrl);
   }
 }

--- a/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
+++ b/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
@@ -31,8 +31,15 @@ class ShareMetadataBuilder {
     return substr_replace($html, $metadata . "\n", $position, 0);
   }
 
-  public function injectShareToolbar(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
-    return $this->injectAfterBodyOpen($html, $this->buildShareToolbar($newsletter, $canonicalUrl));
+  /**
+   * Inject the share toolbar right after <body>. Pass $replaceStateUrl when the
+   * current URL carries subscriber-specific data (e.g. a tokenised view-in-browser
+   * link) — the toolbar's JS will rewrite the address bar to that URL on load so
+   * the subscriber's token isn't shared by accident if they copy from the bar
+   * or use their browser's share menu.
+   */
+  public function injectShareToolbar(string $html, NewsletterEntity $newsletter, string $canonicalUrl, string $replaceStateUrl = ''): string {
+    return $this->injectAfterBodyOpen($html, $this->buildShareToolbar($newsletter, $canonicalUrl, $replaceStateUrl));
   }
 
   public function buildMetadata(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
@@ -70,7 +77,7 @@ class ShareMetadataBuilder {
     return implode("\n", $tags);
   }
 
-  private function buildShareToolbar(NewsletterEntity $newsletter, string $canonicalUrl): string {
+  private function buildShareToolbar(NewsletterEntity $newsletter, string $canonicalUrl, string $replaceStateUrl): string {
     $title = __('Share this email', 'mailpoet');
     $description = __('Copy the public link or share it on your favorite channel.', 'mailpoet');
     $emailTitle = $newsletter->getCampaignNameOrSubject() ?: __('Email', 'mailpoet');
@@ -78,6 +85,11 @@ class ShareMetadataBuilder {
     $shareLabel = _x('Share', 'Web Share button label', 'mailpoet');
     $encodedUrl = rawurlencode($canonicalUrl);
     $encodedTitle = rawurlencode($emailTitle);
+
+    $hostAttrs = ' data-mailpoet-share-host';
+    if ($replaceStateUrl !== '') {
+      $hostAttrs .= ' data-mailpoet-share-replace-state="' . $this->wp->escAttr($replaceStateUrl) . '"';
+    }
 
     $toolbar = $this->buildShareToolbarStyles()
       . '<div class="mailpoet-share-toolbar" role="region" aria-label="' . $this->wp->escAttr($title) . '">'
@@ -101,7 +113,7 @@ class ShareMetadataBuilder {
       . $this->buildShareToolbarLink('email', $this->wp->escUrl('mailto:?subject=' . $encodedTitle . '&body=' . $encodedUrl), __('Email', 'mailpoet'), true)
       . '</div></div></div></div>';
 
-    return '<div data-mailpoet-share-host>' . $toolbar . '</div>' . $this->buildShareToolbarScript();
+    return '<div' . $hostAttrs . '>' . $toolbar . '</div>' . $this->buildShareToolbarScript();
   }
 
   private function buildShareToolbarCopyButton(string $canonicalUrl, string $copyLabel): string {
@@ -179,6 +191,8 @@ class ShareMetadataBuilder {
     return '<script>'
       . '(function(){'
       . 'var hosts=document.querySelectorAll("[data-mailpoet-share-host]");'
+      // Replace state once if any host asks us to scrub a tokenised URL from the address bar.
+      . 'for(var r=0;r<hosts.length;r++){var replace=hosts[r].getAttribute("data-mailpoet-share-replace-state");if(replace&&window.history&&typeof window.history.replaceState==="function"){try{window.history.replaceState(null,document.title,replace);}catch(error){}break;}}'
       . 'function copyUrl(url){'
       . 'if(navigator.clipboard&&window.isSecureContext){return navigator.clipboard.writeText(url);}'
       . 'var input=document.createElement("textarea");'

--- a/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
+++ b/mailpoet/lib/Newsletter/Sharing/ShareMetadataBuilder.php
@@ -7,6 +7,8 @@ use MailPoet\Util\pQuery\pQuery;
 use MailPoet\WP\Functions as WPFunctions;
 
 class ShareMetadataBuilder {
+  private const COPY_BUTTON_ATTRIBUTE = 'data-mailpoet-share-copy';
+
   /** @var WPFunctions */
   private $wp;
 
@@ -27,6 +29,10 @@ class ShareMetadataBuilder {
     // that dollar-digit sequences in the newsletter subject (e.g. "Save $50")
     // are not interpreted as backreferences in the replacement string.
     return substr_replace($html, $metadata . "\n", $position, 0);
+  }
+
+  public function injectShareToolbar(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
+    return $this->injectAfterBodyOpen($html, $this->buildShareToolbar($newsletter, $canonicalUrl));
   }
 
   public function buildMetadata(string $html, NewsletterEntity $newsletter, string $canonicalUrl): string {
@@ -62,6 +68,147 @@ class ShareMetadataBuilder {
     }
 
     return implode("\n", $tags);
+  }
+
+  private function buildShareToolbar(NewsletterEntity $newsletter, string $canonicalUrl): string {
+    $title = __('Share this email', 'mailpoet');
+    $description = __('Copy the public link or share it on your favorite channel.', 'mailpoet');
+    $emailTitle = $newsletter->getCampaignNameOrSubject() ?: __('Email', 'mailpoet');
+    $copyLabel = __('Copy link', 'mailpoet');
+    $shareLabel = _x('Share', 'Web Share button label', 'mailpoet');
+    $encodedUrl = rawurlencode($canonicalUrl);
+    $encodedTitle = rawurlencode($emailTitle);
+
+    $toolbar = $this->buildShareToolbarStyles()
+      . '<div class="mailpoet-share-toolbar" role="region" aria-label="' . $this->wp->escAttr($title) . '">'
+      . '<div class="mailpoet-share-toolbar__inner">'
+      . '<div class="mailpoet-share-toolbar__copy">'
+      . '<strong>' . $this->wp->escHtml($title) . '</strong>'
+      . '<span>' . $this->wp->escHtml($description) . '</span>'
+      . '</div>'
+      . '<div class="mailpoet-share-toolbar__controls">'
+      . '<div class="mailpoet-share-toolbar__url-row">'
+      . '<input class="mailpoet-share-toolbar__url components-text-control__input" type="url" readonly aria-label="' . $this->wp->escAttr(__('Public share link', 'mailpoet')) . '" value="' . $this->wp->escAttr($canonicalUrl) . '" />'
+      . $this->buildShareToolbarCopyButton($canonicalUrl, $copyLabel)
+      . '</div>'
+      . '<div class="mailpoet-share-toolbar__actions">'
+      . '<button type="button" class="mailpoet-share-toolbar__button mailpoet-share-toolbar__web-share components-button is-secondary" aria-label="' . $this->wp->escAttr($shareLabel) . '" data-mailpoet-web-share="' . $this->wp->escAttr($canonicalUrl) . '" data-mailpoet-web-share-title="' . $this->wp->escAttr($emailTitle) . '">'
+      . $this->buildShareToolbarActionContent('share', $shareLabel)
+      . '</button>'
+      . $this->buildShareToolbarLink('facebook', $this->wp->escUrl('https://www.facebook.com/sharer/sharer.php?u=' . $encodedUrl), 'Facebook', true)
+      . $this->buildShareToolbarLink('x', $this->wp->escUrl('https://twitter.com/intent/tweet?url=' . $encodedUrl . '&text=' . $encodedTitle), 'X', true)
+      . $this->buildShareToolbarLink('whatsapp', $this->wp->escUrl('https://api.whatsapp.com/send?text=' . rawurlencode(trim($emailTitle . ' ' . $canonicalUrl))), 'WhatsApp', true)
+      . $this->buildShareToolbarLink('email', $this->wp->escUrl('mailto:?subject=' . $encodedTitle . '&body=' . $encodedUrl), __('Email', 'mailpoet'), true)
+      . '</div></div></div></div>';
+
+    return '<div data-mailpoet-share-host>' . $toolbar . '</div>' . $this->buildShareToolbarScript();
+  }
+
+  private function buildShareToolbarCopyButton(string $canonicalUrl, string $copyLabel): string {
+    return '<button type="button" class="mailpoet-share-toolbar__button mailpoet-share-toolbar__copy-button components-button is-secondary" aria-label="' . $this->wp->escAttr($copyLabel) . '" ' . self::COPY_BUTTON_ATTRIBUTE . '="' . $this->wp->escAttr($canonicalUrl) . '" data-mailpoet-share-copied-label="' . $this->wp->escAttr(__('Copied', 'mailpoet')) . '">'
+      . $this->buildShareToolbarActionContent('copy', $copyLabel)
+      . '</button>';
+  }
+
+  private function buildShareToolbarLink(string $iconName, string $url, string $label, bool $opensNewTab): string {
+    $isSocialLink = in_array($iconName, ['facebook', 'x', 'whatsapp', 'email'], true);
+    $className = $isSocialLink
+      ? 'mailpoet-share-toolbar__link mailpoet-share-toolbar__social-button mailpoet-share-toolbar__social-button--' . $this->wp->escAttr($iconName) . ' components-button'
+      : 'mailpoet-share-toolbar__link components-button is-secondary';
+
+    return '<a class="' . $className . '" href="' . $url . '" aria-label="' . $this->wp->escAttr($label) . '"'
+      . ($opensNewTab ? ' target="_blank" rel="noopener noreferrer"' : '')
+      . '>'
+      . $this->buildShareToolbarActionContent($iconName, $label)
+      . '</a>';
+  }
+
+  private function buildShareToolbarActionContent(string $iconName, string $label): string {
+    return $this->buildShareToolbarIcon($iconName)
+      . '<span data-mailpoet-share-label aria-live="polite">' . $this->wp->escHtml($label) . '</span>';
+  }
+
+  private function buildShareToolbarIcon(string $iconName): string {
+    $icons = [
+      'copy' => '<path d="M16 1H4c-1.1 0-2 .9-2 2v12h2V3h12V1Zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2Zm0 16H8V7h11v14Z" />',
+      'share' => '<path d="M18 16.1c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11A2.99 2.99 0 1 0 15 5c0 .24.04.47.09.7L8.04 9.81A3 3 0 1 0 8.04 14.2l7.12 4.18c-.05.2-.07.41-.07.62a2.91 2.91 0 1 0 2.91-2.9Z" />',
+      'facebook' => '<path d="M14 8.5V6.75c0-.5.4-.75.85-.75H17V2.5h-3.1C10.83 2.5 9 4.33 9 7.2v1.3H6v3.75h3V22h5v-9.75h3.25l.55-3.75H14Z" />',
+      'x' => '<path d="M13.7 10.6 21.4 2h-1.8l-6.7 7.5L7.6 2H1.5l8.1 11.5L1.5 22h1.8l7.1-7.8 5.7 7.8h6.1l-8.5-11.4Zm-2.5 2.8-.8-1.1L3.9 3.4h2.8l5.2 7.2.8 1.1 6.9 9h-2.8l-5.6-7.3Z" />',
+      'whatsapp' => '<path d="M12.04 2C6.58 2 2.15 6.43 2.15 11.9c0 1.75.46 3.45 1.33 4.95L2 22l5.29-1.39a9.85 9.85 0 0 0 4.75 1.21h.01c5.46 0 9.9-4.43 9.9-9.89A9.9 9.9 0 0 0 12.04 2Zm5.82 14.2c-.25.7-1.45 1.34-2.02 1.43-.52.08-1.18.12-1.9-.12-.44-.14-1-.33-1.72-.64-3.02-1.3-4.99-4.33-5.14-4.53-.15-.2-1.23-1.64-1.23-3.13 0-1.49.78-2.22 1.06-2.52.28-.3.61-.37.82-.37h.59c.19 0 .44-.07.69.53.25.6.85 2.08.92 2.23.08.15.13.33.03.53-.1.2-.15.33-.3.51-.15.18-.32.4-.45.54-.15.15-.31.31-.13.61.18.3.8 1.31 1.71 2.12 1.18 1.05 2.17 1.37 2.47 1.52.3.15.48.13.66-.08.18-.2.76-.89.97-1.2.2-.3.41-.25.69-.15.28.1 1.78.84 2.08.99.3.15.51.23.58.36.08.13.08.75-.17 1.45Z" />',
+      'email' => '<path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2Zm0 4-8 5-8-5V6l8 5 8-5v2Z" />',
+    ];
+    if (!isset($icons[$iconName])) {
+      return '';
+    }
+
+    return '<span class="mailpoet-share-toolbar__icon mailpoet-share-toolbar__icon--' . $this->wp->escAttr($iconName) . '" aria-hidden="true">'
+      . '<svg viewBox="0 0 24 24" focusable="false">' . $icons[$iconName] . '</svg>'
+      . '</span>';
+  }
+
+  private function buildShareToolbarStyles(): string {
+    return '<style>'
+      . '.mailpoet-share-toolbar{background:#fff;border-bottom:1px solid #dcdcde;color:#1d2327;font-family:system-ui,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;margin-bottom:20px;position:relative;width:100%}'
+      . '.mailpoet-share-toolbar *{box-sizing:border-box}'
+      . '.mailpoet-share-toolbar__inner{align-items:center;display:flex;gap:24px;margin:0 auto;max-width:800px;padding:16px 24px;width:100%}'
+      . '.mailpoet-share-toolbar__copy{display:flex;flex:0 0 260px;flex-direction:column;gap:4px;min-width:0}'
+      . '.mailpoet-share-toolbar__copy strong{font-size:16px;font-weight:600;line-height:1.3}'
+      . '.mailpoet-share-toolbar__copy span{color:#50575e;font-size:13px;line-height:1.4;text-wrap:balance}'
+      . '.mailpoet-share-toolbar__controls{display:flex;flex:1 1 auto;flex-direction:column;gap:10px;min-width:0}'
+      . '.mailpoet-share-toolbar__url-row{align-items:flex-end;display:flex;gap:10px}'
+      . '.mailpoet-share-toolbar__url{border:1px solid #8c8f94;border-radius:2px;color:#1d2327;flex:1 1 auto;font-family:monospace;font-size:13px;line-height:20px;min-height:40px;min-width:0;padding:8px}'
+      . '.mailpoet-share-toolbar__actions{display:flex;flex-wrap:wrap;gap:10px}'
+      . '.mailpoet-share-toolbar__button,.mailpoet-share-toolbar__link{align-items:center;border-radius:2px;display:inline-flex;font-size:13px;font-weight:500;gap:6px;justify-content:center;line-height:20px;min-height:40px;padding:6px 12px;text-decoration:none;white-space:nowrap}'
+      . '.mailpoet-share-toolbar__button.components-button.is-secondary,.mailpoet-share-toolbar__link.components-button.is-secondary{background:#fff;border:1px solid #2271b1;color:#2271b1;cursor:pointer}'
+      . '.mailpoet-share-toolbar__button.components-button.is-secondary:hover,.mailpoet-share-toolbar__button.components-button.is-secondary:focus,.mailpoet-share-toolbar__link.components-button.is-secondary:hover,.mailpoet-share-toolbar__link.components-button.is-secondary:focus{border-color:#135e96;color:#135e96}'
+      . '.mailpoet-share-toolbar__copy-button{flex:0 0 auto}'
+      . '.mailpoet-share-toolbar__social-button.components-button{border:1px solid transparent;box-shadow:none;color:#fff;flex:1 1 0}'
+      . '.mailpoet-share-toolbar__social-button.components-button:hover,.mailpoet-share-toolbar__social-button.components-button:focus{border-color:transparent;color:#fff;opacity:.85}'
+      . '.mailpoet-share-toolbar__social-button--facebook.components-button{background:#1877f2}'
+      . '.mailpoet-share-toolbar__social-button--x.components-button{background:#111}'
+      . '.mailpoet-share-toolbar__social-button--whatsapp.components-button{background:#25d366}'
+      . '.mailpoet-share-toolbar__social-button--email.components-button{background:#3858e9}'
+      . '.mailpoet-share-toolbar__icon{display:inline-flex;height:20px;width:20px}'
+      . '.mailpoet-share-toolbar__icon svg{display:block;fill:currentColor;height:20px;width:20px}'
+      . '.mailpoet-share-toolbar__web-share{display:none}'
+      . '@media(max-width:782px){.mailpoet-share-toolbar__inner{align-items:stretch;flex-direction:column;gap:12px;padding:16px}.mailpoet-share-toolbar__copy{flex:auto}.mailpoet-share-toolbar__url-row{align-items:stretch;flex-direction:column}.mailpoet-share-toolbar__button,.mailpoet-share-toolbar__link{width:100%}}'
+      . '</style>';
+  }
+
+  private function buildShareToolbarScript(): string {
+    return '<script>'
+      . '(function(){'
+      . 'var hosts=document.querySelectorAll("[data-mailpoet-share-host]");'
+      . 'function copyUrl(url){'
+      . 'if(navigator.clipboard&&window.isSecureContext){return navigator.clipboard.writeText(url);}'
+      . 'var input=document.createElement("textarea");'
+      . 'input.value=url;input.setAttribute("readonly","");input.style.position="fixed";input.style.left="-9999px";document.body.appendChild(input);input.select();'
+      . 'try{document.execCommand("copy");}catch(error){}'
+      . 'document.body.removeChild(input);return Promise.resolve();'
+      . '}'
+      . 'var copyButtons=document.querySelectorAll("[' . self::COPY_BUTTON_ATTRIBUTE . ']");'
+      . 'for(var i=0;i<copyButtons.length;i++){if(copyButtons[i].dataset.mailpoetShareBound){continue;}copyButtons[i].dataset.mailpoetShareBound="1";copyButtons[i].addEventListener("click",function(){var button=this;var labelElement=button.querySelector("[data-mailpoet-share-label]");var label=labelElement?labelElement.textContent:button.textContent;copyUrl(button.getAttribute("' . self::COPY_BUTTON_ATTRIBUTE . '")).then(function(){var copiedLabel=button.getAttribute("data-mailpoet-share-copied-label")||label;if(labelElement){labelElement.textContent=copiedLabel;}else{button.textContent=copiedLabel;}window.setTimeout(function(){if(labelElement){labelElement.textContent=label;}else{button.textContent=label;}},2000);});});}'
+      . 'var shareButtons=document.querySelectorAll("[data-mailpoet-web-share]");'
+      . 'for(var j=0;j<shareButtons.length;j++){if(!navigator.share||shareButtons[j].dataset.mailpoetShareBound){continue;}shareButtons[j].dataset.mailpoetShareBound="1";shareButtons[j].style.display="inline-flex";shareButtons[j].addEventListener("click",function(){navigator.share({title:this.getAttribute("data-mailpoet-web-share-title"),url:this.getAttribute("data-mailpoet-web-share")}).catch(function(){});});}'
+      // Promote each host into its own shadow root so email styles can\'t leak in or out.
+      // Handlers were bound above on the original nodes; moving them into the shadow root preserves listeners.
+      . 'for(var k=0;k<hosts.length;k++){var host=hosts[k];if(host.shadowRoot||typeof host.attachShadow!=="function"){continue;}try{var shadow=host.attachShadow({mode:"open"});while(host.firstChild){shadow.appendChild(host.firstChild);}}catch(error){}}'
+      . '})();'
+      . '</script>';
+  }
+
+  private function injectAfterBodyOpen(string $html, string $markup): string {
+    $bodyPosition = stripos($html, '<body');
+    if ($bodyPosition === false) {
+      return $markup . $html;
+    }
+
+    $bodyOpeningTagEnd = strpos($html, '>', $bodyPosition);
+    if ($bodyOpeningTagEnd === false) {
+      return $markup . $html;
+    }
+
+    return substr($html, 0, $bodyOpeningTagEnd + 1) . $markup . substr($html, $bodyOpeningTagEnd + 1);
   }
 
   /**

--- a/mailpoet/lib/Newsletter/Sharing/ShareVisibility.php
+++ b/mailpoet/lib/Newsletter/Sharing/ShareVisibility.php
@@ -79,9 +79,9 @@ class ShareVisibility {
   }
 
   public function getDefaultVisibility(): string {
-    $visibility = (string)$this->settings->get(self::SETTING_DEFAULT_VISIBILITY, self::VISIBILITY_PRIVATE);
+    $visibility = (string)$this->settings->get(self::SETTING_DEFAULT_VISIBILITY, self::VISIBILITY_PUBLIC);
     return in_array($visibility, [self::VISIBILITY_PUBLIC, self::VISIBILITY_PRIVATE], true)
       ? $visibility
-      : self::VISIBILITY_PRIVATE;
+      : self::VISIBILITY_PUBLIC;
   }
 }

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -79,11 +79,10 @@ class ViewInBrowserController {
 
     $html = $this->viewInBrowserRenderer->render($isPreview, $newsletter, $subscriber, $queue);
     if (!$isPreview && $this->shareVisibility->canShare($newsletter)) {
-      return $this->shareMetadataBuilder->injectShareToolbar(
-        $html,
-        $newsletter,
-        $this->newsletterUrl->getPublicShareUrl($newsletter)
-      );
+      $publicUrl = $this->newsletterUrl->getPublicShareUrl($newsletter);
+      // Pass $publicUrl as both the share target and the replaceState target so the
+      // tokenised view-in-browser URL is scrubbed from the address bar on load.
+      return $this->shareMetadataBuilder->injectShareToolbar($html, $newsletter, $publicUrl, $publicUrl);
     }
     return $html;
   }

--- a/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
+++ b/mailpoet/lib/Newsletter/ViewInBrowser/ViewInBrowserController.php
@@ -6,6 +6,8 @@ use MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sharing\ShareMetadataBuilder;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url as NewsletterUrl;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
@@ -32,6 +34,12 @@ class ViewInBrowserController {
   /** @var DependencyNotice */
   private $dependencyNotice;
 
+  /** @var ShareVisibility */
+  private $shareVisibility;
+
+  /** @var ShareMetadataBuilder */
+  private $shareMetadataBuilder;
+
   public function __construct(
     LinkTokens $linkTokens,
     NewsletterUrl $newsletterUrl,
@@ -39,7 +47,9 @@ class ViewInBrowserController {
     ViewInBrowserRenderer $viewInBrowserRenderer,
     SendingQueuesRepository $sendingQueuesRepository,
     DependencyNotice $dependencyNotice,
-    SubscribersRepository $subscribersRepository
+    SubscribersRepository $subscribersRepository,
+    ShareVisibility $shareVisibility,
+    ShareMetadataBuilder $shareMetadataBuilder
   ) {
     $this->linkTokens = $linkTokens;
     $this->viewInBrowserRenderer = $viewInBrowserRenderer;
@@ -48,6 +58,8 @@ class ViewInBrowserController {
     $this->newsletterUrl = $newsletterUrl;
     $this->dependencyNotice = $dependencyNotice;
     $this->newslettersRepository = $newslettersRepository;
+    $this->shareVisibility = $shareVisibility;
+    $this->shareMetadataBuilder = $shareMetadataBuilder;
   }
 
   public function view(array $data) {
@@ -65,7 +77,15 @@ class ViewInBrowserController {
       throw new \InvalidArgumentException("Subscriber did not receive the newsletter yet");
     }
 
-    return $this->viewInBrowserRenderer->render($isPreview, $newsletter, $subscriber, $queue);
+    $html = $this->viewInBrowserRenderer->render($isPreview, $newsletter, $subscriber, $queue);
+    if (!$isPreview && $this->shareVisibility->canShare($newsletter)) {
+      return $this->shareMetadataBuilder->injectShareToolbar(
+        $html,
+        $newsletter,
+        $this->newsletterUrl->getPublicShareUrl($newsletter)
+      );
+    }
+    return $html;
   }
 
   private function getNewsletter(array $data) {

--- a/mailpoet/lib/Settings/SettingsController.php
+++ b/mailpoet/lib/Settings/SettingsController.php
@@ -99,7 +99,7 @@ class SettingsController {
         'sending_status_retention_days' => self::DEFAULT_SENDING_STATUS_RETENTION_DAYS,
         'sending_queue_body_retention_days' => self::DEFAULT_SENDING_QUEUE_BODY_RETENTION_DAYS,
         'sharing' => [
-          'default_visibility' => 'private',
+          'default_visibility' => 'public',
         ],
       ];
     }

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -5,10 +5,11 @@ namespace MailPoet\Config;
 use Helper\WordPress;
 use MailPoet\DI\ContainerWrapper;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url;
-use MailPoet\Router\Router;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Newsletter as NewsletterFactory;
 use MailPoet\Test\DataFactories\Segment;
@@ -57,27 +58,63 @@ class ShortcodesTest extends \MailPoetTest {
       $args = func_get_args();
       $filterName = array_shift($args);
       switch ($filterName) {
-        case 'mailpoet_archive_date':
+        case 'mailpoet_archive_email_processed_date':
           return $shortcodes->renderArchiveDate($args[0]);
-        case 'mailpoet_archive_subject_line':
+        case 'mailpoet_archive_email_subject_line':
           return $shortcodes->renderArchiveSubject($args[0], $args[1], $args[2]);
       }
       return '';
     });
-    // result contains a link pointing to the "view in browser" router endpoint
+    // result contains a link pointing to the public share URL
     $result = $shortcodes->getArchive();
     WordPress::releaseFunction('apply_filters');
     $dom = pQuery::parseStr($result);
     $link = $dom->query('a');
     /** @var string $link */
     $link = $link->attr('href');
-    verify($link)->stringContainsString('endpoint=view_in_browser');
-    $parsedLink = parse_url($link, PHP_URL_QUERY);
-    parse_str(html_entity_decode((string)$parsedLink), $data);
-    $requestData = $this->newsletterUrl->transformUrlDataObject(
-      Router::decodeRequestData($data['data'])
-    );
-    verify($requestData['newsletter_hash'])->equals($this->newsletter->getHash());
+    verify($link)->equals($this->newsletterUrl->getPublicShareUrl($this->newsletter));
+    verify($link)->stringNotContainsString('endpoint=view_in_browser');
+  }
+
+  public function testArchiveListsPublicAndPrivateEmails(): void {
+    (new NewsletterFactory())
+      ->withSubject('Public newsletter')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+    (new NewsletterFactory())
+      ->withSubject('Private newsletter')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PRIVATE,
+      ])
+      ->create();
+
+    $result = do_shortcode('[mailpoet_archive]');
+
+    verify($result)->stringContainsString('Public newsletter');
+    verify($result)->stringContainsString('Private newsletter');
+  }
+
+  public function testRenderArchiveSubjectDoesNotLinkPrivateEmails(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Private subject')
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->withOptions([
+        NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY => ShareVisibility::VISIBILITY_PRIVATE,
+      ])
+      ->create();
+    $queue = $newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+
+    $result = ContainerWrapper::getInstance()
+      ->get(Shortcodes::class)
+      ->renderArchiveSubject($newsletter, null, $queue);
+
+    verify($result)->stringContainsString('Private subject');
+    verify($result)->stringNotContainsString('<a ');
   }
 
   public function testArchiveAcceptsStartDate() {
@@ -302,9 +339,9 @@ class ShortcodesTest extends \MailPoetTest {
       $args = func_get_args();
       $filterName = array_shift($args);
       switch ($filterName) {
-        case 'mailpoet_archive_date':
+        case 'mailpoet_archive_email_processed_date':
           return $shortcodes->renderArchiveDate($args[0]);
-        case 'mailpoet_archive_subject_line':
+        case 'mailpoet_archive_email_subject_line':
           return $shortcodes->renderArchiveSubject($args[0], $args[1], $args[2]);
       }
       return '';
@@ -345,9 +382,9 @@ class ShortcodesTest extends \MailPoetTest {
       $args = func_get_args();
       $filterName = array_shift($args);
       switch ($filterName) {
-        case 'mailpoet_archive_date':
+        case 'mailpoet_archive_email_processed_date':
           return $shortcodes->renderArchiveDate($args[0]);
-        case 'mailpoet_archive_subject_line':
+        case 'mailpoet_archive_email_subject_line':
           return $shortcodes->renderArchiveSubject($args[0], $args[1], $args[2]);
       }
       return '';

--- a/mailpoet/tests/integration/Config/ShortcodesTest.php
+++ b/mailpoet/tests/integration/Config/ShortcodesTest.php
@@ -97,7 +97,27 @@ class ShortcodesTest extends \MailPoetTest {
     verify($result)->stringContainsString('Private newsletter');
   }
 
-  public function testRenderArchiveSubjectDoesNotLinkPrivateEmails(): void {
+  public function testRenderArchiveSubjectLinksNotificationHistoryToViewInBrowser(): void {
+    $newsletter = (new NewsletterFactory())
+      ->withSubject('Post notification subject')
+      ->withPostNotificationHistoryType()
+      ->withSentStatus()
+      ->withSendingQueue()
+      ->create();
+    $queue = $newsletter->getLatestQueue();
+    $this->assertInstanceOf(SendingQueueEntity::class, $queue);
+
+    $result = ContainerWrapper::getInstance()
+      ->get(Shortcodes::class)
+      ->renderArchiveSubject($newsletter, null, $queue);
+
+    verify($result)->stringContainsString('Post notification subject');
+    verify($result)->stringContainsString('<a ');
+    verify($result)->stringContainsString('endpoint=view_in_browser');
+    verify($result)->stringNotContainsString($this->newsletterUrl->getPublicShareUrl($newsletter));
+  }
+
+  public function testRenderArchiveSubjectLinksPrivateEmailsToViewInBrowser(): void {
     $newsletter = (new NewsletterFactory())
       ->withSubject('Private subject')
       ->withSentStatus()
@@ -114,7 +134,9 @@ class ShortcodesTest extends \MailPoetTest {
       ->renderArchiveSubject($newsletter, null, $queue);
 
     verify($result)->stringContainsString('Private subject');
-    verify($result)->stringNotContainsString('<a ');
+    verify($result)->stringContainsString('<a ');
+    verify($result)->stringContainsString('endpoint=view_in_browser');
+    verify($result)->stringNotContainsString($this->newsletterUrl->getPublicShareUrl($newsletter));
   }
 
   public function testArchiveAcceptsStartDate() {

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
@@ -43,6 +43,7 @@ class PublicEmailControllerTest extends \MailPoetTest {
     verify($result)->stringContainsString('data-mailpoet-share-host');
     verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
     verify($result)->stringContainsString($controller->getCanonicalUrl($newsletter));
+    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state');
     verify($result)->stringContainsString('<meta property="og:title"');
     verify($result)->stringContainsString('<a href="https://example.com">');
     verify($result)->stringNotContainsString(Router::NAME . '&endpoint=track');

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
@@ -43,7 +43,7 @@ class PublicEmailControllerTest extends \MailPoetTest {
     verify($result)->stringContainsString('data-mailpoet-share-host');
     verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
     verify($result)->stringContainsString($controller->getCanonicalUrl($newsletter));
-    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state');
+    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state="');
     verify($result)->stringContainsString('<meta property="og:title"');
     verify($result)->stringContainsString('<a href="https://example.com">');
     verify($result)->stringNotContainsString(Router::NAME . '&endpoint=track');

--- a/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/PublicEmailControllerTest.php
@@ -40,9 +40,13 @@ class PublicEmailControllerTest extends \MailPoetTest {
     $result = $controller->render($controller->getNewsletter($identifier));
 
     verify($result)->stringContainsString('Hello, reader');
+    verify($result)->stringContainsString('data-mailpoet-share-host');
+    verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
+    verify($result)->stringContainsString($controller->getCanonicalUrl($newsletter));
     verify($result)->stringContainsString('<meta property="og:title"');
     verify($result)->stringContainsString('<a href="https://example.com">');
     verify($result)->stringNotContainsString(Router::NAME . '&endpoint=track');
+    verify($result)->stringNotContainsString(Router::NAME . '&endpoint=view_in_browser');
     verify($result)->stringNotContainsString('[mailpoet_open_data]');
   }
 

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
@@ -121,5 +121,29 @@ class ShareMetadataBuilderTest extends \MailPoetTest {
     $dom = \MailPoet\Util\pQuery\pQuery::parseStr($result);
     $main = $dom->query('[data-mailpoet-share-host] main');
     verify(count($main))->equals(0);
+    // no replace-state attribute on the public path
+    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state');
+  }
+
+  public function testItScrubsTokenisedUrlFromAddressBarWhenReplaceStateGiven(): void {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSubject('Recipient update')
+      ->create();
+
+    $result = $this->diContainer->get(ShareMetadataBuilder::class)
+      ->injectShareToolbar(
+        '<html><body><main>Email content</main></body></html>',
+        $newsletter,
+        'https://example.com/mailpoet-email/1-recipient-update/',
+        'https://example.com/mailpoet-email/1-recipient-update/'
+      );
+
+    verify($result)->stringContainsString('data-mailpoet-share-replace-state="https://example.com/mailpoet-email/1-recipient-update/"');
+    verify($result)->stringContainsString('window.history.replaceState');
+    // recipient toolbar carries the same markup as the public one — URL field + social icons
+    verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__url');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__social-button--facebook');
   }
 }

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
@@ -121,8 +121,8 @@ class ShareMetadataBuilderTest extends \MailPoetTest {
     $dom = \MailPoet\Util\pQuery\pQuery::parseStr($result);
     $main = $dom->query('[data-mailpoet-share-host] main');
     verify(count($main))->equals(0);
-    // no replace-state attribute on the public path
-    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state');
+    // no replace-state attribute on the public path (the script still references the name)
+    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state="');
   }
 
   public function testItScrubsTokenisedUrlFromAddressBarWhenReplaceStateGiven(): void {

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareMetadataBuilderTest.php
@@ -71,4 +71,55 @@ class ShareMetadataBuilderTest extends \MailPoetTest {
     verify($result)->stringContainsString('<meta name="twitter:card" content="summary" />');
     verify($result)->stringNotContainsString('og:image');
   }
+
+  public function testItInjectsShareToolbarOutsideEmailContent(): void {
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->withSubject('Shareable update')
+      ->create();
+
+    $result = $this->diContainer->get(ShareMetadataBuilder::class)
+      ->injectShareToolbar(
+        '<html><body><main>Email content</main></body></html>',
+        $newsletter,
+        'https://example.com/mailpoet-email/1-shareable-update/'
+      );
+
+    verify($result)->stringContainsString('data-mailpoet-share-host');
+    verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
+    verify($result)->stringContainsString('data-mailpoet-share-copy="https://example.com/mailpoet-email/1-shareable-update/"');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__controls');
+    $this->assertMatchesRegularExpression('#mailpoet-share-toolbar__url-row.*mailpoet-share-toolbar__url.*mailpoet-share-toolbar__copy-button#s', $result);
+    $this->assertMatchesRegularExpression('#mailpoet-share-toolbar__actions.*mailpoet-share-toolbar__social-button--facebook.*mailpoet-share-toolbar__social-button--x.*mailpoet-share-toolbar__social-button--whatsapp.*mailpoet-share-toolbar__social-button--email#s', $result);
+    verify($result)->stringContainsString('mailpoet-share-toolbar__copy-button components-button is-secondary');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__social-button--facebook components-button');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__social-button--facebook.components-button{background:#1877f2}');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__icon--facebook');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__icon--x');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__icon--whatsapp');
+    verify($result)->stringContainsString('mailpoet-share-toolbar__icon--email');
+    verify($result)->stringContainsString('aria-live="polite"');
+    verify($result)->stringContainsString('mailto:?subject=');
+    // mailto opens in a new tab so clicking it doesn't unload the share page itself.
+    $this->assertMatchesRegularExpression('#<a [^>]*href="mailto:\?[^"]*"[^>]*target="_blank"#', $result);
+    // brand names are not passed through __() so a translation hook on facebook/whatsapp can't break them
+    verify($result)->stringContainsString('>Facebook</span>');
+    verify($result)->stringContainsString('>WhatsApp</span>');
+    // shadow-DOM promotion + navigator.share AbortError silencing
+    verify($result)->stringContainsString('attachShadow');
+    verify($result)->stringContainsString('.catch(function(){})');
+    // toolbar is injected before the <main> content
+    verify(strpos($result, 'data-mailpoet-share-host'))->lessThan(strpos($result, '<main>Email content</main>'));
+    // and the toolbar markup is fully balanced — the email content is NOT a descendant
+    // of the host. (Regression test: if the host wrapper isn't closed before <main>,
+    // the shadow-DOM promotion swallows the entire email body into the shadow root.)
+    $this->assertSame(
+      1,
+      preg_match('#<main>Email content</main>#', $result),
+      'Email content should be present'
+    );
+    $dom = \MailPoet\Util\pQuery\pQuery::parseStr($result);
+    $main = $dom->query('[data-mailpoet-share-host] main');
+    verify(count($main))->equals(0);
+  }
 }

--- a/mailpoet/tests/integration/Newsletter/Sharing/ShareVisibilityTest.php
+++ b/mailpoet/tests/integration/Newsletter/Sharing/ShareVisibilityTest.php
@@ -8,7 +8,7 @@ use MailPoet\Settings\SettingsController;
 use MailPoet\Test\DataFactories\Newsletter;
 
 class ShareVisibilityTest extends \MailPoetTest {
-  public function testItBlocksSentStandardNewslettersByDefault() {
+  public function testItAllowsSentStandardNewslettersByDefault() {
     $newsletter = (new Newsletter())
       ->withSentStatus()
       ->create();
@@ -16,6 +16,21 @@ class ShareVisibilityTest extends \MailPoetTest {
     $shareVisibility = $this->diContainer->get(ShareVisibility::class);
 
     verify($shareVisibility->getConfiguredVisibility($newsletter))->equals(ShareVisibility::VISIBILITY_DEFAULT);
+    verify($shareVisibility->getDefaultVisibility())->equals(ShareVisibility::VISIBILITY_PUBLIC);
+    verify($shareVisibility->canShare($newsletter))->true();
+  }
+
+  public function testItBlocksSentStandardNewslettersWhenGlobalDefaultIsPrivate() {
+    $this->diContainer->get(SettingsController::class)->set(
+      ShareVisibility::SETTING_DEFAULT_VISIBILITY,
+      ShareVisibility::VISIBILITY_PRIVATE
+    );
+    $newsletter = (new Newsletter())
+      ->withSentStatus()
+      ->create();
+
+    $shareVisibility = $this->diContainer->get(ShareVisibility::class);
+
     verify($shareVisibility->getDefaultVisibility())->equals(ShareVisibility::VISIBILITY_PRIVATE);
     verify($shareVisibility->canShare($newsletter))->false();
   }

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -210,17 +210,21 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $viewInBrowserController->view($data);
   }
 
-  public function testItAddsShareToolbarForRecipientViews(): void {
+  public function testItAddsShareToolbarForRecipientViewsAndScrubsTokenisedUrl(): void {
     $newsletter = $this->newslettersRepository->findOneById($this->browserPreviewData['newsletter_id']);
     $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
     $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
     $this->entityManager->flush();
 
     $result = $this->viewInBrowserController->view($this->browserPreviewData);
+    $publicUrl = $this->newsletterUrl->getPublicShareUrl($newsletter);
 
     verify($result)->stringContainsString('data-mailpoet-share-host');
     verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
-    verify($result)->stringContainsString($this->newsletterUrl->getPublicShareUrl($newsletter));
+    verify($result)->stringContainsString($publicUrl);
+    // address-bar scrub: replaceState attribute set to the public URL so the subscriber token
+    // never ends up shared via copy-from-address-bar or browser share menu.
+    verify($result)->stringContainsString('data-mailpoet-share-replace-state="' . $publicUrl . '"');
   }
 
   public function testItDoesNotAddShareToolbarForPrivateRecipientViews(): void {
@@ -237,6 +241,7 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $result = $this->viewInBrowserController->view($this->browserPreviewData);
 
     verify($result)->stringNotContainsString('data-mailpoet-share-host');
+    verify($result)->stringNotContainsString('data-mailpoet-share-replace-state');
   }
 
   public function _after() {

--- a/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
+++ b/mailpoet/tests/integration/Newsletter/ViewInBrowser/ViewInBrowserControllerTest.php
@@ -6,16 +6,20 @@ use Codeception\Stub\Expected;
 use MailPoet\Cron\Workers\SendingQueue\SendingQueue;
 use MailPoet\EmailEditor\Integrations\MailPoet\DependencyNotice;
 use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\NewsletterOptionFieldEntity;
 use MailPoet\Entities\ScheduledTaskEntity;
 use MailPoet\Entities\SendingQueueEntity;
 use MailPoet\Entities\SubscriberEntity;
 use MailPoet\Newsletter\NewslettersRepository;
 use MailPoet\Newsletter\Sending\ScheduledTaskSubscribersRepository;
 use MailPoet\Newsletter\Sending\SendingQueuesRepository;
+use MailPoet\Newsletter\Sharing\ShareMetadataBuilder;
+use MailPoet\Newsletter\Sharing\ShareVisibility;
 use MailPoet\Newsletter\Url;
 use MailPoet\Subscribers\LinkTokens;
 use MailPoet\Subscribers\SubscribersRepository;
 use MailPoet\Test\DataFactories\Newsletter;
+use MailPoet\Test\DataFactories\NewsletterOption;
 use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
 use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 use MailPoet\Util\Security;
@@ -206,6 +210,35 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
     $viewInBrowserController->view($data);
   }
 
+  public function testItAddsShareToolbarForRecipientViews(): void {
+    $newsletter = $this->newslettersRepository->findOneById($this->browserPreviewData['newsletter_id']);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+    $this->entityManager->flush();
+
+    $result = $this->viewInBrowserController->view($this->browserPreviewData);
+
+    verify($result)->stringContainsString('data-mailpoet-share-host');
+    verify($result)->stringContainsString('class="mailpoet-share-toolbar"');
+    verify($result)->stringContainsString($this->newsletterUrl->getPublicShareUrl($newsletter));
+  }
+
+  public function testItDoesNotAddShareToolbarForPrivateRecipientViews(): void {
+    $newsletter = $this->newslettersRepository->findOneById($this->browserPreviewData['newsletter_id']);
+    $this->assertInstanceOf(NewsletterEntity::class, $newsletter);
+    $newsletter->setStatus(NewsletterEntity::STATUS_SENT);
+    (new NewsletterOption())->create(
+      $newsletter,
+      NewsletterOptionFieldEntity::NAME_SHARE_VISIBILITY,
+      ShareVisibility::VISIBILITY_PRIVATE
+    );
+    $this->entityManager->flush();
+
+    $result = $this->viewInBrowserController->view($this->browserPreviewData);
+
+    verify($result)->stringNotContainsString('data-mailpoet-share-host');
+  }
+
   public function _after() {
     parent::_after();
     // reset WP user role
@@ -230,7 +263,9 @@ class ViewInBrowserControllerTest extends \MailPoetTest {
       $viewInBrowserRenderer,
       $this->sendingQueuesRepository,
       $this->diContainer->get(DependencyNotice::class),
-      $this->subscribersRepository
+      $this->subscribersRepository,
+      $this->diContainer->get(ShareVisibility::class),
+      $this->diContainer->get(ShareMetadataBuilder::class)
     );
   }
 }

--- a/mailpoet/views/settings_translations.html
+++ b/mailpoet/views/settings_translations.html
@@ -121,7 +121,7 @@
   'after90days': __('After 90 days'),
   'after365days': __('After 12 months'),
   'emailSharingVisibilityTitle': __('Default email sharing visibility'),
-  'emailSharingVisibilityDescription': __('Choose whether sent standard emails are public by default when they use the site default sharing setting.'),
+  'emailSharingVisibilityDescription': __('Applies to sent standard emails that don\'t have their visibility set explicitly (for example, emails sent before per-email sharing controls existed). New emails default to this setting too, but can be changed individually.'),
   'emailSharingPublic': __('Public'),
   'emailSharingPrivate': __('Private'),
   'libs3rdPartyTitle': __('Load 3rd-party libraries'),


### PR DESCRIPTION
## Description

Built on top of https://github.com/mailpoet/mailpoet/pull/6757 and https://github.com/mailpoet/mailpoet/pull/6758.

Adds a `Share this email` toolbar (copy link + Web Share + Facebook/X/WhatsApp/email) to public share pages and recipient `view-in-browser` pages, scrubbing the subscriber token from the address bar via `history.replaceState`. Also updates `[mailpoet_archive]` to link subjects to public share URLs (private emails render as plain text).

Emails are public by default (with option to change in **Settings > Advanced > Default email sharing visibility**), and each email can be set specifically before sending.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-7991

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="833" height="527" alt="Screenshot 2026-05-16 at 21 46 41" src="https://github.com/user-attachments/assets/12647793-18d8-4841-8d0b-32bcd5c3e782" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-7991-add-public-share-toolbar-and-archive-integration)

_The latest successful build from `stomail-7991-add-public-share-toolbar-and-archive-integration` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->