### PR TITLE
Add date range operators to segment conditions

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_segments.scss
+++ b/mailpoet/assets/css/src/components-plugin/_segments.scss
@@ -35,6 +35,17 @@
     margin-left: 0 !important;
     width: 110px;
   }
+
+  .mailpoet-segments-date-period-controls {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+
+    .mailpoet-segments-datepicker-small {
+      width: 150px;
+    }
+  }
 }
 
 .mailpoet-segments-filter-group {

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-fields.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { isValid, parseISO } from 'date-fns';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 import { MailPoet } from 'mailpoet';
@@ -9,6 +8,7 @@ import { Input } from 'common/form/input/input';
 
 import { DateFormItem, FilterProps } from '../../types';
 import { storeName } from '../../store';
+import { convertDateToString, parseDate } from './date-helpers';
 
 export enum DateOperator {
   BEFORE = 'before',
@@ -17,6 +17,7 @@ export enum DateOperator {
   ON_OR_BEFORE = 'onOrBefore',
   ON_OR_AFTER = 'onOrAfter',
   NOT_ON = 'notOn',
+  BETWEEN = 'between',
   IN_THE_LAST = 'inTheLast',
   NOT_IN_THE_LAST = 'notInTheLast',
 }
@@ -32,30 +33,10 @@ const availableOperators = [
   DateOperator.ON_OR_AFTER,
   DateOperator.ON_OR_BEFORE,
   DateOperator.NOT_ON,
+  DateOperator.BETWEEN,
   DateOperator.IN_THE_LAST,
   DateOperator.NOT_IN_THE_LAST,
 ];
-
-const convertDateToString = (
-  value: Date | [Date, Date],
-): string | undefined => {
-  if (value === null) {
-    return undefined;
-  }
-  if (Array.isArray(value)) {
-    throw new Error(
-      'convertDateToString can process only single date array given',
-    );
-  }
-  return MailPoet.Date.format(value, { format: 'Y-m-d' });
-};
-
-const parseDate = (value: string): Date | undefined => {
-  if (!value) return undefined;
-  const date = parseISO(value);
-  if (!isValid(date)) return undefined;
-  return date;
-};
 
 function DateFields({
   filterIndex,
@@ -79,12 +60,23 @@ function DateFields({
         segment.operator === DateOperator.ON ||
         segment.operator === DateOperator.ON_OR_AFTER ||
         segment.operator === DateOperator.ON_OR_BEFORE ||
+        segment.operator === DateOperator.BETWEEN ||
         segment.operator === DateOperator.NOT_ON) &&
       (parseDate(segment.value) === undefined ||
         !/^\d+-\d+-\d+$/.test(segment.value))
     ) {
       void updateSegmentFilter(
         { value: convertDateToString(new Date()) },
+        filterIndex,
+      );
+    }
+    if (
+      segment.operator === DateOperator.BETWEEN &&
+      (parseDate(segment.value2 || '') === undefined ||
+        !/^\d+-\d+-\d+$/.test(segment.value2 || ''))
+    ) {
+      void updateSegmentFilter(
+        { value2: convertDateToString(new Date()) },
         filterIndex,
       );
     }
@@ -114,6 +106,9 @@ function DateFields({
         </option>
         <option value={DateOperator.ON}>{MailPoet.I18n.t('on')}</option>
         <option value={DateOperator.NOT_ON}>{MailPoet.I18n.t('notOn')}</option>
+        <option value={DateOperator.BETWEEN}>
+          {MailPoet.I18n.t('between')}
+        </option>
         <option value={DateOperator.ON_OR_AFTER}>
           {MailPoet.I18n.t('onOrAfter')}
         </option>
@@ -142,6 +137,32 @@ function DateFields({
           }}
           selected={segment.value ? parseDate(segment.value) : undefined}
         />
+      )}
+      {segment.operator === DateOperator.BETWEEN && (
+        <>
+          <Datepicker
+            className="mailpoet-segments-datepicker-small"
+            dateFormat="MMM d, yyyy"
+            onChange={(value): void => {
+              void updateSegmentFilter(
+                { value: convertDateToString(value) },
+                filterIndex,
+              );
+            }}
+            selected={segment.value ? parseDate(segment.value) : undefined}
+          />
+          <Datepicker
+            className="mailpoet-segments-datepicker-small"
+            dateFormat="MMM d, yyyy"
+            onChange={(value): void => {
+              void updateSegmentFilter(
+                { value2: convertDateToString(value) },
+                filterIndex,
+              );
+            }}
+            selected={segment.value2 ? parseDate(segment.value2) : undefined}
+          />
+        </>
       )}
       {(segment.operator === DateOperator.IN_THE_LAST ||
         segment.operator === DateOperator.NOT_IN_THE_LAST) && (
@@ -190,6 +211,11 @@ export function validateDateField(formItems: DateFormItem): boolean {
   ) {
     const re = /^\d+$/;
     return re.test(formItems.value) && Number(formItems.value) > 0;
+  }
+
+  if (formItems.operator === DateOperator.BETWEEN) {
+    const re = /^\d+-\d+-\d+$/;
+    return re.test(formItems.value) && re.test(formItems.value2 || '');
   }
 
   return false;

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-helpers.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/date-helpers.ts
@@ -1,0 +1,23 @@
+import { isValid, parseISO } from 'date-fns';
+import { MailPoet } from 'mailpoet';
+
+export const convertDateToString = (
+  value: Date | [Date, Date] | null,
+): string | undefined => {
+  if (value === null) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    throw new Error(
+      'convertDateToString can process only single date array given',
+    );
+  }
+  return MailPoet.Date.format(value, { format: 'Y-m-d' });
+};
+
+export const parseDate = (value: string): Date | undefined => {
+  if (!value) return undefined;
+  const date = parseISO(value);
+  if (!isValid(date)) return undefined;
+  return date;
+};

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/days-period-field.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/days-period-field.tsx
@@ -2,20 +2,21 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Input } from 'common';
 import { MailPoet } from 'mailpoet';
 import { Select } from 'common/form/select/select';
+import { Datepicker } from 'common/datepicker/datepicker';
 import { DaysPeriodItem, FilterProps, Timeframe } from 'segments/dynamic/types';
 import { storeName } from 'segments/dynamic/store';
 import { useEffect } from 'react';
 import { isInEnum } from '../../../../utils';
+import { convertDateToString, parseDate } from './date-helpers';
 
-function replaceElementsInDaysSentence(
-  fn: (value) => JSX.Element,
-): JSX.Element[] {
-  return MailPoet.I18n.t('emailActionOpensDaysSentence')
-    .split(/({days})|({timeframe})/gim)
-    .map(fn);
-}
+type Props = FilterProps & {
+  defaultTimeframe?: Timeframe;
+};
 
-export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
+export function DaysPeriodField({
+  filterIndex,
+  defaultTimeframe = Timeframe.IN_THE_LAST,
+}: Props): JSX.Element {
   const segment: DaysPeriodItem = useSelect(
     (select) => select(storeName).getSegmentFilter(filterIndex),
     [filterIndex],
@@ -25,57 +26,124 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
 
   useEffect(() => {
     if (!isInEnum(segment.timeframe, Timeframe)) {
+      void updateSegmentFilter({ timeframe: defaultTimeframe }, filterIndex);
+    }
+    if (
+      segment.timeframe === Timeframe.IN_THE_LAST &&
+      typeof segment.days === 'string' &&
+      !/^\d*$/.exec(segment.days)
+    ) {
+      void updateSegmentFilter({ days: '' }, filterIndex);
+    }
+    if (
+      [Timeframe.BEFORE, Timeframe.AFTER, Timeframe.ON, Timeframe.BETWEEN].some(
+        (timeframe) => timeframe === segment.timeframe,
+      ) &&
+      (parseDate(segment.value || '') === undefined ||
+        !/^\d+-\d+-\d+$/.test(segment.value || ''))
+    ) {
       void updateSegmentFilter(
-        { timeframe: Timeframe.IN_THE_LAST },
+        { value: convertDateToString(new Date()) },
         filterIndex,
       );
     }
-  }, [segment, updateSegmentFilter, filterIndex]);
+    if (
+      segment.timeframe === Timeframe.BETWEEN &&
+      (parseDate(segment.value2 || '') === undefined ||
+        !/^\d+-\d+-\d+$/.test(segment.value2 || ''))
+    ) {
+      void updateSegmentFilter(
+        { value2: convertDateToString(new Date()) },
+        filterIndex,
+      );
+    }
+  }, [segment, updateSegmentFilter, filterIndex, defaultTimeframe]);
 
   const isInTheLast = segment.timeframe === Timeframe.IN_THE_LAST;
+  const isSingleDate =
+    segment.timeframe === Timeframe.BEFORE ||
+    segment.timeframe === Timeframe.AFTER ||
+    segment.timeframe === Timeframe.ON;
 
   return (
     <>
-      {replaceElementsInDaysSentence((match) => {
-        if (isInTheLast && match === '{days}') {
-          return (
-            <Input
-              key="input"
-              type="number"
-              value={segment.days || ''}
-              data-automation-id="segment-number-of-days"
-              onChange={(e) => {
-                void updateSegmentFilterFromEvent('days', filterIndex, e);
-              }}
-              min={1}
-              step={1}
-              placeholder={MailPoet.I18n.t('daysPlaceholder')}
-            />
-          );
-        }
-        if (match === '{timeframe}') {
-          return (
-            <Select
-              key="timeframe-select"
-              value={segment.timeframe}
-              onChange={(e) => {
-                void updateSegmentFilterFromEvent('timeframe', filterIndex, e);
-              }}
-            >
-              <option value="inTheLast">{MailPoet.I18n.t('inTheLast')}</option>
-              <option value="allTime">{MailPoet.I18n.t('overAllTime')}</option>
-            </Select>
-          );
-        }
-        if (
-          isInTheLast &&
-          typeof match === 'string' &&
-          match.trim().length > 1
-        ) {
-          return <div key={match}>{match}</div>;
-        }
-        return null;
-      })}
+      <Select
+        key="timeframe-select"
+        value={segment.timeframe}
+        onChange={(e) => {
+          void updateSegmentFilterFromEvent('timeframe', filterIndex, e);
+        }}
+      >
+        <option value={Timeframe.ALL_TIME}>
+          {MailPoet.I18n.t('overAllTime')}
+        </option>
+        <option value={Timeframe.IN_THE_LAST}>
+          {MailPoet.I18n.t('inTheLast')}
+        </option>
+        <option value={Timeframe.BEFORE}>{MailPoet.I18n.t('before')}</option>
+        <option value={Timeframe.AFTER}>{MailPoet.I18n.t('after')}</option>
+        <option value={Timeframe.ON}>{MailPoet.I18n.t('on')}</option>
+        <option value={Timeframe.BETWEEN}>{MailPoet.I18n.t('between')}</option>
+      </Select>
+      {isInTheLast && (
+        <div className="mailpoet-segments-date-period-controls">
+          <Input
+            className="mailpoet-segments-input-small"
+            key="input"
+            type="number"
+            value={segment.days || ''}
+            data-automation-id="segment-number-of-days"
+            onChange={(e) => {
+              void updateSegmentFilterFromEvent('days', filterIndex, e);
+            }}
+            min={1}
+            step={1}
+            placeholder={MailPoet.I18n.t('daysPlaceholder')}
+          />
+          <span>{MailPoet.I18n.t('daysPlaceholder')}</span>
+        </div>
+      )}
+      {isSingleDate && (
+        <div className="mailpoet-segments-date-period-controls">
+          <Datepicker
+            className="mailpoet-segments-datepicker-small"
+            dateFormat="MMM d, yyyy"
+            onChange={(value): void => {
+              void updateSegmentFilter(
+                { value: convertDateToString(value) },
+                filterIndex,
+              );
+            }}
+            selected={segment.value ? parseDate(segment.value) : undefined}
+          />
+        </div>
+      )}
+      {segment.timeframe === Timeframe.BETWEEN && (
+        <div className="mailpoet-segments-date-period-controls">
+          <Datepicker
+            className="mailpoet-segments-datepicker-small"
+            dateFormat="MMM d, yyyy"
+            onChange={(value): void => {
+              void updateSegmentFilter(
+                { value: convertDateToString(value) },
+                filterIndex,
+              );
+            }}
+            selected={segment.value ? parseDate(segment.value) : undefined}
+          />
+          <Datepicker
+            className="mailpoet-segments-datepicker-small"
+            dateFormat="MMM d, yyyy"
+            onChange={(value): void => {
+              void updateSegmentFilter(
+                { value2: convertDateToString(value) },
+                filterIndex,
+              );
+            }}
+            selected={segment.value2 ? parseDate(segment.value2) : undefined}
+          />
+        </div>
+      )}
     </>
   );
 }
@@ -83,6 +151,19 @@ export function DaysPeriodField({ filterIndex }: FilterProps): JSX.Element {
 export function validateDaysPeriod(formItems: DaysPeriodItem): boolean {
   if (formItems.timeframe === Timeframe.ALL_TIME) {
     return true;
+  }
+  if (
+    [Timeframe.BEFORE, Timeframe.AFTER, Timeframe.ON].some(
+      (timeframe) => timeframe === formItems.timeframe,
+    )
+  ) {
+    return /^\d+-\d+-\d+$/.test(formItems.value || '');
+  }
+  if (formItems.timeframe === Timeframe.BETWEEN) {
+    return (
+      /^\d+-\d+-\d+$/.test(formItems.value || '') &&
+      /^\d+-\d+-\d+$/.test(formItems.value2 || '')
+    );
   }
   const days = parseInt(formItems.days, 10);
   return days >= 1;

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-opens-absolute-count.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-opens-absolute-count.tsx
@@ -77,9 +77,7 @@ export function EmailOpensAbsoluteCountFields({
           return null;
         })}
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/number-of-clicks.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/number-of-clicks.tsx
@@ -78,9 +78,7 @@ export function NumberOfClicksFields({
           return null;
         })}
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/number-of-emails-received.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/number-of-emails-received.tsx
@@ -78,9 +78,7 @@ export function NumberOfEmailsReceivedFields({
           return null;
         })}
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/average-spent.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/average-spent.tsx
@@ -1,6 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { Grid } from 'common/grid';
 import { Input, Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { storeName } from '../../../store';
@@ -72,9 +71,7 @@ export function AverageSpentFields({ filterIndex }: FilterProps): JSX.Element {
         }}
       />
       <div>{wooCurrencySymbol}</div>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/number-of-orders.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/number-of-orders.tsx
@@ -70,9 +70,7 @@ export function NumberOfOrdersFields({
         />
         <div>{MailPoet.I18n.t('wooNumberOfOrdersOrders')}</div>
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/number-of-reviews.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/number-of-reviews.tsx
@@ -1,6 +1,5 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { Grid } from 'common/grid';
 import { Input, Select } from 'common';
 import { MailPoet } from 'mailpoet';
 import { storeName } from '../../../store';
@@ -113,9 +112,7 @@ export function NumberOfReviewsFields({
         }}
       />
       <div>{MailPoet.I18n.t('wooNumberOfReviewsReviews')}</div>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-category.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-category.tsx
@@ -9,9 +9,11 @@ import {
   AnyValueTypes,
   FilterProps,
   SelectOption,
+  Timeframe,
   WindowProductCategories,
   WooCommerceFormItem,
 } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days-period-field';
 
 export function validatePurchasedCategory(
   formItems: WooCommerceFormItem,
@@ -19,7 +21,8 @@ export function validatePurchasedCategory(
   const purchasedCategoryIsInvalid =
     formItems.category_ids === undefined ||
     formItems.category_ids.length === 0 ||
-    !formItems.operator;
+    !formItems.operator ||
+    !validateDaysPeriod(formItems);
 
   return !purchasedCategoryIsInvalid;
 }
@@ -92,6 +95,10 @@ export function PurchasedCategoryFields({
           );
         }}
         automationId="select-segment-category"
+      />
+      <DaysPeriodField
+        filterIndex={filterIndex}
+        defaultTimeframe={Timeframe.ALL_TIME}
       />
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product-variation.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product-variation.tsx
@@ -10,9 +10,11 @@ import {
   AnyValueTypes,
   FilterProps,
   SelectOption,
+  Timeframe,
   WindowProducts,
   WooCommerceFormItem,
 } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days-period-field';
 
 type VariationsResponse = {
   data: {
@@ -27,7 +29,8 @@ export function validatePurchasedProductVariation(
   return (
     Array.isArray(formItems.variation_ids) &&
     formItems.variation_ids.length > 0 &&
-    !!formItems.operator
+    !!formItems.operator &&
+    validateDaysPeriod(formItems)
   );
 }
 
@@ -212,6 +215,10 @@ export function PurchasedProductVariationFields({
           );
         }}
         automationId="select-product-variations"
+      />
+      <DaysPeriodField
+        filterIndex={filterIndex}
+        defaultTimeframe={Timeframe.ALL_TIME}
       />
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-product.tsx
@@ -9,9 +9,11 @@ import {
   AnyValueTypes,
   FilterProps,
   SelectOption,
+  Timeframe,
   WindowProducts,
   WooCommerceFormItem,
 } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days-period-field';
 
 export function validatePurchasedProduct(
   formItems: WooCommerceFormItem,
@@ -19,7 +21,8 @@ export function validatePurchasedProduct(
   const purchasedProductIsInvalid =
     formItems.product_ids === undefined ||
     formItems.product_ids.length === 0 ||
-    !formItems.operator;
+    !formItems.operator ||
+    !validateDaysPeriod(formItems);
 
   return !purchasedProductIsInvalid;
 }
@@ -92,6 +95,10 @@ export function PurchasedProductFields({
           );
         }}
         automationId="select-segment-products"
+      />
+      <DaysPeriodField
+        filterIndex={filterIndex}
+        defaultTimeframe={Timeframe.ALL_TIME}
       />
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-tag.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-tag.tsx
@@ -10,15 +10,18 @@ import {
   AnyValueTypes,
   FilterProps,
   SelectOption,
+  Timeframe,
   WindowProductCategories,
   WooCommerceFormItem,
 } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days-period-field';
 
 export function validatePurchasedTag(formItems: WooCommerceFormItem): boolean {
   const purchasedTagIsInvalid =
     formItems.tag_ids === undefined ||
     formItems.tag_ids.length === 0 ||
-    !formItems.operator;
+    !formItems.operator ||
+    !validateDaysPeriod(formItems);
 
   return !purchasedTagIsInvalid;
 }
@@ -86,6 +89,10 @@ export function PurchasedTagFields({ filterIndex }: FilterProps): JSX.Element {
           );
         }}
         automationId="select-segment-tags"
+      />
+      <DaysPeriodField
+        filterIndex={filterIndex}
+        defaultTimeframe={Timeframe.ALL_TIME}
       />
     </>
   );

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/purchased-with-attribute.tsx
@@ -9,10 +9,12 @@ import {
   AnyValueTypes,
   FilterProps,
   SelectOption,
+  Timeframe,
   WindowLocalProductAttributes,
   WindowProductAttributes,
   WooCommerceFormItem,
 } from '../../../types';
+import { DaysPeriodField, validateDaysPeriod } from '../days-period-field';
 
 export function validatePurchasedWithAttribute(
   formItems: WooCommerceFormItem,
@@ -28,7 +30,8 @@ export function validatePurchasedWithAttribute(
       (!formItems.attribute_local_name ||
         formItems.attribute_local_name.length === 0 ||
         !Array.isArray(formItems.attribute_local_values) ||
-        formItems.attribute_local_values.length === 0));
+        formItems.attribute_local_values.length === 0)) ||
+    !validateDaysPeriod(formItems);
 
   return !purchasedProductWithAttributeIsInvalid;
 }
