### PR TITLE
Fix: show parent category name in ALC term selector (STOMAIL-7231)

### DIFF
--- a/mailpoet/changelog/2026-05-25-16-37-32-improved-distinguish-duplicate-subcategory-names-in-the-aut.md
+++ b/mailpoet/changelog/2026-05-25-16-37-32-improved-distinguish-duplicate-subcategory-names-in-the-aut.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Distinguish duplicate subcategory names in the Automatic Latest Content block by showing the parent category

--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -84,7 +84,7 @@ class AutomatedLatestContent extends APIEndpoint {
       ]);
       $parentMap = [];
       foreach ($parents as $parent) {
-        $parentMap[$parent->term_id] = $parent->name;
+        $parentMap[$parent->term_id] = $parent->name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       }
       foreach ($terms as $term) {
         if ($term->parent && isset($parentMap[$term->parent])) {

--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -74,6 +74,25 @@ class AutomatedLatestContent extends APIEndpoint {
     $args = (array)$this->wp->applyFilters('mailpoet_search_terms_args', $args);
     $terms = WPFunctions::get()->getTerms($args);
 
+    $parentIds = array_unique(array_filter(array_column((array)$terms, 'parent')));
+    if ($parentIds) {
+      $parents = WPFunctions::get()->getTerms([
+        'taxonomy' => $taxonomies,
+        'include' => $parentIds,
+        'hide_empty' => false,
+        'number' => 0,
+      ]);
+      $parentMap = [];
+      foreach ($parents as $parent) {
+        $parentMap[$parent->term_id] = $parent->name;
+      }
+      foreach ($terms as $term) {
+        if ($term->parent && isset($parentMap[$term->parent])) {
+          $term->name = $parentMap[$term->parent] . ' > ' . $term->name;
+        }
+      }
+    }
+
     return $this->successResponse(array_values($terms));
   }
 

--- a/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
+++ b/mailpoet/lib/API/JSON/v1/AutomatedLatestContent.php
@@ -76,19 +76,25 @@ class AutomatedLatestContent extends APIEndpoint {
 
     $parentIds = array_unique(array_filter(array_column((array)$terms, 'parent')));
     if ($parentIds) {
-      $parents = WPFunctions::get()->getTerms([
+      $parentArgs = (array)$this->wp->applyFilters('mailpoet_search_terms_args', [
         'taxonomy' => $taxonomies,
         'include' => $parentIds,
         'hide_empty' => false,
         'number' => 0,
       ]);
+      $parents = WPFunctions::get()->getTerms($parentArgs);
       $parentMap = [];
       foreach ($parents as $parent) {
         $parentMap[$parent->term_id] = $parent->name; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
       }
-      foreach ($terms as $term) {
+      foreach ($terms as $key => $term) {
+        if (!$term instanceof \WP_Term) {
+          continue;
+        }
         if ($term->parent && isset($parentMap[$term->parent])) {
-          $term->name = $parentMap[$term->parent] . ' > ' . $term->name;
+          $cloned = clone $term;
+          $cloned->name = $parentMap[$term->parent] . ' > ' . $term->name;
+          $terms[$key] = $cloned;
         }
       }
     }

--- a/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
+++ b/mailpoet/tests/integration/API/JSON/v1/AutomatedLatestContentTest.php
@@ -50,6 +50,78 @@ class AutomatedLatestContentTest extends \MailPoetTest {
     $this->assertSame('Uncategorized', $response->data['0']->name);
   }
 
+  public function testItPrependsParentNameToHierarchicalTerms() {
+    $parent = $this->createCategory('Music');
+    $child = $this->createCategory('Rock', (int)$parent['term_id']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    try {
+      $response = $this->endpoint->getTerms(['taxonomies' => ['category']]);
+      $names = array_column((array)$response->data, 'name');
+      $this->assertContains('Music', $names);
+      $this->assertContains('Music > Rock', $names);
+      $this->assertNotContains('Rock', $names);
+    } finally {
+      wp_delete_term((int)$child['term_id'], 'category'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      wp_delete_term((int)$parent['term_id'], 'category'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
+  }
+
+  public function testItAppliesSearchTermsArgsFilterToParentLookup() {
+    $parent = $this->createCategory('FilterMusic');
+    $child = $this->createCategory('FilterRock', (int)$parent['term_id']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $parentId = (int)$parent['term_id']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    $filter = function ($args) use ($parentId) {
+      // get_terms() ignores `exclude` when `include` is set, so suppress the
+      // parent lookup by replacing `include` with an ID that cannot exist.
+      if (!empty($args['include']) && in_array($parentId, (array)$args['include'], true)) {
+        $args['include'] = [PHP_INT_MAX];
+      }
+      return $args;
+    };
+
+    $this->wp->addFilter('mailpoet_search_terms_args', $filter);
+    try {
+      $response = $this->endpoint->getTerms(['taxonomies' => ['category']]);
+      $names = array_column((array)$response->data, 'name');
+      $this->assertContains('FilterRock', $names);
+      $this->assertNotContains('FilterMusic > FilterRock', $names);
+    } finally {
+      $this->wp->removeFilter('mailpoet_search_terms_args', $filter);
+      wp_delete_term((int)$child['term_id'], 'category'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+      wp_delete_term((int)$parent['term_id'], 'category'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
+  }
+
+  public function testItDoesNotMutateCachedTermObjects() {
+    $parent = $this->createCategory('CacheMusic');
+    $child = $this->createCategory('CacheRock', (int)$parent['term_id']); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    $childId = (int)$child['term_id']; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    try {
+      $this->endpoint->getTerms(['taxonomies' => ['category']]);
+
+      $cachedTerm = get_term($childId, 'category');
+      $this->assertInstanceOf(\WP_Term::class, $cachedTerm);
+      $this->assertSame('CacheRock', $cachedTerm->name);
+    } finally {
+      wp_delete_term($childId, 'category');
+      wp_delete_term((int)$parent['term_id'], 'category'); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+    }
+  }
+
+  private function createCategory(string $name, ?int $parentId = null): array {
+    $args = [];
+    if ($parentId) {
+      $args['parent'] = $parentId;
+    }
+    $term = wp_insert_term($name, 'category', $args);
+    if (is_wp_error($term)) {
+      $this->fail('Failed to create category "' . $name . '": ' . $term->get_error_message());
+    }
+    return $term;
+  }
+
   /**
    * @dataProvider dataForTestItGetsTransformedPostsWithDifferentStatus
    */


### PR DESCRIPTION
## Description

Subcategories with the same name (e.g. two "General" subcategories under "Music" and "Books") were indistinguishable in the Automatic Latest Content block's category/tag picker. Both appeared as "Category: General", making it impossible to tell them apart.

The fix enriches the `getTerms` API response by fetching the parent term names in a single batch query and prepending them to child term names, so they now display as "Music > General" and "Books > General".

## Code review notes

The fix is in `AutomatedLatestContent::getTerms()`. When any returned term has a non-zero `parent`, we collect all unique parent IDs, fetch them in one `getTerms` call, build a lookup map, then mutate `$term->name` for display. This avoids N+1 queries and doesn't touch the stored term ID (the selector saves `term_id`, not name).

`WPFunctions` has no `getTerm()` method (only `getTerms()`), so the batch approach is also the correct way to call WP functions through the wrapper.

## QA notes

1. Create two subcategories both named "General" — one under "Music", one under "Books"
2. Open a newsletter → add an Automatic Latest Content block → open its settings
3. Search for "general" in the category picker
4. **Before:** two identical "Category: General" entries
5. **After:** "Category: Music > General" and "Category: Books > General"

## Linked tickets

STOMAIL-7231

## Tasks

- [ ] I have added a changelog entry (`./do changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 3

### Bug (1)
- **No WP_Error handling in AutomatedLatestContent::getTerms()**: Both `WPFunctions::get()->getTerms()` calls (lines for fetching initial terms and parent terms) can return WordPress WP_Error objects, but the code doesn't validate the response before processing. The subsequent `array_column((array)$terms, 'parent')` call will fail silently or cause issues if `$terms` is a WP_Error object.

### Suggestions (2)
- **Incomplete refactoring in NewslettersRepository**: The new `getStandardAndAutomationNewsletterList()` method was added to support the "Subscriber Clicks a Link in Email" automation trigger (STOMAIL-7626), but no caller of this new method is visible in the codebase. Meanwhile, `getStandardNewsletterList()` is still being used in `DynamicSegments.php` and other locations. The refactoring appears incomplete.

- **Missing test coverage for parent term display**: The existing test `testItGetTerms()` in `AutomatedLatestContentTest.php` only validates basic term retrieval and doesn't test the new parent term name prefixing logic (e.g., "Category: Music > General"). The feature lacks test coverage for the hierarchical display functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/stomail-7626-automation-email-link-trigger)

_The latest successful build from `fix/stomail-7626-automation-email-link-trigger` will be used. If none is available, the link won't work._