### PR TITLE
Update WooCommerce email editor package

### DIFF
--- a/mailpoet/changelog/2026-05-18-07-20-04-updated-woocommerce-email-editor-package-to-version-210.md
+++ b/mailpoet/changelog/2026-05-18-07-20-04-updated-woocommerce-email-editor-package-to-version-210.md
@@ -1,0 +1,5 @@
+# Type: Updated
+
+# Description
+
+WooCommerce email editor package to version 2.1.0 and enabled template editing from the canvas

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
@@ -2,15 +2,15 @@
 
 namespace MailPoet\EmailEditor\Integrations\MailPoet\Templates\Library;
 
-use MailPoet\Util\CdnAssetUrl;
+use MailPoet\WP\Functions as WPFunctions;
 
 class Newsletter {
-  private CdnAssetUrl $cdnAssetUrl;
+  private WPFunctions $wp;
 
   public function __construct(
-    CdnAssetUrl $cdnAssetUrl
+    WPFunctions $wp
   ) {
-    $this->cdnAssetUrl = $cdnAssetUrl;
+    $this->wp = $wp;
   }
 
   public function getSlug(): string {
@@ -28,6 +28,7 @@ class Newsletter {
   public function getContent(): string {
     // translators: This is a text used in a footer on an email <!--[mailpoet/site-title]--> will be replaced with the site title.
     $footerText = __('You received this email because you are subscribed to the <!--[mailpoet/site-title]-->', 'mailpoet');
+    $siteIdentityBlock = $this->getSiteIdentityBlock();
     return '<!-- wp:group {"backgroundColor":"white","layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} -->
       <div class="wp-block-group has-white-background-color has-background">
         <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|10","left":"var:preset|spacing|40","right":"var:preset|spacing|20"}}}} -->
@@ -40,15 +41,7 @@ class Newsletter {
             padding-left: var(--wp--preset--spacing--40);
           "
             >
-          <!-- wp:image {"width":"130px","sizeSlug":"large"} -->
-          <figure class="wp-block-image size-large is-resized">
-            <img
-              src="' . esc_url($this->cdnAssetUrl->generateCdnUrl('email-editor/your-logo-placeholder.png')) . '"
-              alt="' . __('Your Logo', 'mailpoet') . '"
-              style="width: 130px"
-                />
-          </figure>
-          <!-- /wp:image -->
+          ' . $siteIdentityBlock . '
         </div>
         <!-- /wp:group -->
         <!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"default"}} /-->
@@ -81,5 +74,13 @@ class Newsletter {
         <!-- wp:mailpoet/powered-by-mailpoet {"lock":{"move":true,"remove":true}} /-->
       </div>
       <!-- /wp:group -->';
+  }
+
+  private function getSiteIdentityBlock(): string {
+    if ($this->wp->hasCustomLogo()) {
+      return '<!-- wp:site-logo {"width":130,"isLink":false,"align":"center"} /-->';
+    }
+
+    return '<!-- wp:site-title {"level":2,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/Library/Newsletter.php
@@ -81,6 +81,6 @@ class Newsletter {
       return '<!-- wp:site-logo {"width":130,"isLink":false,"align":"center"} /-->';
     }
 
-    return '<!-- wp:site-title {"level":2,"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
+    return '<!-- wp:site-title {"level":2,"textAlign":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10"}}}} /-->';
   }
 }

--- a/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
+++ b/mailpoet/lib/EmailEditor/Integrations/MailPoet/Templates/TemplatesController.php
@@ -6,21 +6,17 @@ use Automattic\WooCommerce\EmailEditor\Engine\Templates\Template;
 use Automattic\WooCommerce\EmailEditor\Engine\Templates\Templates_Registry;
 use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor;
 use MailPoet\EmailEditor\Integrations\MailPoet\Templates\Library\Newsletter;
-use MailPoet\Util\CdnAssetUrl;
 use MailPoet\WP\Functions as WPFunctions;
 
 class TemplatesController {
   private string $templatePrefix = 'mailpoet';
   private ?string $defaultTemplateSlug = null;
   private WPFunctions $wp;
-  private CdnAssetUrl $cdnAssetUrl;
 
   public function __construct(
-    WPFunctions $wp,
-    CdnAssetUrl $cdnAssetUrl
+    WPFunctions $wp
   ) {
     $this->wp = $wp;
-    $this->cdnAssetUrl = $cdnAssetUrl;
   }
 
   public function initialize() {
@@ -28,7 +24,7 @@ class TemplatesController {
   }
 
   public function registerTemplates(Templates_Registry $templatesRegistry): Templates_Registry {
-    $newsletter = new Newsletter($this->cdnAssetUrl);
+    $newsletter = new Newsletter($this->wp);
 
     $template = new Template(
       $this->templatePrefix,
@@ -56,7 +52,7 @@ class TemplatesController {
   public function getDefaultTemplateSlug(): string {
     // If templates haven't been registered yet, create the Newsletter to get its slug
     if ($this->defaultTemplateSlug === null) {
-      $newsletter = new Newsletter($this->cdnAssetUrl);
+      $newsletter = new Newsletter($this->wp);
       $this->defaultTemplateSlug = $newsletter->getSlug();
     }
     return $this->defaultTemplateSlug;

--- a/mailpoet/lib/WP/Functions.php
+++ b/mailpoet/lib/WP/Functions.php
@@ -212,6 +212,10 @@ class Functions {
     return get_bloginfo($show, $filter);
   }
 
+  public function hasCustomLogo() {
+    return has_custom_logo();
+  }
+
   public function getCategories($args = '') {
     return get_categories($args);
   }

--- a/mailpoet/package.json
+++ b/mailpoet/package.json
@@ -54,7 +54,7 @@
     "@woocommerce/components": "^13.1.0",
     "@woocommerce/currency": "^4.3.0",
     "@woocommerce/date": "^4.3.0",
-    "@woocommerce/email-editor": "2.0.0",
+    "@woocommerce/email-editor": "2.1.0",
     "@wordpress/a11y": "^4.43.0",
     "@wordpress/api-fetch": "^7.43.0",
     "@wordpress/block-editor": "^15.16.0",

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Templates/Library/NewsletterTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Templates/Library/NewsletterTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\EmailEditor\Integrations\MailPoet\Templates\Library;
+
+use MailPoet\EmailEditor\Integrations\MailPoet\Templates\Library\Newsletter;
+use MailPoet\WP\Functions as WPFunctions;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class NewsletterTest extends \MailPoetUnitTest {
+  /** @var MockObject & WPFunctions */
+  private $wp;
+
+  public function _before() {
+    parent::_before();
+    $this->wp = $this->createMock(WPFunctions::class);
+  }
+
+  public function testItUsesSiteLogoWhenCustomLogoExists() {
+    $this->wp->method('hasCustomLogo')->willReturn(true);
+
+    $content = (new Newsletter($this->wp))->getContent();
+
+    $this->assertStringContainsString('<!-- wp:site-logo {"width":130,"isLink":false,"align":"center"} /-->', $content);
+    $this->assertStringNotContainsString('wp:site-title', $content);
+    $this->assertStringNotContainsString('your-logo-placeholder.png', $content);
+  }
+
+  public function testItUsesSiteTitleWhenCustomLogoDoesNotExist() {
+    $this->wp->method('hasCustomLogo')->willReturn(false);
+
+    $content = (new Newsletter($this->wp))->getContent();
+
+    $this->assertStringContainsString('<!-- wp:site-title', $content);
+    $this->assertStringNotContainsString('wp:site-logo', $content);
+    $this->assertStringNotContainsString('your-logo-placeholder.png', $content);
+  }
+}

--- a/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Templates/Library/NewsletterTest.php
+++ b/mailpoet/tests/unit/EmailEditor/Integrations/MailPoet/Templates/Library/NewsletterTest.php
@@ -30,7 +30,7 @@ class NewsletterTest extends \MailPoetUnitTest {
 
     $content = (new Newsletter($this->wp))->getContent();
 
-    $this->assertStringContainsString('<!-- wp:site-title', $content);
+    $this->assertStringContainsString('<!-- wp:site-title {"level":2,"textAlign":"center"', $content);
     $this->assertStringNotContainsString('wp:site-logo', $content);
     $this->assertStringNotContainsString('your-logo-placeholder.png', $content);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0(lodash@4.18.1)
       '@woocommerce/email-editor':
-        specifier: 2.0.0
-        version: 2.0.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
+        specifier: 2.1.0
+        version: 2.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))
       '@wordpress/a11y':
         specifier: ^4.43.0
         version: 4.44.0
@@ -4204,8 +4204,8 @@ packages:
     peerDependencies:
       lodash: ^4.17.0
 
-  '@woocommerce/email-editor@2.0.0':
-    resolution: {integrity: sha512-WQRWiPAgYjYRhQ3WyqVi6n/iC7ipaFeefc7B8swnGNIz+iBfgZ2RRtgyQf/pIPM+fA2RidxQ/YtdbrwdN+XMZA==}
+  '@woocommerce/email-editor@2.1.0':
+    resolution: {integrity: sha512-Zf0jyszKPP+E53OMMfowcjzuV2RZ0XpzETvPioqG7GJ8EaSo7M3ejcNSLcG1FM6I2pJmm0K7GSUTQ2fBUsS0Xg==}
 
   '@woocommerce/navigation@8.2.0':
     resolution: {integrity: sha512-joAbrzdhrnWf91kEwuNO3hzT0IiUuh8SNOs0Qbth/heZaN+SixA5yJ98UqEHNa2Mitjm5BTC4M0Qk7X+I8uUvQ==}
@@ -11015,8 +11015,8 @@ packages:
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -15599,7 +15599,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.59':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@php-wasm/cli-util@3.1.20':
     dependencies:
@@ -17279,7 +17279,7 @@ snapshots:
       moment-timezone: 0.5.45
       qs: 6.15.0
 
-  '@woocommerce/email-editor@2.0.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
+  '@woocommerce/email-editor@2.1.0(@date-fns/tz@1.4.1)(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.28)(date-fns@3.6.0)(stylelint@16.6.1(typescript@5.9.3))':
     dependencies:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/base-styles': 6.20.0
@@ -26519,7 +26519,7 @@ snapshots:
 
   third-party-web@0.27.0: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
## Description

Update `@woocommerce/email-editor` to version `2.1.0` and adjust the default MailPoet email template header to use WordPress site identity blocks. This lets the new email editor template canvas affordance appear in MailPoet emails while preserving the logo header for sites that have a custom logo.

## Code review notes

_N/A_

## QA notes

Create or open a MailPoet email in the block email editor.

On a site without a custom logo, confirm the template header shows the site title and the template canvas affordance is available from the header area.

On a site with a custom logo configured, confirm the template header shows the logo and the template canvas affordance remains available from the header area.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

_N/A_

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:chore/update-email-editor-2-1-0)

_The latest successful build from `chore/update-email-editor-2-1-0` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->