@@ -265,6 +268,10 @@ export function PurchasedWithAttributeFields({
           onChange={attributeValuesOnChange}
         />
       )}
+      <DaysPeriodField
+        filterIndex={filterIndex}
+        defaultTimeframe={Timeframe.ALL_TIME}
+      />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/single-order-value.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/single-order-value.tsx
@@ -75,9 +75,7 @@ export function SingleOrderValueFields({
         />
         <div>{wooCurrencySymbol}</div>
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/total-spent.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/total-spent.tsx
@@ -69,9 +69,7 @@ export function TotalSpentFields({ filterIndex }: FilterProps): JSX.Element {
         />
         <div>{wooCurrencySymbol}</div>
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/used-coupon-code.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/used-coupon-code.tsx
@@ -207,9 +207,7 @@ export function UsedCouponCodeFields({
               onMenuScrollToBottom={handleMenuScrollToBottom}
             />
           </Grid.CenteredRow>
-          <Grid.CenteredRow>
-            <DaysPeriodField filterIndex={filterIndex} />
-          </Grid.CenteredRow>
+          <DaysPeriodField filterIndex={filterIndex} />
         </>
       ) : (
         <Grid.CenteredRow>

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/used-payment-method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/used-payment-method.tsx
@@ -95,9 +95,7 @@ export function UsedPaymentMethodFields({
           automationId="select-payment-methods"
         />
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/used-shipping-method.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/woocommerce/used-shipping-method.tsx
@@ -95,9 +95,7 @@ export function UsedShippingMethodFields({
           automationId="select-shipping-methods"
         />
       </Grid.CenteredRow>
-      <Grid.CenteredRow>
-        <DaysPeriodField filterIndex={filterIndex} />
-      </Grid.CenteredRow>
+      <DaysPeriodField filterIndex={filterIndex} />
     </>
   );
 }

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -90,16 +90,23 @@ export interface FormItem {
 export interface DateFormItem extends FormItem {
   operator?: string;
   value?: string;
+  value2?: string;
 }
 
 export interface DaysPeriodItem extends FormItem {
   days?: string;
   timeframe?: Timeframe;
+  value?: string;
+  value2?: string;
 }
 
 export enum Timeframe {
   ALL_TIME = 'allTime',
   IN_THE_LAST = 'inTheLast',
+  BEFORE = 'before',
+  AFTER = 'after',
+  ON = 'on',
+  BETWEEN = 'between',
 }
 
 export interface TextFormItem extends FormItem {

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -146,6 +146,9 @@ export interface WooCommerceFormItem extends FormItem {
   category_ids?: string[];
   product_ids?: string[];
   variation_ids?: string[];
+  timeframe?: Timeframe;
+  value?: string;
+  value2?: string;
   operator?: string;
   number_of_orders_type?: string;
   number_of_orders_count?: number;

--- a/mailpoet/changelog/2026-05-17-09-46-04-added-date-range-options-for-dynamic-segment-filters.md
+++ b/mailpoet/changelog/2026-05-17-09-46-04-added-date-range-options-for-dynamic-segment-filters.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Before, after, on, and between date options for dynamic segment filters, with date filtering now available on purchased product, category, tag, variation, and attribute conditions

--- a/mailpoet/lib/Entities/DynamicSegmentFilterData.php
+++ b/mailpoet/lib/Entities/DynamicSegmentFilterData.php
@@ -49,6 +49,18 @@ class DynamicSegmentFilterData {
 
   public const TIMEFRAME_ALL_TIME = 'allTime';
   public const TIMEFRAME_IN_THE_LAST = 'inTheLast';
+  public const TIMEFRAME_BEFORE = 'before';
+  public const TIMEFRAME_AFTER = 'after';
+  public const TIMEFRAME_ON = 'on';
+  public const TIMEFRAME_BETWEEN = 'between';
+  public const TIMEFRAMES = [
+    self::TIMEFRAME_ALL_TIME,
+    self::TIMEFRAME_IN_THE_LAST,
+    self::TIMEFRAME_BEFORE,
+    self::TIMEFRAME_AFTER,
+    self::TIMEFRAME_ON,
+    self::TIMEFRAME_BETWEEN,
+  ];
 
   /**
    * @ORM\Column(type="serialized_array")

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -379,15 +379,13 @@ class FilterDataMapper {
     ];
 
     if ($data['action'] === EmailsReceived::ACTION) {
-      $this->filterHelper->validateDaysPeriodData($data);
       if (!isset($data['emails'])) {
         throw new InvalidFilterException('Missing email count value', InvalidFilterException::MISSING_VALUE);
       }
       $filterData['emails'] = $data['emails'];
       $filterData['operator'] = $data['operator'];
-      $filterData['timeframe'] = $data['timeframe'];
       $filterData['connect'] = $data['connect'];
-      $filterData['days'] = $data['days'] ?? 0;
+      $this->copyDatePeriodData($data, $filterData);
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $data['action'], $filterData);
     }
 

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -335,11 +335,15 @@ class FilterDataMapper {
       if (!in_array($data['operator'], $this->dateFilterHelper->getValidOperators())) {
         throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
       }
-      return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], [
+      $filterData = [
         'value' => $data['value'],
         'operator' => $data['operator'],
         'connect' => $data['connect'],
-      ]);
+      ];
+      if (isset($data['value2'])) {
+        $filterData['value2'] = $data['value2'];
+      }
+      return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], $filterData);
     }
     if (empty($data['wordpressRole'])) {
       throw new InvalidFilterException('Missing role', InvalidFilterException::MISSING_ROLE);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -524,7 +524,6 @@ class FilterDataMapper {
       $filterData['total_spent_amount'] = $data['total_spent_amount'];
       $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE) {
-      $this->filterHelper->validateDaysPeriodData($data);
       if (
         !isset($data['single_order_value_type'])
         || !isset($data['single_order_value_amount']) || $data['single_order_value_amount'] < 0
@@ -533,8 +532,7 @@ class FilterDataMapper {
       }
       $filterData['single_order_value_type'] = $data['single_order_value_type'];
       $filterData['single_order_value_amount'] = $data['single_order_value_amount'];
-      $filterData['days'] = $data['days'] ?? 0;
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif (in_array($data['action'], [WooCommercePurchaseDate::ACTION, WooCommerceFirstOrder::ACTION])) {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -599,6 +599,7 @@ class FilterDataMapper {
       $this->wooCommerceTag->validateFilterData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['tag_ids'] = $data['tag_ids'];
+      $this->copyDatePeriodData($data, $filterData, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     } else {
       throw new InvalidFilterException("Unknown action " . $data['action'], InvalidFilterException::MISSING_ACTION);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -492,6 +492,7 @@ class FilterDataMapper {
       }
       $filterData['operator'] = $data['operator'];
       $filterData['variation_ids'] = $data['variation_ids'];
+      $this->copyDatePeriodData($data, $filterData, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     } elseif ($data['action'] === WooCommerceCountry::ACTION_CUSTOMER_COUNTRY) {
       if (!isset($data['country_code'])) {
         throw new InvalidFilterException('Missing country', InvalidFilterException::MISSING_COUNTRY);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -476,6 +476,7 @@ class FilterDataMapper {
       }
       $filterData['operator'] = $data['operator'];
       $filterData['product_ids'] = $data['product_ids'];
+      $this->copyDatePeriodData($data, $filterData, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     } elseif ($data['action'] === WooCommerceProductVariation::ACTION_PRODUCT_VARIATION) {
       if (!isset($data['variation_ids']) || !is_array($data['variation_ids']) || count($data['variation_ids']) === 0) {
         throw new InvalidFilterException('Missing variation', InvalidFilterException::MISSING_VARIATION_ID);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -543,6 +543,9 @@ class FilterDataMapper {
     } elseif (in_array($data['action'], [WooCommercePurchaseDate::ACTION, WooCommerceFirstOrder::ACTION])) {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
+      if ($data['operator'] === DateFilterHelper::BETWEEN && isset($data['value2']) && is_string($filterData['value']) && is_string($data['value2'])) {
+        [$filterData['value'], $filterData['value2']] = $this->orderDateRange($filterData['value'], $data['value2']);
+      }
     } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {
       if (
         !isset($data['average_spent_type'])

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -340,7 +340,25 @@ class FilterDataMapper {
         'operator' => $data['operator'],
         'connect' => $data['connect'],
       ];
-      if (isset($data['value2'])) {
+      if ($data['operator'] === DateFilterHelper::BETWEEN) {
+        $betweenData = [
+          'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+          'value' => $filterData['value'],
+          'value2' => $data['value2'] ?? null,
+        ];
+        if (is_string($betweenData['value']) && is_string($betweenData['value2'])) {
+          [$betweenData['value'], $betweenData['value2']] = $this->orderDateRange($betweenData['value'], $betweenData['value2']);
+        }
+        try {
+          $this->filterHelper->validateDaysPeriodData($betweenData);
+        } catch (InvalidFilterException $e) {
+          throw $e;
+        } catch (\Throwable $e) {
+          throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+        }
+        $filterData['value'] = $betweenData['value'];
+        $filterData['value2'] = $betweenData['value2'];
+      } elseif (isset($data['value2'])) {
         $filterData['value2'] = $data['value2'];
       }
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $data['action'], $filterData);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -563,11 +563,9 @@ class FilterDataMapper {
       if (!isset($data['shipping_methods']) || !is_array($data['shipping_methods']) || empty($data['shipping_methods'])) {
         throw new InvalidFilterException('Missing shipping methods', InvalidFilterException::MISSING_VALUE);
       }
-      $this->filterHelper->validateDaysPeriodData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['shipping_methods'] = $data['shipping_methods'];
-      $filterData['days'] = intval($data['days'] ?? 0);
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif (in_array($data['action'], WooCommerceCustomerTextField::ACTIONS)) {
       if (empty($data['value'])) {
         throw new InvalidFilterException('Missing value', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -553,11 +553,9 @@ class FilterDataMapper {
       if (!isset($data['payment_methods']) || !is_array($data['payment_methods']) || empty($data['payment_methods'])) {
         throw new InvalidFilterException('Missing payment gateways', InvalidFilterException::MISSING_VALUE);
       }
-      $this->filterHelper->validateDaysPeriodData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['payment_methods'] = $data['payment_methods'];
-      $filterData['days'] = intval($data['days'] ?? 0);
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceUsedShippingMethod::ACTION) {
       if (!isset($data['operator']) || !in_array($data['operator'], WooCommerceUsedShippingMethod::VALID_OPERATORS, true)) {
         throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -537,15 +537,13 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
     } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {
-      $this->filterHelper->validateDaysPeriodData($data);
       if (
         !isset($data['average_spent_type'])
         || !isset($data['average_spent_amount']) || $data['average_spent_amount'] < 0
       ) {
         throw new InvalidFilterException('Missing required fields', InvalidFilterException::MISSING_AVERAGE_SPENT_FIELDS);
       }
-      $filterData['days'] = $data['days'] ?? 0;
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
       $filterData['average_spent_amount'] = $data['average_spent_amount'];
       $filterData['average_spent_type'] = $data['average_spent_type'];
     } elseif ($data['action'] === WooCommerceUsedPaymentMethod::ACTION) {

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -514,7 +514,6 @@ class FilterDataMapper {
       $filterData['rating'] = $data['rating'];
       $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceTotalSpent::ACTION_TOTAL_SPENT) {
-      $this->filterHelper->validateDaysPeriodData($data);
       if (
         !isset($data['total_spent_type'])
         || !isset($data['total_spent_amount']) || $data['total_spent_amount'] < 0
@@ -523,8 +522,7 @@ class FilterDataMapper {
       }
       $filterData['total_spent_type'] = $data['total_spent_type'];
       $filterData['total_spent_amount'] = $data['total_spent_amount'];
-      $filterData['days'] = $data['days'] ?? 0;
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE) {
       $this->filterHelper->validateDaysPeriodData($data);
       if (

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -543,7 +543,10 @@ class FilterDataMapper {
     } elseif (in_array($data['action'], [WooCommercePurchaseDate::ACTION, WooCommerceFirstOrder::ACTION])) {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
-      if ($data['operator'] === DateFilterHelper::BETWEEN && isset($data['value2']) && is_string($filterData['value']) && is_string($data['value2'])) {
+      if ($data['operator'] === DateFilterHelper::BETWEEN) {
+        if (!isset($data['value2']) || !is_string($data['value2']) || $data['value2'] === '' || !is_string($filterData['value'])) {
+          throw new InvalidFilterException('Missing second date for between operator', InvalidFilterException::INVALID_DATE_VALUE);
+        }
         [$filterData['value'], $filterData['value2']] = $this->orderDateRange($filterData['value'], $data['value2']);
       }
     } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -509,11 +509,10 @@ class FilterDataMapper {
       $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceNumberOfReviews::ACTION) {
       $this->wooCommerceNumberOfReviews->validateFilterData($data);
-      $filterData['days'] = $data['days'];
       $filterData['count_type'] = $data['count_type'];
       $filterData['count'] = $data['count'];
       $filterData['rating'] = $data['rating'];
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceTotalSpent::ACTION_TOTAL_SPENT) {
       $this->filterHelper->validateDaysPeriodData($data);
       if (

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -562,10 +562,23 @@ class FilterDataMapper {
       $filterData['operator'] = $data['operator'];
       $filterData['value'] = $data['value'];
       if ($data['operator'] === DateFilterHelper::BETWEEN) {
-        if (!isset($data['value2']) || !is_string($data['value2']) || $data['value2'] === '' || !is_string($filterData['value'])) {
-          throw new InvalidFilterException('Missing second date for between operator', InvalidFilterException::INVALID_DATE_VALUE);
+        $betweenData = [
+          'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+          'value' => $filterData['value'],
+          'value2' => $data['value2'] ?? null,
+        ];
+        if (is_string($betweenData['value']) && is_string($betweenData['value2'])) {
+          [$betweenData['value'], $betweenData['value2']] = $this->orderDateRange($betweenData['value'], $betweenData['value2']);
         }
-        [$filterData['value'], $filterData['value2']] = $this->orderDateRange($filterData['value'], $data['value2']);
+        try {
+          $this->filterHelper->validateDaysPeriodData($betweenData);
+        } catch (InvalidFilterException $e) {
+          throw $e;
+        } catch (\Throwable $e) {
+          throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+        }
+        $filterData['value'] = $betweenData['value'];
+        $filterData['value2'] = $betweenData['value2'];
       }
     } elseif ($data['action'] === WooCommerceAverageSpent::ACTION) {
       if (

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -498,7 +498,6 @@ class FilterDataMapper {
       $filterData['country_code'] = $data['country_code'];
       $filterData['operator'] = $data['operator'] ?? DynamicSegmentFilterData::OPERATOR_ANY;
     } elseif (in_array($data['action'], WooCommerceNumberOfOrders::ACTIONS)) {
-      $this->filterHelper->validateDaysPeriodData($data);
       if (
         !isset($data['number_of_orders_type'])
         || !isset($data['number_of_orders_count']) || $data['number_of_orders_count'] < 0
@@ -507,8 +506,7 @@ class FilterDataMapper {
       }
       $filterData['number_of_orders_type'] = $data['number_of_orders_type'];
       $filterData['number_of_orders_count'] = $data['number_of_orders_count'];
-      $filterData['days'] = $data['days'] ?? 0;
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommerceNumberOfReviews::ACTION) {
       $this->wooCommerceNumberOfReviews->validateFilterData($data);
       $filterData['days'] = $data['days'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -595,6 +595,7 @@ class FilterDataMapper {
       $filterData['attribute_type'] = $data['attribute_type'];
       $filterData['attribute_local_name'] = $data['attribute_local_name'] ?? null;
       $filterData['attribute_local_values'] = $data['attribute_local_values'] ?? null;
+      $this->copyDatePeriodData($data, $filterData, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     } elseif ($data['action'] === WooCommerceTag::ACTION) {
       $this->wooCommerceTag->validateFilterData($data);
       $filterData['operator'] = $data['operator'];

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -622,6 +622,39 @@ class FilterDataMapper {
     return new DynamicSegmentFilterData($filterType, $action, $filterData);
   }
 
+  private function copyDatePeriodData(array $data, array &$filterData, string $defaultTimeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): void {
+    $timeframe = $data['timeframe'] ?? $defaultTimeframe;
+    $datePeriodData = [
+      'timeframe' => $timeframe,
+      'days' => $data['days'] ?? 0,
+    ];
+    if (in_array($timeframe, [DynamicSegmentFilterData::TIMEFRAME_BEFORE, DynamicSegmentFilterData::TIMEFRAME_AFTER, DynamicSegmentFilterData::TIMEFRAME_ON, DynamicSegmentFilterData::TIMEFRAME_BETWEEN], true)) {
+      $datePeriodData['value'] = $data['value'] ?? null;
+    }
+    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_BETWEEN) {
+      $datePeriodData['value2'] = $data['value2'] ?? null;
+      if (is_string($datePeriodData['value']) && is_string($datePeriodData['value2'])) {
+        [$datePeriodData['value'], $datePeriodData['value2']] = $this->orderDateRange($datePeriodData['value'], $datePeriodData['value2']);
+      }
+    }
+    $this->filterHelper->validateDaysPeriodData($datePeriodData);
+    $filterData['timeframe'] = $datePeriodData['timeframe'];
+    $filterData['days'] = $timeframe === DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST ? $datePeriodData['days'] : 0;
+    if (isset($datePeriodData['value'])) {
+      $filterData['value'] = $datePeriodData['value'];
+    }
+    if (isset($datePeriodData['value2'])) {
+      $filterData['value2'] = $datePeriodData['value2'];
+    }
+  }
+
+  /**
+   * @return array{0: string, 1: string}
+   */
+  private function orderDateRange(string $value, string $value2): array {
+    return strcmp($value, $value2) <= 0 ? [$value, $value2] : [$value2, $value];
+  }
+
   /**
    * @throws InvalidFilterException
    */

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -467,6 +467,7 @@ class FilterDataMapper {
       }
       $filterData['operator'] = $data['operator'];
       $filterData['category_ids'] = $data['category_ids'];
+      $this->copyDatePeriodData($data, $filterData, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     } elseif ($data['action'] === WooCommerceProduct::ACTION_PRODUCT) {
       if (!isset($data['product_ids'])) {
         throw new InvalidFilterException('Missing product', InvalidFilterException::MISSING_PRODUCT_ID);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -439,14 +439,12 @@ class FilterDataMapper {
     if (!isset($data['opens'])) {
       throw new InvalidFilterException('Missing number of opens', InvalidFilterException::MISSING_VALUE);
     }
-    $this->filterHelper->validateDaysPeriodData($data);
     $filterData = [
       'opens' => $data['opens'],
-      'days' => $data['days'] ?? 0,
       'operator' => $data['operator'] ?? 'more',
-      'timeframe' => $data['timeframe'] ?? DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, // backwards compatibility
       'connect' => $data['connect'],
     ];
+    $this->copyDatePeriodData($data, $filterData);
     $filterType = DynamicSegmentFilterData::TYPE_EMAIL;
     $action = $data['action'];
     return new DynamicSegmentFilterData($filterType, $action, $filterData);

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -390,15 +390,13 @@ class FilterDataMapper {
     }
 
     if ($data['action'] === NumberOfClicks::ACTION) {
-      $this->filterHelper->validateDaysPeriodData($data);
       if (!isset($data['clicks'])) {
         throw new InvalidFilterException('Missing click count value', InvalidFilterException::MISSING_VALUE);
       }
       $filterData['clicks'] = $data['clicks'];
       $filterData['operator'] = $data['operator'];
-      $filterData['timeframe'] = $data['timeframe'];
       $filterData['connect'] = $data['connect'];
-      $filterData['days'] = $data['days'] ?? 0;
+      $this->copyDatePeriodData($data, $filterData);
       return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $data['action'], $filterData);
     }
 

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -583,8 +583,7 @@ class FilterDataMapper {
       $this->wooCommerceUsedCouponCode->validateFilterData($data);
       $filterData['operator'] = $data['operator'];
       $filterData['coupon_code_ids'] = $data['coupon_code_ids'];
-      $filterData['days'] = $data['days'];
-      $filterData['timeframe'] = $data['timeframe'];
+      $this->copyDatePeriodData($data, $filterData);
     } elseif ($data['action'] === WooCommercePurchasedWithAttribute::ACTION) {
       $this->wooCommercePurchasedWithAttribute->validateFilterData($data);
       $filterData['operator'] = $data['operator'];

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
@@ -85,14 +85,6 @@ class DateFilterHelper {
     return $dateValue;
   }
 
-  public function getNextDayStart(string $dateString): string {
-    $date = CarbonImmutable::createFromFormat('Y-m-d', $dateString);
-    if (!$date instanceof CarbonImmutable) {
-      throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
-    }
-    return $date->addDay()->startOfDay()->toDateTimeString();
-  }
-
   public function getOperatorFromFilter(DynamicSegmentFilterEntity $filter): string {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('operator');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/DateFilterHelper.php
@@ -13,6 +13,7 @@ class DateFilterHelper {
   const ON_OR_BEFORE = 'onOrBefore';
   const ON_OR_AFTER = 'onOrAfter';
   const NOT_ON = 'notOn';
+  const BETWEEN = 'between';
   const IN_THE_LAST = 'inTheLast';
   const NOT_IN_THE_LAST = 'notInTheLast';
 
@@ -40,6 +41,7 @@ class DateFilterHelper {
       self::ON_OR_BEFORE,
       self::ON_OR_AFTER,
       self::NOT_ON,
+      self::BETWEEN,
     ];
   }
 
@@ -72,6 +74,23 @@ class DateFilterHelper {
       throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
     }
     return $dateValue;
+  }
+
+  public function getSecondDateValueFromFilter(DynamicSegmentFilterEntity $filter): string {
+    $filterData = $filter->getFilterData();
+    $dateValue = $filterData->getParam('value2');
+    if (!is_string($dateValue)) {
+      throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
+    }
+    return $dateValue;
+  }
+
+  public function getNextDayStart(string $dateString): string {
+    $date = CarbonImmutable::createFromFormat('Y-m-d', $dateString);
+    if (!$date instanceof CarbonImmutable) {
+      throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+    }
+    return $date->addDay()->startOfDay()->toDateTimeString();
   }
 
   public function getOperatorFromFilter(DynamicSegmentFilterEntity $filter): string {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountAction.php
@@ -31,31 +31,18 @@ class EmailOpensAbsoluteCountAction implements Filter {
 
   public function apply(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): QueryBuilder {
     $filterData = $filter->getFilterData();
-    /** @var int $days - for PHPStan because intval() doesn't accept a value of mixed */
-    $days = $filterData->getParam('days');
     $operator = $filterData->getParam('operator');
     $action = $filterData->getAction();
-    $timeframe = $filterData->getParam('timeframe');
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $statsTable = $this->entityManager->getClassMetadata(StatisticsOpenEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
-
-    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
-      $queryBuilder->leftJoin(
-        $subscribersTable,
-        $statsTable,
-        'opens',
-        "{$subscribersTable}.id = opens.subscriber_id AND opens.user_agent_type = :userAgentType{$parameterSuffix}"
-      );
-    } else {
-      $queryBuilder->leftJoin(
-        $subscribersTable,
-        $statsTable,
-        'opens',
-        "{$subscribersTable}.id = opens.subscriber_id AND opens.created_at > :newer{$parameterSuffix} AND opens.user_agent_type = :userAgentType{$parameterSuffix}"
-      );
-      $queryBuilder->setParameter('newer' . $parameterSuffix, $this->filterHelper->getDateNDaysAgoImmutable(intval($days))->startOfDay());
+    $dateCondition = $this->filterHelper->getDatePeriodCondition($queryBuilder, 'opens.created_at', $filterData, true);
+    $joinCondition = "{$subscribersTable}.id = opens.subscriber_id AND opens.user_agent_type = :userAgentType{$parameterSuffix}";
+    if ($dateCondition !== null) {
+      $joinCondition .= " AND $dateCondition";
     }
+
+    $queryBuilder->leftJoin($subscribersTable, $statsTable, 'opens', $joinCondition);
 
     $queryBuilder->groupBy("$subscribersTable.id");
     if ($operator === 'equals') {

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailsReceived.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailsReceived.php
@@ -29,18 +29,15 @@ class EmailsReceived implements Filter {
     $filterData = $filter->getFilterData();
     $emailCount = $filterData->getIntParam('emails');
     $operator = $filterData->getStringParam('operator');
-    $timeframe = $filterData->getStringParam('timeframe');
     $statsTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
     $subscribersTable = $this->filterHelper->getSubscribersTable();
-
-    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
-      $queryBuilder->leftJoin($subscribersTable, $statsTable, 'emails', "{$subscribersTable}.id = emails.subscriber_id");
-    } else {
-      $days = $filterData->getIntParam('days');
-      $dateParam = $this->filterHelper->getUniqueParameterName('days');
-      $queryBuilder->leftJoin($subscribersTable, $statsTable, 'emails', "{$subscribersTable}.id = emails.subscriber_id AND emails.sent_at >= :$dateParam");
-      $queryBuilder->setParameter($dateParam, $this->filterHelper->getDateNDaysAgoImmutable($days)->startOfDay());
+    $dateCondition = $this->filterHelper->getDatePeriodCondition($queryBuilder, 'emails.sent_at', $filterData, true);
+    $joinCondition = "{$subscribersTable}.id = emails.subscriber_id";
+    if ($dateCondition !== null) {
+      $joinCondition .= " AND $dateCondition";
     }
+
+    $queryBuilder->leftJoin($subscribersTable, $statsTable, 'emails', $joinCondition);
 
     $queryBuilder->groupBy("$subscribersTable.id");
     $emailCountParam = $this->filterHelper->getUniqueParameterName('emails');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -115,9 +115,6 @@ class FilterHelper {
         throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
       }
       $days = intval($days);
-      if ($days < 1) {
-        throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
-      }
       $date = $this->getDateNDaysAgoImmutable($days);
       if ($startOfDayForInTheLast) {
         $date = $date->startOfDay();

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -115,6 +115,9 @@ class FilterHelper {
         throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
       }
       $days = intval($days);
+      if ($days < 1) {
+        throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+      }
       $date = $this->getDateNDaysAgoImmutable($days);
       if ($startOfDayForInTheLast) {
         $date = $date->startOfDay();

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/FilterHelper.php
@@ -75,7 +75,7 @@ class FilterHelper {
   }
 
   public function validateDaysPeriodData(array $data): void {
-    if (!isset($data['timeframe']) || !in_array($data['timeframe'], [DynamicSegmentFilterData::TIMEFRAME_ALL_TIME, DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST], true)) {
+    if (!isset($data['timeframe']) || !in_array($data['timeframe'], DynamicSegmentFilterData::TIMEFRAMES, true)) {
       throw new InvalidFilterException('Missing timeframe type', InvalidFilterException::MISSING_VALUE);
     }
 
@@ -83,11 +83,105 @@ class FilterHelper {
       return;
     }
 
-    $days = intval($data['days'] ?? null);
+    if ($data['timeframe'] === DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST) {
+      $days = intval($data['days'] ?? null);
 
-    if ($days < 1) {
-      throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+      if ($days < 1) {
+        throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+      }
+      return;
     }
+
+    $this->getValidDateValue($data['value'] ?? null);
+    if ($data['timeframe'] === DynamicSegmentFilterData::TIMEFRAME_BETWEEN) {
+      $this->getValidDateValue($data['value2'] ?? null);
+    }
+  }
+
+  public function getDatePeriodCondition(QueryBuilder $queryBuilder, string $dateExpression, DynamicSegmentFilterData $filterData, bool $startOfDayForInTheLast = false, string $defaultTimeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): ?string {
+    $timeframe = $filterData->getParam('timeframe') ?? $defaultTimeframe;
+    if (!is_string($timeframe) || !in_array($timeframe, DynamicSegmentFilterData::TIMEFRAMES, true)) {
+      throw new InvalidFilterException('Missing timeframe type', InvalidFilterException::MISSING_VALUE);
+    }
+
+    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
+      return null;
+    }
+
+    $dateParam = $this->getUniqueParameterName('date');
+    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST) {
+      $days = $filterData->getParam('days');
+      if (!is_int($days) && !is_string($days)) {
+        throw new InvalidFilterException('Missing number of days', InvalidFilterException::MISSING_VALUE);
+      }
+      $days = intval($days);
+      $date = $this->getDateNDaysAgoImmutable($days);
+      if ($startOfDayForInTheLast) {
+        $date = $date->startOfDay();
+      }
+      $queryBuilder->setParameter($dateParam, $date->toDateTimeString());
+      return "$dateExpression >= :$dateParam";
+    }
+
+    $startOfDay = $this->getDayBoundary($filterData, 'value');
+    $startOfNextDay = $this->getNextDayBoundary($filterData, 'value');
+
+    switch ($timeframe) {
+      case DynamicSegmentFilterData::TIMEFRAME_BEFORE:
+        $queryBuilder->setParameter($dateParam, $startOfDay);
+        return "$dateExpression < :$dateParam";
+      case DynamicSegmentFilterData::TIMEFRAME_AFTER:
+        $queryBuilder->setParameter($dateParam, $startOfNextDay);
+        return "$dateExpression >= :$dateParam";
+      case DynamicSegmentFilterData::TIMEFRAME_ON:
+        $endParam = $this->getUniqueParameterName('date');
+        $queryBuilder->setParameter($dateParam, $startOfDay);
+        $queryBuilder->setParameter($endParam, $startOfNextDay);
+        return "$dateExpression >= :$dateParam AND $dateExpression < :$endParam";
+      case DynamicSegmentFilterData::TIMEFRAME_BETWEEN:
+        $endParam = $this->getUniqueParameterName('date');
+        $queryBuilder->setParameter($dateParam, $startOfDay);
+        $queryBuilder->setParameter($endParam, $this->getNextDayBoundary($filterData, 'value2'));
+        return "$dateExpression >= :$dateParam AND $dateExpression < :$endParam";
+      default:
+        throw new InvalidFilterException('Missing timeframe type', InvalidFilterException::MISSING_VALUE);
+    }
+  }
+
+  private function getDayBoundary(DynamicSegmentFilterData $filterData, string $paramName): string {
+    return $this->parseValidDate($filterData->getParam($paramName))->startOfDay()->toDateTimeString();
+  }
+
+  private function getNextDayBoundary(DynamicSegmentFilterData $filterData, string $paramName): string {
+    return $this->parseValidDate($filterData->getParam($paramName))->addDay()->startOfDay()->toDateTimeString();
+  }
+
+  public function applyDatePeriodFilter(QueryBuilder $queryBuilder, string $dateExpression, DynamicSegmentFilterData $filterData, bool $startOfDayForInTheLast = false, string $defaultTimeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST): void {
+    $condition = $this->getDatePeriodCondition($queryBuilder, $dateExpression, $filterData, $startOfDayForInTheLast, $defaultTimeframe);
+    if ($condition !== null) {
+      $queryBuilder->andWhere($condition);
+    }
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function parseValidDate($value): CarbonImmutable {
+    if (!is_string($value)) {
+      throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+    }
+    $date = CarbonImmutable::createFromFormat('Y-m-d', $value);
+    if (!$date instanceof CarbonImmutable || $date->toDateString() !== $value) {
+      throw new InvalidFilterException('Invalid date value', InvalidFilterException::INVALID_DATE_VALUE);
+    }
+    return $date;
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function getValidDateValue($value): string {
+    return $this->parseValidDate($value)->toDateString();
   }
 
   /**

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/NumberOfClicks.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/NumberOfClicks.php
@@ -29,18 +29,15 @@ class NumberOfClicks implements Filter {
     $filterData = $filter->getFilterData();
     $clickCount = $filterData->getIntParam('clicks');
     $operator = $filterData->getStringParam('operator');
-    $timeframe = $filterData->getStringParam('timeframe');
     $statsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
     $subscribersTable = $this->filterHelper->getSubscribersTable();
-
-    if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
-      $queryBuilder->leftJoin($subscribersTable, $statsTable, 'clicks', "{$subscribersTable}.id = clicks.subscriber_id");
-    } else {
-      $days = $filterData->getIntParam('days');
-      $dateParam = $this->filterHelper->getUniqueParameterName('days');
-      $queryBuilder->leftJoin($subscribersTable, $statsTable, 'clicks', "{$subscribersTable}.id = clicks.subscriber_id AND clicks.created_at >= :$dateParam");
-      $queryBuilder->setParameter($dateParam, $this->filterHelper->getDateNDaysAgoImmutable($days)->startOfDay());
+    $dateCondition = $this->filterHelper->getDatePeriodCondition($queryBuilder, 'clicks.created_at', $filterData, true);
+    $joinCondition = "{$subscribersTable}.id = clicks.subscriber_id";
+    if ($dateCondition !== null) {
+      $joinCondition .= " AND $dateCondition";
     }
+
+    $queryBuilder->leftJoin($subscribersTable, $statsTable, 'clicks', $joinCondition);
 
     $queryBuilder->groupBy("$subscribersTable.id");
     $clicksCountParam = $this->filterHelper->getUniqueParameterName('clicks');

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
@@ -84,9 +84,9 @@ class SubscriberDateField implements Filter {
           throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
         }
         $parameter2 = $this->filterHelper->getUniqueParameterName('date');
-        $queryBuilder->andWhere("$columnName >= :$parameter AND $columnName < :$parameter2");
-        $queryBuilder->setParameter($parameter, $date . ' 00:00:00');
-        $queryBuilder->setParameter($parameter2, $this->dateFilterHelper->getNextDayStart($date2));
+        $queryBuilder->andWhere("DATE($columnName) >= :$parameter AND DATE($columnName) <= :$parameter2");
+        $queryBuilder->setParameter($parameter, $date);
+        $queryBuilder->setParameter($parameter2, $date2);
         return $queryBuilder;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/SubscriberDateField.php
@@ -48,6 +48,9 @@ class SubscriberDateField implements Filter {
     $value = $this->dateFilterHelper->getDateValueFromFilter($filter);
     $parameter = $this->filterHelper->getUniqueParameterName('date');
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $value);
+    $date2 = $operator === DateFilterHelper::BETWEEN
+      ? $this->dateFilterHelper->getDateStringForOperator($operator, $this->dateFilterHelper->getSecondDateValueFromFilter($filter))
+      : null;
 
     if (!is_string($action)) {
       throw new InvalidFilterException('Missing action', InvalidFilterException::MISSING_ACTION);
@@ -76,6 +79,15 @@ class SubscriberDateField implements Filter {
       case DateFilterHelper::ON_OR_AFTER:
         $queryBuilder->andWhere("DATE($columnName) >= :$parameter");
         break;
+      case DateFilterHelper::BETWEEN:
+        if ($date2 === null) {
+          throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
+        }
+        $parameter2 = $this->filterHelper->getUniqueParameterName('date');
+        $queryBuilder->andWhere("$columnName >= :$parameter AND $columnName < :$parameter2");
+        $queryBuilder->setParameter($parameter, $date . ' 00:00:00');
+        $queryBuilder->setParameter($parameter2, $this->dateFilterHelper->getNextDayStart($date2));
+        return $queryBuilder;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceAverageSpent.php
@@ -27,20 +27,9 @@ class WooCommerceAverageSpent implements Filter {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('average_spent_type');
     $amount = $filterData->getParam('average_spent_amount');
-    $timeframe = $filterData->getParam('timeframe');
 
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-
-    if ($timeframe !== DynamicSegmentFilterData::TIMEFRAME_ALL_TIME) {
-      /** @var int $days */
-      $days = $filterData->getParam('days');
-      $days = intval($days);
-      $date = $this->filterHelper->getDateNDaysAgo($days);
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $queryBuilder
-        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
 
     $queryBuilder->groupBy('inner_subscriber_id');
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceCategory.php
@@ -53,6 +53,7 @@ class WooCommerceCategory implements Filter {
 
     if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
       $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
       $this->applyProductJoin($queryBuilder, $orderStatsAlias);
       $this->applyTermRelationshipsJoin($queryBuilder);
       $this->applyTermTaxonomyJoin($queryBuilder, $parameterSuffix);
@@ -64,6 +65,7 @@ class WooCommerceCategory implements Filter {
         $categoryIdWithChildrenIds = $this->getCategoriesWithChildren([$categoryId]);
         $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
         $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+        $this->filterHelper->applyDatePeriodFilter($subQuery, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
         $this->applyProductJoin($subQuery, $orderStatsAlias);
         $this->applyTermRelationshipsJoin($subQuery);
         $this->applyTermTaxonomyJoin($subQuery, $uniqueParamaterSuffix);
@@ -82,6 +84,7 @@ class WooCommerceCategory implements Filter {
       $subQuery = $this->createQueryBuilder($subscribersTable);
       $subQuery->select("DISTINCT $subscribersTable.id");
       $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+      $this->filterHelper->applyDatePeriodFilter($subQuery, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
       $subQuery = $this->applyProductJoin($subQuery, $orderStatsAlias);
       $subQuery = $this->applyTermRelationshipsJoin($subQuery);
       $subQuery = $this->applyTermTaxonomyJoin($subQuery, $parameterSuffix);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceFirstOrder.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceFirstOrder.php
@@ -33,20 +33,23 @@ class WooCommerceFirstOrder implements Filter {
     $operator = $this->dateFilterHelper->getOperatorFromFilter($filter);
     $dateValue = $this->dateFilterHelper->getDateValueFromFilter($filter);
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $dateValue);
+    $date2 = $operator === DateFilterHelper::BETWEEN
+      ? $this->dateFilterHelper->getDateStringForOperator($operator, $this->dateFilterHelper->getSecondDateValueFromFilter($filter))
+      : null;
     $subscribersTable = $this->filterHelper->getSubscribersTable();
 
     if (in_array($operator, [DateFilterHelper::NOT_ON, DateFilterHelper::NOT_IN_THE_LAST])) {
       $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-      $this->applyConditionsToQueryBuilder($operator, $date, $subQuery);
+      $this->applyConditionsToQueryBuilder($operator, $date, $subQuery, $date2);
       $queryBuilder->andWhere($queryBuilder->expr()->notIn("{$subscribersTable}.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
     } else {
-      $this->applyConditionsToQueryBuilder($operator, $date, $queryBuilder);
+      $this->applyConditionsToQueryBuilder($operator, $date, $queryBuilder, $date2);
     }
 
     return $queryBuilder;
   }
 
-  private function applyConditionsToQueryBuilder(string $operator, string $date, QueryBuilder $queryBuilder): QueryBuilder {
+  private function applyConditionsToQueryBuilder(string $operator, string $date, QueryBuilder $queryBuilder, ?string $date2): QueryBuilder {
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
     $dateParam = $this->filterHelper->getUniqueParameterName('date');
     $subscribersTable = $this->filterHelper->getSubscribersTable();
@@ -72,6 +75,15 @@ class WooCommerceFirstOrder implements Filter {
       case DateFilterHelper::ON_OR_BEFORE:
         $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) <= :$dateParam");
         break;
+      case DateFilterHelper::BETWEEN:
+        if ($date2 === null) {
+          throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
+        }
+        $date2Param = $this->filterHelper->getUniqueParameterName('date');
+        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) >= :$dateParam AND MIN($orderStatsAlias.date_created) < :$date2Param");
+        $queryBuilder->setParameter($dateParam, $date . ' 00:00:00');
+        $queryBuilder->setParameter($date2Param, $this->dateFilterHelper->getNextDayStart($date2));
+        return $queryBuilder;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceFirstOrder.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceFirstOrder.php
@@ -58,31 +58,31 @@ class WooCommerceFirstOrder implements Filter {
 
     switch ($operator) {
       case DateFilterHelper::BEFORE:
-        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) < :$dateParam");
+        $queryBuilder->andHaving("DATE(MIN($orderStatsAlias.date_created)) < :$dateParam");
         break;
       case DateFilterHelper::AFTER:
-        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) > :$dateParam");
+        $queryBuilder->andHaving("DATE(MIN($orderStatsAlias.date_created)) > :$dateParam");
         break;
       case DateFilterHelper::IN_THE_LAST:
       case DateFilterHelper::NOT_IN_THE_LAST:
       case DateFilterHelper::ON_OR_AFTER:
-        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) >= :$dateParam");
+        $queryBuilder->andHaving("DATE(MIN($orderStatsAlias.date_created)) >= :$dateParam");
         break;
       case DateFilterHelper::ON:
       case DateFilterHelper::NOT_ON:
-        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) = :$dateParam");
+        $queryBuilder->andHaving("DATE(MIN($orderStatsAlias.date_created)) = :$dateParam");
         break;
       case DateFilterHelper::ON_OR_BEFORE:
-        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) <= :$dateParam");
+        $queryBuilder->andHaving("DATE(MIN($orderStatsAlias.date_created)) <= :$dateParam");
         break;
       case DateFilterHelper::BETWEEN:
         if ($date2 === null) {
           throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
         }
         $date2Param = $this->filterHelper->getUniqueParameterName('date');
-        $queryBuilder->andHaving("MIN($orderStatsAlias.date_created) >= :$dateParam AND MIN($orderStatsAlias.date_created) < :$date2Param");
-        $queryBuilder->setParameter($dateParam, $date . ' 00:00:00');
-        $queryBuilder->setParameter($date2Param, $this->dateFilterHelper->getNextDayStart($date2));
+        $queryBuilder->andHaving("DATE(MIN($orderStatsAlias.date_created)) >= :$dateParam AND DATE(MIN($orderStatsAlias.date_created)) <= :$date2Param");
+        $queryBuilder->setParameter($dateParam, $date);
+        $queryBuilder->setParameter($date2Param, $date2);
         return $queryBuilder;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrders.php
@@ -54,7 +54,6 @@ class WooCommerceNumberOfOrders implements Filter {
     /** @var string $count - for PHPStan because intval() doesn't accept a value of mixed */
     $count = $filterData->getParam('number_of_orders_count');
     $count = intval($count);
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $collation = $this->collationChecker->getCollateIfNeeded(
       $subscribersTable,
@@ -63,13 +62,12 @@ class WooCommerceNumberOfOrders implements Filter {
       'email'
     );
 
-    /** @var int $days - for PHPStan because intval() doesn't accept a value of mixed */
-    $days = $filterData->getParam('days');
-    $date = $this->filterHelper->getDateNDaysAgo(intval($days));
+    $dateCondition = $this->filterHelper->getDatePeriodCondition($queryBuilder, 'orderStats.date_created', $filterData);
 
-    $joinCondition = $isAllTime
-      ? 'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN (:excludedStatuses' . $parameterSuffix . ')'
-      : 'customer.customer_id = orderStats.customer_id AND orderStats.date_created >= :date' . $parameterSuffix . ' AND orderStats.status NOT IN (:excludedStatuses' . $parameterSuffix . ')';
+    $joinCondition = 'customer.customer_id = orderStats.customer_id AND orderStats.status NOT IN (:excludedStatuses' . $parameterSuffix . ')';
+    if ($dateCondition !== null) {
+      $joinCondition .= " AND $dateCondition";
+    }
 
     $subQuery = $this->entityManager->getConnection()
       ->createQueryBuilder()
@@ -102,7 +100,6 @@ class WooCommerceNumberOfOrders implements Filter {
         'joinCondition' => "$subscribersTable.email = selectedCustomers.email $collation",
       ],
     ], \true)
-      ->setParameter('date' . $parameterSuffix, $date->toDateTimeString())
       ->setParameter('excludedStatuses' . $parameterSuffix, $this->wooFilterHelper->defaultExcludedStatuses(), ArrayParameterType::STRING)
       ->groupBy('inner_subscriber_id');
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviews.php
@@ -36,9 +36,6 @@ class WooCommerceNumberOfReviews implements Filter {
     /** @var string $rating - for PHPStan because strval() doesn't accept a value of mixed */
     $rating = $filterData->getParam('rating');
     $rating = strval($rating);
-    /** @var int $days - for PHPStan because intval() doesn't accept a value of mixed */
-    $days = $filterData->getParam('days');
-    $days = intval($days);
     /** @var int $count - for PHPStan because intval() doesn't accept a value of mixed */
     $count = $filterData->getParam('count');
     $count = intval($count);
@@ -51,15 +48,12 @@ class WooCommerceNumberOfReviews implements Filter {
       'comment_author_email'
     );
 
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
     $joinCondition = "$subscribersTable.email = comments.comment_author_email $collation
       AND comments.comment_type = 'review'";
 
-    if (!$isAllTime) {
-      $date = $this->filterHelper->getDateNDaysAgo($days);
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $joinCondition .= " AND comments.comment_date >= :$dateParam";
-      $queryBuilder->setParameter($dateParam, $date->toDateTimeString());
+    $dateCondition = $this->filterHelper->getDatePeriodCondition($queryBuilder, 'comments.comment_date', $filterData);
+    if ($dateCondition !== null) {
+      $joinCondition .= " AND $dateCondition";
     }
 
     $commentMetaJoinCondition = "comments.comment_ID = commentmeta.comment_id AND commentmeta.meta_key = 'rating'";

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProduct.php
@@ -49,6 +49,7 @@ class WooCommerceProduct implements Filter {
 
     if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
       $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
       $this->applyProductJoin($queryBuilder, $orderStatsAlias);
       $queryBuilder->andWhere("product.product_id IN (:products_{$parameterSuffix})");
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
@@ -57,6 +58,7 @@ class WooCommerceProduct implements Filter {
         $uniqueParameterSuffix = Security::generateRandomString();
         $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
         $subOrderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+        $this->filterHelper->applyDatePeriodFilter($subQuery, "$subOrderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
         $this->applyProductJoin($subQuery, $subOrderStatsAlias);
         $subQuery->andWhere("product.product_id = :product_{$uniqueParameterSuffix}");
         $subQuery->setParameter("product_{$uniqueParameterSuffix}", $productId);
@@ -74,6 +76,7 @@ class WooCommerceProduct implements Filter {
       $subQuery = $this->createQueryBuilder($subscribersTable);
       $subQuery->select("DISTINCT $subscribersTable.id");
       $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+      $this->filterHelper->applyDatePeriodFilter($subQuery, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
       $subQuery = $this->applyProductJoin($subQuery, $orderStatsAlias);
       $subQuery->andWhere("product.product_id IN (:products_{$parameterSuffix})");
       // application subQuery for negation

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProductVariation.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceProductVariation.php
@@ -50,6 +50,7 @@ class WooCommerceProductVariation implements Filter {
 
     if ($operator === DynamicSegmentFilterData::OPERATOR_ANY) {
       $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+      $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
       $this->applyProductJoin($queryBuilder, $orderStatsAlias);
       $queryBuilder->andWhere("product.variation_id IN (:variations_{$parameterSuffix})");
     } elseif ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
@@ -58,6 +59,7 @@ class WooCommerceProductVariation implements Filter {
         $uniqueParameterSuffix = Security::generateRandomString();
         $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
         $subOrderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+        $this->filterHelper->applyDatePeriodFilter($subQuery, "$subOrderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
         $this->applyProductJoin($subQuery, $subOrderStatsAlias);
         $subQuery->andWhere("product.variation_id = :variation_{$uniqueParameterSuffix}");
         $subQuery->setParameter("variation_{$uniqueParameterSuffix}", $variationId);
@@ -74,6 +76,7 @@ class WooCommerceProductVariation implements Filter {
       $subQuery = $this->createQueryBuilder($subscribersTable);
       $subQuery->select("DISTINCT $subscribersTable.id");
       $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($subQuery);
+      $this->filterHelper->applyDatePeriodFilter($subQuery, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
       $subQuery = $this->applyProductJoin($subQuery, $orderStatsAlias);
       $subQuery->andWhere("product.variation_id IN (:variations_{$parameterSuffix})");
       $queryBuilder->where("{$subscribersTable}.id NOT IN ({$this->filterHelper->getInterpolatedSQL($subQuery)})");

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -77,9 +77,9 @@ class WooCommercePurchaseDate implements Filter {
           throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
         }
         $date2Param = $this->filterHelper->getUniqueParameterName('date');
-        $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam AND $orderStatsAlias.date_created < :$date2Param");
-        $queryBuilder->setParameter($dateParam, $date . ' 00:00:00');
-        $queryBuilder->setParameter($date2Param, $this->dateFilterHelper->getNextDayStart($date2));
+        $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) >= :$dateParam AND DATE($orderStatsAlias.date_created) <= :$date2Param");
+        $queryBuilder->setParameter($dateParam, $date);
+        $queryBuilder->setParameter($date2Param, $date2);
         return $queryBuilder;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchaseDate.php
@@ -33,20 +33,23 @@ class WooCommercePurchaseDate implements Filter {
     $operator = $this->dateFilterHelper->getOperatorFromFilter($filter);
     $dateValue = $this->dateFilterHelper->getDateValueFromFilter($filter);
     $date = $this->dateFilterHelper->getDateStringForOperator($operator, $dateValue);
+    $date2 = $operator === DateFilterHelper::BETWEEN
+      ? $this->dateFilterHelper->getDateStringForOperator($operator, $this->dateFilterHelper->getSecondDateValueFromFilter($filter))
+      : null;
     $subscribersTable = $this->filterHelper->getSubscribersTable();
 
     if (in_array($operator, [DateFilterHelper::NOT_ON, DateFilterHelper::NOT_IN_THE_LAST])) {
       $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-      $this->applyConditionsToQueryBuilder($operator, $date, $subQuery);
+      $this->applyConditionsToQueryBuilder($operator, $date, $subQuery, $date2);
       $queryBuilder->andWhere($queryBuilder->expr()->notIn("{$subscribersTable}.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
     } else {
-      $this->applyConditionsToQueryBuilder($operator, $date, $queryBuilder);
+      $this->applyConditionsToQueryBuilder($operator, $date, $queryBuilder, $date2);
     }
 
     return $queryBuilder;
   }
 
-  private function applyConditionsToQueryBuilder(string $operator, string $date, QueryBuilder $queryBuilder): QueryBuilder {
+  private function applyConditionsToQueryBuilder(string $operator, string $date, QueryBuilder $queryBuilder, ?string $date2): QueryBuilder {
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
     $dateParam = $this->filterHelper->getUniqueParameterName('date');
 
@@ -69,6 +72,15 @@ class WooCommercePurchaseDate implements Filter {
       case DateFilterHelper::ON_OR_BEFORE:
         $queryBuilder->andWhere("DATE($orderStatsAlias.date_created) <= :$dateParam");
         break;
+      case DateFilterHelper::BETWEEN:
+        if ($date2 === null) {
+          throw new InvalidFilterException('Incorrect value for date', InvalidFilterException::INVALID_DATE_VALUE);
+        }
+        $date2Param = $this->filterHelper->getUniqueParameterName('date');
+        $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam AND $orderStatsAlias.date_created < :$date2Param");
+        $queryBuilder->setParameter($dateParam, $date . ' 00:00:00');
+        $queryBuilder->setParameter($date2Param, $this->dateFilterHelper->getNextDayStart($date2));
+        return $queryBuilder;
       default:
         throw new InvalidFilterException('Incorrect value for operator', InvalidFilterException::MISSING_VALUE);
     }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttribute.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttribute.php
@@ -51,6 +51,7 @@ class WooCommercePurchasedWithAttribute implements Filter {
     $attributeTermIds = $filterData->getArrayParam('attribute_term_ids');
     $termIdsParam = $this->filterHelper->getUniqueParameterName('attribute_term_ids');
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $productAlias = $this->applyProductJoin($queryBuilder, $orderStatsAlias);
     $attributeAlias = $this->applyTaxonomyAttributeJoin($queryBuilder, $productAlias, $attributeTaxonomySlug);
     $queryBuilder->andWhere("$attributeAlias.term_id IN (:$termIdsParam)");
@@ -193,6 +194,7 @@ class WooCommercePurchasedWithAttribute implements Filter {
     $valuesParam = $this->filterHelper->getUniqueParameterName('attribute_values');
     $keyParam = $this->filterHelper->getUniqueParameterName('attribute_name');
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $productAlias = $this->applyProductJoin($queryBuilder, $orderStatsAlias);
 
     $queryBuilder->innerJoin(

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValue.php
@@ -28,22 +28,10 @@ class WooCommerceSingleOrderValue implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('single_order_value_type');
     $amount = $filterData->getParam('single_order_value_amount');
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
 
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-
-    if (!$isAllTime) {
-      $days = $filterData->getParam('days');
-      if (!is_string($days)) {
-        $days = '1'; // Default to last day
-      }
-      $date = $this->filterHelper->getDateNDaysAgo(intval($days));
-      $dateParam = "date_$parameterSuffix";
-      $queryBuilder
-        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
 
     if ($type === '=') {
       $queryBuilder->andWhere("$orderStatsAlias.total_sales = :amount" . $parameterSuffix);

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTag.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTag.php
@@ -53,6 +53,7 @@ class WooCommerceTag implements Filter {
 
   public function applyForAnyOperator(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData): void {
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $tagIdsParam = $this->filterHelper->getUniqueParameterName('tagIds');
     $productAlias = $this->applyProductJoin($queryBuilder, $orderStatsAlias);
     $queryBuilder->join(

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceTotalSpent.php
@@ -28,19 +28,10 @@ class WooCommerceTotalSpent implements Filter {
     $filterData = $filter->getFilterData();
     $type = $filterData->getParam('total_spent_type');
     $amount = $filterData->getParam('total_spent_amount');
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
 
     $parameterSuffix = $filter->getId() ?? Security::generateRandomString();
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-
-    if (!$isAllTime) {
-      /** @var int $days - for PHPStan because intval() doesn't accept a value of mixed */
-      $days = $filterData->getParam('days');
-      $date = $this->filterHelper->getDateNDaysAgo(intval($days));
-      $dateParam = "date_$parameterSuffix";
-      $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
 
     $queryBuilder->groupBy('inner_subscriber_id');
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCode.php
@@ -60,18 +60,9 @@ class WooCommerceUsedCouponCode implements Filter {
   private function applyForAnyOperator(QueryBuilder $queryBuilder, DynamicSegmentFilterEntity $filter): void {
     $filterData = $filter->getFilterData();
     $couponIds = $this->getNormalizedCouponIds($filterData);
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
 
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder);
-
-    if (!$isAllTime) {
-      /** @var int $days */
-      $days = $filterData->getParam('days');
-      $date = $this->filterHelper->getDateNDaysAgo(intval($days));
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $queryBuilder->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
 
     $queryBuilder->innerJoin(
       $orderStatsAlias,

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethod.php
@@ -6,7 +6,6 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\WooCommerce\Helper;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 use WC_Payment_Gateway;
@@ -43,8 +42,6 @@ class WooCommerceUsedPaymentMethod implements Filter {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('operator');
     $paymentMethods = $filterData->getParam('payment_methods');
-    $days = $filterData->getParam('days');
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
 
     if (!is_string($operator) || !in_array($operator, self::VALID_OPERATORS, true)) {
       throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
@@ -58,18 +55,17 @@ class WooCommerceUsedPaymentMethod implements Filter {
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
     $excludedStatuses = $this->wooFilterHelper->defaultExcludedStatuses();
-    $date = is_int($days) ? $this->filterHelper->getDateNDaysAgo($days) : Carbon::now();
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:
-        $this->applyForAnyOperator($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+        $this->applyForAnyOperator($queryBuilder, $excludedStatuses, $paymentMethods, $filterData);
         break;
       case DynamicSegmentFilterData::OPERATOR_ALL:
-        $this->applyForAllOperator($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+        $this->applyForAllOperator($queryBuilder, $excludedStatuses, $paymentMethods, $filterData);
         break;
       case DynamicSegmentFilterData::OPERATOR_NONE:
         $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-        $this->applyForAnyOperator($subQuery, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+        $this->applyForAnyOperator($subQuery, $excludedStatuses, $paymentMethods, $filterData);
         $subscribersTable = $this->filterHelper->getSubscribersTable();
         $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
         break;
@@ -78,26 +74,26 @@ class WooCommerceUsedPaymentMethod implements Filter {
     return $queryBuilder;
   }
 
-  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime): void {
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, DynamicSegmentFilterData $filterData): void {
     if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
-      $this->applyCustomOrderTableJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+      $this->applyCustomOrderTableJoin($queryBuilder, $excludedStatuses, $paymentMethods, $filterData);
     } else {
-      $this->applyPostmetaOrderJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+      $this->applyPostmetaOrderJoin($queryBuilder, $excludedStatuses, $paymentMethods, $filterData);
     }
   }
 
-  private function applyForAllOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime): void {
+  private function applyForAllOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, DynamicSegmentFilterData $filterData): void {
     if ($this->wooHelper->isWooCommerceCustomOrdersTableEnabled()) {
-      $ordersAlias = $this->applyCustomOrderTableJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+      $ordersAlias = $this->applyCustomOrderTableJoin($queryBuilder, $excludedStatuses, $paymentMethods, $filterData);
       $queryBuilder->groupBy('inner_subscriber_id')
         ->having("COUNT(DISTINCT $ordersAlias.payment_method) = " . count($paymentMethods));
     } else {
-      $postmetaAlias = $this->applyPostmetaOrderJoin($queryBuilder, $excludedStatuses, $paymentMethods, $date, $isAllTime);
+      $postmetaAlias = $this->applyPostmetaOrderJoin($queryBuilder, $excludedStatuses, $paymentMethods, $filterData);
       $queryBuilder->groupBy('inner_subscriber_id')->having("COUNT(DISTINCT $postmetaAlias.meta_value) = " . count($paymentMethods));
     }
   }
 
-  private function applyPostmetaOrderJoin(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime, string $postmetaAlias = 'postmeta'): string {
+  private function applyPostmetaOrderJoin(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, DynamicSegmentFilterData $filterData, string $postmetaAlias = 'postmeta'): string {
     $paymentMethodParam = $this->filterHelper->getUniqueParameterName('paymentMethod');
     $paymentMethodMetaKeyParam = $this->filterHelper->getUniqueParameterName('paymentMethod');
 
@@ -109,16 +105,11 @@ class WooCommerceUsedPaymentMethod implements Filter {
       ->andWhere("postmeta.meta_value IN (:$paymentMethodParam)")
       ->setParameter($paymentMethodMetaKeyParam, '_payment_method')
       ->setParameter($paymentMethodParam, $paymentMethods, ArrayParameterType::STRING);
-    if (!$isAllTime) {
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $queryBuilder
-        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
     return $postmetaAlias;
   }
 
-  private function applyCustomOrderTableJoin(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, Carbon $date, bool $isAllTime, string $ordersAlias = 'orders'): string {
+  private function applyCustomOrderTableJoin(QueryBuilder $queryBuilder, array $excludedStatuses, array $paymentMethods, DynamicSegmentFilterData $filterData, string $ordersAlias = 'orders'): string {
     $paymentMethodParam = $this->filterHelper->getUniqueParameterName('paymentMethod');
     $ordersTable = $this->wooHelper->getOrdersTableName();
     $orderStatsAlias = $this->wooFilterHelper->applyOrderStatusFilter($queryBuilder, $excludedStatuses);
@@ -126,12 +117,7 @@ class WooCommerceUsedPaymentMethod implements Filter {
       ->innerJoin($orderStatsAlias, $ordersTable, 'orders', "$orderStatsAlias.order_id = orders.id")
       ->andWhere("$ordersAlias.payment_method IN (:$paymentMethodParam)")
       ->setParameter($paymentMethodParam, $paymentMethods, ArrayParameterType::STRING);
-    if (!$isAllTime) {
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $queryBuilder
-        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
     return $ordersAlias;
   }
 

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethod.php
@@ -6,7 +6,6 @@ use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\DynamicSegmentFilterEntity;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\WooCommerce\Helper;
-use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Doctrine\DBAL\ArrayParameterType;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
 
@@ -42,9 +41,6 @@ class WooCommerceUsedShippingMethod implements Filter {
     $filterData = $filter->getFilterData();
     $operator = $filterData->getParam('operator');
     $shippingMethodInstanceIds = $filterData->getParam('shipping_methods');
-    $isAllTime = $filterData->getParam('timeframe') === DynamicSegmentFilterData::TIMEFRAME_ALL_TIME;
-
-    $days = $filterData->getParam('days');
 
     if (!is_string($operator) || !in_array($operator, self::VALID_OPERATORS, true)) {
       throw new InvalidFilterException('Invalid operator', InvalidFilterException::MISSING_OPERATOR);
@@ -58,17 +54,16 @@ class WooCommerceUsedShippingMethod implements Filter {
     $this->filterHelper->validateDaysPeriodData((array)$data);
 
     $excludedStatuses = $this->wooFilterHelper->defaultExcludedStatuses();
-    $date = is_int($days) ? $this->filterHelper->getDateNDaysAgo($days) : Carbon::now();
 
     switch ($operator) {
       case DynamicSegmentFilterData::OPERATOR_ANY:
-        $this->applyForAnyOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+        $this->applyForAnyOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $filterData);
         break;
       case DynamicSegmentFilterData::OPERATOR_ALL:
-        $this->applyForAllOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+        $this->applyForAllOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $filterData);
         break;
       case DynamicSegmentFilterData::OPERATOR_NONE:
-        $this->applyForNoneOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+        $this->applyForNoneOperator($queryBuilder, $excludedStatuses, $shippingMethodInstanceIds, $filterData);
         break;
     }
 
@@ -93,7 +88,7 @@ class WooCommerceUsedShippingMethod implements Filter {
     return $lookupData;
   }
 
-  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
+  private function applyForAnyOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, DynamicSegmentFilterData $filterData): void {
     $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 
     $orderItemsTable = $this->filterHelper->getPrefixedTable('woocommerce_order_items');
@@ -108,15 +103,10 @@ class WooCommerceUsedShippingMethod implements Filter {
       ->andWhere("$orderItemMetaTableAlias.meta_key = 'instance_id'")
       ->andWhere("$orderItemMetaTableAlias.meta_value IN (:$instanceIdsParam)")
       ->setParameter($instanceIdsParam, $shippingMethodInstanceIds, ArrayParameterType::STRING);
-    if (!$isAllTime) {
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $queryBuilder
-        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
   }
 
-  private function applyForAllOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
+  private function applyForAllOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, DynamicSegmentFilterData $filterData): void {
     $orderItemTypeParam = $this->filterHelper->getUniqueParameterName('orderItemType');
     $instanceIdsParam = $this->filterHelper->getUniqueParameterName('instanceIds');
 
@@ -137,17 +127,12 @@ class WooCommerceUsedShippingMethod implements Filter {
       ->groupBy('inner_subscriber_id')
       ->having("COUNT(DISTINCT($orderItemMetaTableAlias.meta_value)) = " . count($shippingMethodInstanceIds));
 
-    if (!$isAllTime) {
-      $dateParam = $this->filterHelper->getUniqueParameterName('date');
-      $queryBuilder
-        ->andWhere("$orderStatsAlias.date_created >= :$dateParam")
-        ->setParameter($dateParam, $date->toDateTimeString());
-    }
+    $this->filterHelper->applyDatePeriodFilter($queryBuilder, "$orderStatsAlias.date_created", $filterData);
   }
 
-  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, Carbon $date, bool $isAllTime): void {
+  private function applyForNoneOperator(QueryBuilder $queryBuilder, array $excludedStatuses, array $shippingMethodInstanceIds, DynamicSegmentFilterData $filterData): void {
     $subQuery = $this->filterHelper->getNewSubscribersQueryBuilder();
-    $this->applyForAnyOperator($subQuery, $excludedStatuses, $shippingMethodInstanceIds, $date, $isAllTime);
+    $this->applyForAnyOperator($subQuery, $excludedStatuses, $shippingMethodInstanceIds, $filterData);
     $subscribersTable = $this->filterHelper->getSubscribersTable();
     $queryBuilder->andWhere($queryBuilder->expr()->notIn("$subscribersTable.id", $this->filterHelper->getInterpolatedSQL($subQuery)));
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -1388,6 +1388,48 @@ class FilterDataMapperTest extends \MailPoetTest {
     ]]]);
   }
 
+  public function testItOrdersReversedBetweenDatesForSubscriberDateField(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
+      'action' => SubscriberDateField::SUBSCRIBED_DATE,
+      'operator' => 'between',
+      'value' => '2023-01-05',
+      'value2' => '2023-01-02',
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'connect' => 'and',
+      'operator' => 'between',
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]);
+  }
+
+  public function testItRejectsSubscriberDateBetweenMissingValue2(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_DATE_VALUE);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
+      'action' => SubscriberDateField::SUBSCRIBED_DATE,
+      'operator' => 'between',
+      'value' => '2023-01-02',
+    ]]]);
+  }
+
+  public function testItRejectsSubscriberDateBetweenInvalidValue2(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_DATE_VALUE);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_USER_ROLE,
+      'action' => SubscriberDateField::SUBSCRIBED_DATE,
+      'operator' => 'between',
+      'value' => '2023-01-02',
+      'value2' => 'invalid-date',
+    ]]]);
+  }
+
   public function testItPersistsBetweenValueAndValue2ForCountStyleFilter(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -220,6 +220,8 @@ class FilterDataMapperTest extends \MailPoetTest {
       'category_ids' => ['1', '3'],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+      'days' => 0,
     ]);
   }
 
@@ -276,6 +278,8 @@ class FilterDataMapperTest extends \MailPoetTest {
       'product_ids' => ['10', '11'],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+      'days' => 0,
     ]);
   }
 
@@ -308,6 +312,8 @@ class FilterDataMapperTest extends \MailPoetTest {
       'variation_ids' => ['20', '21'],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+      'days' => 0,
     ]);
   }
 
@@ -1169,6 +1175,8 @@ class FilterDataMapperTest extends \MailPoetTest {
       'attribute_type' => 'taxonomy',
       'attribute_local_name' => null,
       'attribute_local_values' => null,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+      'days' => 0,
     ]);
   }
 
@@ -1197,6 +1205,8 @@ class FilterDataMapperTest extends \MailPoetTest {
       'attribute_type' => 'local',
       'attribute_local_name' => 'color',
       'attribute_local_values' => ['red', 'blue'],
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+      'days' => 0,
     ]);
   }
 
@@ -1219,6 +1229,8 @@ class FilterDataMapperTest extends \MailPoetTest {
       'tag_ids' => ['1', '3'],
       'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
       'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+      'days' => 0,
     ]);
   }
 
@@ -1314,5 +1326,178 @@ class FilterDataMapperTest extends \MailPoetTest {
       'filters' => $filters,
       'filters_connect' => DynamicSegmentFilterData::CONNECT_TYPE_NONE,
     ]);
+  }
+
+  public function testItPersistsBetweenValueAndValue2ForPurchaseDate(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => 'purchaseDate',
+      'operator' => 'between',
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'connect' => 'and',
+      'operator' => 'between',
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]);
+  }
+
+  public function testItOrdersReversedBetweenDatesForPurchaseDate(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => 'purchaseDate',
+      'operator' => 'between',
+      'value' => '2023-01-05',
+      'value2' => '2023-01-02',
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'connect' => 'and',
+      'operator' => 'between',
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]);
+  }
+
+  public function testItRejectsPurchaseDateBetweenMissingValue2(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_DATE_VALUE);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => 'purchaseDate',
+      'operator' => 'between',
+      'value' => '2023-01-02',
+    ]]]);
+  }
+
+  public function testItRejectsFirstOrderBetweenMissingValue2(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_DATE_VALUE);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => 'firstOrder',
+      'operator' => 'between',
+      'value' => '2023-01-02',
+    ]]]);
+  }
+
+  public function testItPersistsBetweenValueAndValue2ForCountStyleFilter(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+      'action' => 'numberOfClicks',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'between',
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'connect' => 'and',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'between',
+      'days' => 0,
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]);
+  }
+
+  public function testItOrdersReversedBetweenDatesForCountStyleFilter(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+      'action' => 'numberOfClicks',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'between',
+      'value' => '2023-01-05',
+      'value2' => '2023-01-02',
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'connect' => 'and',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'between',
+      'days' => 0,
+      'value' => '2023-01-02',
+      'value2' => '2023-01-05',
+    ]);
+  }
+
+  public function testItPersistsAbsoluteTimeframeWithoutDaysForCountStyleFilter(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+      'action' => 'numberOfClicks',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'before',
+      'value' => '2023-01-02',
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter->getData())->equals([
+      'connect' => 'and',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'before',
+      'days' => 0,
+      'value' => '2023-01-02',
+    ]);
+  }
+
+  public function testItRejectsBetweenMissingValue2OnCountStyleFilter(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_DATE_VALUE);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+      'action' => 'numberOfClicks',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'between',
+      'value' => '2023-01-02',
+    ]]]);
+  }
+
+  public function testItRejectsAbsoluteTimeframeMissingValueOnCountStyleFilter(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->expectExceptionCode(InvalidFilterException::INVALID_DATE_VALUE);
+    $this->mapper->map(['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+      'action' => 'numberOfClicks',
+      'operator' => 'equals',
+      'clicks' => '1',
+      'timeframe' => 'on',
+    ]]]);
+  }
+
+  public function testItDefaultsTimeframeToAllTimeForFiltersThatGainedTimeframe(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      'action' => WooCommerceProduct::ACTION_PRODUCT,
+      'operator' => 'any',
+      'product_ids' => [1],
+    ]]];
+    $filters = $this->mapper->map($data);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    $persisted = $filter->getData();
+    $this->assertIsArray($persisted);
+    verify($persisted['timeframe'])->equals(DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
+    verify($persisted['days'])->equals(0);
+    $this->assertArrayNotHasKey('value', $persisted);
+    $this->assertArrayNotHasKey('value2', $persisted);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailOpensAbsoluteCountActionTest.php
@@ -145,6 +145,37 @@ class EmailOpensAbsoluteCountActionTest extends \MailPoetTest {
     ], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $newsletter = $this->createNewsletter();
+    $this->entityManager->flush();
+
+    $inRangeSub = $this->createSubscriber('between-in-range@example.com');
+    $this->createStatsNewsletter($inRangeSub, $newsletter);
+    $open = $this->createStatisticsOpens($inRangeSub, $newsletter);
+    $open->setCreatedAt(new CarbonImmutable('2023-05-11'));
+
+    $beforeRangeSub = $this->createSubscriber('between-before-range@example.com');
+    $this->createStatsNewsletter($beforeRangeSub, $newsletter);
+    $open = $this->createStatisticsOpens($beforeRangeSub, $newsletter);
+    $open->setCreatedAt(new CarbonImmutable('2023-05-09'));
+
+    $afterRangeSub = $this->createSubscriber('between-after-range@example.com');
+    $this->createStatsNewsletter($afterRangeSub, $newsletter);
+    $open = $this->createStatisticsOpens($afterRangeSub, $newsletter);
+    $open->setCreatedAt(new CarbonImmutable('2023-05-13'));
+    $this->entityManager->flush();
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, EmailOpensAbsoluteCountAction::TYPE, [
+      'operator' => 'equals',
+      'opens' => 1,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->action);
+    $this->assertEqualsCanonicalizing(['between-in-range@example.com'], $emails);
+  }
+
   private function getSegmentFilterData(int $opens, string $operator, int $days, string $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, string $action = EmailOpensAbsoluteCountAction::TYPE): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'operator' => $operator,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailsReceivedTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailsReceivedTest.php
@@ -96,6 +96,37 @@ class EmailsReceivedTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['1@e.com'], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $sub1 = (new Subscriber())->withEmail('1@e.com')->create();
+    $newsletter1 = (new Newsletter())->withSendingQueue()->withSentStatus()->create();
+    $stats1 = new StatisticsNewsletterEntity($newsletter1, $newsletter1->getLatestQueue(), $sub1);
+    $stats1->setSentAt(new CarbonImmutable('2023-05-10'));
+    $this->entityManager->persist($stats1);
+
+    $sub2 = (new Subscriber())->withEmail('2@e.com')->create();
+    $newsletter2 = (new Newsletter())->withSendingQueue()->withSentStatus()->create();
+    $stats2 = new StatisticsNewsletterEntity($newsletter2, $newsletter2->getLatestQueue(), $sub2);
+    $stats2->setSentAt(new CarbonImmutable('2023-05-12'));
+    $this->entityManager->persist($stats2);
+
+    $sub3 = (new Subscriber())->withEmail('3@e.com')->create();
+    $newsletter3 = (new Newsletter())->withSendingQueue()->withSentStatus()->create();
+    $stats3 = new StatisticsNewsletterEntity($newsletter3, $newsletter3->getLatestQueue(), $sub3);
+    $stats3->setSentAt(new CarbonImmutable('2023-05-20'));
+    $this->entityManager->persist($stats3);
+    $this->entityManager->flush();
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, EmailsReceived::ACTION, [
+      'operator' => 'equals',
+      'emails' => 1,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com'], $emails);
+  }
+
   private function getSegmentFilterData(int $emails, string $operator, int $days, string $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, string $action = EmailsReceived::ACTION): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'operator' => $operator,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/FilterHelperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/FilterHelperTest.php
@@ -2,7 +2,9 @@
 
 namespace MailPoet\Segments\DynamicSegments\Filters;
 
+use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Entities\SubscriberEntity;
+use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoetVendor\Carbon\Carbon;
 use MailPoetVendor\Carbon\CarbonImmutable;
 use MailPoetVendor\Doctrine\DBAL\Query\QueryBuilder;
@@ -87,5 +89,165 @@ class FilterHelperTest extends \MailPoetTest {
     verify($result->year)->greaterThanOrEqual(1000);
     verify($result->toDateString())->equals('1000-01-01');
     verify($result)->instanceOf(CarbonImmutable::class);
+  }
+
+  public function testGetDatePeriodConditionReturnsNullForAllTime(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+    ]);
+    verify($this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData))->null();
+  }
+
+  public function testGetDatePeriodConditionInTheLast(): void {
+    CarbonImmutable::setTestNow(CarbonImmutable::create(2026, 5, 17, 12, 0, 0));
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
+      'days' => 7,
+    ]);
+    $condition = $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData, true);
+    CarbonImmutable::setTestNow();
+    verify($condition)->stringContainsString('opens.created_at >= :date_');
+    $qb->andWhere((string)$condition);
+    verify($this->filterHelper->getInterpolatedSQL($qb))->stringContainsString("opens.created_at >= '2026-05-10 00:00:00'");
+  }
+
+  public function testGetDatePeriodConditionBefore(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BEFORE,
+      'value' => '2026-05-17',
+    ]);
+    $condition = $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+    $qb->andWhere((string)$condition);
+    verify($this->filterHelper->getInterpolatedSQL($qb))->stringContainsString("opens.created_at < '2026-05-17 00:00:00'");
+  }
+
+  public function testGetDatePeriodConditionAfterUsesStartOfNextDay(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_AFTER,
+      'value' => '2026-05-17',
+    ]);
+    $condition = $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+    $qb->andWhere((string)$condition);
+    verify($this->filterHelper->getInterpolatedSQL($qb))->stringContainsString("opens.created_at >= '2026-05-18 00:00:00'");
+  }
+
+  public function testGetDatePeriodConditionOnIsHalfOpenDayRange(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ON,
+      'value' => '2026-05-17',
+    ]);
+    $condition = $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+    $qb->andWhere((string)$condition);
+    $sql = $this->filterHelper->getInterpolatedSQL($qb);
+    verify($sql)->stringContainsString("opens.created_at >= '2026-05-17 00:00:00'");
+    verify($sql)->stringContainsString("opens.created_at < '2026-05-18 00:00:00'");
+  }
+
+  public function testGetDatePeriodConditionBetweenIsInclusiveOfBothDays(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2026-05-10',
+      'value2' => '2026-05-17',
+    ]);
+    $condition = $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+    $qb->andWhere((string)$condition);
+    $sql = $this->filterHelper->getInterpolatedSQL($qb);
+    verify($sql)->stringContainsString("opens.created_at >= '2026-05-10 00:00:00'");
+    verify($sql)->stringContainsString("opens.created_at < '2026-05-18 00:00:00'");
+  }
+
+  public function testGetDatePeriodConditionUsesDefaultTimeframeWhenMissing(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('woocommerce', 'product', []);
+    verify($this->filterHelper->getDatePeriodCondition($qb, 'orderStats.date_created', $filterData, false, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME))->null();
+  }
+
+  public function testGetDatePeriodConditionThrowsOnInvalidTimeframe(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => 'nonsense',
+    ]);
+    $this->expectException(InvalidFilterException::class);
+    $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+  }
+
+  public function testGetDatePeriodConditionThrowsWhenInTheLastMissesDays(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST,
+    ]);
+    $this->expectException(InvalidFilterException::class);
+    $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+  }
+
+  public function testGetDatePeriodConditionThrowsOnMissingValueForAbsoluteTimeframe(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BEFORE,
+    ]);
+    $this->expectException(InvalidFilterException::class);
+    $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+  }
+
+  public function testGetDatePeriodConditionThrowsOnMalformedDate(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ON,
+      'value' => '2026-5-1',
+    ]);
+    $this->expectException(InvalidFilterException::class);
+    $this->filterHelper->getDatePeriodCondition($qb, 'opens.created_at', $filterData);
+  }
+
+  public function testApplyDatePeriodFilterAppendsWhereForBetween(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('email', 'opened', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2026-05-10',
+      'value2' => '2026-05-17',
+    ]);
+    $this->filterHelper->applyDatePeriodFilter($qb, 'opens.created_at', $filterData);
+    verify($qb->getSQL())->stringContainsString('WHERE');
+  }
+
+  public function testApplyDatePeriodFilterIsNoOpForAllTime(): void {
+    $qb = $this->getSubscribersQueryBuilder();
+    $filterData = new DynamicSegmentFilterData('woocommerce', 'product', [
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_ALL_TIME,
+    ]);
+    $before = $qb->getSQL();
+    $this->filterHelper->applyDatePeriodFilter($qb, 'orderStats.date_created', $filterData);
+    verify($qb->getSQL())->equals($before);
+  }
+
+  public function testValidateDaysPeriodDataAcceptsAllNewTimeframes(): void {
+    foreach (DynamicSegmentFilterData::TIMEFRAMES as $timeframe) {
+      $data = ['timeframe' => $timeframe];
+      if ($timeframe === DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST) {
+        $data['days'] = 7;
+      } elseif (in_array($timeframe, [DynamicSegmentFilterData::TIMEFRAME_BEFORE, DynamicSegmentFilterData::TIMEFRAME_AFTER, DynamicSegmentFilterData::TIMEFRAME_ON], true)) {
+        $data['value'] = '2026-05-17';
+      } elseif ($timeframe === DynamicSegmentFilterData::TIMEFRAME_BETWEEN) {
+        $data['value'] = '2026-05-10';
+        $data['value2'] = '2026-05-17';
+      }
+      // Should not throw.
+      $this->filterHelper->validateDaysPeriodData($data);
+    }
+    verify(true)->true();
+  }
+
+  public function testValidateDaysPeriodDataRejectsBetweenMissingValue2(): void {
+    $this->expectException(InvalidFilterException::class);
+    $this->filterHelper->validateDaysPeriodData([
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2026-05-17',
+    ]);
   }
 }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/NumberOfClicksTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/NumberOfClicksTest.php
