### PR TITLE
Migrate Logs page to DataViews

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -48,6 +48,8 @@
     width: 100%;
   }
 
+  // DataViews table column sizing is exposed through generated column classes;
+  // keep these selectors aligned with getLogFields() when columns change.
   .dataviews-view-table col.dataviews-view-table__col-first-data {
     width: 240px !important;
   }

--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -42,6 +42,62 @@
 }
 
 .mailpoet-logs-dataviews {
+  .dataviews-view-table {
+    max-width: 100%;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  .dataviews-view-table col.dataviews-view-table__col-first-data {
+    width: 240px !important;
+  }
+
+  .dataviews-view-table
+    col[class^='dataviews-view-table__col-'].dataviews-view-table__col-message {
+    width: auto !important;
+  }
+
+  .dataviews-view-table
+    col[class^='dataviews-view-table__col-'].dataviews-view-table__col-action {
+    width: 120px !important;
+  }
+
+  .dataviews-view-table
+    col[class^='dataviews-view-table__col-'].dataviews-view-table__col-created_at {
+    width: 180px !important;
+  }
+
+  .dataviews-view-table tr > :nth-child(1) {
+    width: 240px;
+  }
+
+  .dataviews-view-table tr > :nth-child(3) {
+    width: 120px;
+  }
+
+  .dataviews-view-table tr > :nth-child(4) {
+    width: 180px;
+  }
+
+  .dataviews-view-table td,
+  .dataviews-view-table th {
+    overflow: hidden;
+  }
+
+  .dataviews-view-table__cell-content-wrapper:not(.dataviews-column-primary__media),
+  .dataviews-view-table__primary-column-content:not(.dataviews-column-primary__media) {
+    max-width: none;
+    min-width: 0;
+  }
+
+  .mailpoet-logs-min-width {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: auto;
+  }
+
   .mailpoet-logs-dataviews__toolbar {
     align-items: flex-start;
     display: flex;
@@ -67,6 +123,10 @@
   .mailpoet-datepicker {
     margin-left: 0;
     margin-right: 0;
+  }
+
+  .react-datepicker-popper {
+    z-index: 20;
   }
 
   .mailpoet-logs-date-error {

--- a/mailpoet/assets/css/src/components-plugin/_logs.scss
+++ b/mailpoet/assets/css/src/components-plugin/_logs.scss
@@ -3,6 +3,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  word-break: break-word;
 }
 
 .mailpoet-logs-message-full {
@@ -37,5 +38,39 @@
 
   .mailpoet-logs-limit .mailpoet-form-input-small {
     width: 100px;
+  }
+}
+
+.mailpoet-logs-dataviews {
+  .mailpoet-logs-dataviews__toolbar {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: $grid-gap;
+    margin-bottom: $grid-gap;
+  }
+
+  .mailpoet-logs-date-filters,
+  .mailpoet-logs-error {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: $grid-gap-half;
+  }
+
+  .mailpoet-logs-date-filter {
+    align-items: center;
+    display: flex;
+    gap: $grid-gap-half;
+  }
+
+  .mailpoet-datepicker {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .mailpoet-logs-date-error {
+    color: #d63638;
+    flex-basis: 100%;
   }
 }

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -11,6 +11,7 @@ import type { ListingMeta, ListingQueryParams, ListingResponse } from './types';
 
 export type LoadListing<T> = (
   params: ListingQueryParams,
+  signal?: AbortSignal,
 ) => Promise<ListingResponse<T>>;
 
 type UseDataViewsQueryOptions<T> = {
@@ -71,6 +72,7 @@ export function useDataViewsQuery<T>({
   const clearError = useCallback(() => setError(null), []);
 
   useEffect(() => {
+    const controller = new AbortController();
     const requestId = latestRequestIdRef.current + 1;
     latestRequestIdRef.current = requestId;
     setIsLoading(true);
@@ -85,7 +87,7 @@ export function useDataViewsQuery<T>({
       ...(extraParamsRef.current ? extraParamsRef.current(view) : {}),
     };
 
-    load(params)
+    load(params, controller.signal)
       .then((result) => {
         if (requestId !== latestRequestIdRef.current) {
           return;
@@ -107,6 +109,9 @@ export function useDataViewsQuery<T>({
         if (requestId !== latestRequestIdRef.current) {
           return;
         }
+        if (controller.signal.aborted) {
+          return;
+        }
         const message =
           err && typeof err === 'object' && 'message' in err
             ? String((err as { message?: unknown }).message ?? '')
@@ -121,6 +126,7 @@ export function useDataViewsQuery<T>({
           setIsLoading(false);
         }
       });
+    return () => controller.abort();
     // `extraParams` is read via a ref above so the effect doesn't depend on
     // its identity (callers don't need to memoize it). The effect re-runs
     // whenever the DataViews view changes (sort, search, page, perPage,

--- a/mailpoet/assets/js/src/logs/api.ts
+++ b/mailpoet/assets/js/src/logs/api.ts
@@ -46,11 +46,13 @@ export function buildLogsRequestParams(
 
 export async function getLogs(
   params: ListingQueryParams,
+  signal?: AbortSignal,
 ): Promise<ListingResponse<LogListingItem>> {
   ensureInitialized();
   const response = await apiFetch<ListingEnvelope<LogListingItem>>({
     path: addQueryArgs('/mailpoet/v1/logs', params as Record<string, unknown>),
     method: 'GET',
+    signal,
   });
   return response.data;
 }

--- a/mailpoet/assets/js/src/logs/api.ts
+++ b/mailpoet/assets/js/src/logs/api.ts
@@ -5,6 +5,7 @@ import type {
   ListingQueryParams,
   ListingResponse,
 } from 'common/dataviews';
+import type { DateFilters } from './url-state';
 
 declare global {
   interface Window {
@@ -30,6 +31,27 @@ export type LogListingItem = {
   message: string;
   created_at: string | null;
 };
+
+export function buildLogsRequestParams(
+  params: ListingQueryParams,
+  dateFilters: DateFilters,
+  legacyOffset?: number,
+): ListingQueryParams {
+  const search = params.search?.trim();
+  const requestParams: ListingQueryParams = {
+    ...params,
+    search: search || undefined,
+    filter: dateFilters,
+  };
+
+  if (legacyOffset !== undefined) {
+    delete requestParams.page;
+    requestParams.offset = legacyOffset;
+    requestParams.limit = requestParams.per_page;
+  }
+
+  return requestParams;
+}
 
 export async function getLogs(
   params: ListingQueryParams,

--- a/mailpoet/assets/js/src/logs/api.ts
+++ b/mailpoet/assets/js/src/logs/api.ts
@@ -1,0 +1,43 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import type {
+  ListingEnvelope,
+  ListingQueryParams,
+  ListingResponse,
+} from 'common/dataviews';
+
+declare global {
+  interface Window {
+    mailpoet_logs_api: {
+      root: string;
+      nonce: string;
+    };
+  }
+}
+
+let initialized = false;
+function ensureInitialized(): void {
+  if (initialized) return;
+  const config = window.mailpoet_logs_api;
+  apiFetch.use(apiFetch.createRootURLMiddleware(`${config.root}/`));
+  apiFetch.use(apiFetch.createNonceMiddleware(config.nonce));
+  initialized = true;
+}
+
+export type LogListingItem = {
+  id: number;
+  name: string;
+  message: string;
+  created_at: string | null;
+};
+
+export async function getLogs(
+  params: ListingQueryParams,
+): Promise<ListingResponse<LogListingItem>> {
+  ensureInitialized();
+  const response = await apiFetch<ListingEnvelope<LogListingItem>>({
+    path: addQueryArgs('/mailpoet/v1/logs', params as Record<string, unknown>),
+    method: 'GET',
+  });
+  return response.data;
+}

--- a/mailpoet/assets/js/src/logs/api.ts
+++ b/mailpoet/assets/js/src/logs/api.ts
@@ -35,22 +35,13 @@ export type LogListingItem = {
 export function buildLogsRequestParams(
   params: ListingQueryParams,
   dateFilters: DateFilters,
-  legacyOffset?: number,
 ): ListingQueryParams {
   const search = params.search?.trim();
-  const requestParams: ListingQueryParams = {
+  return {
     ...params,
     search: search || undefined,
     filter: dateFilters,
   };
-
-  if (legacyOffset !== undefined) {
-    delete requestParams.page;
-    requestParams.offset = legacyOffset;
-    requestParams.limit = requestParams.per_page;
-  }
-
-  return requestParams;
 }
 
 export async function getLogs(

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -60,6 +60,7 @@ export function getLogFields(
       type: 'text',
       enableSorting: false,
       enableGlobalSearch: false,
+      filterBy: false,
       render: ({ item }) =>
         createElement(
           'span',
@@ -73,6 +74,7 @@ export function getLogFields(
       type: 'text',
       enableSorting: false,
       enableGlobalSearch: false,
+      filterBy: false,
       render: ({ item }) => {
         const isExpanded = expandedLogIds.has(item.id);
         return createElement(
@@ -92,6 +94,7 @@ export function getLogFields(
       label: __('Action', 'mailpoet'),
       enableSorting: false,
       enableGlobalSearch: false,
+      filterBy: false,
       render: ({ item }) =>
         createElement(LogExpansionButton, {
           item,
@@ -105,6 +108,7 @@ export function getLogFields(
       type: 'datetime',
       enableSorting: false,
       enableGlobalSearch: false,
+      filterBy: false,
       render: ({ item }) =>
         createElement(
           'span',

--- a/mailpoet/assets/js/src/logs/fields.tsx
+++ b/mailpoet/assets/js/src/logs/fields.tsx
@@ -1,0 +1,116 @@
+import { createElement } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+import { MailPoetDate } from '../date';
+import type { LogListingItem } from './api';
+
+export function formatCreatedAt(createdAt: string | null): string {
+  return createdAt ? MailPoetDate.full(createdAt) : '—';
+}
+
+type LogExpansionButtonProps = {
+  item: LogListingItem;
+  isExpanded: boolean;
+  onToggle: (logId: number) => void;
+};
+
+function LogExpansionButton({
+  item,
+  isExpanded,
+  onToggle,
+}: LogExpansionButtonProps): JSX.Element {
+  const messageId = `mailpoet-log-message-${item.id}`;
+
+  return (
+    <button
+      type="button"
+      className="button button-secondary button-small mailpoet-button"
+      aria-expanded={isExpanded}
+      aria-controls={messageId}
+      aria-label={
+        isExpanded
+          ? sprintf(
+              // translators: %d is a log entry ID.
+              __('Show less of log message %d', 'mailpoet'),
+              item.id,
+            )
+          : sprintf(
+              // translators: %d is a log entry ID.
+              __('Show more of log message %d', 'mailpoet'),
+              item.id,
+            )
+      }
+      onClick={() => onToggle(item.id)}
+    >
+      <span>
+        {isExpanded ? __('Show less', 'mailpoet') : __('Show more', 'mailpoet')}
+      </span>
+    </button>
+  );
+}
+
+export function getLogFields(
+  expandedLogIds: Set<number>,
+  onToggleExpanded: (logId: number) => void,
+): Field<LogListingItem>[] {
+  return [
+    {
+      id: 'name',
+      label: __('Name', 'mailpoet'),
+      type: 'text',
+      enableSorting: false,
+      enableGlobalSearch: false,
+      render: ({ item }) =>
+        createElement(
+          'span',
+          { className: 'mailpoet-logs-min-width' },
+          item.name,
+        ),
+    },
+    {
+      id: 'message',
+      label: __('Message', 'mailpoet'),
+      type: 'text',
+      enableSorting: false,
+      enableGlobalSearch: false,
+      render: ({ item }) => {
+        const isExpanded = expandedLogIds.has(item.id);
+        return createElement(
+          'div',
+          {
+            id: `mailpoet-log-message-${item.id}`,
+            className: `mailpoet-logs-message ${
+              isExpanded ? 'mailpoet-logs-message-full' : ''
+            }`,
+          },
+          item.message,
+        );
+      },
+    },
+    {
+      id: 'action',
+      label: __('Action', 'mailpoet'),
+      enableSorting: false,
+      enableGlobalSearch: false,
+      render: ({ item }) =>
+        createElement(LogExpansionButton, {
+          item,
+          isExpanded: expandedLogIds.has(item.id),
+          onToggle: onToggleExpanded,
+        }),
+    },
+    {
+      id: 'created_at',
+      label: __('Created On', 'mailpoet'),
+      type: 'datetime',
+      enableSorting: false,
+      enableGlobalSearch: false,
+      render: ({ item }) =>
+        createElement(
+          'span',
+          { className: 'mailpoet-logs-min-width' },
+          formatCreatedAt(item.created_at),
+        ),
+    },
+  ];
+}

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -34,7 +34,6 @@ type Props = {
 function buildInitialView(defaultFrom: string): {
   view: View;
   dateFilters: DateFilters;
-  legacyOffset?: number;
 } {
   const state = parseLogsUrlState(window.location.href, defaultFrom);
 
@@ -46,11 +45,11 @@ function buildInitialView(defaultFrom: string): {
       search: state.search,
     },
     dateFilters: state.dateFilters,
-    legacyOffset: state.legacyOffset,
   };
 }
 
 export function List({ defaultFrom }: Props): JSX.Element {
+  const dateRangeErrorId = 'mailpoet-logs-date-error';
   const initialState = useMemo(
     () => buildInitialView(defaultFrom),
     [defaultFrom],
@@ -65,7 +64,6 @@ export function List({ defaultFrom }: Props): JSX.Element {
     () => new Set(),
   );
   const didMountRef = useRef(false);
-  const legacyOffsetRef = useRef(initialState.legacyOffset);
 
   const load = useCallback(
     (params: ListingQueryParams) => {
@@ -77,11 +75,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
           groups: [],
         });
       }
-      const legacyOffset = legacyOffsetRef.current;
-      if (legacyOffset !== undefined) {
-        legacyOffsetRef.current = undefined;
-      }
-      return getLogs(buildLogsRequestParams(params, dateFilters, legacyOffset));
+      return getLogs(buildLogsRequestParams(params, dateFilters));
     },
     [dateFilters],
   );
@@ -101,10 +95,13 @@ export function List({ defaultFrom }: Props): JSX.Element {
   });
 
   const dateRangeError = getDateRangeError(pendingDateFilters);
+  const emptyState =
+    loadError || dateRangeError ? null : (
+      <div>{__('No logs found.', 'mailpoet')}</div>
+    );
 
   const updateView = useCallback(
     (nextView: View) => {
-      legacyOffsetRef.current = undefined;
       const searchChanged = (nextView.search ?? '') !== (view.search ?? '');
       const perPageChanged = nextView.perPage !== view.perPage;
 
@@ -152,14 +149,12 @@ export function List({ defaultFrom }: Props): JSX.Element {
     if (dateRangeError) {
       return;
     }
-    legacyOffsetRef.current = undefined;
     setDateFilters(pendingDateFilters);
     setView((currentView) => ({ ...currentView, page: 1 }));
   }, [dateRangeError, pendingDateFilters, setView]);
 
   const clearDateFilters = useCallback((): void => {
     const emptyFilters: DateFilters = {};
-    legacyOffsetRef.current = undefined;
     setPendingDateFilters(emptyFilters);
     setDateFilters(emptyFilters);
     setView((currentView) => ({ ...currentView, page: 1 }));
@@ -197,7 +192,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
         defaultLayouts={{ table: {} }}
         getItemId={(item) => String(item.id)}
         isLoading={isLoading}
-        empty={<div>{__('No logs found.', 'mailpoet')}</div>}
+        empty={emptyState}
       >
         <div className="mailpoet-logs-dataviews__toolbar">
           <DataViews.Search label={__('Search logs', 'mailpoet')} />
@@ -222,6 +217,8 @@ export function List({ defaultFrom }: Props): JSX.Element {
                 disabled={isLoading}
                 isClearable
                 aria-label={__('Filter logs from date', 'mailpoet')}
+                aria-invalid={Boolean(dateRangeError) || undefined}
+                aria-describedby={dateRangeError ? dateRangeErrorId : undefined}
               />
             </label>
             <label
@@ -244,6 +241,8 @@ export function List({ defaultFrom }: Props): JSX.Element {
                 disabled={isLoading}
                 isClearable
                 aria-label={__('Filter logs to date', 'mailpoet')}
+                aria-invalid={Boolean(dateRangeError) || undefined}
+                aria-describedby={dateRangeError ? dateRangeErrorId : undefined}
               />
             </label>
             <Button
@@ -263,7 +262,11 @@ export function List({ defaultFrom }: Props): JSX.Element {
             </Button>
           </div>
           {dateRangeError && (
-            <div className="mailpoet-logs-date-error" role="alert">
+            <div
+              className="mailpoet-logs-date-error"
+              id={dateRangeErrorId}
+              role="alert"
+            >
               {dateRangeError}
             </div>
           )}

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from 'common';
 import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
 import { Datepicker } from '../common/datepicker/datepicker';
-import { getLogs, type LogListingItem } from './api';
+import { buildLogsRequestParams, getLogs, type LogListingItem } from './api';
 import { getLogFields } from './fields';
 import {
   buildLogsUrl,
@@ -34,6 +34,7 @@ type Props = {
 function buildInitialView(defaultFrom: string): {
   view: View;
   dateFilters: DateFilters;
+  legacyOffset?: number;
 } {
   const state = parseLogsUrlState(window.location.href, defaultFrom);
 
@@ -45,6 +46,7 @@ function buildInitialView(defaultFrom: string): {
       search: state.search,
     },
     dateFilters: state.dateFilters,
+    legacyOffset: state.legacyOffset,
   };
 }
 
@@ -63,6 +65,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
     () => new Set(),
   );
   const didMountRef = useRef(false);
+  const legacyOffsetRef = useRef(initialState.legacyOffset);
 
   const load = useCallback(
     (params: ListingQueryParams) => {
@@ -74,12 +77,11 @@ export function List({ defaultFrom }: Props): JSX.Element {
           groups: [],
         });
       }
-      const search = params.search?.trim();
-      return getLogs({
-        ...params,
-        search: search || undefined,
-        filter: dateFilters,
-      });
+      const legacyOffset = legacyOffsetRef.current;
+      if (legacyOffset !== undefined) {
+        legacyOffsetRef.current = undefined;
+      }
+      return getLogs(buildLogsRequestParams(params, dateFilters, legacyOffset));
     },
     [dateFilters],
   );
@@ -102,6 +104,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
 
   const updateView = useCallback(
     (nextView: View) => {
+      legacyOffsetRef.current = undefined;
       const searchChanged = (nextView.search ?? '') !== (view.search ?? '');
       const perPageChanged = nextView.perPage !== view.perPage;
 
@@ -149,12 +152,14 @@ export function List({ defaultFrom }: Props): JSX.Element {
     if (dateRangeError) {
       return;
     }
+    legacyOffsetRef.current = undefined;
     setDateFilters(pendingDateFilters);
     setView((currentView) => ({ ...currentView, page: 1 }));
   }, [dateRangeError, pendingDateFilters, setView]);
 
   const clearDateFilters = useCallback((): void => {
     const emptyFilters: DateFilters = {};
+    legacyOffsetRef.current = undefined;
     setPendingDateFilters(emptyFilters);
     setDateFilters(emptyFilters);
     setView((currentView) => ({ ...currentView, page: 1 }));

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -1,237 +1,273 @@
-import { useCallback, useState } from 'react';
-import { MailPoet } from 'mailpoet';
-import { curry } from 'lodash';
-import { parseISO } from 'date-fns';
-import { __, _x } from '@wordpress/i18n';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Notice } from '@wordpress/components';
+import { DataViews, View } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
+import { Button } from 'common';
+import { useDataViewsQuery, type ListingQueryParams } from 'common/dataviews';
 import { Datepicker } from '../common/datepicker/datepicker';
-import { Button, ErrorBoundary, Input } from '../common';
-import { Icon } from '../listing/assets/search-icon';
+import { getLogs, type LogListingItem } from './api';
+import { getLogFields } from './fields';
+import {
+  buildLogsUrl,
+  dateFromString,
+  formatDateAsYmd,
+  getDateRangeError,
+  parseLogsUrlState,
+  type DateFilters,
+} from './url-state';
 
-type LogData = {
-  id: number;
-  name: string;
-  message: string;
-  created_at: string;
+const DEFAULT_VIEW: View = {
+  type: 'table',
+  perPage: 20,
+  page: 1,
+  sort: { field: 'created_at', direction: 'desc' },
+  fields: ['message', 'action', 'created_at'],
+  titleField: 'name',
+  showTitle: true,
 };
 
-export type Logs = LogData[];
-
-type LogProps = {
-  log: LogData;
+type Props = {
+  defaultFrom: string;
 };
 
-function Log({ log }: LogProps): JSX.Element {
-  const [showFullMessage, setShowFullMessage] = useState(false);
+function buildInitialView(defaultFrom: string): {
+  view: View;
+  dateFilters: DateFilters;
+} {
+  const state = parseLogsUrlState(window.location.href, defaultFrom);
 
-  const toggleFullMessage = () => {
-    setShowFullMessage(!showFullMessage);
+  return {
+    view: {
+      ...DEFAULT_VIEW,
+      page: state.page,
+      perPage: state.perPage,
+      search: state.search,
+    },
+    dateFilters: state.dateFilters,
   };
-
-  return (
-    <tr key={`log-row-${log.id}`}>
-      <td role="gridcell" className="mailpoet-logs-min-width">
-        {log.name}
-      </td>
-      <td role="gridcell">
-        <div
-          className={`mailpoet-logs-message ${
-            showFullMessage ? 'mailpoet-logs-message-full' : ''
-          }`}
-        >
-          {log.message}
-        </div>
-      </td>
-      <td role="gridcell" className="mailpoet-logs-min-width">
-        <Button
-          dimension="small"
-          variant="secondary"
-          onClick={toggleFullMessage}
-        >
-          {showFullMessage
-            ? __('Show less', 'mailpoet')
-            : __('Show more', 'mailpoet')}
-        </Button>
-      </td>
-      <td className="mailpoet-logs-min-width" role="gridcell">
-        {MailPoet.Date.full(log.created_at)}
-      </td>
-    </tr>
-  );
 }
 
-Log.displayName = 'Log';
-export type FilterType = {
-  from?: string;
-  to?: string;
-  search?: string;
-  offset?: string;
-  limit?: string;
-};
+export function List({ defaultFrom }: Props): JSX.Element {
+  const initialState = useMemo(
+    () => buildInitialView(defaultFrom),
+    [defaultFrom],
+  );
+  const [dateFilters, setDateFilters] = useState<DateFilters>(
+    initialState.dateFilters,
+  );
+  const [pendingDateFilters, setPendingDateFilters] = useState<DateFilters>(
+    initialState.dateFilters,
+  );
+  const [expandedLogIds, setExpandedLogIds] = useState<Set<number>>(
+    () => new Set(),
+  );
+  const didMountRef = useRef(false);
 
-type ListProps = {
-  logs: Logs;
-  originalFrom?: string;
-  originalTo?: string;
-  originalSearch?: string;
-  originalOffset?: string;
-  originalLimit?: string;
-  onFilter: (FilterType) => void;
-};
-
-function List({
-  logs,
-  onFilter,
-  originalFrom,
-  originalTo,
-  originalSearch,
-  originalOffset,
-  originalLimit,
-}: ListProps): JSX.Element {
-  const [from, setFrom] = useState(originalFrom ?? undefined);
-  const [to, setTo] = useState(originalTo ?? undefined);
-  const [offset, setOffset] = useState(originalOffset ?? '');
-  const [limit, setLimit] = useState(originalLimit ?? '');
-  const [search, setSearch] = useState(originalSearch || '');
-
-  const dateChanged = curry(
-    (setter: (value: string) => void, value: string): void => {
-      if (value === null) {
-        setter(undefined);
-        return;
+  const load = useCallback(
+    (params: ListingQueryParams) => {
+      if (getDateRangeError(dateFilters)) {
+        return Promise.resolve({
+          items: [],
+          meta: { count: 0, pages: 0 },
+          filters: [],
+          groups: [],
+        });
       }
-      // Swap display format to storage format
-      const formatting = {
-        format: 'Y-m-d',
-      };
-      setter(MailPoet.Date.format(value, formatting));
+      const search = params.search?.trim();
+      return getLogs({
+        ...params,
+        search: search || undefined,
+        filter: dateFilters,
+      });
     },
+    [dateFilters],
   );
 
-  const filterClick = useCallback((): void => {
-    const data: FilterType = {};
-    if (from) {
-      data.from = from;
+  const {
+    view,
+    setView,
+    items,
+    meta,
+    isLoading,
+    error: loadError,
+    clearError: clearLoadError,
+    refresh,
+  } = useDataViewsQuery<LogListingItem>({
+    initialView: initialState.view,
+    load,
+  });
+
+  const dateRangeError = getDateRangeError(pendingDateFilters);
+
+  const updateView = useCallback(
+    (nextView: View) => {
+      const searchChanged = (nextView.search ?? '') !== (view.search ?? '');
+      const perPageChanged = nextView.perPage !== view.perPage;
+
+      setView({
+        ...nextView,
+        page: searchChanged || perPageChanged ? 1 : nextView.page,
+      });
+    },
+    [setView, view],
+  );
+
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
     }
-    if (to) {
-      data.to = to;
+
+    const nextUrl = buildLogsUrl(window.location.href, view, dateFilters);
+    window.history.replaceState({}, '', nextUrl);
+  }, [dateFilters, view]);
+
+  const toggleExpanded = useCallback((logId: number): void => {
+    setExpandedLogIds((current) => {
+      const next = new Set(current);
+      if (next.has(logId)) {
+        next.delete(logId);
+      } else {
+        next.add(logId);
+      }
+      return next;
+    });
+  }, []);
+
+  const fields = useMemo(
+    () => getLogFields(expandedLogIds, toggleExpanded),
+    [expandedLogIds, toggleExpanded],
+  );
+
+  const paginationInfo = useMemo(
+    () => ({ totalItems: meta.count, totalPages: meta.pages }),
+    [meta],
+  );
+
+  const applyDateFilters = useCallback((): void => {
+    if (dateRangeError) {
+      return;
     }
-    if (offset && offset.trim() !== '') {
-      data.offset = offset;
-    }
-    if (limit && limit.trim() !== '') {
-      data.limit = limit;
-    }
-    if (search && search.trim() !== '') {
-      data.search = search.trim();
-    }
-    onFilter(data);
-  }, [from, limit, offset, search, to, onFilter]);
+    setDateFilters(pendingDateFilters);
+    setView((currentView) => ({ ...currentView, page: 1 }));
+  }, [dateRangeError, pendingDateFilters, setView]);
+
+  const clearDateFilters = useCallback((): void => {
+    const emptyFilters: DateFilters = {};
+    setPendingDateFilters(emptyFilters);
+    setDateFilters(emptyFilters);
+    setView((currentView) => ({ ...currentView, page: 1 }));
+  }, [setView]);
+
+  const retryLoading = useCallback((): void => {
+    clearLoadError();
+    refresh();
+  }, [clearLoadError, refresh]);
 
   return (
-    <div className="mailpoet-listing mailpoet-logs">
-      <div className="mailpoet-listing-header">
-        <div className="mailpoet-listing-search">
-          <label htmlFor="search_input" className="screen-reader-text">
-            {__('Search', 'mailpoet')}
-          </label>
-          <Input
-            dimension="small"
-            iconStart={Icon}
-            type="search"
-            id="search_input"
-            name="s"
-            onChange={(event): void => setSearch(event.target.value)}
-            value={search}
-            placeholder={__('Search', 'mailpoet')}
-          />
-        </div>
-        <div className="mailpoet-listing-filters">
-          {
-            // translators: Date from when filtering
-            `${__('From', 'mailpoet')}:`
-          }
-          <ErrorBoundary>
-            <Datepicker
-              dateFormat="MMMM d, yyyy"
-              onChange={dateChanged(setFrom)}
-              maxDate={new Date()}
-              selected={from ? parseISO(from) : undefined}
+    <div className="mailpoet-listing mailpoet-logs mailpoet-logs-dataviews">
+      {loadError && (
+        <Notice status="error" isDismissible={false}>
+          <div className="mailpoet-logs-error">
+            <span>{__('Logs could not be loaded.', 'mailpoet')}</span>
+            <Button
               dimension="small"
-            />
-            {
-              // translators: Date to when filtering
-              `${__('To', 'mailpoet')}:`
-            }
-            <Datepicker
-              dateFormat="MMMM d, yyyy"
-              onChange={dateChanged(setTo)}
-              maxDate={new Date()}
-              selected={to ? parseISO(to) : undefined}
-              dimension="small"
-            />
-          </ErrorBoundary>
-        </div>
-        <div className="mailpoet-logs-limit">
-          <label htmlFor="offset_input" className="screen-reader-text">
-            {
-              // translators: Offset of search results when filtering
-              __('Offset', 'mailpoet')
-            }
-          </label>
-          <Input
-            dimension="small"
-            id="offset_input"
-            name="o"
-            type="number"
-            onChange={(event): void => setOffset(event.target.value)}
-            value={offset}
-            placeholder={__('Offset', 'mailpoet')}
-          />
-        </div>
-        <div className="mailpoet-logs-limit">
-          <label htmlFor="limit_input" className="screen-reader-text">
-            {__('Limit', 'mailpoet')}
-          </label>
-          <Input
-            dimension="small"
-            id="limit_input"
-            name="l"
-            type="number"
-            onChange={(event): void => setLimit(event.target.value)}
-            value={limit}
-            placeholder={__('Limit', 'mailpoet')}
-          />
-        </div>
-        <Button dimension="small" onClick={filterClick}>
-          {
-            // translators: Button to filter logs
-            _x('Filter', 'verb', 'mailpoet')
-          }
-        </Button>
-      </div>
+              variant="secondary"
+              onClick={retryLoading}
+              isDisabled={isLoading}
+            >
+              {__('Retry', 'mailpoet')}
+            </Button>
+          </div>
+        </Notice>
+      )}
 
-      <table className="mailpoet-listing-table widefat striped" role="grid">
-        <thead>
-          <tr>
-            <th>{__('Name', 'mailpoet')}</th>
-            <th>{__('Message', 'mailpoet')}</th>
-            <th>{__('Action', 'mailpoet')}</th>
-            <th>{__('Created On', 'mailpoet')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <ErrorBoundary>
-            {logs.map((log) => (
-              <Log log={log} key={`log-${log.id}`} />
-            ))}
-          </ErrorBoundary>
-        </tbody>
-      </table>
+      <DataViews<LogListingItem>
+        data={items}
+        fields={fields}
+        view={view}
+        onChangeView={updateView}
+        paginationInfo={paginationInfo}
+        defaultLayouts={{ table: {} }}
+        getItemId={(item) => String(item.id)}
+        isLoading={isLoading}
+        empty={<div>{__('No logs found.', 'mailpoet')}</div>}
+      >
+        <div className="mailpoet-logs-dataviews__toolbar">
+          <DataViews.Search label={__('Search logs', 'mailpoet')} />
+          <div className="mailpoet-logs-date-filters">
+            <label
+              className="mailpoet-logs-date-filter"
+              htmlFor="mailpoet-logs-from"
+            >
+              <span>{__('From', 'mailpoet')}</span>
+              <Datepicker
+                id="mailpoet-logs-from"
+                dateFormat="MMMM d, yyyy"
+                onChange={(date: Date | null): void =>
+                  setPendingDateFilters((current) => ({
+                    ...current,
+                    from: formatDateAsYmd(date),
+                  }))
+                }
+                maxDate={new Date()}
+                selected={dateFromString(pendingDateFilters.from)}
+                dimension="small"
+                disabled={isLoading}
+                isClearable
+                aria-label={__('Filter logs from date', 'mailpoet')}
+              />
+            </label>
+            <label
+              className="mailpoet-logs-date-filter"
+              htmlFor="mailpoet-logs-to"
+            >
+              <span>{__('To', 'mailpoet')}</span>
+              <Datepicker
+                id="mailpoet-logs-to"
+                dateFormat="MMMM d, yyyy"
+                onChange={(date: Date | null): void =>
+                  setPendingDateFilters((current) => ({
+                    ...current,
+                    to: formatDateAsYmd(date),
+                  }))
+                }
+                maxDate={new Date()}
+                selected={dateFromString(pendingDateFilters.to)}
+                dimension="small"
+                disabled={isLoading}
+                isClearable
+                aria-label={__('Filter logs to date', 'mailpoet')}
+              />
+            </label>
+            <Button
+              dimension="small"
+              onClick={applyDateFilters}
+              isDisabled={isLoading || Boolean(dateRangeError)}
+            >
+              {__('Apply', 'mailpoet')}
+            </Button>
+            <Button
+              dimension="small"
+              variant="secondary"
+              onClick={clearDateFilters}
+              isDisabled={isLoading}
+            >
+              {__('Clear', 'mailpoet')}
+            </Button>
+          </div>
+          {dateRangeError && (
+            <div className="mailpoet-logs-date-error" role="alert">
+              {dateRangeError}
+            </div>
+          )}
+        </div>
+        <DataViews.Layout />
+        <DataViews.Footer />
+      </DataViews>
     </div>
   );
 }
 
 List.displayName = 'LogsList';
-
-export { List };

--- a/mailpoet/assets/js/src/logs/list.tsx
+++ b/mailpoet/assets/js/src/logs/list.tsx
@@ -66,8 +66,10 @@ export function List({ defaultFrom }: Props): JSX.Element {
   const didMountRef = useRef(false);
 
   const load = useCallback(
-    (params: ListingQueryParams) => {
+    (params: ListingQueryParams, signal?: AbortSignal) => {
       if (getDateRangeError(dateFilters)) {
+        // Invalid bookmarked ranges are rendered as validation errors instead
+        // of being sent to REST.
         return Promise.resolve({
           items: [],
           meta: { count: 0, pages: 0 },
@@ -75,7 +77,7 @@ export function List({ defaultFrom }: Props): JSX.Element {
           groups: [],
         });
       }
-      return getLogs(buildLogsRequestParams(params, dateFilters));
+      return getLogs(buildLogsRequestParams(params, dateFilters), signal);
     },
     [dateFilters],
   );
@@ -122,6 +124,10 @@ export function List({ defaultFrom }: Props): JSX.Element {
     const nextUrl = buildLogsUrl(window.location.href, view, dateFilters);
     window.history.replaceState({}, '', nextUrl);
   }, [dateFilters, view]);
+
+  useEffect(() => {
+    setExpandedLogIds((current) => (current.size > 0 ? new Set() : current));
+  }, [dateFilters, view.page, view.perPage, view.search]);
 
   const toggleExpanded = useCallback((logId: number): void => {
     setExpandedLogIds((current) => {

--- a/mailpoet/assets/js/src/logs/logs.tsx
+++ b/mailpoet/assets/js/src/logs/logs.tsx
@@ -1,44 +1,21 @@
 import { createRoot } from 'react-dom/client';
 
 import { ErrorBoundary } from 'common';
-import { FilterType, List, Logs } from './list';
+import { List } from './list';
 
-interface LogsWindow extends Window {
-  mailpoet_logs: Logs;
-  mailpoet_logs_default_from: string;
+declare global {
+  interface Window {
+    mailpoet_logs_default_from: string;
+  }
 }
-
-declare let window: LogsWindow;
 
 const container = document.getElementById('mailpoet_logs_container');
 
 if (container) {
-  const url = new URL(window.location.href);
-
   const root = createRoot(container);
   root.render(
     <ErrorBoundary>
-      <List
-        logs={window.mailpoet_logs}
-        originalFrom={
-          url.searchParams.get('from') || window.mailpoet_logs_default_from
-        }
-        originalTo={url.searchParams.get('to')}
-        originalSearch={url.searchParams.get('search')}
-        originalOffset={url.searchParams.get('offset')}
-        originalLimit={url.searchParams.get('limit')}
-        onFilter={(data: FilterType): void => {
-          url.searchParams.delete('from');
-          url.searchParams.delete('to');
-          url.searchParams.delete('search');
-          url.searchParams.delete('offset');
-          url.searchParams.delete('limit');
-          Object.entries(data).forEach(([key, value]) => {
-            url.searchParams.append(key, value);
-          });
-          window.location.href = url.href;
-        }}
-      />
+      <List defaultFrom={window.mailpoet_logs_default_from} />
     </ErrorBoundary>,
   );
 }

--- a/mailpoet/assets/js/src/logs/url-state.ts
+++ b/mailpoet/assets/js/src/logs/url-state.ts
@@ -15,7 +15,6 @@ export type LogsUrlState = {
   perPage: number;
   search?: string;
   dateFilters: DateFilters;
-  legacyOffset?: number;
 };
 
 function parsePositiveInt(value: string | null): number | undefined {
@@ -148,14 +147,6 @@ function getPage(searchParams: URLSearchParams, perPage: number): number {
   return DEFAULT_PAGE;
 }
 
-function getLegacyOffset(searchParams: URLSearchParams): number | undefined {
-  if (parsePositiveInt(searchParams.get('logs_page'))) {
-    return undefined;
-  }
-
-  return parseOffset(searchParams.get('offset'));
-}
-
 function getPerPage(searchParams: URLSearchParams): number {
   const logsPerPage = parsePositiveInt(searchParams.get('per_page'));
   if (logsPerPage) {
@@ -171,20 +162,13 @@ export function parseLogsUrlState(
 ): LogsUrlState {
   const searchParams = new URL(url).searchParams;
   const perPage = getPerPage(searchParams);
-  const legacyOffset = getLegacyOffset(searchParams);
 
-  const state: LogsUrlState = {
+  return {
     page: getPage(searchParams, perPage),
     perPage,
     search: getSearch(searchParams),
     dateFilters: getDateFilters(searchParams, defaultFrom),
   };
-
-  if (legacyOffset !== undefined) {
-    state.legacyOffset = legacyOffset;
-  }
-
-  return state;
 }
 
 export function buildLogsUrl(

--- a/mailpoet/assets/js/src/logs/url-state.ts
+++ b/mailpoet/assets/js/src/logs/url-state.ts
@@ -1,0 +1,217 @@
+import { __ } from '@wordpress/i18n';
+import type { View } from '@wordpress/dataviews';
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PER_PAGE = 20;
+export const MAX_PER_PAGE = 100;
+
+export type DateFilters = {
+  from?: string;
+  to?: string;
+};
+
+export type LogsUrlState = {
+  page: number;
+  perPage: number;
+  search?: string;
+  dateFilters: DateFilters;
+};
+
+function parsePositiveInt(value: string | null): number | undefined {
+  if (!value) return undefined;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function clampPerPage(perPage: number | undefined): number {
+  if (!perPage) {
+    return DEFAULT_PER_PAGE;
+  }
+  return Math.min(perPage, MAX_PER_PAGE);
+}
+
+function parseOffset(value: string | null): number | undefined {
+  if (value === null || value.trim() === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function hasOnlyDigits(value: string): boolean {
+  return value
+    .split('')
+    .every((character) => character >= '0' && character <= '9');
+}
+
+export function isStrictDateString(value: string | undefined | null): boolean {
+  if (!value || value.length !== 10) {
+    return false;
+  }
+
+  const parts = value.split('-');
+  if (
+    parts.length !== 3 ||
+    parts[0].length !== 4 ||
+    parts[1].length !== 2 ||
+    parts[2].length !== 2 ||
+    !parts.every(hasOnlyDigits)
+  ) {
+    return false;
+  }
+
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+export function dateFromString(value: string | undefined): Date | undefined {
+  if (!isStrictDateString(value)) {
+    return undefined;
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function padDatePart(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+export function formatDateAsYmd(date: Date | null): string | undefined {
+  if (!date || Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return [
+    date.getFullYear(),
+    padDatePart(date.getMonth() + 1),
+    padDatePart(date.getDate()),
+  ].join('-');
+}
+
+function getSearch(searchParams: URLSearchParams): string | undefined {
+  const search = searchParams.get('search')?.trim();
+  return search || undefined;
+}
+
+function getDateFilters(
+  searchParams: URLSearchParams,
+  defaultFrom: string,
+): DateFilters {
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  const filters: DateFilters = {};
+
+  if (isStrictDateString(from)) {
+    filters.from = from;
+  } else if (isStrictDateString(defaultFrom)) {
+    filters.from = defaultFrom;
+  }
+
+  if (isStrictDateString(to)) {
+    filters.to = to;
+  }
+
+  return filters;
+}
+
+function getPage(searchParams: URLSearchParams, perPage: number): number {
+  const logsPage = parsePositiveInt(searchParams.get('logs_page'));
+  if (logsPage) {
+    return logsPage;
+  }
+
+  const offset = parseOffset(searchParams.get('offset'));
+  if (offset !== undefined) {
+    return Math.floor(offset / perPage) + 1;
+  }
+
+  return DEFAULT_PAGE;
+}
+
+function getPerPage(searchParams: URLSearchParams): number {
+  const logsPerPage = parsePositiveInt(searchParams.get('per_page'));
+  if (logsPerPage) {
+    return clampPerPage(logsPerPage);
+  }
+
+  return clampPerPage(parsePositiveInt(searchParams.get('limit')));
+}
+
+export function parseLogsUrlState(
+  url: string,
+  defaultFrom: string,
+): LogsUrlState {
+  const searchParams = new URL(url).searchParams;
+  const perPage = getPerPage(searchParams);
+
+  return {
+    page: getPage(searchParams, perPage),
+    perPage,
+    search: getSearch(searchParams),
+    dateFilters: getDateFilters(searchParams, defaultFrom),
+  };
+}
+
+export function buildLogsUrl(
+  currentUrl: string,
+  view: View,
+  dateFilters: DateFilters,
+): string {
+  const url = new URL(currentUrl);
+  const search = view.search?.trim();
+
+  url.searchParams.set('page', 'mailpoet-logs');
+  url.searchParams.delete('offset');
+  url.searchParams.delete('limit');
+  url.searchParams.delete('search');
+  url.searchParams.delete('from');
+  url.searchParams.delete('to');
+
+  if (search) {
+    url.searchParams.set('search', search);
+  }
+  if (dateFilters.from) {
+    url.searchParams.set('from', dateFilters.from);
+  }
+  if (dateFilters.to) {
+    url.searchParams.set('to', dateFilters.to);
+  }
+
+  url.searchParams.set('logs_page', String(view.page ?? DEFAULT_PAGE));
+  url.searchParams.set(
+    'per_page',
+    String(clampPerPage(view.perPage ?? DEFAULT_PER_PAGE)),
+  );
+
+  return url.href;
+}
+
+export function getDateRangeError(dateFilters: DateFilters): string | null {
+  if (dateFilters.from && dateFilters.to && dateFilters.from > dateFilters.to) {
+    return __(
+      'The start date must be before or equal to the end date.',
+      'mailpoet',
+    );
+  }
+
+  return null;
+}

--- a/mailpoet/assets/js/src/logs/url-state.ts
+++ b/mailpoet/assets/js/src/logs/url-state.ts
@@ -206,6 +206,8 @@ export function buildLogsUrl(
 }
 
 export function getDateRangeError(dateFilters: DateFilters): string | null {
+  // Keep in sync with LogsListingEndpoint::validateFilters; the browser blocks
+  // invalid ranges, while REST validates direct requests.
   if (dateFilters.from && dateFilters.to && dateFilters.from > dateFilters.to) {
     return __(
       'The start date must be before or equal to the end date.',

--- a/mailpoet/assets/js/src/logs/url-state.ts
+++ b/mailpoet/assets/js/src/logs/url-state.ts
@@ -15,6 +15,7 @@ export type LogsUrlState = {
   perPage: number;
   search?: string;
   dateFilters: DateFilters;
+  legacyOffset?: number;
 };
 
 function parsePositiveInt(value: string | null): number | undefined {
@@ -147,6 +148,14 @@ function getPage(searchParams: URLSearchParams, perPage: number): number {
   return DEFAULT_PAGE;
 }
 
+function getLegacyOffset(searchParams: URLSearchParams): number | undefined {
+  if (parsePositiveInt(searchParams.get('logs_page'))) {
+    return undefined;
+  }
+
+  return parseOffset(searchParams.get('offset'));
+}
+
 function getPerPage(searchParams: URLSearchParams): number {
   const logsPerPage = parsePositiveInt(searchParams.get('per_page'));
   if (logsPerPage) {
@@ -162,13 +171,20 @@ export function parseLogsUrlState(
 ): LogsUrlState {
   const searchParams = new URL(url).searchParams;
   const perPage = getPerPage(searchParams);
+  const legacyOffset = getLegacyOffset(searchParams);
 
-  return {
+  const state: LogsUrlState = {
     page: getPage(searchParams, perPage),
     perPage,
     search: getSearch(searchParams),
     dateFilters: getDateFilters(searchParams, defaultFrom),
   };
+
+  if (legacyOffset !== undefined) {
+    state.legacyOffset = legacyOffset;
+  }
+
+  return state;
 }
 
 export function buildLogsUrl(

--- a/mailpoet/changelog/2026-05-18-14-45-29-improved-improve-the-logs-listing-page-with-dataviews-contr.md
+++ b/mailpoet/changelog/2026-05-18-14-45-29-improved-improve-the-logs-listing-page-with-dataviews-contr.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improve the Logs listing page with DataViews controls

--- a/mailpoet/lib/API/REST/AbstractListingEndpoint.php
+++ b/mailpoet/lib/API/REST/AbstractListingEndpoint.php
@@ -126,7 +126,7 @@ abstract class AbstractListingEndpoint extends Endpoint {
     $sortBy = is_string($orderByParam) && $orderByParam !== '' ? $orderByParam : $this->getDefaultSortBy();
 
     $orderParam = $request->getParam('order') ?? $request->getParam('sort_order');
-    $sortOrder = is_string($orderParam) ? strtolower($orderParam) : $this->getDefaultSortOrder();
+    $sortOrder = is_string($orderParam) && $orderParam !== '' ? strtolower($orderParam) : $this->getDefaultSortOrder();
 
     $searchParam = $request->getParam('search');
     $search = is_string($searchParam) ? $searchParam : null;

--- a/mailpoet/lib/AdminPages/Pages/Logs.php
+++ b/mailpoet/lib/AdminPages/Pages/Logs.php
@@ -2,53 +2,42 @@
 
 namespace MailPoet\AdminPages\Pages;
 
+use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
-use MailPoet\Logging\LogRepository;
+use MailPoet\WP\Functions as WPFunctions;
 use MailPoetVendor\Carbon\Carbon;
 
 class Logs {
+  /** @var AssetsController */
+  private $assetsController;
+
   /** @var PageRenderer */
   private $pageRenderer;
 
-  /** @var LogRepository */
-  private $logRepository;
+  /** @var WPFunctions */
+  private $wp;
 
   public function __construct(
-    LogRepository $logRepository,
-    PageRenderer $pageRenderer
+    AssetsController $assetsController,
+    PageRenderer $pageRenderer,
+    WPFunctions $wp
   ) {
+    $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
-    $this->logRepository = $logRepository;
+    $this->wp = $wp;
   }
 
   public function render() {
-    $search = isset($_GET['search']) && is_string($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : null;
-    $from = isset($_GET['from']) && is_string($_GET['from']) ? sanitize_text_field(wp_unslash($_GET['from'])) : null;
-    $to = isset($_GET['to']) && is_string($_GET['to']) ? sanitize_text_field(wp_unslash($_GET['to'])) : null;
-    $offset = isset($_GET['offset']) && is_string($_GET['offset']) ? sanitize_text_field(wp_unslash($_GET['offset'])) : null;
-    $limit = isset($_GET['limit']) && is_string($_GET['limit']) ? sanitize_text_field(wp_unslash($_GET['limit'])) : null;
+    $this->assetsController->setupDataViewsDependencies();
+
     $dateFrom = (new Carbon())->subDays(7);
-    $defaultFrom = $dateFrom->format('Y-m-d');
-    if (isset($from)) {
-      $dateFrom = new Carbon($from);
-    }
-    $dateTo = null;
-    if (isset($to)) {
-      $dateTo = new Carbon($to);
-    }
-    $logs = $this->logRepository->getLogs($dateFrom, $dateTo, $search, $offset, $limit);
     $data = [
-      'logs' => [],
-      'logs_default_from' => $defaultFrom,
+      'logs_default_from' => $dateFrom->format('Y-m-d'),
+      'api' => [
+        'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+        'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+      ],
     ];
-    foreach ($logs as $log) {
-      $data['logs'][] = [
-        'id' => $log->getId(),
-        'name' => $log->getName(),
-        'message' => $log->getMessage(),
-        'created_at' => ($createdAt = $log->getCreatedAt()) ? $createdAt->format('Y-m-d H:i:s') : null,
-      ];
-    }
     $this->pageRenderer->displayPage('logs.html', $data);
   }
 }

--- a/mailpoet/lib/Config/Initializer.php
+++ b/mailpoet/lib/Config/Initializer.php
@@ -20,6 +20,7 @@ use MailPoet\EmailEditor\Integrations\MailPoet\EmailEditor as MailpoetEmailEdito
 use MailPoet\EmailEditor\Integrations\MailPoet\Logger;
 use MailPoet\Form\RestApi\Api as FormsRestApi;
 use MailPoet\InvalidStateException;
+use MailPoet\Logging\RestApi\Api as LogsRestApi;
 use MailPoet\Migrator\Cli as MigratorCli;
 use MailPoet\Newsletter\Sharing\PublicEmailRoute;
 use MailPoet\PostEditorBlocks\PostEditorBlock;
@@ -129,6 +130,9 @@ class Initializer {
   /** @var SegmentsRestApi */
   private $segmentsRestApi;
 
+  /** @var LogsRestApi */
+  private $logsRestApi;
+
   /** @var MailPoetIntegration */
   private $automationMailPoetIntegration;
 
@@ -194,6 +198,7 @@ class Initializer {
     CustomFieldsRestApi $customFieldsRestApi,
     FormsRestApi $formsRestApi,
     SegmentsRestApi $segmentsRestApi,
+    LogsRestApi $logsRestApi,
     PublicEmailRoute $publicEmailRoute
   ) {
     $this->rendererFactory = $rendererFactory;
@@ -231,6 +236,7 @@ class Initializer {
     $this->customFieldsRestApi = $customFieldsRestApi;
     $this->formsRestApi = $formsRestApi;
     $this->segmentsRestApi = $segmentsRestApi;
+    $this->logsRestApi = $logsRestApi;
     $this->publicEmailRoute = $publicEmailRoute;
 
     $emailEditorContainer = Email_Editor_Container::container();
@@ -403,6 +409,7 @@ class Initializer {
       $this->customFieldsRestApi->initialize();
       $this->formsRestApi->initialize();
       $this->segmentsRestApi->initialize();
+      $this->logsRestApi->initialize();
       $this->blockTypesController->initialize();
       $this->wpFunctions->doAction('mailpoet_initialized', MAILPOET_VERSION);
     } catch (InvalidStateException $e) {

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -436,6 +436,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     // Logging
     $container->autowire(\MailPoet\Logging\LoggerFactory::class)->setPublic(true);
     $container->autowire(\MailPoet\Logging\LogRepository::class)->setPublic(true);
+    $container->autowire(\MailPoet\Logging\LogListingRepository::class)->setPublic(true);
     // Notices
     $container->autowire(\MailPoet\Util\Notices\PermanentNotices::class);
     $container->autowire(\MailPoet\Util\Notices\PendingApprovalNotice::class)->setPublic(true);
@@ -750,6 +751,9 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Segments\RestApi\Endpoints\SegmentsBulkActionEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\RestApi\Endpoints\DynamicSegmentsListingEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Segments\RestApi\Endpoints\DynamicSegmentsBulkActionEndpoint::class)->setPublic(true);
+    // Logs REST API
+    $container->autowire(\MailPoet\Logging\RestApi\Api::class)->setPublic(true);
+    $container->autowire(\MailPoet\Logging\RestApi\Endpoints\LogsListingEndpoint::class)->setPublic(true);
     // CAPTCHA
     $container->autowire(\MailPoet\Captcha\ReCaptchaHooks::class)->setPublic(true);
     $container->autowire(\MailPoet\Captcha\ReCaptchaValidator::class)->setPublic(true);

--- a/mailpoet/lib/Listing/ListingRepository.php
+++ b/mailpoet/lib/Listing/ListingRepository.php
@@ -71,7 +71,7 @@ abstract class ListingRepository {
     $search = $definition->getSearch();
     $parameters = $definition->getParameters();
 
-    if ($search && strlen(trim($search)) > 0) {
+    if ($search !== null && strlen(trim($search)) > 0) {
       $this->applySearch($queryBuilder, $search, $parameters ?: []);
     }
 

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -21,6 +21,9 @@ class LogListingRepository extends ListingRepository {
 
   protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
     $queryBuilder->addOrderBy("l.$sortBy", $sortOrder);
+    if ($sortBy !== 'id') {
+      $queryBuilder->addOrderBy('l.id', $sortOrder);
+    }
   }
 
   protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters) {

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -30,12 +30,12 @@ class LogListingRepository extends ListingRepository {
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
-    if (isset($filters['from'])) {
+    if (!empty($filters['from'])) {
       $queryBuilder
         ->andWhere('l.createdAt >= :dateFrom')
         ->setParameter('dateFrom', $filters['from'] . ' 00:00:00');
     }
-    if (isset($filters['to'])) {
+    if (!empty($filters['to'])) {
       $queryBuilder
         ->andWhere('l.createdAt <= :dateTo')
         ->setParameter('dateTo', $filters['to'] . ' 23:59:59');

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -27,9 +27,15 @@ class LogListingRepository extends ListingRepository {
   }
 
   protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters) {
+    $search = trim($search);
+    if ($search === '') {
+      return;
+    }
+
+    // LOCATE() keeps SQL wildcard characters literal for admin log searches.
     $queryBuilder
       ->andWhere('LOCATE(:search, l.name) > 0 or LOCATE(:search, l.message) > 0')
-      ->setParameter('search', trim($search));
+      ->setParameter('search', $search);
   }
 
   protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -34,7 +34,7 @@ class LogListingRepository extends ListingRepository {
 
     // LOCATE() keeps SQL wildcard characters literal for admin log searches.
     $queryBuilder
-      ->andWhere('LOCATE(:search, l.name) > 0 or LOCATE(:search, l.message) > 0')
+      ->andWhere('(LOCATE(:search, l.name) > 0 OR LOCATE(:search, l.message) > 0)')
       ->setParameter('search', $search);
   }
 

--- a/mailpoet/lib/Logging/LogListingRepository.php
+++ b/mailpoet/lib/Logging/LogListingRepository.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging;
+
+use MailPoet\Entities\LogEntity;
+use MailPoet\Listing\ListingRepository;
+use MailPoetVendor\Doctrine\ORM\QueryBuilder;
+
+class LogListingRepository extends ListingRepository {
+  protected function applySelectClause(QueryBuilder $queryBuilder) {
+    $queryBuilder->select('PARTIAL l.{id,name,message,createdAt}');
+  }
+
+  protected function applyFromClause(QueryBuilder $queryBuilder) {
+    $queryBuilder->from(LogEntity::class, 'l');
+  }
+
+  protected function applyGroup(QueryBuilder $queryBuilder, string $group) {
+    // Logs listing does not support groups.
+  }
+
+  protected function applySorting(QueryBuilder $queryBuilder, string $sortBy, string $sortOrder) {
+    $queryBuilder->addOrderBy("l.$sortBy", $sortOrder);
+  }
+
+  protected function applySearch(QueryBuilder $queryBuilder, string $search, array $parameters) {
+    $queryBuilder
+      ->andWhere('LOCATE(:search, l.name) > 0 or LOCATE(:search, l.message) > 0')
+      ->setParameter('search', trim($search));
+  }
+
+  protected function applyFilters(QueryBuilder $queryBuilder, array $filters) {
+    if (isset($filters['from'])) {
+      $queryBuilder
+        ->andWhere('l.createdAt >= :dateFrom')
+        ->setParameter('dateFrom', $filters['from'] . ' 00:00:00');
+    }
+    if (isset($filters['to'])) {
+      $queryBuilder
+        ->andWhere('l.createdAt <= :dateTo')
+        ->setParameter('dateTo', $filters['to'] . ' 23:59:59');
+    }
+  }
+
+  protected function applyParameters(QueryBuilder $queryBuilder, array $parameters) {
+    // Logs listing does not support additional parameters.
+  }
+}

--- a/mailpoet/lib/Logging/RestApi/Api.php
+++ b/mailpoet/lib/Logging/RestApi/Api.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging\RestApi;
+
+use MailPoet\API\REST\API as RestApi;
+use MailPoet\Logging\RestApi\Endpoints\LogsListingEndpoint;
+use MailPoet\WP\Functions as WPFunctions;
+
+class Api {
+  /** @var RestApi */
+  private $api;
+
+  /** @var WPFunctions */
+  private $wp;
+
+  public function __construct(
+    RestApi $api,
+    WPFunctions $wp
+  ) {
+    $this->api = $api;
+    $this->wp = $wp;
+  }
+
+  public function initialize(): void {
+    $this->wp->addAction(RestApi::REST_API_INIT_ACTION, function (): void {
+      $this->api->registerGetRoute('logs', LogsListingEndpoint::class);
+    });
+  }
+}

--- a/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
+++ b/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
@@ -1,0 +1,218 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Logging\RestApi\Endpoints;
+
+use DateTimeImmutable;
+use MailPoet\API\REST\AbstractListingEndpoint;
+use MailPoet\API\REST\ApiException;
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Config\AccessControl;
+use MailPoet\Entities\LogEntity;
+use MailPoet\Listing\Handler as ListingHandler;
+use MailPoet\Listing\ListingRepository;
+use MailPoet\Logging\LogListingRepository;
+use MailPoet\Validator\Builder;
+use MailPoet\WP\Functions as WPFunctions;
+
+class LogsListingEndpoint extends AbstractListingEndpoint {
+  private const ALLOWED_SORT_FIELD = 'created_at';
+  private const ALLOWED_SORT_ORDER = 'desc';
+
+  /** @var LogListingRepository */
+  private $logListingRepository;
+
+  public function __construct(
+    ListingHandler $listingHandler,
+    LogListingRepository $logListingRepository
+  ) {
+    parent::__construct($listingHandler);
+    $this->logListingRepository = $logListingRepository;
+  }
+
+  public function handle(Request $request): Response {
+    $this->validateRequest($request);
+    return parent::handle($request);
+  }
+
+  public function checkPermissions(): bool {
+    return WPFunctions::get()->currentUserCan(AccessControl::PERMISSION_ACCESS_PLUGIN_ADMIN);
+  }
+
+  public static function getRequestSchema(): array {
+    $schema = parent::getRequestSchema();
+    $schema['limit'] = Builder::integer();
+    $schema['offset'] = Builder::integer();
+    $schema['filter'] = Builder::object();
+    return $schema;
+  }
+
+  protected function getListingRepository(): ListingRepository {
+    return $this->logListingRepository;
+  }
+
+  protected function buildItems(array $rows): array {
+    $items = [];
+    foreach ($rows as $row) {
+      if (!$row instanceof LogEntity) {
+        continue;
+      }
+      $items[] = $this->buildItem($row);
+    }
+    return $items;
+  }
+
+  private function buildItem(LogEntity $log): array {
+    $createdAt = $log->getCreatedAt();
+    return [
+      'id' => (int)$log->getId(),
+      'name' => $log->getName() ?? '',
+      'message' => $log->getMessage() ?? '',
+      'created_at' => $createdAt ? $createdAt->format('Y-m-d H:i:s') : null,
+    ];
+  }
+
+  protected function getDefaultSortBy(): string {
+    return self::ALLOWED_SORT_FIELD;
+  }
+
+  protected function getDefaultSortOrder(): string {
+    return self::ALLOWED_SORT_ORDER;
+  }
+
+  private function validateRequest(Request $request): void {
+    $this->validateSortField($request->getParam('orderby'));
+    $this->validateSortField($request->getParam('sort_by'));
+    $this->validateSortOrder($request->getParam('order'));
+    $this->validateSortOrder($request->getParam('sort_order'));
+    $this->validatePositiveInteger($request->getParam('page'), 'page', 1, self::MAX_PAGE);
+    $this->validatePositiveInteger($request->getParam('per_page'), 'per_page', 1, self::MAX_PER_PAGE);
+    $this->validatePositiveInteger($request->getParam('limit'), 'limit', 1, self::MAX_PER_PAGE);
+    $this->validatePositiveInteger($request->getParam('offset'), 'offset', 0, self::MAX_PAGE);
+    $this->validateFilters($request->getParam('filter'));
+  }
+
+  /** @param mixed $sortField */
+  private function validateSortField($sortField): void {
+    if ($sortField === null || $sortField === '') {
+      return;
+    }
+    if (!is_string($sortField) || $sortField !== self::ALLOWED_SORT_FIELD) {
+      throw new ApiException(
+        __('Unsupported sort field. Allowed values are: created_at.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_orderby'
+      );
+    }
+  }
+
+  /** @param mixed $sortOrder */
+  private function validateSortOrder($sortOrder): void {
+    if ($sortOrder === null || $sortOrder === '') {
+      return;
+    }
+    if (!is_string($sortOrder) || strtolower($sortOrder) !== self::ALLOWED_SORT_ORDER) {
+      throw new ApiException(
+        __('Unsupported sort order. Allowed values are: desc.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_order'
+      );
+    }
+  }
+
+  /**
+   * @param mixed $value
+   */
+  private function validatePositiveInteger($value, string $name, int $min, int $max): void {
+    if ($value === null || $value === '') {
+      return;
+    }
+    $integer = $this->getIntegerValue($value);
+    if ($integer === null || $integer < $min || $integer > $max) {
+      throw new ApiException(
+        sprintf(
+          // translators: %1$s is a request parameter name, %2$d is the maximum accepted value.
+          __('%1$s must be an integer no greater than %2$d.', 'mailpoet'),
+          $name,
+          $max
+        ),
+        400,
+        'mailpoet_logs_invalid_' . $name
+      );
+    }
+  }
+
+  /** @param mixed $value */
+  private function getIntegerValue($value): ?int {
+    if (is_int($value)) {
+      return $value;
+    }
+    if (is_string($value) && ctype_digit($value)) {
+      return (int)$value;
+    }
+    return null;
+  }
+
+  /** @param mixed $filters */
+  private function validateFilters($filters): void {
+    if ($filters === null || $filters === []) {
+      return;
+    }
+    if (!is_array($filters)) {
+      throw new ApiException(
+        __('Filters must be an object.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_filter'
+      );
+    }
+
+    $normalizedFilters = [];
+    foreach ($filters as $filter => $value) {
+      if (!is_string($filter) || !in_array($filter, ['from', 'to'], true)) {
+        throw new ApiException(
+          __('Unsupported logs filter.', 'mailpoet'),
+          400,
+          'mailpoet_logs_invalid_filter'
+        );
+      }
+      $normalizedFilters[$filter] = $value;
+    }
+
+    $from = $this->validateDateFilter($normalizedFilters, 'from');
+    $to = $this->validateDateFilter($normalizedFilters, 'to');
+    if ($from && $to && $from > $to) {
+      throw new ApiException(
+        __('The from date must be before or equal to the to date.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_date_range'
+      );
+    }
+  }
+
+  /**
+   * @param array<string, mixed> $filters
+   */
+  private function validateDateFilter(array $filters, string $field): ?DateTimeImmutable {
+    if (!array_key_exists($field, $filters) || $filters[$field] === '') {
+      return null;
+    }
+    if (!is_string($filters[$field])) {
+      throw new ApiException(
+        __('Log date filters must use the YYYY-MM-DD format.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_' . $field
+      );
+    }
+
+    $date = DateTimeImmutable::createFromFormat('!Y-m-d', $filters[$field]);
+    $errors = DateTimeImmutable::getLastErrors();
+    if (!$date || (is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) || $date->format('Y-m-d') !== $filters[$field]) {
+      throw new ApiException(
+        __('Log date filters must use the YYYY-MM-DD format.', 'mailpoet'),
+        400,
+        'mailpoet_logs_invalid_' . $field
+      );
+    }
+    return $date;
+  }
+}

--- a/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
+++ b/mailpoet/lib/Logging/RestApi/Endpoints/LogsListingEndpoint.php
@@ -180,6 +180,7 @@ class LogsListingEndpoint extends AbstractListingEndpoint {
 
     $from = $this->validateDateFilter($normalizedFilters, 'from');
     $to = $this->validateDateFilter($normalizedFilters, 'to');
+    // Keep in sync with getDateRangeError() in logs/url-state.ts.
     if ($from && $to && $from > $to) {
       throw new ApiException(
         __('The from date must be before or equal to the to date.', 'mailpoet'),

--- a/mailpoet/tests/DataFactories/Log.php
+++ b/mailpoet/tests/DataFactories/Log.php
@@ -31,6 +31,20 @@ class Log {
     return $this->update('created_at', $date);
   }
 
+  /**
+   * @return static
+   */
+  public function withName(?string $name): Log {
+    return $this->update('name', $name);
+  }
+
+  /**
+   * @return static
+   */
+  public function withMessage(?string $message): Log {
+    return $this->update('message', $message);
+  }
+
   public function create(): LogEntity {
     $entity = new LogEntity();
     $entity->setName($this->data['name']);

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -83,6 +83,16 @@ class LogsEndpointsTest extends Test {
     $this->assertSame([(int)$backslash->getId()], $backslashIds);
   }
 
+  public function testGetSearchesZeroAsLiteralTerm(): void {
+    $match = (new LogFactory())->withName('0')->withMessage('matching zero log')->create();
+    $nonMatch = (new LogFactory())->withName('one')->withMessage('matching one log')->create();
+
+    $ids = $this->getIdsForSearch('0');
+
+    $this->assertContains((int)$match->getId(), $ids);
+    $this->assertNotContains((int)$nonMatch->getId(), $ids);
+  }
+
   public function testGetAppliesInclusiveDateFiltersAndNewestFirstOrdering(): void {
     $suffix = uniqid();
     $before = (new LogFactory())
@@ -115,6 +125,30 @@ class LogsEndpointsTest extends Test {
     $this->assertSame([(int)$end->getId(), (int)$start->getId()], $ids);
     $this->assertNotContains((int)$before->getId(), $ids);
     $this->assertNotContains((int)$after->getId(), $ids);
+  }
+
+  public function testGetIgnoresEmptyDateFilters(): void {
+    $suffix = uniqid();
+    $old = (new LogFactory())
+      ->withName("empty-date-old-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-01 00:00:00'))
+      ->create();
+    $new = (new LogFactory())
+      ->withName("empty-date-new-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-02 00:00:00'))
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'filter' => [
+        'from' => '',
+        'to' => '',
+      ],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    $this->assertSame([(int)$new->getId(), (int)$old->getId()], $ids);
   }
 
   public function testGetSupportsCanonicalAndLegacyPagination(): void {

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -1,0 +1,182 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Test\REST\Logs;
+
+use MailPoet\REST\Test;
+use MailPoet\Test\DataFactories\Log as LogFactory;
+use MailPoetVendor\Carbon\Carbon;
+
+require_once __DIR__ . '/../Test.php';
+
+class LogsEndpointsTest extends Test {
+  private const BASE_PATH = '/mailpoet/v1/logs';
+
+  /** @var int */
+  private $editorUserId;
+
+  public function _before() {
+    parent::_before();
+    wp_set_current_user(1);
+    $userId = wp_create_user('logs_subscriber_' . uniqid(), 'password', 'logs-subscriber-' . uniqid() . '@localhost.test');
+    $this->assertIsNumeric($userId);
+    $user = new \WP_User($userId);
+    $user->add_role('subscriber');
+    $this->editorUserId = (int)$userId;
+  }
+
+  public function _after() {
+    parent::_after();
+    wp_set_current_user(0);
+    is_multisite() ? wpmu_delete_user($this->editorUserId) : wp_delete_user($this->editorUserId);
+  }
+
+  public function testGetReturnsLogsEnvelopeAndNormalizesNullableFields(): void {
+    $suffix = uniqid();
+    $logWithNullName = (new LogFactory())
+      ->withName(null)
+      ->withMessage("nullable-name-{$suffix}")
+      ->create();
+    $logWithNullMessage = (new LogFactory())
+      ->withName("nullable-message-{$suffix}")
+      ->withMessage(null)
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'per_page' => 100,
+    ]]);
+
+    $this->assertIsArray($data['data']);
+    $this->assertArrayHasKey('items', $data['data']);
+    $this->assertArrayHasKey('meta', $data['data']);
+    $this->assertArrayHasKey('filters', $data['data']);
+    $this->assertArrayHasKey('groups', $data['data']);
+    $this->assertSame([], $data['data']['filters']);
+    $this->assertSame([], $data['data']['groups']);
+    $this->assertSame(2, $data['data']['meta']['count']);
+    $this->assertSame(1, $data['data']['meta']['pages']);
+
+    $itemsById = [];
+    foreach ($data['data']['items'] as $item) {
+      $itemsById[(int)$item['id']] = $item;
+    }
+    $this->assertSame('', $itemsById[(int)$logWithNullName->getId()]['name']);
+    $this->assertSame("nullable-name-{$suffix}", $itemsById[(int)$logWithNullName->getId()]['message']);
+    $this->assertSame("nullable-message-{$suffix}", $itemsById[(int)$logWithNullMessage->getId()]['name']);
+    $this->assertSame('', $itemsById[(int)$logWithNullMessage->getId()]['message']);
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $itemsById[(int)$logWithNullName->getId()]['created_at']);
+  }
+
+  public function testGetSearchesNameAndMessageWithLiteralWildcards(): void {
+    $suffix = uniqid();
+    $percent = (new LogFactory())->withName("literal%{$suffix}")->withMessage('plain')->create();
+    $underscore = (new LogFactory())->withName('plain')->withMessage("literal_{$suffix}")->create();
+    $backslash = (new LogFactory())->withName("literal\\{$suffix}")->withMessage('plain')->create();
+    (new LogFactory())->withName("literalA{$suffix}")->withMessage("literalB{$suffix}")->create();
+
+    $percentIds = $this->getIdsForSearch("literal%{$suffix}");
+    $underscoreIds = $this->getIdsForSearch("literal_{$suffix}");
+    $backslashIds = $this->getIdsForSearch(wp_slash("literal\\{$suffix}"));
+
+    $this->assertSame([(int)$percent->getId()], $percentIds);
+    $this->assertSame([(int)$underscore->getId()], $underscoreIds);
+    $this->assertSame([(int)$backslash->getId()], $backslashIds);
+  }
+
+  public function testGetAppliesInclusiveDateFiltersAndNewestFirstOrdering(): void {
+    $suffix = uniqid();
+    $before = (new LogFactory())
+      ->withName("date-before-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-09 23:59:59'))
+      ->create();
+    $start = (new LogFactory())
+      ->withName("date-start-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-10 00:00:00'))
+      ->create();
+    $end = (new LogFactory())
+      ->withName("date-end-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-10 23:59:59'))
+      ->create();
+    $after = (new LogFactory())
+      ->withName("date-after-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-11 00:00:00'))
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'filter' => [
+        'from' => '2025-01-10',
+        'to' => '2025-01-10',
+      ],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    $this->assertSame([(int)$end->getId(), (int)$start->getId()], $ids);
+    $this->assertNotContains((int)$before->getId(), $ids);
+    $this->assertNotContains((int)$after->getId(), $ids);
+  }
+
+  public function testGetSupportsCanonicalAndLegacyPagination(): void {
+    $suffix = uniqid();
+    $oldest = (new LogFactory())->withName("pagination-oldest-{$suffix}")->withCreatedAt(new Carbon('2025-02-01 00:00:00'))->create();
+    $middle = (new LogFactory())->withName("pagination-middle-{$suffix}")->withCreatedAt(new Carbon('2025-02-02 00:00:00'))->create();
+    $newest = (new LogFactory())->withName("pagination-newest-{$suffix}")->withCreatedAt(new Carbon('2025-02-03 00:00:00'))->create();
+
+    $pageTwo = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'page' => 2,
+      'per_page' => 2,
+    ]]);
+
+    $this->assertSame(3, $pageTwo['data']['meta']['count']);
+    $this->assertSame(2, $pageTwo['data']['meta']['pages']);
+    $this->assertSame([(int)$oldest->getId()], array_map('intval', array_column($pageTwo['data']['items'], 'id')));
+
+    $legacy = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'offset' => 1,
+      'limit' => 1,
+    ]]);
+
+    $this->assertSame([(int)$middle->getId()], array_map('intval', array_column($legacy['data']['items'], 'id')));
+    $this->assertSame(3, $legacy['data']['meta']['count']);
+    $this->assertSame(3, $legacy['data']['meta']['pages']);
+    $this->assertNotSame((int)$newest->getId(), (int)$oldest->getId());
+  }
+
+  public function testGetRejectsInvalidListingParams(): void {
+    $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'name']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['sort_by' => 'name']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_order', $this->get(self::BASE_PATH, ['query' => ['order' => 'asc']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_order', $this->get(self::BASE_PATH, ['query' => ['sort_order' => 'asc']])['code']);
+    $this->assertSame('mailpoet_logs_invalid_page', $this->get(self::BASE_PATH, ['query' => ['page' => 0]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_per_page', $this->get(self::BASE_PATH, ['query' => ['per_page' => 101]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_limit', $this->get(self::BASE_PATH, ['query' => ['limit' => 0]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_offset', $this->get(self::BASE_PATH, ['query' => ['offset' => 100001]])['code']);
+  }
+
+  public function testGetRejectsInvalidDateFilters(): void {
+    $this->assertSame('mailpoet_logs_invalid_from', $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => '2025-02-30']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_to', $this->get(self::BASE_PATH, ['query' => ['filter' => ['to' => '2025-2-01']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_date_range', $this->get(self::BASE_PATH, ['query' => ['filter' => ['from' => '2025-02-02', 'to' => '2025-02-01']]])['code']);
+    $this->assertSame('mailpoet_logs_invalid_filter', $this->get(self::BASE_PATH, ['query' => ['filter' => ['level' => 'error']]])['code']);
+  }
+
+  public function testGetRejectsUsersWithoutPermission(): void {
+    wp_set_current_user($this->editorUserId);
+
+    $data = $this->get(self::BASE_PATH);
+    $this->assertSame('rest_forbidden', $data['code']);
+  }
+
+  /** @return int[] */
+  private function getIdsForSearch(string $search): array {
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $search,
+      'per_page' => 100,
+    ]]);
+
+    return array_map('intval', array_column($data['data']['items'], 'id'));
+  }
+}

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -179,6 +179,49 @@ class LogsEndpointsTest extends Test {
     $this->assertNotSame((int)$newest->getId(), (int)$oldest->getId());
   }
 
+  public function testGetDefaultsEmptySortOrderToNewestFirst(): void {
+    $suffix = uniqid();
+    $old = (new LogFactory())->withName("empty-order-old-{$suffix}")->withCreatedAt(new Carbon('2025-03-01 00:00:00'))->create();
+    $new = (new LogFactory())->withName("empty-order-new-{$suffix}")->withCreatedAt(new Carbon('2025-03-02 00:00:00'))->create();
+
+    $order = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'order' => '',
+      'per_page' => 100,
+    ]]);
+    $sortOrder = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'sort_order' => '',
+      'per_page' => 100,
+    ]]);
+
+    $expectedIds = [(int)$new->getId(), (int)$old->getId()];
+    $this->assertSame($expectedIds, array_map('intval', array_column($order['data']['items'], 'id')));
+    $this->assertSame($expectedIds, array_map('intval', array_column($sortOrder['data']['items'], 'id')));
+  }
+
+  public function testGetUsesStableOrderingForLogsWithSameTimestamp(): void {
+    $suffix = uniqid();
+    $createdAt = new Carbon('2025-03-03 00:00:00');
+    $first = (new LogFactory())->withName("same-time-first-{$suffix}")->withCreatedAt($createdAt)->create();
+    $second = (new LogFactory())->withName("same-time-second-{$suffix}")->withCreatedAt($createdAt)->create();
+    $third = (new LogFactory())->withName("same-time-third-{$suffix}")->withCreatedAt($createdAt)->create();
+
+    $pageOne = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'page' => 1,
+      'per_page' => 2,
+    ]]);
+    $pageTwo = $this->get(self::BASE_PATH, ['query' => [
+      'search' => $suffix,
+      'page' => 2,
+      'per_page' => 2,
+    ]]);
+
+    $this->assertSame([(int)$third->getId(), (int)$second->getId()], array_map('intval', array_column($pageOne['data']['items'], 'id')));
+    $this->assertSame([(int)$first->getId()], array_map('intval', array_column($pageTwo['data']['items'], 'id')));
+  }
+
   public function testGetRejectsInvalidListingParams(): void {
     $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['orderby' => 'name']])['code']);
     $this->assertSame('mailpoet_logs_invalid_orderby', $this->get(self::BASE_PATH, ['query' => ['sort_by' => 'name']])['code']);

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -93,6 +93,31 @@ class LogsEndpointsTest extends Test {
     $this->assertNotContains((int)$nonMatch->getId(), $ids);
   }
 
+  public function testGetIgnoresWhitespaceOnlySearch(): void {
+    $suffix = uniqid();
+    $old = (new LogFactory())
+      ->withName("whitespace-old-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-01 00:00:00'))
+      ->create();
+    $new = (new LogFactory())
+      ->withName("whitespace-new-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-02 00:00:00'))
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => '   ',
+      'filter' => [
+        'from' => '2025-01-01',
+        'to' => '2025-01-02',
+      ],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    $this->assertContains((int)$new->getId(), $ids);
+    $this->assertContains((int)$old->getId(), $ids);
+  }
+
   public function testGetAppliesInclusiveDateFiltersAndNewestFirstOrdering(): void {
     $suffix = uniqid();
     $before = (new LogFactory())

--- a/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
+++ b/mailpoet/tests/integration/REST/Logs/LogsEndpointsTest.php
@@ -93,6 +93,33 @@ class LogsEndpointsTest extends Test {
     $this->assertNotContains((int)$nonMatch->getId(), $ids);
   }
 
+  public function testGetAppliesDateFiltersToNameAndMessageSearchResults(): void {
+    $suffix = uniqid();
+    $matchingNameOutsideDate = (new LogFactory())
+      ->withName("grouped-search-{$suffix}")
+      ->withMessage('plain')
+      ->withCreatedAt(new Carbon('2025-01-09 23:59:59'))
+      ->create();
+    $matchingMessageInsideDate = (new LogFactory())
+      ->withName('plain')
+      ->withMessage("grouped-search-{$suffix}")
+      ->withCreatedAt(new Carbon('2025-01-10 12:00:00'))
+      ->create();
+
+    $data = $this->get(self::BASE_PATH, ['query' => [
+      'search' => "grouped-search-{$suffix}",
+      'filter' => [
+        'from' => '2025-01-10',
+        'to' => '2025-01-10',
+      ],
+      'per_page' => 100,
+    ]]);
+
+    $ids = array_map('intval', array_column($data['data']['items'], 'id'));
+    $this->assertSame([(int)$matchingMessageInsideDate->getId()], $ids);
+    $this->assertNotContains((int)$matchingNameOutsideDate->getId(), $ids);
+  }
+
   public function testGetIgnoresWhitespaceOnlySearch(): void {
     $suffix = uniqid();
     $old = (new LogFactory())

--- a/mailpoet/tests/javascript/logs/api.spec.ts
+++ b/mailpoet/tests/javascript/logs/api.spec.ts
@@ -1,0 +1,24 @@
+import { buildLogsRequestParams } from '../../../assets/js/src/logs/api';
+
+describe('logs API params', () => {
+  it('uses a one-shot legacy offset instead of page params', () => {
+    const params = buildLogsRequestParams(
+      {
+        page: 2,
+        per_page: 20,
+        orderby: 'created_at',
+        order: 'desc',
+        search: ' 0 ',
+      },
+      { from: '2026-05-11' },
+      35,
+    );
+
+    expect(params.page).to.equal(undefined);
+    expect(params.offset).to.equal(35);
+    expect(params.limit).to.equal(20);
+    expect(params.per_page).to.equal(20);
+    expect(params.search).to.equal('0');
+    expect(params.filter).to.deep.equal({ from: '2026-05-11' });
+  });
+});

--- a/mailpoet/tests/javascript/logs/api.spec.ts
+++ b/mailpoet/tests/javascript/logs/api.spec.ts
@@ -1,7 +1,7 @@
 import { buildLogsRequestParams } from '../../../assets/js/src/logs/api';
 
 describe('logs API params', () => {
-  it('uses a one-shot legacy offset instead of page params', () => {
+  it('builds DataViews request params with trimmed search and date filters', () => {
     const params = buildLogsRequestParams(
       {
         page: 2,
@@ -11,12 +11,9 @@ describe('logs API params', () => {
         search: ' 0 ',
       },
       { from: '2026-05-11' },
-      35,
     );
 
-    expect(params.page).to.equal(undefined);
-    expect(params.offset).to.equal(35);
-    expect(params.limit).to.equal(20);
+    expect(params.page).to.equal(2);
     expect(params.per_page).to.equal(20);
     expect(params.search).to.equal('0');
     expect(params.filter).to.deep.equal({ from: '2026-05-11' });

--- a/mailpoet/tests/javascript/logs/fields.spec.ts
+++ b/mailpoet/tests/javascript/logs/fields.spec.ts
@@ -1,0 +1,8 @@
+import { formatCreatedAt } from '../../../assets/js/src/logs/fields';
+
+describe('logs fields', () => {
+  it('does not render Invalid date for null created_at values', () => {
+    expect(formatCreatedAt(null)).to.equal('—');
+    expect(formatCreatedAt(null)).not.to.equal('Invalid date');
+  });
+});

--- a/mailpoet/tests/javascript/logs/fields.spec.ts
+++ b/mailpoet/tests/javascript/logs/fields.spec.ts
@@ -1,8 +1,22 @@
-import { formatCreatedAt } from '../../../assets/js/src/logs/fields';
+import {
+  formatCreatedAt,
+  getLogFields,
+} from '../../../assets/js/src/logs/fields';
 
 describe('logs fields', () => {
   it('does not render Invalid date for null created_at values', () => {
     expect(formatCreatedAt(null)).to.equal('—');
     expect(formatCreatedAt(null)).not.to.equal('Invalid date');
+  });
+
+  it('does not expose unsupported DataViews column filters', () => {
+    const fields = getLogFields(new Set(), () => {});
+
+    expect(fields.map((field) => field.filterBy)).to.deep.equal([
+      false,
+      false,
+      false,
+      false,
+    ]);
   });
 });

--- a/mailpoet/tests/javascript/logs/url-state.spec.ts
+++ b/mailpoet/tests/javascript/logs/url-state.spec.ts
@@ -1,0 +1,113 @@
+import {
+  buildLogsUrl,
+  dateFromString,
+  formatDateAsYmd,
+  getDateRangeError,
+  isStrictDateString,
+  parseLogsUrlState,
+} from '../../../assets/js/src/logs/url-state';
+
+describe('logs URL state', () => {
+  const defaultFrom = '2026-05-11';
+
+  it('uses the default date and default pagination', () => {
+    const state = parseLogsUrlState(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs',
+      defaultFrom,
+    );
+
+    expect(state).to.deep.equal({
+      page: 1,
+      perPage: 20,
+      search: undefined,
+      dateFilters: { from: defaultFrom },
+    });
+  });
+
+  it('maps legacy offset and limit to DataViews pagination', () => {
+    const state = parseLogsUrlState(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs&offset=35&limit=20',
+      defaultFrom,
+    );
+
+    expect(state.page).to.equal(2);
+    expect(state.perPage).to.equal(20);
+  });
+
+  it('prefers logs_page and per_page over legacy pagination', () => {
+    const state = parseLogsUrlState(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs&logs_page=4&per_page=50&offset=20&limit=10',
+      defaultFrom,
+    );
+
+    expect(state.page).to.equal(4);
+    expect(state.perPage).to.equal(50);
+  });
+
+  it('does not use the WordPress admin page parameter for listing pagination', () => {
+    const state = parseLogsUrlState(
+      'http://example.test/wp-admin/admin.php?page=8&per_page=30',
+      defaultFrom,
+    );
+
+    expect(state.page).to.equal(1);
+    expect(state.perPage).to.equal(30);
+  });
+
+  it('trims search and ignores invalid URL dates', () => {
+    const state = parseLogsUrlState(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs&search=%20error%20&from=2026-2-1&to=2026-05-18',
+      defaultFrom,
+    );
+
+    expect(state.search).to.equal('error');
+    expect(state.dateFilters).to.deep.equal({
+      from: defaultFrom,
+      to: '2026-05-18',
+    });
+  });
+
+  it('builds canonical listing URL params while preserving admin routing', () => {
+    const url = buildLogsUrl(
+      'http://example.test/wp-admin/admin.php?page=mailpoet-logs&offset=20&limit=10&foo=bar',
+      {
+        type: 'table',
+        page: 3,
+        perPage: 40,
+        search: ' warning ',
+      },
+      { from: '2026-05-01', to: '2026-05-18' },
+    );
+    const searchParams = new URL(url).searchParams;
+
+    expect(searchParams.get('page')).to.equal('mailpoet-logs');
+    expect(searchParams.get('foo')).to.equal('bar');
+    expect(searchParams.get('search')).to.equal('warning');
+    expect(searchParams.get('from')).to.equal('2026-05-01');
+    expect(searchParams.get('to')).to.equal('2026-05-18');
+    expect(searchParams.get('logs_page')).to.equal('3');
+    expect(searchParams.get('per_page')).to.equal('40');
+    expect(searchParams.has('offset')).to.equal(false);
+    expect(searchParams.has('limit')).to.equal(false);
+  });
+
+  it('validates strict dates and date ranges', () => {
+    expect(isStrictDateString('2026-05-18')).to.equal(true);
+    expect(isStrictDateString('2026-5-18')).to.equal(false);
+    expect(isStrictDateString('2026-02-30')).to.equal(false);
+    expect(getDateRangeError({ from: '2026-05-18', to: '2026-05-17' })).to.be.a(
+      'string',
+    );
+    expect(
+      getDateRangeError({ from: '2026-05-17', to: '2026-05-18' }),
+    ).to.equal(null);
+  });
+
+  it('converts strict date strings and Datepicker values without timezone drift', () => {
+    const date = dateFromString('2026-05-18');
+
+    expect(date).to.be.instanceOf(Date);
+    expect(formatDateAsYmd(date)).to.equal('2026-05-18');
+    expect(formatDateAsYmd(null)).to.equal(undefined);
+  });
+});

--- a/mailpoet/tests/javascript/logs/url-state.spec.ts
+++ b/mailpoet/tests/javascript/logs/url-state.spec.ts
@@ -32,6 +32,7 @@ describe('logs URL state', () => {
 
     expect(state.page).to.equal(2);
     expect(state.perPage).to.equal(20);
+    expect(state.legacyOffset).to.equal(35);
   });
 
   it('prefers logs_page and per_page over legacy pagination', () => {
@@ -42,6 +43,7 @@ describe('logs URL state', () => {
 
     expect(state.page).to.equal(4);
     expect(state.perPage).to.equal(50);
+    expect(state.legacyOffset).to.equal(undefined);
   });
 
   it('does not use the WordPress admin page parameter for listing pagination', () => {

--- a/mailpoet/tests/javascript/logs/url-state.spec.ts
+++ b/mailpoet/tests/javascript/logs/url-state.spec.ts
@@ -32,7 +32,6 @@ describe('logs URL state', () => {
 
     expect(state.page).to.equal(2);
     expect(state.perPage).to.equal(20);
-    expect(state.legacyOffset).to.equal(35);
   });
 
   it('prefers logs_page and per_page over legacy pagination', () => {
@@ -43,7 +42,6 @@ describe('logs URL state', () => {
 
     expect(state.page).to.equal(4);
     expect(state.perPage).to.equal(50);
-    expect(state.legacyOffset).to.equal(undefined);
   });
 
   it('does not use the WordPress admin page parameter for listing pagination', () => {

--- a/mailpoet/views/logs.html
+++ b/mailpoet/views/logs.html
@@ -9,8 +9,8 @@
 
   <script type="text/javascript">
     <% autoescape 'js' %>
-      var mailpoet_logs = <%= json_encode(logs) %>;
       var mailpoet_logs_default_from = '<%= logs_default_from %>';
+      var mailpoet_logs_api = <%= json_encode(api) %>;
     <% endautoescape %>
   </script>
 </div>


### PR DESCRIPTION
## Description

Migrate the Logs admin page to DataViews and add a REST listing endpoint to load, filter, and paginate logs.

## Code review notes

_N/A_

## QA notes

1. Open `MailPoet > Help > Logs`.
2. Confirm logs load in the DataViews table without a full page reload.
3. Search by log name or message and confirm results update.
4. Apply valid `From` and `To` dates and confirm the filter is inclusive for whole days.
5. Enter a date range where `From` is after `To` and confirm an inline validation error appears and no request is sent.
6. Use pagination controls and confirm the URL updates with `logs_page` and `per_page`.
7. Open a legacy URL with `search`, `from`, `to`, `offset`, or `limit` and confirm the listing loads with normalized DataViews URL state.
8. Expand and collapse a long log message with the Action column button.

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8098

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->


| Before                          | After                          |
| ------------------------------- | ------------------------------ |
|  <img width="1552" height="688" alt="Screenshot 2026-05-18 at 16 30 39" src="https://github.com/user-attachments/assets/0f6d2267-a7fb-4ad5-8f23-39dd53bed50e" />  |  <img width="1555" height="764" alt="logs-after" src="https://github.com/user-attachments/assets/59fc72c1-3448-4f22-9493-8aec1ffa5828" />  |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/STOMAIL-8098-migrate-logs-to-dataviews)

_The latest successful build from `update/STOMAIL-8098-migrate-logs-to-dataviews` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 1 issue found

### Bug: Timezone Handling Mismatch in Date Filters (High Severity)

**Location:** mailpoet/assets/js/src/logs/url-state.ts — dateFromString() and formatDateAsYmd()

**Issue:**
There is inconsistent timezone handling between date validation and date creation/formatting:

- isStrictDateString() validates using UTC (new Date(Date.UTC(...)) and getUTC* methods).
- dateFromString() constructs Date using local timezone (new Date(year, month - 1, day)).
- formatDateAsYmd() formats using local timezone methods (getFullYear(), getMonth(), getDate()).

**Impact:**
Users in non-UTC timezones can get off-by-one-day results when applying From/To filters: frontend date values created in local time may not match backend expectations (which treat YYYY-MM-DD as UTC-day boundaries), causing incorrect log filtering.

**Fix:**
Use UTC-consistent operations: construct dates with Date.UTC(...) (or new Date(Date.UTC(...))) in dateFromString(), and use getUTCFullYear(), getUTCMonth(), getUTCDate() in formatDateAsYmd() to match isStrictDateString() and backend semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->