### PR TITLE
Support campaign stats DataViews

### DIFF
--- a/mailpoet/assets/css/src/components-plugin/_stats.scss
+++ b/mailpoet/assets/css/src/components-plugin/_stats.scss
@@ -48,6 +48,131 @@
   }
 }
 
+.mailpoet-campaign-stats-dataviews {
+  .dataviews-wrapper {
+    background: $color-white;
+  }
+
+  .dataviews-view-table__cell-content-wrapper:not(.dataviews-column-primary__media),
+  .dataviews-view-table__primary-column-content:not(.dataviews-column-primary__media) {
+    max-width: none;
+    min-width: 0;
+  }
+}
+
+.mailpoet-campaign-stats-dataviews__subscriber {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.mailpoet-campaign-stats-dataviews__subscriber-email {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: fit-content;
+}
+
+.mailpoet-campaign-stats-dataviews__subscriber-name {
+  color: $color-text-light;
+  display: block;
+  line-height: 1.4;
+}
+
+.mailpoet-campaign-stats-dataviews__product,
+.mailpoet-campaign-stats-dataviews__product-link {
+  align-items: center;
+  color: $color-text;
+  display: flex;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mailpoet-campaign-stats-dataviews__product-link {
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: $color-text;
+    text-decoration: none;
+
+    .mailpoet-campaign-stats-dataviews__product-name {
+      text-decoration: underline;
+    }
+  }
+}
+
+.mailpoet-campaign-stats-dataviews__product-image {
+  background-color: $color-tertiary-light;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  border-radius: $form-control-border-radius;
+  flex: 0 0 40px;
+  height: 40px;
+  width: 40px;
+}
+
+.mailpoet-campaign-stats-dataviews__product-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mailpoet-campaign-stats-dataviews__groups,
+.mailpoet-campaign-stats-dataviews__toolbar {
+  align-items: center;
+  background: $color-white;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: $grid-gap-half $grid-gap;
+}
+
+.mailpoet-campaign-stats-dataviews__groups {
+  border-bottom: 1px solid $color-tertiary-light;
+
+  button {
+    align-items: center;
+    background: $color-white;
+    border: 1px solid $color-tertiary-light;
+    border-radius: $form-control-border-radius;
+    color: $color-text-light;
+    cursor: pointer;
+    display: inline-flex;
+    font-weight: 400;
+    line-height: 1.25;
+    min-height: 32px;
+    padding: 6px 10px;
+
+    &:hover {
+      border-color: $color-tertiary;
+      color: $color-text;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-text;
+      outline-offset: 1px;
+    }
+
+    &.is-active {
+      background: $color-white;
+      border-color: $color-tertiary-light;
+      box-shadow: none;
+      color: $color-text;
+      font-weight: 700;
+    }
+  }
+}
+
 .mailpoet-stats-info,
 .mailpoet-stats-general {
   background-color: $color-white;
@@ -177,79 +302,4 @@
 
 .mailpoet-stats-premium-required .mailpoet-premium-required {
   margin: 70px auto;
-}
-
-.mailpoet-stats-products {
-  display: grid;
-  grid-gap: $grid-gap;
-  grid-template-columns: repeat(auto-fill, minmax(440px, 1fr));
-
-  @include respond-to(small-screen) {
-    grid-template-columns: 1fr;
-    padding-top: $grid-gap;
-  }
-}
-
-.mailpoet-stats-product {
-  background: #fff;
-  border: 1px solid $color-tertiary-light;
-  border-radius: $form-control-border-radius;
-  color: $color-text;
-  display: grid;
-  grid-gap: $grid-gap;
-  grid-template-columns: 176px 1fr;
-  height: 136px;
-
-  @include respond-to(small-screen) {
-    grid-template-columns: 1fr;
-    height: auto;
-  }
-}
-
-a.mailpoet-stats-product {
-  cursor: pointer;
-  text-decoration: none;
-
-  &:hover,
-  &:focus {
-    box-shadow: 0 2px 4px 0 rgba($color-tertiary-light, 0.4),
-      0 10px 30px 0 $color-tertiary-light;
-    color: $color-text;
-    text-decoration: none;
-
-    .mailpoet-h5 {
-      color: $color-secondary;
-    }
-  }
-}
-
-.mailpoet-stats-product-image {
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
-
-  @include respond-to(small-screen) {
-    height: 136px;
-  }
-}
-
-.mailpoet-stats-product-info {
-  align-items: flex-start;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-
-  .mailpoet-h5 {
-    font-weight: bold;
-    margin: 0 0 $grid-gap;
-  }
-
-  p {
-    font-size: $font-size-small;
-    margin: 0;
-  }
-
-  @include respond-to(small-screen) {
-    padding: 0 $grid-gap $grid-gap;
-  }
 }

--- a/mailpoet/assets/css/src/components-plugin/_subscribers.scss
+++ b/mailpoet/assets/css/src/components-plugin/_subscribers.scss
@@ -341,6 +341,37 @@
   padding: $grid-gap 0;
 }
 
+.mailpoet-subscriber-stats-activity-dataviews {
+  .dataviews-wrapper {
+    min-height: 240px;
+  }
+
+  .dataviews-view-table__cell-content-wrapper:not(.dataviews-column-primary__media),
+  .dataviews-view-table__primary-column-content:not(.dataviews-column-primary__media) {
+    max-width: none;
+    min-width: 0;
+  }
+}
+
+.mailpoet-subscriber-stats-activity-dataviews__toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-bottom: $grid-gap-half;
+}
+
+.mailpoet-subscriber-stats-activity-dataviews__details {
+  min-width: 0;
+}
+
+.mailpoet-subscriber-stats-activity-dataviews__event {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+  white-space: nowrap;
+}
+
 .mailpoet-subscriber-stats-activity-list-sample {
   opacity: 0.72;
 }

