### PR TITLE
Add automation email support to opens, clicks, and sent segment conditions

### DIFF
--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-clicks.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-clicks.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { __ } from '@wordpress/i18n';
 import { MailPoet } from 'mailpoet';
-import { find, filter } from 'lodash/fp';
+import { filter } from 'lodash/fp';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 import { APIErrorsNotice } from 'notices/api-errors-notice';
@@ -15,9 +14,15 @@ import {
   WindowNewslettersList,
 } from '../../../types';
 import { storeName } from '../../../store';
+import {
+  getGroupedNewsletterOptions,
+  NewsletterOption,
+} from './newsletter-options';
 
-const shouldDisplayLinks = (itemNewsletterId?: string): boolean =>
+const shouldDisplayLinks = (itemNewsletterId?: string | number): boolean =>
   !!itemNewsletterId;
+
+type EmailLinkOption = SelectOption<string | number>;
 
 export function EmailClickStatisticsFields({
   filterIndex,
@@ -36,21 +41,17 @@ export function EmailClickStatisticsFields({
   );
 
   const [errors, setErrors] = useState([]);
-  const [links, setLinks] = useState<SelectOption[]>([]);
+  // Standard newsletters return numeric link ids; the newsletter_links endpoint
+  // collapses automation link rows down to one row per URL and returns the URL
+  // as the id, so link_ids in this filter is a mixed-type list (see
+  // EmailFormItem.link_ids and the API in NewsletterLinks::getAutomationLinks).
+  const [links, setLinks] = useState<EmailLinkOption[]>([]);
   const [loadingLinks, setLoadingLinks] = useState<boolean>(false);
 
-  const newsletterOptions = newslettersList?.map((newsletter) => {
-    const sentAt = newsletter.sent_at
-      ? MailPoet.Date.format(newsletter.sent_at)
-      : __('Not sent yet', 'mailpoet');
-    return {
-      label: newsletter.name,
-      tag: sentAt,
-      value: Number(newsletter.id),
-    };
-  });
+  const { flatOptions, groupedOptions } =
+    getGroupedNewsletterOptions(newslettersList);
 
-  function loadLinks(newsletterId: string): void {
+  function loadLinks(newsletterId: string | number): void {
     setErrors([]);
     setLoadingLinks(true);
     void MailPoet.Ajax.post({
@@ -66,7 +67,7 @@ export function EmailClickStatisticsFields({
           label: link.url,
         }));
         setLoadingLinks(false);
-        setLinks(loadedLinks as SelectOption[]);
+        setLinks(loadedLinks as EmailLinkOption[]);
       })
       .fail((response: ErrorResponse) => {
         setErrors(response.errors as { message: string }[]);
@@ -98,9 +99,11 @@ export function EmailClickStatisticsFields({
       {errors.length > 0 && <APIErrorsNotice errors={errors} />}
       <ReactSelect
         placeholder={MailPoet.I18n.t('selectNewsletterPlaceholder')}
-        options={newsletterOptions}
-        value={find(['value', segment.newsletter_id], newsletterOptions)}
-        onChange={(option: SelectOption): void => {
+        options={groupedOptions}
+        value={flatOptions.find(
+          ({ value }) => value === Number(segment.newsletter_id),
+        )}
+        onChange={(option: NewsletterOption): void => {
           void updateSegmentFilter(
             { newsletter_id: option.value, link_ids: [] },
             filterIndex,
@@ -144,7 +147,7 @@ export function EmailClickStatisticsFields({
             if (!segment.link_ids) return false;
             return segment.link_ids.indexOf(option.value) !== -1;
           }, links)}
-          onChange={(options: SelectOption[]): void => {
+          onChange={(options: EmailLinkOption[]): void => {
             void updateSegmentFilter(
               { link_ids: (options || []).map((x) => x.value) },
               filterIndex,

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-opens.tsx
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/email-statistics-opens.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { MailPoet } from 'mailpoet';
-import { filter, map, parseInt } from 'lodash/fp';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 import { ReactSelect } from 'common/form/react-select/react-select';
@@ -10,10 +9,13 @@ import {
   EmailActionTypes,
   EmailFormItem,
   FilterProps,
-  SelectOption,
   WindowNewslettersList,
 } from '../../../types';
 import { storeName } from '../../../store';
+import {
+  getGroupedNewsletterOptions,
+  NewsletterOption,
+} from './newsletter-options';
 
 export function EmailOpenStatisticsFields({
   filterIndex,
@@ -31,16 +33,8 @@ export function EmailOpenStatisticsFields({
     [],
   );
 
-  const newsletterOptions = newslettersList?.map((newsletter) => {
-    const sentAt = newsletter.sent_at
-      ? MailPoet.Date.format(newsletter.sent_at)
-      : MailPoet.I18n.t('notSentYet');
-    return {
-      label: newsletter.name,
-      tag: sentAt,
-      value: Number(newsletter.id),
-    };
-  });
+  const { flatOptions, groupedOptions } =
+    getGroupedNewsletterOptions(newslettersList);
 
   useEffect(() => {
     if (
@@ -82,16 +76,14 @@ export function EmailOpenStatisticsFields({
         dimension="small"
         isMulti
         placeholder={MailPoet.I18n.t('selectNewsletterPlaceholder')}
-        options={newsletterOptions}
+        options={groupedOptions}
         automationId="segment-email"
-        value={filter((option) => {
-          if (!segment.newsletters) return undefined;
-          const newsletterId = option.value;
-          return segment.newsletters.indexOf(newsletterId) !== -1;
-        }, newsletterOptions)}
-        onChange={(options: SelectOption[]): void => {
+        value={flatOptions.filter(({ value }) =>
+          segment.newsletters?.includes(value),
+        )}
+        onChange={(options: NewsletterOption[]): void => {
           void updateSegmentFilter(
-            { newsletters: map(parseInt(10), map('value', options)) },
+            { newsletters: (options || []).map(({ value }) => value) },
             filterIndex,
           );
         }}

--- a/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/newsletter-options.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/newsletter-options.ts
@@ -1,0 +1,88 @@
+import { __ } from '@wordpress/i18n';
+import { MailPoetDate } from '../../../../../date';
+
+import { SelectOption, WindowNewslettersList } from '../../../types';
+
+export type NewsletterOption = SelectOption<number> & {
+  tag?: string;
+};
+
+type NewsletterOptionGroup = {
+  label: string;
+  options: NewsletterOption[];
+};
+
+type FormatDate = (date: string) => string;
+
+const automationEmailTypes = ['automation', 'automation_transactional'];
+
+const defaultFormatDate: FormatDate = (date) => MailPoetDate.format(date);
+
+function isAutomationEmailType(
+  type: WindowNewslettersList[number]['type'],
+): boolean {
+  return automationEmailTypes.includes(type);
+}
+
+function createStandardNewsletterOption(
+  newsletter: WindowNewslettersList[number],
+  formatDate: FormatDate,
+): NewsletterOption {
+  return {
+    label: newsletter.name,
+    tag: newsletter.sent_at
+      ? formatDate(newsletter.sent_at)
+      : __('Not sent yet', 'mailpoet'),
+    value: Number(newsletter.id),
+  };
+}
+
+// Automation emails track sentAt per send on the queue, not on the newsletter
+// entity, so a sent_at-derived tag would always read "Not sent yet" — omit it.
+function createAutomationNewsletterOption(
+  newsletter: WindowNewslettersList[number],
+): NewsletterOption {
+  return {
+    label: newsletter.name,
+    value: Number(newsletter.id),
+  };
+}
+
+export function getGroupedNewsletterOptions(
+  // Typed optional because window.mailpoet_newsletters_list may be missing if
+  // the dynamic-segments page hasn't bootstrapped the global yet.
+  newslettersList: WindowNewslettersList | undefined,
+  formatDate: FormatDate = defaultFormatDate,
+): {
+  flatOptions: NewsletterOption[];
+  groupedOptions: NewsletterOptionGroup[];
+} {
+  const newsletters = newslettersList ?? [];
+  const standardOptions = newsletters
+    .filter(({ type }) => type === 'standard')
+    .map((newsletter) =>
+      createStandardNewsletterOption(newsletter, formatDate),
+    );
+  const automationOptions = newsletters
+    .filter(({ type }) => isAutomationEmailType(type))
+    .map((newsletter) => createAutomationNewsletterOption(newsletter));
+  const groupedOptions: NewsletterOptionGroup[] = [];
+
+  if (standardOptions.length > 0) {
+    groupedOptions.push({
+      label: __('Standard emails', 'mailpoet'),
+      options: standardOptions,
+    });
+  }
+  if (automationOptions.length > 0) {
+    groupedOptions.push({
+      label: __('Automation emails', 'mailpoet'),
+      options: automationOptions,
+    });
+  }
+
+  return {
+    flatOptions: [...standardOptions, ...automationOptions],
+    groupedOptions,
+  };
+}

--- a/mailpoet/assets/js/src/segments/dynamic/types.ts
+++ b/mailpoet/assets/js/src/segments/dynamic/types.ts
@@ -65,8 +65,8 @@ export type GroupFilterValue = {
   options: FilterValue[];
 };
 
-export interface SelectOption {
-  value: string;
+export interface SelectOption<TValue = string> {
+  value: TValue;
   label: string;
 }
 
@@ -190,9 +190,9 @@ export interface WooCommerceSubscriptionFormItem extends FormItem {
 }
 
 export interface EmailFormItem extends FormItem {
-  newsletter_id?: string;
+  newsletter_id?: string | number;
   newsletters?: number[];
-  link_ids?: string[];
+  link_ids?: Array<string | number>;
   operator?: string;
   opens?: string;
   emails?: string;
@@ -303,6 +303,7 @@ export type WindowNewslettersList = {
   subject: string;
   name: string;
   id: string;
+  type: 'standard' | 'automation' | 'automation_transactional';
 }[];
 
 export type WindowWooCommerceCountries = {

--- a/mailpoet/changelog/2026-05-17-22-11-29-added-automation-email-support-for-opened-clicked-and-se.md
+++ b/mailpoet/changelog/2026-05-17-22-11-29-added-automation-email-support-for-opened-clicked-and-se.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Automation email support for opened, clicked, and sent email segment conditions

--- a/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
+++ b/mailpoet/lib/AdminPages/Pages/DynamicSegments.php
@@ -257,11 +257,12 @@ class DynamicSegments {
 
   private function getNewslettersList(): array {
     $result = [];
-    foreach ($this->newslettersRepository->getStandardNewsletterList() as $newsletter) {
+    foreach ($this->newslettersRepository->getStandardAndAutomationNewsletterList() as $newsletter) {
       $result[] = [
         'id' => (string)$newsletter->getId(),
         'subject' => $newsletter->getSubject(),
         'name' => $newsletter->getCampaignNameOrSubject(),
+        'type' => $newsletter->getType(),
         'sent_at' => ($sentAt = $newsletter->getSentAt()) ? $sentAt->format('Y-m-d H:i:s') : null,
       ];
     }

--- a/mailpoet/lib/Newsletter/NewslettersRepository.php
+++ b/mailpoet/lib/Newsletter/NewslettersRepository.php
@@ -584,7 +584,10 @@ class NewslettersRepository extends Repository {
   }
 
   /**
-   * Returns standard newsletters and active automation emails ordered by sentAt
+   * Returns standard newsletters and active automation emails ordered by sentAt.
+   * Drafts (which includes deactivated automations) are excluded to keep the
+   * dropdown focused on automations the user is currently running.
+   *
    * @return NewsletterEntity[]
    */
   public function getStandardAndAutomationNewsletterList(): array {

--- a/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
+++ b/mailpoet/lib/Segments/DynamicSegments/FilterDataMapper.php
@@ -439,15 +439,36 @@ class FilterDataMapper {
     $filterType = DynamicSegmentFilterData::TYPE_EMAIL;
     $action = $data['action'];
     if (isset($data['link_ids']) && is_array($data['link_ids'])) {
-      $filterData['link_ids'] = array_values(
-        array_map('intval', array_filter($data['link_ids'], 'is_scalar'))
-      );
+      $filterData['link_ids'] = $this->normalizeEmailLinkIds($data['link_ids']);
       if (!isset($data['operator'])) {
         throw new InvalidFilterException('Missing operator', InvalidFilterException::MISSING_OPERATOR);
       }
       $filterData['operator'] = $data['operator'];
     }
     return new DynamicSegmentFilterData($filterType, $action, $filterData);
+  }
+
+  private function normalizeEmailLinkIds(array $linkIds): array {
+    $normalizedLinkIds = [];
+    foreach ($linkIds as $linkId) {
+      if (is_int($linkId)) {
+        $normalizedLinkIds[] = $linkId;
+        continue;
+      }
+      if (is_float($linkId) && floor($linkId) === $linkId) {
+        $normalizedLinkIds[] = (int)$linkId;
+        continue;
+      }
+      if (!is_string($linkId)) {
+        continue;
+      }
+      $linkId = trim($linkId);
+      if ($linkId === '') {
+        continue;
+      }
+      $normalizedLinkIds[] = ctype_digit($linkId) ? (int)$linkId : $linkId;
+    }
+    return $normalizedLinkIds;
   }
 
   /**

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailAction.php
@@ -40,6 +40,11 @@ class EmailAction implements Filter {
     NumberOfClicks::ACTION,
   ];
 
+  const AUTOMATION_EMAIL_TYPES = [
+    NewsletterEntity::TYPE_AUTOMATION,
+    NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL,
+  ];
+
   /** @var EntityManager */
   private $entityManager;
   /** @var FilterHelper */
@@ -80,66 +85,122 @@ class EmailAction implements Filter {
   private function applyForClickedActions(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData, string $parameterSuffix): QueryBuilder {
     $operator = $filterData->getParam('operator') ?? DynamicSegmentFilterData::OPERATOR_ANY;
     $action = $filterData->getAction();
-    $newsletterId = $filterData->getParam('newsletter_id');
-    $linkIds = $filterData->getParam('link_ids');
-    if (!is_array($linkIds)) {
-      $linkIds = [];
+    $newsletterId = $this->normalizeNewsletterId($filterData->getParam('newsletter_id'));
+    $rawLinkIds = $filterData->getParam('link_ids');
+    if (!is_array($rawLinkIds)) {
+      $rawLinkIds = [];
+    }
+    $linkFilter = $this->buildEmailLinkFilter($newsletterId, $rawLinkIds, $parameterSuffix);
+    $isAllOperator = $operator === DynamicSegmentFilterData::OPERATOR_ALL;
+
+    $linksTable = $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName();
+    $where = '1';
+
+    $isNoneOperator = ($action === self::ACTION_NOT_CLICKED) || ($operator === DynamicSegmentFilterData::OPERATOR_NONE);
+    if ($isNoneOperator) {
+      $queryBuilder = $this->joinStatsForNoneOperator($queryBuilder, $linkFilter, $newsletterId, $parameterSuffix);
+      $where .= ' AND stats.id IS NULL';
+    } else {
+      $queryBuilder = $this->joinStatsForAnyOrAllOperator($queryBuilder, $linkFilter, $newsletterId, $linksTable, $parameterSuffix, $isAllOperator);
     }
 
+    if (!$isNoneOperator && $linkFilter->hasSpecificLinks()) {
+      $where .= ' AND ' . $this->buildSelectedLinkWhere($linkFilter, $parameterSuffix);
+    }
+    if ($isAllOperator) {
+      $queryBuilder->groupBy('subscriber_id');
+      $queryBuilder->having($this->buildClickedAllHavingClause($linkFilter, $newsletterId, $linksTable));
+    }
+    $queryBuilder = $queryBuilder->andWhere($where);
+    $this->bindLinkFilterParameters($queryBuilder, $linkFilter, $parameterSuffix);
+    return $queryBuilder;
+  }
+
+  private function joinStatsForNoneOperator(QueryBuilder $queryBuilder, EmailLinkFilter $linkFilter, int $newsletterId, string $parameterSuffix): QueryBuilder {
     $statsSentTable = $this->entityManager->getClassMetadata(StatisticsNewsletterEntity::class)->getTableName();
     $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
     $statsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
 
-    $where = '1';
+    return $queryBuilder->innerJoin(
+      $subscribersTable,
+      $statsSentTable,
+      'statssent',
+      "$subscribersTable.id = statssent.subscriber_id AND statssent.newsletter_id = :newsletter" . $parameterSuffix
+    )->leftJoin(
+      'statssent',
+      $statsTable,
+      'stats',
+      $this->createNotStatsJoinCondition($parameterSuffix, $linkFilter->getLinkIds(), $linkFilter->getLinkUrls())
+    )->setParameter('newsletter' . $parameterSuffix, $newsletterId);
+  }
 
-    if (($action === self::ACTION_NOT_CLICKED) || ($operator === DynamicSegmentFilterData::OPERATOR_NONE)) {
-      $queryBuilder = $queryBuilder->innerJoin(
-        $subscribersTable,
-        $statsSentTable,
-        'statssent',
-        "$subscribersTable.id = statssent.subscriber_id AND statssent.newsletter_id = :newsletter" . $parameterSuffix
-      )->leftJoin(
-        'statssent',
-        $statsTable,
-        'stats',
-        $this->createNotStatsJoinCondition($parameterSuffix, $linkIds)
-      )->setParameter('newsletter' . $parameterSuffix, $newsletterId);
-      $where .= ' AND stats.id IS NULL';
-    } else {
-      $queryBuilder = $queryBuilder->innerJoin(
-        $subscribersTable,
-        $statsTable,
-        'stats',
-        "stats.subscriber_id = $subscribersTable.id AND stats.newsletter_id = :newsletter" . $parameterSuffix
-      )->setParameter('newsletter' . $parameterSuffix, $newsletterId);
-    }
+  private function joinStatsForAnyOrAllOperator(
+    QueryBuilder $queryBuilder,
+    EmailLinkFilter $linkFilter,
+    int $newsletterId,
+    string $linksTable,
+    string $parameterSuffix,
+    bool $isAllOperator
+  ): QueryBuilder {
+    $subscribersTable = $this->entityManager->getClassMetadata(SubscriberEntity::class)->getTableName();
+    $statsTable = $this->entityManager->getClassMetadata(StatisticsClickEntity::class)->getTableName();
 
-    if ($action === EmailAction::ACTION_CLICKED && $operator !== DynamicSegmentFilterData::OPERATOR_NONE && $linkIds) {
-      $where .= ' AND stats.link_id IN (:links' . $parameterSuffix . ')';
-    }
-    if ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
-      $queryBuilder->groupBy('subscriber_id');
-      if ($linkIds) {
-        $queryBuilder->having('COUNT(1) = ' . count($linkIds));
-      } else {
-        // Case when a user selects all of, but doesn't specify links == all of all links.
-        $linksTable = $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName();
-        $linksQueryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
-        $linkCount = $linksQueryBuilder->select('count(id)')
-          ->from($linksTable)
-          ->where('newsletter_id = :newsletter_id')
-          ->setParameter('newsletter_id', $newsletterId)
-          ->execute()
-          ->fetchOne();
-        $queryBuilder->having('COUNT(1) = ' . (is_scalar($linkCount) ? (int)$linkCount : 0));
-      }
-    }
-    $queryBuilder = $queryBuilder->andWhere($where);
-    if ($linkIds) {
-      $queryBuilder = $queryBuilder
-        ->setParameter('links' . $parameterSuffix, $linkIds, ArrayParameterType::STRING);
+    $queryBuilder->innerJoin(
+      $subscribersTable,
+      $statsTable,
+      'stats',
+      "stats.subscriber_id = $subscribersTable.id AND stats.newsletter_id = :newsletter" . $parameterSuffix
+    )->setParameter('newsletter' . $parameterSuffix, $newsletterId);
+
+    if ($linkFilter->needsLinkJoin($isAllOperator)) {
+      $alias = $linkFilter->getStatsLinkAlias();
+      $queryBuilder->innerJoin('stats', $linksTable, $alias, "stats.link_id = $alias.id");
     }
     return $queryBuilder;
+  }
+
+  private function buildSelectedLinkWhere(EmailLinkFilter $linkFilter, string $parameterSuffix): string {
+    if ($linkFilter->matchesByUrl()) {
+      $alias = $linkFilter->getStatsLinkAlias();
+      return "LOWER($alias.url) IN (:linkUrls$parameterSuffix)";
+    }
+    return 'stats.link_id IN (:links' . $parameterSuffix . ')';
+  }
+
+  private function buildClickedAllHavingClause(EmailLinkFilter $linkFilter, int $newsletterId, string $linksTable): string {
+    if ($linkFilter->matchesByUrl()) {
+      $alias = $linkFilter->getStatsLinkAlias();
+      return "COUNT(DISTINCT LOWER($alias.url)) = " . count($linkFilter->getLinkUrls());
+    }
+    if ($linkFilter->getLinkIds()) {
+      return 'COUNT(DISTINCT stats.link_id) = ' . count($linkFilter->getLinkIds());
+    }
+    // User selected "all of" but no specific links — they need to have clicked every link of the newsletter.
+    $alias = $linkFilter->getStatsLinkAlias();
+    $totalLinkCount = $this->countNewsletterLinks($linksTable, $newsletterId, $linkFilter->isAutomationNewsletter());
+    $clickCountSelect = $linkFilter->aggregatesAllLinksByUrl() ? "COUNT(DISTINCT LOWER($alias.url))" : 'COUNT(1)';
+    return $clickCountSelect . ' = ' . $totalLinkCount;
+  }
+
+  private function countNewsletterLinks(string $linksTable, int $newsletterId, bool $isAutomationNewsletter): int {
+    $linksQueryBuilder = $this->entityManager->getConnection()->createQueryBuilder();
+    $linkCountSelect = $isAutomationNewsletter ? 'COUNT(DISTINCT LOWER(url))' : 'COUNT(id)';
+    $linkCount = $linksQueryBuilder->select($linkCountSelect)
+      ->from($linksTable)
+      ->where('newsletter_id = :newsletter_id')
+      ->setParameter('newsletter_id', $newsletterId)
+      ->execute()
+      ->fetchOne();
+    return is_scalar($linkCount) ? (int)$linkCount : 0;
+  }
+
+  private function bindLinkFilterParameters(QueryBuilder $queryBuilder, EmailLinkFilter $linkFilter, string $parameterSuffix): void {
+    if ($linkFilter->getLinkIds()) {
+      $queryBuilder->setParameter('links' . $parameterSuffix, $linkFilter->getLinkIds(), ArrayParameterType::INTEGER);
+    }
+    if ($linkFilter->getLinkUrls()) {
+      $queryBuilder->setParameter('linkUrls' . $parameterSuffix, $linkFilter->getLinkUrls(), ArrayParameterType::STRING);
+    }
   }
 
   private function applyForOpenedActions(QueryBuilder $queryBuilder, DynamicSegmentFilterData $filterData, string $parameterSuffix): QueryBuilder {
@@ -177,7 +238,7 @@ class EmailAction implements Filter {
 
       if ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
         $queryBuilder->groupBy('subscriber_id');
-        $queryBuilder->having('COUNT(1) = ' . count($newsletters));
+        $queryBuilder->having('COUNT(DISTINCT stats.newsletter_id) = ' . count($newsletters));
       }
     }
     if (($action === EmailAction::ACTION_OPENED) && ($operator !== DynamicSegmentFilterData::OPERATOR_NONE)) {
@@ -192,9 +253,15 @@ class EmailAction implements Filter {
     return $queryBuilder;
   }
 
-  private function createNotStatsJoinCondition(string $parameterSuffix, ?array $linkIds = null): string {
+  private function createNotStatsJoinCondition(string $parameterSuffix, array $linkIds = [], array $linkUrls = []): string {
     $clause = "statssent.subscriber_id = stats.subscriber_id AND stats.newsletter_id = :newsletter" . $parameterSuffix;
-    if ($linkIds) {
+    if ($linkUrls) {
+      $linksTable = $this->entityManager->getClassMetadata(NewsletterLinkEntity::class)->getTableName();
+      $statsLinkAlias = 'notstatslinks' . $parameterSuffix;
+      $clause .= " AND stats.link_id IN (SELECT $statsLinkAlias.id FROM $linksTable $statsLinkAlias";
+      $clause .= " WHERE $statsLinkAlias.newsletter_id = :newsletter" . $parameterSuffix;
+      $clause .= ' AND LOWER(' . $statsLinkAlias . '.url) IN (:linkUrls' . $parameterSuffix . '))';
+    } elseif ($linkIds) {
       $clause .= ' AND stats.link_id IN (:links' . $parameterSuffix . ')';
     }
     return $clause;
@@ -225,7 +292,7 @@ class EmailAction implements Filter {
 
       if ($operator === DynamicSegmentFilterData::OPERATOR_ALL) {
         $queryBuilder->groupBy('subscriber_id');
-        $queryBuilder->having('COUNT(1) = ' . count($newsletters));
+        $queryBuilder->having('COUNT(DISTINCT statisticsNewsletter.newsletter_id) = ' . count($newsletters));
       }
     }
 
@@ -266,6 +333,10 @@ class EmailAction implements Filter {
 
     foreach ($linkIds as $linkId) {
       if (!is_numeric($linkId)) {
+        if (is_string($linkId) && trim($linkId) !== '') {
+          $linkUrl = trim($linkId);
+          $lookupData['links'][$linkUrl] = $linkUrl;
+        }
         continue;
       }
       $linkIdInt = (int)$linkId;
@@ -276,5 +347,82 @@ class EmailAction implements Filter {
     }
 
     return $lookupData;
+  }
+
+  /** @param mixed $newsletterId */
+  private function normalizeNewsletterId($newsletterId): int {
+    if (is_int($newsletterId)) {
+      return $newsletterId;
+    }
+    if (is_float($newsletterId) && floor($newsletterId) === $newsletterId) {
+      return (int)$newsletterId;
+    }
+    if (is_string($newsletterId)) {
+      $newsletterId = trim($newsletterId);
+      if (ctype_digit($newsletterId)) {
+        return (int)$newsletterId;
+      }
+    }
+    return 0;
+  }
+
+  /** @param mixed[] $rawLinkIds */
+  private function buildEmailLinkFilter(int $newsletterId, array $rawLinkIds, string $parameterSuffix): EmailLinkFilter {
+    $isAutomationNewsletter = $this->isAutomationNewsletter($newsletterId);
+    $matchByUrl = $isAutomationNewsletter || $this->hasUrlLinkIds($rawLinkIds);
+    $selectedLinkIds = [];
+    $selectedLinkUrls = [];
+    foreach ($rawLinkIds as $linkId) {
+      if ($this->isNumericLinkId($linkId)) {
+        if ($matchByUrl) {
+          $link = $this->newsletterLinkRepository->findOneById((int)$linkId);
+          if ($link instanceof NewsletterLinkEntity) {
+            $selectedLinkUrls[] = $this->normalizeUrlForMatching($link->getUrl());
+          }
+        } else {
+          $selectedLinkIds[] = (int)$linkId;
+        }
+        continue;
+      }
+      if (is_string($linkId) && trim($linkId) !== '') {
+        $selectedLinkUrls[] = $this->normalizeUrlForMatching($linkId);
+      }
+    }
+    return new EmailLinkFilter(
+      $isAutomationNewsletter,
+      array_values(array_unique($selectedLinkIds)),
+      array_values(array_unique($selectedLinkUrls)),
+      'statslinks' . $parameterSuffix
+    );
+  }
+
+  private function normalizeUrlForMatching(string $url): string {
+    return strtolower(trim($url));
+  }
+
+  /**
+   * @param mixed $linkId
+   * @phpstan-assert-if-true int|float|numeric-string $linkId
+   */
+  private function isNumericLinkId($linkId): bool {
+    return is_int($linkId)
+      || (is_float($linkId) && floor($linkId) === $linkId)
+      || (is_string($linkId) && ctype_digit($linkId));
+  }
+
+  private function isAutomationNewsletter(int $newsletterId): bool {
+    $newsletter = $this->newslettersRepository->findOneById($newsletterId);
+    return $newsletter instanceof NewsletterEntity
+      && in_array($newsletter->getType(), self::AUTOMATION_EMAIL_TYPES, true);
+  }
+
+  /** @param mixed[] $linkIds */
+  private function hasUrlLinkIds(array $linkIds): bool {
+    foreach ($linkIds as $linkId) {
+      if (is_string($linkId) && !$this->isNumericLinkId($linkId) && trim($linkId) !== '') {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/mailpoet/lib/Segments/DynamicSegments/Filters/EmailLinkFilter.php
+++ b/mailpoet/lib/Segments/DynamicSegments/Filters/EmailLinkFilter.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Segments\DynamicSegments\Filters;
+
+/**
+ * Captures the link-matching strategy for the email click segment filter.
+ *
+ * Standard newsletters match by `statistics_clicks.link_id`. Automation
+ * newsletters match by `LOWER(newsletter_links.url)` because each send
+ * inserts a new link row with a fresh hash for the same URL, so the
+ * stored link_id alone can't capture "clicked the URL the user picked
+ * in the UI" across sends.
+ */
+final class EmailLinkFilter {
+  /** @var bool */
+  private $isAutomationNewsletter;
+
+  /** @var int[] */
+  private $linkIds;
+
+  /** @var string[] */
+  private $linkUrls;
+
+  /** @var string */
+  private $statsLinkAlias;
+
+  /**
+   * @param int[] $linkIds
+   * @param string[] $linkUrls
+   */
+  public function __construct(
+    bool $isAutomationNewsletter,
+    array $linkIds,
+    array $linkUrls,
+    string $statsLinkAlias
+  ) {
+    $this->isAutomationNewsletter = $isAutomationNewsletter;
+    $this->linkIds = $linkIds;
+    $this->linkUrls = $linkUrls;
+    $this->statsLinkAlias = $statsLinkAlias;
+  }
+
+  public function isAutomationNewsletter(): bool {
+    return $this->isAutomationNewsletter;
+  }
+
+  public function hasSpecificLinks(): bool {
+    return (bool)$this->linkIds || (bool)$this->linkUrls;
+  }
+
+  public function matchesByUrl(): bool {
+    return (bool)$this->linkUrls;
+  }
+
+  /**
+   * "All of" with no specific picks on an automation: count by distinct URL
+   * because each send duplicates the URL across fresh link rows. Caller is
+   * expected to use this in an "all of" context.
+   */
+  public function aggregatesAllLinksByUrl(): bool {
+    return $this->isAutomationNewsletter && !$this->hasSpecificLinks();
+  }
+
+  /**
+   * Whether the stats query needs to join `newsletter_links`. Either because
+   * we match by URL (and need the URL column), or because the "all of" count
+   * needs to deduplicate URLs across multiple automation sends.
+   */
+  public function needsLinkJoin(bool $isAllOperator): bool {
+    return $this->matchesByUrl() || ($isAllOperator && $this->aggregatesAllLinksByUrl());
+  }
+
+  /** @return int[] */
+  public function getLinkIds(): array {
+    return $this->linkIds;
+  }
+
+  /** @return string[] */
+  public function getLinkUrls(): array {
+    return $this->linkUrls;
+  }
+
+  public function getStatsLinkAlias(): string {
+    return $this->statsLinkAlias;
+  }
+}

--- a/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
+++ b/mailpoet/tests/integration/Newsletter/NewsletterRepositoryTest.php
@@ -28,9 +28,12 @@ class NewsletterRepositoryTest extends \MailPoetTest {
 
   public function testItGetsStandardAndAutomationNewsletterList() {
     $standardNewsletter = $this->createNewsletter(NewsletterEntity::TYPE_STANDARD, NewsletterEntity::STATUS_SENT);
-    $automationEmail = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
-    $automationTransactionalEmail = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_ACTIVE);
-    $automationDraftEmail = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_DRAFT);
+    $activeAutomation = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $transactionalAutomation = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION_TRANSACTIONAL, NewsletterEntity::STATUS_ACTIVE);
+    $draftAutomation = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_DRAFT);
+    $deletedAutomation = $this->createNewsletter(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $deletedAutomation->setDeletedAt(new \DateTimeImmutable());
+    $this->entityManager->flush();
     $notification = $this->createNewsletter(NewsletterEntity::TYPE_NOTIFICATION, NewsletterEntity::STATUS_ACTIVE);
 
     $newsletterIds = array_map(function(NewsletterEntity $newsletter) {
@@ -38,9 +41,10 @@ class NewsletterRepositoryTest extends \MailPoetTest {
     }, $this->repository->getStandardAndAutomationNewsletterList());
 
     $this->assertContains($standardNewsletter->getId(), $newsletterIds);
-    $this->assertContains($automationEmail->getId(), $newsletterIds);
-    $this->assertContains($automationTransactionalEmail->getId(), $newsletterIds);
-    $this->assertNotContains($automationDraftEmail->getId(), $newsletterIds);
+    $this->assertContains($activeAutomation->getId(), $newsletterIds);
+    $this->assertContains($transactionalAutomation->getId(), $newsletterIds);
+    $this->assertNotContains($draftAutomation->getId(), $newsletterIds);
+    $this->assertNotContains($deletedAutomation->getId(), $newsletterIds);
     $this->assertNotContains($notification->getId(), $newsletterIds);
   }
 

--- a/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/FilterDataMapperTest.php
@@ -125,6 +125,31 @@ class FilterDataMapperTest extends \MailPoetTest {
     ]);
   }
 
+  public function testItMapsEmailFilterForClicksWithUrlLinks(): void {
+    $data = ['filters' => [[
+      'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,
+      'action' => EmailAction::ACTION_CLICKED,
+      'newsletter_id' => 1,
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'link_ids' => ['https://example.com/automation-link', '[link:subscription_manage_url]'],
+    ]],
+    ];
+    $filters = $this->mapper->map($data);
+    verify($filters)->isArray();
+    verify($filters)->arrayCount(1);
+    $filter = reset($filters);
+    $this->assertInstanceOf(DynamicSegmentFilterData::class, $filter);
+    verify($filter)->instanceOf(DynamicSegmentFilterData::class);
+    verify($filter->getFilterType())->equals(DynamicSegmentFilterData::TYPE_EMAIL);
+    verify($filter->getAction())->equals(EmailAction::ACTION_CLICKED);
+    verify($filter->getData())->equals([
+      'newsletter_id' => 1,
+      'link_ids' => ['https://example.com/automation-link', '[link:subscription_manage_url]'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+      'connect' => DynamicSegmentFilterData::CONNECT_TYPE_AND,
+    ]);
+  }
+
   public function testItChecksOperatorForEmailFilterForClicksWithLinks(): void {
     $data = ['filters' => [[
       'segmentType' => DynamicSegmentFilterData::TYPE_EMAIL,

--- a/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
+++ b/mailpoet/tests/integration/Segments/DynamicSegments/Filters/EmailActionTest.php
@@ -143,6 +143,26 @@ class EmailActionTest extends \MailPoetTest {
     $this->assertEqualsCanonicalizing(['not_opened@example.com'], $emails);
   }
 
+  public function testGetOpenedOperatorAllCountsRepeatedAutomationEmailSendsOnce(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriber = $this->createSubscriber('automation_opened_twice@example.com');
+    $this->createStatsNewsletter($subscriber, $automationEmail);
+    $this->createStatsNewsletter($subscriber, $automationEmail);
+    $this->createStatisticsOpens($subscriber, $automationEmail);
+    $this->createStatisticsOpens($subscriber, $automationEmail);
+
+    $segmentFilterData = $this->getSegmentFilterData(
+      EmailAction::ACTION_OPENED,
+      [
+        'newsletters' => [(int)$automationEmail->getId()],
+        'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
+      ]
+    );
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(['automation_opened_twice@example.com'], $emails);
+  }
+
   public function testGetClickedWithoutSavedLinks(): void {
     $this->createClickedLink('http://example.com', $this->newsletter, $this->subscriberOpenedClicked); // id 1
     $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
@@ -226,6 +246,135 @@ class EmailActionTest extends \MailPoetTest {
     ]);
     $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
     $this->assertEqualsCanonicalizing(['opened_not_clicked@example.com', 'not_opened@example.com'], $emails);
+  }
+
+  public function testGetClickedAutomationEmailWithAnyOfUrlLinks(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriberClickedSelected = $this->createSubscriber('automation_clicked_selected@example.com');
+    $subscriberClickedOther = $this->createSubscriber('automation_clicked_other@example.com');
+    $this->createStatsNewsletter($subscriberClickedSelected, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedOther, $automationEmail);
+    $this->createClickedLink('https://example.com/automation-selected', $automationEmail, $subscriberClickedSelected);
+    $this->createClickedLink('https://example.com/automation-other', $automationEmail, $subscriberClickedOther);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => ['https://example.com/automation-selected'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(['automation_clicked_selected@example.com'], $emails);
+  }
+
+  public function testGetClickedAutomationEmailWithAllOfUrlLinks(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriberClickedAll = $this->createSubscriber('automation_clicked_all@example.com');
+    $subscriberClickedOne = $this->createSubscriber('automation_clicked_one@example.com');
+    $this->createStatsNewsletter($subscriberClickedAll, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedOne, $automationEmail);
+    $this->createClickedLink('https://example.com/automation-first', $automationEmail, $subscriberClickedAll);
+    $this->createClickedLink('https://example.com/automation-second', $automationEmail, $subscriberClickedAll);
+    $this->createClickedLink('https://example.com/automation-first', $automationEmail, $subscriberClickedOne);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => [
+        'https://example.com/automation-first',
+        'https://example.com/automation-second',
+      ],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(['automation_clicked_all@example.com'], $emails);
+  }
+
+  public function testGetClickedAutomationEmailWithAllLinksCountsDistinctUrls(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriberClickedAll = $this->createSubscriber('automation_clicked_all_links@example.com');
+    $subscriberClickedDuplicateUrl = $this->createSubscriber('automation_clicked_duplicate_url@example.com');
+    $this->createStatsNewsletter($subscriberClickedAll, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedDuplicateUrl, $automationEmail);
+    $this->createClickedLink('https://example.com/automation-first', $automationEmail, $subscriberClickedAll);
+    $this->createClickedLink('https://example.com/automation-second', $automationEmail, $subscriberClickedAll);
+    $this->createClickedLink('https://example.com/automation-first', $automationEmail, $subscriberClickedDuplicateUrl);
+    $this->createClickedLink('https://example.com/automation-first', $automationEmail, $subscriberClickedDuplicateUrl);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => [],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(['automation_clicked_all_links@example.com'], $emails);
+  }
+
+  public function testGetClickedAutomationEmailMatchesUrlsCaseInsensitively(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriberClickedMixed = $this->createSubscriber('automation_clicked_mixed_case@example.com');
+    $subscriberClickedLower = $this->createSubscriber('automation_clicked_lower_case@example.com');
+    $this->createStatsNewsletter($subscriberClickedMixed, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedLower, $automationEmail);
+    $this->createClickedLink('https://Example.com/Automation-Target', $automationEmail, $subscriberClickedMixed);
+    $this->createClickedLink('https://example.com/automation-target', $automationEmail, $subscriberClickedLower);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => ['HTTPS://EXAMPLE.COM/automation-TARGET'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(
+      ['automation_clicked_mixed_case@example.com', 'automation_clicked_lower_case@example.com'],
+      $emails
+    );
+  }
+
+  public function testGetClickedAutomationEmailWithNoneOfUrlLinks(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriberClickedSelected = $this->createSubscriber('automation_clicked_selected@example.com');
+    $subscriberClickedOther = $this->createSubscriber('automation_clicked_other@example.com');
+    $this->createStatsNewsletter($subscriberClickedSelected, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedOther, $automationEmail);
+    $this->createClickedLink('https://example.com/automation-selected', $automationEmail, $subscriberClickedSelected);
+    $this->createClickedLink('https://example.com/automation-other', $automationEmail, $subscriberClickedOther);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => ['https://example.com/automation-selected'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(['automation_clicked_other@example.com'], $emails);
+  }
+
+  public function testGetClickedAutomationEmailWithNoneOfUrlLinksAcrossMultipleSends(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    // Each automation send creates a fresh newsletter_links row for the same URL,
+    // so the NONE branch must look up matching link ids by URL — not just by the
+    // numeric id the user picked — or a subscriber who clicked the target URL on
+    // an earlier send would slip through the filter.
+    $subscriberClickedTargetOnFirstSend = $this->createSubscriber('automation_clicked_target_first_send@example.com');
+    $subscriberClickedOtherOnly = $this->createSubscriber('automation_clicked_other_only@example.com');
+    $this->createStatsNewsletter($subscriberClickedTargetOnFirstSend, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedOtherOnly, $automationEmail);
+    $this->createClickedLink('https://example.com/automation-target', $automationEmail, $subscriberClickedTargetOnFirstSend);
+    $this->createClickedLink('https://example.com/automation-other', $automationEmail, $subscriberClickedTargetOnFirstSend);
+    $this->createClickedLink('https://example.com/automation-other', $automationEmail, $subscriberClickedOtherOnly);
+    $this->createClickedLink('https://example.com/automation-other', $automationEmail, $subscriberClickedOtherOnly);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => ['https://example.com/automation-target'],
+      'operator' => DynamicSegmentFilterData::OPERATOR_NONE,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(['automation_clicked_other_only@example.com'], $emails);
   }
 
   public function testOpensNotIncludeMachineOpens(): void {
@@ -335,6 +484,22 @@ class EmailActionTest extends \MailPoetTest {
     verify($emails)->arrayNotContains('3@example.com');
   }
 
+  public function testSentEmailAllCountsRepeatedAutomationEmailSendsOnce(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriber = $this->createSubscriber('automation_sent_twice@example.com');
+    $this->createStatsNewsletter($subscriber, $automationEmail);
+    $this->createStatsNewsletter($subscriber, $automationEmail);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_WAS_SENT, [
+      'newsletters' => [$automationEmail->getId()],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ALL,
+    ]);
+
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    verify($emails)->arrayContains('automation_sent_twice@example.com');
+  }
+
   public function testSentEmailNone(): void {
     $subscriber1 = $this->createSubscriber('1@example.com');
     $subscriber2 = $this->createSubscriber('2@example.com');
@@ -389,6 +554,48 @@ class EmailActionTest extends \MailPoetTest {
     ], $lookupData);
   }
 
+  public function testItRetrievesLookupDataForUrlLinkIds(): void {
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$this->newsletter->getId(),
+      'link_ids' => ['https://example.com/from-url', '[link:subscription_manage_url]'],
+    ]);
+    $lookupData = $this->emailAction->getLookupData($segmentFilterData);
+    $this->assertEqualsCanonicalizing([
+      'newsletters' => [
+        $this->newsletter->getId() => $this->newsletter->getSubject(),
+      ],
+      'links' => [
+        'https://example.com/from-url' => 'https://example.com/from-url',
+        '[link:subscription_manage_url]' => '[link:subscription_manage_url]',
+      ],
+    ], $lookupData);
+  }
+
+  public function testGetClickedAutomationEmailResolvesNumericLinkIdsToUrls(): void {
+    $automationEmail = $this->createNewsletterWithQueue(NewsletterEntity::TYPE_AUTOMATION, NewsletterEntity::STATUS_ACTIVE);
+    $subscriberClickedTarget = $this->createSubscriber('automation_matches_url@example.com');
+    $subscriberClickedOther = $this->createSubscriber('automation_clicks_other@example.com');
+    $this->createStatsNewsletter($subscriberClickedTarget, $automationEmail);
+    $this->createStatsNewsletter($subscriberClickedOther, $automationEmail);
+    // The UI selects a single numeric id, but each automation send creates
+    // a fresh link row for the same URL. The filter must still match clicks
+    // on any other send of the same URL — not only the id that was picked.
+    $pickedLink = $this->createClickedLink('https://example.com/automation-target', $automationEmail, $subscriberClickedTarget);
+    $this->createClickedLink('https://example.com/automation-target', $automationEmail, $subscriberClickedOther);
+
+    $segmentFilterData = $this->getSegmentFilterData(EmailAction::ACTION_CLICKED, [
+      'newsletter_id' => (int)$automationEmail->getId(),
+      'link_ids' => [$pickedLink->getId()],
+      'operator' => DynamicSegmentFilterData::OPERATOR_ANY,
+    ]);
+    $emails = $this->tester->getSubscriberEmailsMatchingDynamicFilter($segmentFilterData, $this->emailAction);
+
+    $this->assertEqualsCanonicalizing(
+      ['automation_matches_url@example.com', 'automation_clicks_other@example.com'],
+      $emails
+    );
+  }
+
   private function getSegmentFilterData(string $action, array $data): DynamicSegmentFilterData {
     return new DynamicSegmentFilterData(DynamicSegmentFilterData::TYPE_EMAIL, $action, $data);
   }
@@ -404,8 +611,25 @@ class EmailActionTest extends \MailPoetTest {
     return $subscriber;
   }
 
+  private function createNewsletterWithQueue(string $type, string $status): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $task = new ScheduledTaskEntity();
+    $this->entityManager->persist($task);
+    $queue = new SendingQueueEntity();
+    $queue->setNewsletter($newsletter);
+    $queue->setTask($task);
+    $this->entityManager->persist($queue);
+    $newsletter->getQueues()->add($queue);
+    $newsletter->setSubject('automation email');
+    $newsletter->setStatus($status);
+    $newsletter->setType($type);
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    return $newsletter;
+  }
+
   private function createStatsNewsletter(SubscriberEntity $subscriber, NewsletterEntity $newsletter): StatisticsNewsletterEntity {
-    $queue = $this->newsletter->getLatestQueue();
+    $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
     $stats = new StatisticsNewsletterEntity($newsletter, $queue, $subscriber);
     $this->entityManager->persist($stats);
@@ -425,7 +649,7 @@ class EmailActionTest extends \MailPoetTest {
   private function createClickedLink(string $link, NewsletterEntity $newsletter, SubscriberEntity $subscriber): NewsletterLinkEntity {
     $queue = $newsletter->getLatestQueue();
     $this->assertInstanceOf(SendingQueueEntity::class, $queue);
-    $link = new NewsletterLinkEntity($this->newsletter, $queue, $link, uniqid());
+    $link = new NewsletterLinkEntity($newsletter, $queue, $link, uniqid());
     $this->entityManager->persist($link);
     $this->entityManager->flush();
     $click = new StatisticsClickEntity(

--- a/mailpoet/tests/javascript/segments/dynamic/dynamic-segments-filters/fields/email/newsletter-options.spec.ts
+++ b/mailpoet/tests/javascript/segments/dynamic/dynamic-segments-filters/fields/email/newsletter-options.spec.ts
@@ -1,0 +1,178 @@
+import { JSDOM } from 'jsdom';
+import { getGroupedNewsletterOptions } from '../../../../../../../assets/js/src/segments/dynamic/dynamic-segments-filters/fields/email/newsletter-options';
+
+type Newsletter = {
+  id: string;
+  name: string;
+  subject: string;
+  sent_at: string | null;
+  type: 'standard' | 'automation' | 'automation_transactional';
+};
+
+const setBrowserGlobals = (): void => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  const globals = global as typeof globalThis & { window: Window };
+  globals.window = dom.window as unknown as Window & typeof globalThis;
+  globals.document = dom.window.document;
+};
+
+const makeNewsletter = (overrides: Partial<Newsletter>): Newsletter => ({
+  id: '1',
+  name: 'A newsletter',
+  subject: 'subject',
+  sent_at: null,
+  type: 'standard',
+  ...overrides,
+});
+
+const formatDate = (date: string): string => `formatted(${date})`;
+
+describe('getGroupedNewsletterOptions', () => {
+  before(() => {
+    setBrowserGlobals();
+  });
+
+  it('returns empty arrays for an empty list', () => {
+    const { flatOptions, groupedOptions } = getGroupedNewsletterOptions(
+      [],
+      formatDate,
+    );
+    expect(flatOptions).to.deep.equal([]);
+    expect(groupedOptions).to.deep.equal([]);
+  });
+
+  it('returns empty arrays when the newsletters list is undefined', () => {
+    const { flatOptions, groupedOptions } = getGroupedNewsletterOptions(
+      undefined,
+      formatDate,
+    );
+    expect(flatOptions).to.deep.equal([]);
+    expect(groupedOptions).to.deep.equal([]);
+  });
+
+  it('groups standard newsletters under the Standard emails label', () => {
+    const { groupedOptions } = getGroupedNewsletterOptions(
+      [makeNewsletter({ id: '7', name: 'Welcome', type: 'standard' })],
+      formatDate,
+    );
+    expect(groupedOptions).to.have.lengthOf(1);
+    expect(groupedOptions[0].label).to.equal('Standard emails');
+    expect(groupedOptions[0].options).to.have.lengthOf(1);
+    expect(groupedOptions[0].options[0]).to.include({
+      label: 'Welcome',
+      value: 7,
+    });
+  });
+
+  it('groups automation and automation_transactional under the Automation emails label', () => {
+    const { groupedOptions } = getGroupedNewsletterOptions(
+      [
+        makeNewsletter({ id: '11', name: 'Drip 1', type: 'automation' }),
+        makeNewsletter({
+          id: '12',
+          name: 'Receipt',
+          type: 'automation_transactional',
+        }),
+      ],
+      formatDate,
+    );
+    expect(groupedOptions).to.have.lengthOf(1);
+    expect(groupedOptions[0].label).to.equal('Automation emails');
+    const automationOptionValues = groupedOptions[0].options.map(
+      (option) => option.value,
+    );
+    expect(automationOptionValues).to.deep.equal([11, 12]);
+  });
+
+  it('orders the Standard group before the Automation group', () => {
+    const { groupedOptions } = getGroupedNewsletterOptions(
+      [
+        makeNewsletter({ id: '20', name: 'Drip', type: 'automation' }),
+        makeNewsletter({ id: '21', name: 'Welcome', type: 'standard' }),
+      ],
+      formatDate,
+    );
+    expect(groupedOptions.map((group) => group.label)).to.deep.equal([
+      'Standard emails',
+      'Automation emails',
+    ]);
+  });
+
+  it('omits a group when there are no newsletters of that kind', () => {
+    const { groupedOptions } = getGroupedNewsletterOptions(
+      [makeNewsletter({ id: '1', type: 'standard' })],
+      formatDate,
+    );
+    expect(groupedOptions.map((group) => group.label)).to.deep.equal([
+      'Standard emails',
+    ]);
+  });
+
+  it('flat options mirror the grouped options in order', () => {
+    const { flatOptions, groupedOptions } = getGroupedNewsletterOptions(
+      [
+        makeNewsletter({ id: '3', type: 'automation' }),
+        makeNewsletter({ id: '1', type: 'standard' }),
+        makeNewsletter({ id: '2', type: 'standard' }),
+      ],
+      formatDate,
+    );
+    const flatValues = flatOptions.map((option) => option.value);
+    const groupedValues = groupedOptions.flatMap((group) =>
+      group.options.map((option) => option.value),
+    );
+    expect(flatValues).to.deep.equal(groupedValues);
+    expect(flatValues).to.deep.equal([1, 2, 3]);
+  });
+
+  it('uses the not sent yet tag when sent_at is missing', () => {
+    const { flatOptions } = getGroupedNewsletterOptions(
+      [makeNewsletter({ id: '1', sent_at: null, type: 'standard' })],
+      formatDate,
+    );
+    expect(flatOptions[0].tag).to.equal('Not sent yet');
+  });
+
+  it('formats the tag through the injected formatter when sent_at is present', () => {
+    const { flatOptions } = getGroupedNewsletterOptions(
+      [
+        makeNewsletter({
+          id: '1',
+          sent_at: '2025-01-15 09:30:00',
+          type: 'standard',
+        }),
+      ],
+      formatDate,
+    );
+    expect(flatOptions[0].tag).to.equal('formatted(2025-01-15 09:30:00)');
+  });
+
+  it('coerces the newsletter id from string to number', () => {
+    const { flatOptions } = getGroupedNewsletterOptions(
+      [makeNewsletter({ id: '42', type: 'standard' })],
+      formatDate,
+    );
+    expect(flatOptions[0].value).to.equal(42);
+    expect(typeof flatOptions[0].value).to.equal('number');
+  });
+
+  it('omits the sent-at tag on automation emails because sent_at lives on the queue', () => {
+    const { flatOptions } = getGroupedNewsletterOptions(
+      [
+        makeNewsletter({
+          id: '1',
+          sent_at: '2025-01-15 09:30:00',
+          type: 'automation',
+        }),
+        makeNewsletter({
+          id: '2',
+          sent_at: null,
+          type: 'automation_transactional',
+        }),
+      ],
+      formatDate,
+    );
+    expect(flatOptions[0].tag).to.equal(undefined);
+    expect(flatOptions[1].tag).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
## Description

The opens, clicks, and sent dynamic-segment conditions previously only listed standard newsletters. This branch surfaces active automation emails in the same dropdown (grouped under "Automation emails"). It also

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

STOMAIL-8096

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="861" height="441" alt="Screenshot 2026-05-19 at 13 56 57" src="https://github.com/user-attachments/assets/266fc7b3-ede9-40ba-9d09-d1268cb77d85" />

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:add/stomail-8096-automation-email-segments)

_The latest successful build from `add/stomail-8096-automation-email-segments` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issues Found: 2

### Bug (1)

**Silent Invalid Newsletter ID Handling in Frontend**

In `email-statistics-clicks.tsx`, when `segment.newsletter_id` is `undefined` or contains a non-numeric string value, `Number(segment.newsletter_id)` will result in `NaN`. The component lacks validation for this case, which means the newsletter dropdown's `find()` comparison (`value === Number(segment.newsletter_id)`) will silently fail to match any option when an invalid ID is present. This could result in the dropdown appearing empty even though newsletters are available, causing a confusing UX.

### Suggestion (1)

**Potential Silent Failure with Invalid Newsletter ID in Backend**

In `EmailAction.php`, the `normalizeNewsletterId()` method returns `0` when given an invalid input (non-numeric string, null, etc.). This `0` value is then passed to `isAutomationNewsletter(0)`, which attempts to find a newsletter with ID 0. While the code uses `instanceof` checks to prevent errors, relying on a `0` ID that likely doesn't exist silently defaults to treating the email as "not automation," which could result in incorrect query logic (URL matching vs. link_id matching). Adding explicit validation or throwing an exception for invalid newsletter IDs would improve error visibility and prevent incorrect behavior downstream.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->