### PR TITLE
View automation analytics per saved version

### DIFF
--- a/mailpoet/assets/css/src/components-automation-analytics/_header.scss
+++ b/mailpoet/assets/css/src/components-automation-analytics/_header.scss
@@ -32,6 +32,15 @@
     }
   }
 
+  .woocommerce-filters-label {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 500;
+    margin-bottom: 8px;
+    padding: 0;
+    text-transform: uppercase;
+  }
+
   .components-dropdown {
     .components-button.is-primary {
       box-shadow: none;

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/index.tsx
@@ -9,6 +9,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
 import { chevronDown, Icon } from '@wordpress/icons';
 import { Filter } from './filter';
+import { VersionSelector } from './version-selector';
 import { MailPoet } from '../../../../../../mailpoet';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
 import { AutomationStatus } from '../../../../../listing/automation';
@@ -26,6 +27,7 @@ export function Header(): JSX.Element {
   return (
     <header className="mailpoet-analytics-header">
       <Filter />
+      <VersionSelector />
       <EditorNotices />
       <Dropdown
         focusOnMount={false}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/version-selector.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/components/header/version-selector.tsx
@@ -1,0 +1,69 @@
+import { SelectControl } from '@wordpress/components';
+import { dispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n, getSettings } from '@wordpress/date';
+import { storeName } from '../../store';
+import { AutomationVersion } from '../../store/types';
+
+const ALL_VERSIONS = 'all';
+
+function formatLabel(version: AutomationVersion): string {
+  const settings = getSettings();
+  const date = dateI18n(
+    `${settings.formats.date}, ${settings.formats.time}`,
+    version.created_at,
+    settings.timezone.string,
+  );
+  return version.is_current
+    ? sprintf(
+        // translators: %s is a localised date/time, e.g. "Mar 5, 2026, 2:15 pm"
+        __('Current version (saved %s)', 'mailpoet'),
+        date,
+      )
+    : sprintf(
+        // translators: %s is a localised date/time
+        __('Version saved %s', 'mailpoet'),
+        date,
+      );
+}
+
+export function VersionSelector(): JSX.Element | null {
+  const { versions, selectedVersionId } = useSelect(
+    (s) => ({
+      versions: s(storeName).getVersions(),
+      selectedVersionId: s(storeName).getSelectedVersionId(),
+    }),
+    [],
+  );
+
+  if (versions.length <= 1) {
+    return null;
+  }
+
+  const value =
+    selectedVersionId === undefined ? ALL_VERSIONS : String(selectedVersionId);
+
+  const options = [
+    { label: __('All versions', 'mailpoet'), value: ALL_VERSIONS },
+    ...versions.map((version) => ({
+      label: formatLabel(version),
+      value: String(version.id),
+    })),
+  ];
+
+  return (
+    <div className="mailpoet-analytics-version-selector">
+      <SelectControl
+        label={__('Version:', 'mailpoet')}
+        value={value}
+        options={options}
+        onChange={(next) => {
+          void dispatch(storeName).setSelectedVersionId(
+            next === ALL_VERSIONS ? undefined : Number(next),
+          );
+        }}
+        __nextHasNoMarginBottom
+      />
+    </div>
+  );
+}

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/index.tsx
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/index.tsx
@@ -71,8 +71,9 @@ function App(): JSX.Element {
   );
 }
 
-function boot() {
+async function boot() {
   initializeApi();
+  await dispatch(storeName).loadVersions();
   select(storeName)
     .getSections()
     .forEach((section: Section) => {
@@ -89,7 +90,7 @@ window.addEventListener('DOMContentLoaded', () => {
   editorStoreCreate();
   initializeIntegrations();
   registerApiErrorHandler();
-  boot();
+  void boot();
   const root = createRoot(container);
   root.render(<App />);
 });

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/actions/index.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/actions/index.ts
@@ -6,7 +6,13 @@ import { apiFetch } from '@wordpress/data-controls';
 import { store as noticesStore } from '@wordpress/notices';
 import { Hooks } from 'wp-js-hooks';
 import { Data } from 'common/premium-modal/upgrade-info';
-import { CurrentView, Query, Section, SectionData } from '../types';
+import {
+  AutomationVersion,
+  CurrentView,
+  Query,
+  Section,
+  SectionData,
+} from '../types';
 import { storeName } from '../constants';
 import { getSampleData } from '../samples';
 import { storeName as editorStoreName } from '../../../../../editor/store/constants';
@@ -20,6 +26,50 @@ export function setQuery(query: Query) {
     type: 'SET_QUERY',
     payload: query,
   };
+}
+
+export function setVersions(versions: AutomationVersion[]) {
+  return {
+    type: 'SET_VERSIONS',
+    payload: versions,
+  } as const;
+}
+
+export function* setSelectedVersionId(versionId: number | undefined) {
+  yield {
+    type: 'SET_SELECTED_VERSION_ID',
+    payload: versionId,
+  };
+  const sections = select(storeName).getSections();
+  sections.forEach((section: Section) => {
+    void dispatch(storeName).updateSection(section);
+  });
+}
+
+export function* loadVersions() {
+  const id = select(editorStoreName).getAutomationData().id;
+  if (!id) {
+    return { type: 'NOOP' } as const;
+  }
+  try {
+    const response: { data: { items: AutomationVersion[] } } = yield apiFetch({
+      path: `/automations/${id}/versions`,
+      method: 'GET',
+    });
+    const items = response?.data?.items ?? [];
+    void dispatch(storeName).setVersions(items);
+
+    const current = items.length > 1 ? items.find((v) => v.is_current) : null;
+    if (current && select(storeName).getSelectedVersionId() === undefined) {
+      yield {
+        type: 'SET_SELECTED_VERSION_ID',
+        payload: current.id,
+      };
+    }
+  } catch (_error) {
+    // ignore — analytics still loads, just without version filtering
+  }
+  return { type: 'NOOP' } as const;
 }
 
 export function setSectionData(payload: Section) {
@@ -105,7 +155,15 @@ export function* updateSection(
 
   const id = select(editorStoreName).getAutomationData().id;
   const customQuery = section.customQuery ?? {};
-  const args = { id, query: { ...dates, ...customQuery } };
+  const versionId = select(storeName).getSelectedVersionId();
+  const args = {
+    id,
+    query: {
+      ...dates,
+      ...customQuery,
+      ...(versionId ? { version_id: versionId } : {}),
+    },
+  };
 
   const response: { data: SectionData } = yield apiFetch({
     path: addQueryArgs(section.endpoint, args),

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/initial-state.ts
@@ -82,4 +82,6 @@ export const getInitialState = (): State => ({
     before: undefined,
   },
   runStatusUpdates: {},
+  versions: [],
+  selectedVersionId: undefined,
 });

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/reducer.ts
@@ -25,6 +25,16 @@ export function reducer(state: State, action): State {
         ...state,
         query: action.payload,
       };
+    case 'SET_VERSIONS':
+      return {
+        ...state,
+        versions: action.payload,
+      };
+    case 'SET_SELECTED_VERSION_ID':
+      return {
+        ...state,
+        selectedVersionId: action.payload,
+      };
     case 'SET_SECTION_DATA':
       return {
         ...state,

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/selectors/index.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/selectors/index.ts
@@ -1,4 +1,4 @@
-import { Query, Section, State } from '../types';
+import { AutomationVersion, Query, Section, State } from '../types';
 
 export function getCurrentQuery(state: State): Query {
   return state.query;
@@ -18,4 +18,12 @@ export function getPremiumModal(state: State): State['premiumModal'] {
 
 export function getRunStatusUpdate(state: State, runId: number) {
   return state.runStatusUpdates[runId];
+}
+
+export function getVersions(state: State): AutomationVersion[] {
+  return state.versions;
+}
+
+export function getSelectedVersionId(state: State): number | undefined {
+  return state.selectedVersionId;
 }

--- a/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
+++ b/mailpoet/assets/js/src/automation/integrations/mailpoet/analytics/store/types.ts
@@ -184,10 +184,19 @@ export type RunStatusUpdate = {
   status: string;
   error?: string;
 };
+
+export type AutomationVersion = {
+  id: number;
+  created_at: string;
+  is_current: boolean;
+};
+
 export type State = {
   sections: Record<string, Section>;
   query: Query;
   runStatusUpdates: Record<number, RunStatusUpdate>;
+  versions: AutomationVersion[];
+  selectedVersionId: number | undefined;
   premiumModal?: {
     content: string | JSX.Element;
     utmCampaign?: string;

--- a/mailpoet/changelog/2026-05-04-16-46-35-added-view-automation-analytics-for-a-specific-saved-ver.md
+++ b/mailpoet/changelog/2026-05-04-16-46-35-added-view-automation-analytics-for-a-specific-saved-ver.md
@@ -1,0 +1,5 @@
+# Type: Added
+
+# Description
+
+Filter automation analytics by saved version, or aggregate across all of them; new runs always use the latest version

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationVersionsGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationVersionsGetEndpoint.php
@@ -20,7 +20,9 @@ class AutomationVersionsGetEndpoint extends Endpoint {
   }
 
   public function handle(Request $request): Response {
-    $automationId = (int)$request->getParam('id');
+    /** @var int $automationId */
+    $automationId = $request->getParam('id');
+    $automationId = intval($automationId);
     $automation = $this->automationStorage->getAutomation($automationId);
     if (!$automation) {
       throw Exceptions::automationNotFound($automationId);

--- a/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationVersionsGetEndpoint.php
+++ b/mailpoet/lib/Automation/Engine/Endpoints/Automations/AutomationVersionsGetEndpoint.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\Automation\Engine\Endpoints\Automations;
+
+use MailPoet\API\REST\Request;
+use MailPoet\API\REST\Response;
+use MailPoet\Automation\Engine\API\Endpoint;
+use MailPoet\Automation\Engine\Exceptions;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Validator\Builder;
+
+class AutomationVersionsGetEndpoint extends Endpoint {
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  public function __construct(
+    AutomationStorage $automationStorage
+  ) {
+    $this->automationStorage = $automationStorage;
+  }
+
+  public function handle(Request $request): Response {
+    $automationId = (int)$request->getParam('id');
+    $automation = $this->automationStorage->getAutomation($automationId);
+    if (!$automation) {
+      throw Exceptions::automationNotFound($automationId);
+    }
+
+    $versions = $this->automationStorage->getAutomationVersionDates($automationId);
+    $currentVersionId = $automation->getVersionId();
+
+    $items = array_map(
+      function (array $version) use ($currentVersionId): array {
+        return [
+          'id' => $version['id'],
+          'created_at' => $version['created_at']->format(\DateTimeInterface::ATOM),
+          'is_current' => $version['id'] === $currentVersionId,
+        ];
+      },
+      $versions
+    );
+
+    return new Response(['items' => $items]);
+  }
+
+  public static function getRequestSchema(): array {
+    return [
+      'id' => Builder::integer()->required(),
+    ];
+  }
+}

--- a/mailpoet/lib/Automation/Engine/Engine.php
+++ b/mailpoet/lib/Automation/Engine/Engine.php
@@ -12,6 +12,7 @@ use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint;
 use MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint;
+use MailPoet\Automation\Engine\Endpoints\Automations\AutomationVersionsGetEndpoint;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
 use MailPoet\Automation\Integrations\Core\CoreIntegration;
 use MailPoet\Automation\Integrations\WordPress\WordPressIntegration;
@@ -80,6 +81,7 @@ class Engine {
     $this->wordPress->addAction(Hooks::API_INITIALIZE, function (API $api) {
       $api->registerGetRoute('automations', AutomationsGetEndpoint::class);
       $api->registerPutRoute('automations/(?P<id>\d+)', AutomationsPutEndpoint::class);
+      $api->registerGetRoute('automations/(?P<id>\d+)/versions', AutomationVersionsGetEndpoint::class);
       $api->registerDeleteRoute('automations/(?P<id>\d+)', AutomationsDeleteEndpoint::class);
       $api->registerPostRoute('automations/(?P<id>\d+)/duplicate', AutomationsDuplicateEndpoint::class);
       $api->registerPostRoute('automations/create-from-template', AutomationsCreateFromTemplateEndpoint::class);

--- a/mailpoet/lib/Automation/Engine/Storage/AutomationStatisticsStorage.php
+++ b/mailpoet/lib/Automation/Engine/Storage/AutomationStatisticsStorage.php
@@ -123,7 +123,7 @@ class AutomationStatisticsStorage {
           SELECT steps
           FROM %i
           WHERE automation_id = %d
-          AND version_id = %d
+          AND id = %d
         ',
         [$versionsTable, $automationId, $versionId]
       );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanController.php
@@ -24,7 +24,16 @@ class AutomationTimeSpanController {
     $this->newslettersRepository = $newslettersRepository;
   }
 
-  public function getAutomationsInTimespan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before): array {
+  public function getAutomationsInTimespan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
+    if ($versionId !== null) {
+      return array_values(array_filter(
+        $this->automationStorage->getAutomationWithDifferentVersions([$versionId]),
+        function (Automation $versionedAutomation) use ($automation): bool {
+          return $versionedAutomation->getId() === $automation->getId();
+        }
+      ));
+    }
+
     $automationVersions = $this->automationStorage->getAutomationVersionDates($automation->getId());
     usort(
       $automationVersions,
@@ -57,8 +66,8 @@ class AutomationTimeSpanController {
    * @param \DateTimeImmutable $before
    * @return NewsletterEntity[]
    */
-  public function getAutomationEmailsInTimeSpan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before): array {
-    $automations = $this->getAutomationsInTimespan($automation, $after, $before);
+  public function getAutomationEmailsInTimeSpan(Automation $automation, \DateTimeImmutable $after, \DateTimeImmutable $before, ?int $versionId = null): array {
+    $automations = $this->getAutomationsInTimespan($automation, $after, $before, $versionId);
     return count($automations) > 0 ? $this->getEmailsFromAutomations($automations) : [];
   }
 

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/OverviewStatisticsController.php
@@ -37,8 +37,8 @@ class OverviewStatisticsController {
   }
 
   public function getStatisticsForAutomation(Automation $automation, QueryWithCompare $query): array {
-    $currentEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getAfter(), $query->getBefore());
-    $previousEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getCompareWithAfter(), $query->getCompareWithBefore());
+    $currentEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getAfter(), $query->getBefore(), $query->getVersionId());
+    $previousEmails = $this->automationTimeSpanController->getAutomationEmailsInTimeSpan($automation, $query->getCompareWithAfter(), $query->getCompareWithBefore(), $query->getVersionId());
     $data = [
       'sent' => ['current' => 0, 'previous' => 0],
       'opened' => ['current' => 0, 'previous' => 0],

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/StepStatisticController.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Controller/StepStatisticController.php
@@ -31,7 +31,8 @@ class StepStatisticController {
       $automation->getId(),
       AutomationRun::STATUS_RUNNING,
       $query->getAfter(),
-      $query->getBefore()
+      $query->getBefore(),
+      $query->getVersionId()
     );
 
     $data = [];
@@ -50,7 +51,8 @@ class StepStatisticController {
       $automation->getId(),
       AutomationRun::STATUS_FAILED,
       $query->getAfter(),
-      $query->getBefore()
+      $query->getBefore(),
+      $query->getVersionId()
     );
 
     $data = [];
@@ -69,7 +71,8 @@ class StepStatisticController {
       $automation->getId(),
       AutomationRunLog::STATUS_COMPLETE,
       $query->getAfter(),
-      $query->getBefore()
+      $query->getBefore(),
+      $query->getVersionId()
     );
 
     $data = [];

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/AutomationFlowEndpoint.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Endpoints/AutomationFlowEndpoint.php
@@ -53,14 +53,14 @@ class AutomationFlowEndpoint extends Endpoint {
       throw Exceptions::automationNotFound($id);
     }
     $query = Query::fromRequest($request);
-    $automations = $this->automationTimeSpanController->getAutomationsInTimespan($automation, $query->getAfter(), $query->getBefore());
+    $automations = $this->automationTimeSpanController->getAutomationsInTimespan($automation, $query->getAfter(), $query->getBefore(), $query->getVersionId());
     if (!count($automations)) {
       throw Exceptions::automationNotFoundInTimeSpan($id);
     }
     $automation = current($automations);
     $shortStatistics = $this->automationStatisticsStorage->getAutomationStats(
       $automation->getId(),
-      null,
+      $query->getVersionId(),
       $query->getAfter(),
       $query->getBefore()
     );

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/Query.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/Query.php
@@ -33,6 +33,9 @@ class Query {
   /** @var string | null */
   private $search;
 
+  /** @var int | null */
+  private $versionId;
+
   public function __construct(
     \DateTimeImmutable $primaryAfter,
     \DateTimeImmutable $primaryBefore,
@@ -41,7 +44,8 @@ class Query {
     string $orderDirection = 'asc',
     int $page = 1,
     array $filter = [],
-    ?string $search = null
+    ?string $search = null,
+    ?int $versionId = null
   ) {
     $this->primaryAfter = $primaryAfter;
     $this->primaryBefore = $primaryBefore;
@@ -51,6 +55,7 @@ class Query {
     $this->page = $page;
     $this->filter = $filter;
     $this->search = $search;
+    $this->versionId = $versionId;
   }
 
   public function getAfter(): \DateTimeImmutable {
@@ -85,6 +90,10 @@ class Query {
     return $this->search;
   }
 
+  public function getVersionId(): ?int {
+    return $this->versionId;
+  }
+
   /**
    * @param Request $request
    * @return Query
@@ -115,6 +124,7 @@ class Query {
     $page = is_int($query['page'] ?? null) ? $query['page'] : 1;
     $filter = is_array($query['filter'] ?? null) ? $query['filter'] : [];
     $search = isset($query['search']) && is_string($query['search']) ? $query['search'] : null;
+    $versionId = is_int($query['version_id'] ?? null) ? $query['version_id'] : null;
 
     return new self(
       new \DateTimeImmutable($primaryAfter),
@@ -124,7 +134,8 @@ class Query {
       $orderDirection,
       $page,
       $filter,
-      $search
+      $search,
+      $versionId
     );
   }
 
@@ -143,6 +154,7 @@ class Query {
         'page' => Builder::integer()->minimum(1),
         'filter' => Builder::object([]),
         'search' => Builder::string()->nullable(),
+        'version_id' => Builder::integer()->minimum(1)->nullable(),
       ]
     );
   }

--- a/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/QueryWithCompare.php
+++ b/mailpoet/lib/Automation/Integrations/MailPoet/Analytics/Entities/QueryWithCompare.php
@@ -25,9 +25,10 @@ class QueryWithCompare extends Query {
     string $orderDirection = 'asc',
     int $page = 0,
     array $filter = [],
-    ?string $search = null
+    ?string $search = null,
+    ?int $versionId = null
   ) {
-    parent::__construct($primaryAfter, $primaryBefore, $limit, $orderBy, $orderDirection, $page, $filter, $search);
+    parent::__construct($primaryAfter, $primaryBefore, $limit, $orderBy, $orderDirection, $page, $filter, $search, $versionId);
     $this->secondaryAfter = $secondaryAfter;
     $this->secondaryBefore = $secondaryBefore;
   }
@@ -75,6 +76,7 @@ class QueryWithCompare extends Query {
     $page = is_int($query['page'] ?? null) ? $query['page'] : 0;
     $filter = is_array($query['filter'] ?? null) ? $query['filter'] : [];
     $search = isset($query['search']) && is_string($query['search']) ? $query['search'] : null;
+    $versionId = is_int($query['version_id'] ?? null) ? $query['version_id'] : null;
 
     return new self(
       new \DateTimeImmutable($primaryAfter),
@@ -86,7 +88,8 @@ class QueryWithCompare extends Query {
       $orderDirection,
       $page,
       $filter,
-      $search
+      $search,
+      $versionId
     );
   }
 
@@ -111,6 +114,7 @@ class QueryWithCompare extends Query {
         'page' => Builder::integer()->minimum(1),
         'filter' => Builder::object(),
         'search' => Builder::string()->nullable(),
+        'version_id' => Builder::integer()->minimum(1)->nullable(),
       ]
     );
   }

--- a/mailpoet/lib/DI/ContainerConfigurator.php
+++ b/mailpoet/lib/DI/ContainerConfigurator.php
@@ -166,6 +166,7 @@ class ContainerConfigurator implements IContainerConfigurator {
     $container->autowire(\MailPoet\Automation\Engine\WordPress::class)->setPublic(true);
     // Automation - API endpoints
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsGetEndpoint::class)->setPublic(true);
+    $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationVersionsGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplateGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationTemplatesGetEndpoint::class)->setPublic(true);
     $container->autowire(\MailPoet\Automation\Engine\Endpoints\Automations\AutomationsPutEndpoint::class)->setPublic(true);

--- a/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
+++ b/mailpoet/tests/integration/Automation/Engine/Storage/AutomationStatisticsStorageTest.php
@@ -4,9 +4,17 @@ namespace MailPoet\Test\Automation\Engine\Storage;
 
 use MailPoet\Automation\Engine\Data\Automation;
 use MailPoet\Automation\Engine\Data\AutomationRun;
+use MailPoet\Automation\Engine\Data\NextStep;
+use MailPoet\Automation\Engine\Data\Step;
 use MailPoet\Automation\Engine\Storage\AutomationRunStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStatisticsStorage;
 use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\Automation\Integrations\MailPoet\Actions\SendEmailAction;
+use MailPoet\Cron\Workers\SendingQueue\SendingQueue as SendingQueueWorker;
+use MailPoet\Entities\NewsletterEntity;
+use MailPoet\Entities\ScheduledTaskEntity;
+use MailPoet\Test\DataFactories\ScheduledTask as ScheduledTaskFactory;
+use MailPoet\Test\DataFactories\SendingQueue as SendingQueueFactory;
 
 class AutomationStatisticsStorageTest extends \MailPoetTest {
 
@@ -213,6 +221,32 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
     ], $array['emails']);
   }
 
+  public function testItCalculatesEmailStatisticsForSpecificVersion(): void {
+    $newsletter = $this->createEmail();
+    $trigger = new Step(
+      'trigger',
+      Step::TYPE_TRIGGER,
+      'mailpoet:someone-subscribes',
+      [],
+      [
+        new NextStep('email'),
+      ]
+    );
+    $email = new Step(
+      'email',
+      Step::TYPE_ACTION,
+      SendEmailAction::KEY,
+      ['email_id' => $newsletter->getId()],
+      []
+    );
+    $automation = $this->tester->createAutomation('with-email', $trigger, $email);
+    $this->createCompletedQueue($newsletter, 3);
+
+    $statistics = $this->testee->getAutomationStats($automation->getId(), $automation->getVersionId());
+
+    $this->assertEquals(3, $statistics->getEmailsSent());
+  }
+
   private function createRun(Automation $automation, string $status) {
     $run = AutomationRun::fromArray([
       'automation_id' => $automation->getId(),
@@ -225,5 +259,22 @@ class AutomationStatisticsStorageTest extends \MailPoetTest {
       'updated_at' => (new \DateTimeImmutable())->format(\DateTimeImmutable::W3C),
     ]);
     $this->automationRunStorage->createAutomationRun($run);
+  }
+
+  private function createEmail(): NewsletterEntity {
+    $newsletter = new NewsletterEntity();
+    $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);
+    $newsletter->setSubject('subject');
+    $newsletter->setStatus(NewsletterEntity::STATUS_ACTIVE);
+    $this->entityManager->persist($newsletter);
+    $this->entityManager->flush();
+    return $newsletter;
+  }
+
+  private function createCompletedQueue(NewsletterEntity $newsletter, int $countProcessed): void {
+    $task = (new ScheduledTaskFactory())->create(SendingQueueWorker::TASK_TYPE, ScheduledTaskEntity::STATUS_COMPLETED);
+    $queue = (new SendingQueueFactory())->create($task, $newsletter);
+    $queue->setCountProcessed($countProcessed);
+    $this->entityManager->flush();
   }
 }

--- a/mailpoet/tests/integration/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanControllerTest.php
+++ b/mailpoet/tests/integration/Automation/Integrations/MailPoet/Analytics/Controller/AutomationTimeSpanControllerTest.php
@@ -166,6 +166,38 @@ class AutomationTimeSpanControllerTest extends \MailPoetTest {
     $this->assertEquals($expectedIds, $actualIds);
   }
 
+  public function testItReturnsExplicitVersionOutsideTheDateRange(): void {
+    $automation = $this->tester->createAutomation('test');
+    $automation->setName('updated test');
+    $this->automationStorage->updateAutomation($automation);
+    $updatedAutomation = $this->automationStorage->getAutomation($automation->getId());
+    $this->assertInstanceOf(Automation::class, $updatedAutomation);
+
+    $automations = $this->testee->getAutomationsInTimespan(
+      $updatedAutomation,
+      new \DateTimeImmutable('2022-01-01 00:00:00'),
+      new \DateTimeImmutable('2022-01-02 00:00:00'),
+      $updatedAutomation->getVersionId()
+    );
+
+    $this->assertCount(1, $automations);
+    $this->assertSame($updatedAutomation->getVersionId(), $automations[0]->getVersionId());
+  }
+
+  public function testItDoesNotReturnVersionFromAnotherAutomation(): void {
+    $automation = $this->tester->createAutomation('test');
+    $otherAutomation = $this->tester->createAutomation('other test');
+
+    $automations = $this->testee->getAutomationsInTimespan(
+      $automation,
+      new \DateTimeImmutable('2022-01-01 00:00:00'),
+      new \DateTimeImmutable('2022-01-02 00:00:00'),
+      $otherAutomation->getVersionId()
+    );
+
+    $this->assertSame([], $automations);
+  }
+
   private function createEmail(string $subject = 'subject'): NewsletterEntity {
     $newsletter = new NewsletterEntity();
     $newsletter->setType(NewsletterEntity::TYPE_AUTOMATION);

--- a/mailpoet/tests/integration/REST/Automation/Automations/AutomationVersionsGetEndpointTest.php
+++ b/mailpoet/tests/integration/REST/Automation/Automations/AutomationVersionsGetEndpointTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace MailPoet\REST\Automation\Automations;
+
+use MailPoet\Automation\Engine\Data\Automation;
+use MailPoet\Automation\Engine\Storage\AutomationStorage;
+use MailPoet\REST\Automation\AutomationTest;
+
+require_once __DIR__ . '/../AutomationTest.php';
+
+class AutomationVersionsGetEndpointTest extends AutomationTest {
+  private const ENDPOINT_PATH = '/mailpoet/v1/automations/%d/versions';
+
+  /** @var AutomationStorage */
+  private $automationStorage;
+
+  /** @var Automation */
+  private $automation;
+
+  public function _before() {
+    parent::_before();
+    $this->automationStorage = $this->diContainer->get(AutomationStorage::class);
+    $this->automation = $this->tester->createAutomation('Test automation');
+  }
+
+  public function testEditorIsAllowed(): void {
+    wp_set_current_user($this->editorUserId);
+
+    $data = $this->get(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));
+
+    $this->assertCount(1, $data['data']['items']);
+  }
+
+  public function testGuestNotAllowed(): void {
+    wp_set_current_user(0);
+
+    $data = $this->get(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));
+
+    $this->assertSame([
+      'code' => 'rest_forbidden',
+      'message' => 'Sorry, you are not allowed to do that.',
+      'data' => ['status' => 401],
+    ], $data);
+  }
+
+  public function testItReturnsVersionDataWithCurrentFlag(): void {
+    $this->automation->setName('Updated automation');
+    $this->automationStorage->updateAutomation($this->automation);
+    $updatedAutomation = $this->automationStorage->getAutomation($this->automation->getId());
+    $this->assertInstanceOf(Automation::class, $updatedAutomation);
+
+    $data = $this->get(sprintf(self::ENDPOINT_PATH, $this->automation->getId()));
+
+    $this->assertCount(2, $data['data']['items']);
+    $this->assertSame($updatedAutomation->getVersionId(), $data['data']['items'][0]['id']);
+    $this->assertTrue($data['data']['items'][0]['is_current']);
+    $this->assertFalse($data['data']['items'][1]['is_current']);
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $data['data']['items'][0]['created_at']);
+  }
+}


### PR DESCRIPTION
## Description

Adds a version selector to the automation analytics page so users can view stats for any saved version of  an automation, backed by a new GET `/automations/{id}/versions` endpoint and `version_id` filtering across the analytics controllers. 

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet-premium/pull/1074

## Linked tickets

STOMAIL-8020

## After-merge notes

_N/A_

## Screenshots or screencast <!-- if applicable -->

<img width="1326" height="635" alt="Screenshot 2026-05-19 at 16 37 41" src="https://github.com/user-attachments/assets/50f87e65-bb5f-4294-8362-13ba8d6b0fda" />

<img width="1322" height="774" alt="Screenshot 2026-05-19 at 16 38 11" src="https://github.com/user-attachments/assets/d2ec957c-bd9d-43a4-9ea3-c355fc320973" />


## Tasks

- [x] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [x] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [x] I added sufficient test coverage
- [x] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:stomail-8020-allow-viewing-automation-stats-per-version)

_The latest successful build from `stomail-8020-allow-viewing-automation-stats-per-version` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->