### PR TITLE
Stabilize bulk-resend modal aria-labelledby check

### DIFF
--- a/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
+++ b/mailpoet/tests/acceptance/Subscribers/SubscribersListingCest.php
@@ -233,7 +233,7 @@ class SubscribersListingCest {
       'bulk-resend-confirmation-checkbox-input',
       $i->executeJS('return document.activeElement.id;')
     );
-    $i->seeElement('div[role="dialog"][aria-labelledby]');
+    $i->waitForElement('div[role="dialog"][aria-labelledby]');
     $i->seeElement('div[role="dialog"] button[aria-label="Close"]');
     $modalTitleId = $i->grabAttributeFrom('div[role="dialog"]', 'aria-labelledby');
     Assert::assertSame(


### PR DESCRIPTION
## Description

Test-only stabilization. `acceptance_oldest` failed on `trunk` in the May 19 nightly ([job 411393](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/23441/workflows/c6487f2b-510b-426d-832d-5aee2bfb5037/jobs/411393)) at `SubscribersListingCest::bulkResendConfirmationEmailModalAndNotice` line 236:

```php
$i->seeElement('div[role="dialog"][aria-labelledby]');   // "Failed asserting that an array is not empty."
```

The captured `.fail.html` shows the dialog **does** carry `aria-labelledby="components-modal-header-0"`. The `-0` suffix is the giveaway — WP 6.8.3's `@wordpress/components` Modal still uses the legacy `useInstanceId` (`useState(undefined)` + `useEffect`) pattern; modern `useId()` produces `:r1:`-style ids. Because React fires child effects before parent ones in the same commit, the inner checkbox focus effect sets focus before the Modal's instanceId effect adds `aria-labelledby`. On a loaded CI container that window is wide enough for `seeElement` (an instantaneous check) to miss the attribute; the page dump, captured a moment later, shows the post-update state.

Same test passed on the **identical** WP/PHP stack in `acceptance_with_premium_oldest` in the same nightly and in the next nightly — supports the timing-race read, rules out a regression.

The fix swaps the instantaneous `seeElement` for `waitForElement` so the assertion polls until the re-render lands. The follow-up `grabAttributeFrom` then has a value to grab. Modal a11y is fine in production — the attribute is set, just not synchronously.

## Code review notes

The `seeElement` → `waitForElement` swap is the only change. I considered three alternatives:

1. Insert a short `wait(N)` — fragile, papers over the symptom.
2. Hold the second `seeElement` (Close button) and `grabAttributeFrom` behind their own waits — unnecessary; once aria-labelledby is present, the parent has finished re-rendering, so subsequent reads on the same dialog are safe.
3. Change the Modal in production — would mean wrapping or replacing `WordPressModal`, which is owned by core; not appropriate to mitigate test flake.

## QA notes

- `pnpm qa:php` ✅, `pnpm qa:phpstan` ✅ locally.
- `pnpm qa:prettier` flagged only files outside this change (`.claude/settings.local.json`, `.venv/…`, `tests_env/docker/docker-compose.override.yml`) — pre-existing.
- I did **not** run the acceptance suite locally. The race only reproduces under CI load on WP 6.8.3's lazy `useInstanceId`; a local run can confirm the test still parses but cannot exercise the original failure mode. CI will be the real verification.

## Linked PRs

_N/A_

## Linked tickets

_N/A_

## After-merge notes

_N/A_

## Tasks

- [ ] I have added a changelog entry (`pnpm changelog:add --type=<type> --description=<description>`)
- [ ] I followed [best practices](https://codex.wordpress.org/I18n_for_WordPress_Developers) for translations
- [ ] I added sufficient test coverage
- [ ] I embraced TypeScript by either creating new files in TypeScript or converting existing JavaScript files when making changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

[Preview in WordPress Playground](https://account.mailpoet.com/playground/new/branch:fix/subscribers-listing-modal-test-flake)

_The latest successful build from `fix/subscribers-listing-modal-test-flake` will be used. If none is available, the link won't work._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

No issues found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailpoet/mailpoet/pull/6776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->