--- a/mailpoet/assets/js/src/common/dataviews/types.ts
+++ b/mailpoet/assets/js/src/common/dataviews/types.ts
@@ -26,7 +26,7 @@ export type ListingGroup = {
 export type ListingResponse<T> = {
   items: T[];
   meta: ListingMeta;
-  filters?: Array<Record<string, unknown>>;
+  filters?: Record<string, unknown> | Array<Record<string, unknown>>;
   groups?: ListingGroup[];
 };
 

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -29,6 +29,7 @@ type UseDataViewsQueryResult<T> = {
   setView: Dispatch<SetStateAction<View>>;
   items: T[];
   meta: ListingMeta;
+  filters: ListingResponse<T>['filters'];
   groups: ListingResponse<T>['groups'];
   isLoading: boolean;
   error: string | null;
@@ -53,6 +54,8 @@ export function useDataViewsQuery<T>({
   const [view, setView] = useState<View>(initialView);
   const [items, setItems] = useState<T[]>([]);
   const [meta, setMeta] = useState<ListingMeta>(EMPTY_META);
+  const [filters, setFilters] =
+    useState<ListingResponse<T>['filters']>(undefined);
   const [groups, setGroups] = useState<ListingResponse<T>['groups']>(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -102,6 +105,7 @@ export function useDataViewsQuery<T>({
         }
         setItems(result.items);
         setMeta(result.meta);
+        setFilters(result.filters);
         setGroups(result.groups);
         setError(null);
       })
@@ -118,6 +122,7 @@ export function useDataViewsQuery<T>({
             : '';
         setItems([]);
         setMeta({ count: 0, pages: 0 });
+        setFilters([]);
         setGroups([]);
         setError(message || 'Failed to load data.');
       })
@@ -139,6 +144,7 @@ export function useDataViewsQuery<T>({
     setView,
     items,
     meta,
+    filters,
     groups,
     isLoading,
     error,

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -27,6 +27,7 @@ type UseDataViewsQueryOptions<T> = {
 type UseDataViewsQueryResult<T> = {
   view: View;
   setView: Dispatch<SetStateAction<View>>;
+  onChangeView: (nextView: View) => void;
   items: T[];
   meta: ListingMeta;
   filters: ListingResponse<T>['filters'];
@@ -38,6 +39,13 @@ type UseDataViewsQueryResult<T> = {
 };
 
 const EMPTY_META: ListingMeta = { count: 0, pages: 0 };
+
+function wasInitialUrlStateReset(currentView: View, nextView: View): boolean {
+  const pageReset = (currentView.page ?? 1) > 1 && (nextView.page ?? 1) === 1;
+  const searchReset = Boolean(currentView.search) && !nextView.search;
+
+  return pageReset || searchReset;
+}
 
 /**
  * Bind a `@wordpress/dataviews` view to a MailPoet REST listing endpoint.
@@ -61,6 +69,7 @@ export function useDataViewsQuery<T>({
   const [error, setError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
   const latestRequestIdRef = useRef(0);
+  const completedInitialRequestRef = useRef(false);
   // Stash `extraParams` in a ref so a non-memoized callback from the caller
   // doesn't retrigger the fetch effect on every render. Reading from the ref
   // also lets us keep `extraParams` out of the effect's dependency array
@@ -74,19 +83,45 @@ export function useDataViewsQuery<T>({
 
   const clearError = useCallback(() => setError(null), []);
 
+  const onChangeView = useCallback((nextView: View): void => {
+    setView((currentView) => {
+      if (
+        !completedInitialRequestRef.current &&
+        wasInitialUrlStateReset(currentView, nextView)
+      ) {
+        return currentView;
+      }
+
+      const searchChanged =
+        (nextView.search ?? '') !== (currentView.search ?? '');
+      const perPageChanged = nextView.perPage !== currentView.perPage;
+
+      return {
+        ...nextView,
+        page: searchChanged || perPageChanged ? 1 : nextView.page,
+      };
+    });
+  }, []);
+
+  const queryPage = view.page ?? 1;
+  const queryPerPage = view.perPage ?? 20;
+  const queryOrderBy = view.sort?.field;
+  const queryOrder = view.sort?.direction;
+  const querySearch = view.search || undefined;
+
   useEffect(() => {
     const controller = new AbortController();
     const requestId = latestRequestIdRef.current + 1;
     latestRequestIdRef.current = requestId;
     setIsLoading(true);
 
-    const requestedPage = view.page ?? 1;
+    const requestedPage = queryPage;
     const params: ListingQueryParams = {
       page: requestedPage,
-      per_page: view.perPage ?? 20,
-      orderby: view.sort?.field,
-      order: view.sort?.direction,
-      search: view.search || undefined,
+      per_page: queryPerPage,
+      orderby: queryOrderBy,
+      order: queryOrder,
+      search: querySearch,
       ...(extraParamsRef.current ? extraParamsRef.current(view) : {}),
     };
 
@@ -100,7 +135,7 @@ export function useDataViewsQuery<T>({
           // Avoid leaving a stale error visible while we re-fetch the
           // clamped page below.
           setError(null);
-          setView({ ...view, page: lastValidPage });
+          setView((currentView) => ({ ...currentView, page: lastValidPage }));
           return;
         }
         setItems(result.items);
@@ -128,20 +163,30 @@ export function useDataViewsQuery<T>({
       })
       .finally(() => {
         if (requestId === latestRequestIdRef.current) {
+          completedInitialRequestRef.current = true;
           setIsLoading(false);
         }
       });
     return () => controller.abort();
     // `extraParams` is read via a ref above so the effect doesn't depend on
     // its identity (callers don't need to memoize it). The effect re-runs
-    // whenever the DataViews view changes (sort, search, page, perPage,
-    // filters), the load function changes, or refresh() bumps the token.
+    // whenever the query-relevant DataViews view values change (sort, search,
+    // page, perPage), the load function changes, or refresh() bumps the token.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [view, load, refreshToken]);
+  }, [
+    queryPage,
+    queryPerPage,
+    queryOrderBy,
+    queryOrder,
+    querySearch,
+    load,
+    refreshToken,
+  ]);
 
   return {
     view,
     setView,
+    onChangeView,
     items,
     meta,
     filters,

--- a/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
+++ b/mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
@@ -108,6 +108,10 @@ export function useDataViewsQuery<T>({
   const queryOrderBy = view.sort?.field;
   const queryOrder = view.sort?.direction;
   const querySearch = view.search || undefined;
+  const extraQueryParams = extraParamsRef.current
+    ? extraParamsRef.current(view)
+    : {};
+  const extraQueryParamsKey = JSON.stringify(extraQueryParams);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -122,7 +126,7 @@ export function useDataViewsQuery<T>({
       orderby: queryOrderBy,
       order: queryOrder,
       search: querySearch,
-      ...(extraParamsRef.current ? extraParamsRef.current(view) : {}),
+      ...extraQueryParams,
     };
 
     load(params, controller.signal)
@@ -169,9 +173,9 @@ export function useDataViewsQuery<T>({
       });
     return () => controller.abort();
     // `extraParams` is read via a ref above so the effect doesn't depend on
-    // its identity (callers don't need to memoize it). The effect re-runs
-    // whenever the query-relevant DataViews view values change (sort, search,
-    // page, perPage), the load function changes, or refresh() bumps the token.
+    // its identity (callers don't need to memoize it). The effect re-runs when
+    // query params change, including listing-specific params derived from the
+    // full DataViews view.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     queryPage,
@@ -179,6 +183,7 @@ export function useDataViewsQuery<T>({
     queryOrderBy,
     queryOrder,
     querySearch,
+    extraQueryParamsKey,
     load,
     refreshToken,
   ]);

--- a/mailpoet/assets/js/src/common/index.ts
+++ b/mailpoet/assets/js/src/common/index.ts
@@ -14,6 +14,7 @@ export * from './functions';
 export * from './utils';
 export * from './thumbnail';
 export * from './controls';
+export * from './dataviews';
 export * from './confirm-alert';
 export * from './newsletter-status-string';
 export * from './notices/inline-notice';

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -117,7 +117,18 @@ export function CampaignStatsPage() {
 
   const { item, loading } = state;
   const newsletter = item;
-  let activeTab = getActiveStatsTab(params['*']);
+  const requestedTab = getActiveStatsTab(params['*']);
+  let activeTab = requestedTab;
+
+  useEffect(() => {
+    if (loading || !newsletter) {
+      return;
+    }
+
+    if (requestedTab === 'products' && !MailPoet.isWoocommerceActive) {
+      navigate(getStatsTabUrl(newsletter.id, 'clicked'), { replace: true });
+    }
+  }, [loading, navigate, newsletter, requestedTab]);
 
   if (loading) return null;
 

--- a/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
+++ b/mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
@@ -13,10 +13,52 @@ import { NewsletterType } from './newsletter-type';
 import { NewsletterStatsInfo } from './newsletter-stats-info';
 import { PremiumBanner } from './premium-banner';
 
+type StatsTabKey =
+  | 'clicked'
+  | 'products'
+  | 'engagement'
+  | 'bounces'
+  | 'unsubscribe-reasons';
+
 type State = {
   item?: NewsletterType;
   loading: boolean;
 };
+
+const statsTabKeys: StatsTabKey[] = [
+  'clicked',
+  'products',
+  'engagement',
+  'bounces',
+  'unsubscribe-reasons',
+];
+
+const legacyListingParamKeys = [
+  'group',
+  'filter',
+  'search',
+  'page',
+  'sort_by',
+  'sort_order',
+];
+
+function getActiveStatsTab(path?: string): StatsTabKey {
+  const firstPart = (path || '').split('/').filter(Boolean)[0];
+  if (statsTabKeys.includes(firstPart as StatsTabKey)) {
+    return firstPart as StatsTabKey;
+  }
+  if (legacyListingParamKeys.some((key) => firstPart?.startsWith(`${key}[`))) {
+    return 'engagement';
+  }
+  return 'clicked';
+}
+
+function getStatsTabUrl(newsletterId: string, tabKey: string): string {
+  if (tabKey === 'clicked') {
+    return `/stats/${newsletterId}`;
+  }
+  return `/stats/${newsletterId}/${tabKey}`;
+}
 
 export function CampaignStatsPage() {
   const [state, setState] = useState<State>({
@@ -75,11 +117,16 @@ export function CampaignStatsPage() {
 
   const { item, loading } = state;
   const newsletter = item;
+  let activeTab = getActiveStatsTab(params['*']);
 
   if (loading) return null;
 
   if (!newsletter) {
     return <h3> {__('This email does not exist.', 'mailpoet')} </h3>;
+  }
+
+  if (activeTab === 'products' && !MailPoet.isWoocommerceActive) {
+    activeTab = 'clicked';
   }
 
   return (
@@ -99,7 +146,12 @@ export function CampaignStatsPage() {
           />
         </ErrorBoundary>
 
-        <Tabs activeKey="clicked">
+        <Tabs
+          activeKey={activeTab}
+          onSwitch={(tabKey) => {
+            navigate(getStatsTabUrl(newsletter.id, tabKey));
+          }}
+        >
           <Tab key="clicked" title={__('Clicked Links', 'mailpoet')}>
             {Hooks.applyFilters(
               'mailpoet_newsletters_clicked_links_table',

--- a/mailpoet/assets/js/src/webpack-admin-expose.js
+++ b/mailpoet/assets/js/src/webpack-admin-expose.js
@@ -31,6 +31,7 @@ export { TreeSelect as WordpressComponentsTreeSelect } from '@wordpress/componen
 export { Spinner as WordpressComponentsSpinner } from '@wordpress/components';
 export { ToggleControl as WordpressComponentsToggleControl } from '@wordpress/components';
 export * as WordPressAPIFetch from '@wordpress/api-fetch';
+export * as WordPressDataViews from '@wordpress/dataviews';
 export * as WordPressData from '@wordpress/data';
 export * as WordPressDate from '@wordpress/date';
 export * as WordPressUrl from '@wordpress/url';

--- a/mailpoet/changelog/2026-05-19-12-24-35-improved-improve-campaign-statistics-list-views.md
+++ b/mailpoet/changelog/2026-05-19-12-24-35-improved-improve-campaign-statistics-list-views.md
@@ -1,0 +1,5 @@
+# Type: Improved
+
+# Description
+
+Improve campaign statistics list views

--- a/mailpoet/lib/AdminPages/Pages/Newsletters.php
+++ b/mailpoet/lib/AdminPages/Pages/Newsletters.php
@@ -4,6 +4,7 @@ namespace MailPoet\AdminPages\Pages;
 
 use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
 use Automattic\WooCommerce\EmailEditor\Engine\Dependency_Check;
+use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\AutomaticEmails\AutomaticEmails;
 use MailPoet\Config\Env;
@@ -28,6 +29,8 @@ use MailPoet\WP\DateTime;
 use MailPoet\WP\Functions as WPFunctions;
 
 class Newsletters {
+  private AssetsController $assetsController;
+
   private PageRenderer $pageRenderer;
 
   private PageLimit $listingPageLimit;
@@ -63,6 +66,7 @@ class Newsletters {
   private CapabilitiesManager $capabilitiesManager;
 
   public function __construct(
+    AssetsController $assetsController,
     PageRenderer $pageRenderer,
     PageLimit $listingPageLimit,
     WPFunctions $wp,
@@ -80,6 +84,7 @@ class Newsletters {
     DependencyNotice $dependencyNotice,
     CapabilitiesManager $capabilitiesManager
   ) {
+    $this->assetsController = $assetsController;
     $this->pageRenderer = $pageRenderer;
     $this->listingPageLimit = $listingPageLimit;
     $this->wp = $wp;
@@ -101,6 +106,8 @@ class Newsletters {
 
   public function render() {
     global $wp_roles; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+    $this->assetsController->setupDataViewsDependencies();
 
     $data = [];
 
@@ -138,6 +145,10 @@ class Newsletters {
     $data['woocommerce_transactional_email_id'] = $this->settings->get(TransactionalEmails::SETTING_EMAIL_ID);
     $detailedAnalyticsCapability = $this->capabilitiesManager->getCapability('detailedAnalytics');
     $data['display_detailed_stats'] = isset($detailedAnalyticsCapability) && !$detailedAnalyticsCapability->isRestricted;
+    $data['api'] = [
+      'root' => rtrim($this->wp->escUrlRaw($this->wp->restUrl()), '/'),
+      'nonce' => $this->wp->wpCreateNonce('wp_rest'),
+    ];
     $data['newsletters_templates_recently_sent_count'] = $this->newsletterTemplatesRepository->getRecentlySentCount();
 
     $data['product_categories'] = $this->wpPostListLoader->getWooCommerceCategories();

--- a/mailpoet/lib/AdminPages/Pages/Subscribers.php
+++ b/mailpoet/lib/AdminPages/Pages/Subscribers.php
@@ -2,6 +2,7 @@
 
 namespace MailPoet\AdminPages\Pages;
 
+use MailPoet\AdminPages\AssetsController;
 use MailPoet\AdminPages\PageRenderer;
 use MailPoet\API\JSON\ResponseBuilders\CustomFieldsResponseBuilder;
 use MailPoet\CustomFields\CustomFieldsRepository;
@@ -15,6 +16,9 @@ use MailPoet\Subscribers\BulkConfirmationEmailResender;
 class Subscribers {
   /** @var PageRenderer */
   private $pageRenderer;
+
+  /** @var AssetsController */
+  private $assetsController;
 
   /** @var PageLimit */
   private $listingPageLimit;
@@ -36,6 +40,7 @@ class Subscribers {
 
   public function __construct(
     PageRenderer $pageRenderer,
+    AssetsController $assetsController,
     PageLimit $listingPageLimit,
     Block\Date $dateBlock,
     SegmentsSimpleListRepository $segmentsListRepository,
@@ -44,6 +49,7 @@ class Subscribers {
     SettingsController $settings
   ) {
     $this->pageRenderer = $pageRenderer;
+    $this->assetsController = $assetsController;
     $this->listingPageLimit = $listingPageLimit;
     $this->dateBlock = $dateBlock;
     $this->segmentsListRepository = $segmentsListRepository;
@@ -78,6 +84,7 @@ class Subscribers {
       'signup_confirmation.enabled'
     );
     $data['bulk_confirmation_resend_limit'] = BulkConfirmationEmailResender::BULK_CONFIRMATION_RESEND_LIMIT;
+    $this->assetsController->setupDataViewsDependencies();
     $this->pageRenderer->displayPage('subscribers/subscribers.html', $data);
   }
 }

--- a/mailpoet/views/newsletters.html
+++ b/mailpoet/views/newsletters.html
@@ -29,6 +29,7 @@
 
       var mailpoet_woocommerce_transactional_email_id = <%= json_encode(woocommerce_transactional_email_id) %>;
       var mailpoet_display_detailed_stats = <%= json_encode(display_detailed_stats) %>;
+      var mailpoet_newsletters_api = <%= json_encode(api) %>;
       var mailpoet_user_locale = '<%= get_locale() %>';
       var mailpoet_congratulations_success_images = [
         '<%= cdn_url('newsletter/congratulate-1.png') %>',


### PR DESCRIPTION
## Description

Adds the shared free-plugin support needed by the premium Campaign Stats DataViews migration. This exposes DataViews utilities, enqueues the required stats assets, styles the migrated stats tables, and restores campaign stats tab state from the URL so refreshed pages reopen on the expected tab.

## Code review notes

Legacy campaign stats URLs with listing parameters, for example `#/stats/5/page[2]`, are treated as Subscriber Engagement URLs so existing links keep resolving to the closest old behavior.

## QA notes

With the premium PR active, open a sent campaign’s stats page and verify:

- Switching between stats tabs updates the URL and refreshes back to the same tab.
- Subscriber Engagement restores group, search, sort, and pagination state after refresh.
- Bounces restores search, sort, and pagination state after refresh.
- The migrated DataViews lists remain visually aligned with the campaign stats layout.

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1073

## Linked tickets

Related to STOMAIL-8095

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

Screenshots captured separately and will be attached before review.

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <!-- Before screenshot here --> | <!-- After screenshot here --> |

## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Issues found: 3

- Bug (5 occurrences): Syntax/parsing errors reported in JS/TS files:
  - mailpoet/assets/js/src/common/dataviews/types.ts
  - mailpoet/assets/js/src/common/dataviews/use-dataviews-query.ts
  - mailpoet/assets/js/src/common/index.ts
  - mailpoet/assets/js/src/newsletters/campaign-stats/page.tsx
  - mailpoet/assets/js/src/webpack-admin-expose.js

- Security (1 occurrence): REST nonce and API root are injected into page data and exposed via a global (mailpoet_newsletters_api); webpack expose adds WordPressDataViews to window.MailPoetLib — review for unintended exposure of sensitive tokens/privileges.

- Suggestion (1 occurrence): Tests not yet added (noted in PR); add automated tests and attach promised screenshots before review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:update/campaign-stats-dataviews)

_The latest successful build from `update/campaign-stats-dataviews` will be used. If none is available, the link won't work._