@@ -80,6 +80,30 @@ class NumberOfClicksTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['2@e.com'], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $subBefore = (new Subscriber())->withEmail('before@e.com')->create();
+    $this->createClicks($subBefore, 1, new CarbonImmutable('2023-05-09'));
+
+    $subStart = (new Subscriber())->withEmail('start@e.com')->create();
+    $this->createClicks($subStart, 1, new CarbonImmutable('2023-05-10'));
+
+    $subEnd = (new Subscriber())->withEmail('end@e.com')->create();
+    $this->createClicks($subEnd, 1, new CarbonImmutable('2023-05-12'));
+
+    $subAfter = (new Subscriber())->withEmail('after@e.com')->create();
+    $this->createClicks($subAfter, 1, new CarbonImmutable('2023-05-13'));
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, NumberOfClicks::ACTION, [
+      'operator' => 'equals',
+      'clicks' => 1,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['start@e.com', 'end@e.com'], $emails);
+  }
+
   private function getSegmentFilterData(int $clicks, string $operator, int $days, string $timeframe = DynamicSegmentFilterData::TIMEFRAME_IN_THE_LAST, string $action = NumberOfClicks::ACTION): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, [
       'operator' => $operator,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberDateFieldTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/SubscriberDateFieldTest.php
@@ -81,6 +81,26 @@ class SubscriberDateFieldTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('lastClickDate', 'on', '2023-07-12', ['2@example.com']);
   }
 
+  public function testItWorksForBetween(): void {
+    (new Subscriber())
+      ->withEmail('1@example.com')
+      ->withLastEngagementAt(new CarbonImmutable('2023-07-11'))
+      ->create();
+    (new Subscriber())
+      ->withEmail('2@example.com')
+      ->withLastEngagementAt(new CarbonImmutable('2023-07-12'))
+      ->create();
+    (new Subscriber())
+      ->withEmail('3@example.com')
+      ->withLastEngagementAt(new CarbonImmutable('2023-07-13'))
+      ->create();
+    (new Subscriber())
+      ->withEmail('4@example.com')
+      ->withLastEngagementAt(new CarbonImmutable('2023-07-14'))
+      ->create();
+    $this->assertFilterReturnsEmails('lastEngagementDate', 'between', '2023-07-12', ['2@example.com', '3@example.com'], '2023-07-13');
+  }
+
   public function testItWorksForOnOrBefore(): void {
     (new Subscriber())
       ->withEmail('1@example.com')
@@ -193,11 +213,15 @@ class SubscriberDateFieldTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('subscribedDate', 'notInTheLast', '3', ['1@example.com', '2@example.com']);
   }
 
-  private function assertFilterReturnsEmails(string $action, string $operator, string $value, array $expectedEmails): void {
-    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $action, [
+  private function assertFilterReturnsEmails(string $action, string $operator, string $value, array $expectedEmails, ?string $value2 = null): void {
+    $data = [
       'operator' => $operator,
       'value' => $value,
-    ]);
+    ];
+    if ($value2 !== null) {
+      $data['value2'] = $value2;
+    }
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_USER_ROLE, $action, $data);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceAverageSpentTest.php
@@ -131,6 +131,39 @@ class WooCommerceAverageSpentTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['1@e.com', '2@e.com', '3@e.com'], $matchingEmails);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@e.com');
+    $this->tester->createWooCommerceOrder([
+      'date_created' => '2023-05-11 12:00:00',
+      'status' => 'wc-completed',
+      'customer_id' => $customerInRange,
+      'total' => '100',
+    ]);
+    $customerBefore = $this->tester->createCustomer('between-before@e.com');
+    $this->tester->createWooCommerceOrder([
+      'date_created' => '2023-05-09 12:00:00',
+      'status' => 'wc-completed',
+      'customer_id' => $customerBefore,
+      'total' => '100',
+    ]);
+    $customerAfter = $this->tester->createCustomer('between-after@e.com');
+    $this->tester->createWooCommerceOrder([
+      'date_created' => '2023-05-13 12:00:00',
+      'status' => 'wc-completed',
+      'customer_id' => $customerAfter,
+      'total' => '100',
+    ]);
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceAverageSpent::ACTION, [
+      'average_spent_type' => '=',
+      'average_spent_amount' => 100,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $matchingEmails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->averageSpentFilter);
+    $this->assertEqualsCanonicalizing(['between-in@e.com'], $matchingEmails);
+  }
+
   public function testItWorksWithAllTimeOption(): void {
     $id1 = $this->tester->createCustomer('1@e.com');
     $this->createOrder($id1, 100, 3);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceCategoryTest.php
@@ -215,6 +215,36 @@ class WooCommerceCategoryTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
+  public function testItGetsSubscribersThatPurchasedCategoryBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+
+    $category = $this->createCategory('productCatBetween');
+    $product = $this->createProduct('productBetween', [$category]);
+
+    $orderInRange = $this->createOrder($customerInRange, Carbon::parse('2023-05-11'));
+    $this->addToOrder(11, $orderInRange, $product, $customerInRange);
+    $orderBefore = $this->createOrder($customerBefore, Carbon::parse('2023-05-09'));
+    $this->addToOrder(12, $orderBefore, $product, $customerBefore);
+    $orderAfter = $this->createOrder($customerAfter, Carbon::parse('2023-05-13'));
+    $this->addToOrder(13, $orderAfter, $product, $customerAfter);
+
+    $filterData = new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceCategory::ACTION_CATEGORY,
+      [
+        'category_ids' => [$category],
+        'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+        'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+        'value' => '2023-05-10',
+        'value2' => '2023-05-12',
+      ]
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->wooCommerceCategoryFilter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   public function testItRetrievesLookupData(): void {
     $category1name = 'category' . rand();
     $category2name = 'category' . rand();

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceFirstOrderTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceFirstOrderTest.php
@@ -142,6 +142,20 @@ class WooCommerceFirstOrderTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing([$subscriber->getEmail(), 'c1@example.com'], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $customerId1 = $this->tester->createCustomer('c1@example.com');
+    $customerId2 = $this->tester->createCustomer('c2@example.com');
+    $customerId3 = $this->tester->createCustomer('c3@example.com');
+    $customerId4 = $this->tester->createCustomer('c4@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-01-01'));
+    $this->createOrder($customerId2, new Carbon('2023-01-02'));
+    $this->createOrder($customerId3, new Carbon('2023-01-03'));
+    $this->createOrder($customerId4, new Carbon('2023-01-04'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('between', '2023-01-02', '2023-01-03');
+    verify(count($emails))->equals(2);
+    $this->assertEqualsCanonicalizing(['c2@example.com', 'c3@example.com'], $emails);
+  }
+
   public function testItOnlyIncludesCompletedAndProcessingOrders(): void {
     $validStatuses = ['wc-processing', 'wc-completed'];
     $invalidstatuses = ['wc-pending', 'wc-refunded', 'wc-on-hold', 'wc-cancelled', 'wc-failed', 'any-custom-status'];
@@ -159,14 +173,18 @@ class WooCommerceFirstOrderTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['wc-processing@example.com', 'wc-completed@example.com'], $emails);
   }
 
-  private function getSubscriberEmailsMatchingFilter(string $operator, string $value): array {
+  private function getSubscriberEmailsMatchingFilter(string $operator, string $value, ?string $value2 = null): array {
+    $filterData = [
+      'operator' => $operator,
+      'value' => $value,
+    ];
+    if ($value2 !== null) {
+      $filterData['value2'] = $value2;
+    }
     $data = new DynamicSegmentFilterData(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       WooCommerceFirstOrder::ACTION,
-      [
-        'operator' => $operator,
-        'value' => $value,
-      ]
+      $filterData
     );
     return $this->tester->getSubscriberEmailsMatchingDynamicFilter($data, $this->wooCommerceFirstOrder);
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfOrdersTest.php
@@ -122,6 +122,25 @@ class WooCommerceNumberOfOrdersTest extends \MailPoetTest {
     ], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $this->createOrder($customerInRange, Carbon::parse('2023-05-11'));
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $this->createOrder($customerBefore, Carbon::parse('2023-05-09'));
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+    $this->createOrder($customerAfter, Carbon::parse('2023-05-13'));
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfOrders::ACTION_NUMBER_OF_ORDERS, [
+      'number_of_orders_type' => '>',
+      'number_of_orders_count' => 0,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->numberOfOrdersFilter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   public function testItWorksWithNumberOfOrdersWithCoupon(): void {
     $customerWithoutCouponOrder = $this->tester->createCustomer('customerwithoutcoupon@example.com');
     $this->createOrder($customerWithoutCouponOrder, Carbon::now()->subDays(2));

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviewsTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceNumberOfReviewsTest.php
@@ -121,6 +121,26 @@ class WooCommerceNumberOfReviewsTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('4', '=', 1, 50, 'inTheLast', ['3@e.com']);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@e.com');
+    $this->tester->createWooProductReview($customerInRange, 'between-in@e.com', $this->productId, 5, Carbon::parse('2023-05-11'));
+    $customerBefore = $this->tester->createCustomer('between-before@e.com');
+    $this->tester->createWooProductReview($customerBefore, 'between-before@e.com', $this->productId, 5, Carbon::parse('2023-05-09'));
+    $customerAfter = $this->tester->createCustomer('between-after@e.com');
+    $this->tester->createWooProductReview($customerAfter, 'between-after@e.com', $this->productId, 5, Carbon::parse('2023-05-13'));
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceNumberOfReviews::ACTION, [
+      'count_type' => '>',
+      'count' => 0,
+      'rating' => 'any',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['between-in@e.com'], $emails);
+  }
+
   public function testItValidatesRatingPresence(): void {
     $this->expectException(InvalidFilterException::class);
     $this->expectExceptionCode(InvalidFilterException::MISSING_VALUE);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductTest.php
@@ -96,6 +96,40 @@ class WooCommerceProductTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
+  public function testItGetsSubscribersThatPurchasedProductBetweenDates(): void {
+    $customerIdBefore = $this->tester->createCustomer('customer-before-range@example.com');
+    $customerIdStart = $this->tester->createCustomer('customer-start-range@example.com');
+    $customerIdEnd = $this->tester->createCustomer('customer-end-range@example.com');
+    $customerIdAfter = $this->tester->createCustomer('customer-after-range@example.com');
+    $customerIdDifferentProduct = $this->tester->createCustomer('customer-different-product@example.com');
+
+    $orderIdBefore = $this->createOrder($customerIdBefore, new Carbon('2023-05-09'));
+    $this->addToOrder(7, $orderIdBefore, $this->productIds[0], $customerIdBefore);
+    $orderIdStart = $this->createOrder($customerIdStart, new Carbon('2023-05-10'));
+    $this->addToOrder(8, $orderIdStart, $this->productIds[0], $customerIdStart);
+    $orderIdEnd = $this->createOrder($customerIdEnd, new Carbon('2023-05-12'));
+    $this->addToOrder(9, $orderIdEnd, $this->productIds[0], $customerIdEnd);
+    $orderIdAfter = $this->createOrder($customerIdAfter, new Carbon('2023-05-13'));
+    $this->addToOrder(10, $orderIdAfter, $this->productIds[0], $customerIdAfter);
+    $orderIdDifferentProduct = $this->createOrder($customerIdDifferentProduct, new Carbon('2023-05-11'));
+    $this->addToOrder(11, $orderIdDifferentProduct, $this->productIds[1], $customerIdDifferentProduct);
+
+    $segmentFilterData = $this->getSegmentFilterData(
+      [$this->productIds[0]],
+      DynamicSegmentFilterData::OPERATOR_ANY,
+      [
+        'timeframe' => 'between',
+        'value' => '2023-05-10',
+        'value2' => '2023-05-12',
+      ]
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->wooCommerceProductFilter);
+    $this->assertEqualsCanonicalizing([
+      'customer-start-range@example.com',
+      'customer-end-range@example.com',
+    ], $emails);
+  }
+
   public function testItRetrievesLookupData(): void {
     $productId1 = $this->createProduct('product one');
     $productId2 = $this->createProduct('product two');
@@ -113,7 +147,7 @@ class WooCommerceProductTest extends \MailPoetTest {
     ], $lookupData);
   }
 
-  private function getSegmentFilterData(array $productIds, string $operator): DynamicSegmentFilterData {
+  private function getSegmentFilterData(array $productIds, string $operator, array $dateFilterData = []): DynamicSegmentFilterData {
     $filterData = [
       'product_ids' => $productIds,
       'operator' => $operator,
@@ -122,7 +156,7 @@ class WooCommerceProductTest extends \MailPoetTest {
     return new DynamicSegmentFilterData(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       WooCommerceProduct::ACTION_PRODUCT,
-      $filterData
+      array_merge($filterData, $dateFilterData)
     );
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductVariationTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceProductVariationTest.php
@@ -111,6 +111,39 @@ class WooCommerceProductVariationTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
+  public function testItGetsSubscribersThatPurchasedVariationBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+
+    $variationId = $this->variationIds[0];
+    $productId = $this->productIds[0];
+
+    $orderInRange = $this->createOrder($customerInRange, Carbon::parse('2023-05-11'));
+    $this->orderIds[] = $orderInRange;
+    $this->addToOrder(100, $orderInRange, $productId, $variationId, $customerInRange);
+    $orderBefore = $this->createOrder($customerBefore, Carbon::parse('2023-05-09'));
+    $this->orderIds[] = $orderBefore;
+    $this->addToOrder(101, $orderBefore, $productId, $variationId, $customerBefore);
+    $orderAfter = $this->createOrder($customerAfter, Carbon::parse('2023-05-13'));
+    $this->orderIds[] = $orderAfter;
+    $this->addToOrder(102, $orderAfter, $productId, $variationId, $customerAfter);
+
+    $filterData = new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceProductVariation::ACTION_PRODUCT_VARIATION,
+      [
+        'variation_ids' => [$variationId],
+        'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+        'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+        'value' => '2023-05-10',
+        'value2' => '2023-05-12',
+      ]
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->wooCommerceProductVariationFilter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   public function testItRetrievesLookupData(): void {
     $segmentFilterData = $this->getSegmentFilterData(
       [$this->variationIds[0], 999999],

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchaseDateTest.php
@@ -86,6 +86,20 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
     verify($emails)->equals(['c2@example.com']);
   }
 
+  public function testBetweenDates(): void {
+    $customerId1 = $this->tester->createCustomer('c1@example.com');
+    $customerId2 = $this->tester->createCustomer('c2@example.com');
+    $customerId3 = $this->tester->createCustomer('c3@example.com');
+    $customerId4 = $this->tester->createCustomer('c4@example.com');
+    $this->createOrder($customerId1, new Carbon('2023-01-01'));
+    $this->createOrder($customerId2, new Carbon('2023-01-02'));
+    $this->createOrder($customerId3, new Carbon('2023-01-03'));
+    $this->createOrder($customerId4, new Carbon('2023-01-04'));
+    $emails = $this->getSubscriberEmailsMatchingFilter('between', '2023-01-02', '2023-01-03');
+    verify(count($emails))->equals(2);
+    verify($emails)->equals(['c2@example.com', 'c3@example.com']);
+  }
+
   public function testOnOrAfterDate(): void {
     $customerId1 = $this->tester->createCustomer('c1@example.com');
     $customerId2 = $this->tester->createCustomer('c2@example.com');
@@ -148,14 +162,18 @@ class WooCommercePurchaseDateTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['wc-processing@example.com', 'wc-completed@example.com'], $emails);
   }
 
-  private function getSubscriberEmailsMatchingFilter(string $operator, string $value): array {
+  private function getSubscriberEmailsMatchingFilter(string $operator, string $value, ?string $value2 = null): array {
+    $filterData = [
+      'operator' => $operator,
+      'value' => $value,
+    ];
+    if ($value2 !== null) {
+      $filterData['value2'] = $value2;
+    }
     $data = new DynamicSegmentFilterData(
       DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
       WooCommercePurchaseDate::ACTION,
-      [
-        'operator' => $operator,
-        'value' => $value,
-      ]
+      $filterData
     );
     return $this->tester->getSubscriberEmailsMatchingDynamicFilter($data, $this->wooCommercePurchaseDate);
   }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommercePurchasedWithAttributeTest.php
@@ -5,6 +5,7 @@ namespace integration\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommercePurchasedWithAttribute;
+use MailPoetVendor\Carbon\Carbon;
 
 /**
  * @group woo
@@ -174,6 +175,37 @@ class WooCommercePurchasedWithAttributeTest extends \MailPoetTest {
     $this->assertFilterReturnsEmailsForLocalAttributes('none', 'color', ['red', 'blue'], ['customer4@example.com']);
     $this->assertFilterReturnsEmailsForLocalAttributes('none', 'color', ['red'], ['customer3@example.com', 'customer4@example.com']);
     $this->assertFilterReturnsEmailsForLocalAttributes('none', 'color', ['blue'], ['customer2@example.com', 'customer4@example.com']);
+  }
+
+  public function testItWorksWithBetweenDatesForTaxonomies(): void {
+    $product = $this->tester->createWooCommerceProduct([
+      'price' => 20,
+      'attributes' => [
+        $this->tester->getWooCommerceProductAttribute('color', ['blue']),
+      ],
+    ]);
+
+    $blueTermId = $this->tester->getWooCommerceProductAttributeTermId('color', 'blue');
+
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+
+    $this->createOrder($customerInRange, [$product], Carbon::parse('2023-05-11'));
+    $this->createOrder($customerBefore, [$product], Carbon::parse('2023-05-09'));
+    $this->createOrder($customerAfter, [$product], Carbon::parse('2023-05-13'));
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommercePurchasedWithAttribute::ACTION, [
+      'operator' => 'any',
+      'attribute_taxonomy_slug' => 'pa_color',
+      'attribute_term_ids' => [$blueTermId],
+      'attribute_type' => 'taxonomy',
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
   }
 
   public function testItRetrievesLookupData(): void {
@@ -349,10 +381,13 @@ class WooCommercePurchasedWithAttributeTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing($expectedEmails, $emails);
   }
 
-  private function createOrder(int $customerId, array $products): int {
+  private function createOrder(int $customerId, array $products, ?Carbon $createdAt = null): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
     $order->set_status('wc-completed');
+    if ($createdAt !== null) {
+      $order->set_date_created($createdAt->toDateTimeString());
+    }
     foreach ($products as $product) {
       $order->add_product($product);
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceSingleOrderValueTest.php
@@ -63,6 +63,25 @@ class WooCommerceSingleOrderValueTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['customer2@example.com', 'customer3@example.com'], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $this->createOrder($customerInRange, Carbon::parse('2023-05-11'), 50);
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $this->createOrder($customerBefore, Carbon::parse('2023-05-09'), 50);
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+    $this->createOrder($customerAfter, Carbon::parse('2023-05-13'), 50);
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceSingleOrderValue::ACTION_SINGLE_ORDER_VALUE, [
+      'single_order_value_type' => '=',
+      'single_order_value_amount' => 50,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->singleOrderValue);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   public function testItWorksWithLifetimeOption(): void {
     $segmentFilterData = $this->getSegmentFilterData('<', 1000000000, 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->singleOrderValue);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTagTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTagTest.php
@@ -5,6 +5,7 @@ namespace integration\Segments\DynamicSegments\Filters;
 use MailPoet\Entities\DynamicSegmentFilterData;
 use MailPoet\Segments\DynamicSegments\Exceptions\InvalidFilterException;
 use MailPoet\Segments\DynamicSegments\Filters\WooCommerceTag;
+use MailPoetVendor\Carbon\Carbon;
 
 /**
  * @group woo
@@ -88,6 +89,33 @@ class WooCommerceTagTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('none', [$tag1, $tag2], ['customer3@example.com']);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+
+    $tag = $this->tester->createWooTag('between-tag');
+    $product = $this->tester->createWooCommerceProduct(['tag_ids' => [$tag]]);
+
+    $this->createOrder($customerInRange, [$product], Carbon::parse('2023-05-11'));
+    $this->createOrder($customerBefore, [$product], Carbon::parse('2023-05-09'));
+    $this->createOrder($customerAfter, [$product], Carbon::parse('2023-05-13'));
+
+    $filterData = new DynamicSegmentFilterData(
+      DynamicSegmentFilterData::TYPE_WOOCOMMERCE,
+      WooCommerceTag::ACTION,
+      [
+        'operator' => 'any',
+        'tag_ids' => [(string)$tag],
+        'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+        'value' => '2023-05-10',
+        'value2' => '2023-05-12',
+      ]
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   public function testItRetrievesLookupData(): void {
     $tagId1 = $this->tester->createWooTag('tag50');
     $tagId2 = $this->tester->createWooTag('tag51');
@@ -156,10 +184,13 @@ class WooCommerceTagTest extends \MailPoetTest {
     ];
   }
 
-  private function createOrder(int $customerId, array $products = []): int {
+  private function createOrder(int $customerId, array $products = [], ?Carbon $createdAt = null): int {
     $order = $this->tester->createWooCommerceOrder();
     $order->set_customer_id($customerId);
     $order->set_status('wc-completed');
+    if ($createdAt !== null) {
+      $order->set_date_created($createdAt->toDateTimeString());
+    }
     foreach ($products as $product) {
       $order->add_product($product);
     }

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceTotalSpentTest.php
@@ -70,6 +70,25 @@ class WooCommerceTotalSpentTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['customer1@example.com', 'customer2@example.com', 'customer3@example.com'], $emails);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $this->orders[] = $this->createOrder($customerInRange, Carbon::parse('2023-05-11'), 50);
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $this->orders[] = $this->createOrder($customerBefore, Carbon::parse('2023-05-09'), 50);
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+    $this->orders[] = $this->createOrder($customerAfter, Carbon::parse('2023-05-13'), 50);
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceTotalSpent::ACTION_TOTAL_SPENT, [
+      'total_spent_type' => '=',
+      'total_spent_amount' => 50,
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->totalSpentFilter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   public function testItWorksWithAllTimeOption(): void {
     $segmentFilterData = $this->getSegmentFilterData('<', 100000000000, 0, DynamicSegmentFilterData::TIMEFRAME_ALL_TIME);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->totalSpentFilter);

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCodeTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedCouponCodeTest.php
@@ -190,6 +190,27 @@ class WooCommerceUsedCouponCodeTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('none', [$coupon1Id], 0, 'allTime', ['customer2@example.com']);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@example.com');
+    $customerBefore = $this->tester->createCustomer('between-before@example.com');
+    $customerAfter = $this->tester->createCustomer('between-after@example.com');
+    $coupon1Id = $this->tester->createWooCommerceCoupon(['code' => 'Coupon 1']);
+
+    $this->createOrder($customerInRange, ['Coupon 1'], Carbon::parse('2023-05-11'));
+    $this->createOrder($customerBefore, ['Coupon 1'], Carbon::parse('2023-05-09'));
+    $this->createOrder($customerAfter, ['Coupon 1'], Carbon::parse('2023-05-13'));
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedCouponCode::ACTION, [
+      'operator' => 'any',
+      'coupon_code_ids' => [$coupon1Id],
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['between-in@example.com'], $emails);
+  }
+
   /**
    * @dataProvider filterDataProvider
    */

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedPaymentMethodTest.php
@@ -116,6 +116,25 @@ class WooCommerceUsedPaymentMethodTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('none', ['cash', 'paypal'], 1, 'allTime', []);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@e.com');
+    $this->createOrder($customerInRange, Carbon::parse('2023-05-11'), 'paypal');
+    $customerBefore = $this->tester->createCustomer('between-before@e.com');
+    $this->createOrder($customerBefore, Carbon::parse('2023-05-09'), 'paypal');
+    $customerAfter = $this->tester->createCustomer('between-after@e.com');
+    $this->createOrder($customerAfter, Carbon::parse('2023-05-13'), 'paypal');
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedPaymentMethod::ACTION, [
+      'operator' => 'any',
+      'payment_methods' => ['paypal'],
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['between-in@e.com'], $emails);
+  }
+
   public function testItRetrievesLookupData(): void {
     $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedPaymentMethod::ACTION, [
       'operator' => 'all',

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/WooCommerceUsedShippingMethodTest.php
@@ -127,6 +127,25 @@ class WooCommerceUsedShippingMethodTest extends \MailPoetTest {
     $this->assertFilterReturnsEmails('all', [2], 1, 'allTime', ['c1@e.com']);
   }
 
+  public function testBetweenDates(): void {
+    $customerInRange = $this->tester->createCustomer('between-in@e.com');
+    $this->createOrder($customerInRange, Carbon::parse('2023-05-11'), 'flat_rate', 1);
+    $customerBefore = $this->tester->createCustomer('between-before@e.com');
+    $this->createOrder($customerBefore, Carbon::parse('2023-05-09'), 'flat_rate', 1);
+    $customerAfter = $this->tester->createCustomer('between-after@e.com');
+    $this->createOrder($customerAfter, Carbon::parse('2023-05-13'), 'flat_rate', 1);
+
+    $filterData = new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_WOOCOMMERCE, WooCommerceUsedShippingMethod::ACTION, [
+      'operator' => 'any',
+      'shipping_methods' => [1],
+      'timeframe' => DynamicSegmentFilterData::TIMEFRAME_BETWEEN,
+      'value' => '2023-05-10',
+      'value2' => '2023-05-12',
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($filterData, $this->filter);
+    $this->assertEqualsCanonicalizing(['between-in@e.com'], $emails);
+  }
+
   public function testItRetrievesLookupData(): void {
     $defaultZone = WC_Shipping_Zones::get_zone(0);
     $this->assertInstanceOf(WC_Shipping_Zone::class, $defaultZone);

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -102,6 +102,7 @@
   'isNotBlank': __('is not blank'),
   'onOrBefore': __('on or before'),
   'on': _x('on', 'Meaning: "Subscriber subscribed on a given date"'),
+  'between': _x('between', 'Meaning: "Subscriber subscribed between two dates"'),
   'onOrAfter': __('on or after'),
   'notOn': _x('not on', 'Meaning: "Subscriber subscribed on a date other than the given date"'),
   'inTheLast': _x('in the last', 'Meaning: "Subscriber subscribed in the last 3 days"'),

--- a/mailpoet/views/segments/translations.html
+++ b/mailpoet/views/segments/translations.html
@@ -64,7 +64,6 @@
   'selectCustomFieldPlaceholder': __('Select custom field'),
   'emailActionOpens': __('opens'),
   'emailActionOpensSentence': _x('{condition} {opens} opens', 'The result will be "more than 20 opens"'),
-  'emailActionOpensDaysSentence': _x('{timeframe} {days} days', 'The result will be "in the last 5 days"'),
   'moreThan': __('more than'),
   'lessThan': __('less than'),
   'higherThan': __('higher than'),


### PR DESCRIPTION
## Description

Adds **before**, **after**, **on**, and **between** date options to dynamic segment filters, and extends purchased product / category / tag / variation / attribute conditions with optional date scoping. 

### Conditions that gained the new timeframe options

**Email statistics**
- Emails received
- Number of clicks
- Email opens (absolute count)

**WooCommerce — order metrics**
- Total spent
- Average spent
- Single order value
- Number of orders

**WooCommerce — order attributes**
- Used coupon code
- Used payment method
- Used shipping method
- Number of reviews

**WooCommerce — gained date scoping for the first time**
- Purchased product
- Purchased category
- Purchased tag
- Purchased product variation
- Purchased with attribute

**Operator-style date filters that gained the between operator**
- Subscriber date fields (last engagement, last open, last click, last page view, last purchase, last sending, subscribed date)
- WooCommerce purchase date
- WooCommerce first order

Timeframe options now available on the gained-scoping filters

- All time
- In the last N days
- Before (date)
- After (date)
- On (date)
- Between (date, date)

## Code review notes

New timeframe SQL is centralised in `FilterHelper::getDatePeriodCondition` and save-time normalisation in `FilterDataMapper::copyDatePeriodData`, with auto-ordering of reversed between ranges and strict `Y-m-d` validation.

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8092

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="835" height="480" alt="Screenshot 2026-05-17 at 21 12 48" src="https://github.com/user-attachments/assets/aaa7a680-aa53-4920-beb3-0c1519a26388" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8092-add-date-range-operators-to-segment-conditions)

_The latest successful build from `stomail-8092-add-date-range-operators-to-segment-conditions` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->